### PR TITLE
Optimize `DiscountingSwapEngine`

### DIFF
--- a/QuantLib/ql/cashflows/cashflows.cpp
+++ b/QuantLib/ql/cashflows/cashflows.cpp
@@ -505,20 +505,21 @@ namespace QuantLib {
             return;
         }
 
-        BPSCalculator calc(discountCurve);
         for (Size i=0; i<leg.size(); ++i) {
             CashFlow& cf = *leg[i];
+            boost::shared_ptr<Coupon> cp = boost::dynamic_pointer_cast<Coupon>(leg[i]);
             if (!cf.hasOccurred(settlementDate,
                                 includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
-                npv += cf.amount() *
-                       discountCurve.discount(cf.date());
-                cf.accept(calc);
+                Real df = discountCurve.discount(cf.date());
+                npv += cf.amount() * df;
+                if(cp != NULL)
+                    bps += cp->nominal() * cp->accrualPeriod() * df;
             }
         }
         DiscountFactor d = discountCurve.discount(npvDate);
         npv /= d;
-        bps = basisPoint_ * calc.bps() / d;
+        bps = basisPoint_ * bps / d;
     }
 
     Rate CashFlows::atmRate(const Leg& leg,

--- a/QuantLib/ql/cashflows/cashflows.cpp
+++ b/QuantLib/ql/cashflows/cashflows.cpp
@@ -507,10 +507,11 @@ namespace QuantLib {
 
         for (Size i=0; i<leg.size(); ++i) {
             CashFlow& cf = *leg[i];
-            boost::shared_ptr<Coupon> cp = boost::dynamic_pointer_cast<Coupon>(leg[i]);
             if (!cf.hasOccurred(settlementDate,
                                 includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
+                boost::shared_ptr<Coupon> cp =
+                    boost::dynamic_pointer_cast<Coupon>(leg[i]);
                 Real df = discountCurve.discount(cf.date());
                 npv += cf.amount() * df;
                 if(cp != NULL)

--- a/QuantLib/ql/cashflows/coupon.cpp
+++ b/QuantLib/ql/cashflows/coupon.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     : paymentDate_(paymentDate), nominal_(nominal), 
       accrualStartDate_(accrualStartDate), accrualEndDate_(accrualEndDate),
       refPeriodStart_(refPeriodStart), refPeriodEnd_(refPeriodEnd),
-      exCouponDate_(exCouponDate) {
+      exCouponDate_(exCouponDate), accrualPeriod_(Null<Real>()) {
         if (refPeriodStart_ == Date())
             refPeriodStart_ = accrualStartDate_;
         if (refPeriodEnd_ == Date())
@@ -42,10 +42,11 @@ namespace QuantLib {
     }
 
     Time Coupon::accrualPeriod() const {
-        return dayCounter().yearFraction(accrualStartDate_,
-                                         accrualEndDate_,
-                                         refPeriodStart_,
-                                         refPeriodEnd_);
+        if (accrualPeriod_ == Null<Real>())
+            accrualPeriod_ =
+                dayCounter().yearFraction(accrualStartDate_, accrualEndDate_,
+                                          refPeriodStart_, refPeriodEnd_);
+        return accrualPeriod_;
     }
 
     BigInteger Coupon::accrualDays() const {

--- a/QuantLib/ql/cashflows/coupon.hpp
+++ b/QuantLib/ql/cashflows/coupon.hpp
@@ -91,6 +91,7 @@ namespace QuantLib {
         Real nominal_;
         Date accrualStartDate_,accrualEndDate_, refPeriodStart_,refPeriodEnd_;
         Date exCouponDate_;
+        mutable Real accrualPeriod_;
     };
 
 


### PR DESCRIPTION
the npvbps change seems to give a speedup of 1.2x - 1.3x, the caching of the accrual period another 1.1x if the same swap is priced several times.