### PR TITLE
Add explicit python references

### DIFF
--- a/ObjectHandler/gensrc/Makefile.vc
+++ b/ObjectHandler/gensrc/Makefile.vc
@@ -24,7 +24,7 @@ $(BUILD_DIR) :
     if not exist $(BUILD_DIR) mkdir $(BUILD_DIR)
 
 $(BUILDFLAG) : $(INPUTS) $(BUILD_DIR)
-	$(GENSRC_DIR)\gensrc.py -xdlv --oh_dir=$(OH_DIR)
+	python.exe $(GENSRC_DIR)\gensrc.py -xdlv --oh_dir=$(OH_DIR)
 	echo flagged > $@
 
 CLEAN :

--- a/QuantLibAddin/gensrc/Makefile.vc
+++ b/QuantLibAddin/gensrc/Makefile.vc
@@ -25,7 +25,7 @@ $(BUILD_DIR) :
     if not exist $(BUILD_DIR) mkdir $(BUILD_DIR)
 
 $(BUILDFLAG) : $(INPUTS) $(BUILD_DIR)
-    $(GENSRC_DIR)\gensrc.py -a --oh_dir=$(OH_DIR)
+    python.exe $(GENSRC_DIR)\gensrc.py -a --oh_dir=$(OH_DIR)
 	echo flagged > $@
 
 CLEAN :


### PR DESCRIPTION
Refer to discussion on http://quantlib.10058.n7.nabble.com/problems-compiling-QuantLibXL-from-td15602.html

Many people, including myself, find the implicit .py file execution doesn't work. Adding the python.exe fixes this. This assumes the user has python.exe in the PATH variable.