### PR TITLE
Add parameter to specify that index fixes at end of month

### DIFF
--- a/QuantLib/ql/indexes/inflationindex.cpp
+++ b/QuantLib/ql/indexes/inflationindex.cpp
@@ -39,6 +39,22 @@ namespace QuantLib {
         registerWith(IndexManager::instance().notifier(name()));
     }
 
+    InflationIndex::InflationIndex(const std::string& familyName,
+                                   const Region& region,
+                                   bool revised,
+                                   bool interpolated,
+                                   bool fixesAtEndOfMonth,
+                                   Frequency frequency,
+                                   const Period& availabilityLag,
+                                   const Currency& currency)
+    : familyName_(familyName), region_(region),
+      revised_(revised), interpolated_(interpolated),
+      fixesAtEndOfMonth_(fixesAtEndOfMonth), frequency_(frequency),
+      availabilityLag_(availabilityLag), currency_(currency) {
+        name_ = region_.name() + " " + familyName_;
+        registerWith(Settings::instance().evaluationDate());
+        registerWith(IndexManager::instance().notifier(name()));
+    }
 
     Calendar InflationIndex::fixingCalendar() const {
         static NullCalendar c;
@@ -99,8 +115,11 @@ namespace QuantLib {
                                "Missing " << name() << " fixing for " << fixingDate2);
                     // now linearly interpolate
                     Real daysInPeriod = lim.second+1 - lim.first;
+                    Real daysElapsed = aFixingDate-lim.first;
+                    if (fixesAtEndOfMonth_)
+                        daysElapsed += 1;
                     theFixing = pastFixing
-                        + (pastFixing2-pastFixing)*(aFixingDate-lim.first)/daysInPeriod;
+                        + (pastFixing2-pastFixing)*daysElapsed/daysInPeriod;
                 }
             }
             return theFixing;

--- a/QuantLib/ql/indexes/inflationindex.hpp
+++ b/QuantLib/ql/indexes/inflationindex.hpp
@@ -55,6 +55,14 @@ namespace QuantLib {
                        Frequency frequency,
                        const Period& availabilitiyLag,
                        const Currency& currency);
+        InflationIndex(const std::string& familyName,
+                       const Region& region,
+                       bool revised,
+                       bool interpolated,
+                       bool fixesAtEndOfMonth,
+                       Frequency frequency,
+                       const Period& availabilitiyLag,
+                       const Currency& currency);
         //! \name Index interface
         //@{
         std::string name() const;
@@ -107,6 +115,7 @@ namespace QuantLib {
             the mid-period extrapolated value.
         */
         bool interpolated() const;
+        bool fixesAtEndOfMonth() const;
         Frequency frequency() const;
         /*! The availability lag describes when the index is
             <i>available</i>, not how it is used.  Specifically the
@@ -125,6 +134,7 @@ namespace QuantLib {
         Region region_;
         bool revised_;
         bool interpolated_;
+        bool fixesAtEndOfMonth_;
         Frequency frequency_;
         Period availabilityLag_;
         Currency currency_;
@@ -141,6 +151,17 @@ namespace QuantLib {
                            const Region& region,
                            bool revised,
                            bool interpolated,
+                           Frequency frequency,
+                           const Period& availabilityLag,
+                           const Currency& currency,
+                           const Handle<ZeroInflationTermStructure>& ts =
+                                        Handle<ZeroInflationTermStructure>());
+
+        ZeroInflationIndex(const std::string& familyName,
+                           const Region& region,
+                           bool revised,
+                           bool interpolated,
+                           bool fixesAtEndOfMonth,
                            Frequency frequency,
                            const Period& availabilityLag,
                            const Currency& currency,
@@ -231,6 +252,10 @@ namespace QuantLib {
 
     inline bool InflationIndex::interpolated() const {
         return interpolated_;
+    }
+
+    inline bool InflationIndex::fixesAtEndOfMonth() const {
+        return fixesAtEndOfMonth_;
     }
 
     inline Frequency InflationIndex::frequency() const {


### PR DESCRIPTION
For indices that fix at the end of the month and are applicable backwards to the start of the month.

Interpolation should result in exact index if date is last day of month.