### PR TITLE
Overload operator >> for Date type

### DIFF
--- a/QuantLib/ql/time/date.cpp
+++ b/QuantLib/ql/time/date.cpp
@@ -432,8 +432,7 @@ namespace QuantLib {
 
 
     // date formatting
-	std::istream& operator >> (std::istream& in , Date& date){
- 
+	std::istream& operator>>(std::istream& in , Date& date) {
 	    Year  y;  Month m; Day   d;
 	    int month;
 	    in >> y >> month >> d;
@@ -442,6 +441,7 @@ namespace QuantLib {
 	    date = date_temp;
 	    return in;
 	}
+	
     std::ostream& operator<<(std::ostream& out, const Date& d) {
         return out << io::long_date(d);
     }

--- a/QuantLib/ql/time/date.cpp
+++ b/QuantLib/ql/time/date.cpp
@@ -432,11 +432,20 @@ namespace QuantLib {
 
 
     // date formatting
-
+	std::istream& operator >> (std::istream& in , Date& date){
+ 
+	    Year  y;  Month m; Day   d;
+	    int month;
+	    in >> y >> month >> d;
+	    m = (QuantLib::Month) month;
+	    Date date_temp(d,m,y);
+	    date = date_temp;
+	    return in;
+	}
     std::ostream& operator<<(std::ostream& out, const Date& d) {
         return out << io::long_date(d);
     }
-
+	
     namespace detail {
 
         std::ostream& operator<<(std::ostream& out,

--- a/QuantLib/ql/time/date.hpp
+++ b/QuantLib/ql/time/date.hpp
@@ -199,7 +199,7 @@ namespace QuantLib {
     bool operator>=(const Date&, const Date&);
     /*! \relates Date */
     std::ostream& operator<<(std::ostream&, const Date&);
-
+	std::istream& operator<<(std::istream&, const Date&);
     namespace detail {
 
         struct short_date_holder {

--- a/QuantLib/ql/time/date.hpp
+++ b/QuantLib/ql/time/date.hpp
@@ -199,7 +199,7 @@ namespace QuantLib {
     bool operator>=(const Date&, const Date&);
     /*! \relates Date */
     std::ostream& operator<<(std::ostream&, const Date&);
-	std::istream& operator<<(std::istream&, const Date&);
+	std::istream& operator>>(std::istream&, const Date&);
     namespace detail {
 
         struct short_date_holder {


### PR DESCRIPTION
When I use QuantLib, I found that it'll be more convenient if users are allowed to input date type from command line to test the code. So I implement the >> operator, user could use YYYY MM DD format to input date.