### PR TITLE
Check in BlackVarianceMoneynessSurface to experimental. 

### DIFF
--- a/QuantLib/ql/experimental/volatility/Makefile.am
+++ b/QuantLib/ql/experimental/volatility/Makefile.am
@@ -12,7 +12,8 @@ this_include_HEADERS = \
     extendedblackvariancesurface.hpp \
     interestratevolsurface.hpp \
     sabrvolsurface.hpp \
-    volcube.hpp
+    volcube.hpp \
+    blackvariancemoneynesssurface.hpp 
 
 libVolatility_la_SOURCES = \
     abcdatmvolcurve.cpp \
@@ -23,7 +24,8 @@ libVolatility_la_SOURCES = \
     extendedblackvariancesurface.cpp \
     interestratevolsurface.cpp \
     sabrvolsurface.cpp \
-    volcube.cpp
+    volcube.cpp \
+    blackvariancemoneynesssurface.cpp 
 
 noinst_LTLIBRARIES = libVolatility.la
 

--- a/QuantLib/ql/experimental/volatility/blackvariancemoneynesssurface.cpp
+++ b/QuantLib/ql/experimental/volatility/blackvariancemoneynesssurface.cpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2013 Paul Cao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/experimental/volatility/blackvariancemoneynesssurface.hpp>
+#include <ql/math/matrix.hpp>
+#include <ql/math/interpolations/interpolation2d.hpp>
+#include <vector>
+#include <cstdlib>
+#include <boost/assign/std/vector.hpp>
+using namespace QuantLib;
+using namespace boost::assign;
+using namespace std;
+
+BlackVarianceMoneynessSurface::BlackVarianceMoneynessSurface(const Date& referenceDate, const Calendar& cal,
+						 const std::vector<Date>& dates,
+						 const std::vector<Real>& strikes,
+						 const Matrix& blackVolMatrix,
+						 const DayCounter& dayCounter,
+						 const double currentPrice,
+						 BlackVarianceSurface::Extrapolation lowerExtrapolation,
+						 BlackVarianceSurface::Extrapolation upperExtrapolation)
+: BlackVarianceSurface(referenceDate, cal, dates, convertToMoneyness(strikes, currentPrice), blackVolMatrix, dayCounter,
+								lowerExtrapolation, upperExtrapolation),
+  currentPrice_(currentPrice)
+{
+}
+
+void BlackVarianceMoneynessSurface::setCurrentPrice(double currentPrice) {
+	currentPrice_ = currentPrice;
+}
+
+Volatility BlackVarianceMoneynessSurface::blackVol(const Date& maturity, Real strike, bool extrapolate) {
+	strike = log(strike /currentPrice_); // convert the strike price to moneyness
+	return BlackVarianceSurface::blackVol(maturity, strike, extrapolate);
+}
+
+const std::vector<Real> BlackVarianceMoneynessSurface::convertToMoneyness(const std::vector<Real>& strikes, const double currentPrice) {
+	std::vector<double> moneynessStrikes;
+
+	// convert strikes to moneyness
+	for (std::vector<Real>::const_iterator it = strikes.begin(); it != strikes.end(); ++it) {
+		double moneyness = log(*it / currentPrice);
+		moneynessStrikes += moneyness;
+	}
+	return moneynessStrikes;
+}
+

--- a/QuantLib/ql/experimental/volatility/blackvariancemoneynesssurface.hpp
+++ b/QuantLib/ql/experimental/volatility/blackvariancemoneynesssurface.hpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2013 Paul Cao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+ /*
+  Black Variance Surface that is plotted in moneyness
+  so that it can extrapolates volatility at a new price with the 
+  original volatility surface. e.g.,
+
+  BlackVarianceSurface volatilitySurface(...)
+  volatilitySurface.enableExtrapolation();
+  volatilitySurface.setCurrentPrice(newPrice);
+  volatilitySurface.blackVol(expiration, strikePrice, true);
+ */
+
+#ifndef BLACKVARIANCEMONEYNESSSURFACE_HPP_
+#define BLACKVARIANCEMONEYNESSSURFACE_HPP_
+#include <vector>
+#include <ql/quantlib.hpp>
+#include <cstdlib>
+#include <ql/termstructures/volatility/equityfx/blackvariancesurface.hpp>
+using namespace QuantLib;
+using namespace std;
+
+class BlackVarianceMoneynessSurface : public BlackVarianceSurface {
+public:
+	BlackVarianceMoneynessSurface(const Date& referenceDate, const Calendar& cal,
+		     	 	 	 	 const std::vector<Date>& dates,
+		     	 	 	 	 const std::vector<Real>& strikes,
+		     	 	 	 	 const Matrix& blackVolMatrix,
+		     	 	 	 	 const DayCounter& dayCounter,
+		     	 	 	 	 const double currentPrice,
+		     	 	 	 	 Extrapolation lowerExtrapolation = InterpolatorDefaultExtrapolation,
+		     	 	 	 	 Extrapolation upperExtrapolation = InterpolatorDefaultExtrapolation);
+
+	Volatility blackVol(const Date& maturity, Real strike, bool extrapolate = false);
+	void setCurrentPrice(double currentPrice);
+
+private:
+	double currentPrice_;
+	const std::vector<Real> convertToMoneyness(const std::vector<Real>& strikes, const double currentPrice);
+};
+
+#endif /* BLACKVARIANCEMONEYNESSSURFACE_HPP_ */


### PR DESCRIPTION
It's an extension of BlackVarianceSurface that is plotted in moneyness so that the surface can extrapolate volatility at a new price point with the original volatility term structure.

e.g., demonstration of the usage of this new class: 
http://pastebin.com/BL7bFuUj