### PR TITLE
intraday patch

### DIFF
--- a/QuantLib-SWIG/SWIG/date.i
+++ b/QuantLib-SWIG/SWIG/date.i
@@ -4,6 +4,7 @@
  Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008 StatPro Italia srl
  Copyright (C) 2005 Johan Witters
  Copyright (C) 2013 Simon Shakeshaft
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -29,10 +30,19 @@
 %{
 using QuantLib::Day;
 using QuantLib::Year;
+using QuantLib::Hour;
+using QuantLib::Minute;
+using QuantLib::Second;
+using QuantLib::Millisecond;
 %}
 
 typedef Integer Day;
 typedef Integer Year;
+typedef Integer Hour;
+typedef Integer Minute;
+typedef Integer Second;
+typedef Integer Millisecond;
+
 
 #if defined(SWIGJAVA)
 %javaconst(1);
@@ -209,6 +219,7 @@ namespace std {
 %{
 using QuantLib::Date;
 using QuantLib::DateParser;
+ using QuantLib::TimeStamp;
 %}
 
 #if defined(SWIGR)
@@ -427,6 +438,19 @@ class Date {
         }
         #endif
     }
+};
+
+class TimeStamp : public Date {
+ public:
+  TimeStamp();
+  TimeStamp(Day d, Month m, Year y, Hour h, 
+    Minute mt, Second s, Millisecond ms = 0);
+  TimeStamp(Date d, Minute mt, Second s, Millisecond ms = 0);
+  static TimeStamp now() const;
+  Hour hour();
+  Minute minute();
+  Second second();
+  Millisecond millisecond();
 };
 
 class DateParser {

--- a/QuantLib-SWIG/SWIG/daycounters.i
+++ b/QuantLib-SWIG/SWIG/daycounters.i
@@ -3,6 +3,7 @@
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
  Copyright (C) 2003, 2004, 2005 StatPro Italia srl
  Copyright (C) 2005 Johan Witters
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -44,6 +45,7 @@ class DayCounter {
                       const Date& startRef = Date(),
                       const Date& endRef = Date()) const;
     std::string name() const;
+
     %extend {
         #if !defined(SWIGPERL)
         std::string __str__() {
@@ -90,6 +92,14 @@ namespace QuantLib {
     class OneDayCounter : public DayCounter {};
     class SimpleDayCounter : public DayCounter {};
     class Business252 : public DayCounter {};
+    class ContinuousTime : public DayCounter {
+    public:
+      ContinuousTime(TimeUnit);
+      static ContinuousTime perYear();
+      static ContinuousTime perMonth();
+      static ContinuousTime perWeek();
+      static ContinuousTime perDay();
+    };
 }
 
 

--- a/QuantLib/ql/time/Makefile.am
+++ b/QuantLib/ql/time/Makefile.am
@@ -10,12 +10,13 @@ this_include_HEADERS = \
     calendar.hpp \
     date.hpp \
     dategenerationrule.hpp \
-	daycounter.hpp \
-	ecb.hpp \
+    daycounter.hpp \
+    ecb.hpp \
     frequency.hpp \
     imm.hpp \
     period.hpp \
     schedule.hpp \
+    timestamp.hpp \
     timeunit.hpp \
     weekday.hpp
 
@@ -29,6 +30,7 @@ libTime_la_SOURCES = \
     imm.cpp \
     period.cpp \
     schedule.cpp \
+    timestamp.cpp \
     timeunit.cpp \
     weekday.cpp
 

--- a/QuantLib/ql/time/all.hpp
+++ b/QuantLib/ql/time/all.hpp
@@ -11,6 +11,7 @@
 #include <ql/time/imm.hpp>
 #include <ql/time/period.hpp>
 #include <ql/time/schedule.hpp>
+#include <ql/time/timestamp.hpp>
 #include <ql/time/timeunit.hpp>
 #include <ql/time/weekday.hpp>
 

--- a/QuantLib/ql/time/date.cpp
+++ b/QuantLib/ql/time/date.cpp
@@ -404,6 +404,10 @@ namespace QuantLib {
                    minDate() << "-" << maxDate() << "]");
     }
 
+    Time Date::dayFraction() const {
+        return 0.0;
+    }
+
     // month formatting
 
     std::ostream& operator<<(std::ostream& out, Month m) {

--- a/QuantLib/ql/time/date.hpp
+++ b/QuantLib/ql/time/date.hpp
@@ -96,6 +96,9 @@ namespace QuantLib {
         explicit Date(BigInteger serialNumber);
         //! More traditional constructor.
         Date(Day d, Month m, Year y);
+
+        // virtual destructor
+        virtual ~Date() {};
         //@}
         //! \name inspectors
         //@{
@@ -106,6 +109,9 @@ namespace QuantLib {
         Month month() const;
         Year year() const;
         BigInteger serialNumber() const;
+
+        //! dayFraction
+        virtual Time dayFraction() const;
         //@}
 
         //! \name date algebra

--- a/QuantLib/ql/time/daycounter.hpp
+++ b/QuantLib/ql/time/daycounter.hpp
@@ -56,6 +56,13 @@ namespace QuantLib {
                                       const Date& d2,
                                       const Date& refPeriodStart,
                                       const Date& refPeriodEnd) const = 0;
+            virtual Time timeFraction(const Date& d1,
+                                       const Date& d2,
+                                       const Date& refPeriodStart,
+                                       const Date& refPeriodEnd) const {
+                return yearFraction(d1, d2, refPeriodStart, 
+                                    refPeriodEnd);
+            }
         };
         boost::shared_ptr<Impl> impl_;
         /*! This constructor can be invoked by derived classes which
@@ -83,6 +90,10 @@ namespace QuantLib {
                             const Date&) const;
         //! Returns the period between two dates as a fraction of year.
         Time yearFraction(const Date&, const Date&,
+                          const Date& refPeriodStart = Date(),
+                          const Date& refPeriodEnd = Date()) const;
+        //! Returns the period between two dates as a fraction of year.
+        Time timeFraction(const Date&, const Date&,
                           const Date& refPeriodStart = Date(),
                           const Date& refPeriodEnd = Date()) const;
         //@}
@@ -127,6 +138,12 @@ namespace QuantLib {
         const Date& refPeriodStart, const Date& refPeriodEnd) const {
             QL_REQUIRE(impl_, "no implementation provided");
             return impl_->yearFraction(d1,d2,refPeriodStart,refPeriodEnd);
+    }
+
+    inline Time DayCounter::timeFraction(const Date& d1, const Date& d2,
+        const Date& refPeriodStart, const Date& refPeriodEnd) const {
+            QL_REQUIRE(impl_, "no implementation provided");
+            return impl_->timeFraction(d1,d2,refPeriodStart,refPeriodEnd);
     }
 
 

--- a/QuantLib/ql/time/daycounters/Makefile.am
+++ b/QuantLib/ql/time/daycounters/Makefile.am
@@ -10,13 +10,15 @@ this_include_HEADERS = \
 	actualactual.hpp \
 	business252.hpp \
 	one.hpp \
+        continuoustime.hpp \
 	simpledaycounter.hpp \
 	thirty360.hpp
 
 libDayCounters_la_SOURCES = \
     actualactual.cpp \
     business252.cpp \
-	simpledaycounter.cpp \
+    continuoustime.cpp \
+    simpledaycounter.cpp \
     thirty360.cpp
 
 noinst_LTLIBRARIES = libDayCounters.la

--- a/QuantLib/ql/time/daycounters/all.hpp
+++ b/QuantLib/ql/time/daycounters/all.hpp
@@ -7,6 +7,7 @@
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/time/daycounters/business252.hpp>
 #include <ql/time/daycounters/one.hpp>
+#include <ql/time/daycounters/continuoustime.hpp>
 #include <ql/time/daycounters/simpledaycounter.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 

--- a/QuantLib/ql/time/daycounters/continuoustime.cpp
+++ b/QuantLib/ql/time/daycounters/continuoustime.cpp
@@ -1,0 +1,52 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/time/daycounters/continuoustime.hpp>
+#include <ql/time/timestamp.hpp>
+
+namespace QuantLib {
+    ContinuousTime::Impl::Impl(TimeUnit units) :
+        units_(units) {};
+
+
+    Time ContinuousTime::Impl::yearFraction(const Date& d1,
+                                            const Date& d2,
+                                            const Date&,
+                                            const Date&) const {
+        BigInteger days = dayCount(d1, d2);
+        Time divisor;
+        switch (units_) {
+        case Years:
+            divisor = 365.25;
+            break;
+        case Months:
+            divisor = 30.0;
+            break;
+        case Weeks:
+            divisor = 7.0;
+            break;
+        case Days:
+            divisor = 1.0;
+            break;
+        default:
+            QL_FAIL("unknown time unit (" << units_ << ")");
+        }
+        return (days + d2.dayFraction() - d1.dayFraction()) / divisor;
+    }
+}

--- a/QuantLib/ql/time/daycounters/continuoustime.hpp
+++ b/QuantLib/ql/time/daycounters/continuoustime.hpp
@@ -1,0 +1,66 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file continoustime.hpp
+     \brief Day counter for continuous time measurements
+*/
+
+#ifndef quantlib_continuous_time_hpp
+#define quantlib_continuous_time_hpp
+
+#include <ql/time/daycounter.hpp>
+#include <ql/time/timeunit.hpp>
+
+namespace QuantLib {
+
+    //! Continous day counter 
+
+    class ContinuousTime : public DayCounter {
+      private:
+        class Impl : public DayCounter::Impl {
+          public:
+            Impl(TimeUnit units);
+            std::string name() const { return "ContinuousTime"; }
+            Time yearFraction(const Date& d1,
+                              const Date& d2,
+                              const Date&,
+                              const Date&) const;
+            TimeUnit units_;
+        };
+      public:
+        ContinuousTime(TimeUnit units)
+        : DayCounter(boost::shared_ptr<ContinuousTime::Impl>(
+                     new ContinuousTime::Impl(units))) {}
+        static ContinuousTime perYear() {
+            return ContinuousTime(Years);
+        }
+        static ContinuousTime perMonth() {
+            return ContinuousTime(Months);
+        }
+        static ContinuousTime perWeek() {
+            return ContinuousTime(Weeks);
+        }
+        static ContinuousTime perDay() {
+            return ContinuousTime(Days);
+        }
+    };
+
+}
+
+#endif

--- a/QuantLib/ql/time/timestamp.cpp
+++ b/QuantLib/ql/time/timestamp.cpp
@@ -1,0 +1,108 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/time/timestamp.hpp>
+#include <ql/errors.hpp>
+#include <ctime>
+
+#if defined(BOOST_NO_STDC_NAMESPACE)
+    namespace std { using ::time; using ::time_t; using ::tm;
+                    using ::gmtime; using ::localtime; }
+#endif
+
+namespace QuantLib {
+
+    // constructors
+    TimeStamp::TimeStamp()
+        : Date(),
+          serialTimeStamp_(BigInteger(0)) {}
+    TimeStamp::TimeStamp(Day d,
+                         Month m,
+                         Year y,
+                         Hour h,
+                         Minute mt,
+                         Second s,
+                         Millisecond ms)
+        : Date(d, m, y) {
+        setSerial(h, mt, s, ms);
+    }
+
+    TimeStamp::TimeStamp(Date &date,
+                         Hour h,
+                         Minute mt,
+                         Second s,
+                         Millisecond ms)
+        : Date(date) {
+        setSerial(h, mt, s, ms);
+    }
+
+    void TimeStamp::setSerial(Hour h, Minute mt, Second s, 
+                               Millisecond ms) {
+        QL_REQUIRE(h >= 0 && h <= 23,
+                   "hour " << h << " out of bound. It must be in [0, 59]");
+        QL_REQUIRE(mt >= 0 && mt <= 59,
+                   "minute " << mt << " out of bound. It must be in [0, 59]");
+        QL_REQUIRE(s >= 0 && s <= 60,
+                   "second " << s << " out of bound. It must be in [0, 60]");
+        QL_REQUIRE(ms >= 0 && ms <= 59,
+                   "millisecond " << ms << " out of bound. It must be in [0, 59]");
+        serialTimeStamp_ = ((((h * 60 + mt) *60) + s) * 1000) + ms;
+    }
+
+    TimeStamp TimeStamp::now() {
+        std::time_t t;
+
+        if (std::time(&t) == std::time_t(-1)) // -1 means time() didn't work
+            return TimeStamp();
+        std::tm *lt = std::gmtime(&t);
+        return TimeStamp(Day(lt->tm_mday),
+                         Month(lt->tm_mon+1),
+                         Year(lt->tm_year+1900),
+                         Hour(lt->tm_hour),
+                         Minute(lt->tm_min),
+                         Second(lt->tm_sec));
+    }
+
+    BigInteger TimeStamp::serialTimeStamp() const {
+        return serialTimeStamp_;
+    }
+
+    Time TimeStamp::dayFraction() const {
+        return (float) serialTimeStamp_ / 86400.0 / 1000.0;
+    }
+
+    Hour TimeStamp::hour() const {
+        Integer h = serialTimeStamp_ / 1000 / 60 / 60;
+        return Hour(h);
+    }
+
+    Minute TimeStamp::minute() const {
+        Integer m = (serialTimeStamp_ % (60 * 60 * 1000)) / 1000 / 60;  
+        return Minute(m);
+    }
+
+    Second TimeStamp::second() const {
+        Integer s = (serialTimeStamp_ % 60 * 1000) / 1000;
+        return Second(s);
+    }
+
+    Millisecond TimeStamp::millisecond() const {
+        return serialTimeStamp_ % 1000;
+    }
+}

--- a/QuantLib/ql/time/timestamp.hpp
+++ b/QuantLib/ql/time/timestamp.hpp
@@ -1,0 +1,68 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2014 Bitquant Research Laboratories (Asia) Ltd.
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file timestamp.hpp
+    \brief Simple time stamp implementation
+*/
+
+#ifndef quantlib_timestamp_hpp
+#define quantlib_timestamp_hpp
+
+#include <ql/time/date.hpp>
+
+namespace QuantLib {
+    //! Hour number
+    /*! \ingroup datetime */
+    typedef Integer Hour;
+    typedef Integer Minute;
+    typedef Integer Second;
+    typedef Integer Millisecond;
+
+
+  class TimeStamp : Date  {
+      public:
+        //! \name constructors
+        //@{
+        //! Default constructor returning a null date.
+        TimeStamp();
+        //! More traditional constructor.
+        TimeStamp(Day d, Month m, Year y, Hour h, Minute mt, Second s,
+	      Millisecond ms = 0);
+        TimeStamp(Date &d, Hour h=0, Minute m=0, Second s =0,
+		  Millisecond ms = 0);
+
+        Time dayFraction() const;
+        //! \name static methods
+        //@{
+        //! now
+        static TimeStamp now();
+        Hour hour() const;
+        Minute minute() const;
+        Second second() const;
+        Millisecond millisecond() const;
+        BigInteger serialTimeStamp() const;
+      private:
+        void setSerial(Hour h, Minute mt, Second s, Millisecond ms);
+        //! Milliseconds since 00:00:00 GMT
+        BigInteger serialTimeStamp_;
+    };
+}
+
+
+#endif

--- a/QuantLib/ql/time/timeunit.hpp
+++ b/QuantLib/ql/time/timeunit.hpp
@@ -37,7 +37,11 @@ namespace QuantLib {
     enum TimeUnit { Days,
                     Weeks,
                     Months,
-                    Years
+                    Years,
+                    Hours,
+                    Minutes,
+                    Seconds,
+                    Milliseconds
     };
 
     /*! \relates TimeUnit */


### PR DESCRIPTION
This set of patches implements support for intraday timestamps, and
creates a continuoustime day counter which allows for intraday
calculations.

There is one backward compatibility issue.  Although the new DCC
allows support for time computations in which the base unit is not
one year, the time computation is done with the method yearFraction
for backwards compatibility.  A new interface timeFraction has been
created to provide a better name for time computations.