### PR TITLE
Moscow Exchange (MOEX) calendar

### DIFF
--- a/QuantLib/ql/experimental/commodities/commodity.cpp
+++ b/QuantLib/ql/experimental/commodities/commodity.cpp
@@ -50,7 +50,7 @@ namespace QuantLib {
         for (SecondaryCostAmounts::const_iterator i = secondaryCostAmounts.begin();
              i != secondaryCostAmounts.end(); ++i) {
             Real amount = i->second.value();
-            if (currencyCode.empty())
+            if (currencyCode == "")
                 currencyCode = i->second.currency().code();
             totalAmount += amount;
             out << std::setw(28) << std::left << i->first

--- a/QuantLib/ql/experimental/commodities/commodity.cpp
+++ b/QuantLib/ql/experimental/commodities/commodity.cpp
@@ -50,7 +50,7 @@ namespace QuantLib {
         for (SecondaryCostAmounts::const_iterator i = secondaryCostAmounts.begin();
              i != secondaryCostAmounts.end(); ++i) {
             Real amount = i->second.value();
-            if (currencyCode == "")
+            if (currencyCode.empty())
                 currencyCode = i->second.currency().code();
             totalAmount += amount;
             out << std::setw(28) << std::left << i->first

--- a/QuantLib/ql/time/calendars/russia.cpp
+++ b/QuantLib/ql/time/calendars/russia.cpp
@@ -22,12 +22,25 @@
 
 namespace QuantLib {
 
-    Russia::Russia() {
+    Russia::Russia(Russia::Market market) {
         // all calendar instances share the same implementation
         // instance
         static boost::shared_ptr<Calendar::Impl> settlementImpl(
                                                   new Russia::SettlementImpl);
-        impl_ = settlementImpl;
+        static boost::shared_ptr<Calendar::Impl> exchangeImpl(
+          new Russia::ExchangeImpl);
+        
+        switch (market)
+        {
+        case Settlement:
+          impl_ = settlementImpl;
+          break;
+        case Exchange:
+          impl_ = exchangeImpl;
+          break;
+        default:
+          QL_FAIL("unknown market");
+        }
     }
 
 
@@ -60,4 +73,106 @@ namespace QuantLib {
         return true;
     }
 
+  bool Russia::ExchangeImpl::isHoliday2015(const Date& date) const
+  {
+    Month month = date.month();
+    Day d = date.dayOfMonth();
+    switch (month) {
+    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 7 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
+    case 2: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 23 || d == 28);
+    case 3: return (d == 1 || d == 7 || d == 8 || d == 9 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 4: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 5: return (d == 1 || d == 2 || d == 3 || d == 9 || d == 10 || d == 11 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
+    case 6: return (d == 6 || d == 7 || d == 12 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
+    case 7: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 8: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
+    case 9: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 10: return (d == 3 || d == 4 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
+    case 11: return (d == 1 || d == 4 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 12: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27 || d == 31);
+    }
+    return false;
+  }
+
+  bool Russia::ExchangeImpl::isHoliday2014(const Date& date) const
+  {
+    Month month = date.month();
+    Day d = date.dayOfMonth();
+    switch (month) {
+    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 5 || d == 7 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 2: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23);
+    case 3: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 10 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
+    case 4: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 5: return (d == 1 || d == 3 || d == 4 || d == 9 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
+    case 6: return (d == 1 || d == 7 || d == 8 || d == 12 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 7: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 8: return (d == 2 || d == 3 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
+    case 9: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
+    case 10: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 11: return (d == 1 || d == 2 || d == 4 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
+    case 12: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28 || d == 31);
+    }
+    return false;
+  }
+
+  bool Russia::ExchangeImpl::isHoliday2013(const Date& date) const
+  {
+    Month month = date.month();
+    Day d = date.dayOfMonth();
+    switch (month) {
+    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 5 || d == 6 || d == 7 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 2: return (d == 2 || d == 3 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24);
+    case 3: return (d == 2 || d == 3 || d == 8 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
+    case 4: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
+    case 5: return (d == 1 || d == 4 || d == 5 || d == 9 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 6: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 12 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
+    case 7: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
+    case 8: return (d == 3 || d == 4 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
+    case 9: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 10: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 11: return (d == 2 || d == 3 || d == 4 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30);
+    case 12: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29 || d == 31);
+    }
+    return false;
+  }
+
+  bool Russia::ExchangeImpl::isHoliday2012(const Date& date) const
+  {
+    Month month = date.month();
+    Day d = date.dayOfMonth();
+    switch (month) {
+    case 1: return (d == 1 || d == 2 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 2: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 23 || d == 25 || d == 26);
+    case 3: return (d == 3 || d == 4 || d == 8 || d == 9 || d == 10 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
+    case 4: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 29 || d == 30);
+    case 5: return (d == 1 || d == 6 || d == 9 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
+    case 6: return (d == 2 || d == 3 || d == 10 || d == 11 || d == 12 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30);
+    case 7: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
+    case 8: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
+    case 9: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
+    case 10: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
+    case 11: return (d == 3 || d == 4 || d == 5 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25);
+    case 12: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30 || d == 31);
+    }
+    return false;
+  }
+
+  bool Russia::ExchangeImpl::isBusinessDay(const Date& date) const
+  {
+    // the exchange was formally established 2011, so data is only available
+    // from 2012 to present
+    auto year = date.year();
+
+    switch (year)
+    {
+    case 2012: return !isHoliday2012(date);
+    case 2013: return !isHoliday2013(date);
+    case 2014: return !isHoliday2014(date);
+    case 2015: return !isHoliday2015(date);
+    default: 
+      std::ostringstream oss;
+      oss << "MOEX calendar for the year " << year << " does not exist.";
+      QL_FAIL(oss.str());
+    }
+  }
 }

--- a/QuantLib/ql/time/calendars/russia.cpp
+++ b/QuantLib/ql/time/calendars/russia.cpp
@@ -85,17 +85,16 @@ namespace QuantLib {
 	  }
 	  else {
 		  switch (month) {
-		  case Jan: return d != 1 && d != 2 && d != 7;
-		  case Feb: return d != 23;
-		  case Mar: return d != 9;
-		  case May: return d != 1 && d != 4 && d != 11;
-		  case Jun: return d != 12;
-		  case Nov: return d != 4;
-		  case Dec: return d != 31;
+		  case Jan: return d == 1 || d == 2 || d == 7;
+		  case Feb: return d == 23;
+		  case Mar: return d == 9;
+		  case May: return d == 1 || d == 4 || d == 11;
+		  case Jun: return d == 12;
+		  case Nov: return d == 4;
+		  case Dec: return d == 31;
 		  default: return false;
 		  }
 	  }
-
   }
 
   bool Russia::ExchangeImpl::isHoliday2014(const Date& date) const
@@ -110,12 +109,12 @@ namespace QuantLib {
 	  }
 	  else {
 		  switch (month) {
-		  case Jan: return d != 1 && d != 2 && d != 3 && d != 7;
-		  case Mar: return d != 10;
-		  case May: return d != 1 && d != 9;
-		  case Jun: return d != 12;
-		  case Nov: return d != 4;
-		  case Dec: return d != 31;
+		  case Jan: return d == 1 || d == 2 || d == 3 || d == 7;
+		  case Mar: return d == 10;
+		  case May: return d == 1 || d == 9;
+		  case Jun: return d == 12;
+		  case Nov: return d == 4;
+		  case Dec: return d == 31;
 		  default: return false;
 		  }
 	  }
@@ -134,16 +133,15 @@ namespace QuantLib {
 	  }
 	  else {
 		  switch (month) {
-		  case Jan: return d != 1 && d != 2 && d != 3 && d != 4 && d != 7;
-		  case Mar: return d != 8;
-		  case May: return d != 1 && d != 9;
-		  case Jun: return d != 12;
-		  case Nov: return d != 4;
-		  case Dec: return d != 31;
+		  case Jan: return d == 1 || d == 2 || d == 3 || d == 4 || d == 7;
+		  case Mar: return d == 8;
+		  case May: return d == 1 || d == 9;
+		  case Jun: return d == 12;
+		  case Nov: return d == 4;
+		  case Dec: return d == 31;
 		  default: return false;
 		  }
 	  }
-
   }
 
   bool Russia::ExchangeImpl::isHoliday2012(const Date& date) const
@@ -165,14 +163,14 @@ namespace QuantLib {
 	  }
 	  else {
 		  switch (month) {
-		  case Jan: return d != 2;
-		  case Feb: return d != 23;
-		  case Mar: return d != 8 && d != 9;
-		  case Apr: return d != 30;
-		  case May: return d != 1 && d != 9;
-		  case Jun: return d != 11 && d != 12;
-		  case Nov: return d != 5;
-		  case Dec: return d != 31;
+		  case Jan: return d == 2;
+		  case Feb: return d == 23;
+		  case Mar: return d == 8 || d == 9;
+		  case Apr: return d == 30;
+		  case May: return d == 1 || d == 9;
+		  case Jun: return d == 11 || d == 12;
+		  case Nov: return d == 5;
+		  case Dec: return d == 31;
 		  default: return false;
 		  }
 	  }

--- a/QuantLib/ql/time/calendars/russia.cpp
+++ b/QuantLib/ql/time/calendars/russia.cpp
@@ -75,86 +75,108 @@ namespace QuantLib {
 
   bool Russia::ExchangeImpl::isHoliday2015(const Date& date) const
   {
-    Month month = date.month();
-    Day d = date.dayOfMonth();
-    switch (month) {
-    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 7 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
-    case 2: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 23 || d == 28);
-    case 3: return (d == 1 || d == 7 || d == 8 || d == 9 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 4: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 5: return (d == 1 || d == 2 || d == 3 || d == 9 || d == 10 || d == 11 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
-    case 6: return (d == 6 || d == 7 || d == 12 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
-    case 7: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 8: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
-    case 9: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 10: return (d == 3 || d == 4 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
-    case 11: return (d == 1 || d == 4 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 12: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27 || d == 31);
-    }
-    return false;
+	  Month month = date.month();
+	  Day d = date.dayOfMonth();
+	  Weekday wd = date.weekday();
+
+	  if (wd == Saturday || wd == Sunday)
+	  {
+		  return true;
+	  }
+	  else {
+		  switch (month) {
+		  case Jan: return d != 1 && d != 2 && d != 7;
+		  case Feb: return d != 23;
+		  case Mar: return d != 9;
+		  case May: return d != 1 && d != 4 && d != 11;
+		  case Jun: return d != 12;
+		  case Nov: return d != 4;
+		  case Dec: return d != 31;
+		  default: return false;
+		  }
+	  }
+
   }
 
   bool Russia::ExchangeImpl::isHoliday2014(const Date& date) const
   {
-    Month month = date.month();
-    Day d = date.dayOfMonth();
-    switch (month) {
-    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 5 || d == 7 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 2: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23);
-    case 3: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 10 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
-    case 4: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 5: return (d == 1 || d == 3 || d == 4 || d == 9 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
-    case 6: return (d == 1 || d == 7 || d == 8 || d == 12 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 7: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 8: return (d == 2 || d == 3 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
-    case 9: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
-    case 10: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 11: return (d == 1 || d == 2 || d == 4 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
-    case 12: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28 || d == 31);
-    }
-    return false;
+	  Month month = date.month();
+	  Day d = date.dayOfMonth();
+	  Weekday wd = date.weekday();
+
+	  if (wd == Saturday || wd == Sunday)
+	  {
+		  return true;
+	  }
+	  else {
+		  switch (month) {
+		  case Jan: return d != 1 && d != 2 && d != 3 && d != 7;
+		  case Mar: return d != 10;
+		  case May: return d != 1 && d != 9;
+		  case Jun: return d != 12;
+		  case Nov: return d != 4;
+		  case Dec: return d != 31;
+		  default: return false;
+		  }
+	  }
+
   }
 
   bool Russia::ExchangeImpl::isHoliday2013(const Date& date) const
   {
-    Month month = date.month();
-    Day d = date.dayOfMonth();
-    switch (month) {
-    case 1: return (d == 1 || d == 2 || d == 3 || d == 4 || d == 5 || d == 6 || d == 7 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 2: return (d == 2 || d == 3 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24);
-    case 3: return (d == 2 || d == 3 || d == 8 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30 || d == 31);
-    case 4: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
-    case 5: return (d == 1 || d == 4 || d == 5 || d == 9 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 6: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 12 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
-    case 7: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
-    case 8: return (d == 3 || d == 4 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
-    case 9: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 10: return (d == 5 || d == 6 || d == 12 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 11: return (d == 2 || d == 3 || d == 4 || d == 9 || d == 10 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30);
-    case 12: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29 || d == 31);
-    }
-    return false;
+	  Month month = date.month();
+	  Day d = date.dayOfMonth();
+	  Weekday wd = date.weekday();
+
+	  if (wd == Saturday || wd == Sunday)
+	  {
+		  return true;
+	  }
+	  else {
+		  switch (month) {
+		  case Jan: return d != 1 && d != 2 && d != 3 && d != 4 && d != 7;
+		  case Mar: return d != 8;
+		  case May: return d != 1 && d != 9;
+		  case Jun: return d != 12;
+		  case Nov: return d != 4;
+		  case Dec: return d != 31;
+		  default: return false;
+		  }
+	  }
+
   }
 
   bool Russia::ExchangeImpl::isHoliday2012(const Date& date) const
   {
-    Month month = date.month();
-    Day d = date.dayOfMonth();
-    switch (month) {
-    case 1: return (d == 1 || d == 2 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 2: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 23 || d == 25 || d == 26);
-    case 3: return (d == 3 || d == 4 || d == 8 || d == 9 || d == 10 || d == 17 || d == 18 || d == 24 || d == 25 || d == 31);
-    case 4: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 29 || d == 30);
-    case 5: return (d == 1 || d == 6 || d == 9 || d == 13 || d == 19 || d == 20 || d == 26 || d == 27);
-    case 6: return (d == 2 || d == 3 || d == 10 || d == 11 || d == 12 || d == 16 || d == 17 || d == 23 || d == 24 || d == 30);
-    case 7: return (d == 1 || d == 7 || d == 8 || d == 14 || d == 15 || d == 21 || d == 22 || d == 28 || d == 29);
-    case 8: return (d == 4 || d == 5 || d == 11 || d == 12 || d == 18 || d == 19 || d == 25 || d == 26);
-    case 9: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30);
-    case 10: return (d == 6 || d == 7 || d == 13 || d == 14 || d == 20 || d == 21 || d == 27 || d == 28);
-    case 11: return (d == 3 || d == 4 || d == 5 || d == 10 || d == 11 || d == 17 || d == 18 || d == 24 || d == 25);
-    case 12: return (d == 1 || d == 2 || d == 8 || d == 9 || d == 15 || d == 16 || d == 22 || d == 23 || d == 29 || d == 30 || d == 31);
-    }
-    return false;
+	  Month month = date.month();
+	  Day d = date.dayOfMonth();
+	  Weekday wd = date.weekday();
+
+	  if (wd == Saturday || wd == Sunday)
+	  {
+		  switch (month)
+		  {
+		  case Mar: return d != 11;
+		  case Apr: return d != 28;
+		  case May: return d != 5 && d != 12;
+		  case Jun: return d != 9;
+		  default: return true;
+		  }
+	  }
+	  else {
+		  switch (month) {
+		  case Jan: return d != 2;
+		  case Feb: return d != 23;
+		  case Mar: return d != 8 && d != 9;
+		  case Apr: return d != 30;
+		  case May: return d != 1 && d != 9;
+		  case Jun: return d != 11 && d != 12;
+		  case Nov: return d != 5;
+		  case Dec: return d != 31;
+		  default: return false;
+		  }
+	  }
+
   }
 
   bool Russia::ExchangeImpl::isBusinessDay(const Date& date) const

--- a/QuantLib/ql/time/calendars/russia.hpp
+++ b/QuantLib/ql/time/calendars/russia.hpp
@@ -28,7 +28,7 @@
 
 namespace QuantLib {
 
-    //! Russian calendar
+    //! Russian calendars
     /*! Public holidays (see <http://www.cbr.ru/eng/>:):
         <ul>
         <li>Saturdays</li>
@@ -44,17 +44,38 @@ namespace QuantLib {
         <li>Unity Day, November 4th (possibly moved to Monday)</li>
         </ul>
 
+        Holidays for the Moscow Exchange (MOEX) taken from http://moex.com/s726 and related pages.
+        These holidays are <em>not</em> consistent year-to-year, and are only available
+        for dates since the introduction of the MOEX 'brand'.
+
         \ingroup calendars
     */
     class Russia : public Calendar {
       private:
-        class SettlementImpl : public Calendar::WesternImpl {
+        class SettlementImpl : public Calendar::OrthodoxImpl {
           public:
             std::string name() const { return "Russian settlement"; }
             bool isBusinessDay(const Date&) const;
         };
+        class ExchangeImpl : public Calendar::OrthodoxImpl
+        {
+          bool isHoliday2015(const Date&) const;
+          bool isHoliday2014(const Date&) const;
+          bool isHoliday2013(const Date&) const;
+          bool isHoliday2012(const Date&) const;
+        public:
+          std::string name() const { return "Moscow exchange"; }
+          bool isBusinessDay(const Date&) const;
+        };
+
       public:
-        Russia();
+        //! Russian calendars
+        enum Market
+        {
+          Settlement, //!< generic settlement calendar
+          Exchange, //!< Moscow Exchange calendar
+        };
+        Russia(Market = Settlement);
     };
 
 }

--- a/QuantLib/ql/time/calendars/russia.hpp
+++ b/QuantLib/ql/time/calendars/russia.hpp
@@ -45,8 +45,9 @@ namespace QuantLib {
         </ul>
 
         Holidays for the Moscow Exchange (MOEX) taken from http://moex.com/s726 and related pages.
-        These holidays are <em>not</em> consistent year-to-year, and are only available
-        for dates since the introduction of the MOEX 'brand'.
+        These holidays are <em>not</em> consistent year-to-year, may or may not correlate to
+		public holidays, and are only available for dates since the introduction of the MOEX 'brand'
+		(a merger of the stock and futures markets).
 
         \ingroup calendars
     */


### PR DESCRIPTION
I've added an implementation of the Moscow Exchange (MOEX) calendar for years 2012..2015, as the exchange itself was opened in 2011. The calendar is non-uniform (it changes every year); some week-end days are in fact working days.

This is my first PR for QuantLib, so I'll be happy to revise this however necessary.