### PR TITLE
Allow for SABR alpha-only calibration on one strike

### DIFF
--- a/QuantLib/ql/math/interpolation.hpp
+++ b/QuantLib/ql/math/interpolation.hpp
@@ -64,10 +64,12 @@ namespace QuantLib {
         template <class I1, class I2>
         class templateImpl : public Impl {
           public:
-            templateImpl(const I1& xBegin, const I1& xEnd, const I2& yBegin)
+            templateImpl(const I1& xBegin, const I1& xEnd, const I2& yBegin,
+                         const int requiredPoints = 2)
             : xBegin_(xBegin), xEnd_(xEnd), yBegin_(yBegin) {
-                QL_REQUIRE(static_cast<int>(xEnd_-xBegin_) >= 2,
-                           "not enough points to interpolate: at least 2 "
+                QL_REQUIRE(static_cast<int>(xEnd_-xBegin_) >= requiredPoints,
+                           "not enough points to interpolate: at least " <<
+                           requiredPoints <<
                            "required, " << static_cast<int>(xEnd_-xBegin_)<< " provided");
             }
             Real xMin() const {

--- a/QuantLib/ql/math/interpolations/backwardflatinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/backwardflatinterpolation.hpp
@@ -30,6 +30,36 @@
 namespace QuantLib {
 
     namespace detail {
+        template<class I1, class I2> class BackwardFlatInterpolationImpl;
+    }
+
+    //! Backward-flat interpolation between discrete points
+    class BackwardFlatInterpolation : public Interpolation {
+      public:
+        /*! \pre the \f$ x \f$ values must be sorted. */
+        template <class I1, class I2>
+        BackwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
+                                  const I2& yBegin) {
+            impl_ = boost::shared_ptr<Interpolation::Impl>(new
+                detail::BackwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
+                                                             yBegin));
+            impl_->update();
+        }
+    };
+
+    //! Backward-flat interpolation factory and traits
+    class BackwardFlat {
+      public:
+        template <class I1, class I2>
+        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
+                                  const I2& yBegin) const {
+            return BackwardFlatInterpolation(xBegin, xEnd, yBegin);
+        }
+        static const bool global = false;
+        static const Size requiredPoints = 2;
+    };
+
+    namespace detail {
 
         template <class I1, class I2>
         class BackwardFlatInterpolationImpl
@@ -37,7 +67,8 @@ namespace QuantLib {
           public:
             BackwardFlatInterpolationImpl(const I1& xBegin, const I1& xEnd,
                                           const I2& yBegin)
-            : Interpolation::templateImpl<I1,I2>(xBegin,xEnd,yBegin),
+            : Interpolation::templateImpl<I1,I2>(xBegin,xEnd,yBegin,
+                                                 BackwardFlat::requiredPoints),
               primitive_(xEnd-xBegin) {}
             void update() {
                 Size n = this->xEnd_-this->xBegin_;
@@ -72,32 +103,6 @@ namespace QuantLib {
         };
 
     }
-
-    //! Backward-flat interpolation between discrete points
-    class BackwardFlatInterpolation : public Interpolation {
-      public:
-        /*! \pre the \f$ x \f$ values must be sorted. */
-        template <class I1, class I2>
-        BackwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) {
-            impl_ = boost::shared_ptr<Interpolation::Impl>(new
-                detail::BackwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
-                                                             yBegin));
-            impl_->update();
-        }
-    };
-
-    //! Backward-flat interpolation factory and traits
-    class BackwardFlat {
-      public:
-        template <class I1, class I2>
-        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return BackwardFlatInterpolation(xBegin, xEnd, yBegin);
-        }
-        static const bool global = false;
-        static const Size requiredPoints = 2;
-    };
 
 }
 

--- a/QuantLib/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -30,6 +30,131 @@
 namespace QuantLib {
 
     namespace detail {
+        template<class I1, class I2> class ConvexMonotoneImpl;
+        class SectionHelper;
+    }
+
+    //! Convex monotone yield-curve interpolation method.
+    /*! Enhances implementation of the convex monotone method
+        described in "Interpolation Methods for Curve Construction" by
+        Hagan & West AMF Vol 13, No2 2006.
+
+        A setting of monotonicity = 1 and quadraticity = 0 will
+        reproduce the basic Hagan/West method. However, this can
+        produce excessive gradients which can mean P&L swings for some
+        curves.  Setting monotonicity < 1 and/or quadraticity > 0
+        produces smoother curves.  Extra enhancement to avoid negative
+        values (if required) is in place.
+    */
+    template <class I1, class I2>
+    class ConvexMonotoneInterpolation : public Interpolation {
+        typedef std::map<Real, boost::shared_ptr<detail::SectionHelper> >
+                                                                   helper_map;
+      public:
+        ConvexMonotoneInterpolation(const I1& xBegin, const I1& xEnd,
+                                    const I2& yBegin, Real quadraticity,
+                                    Real monotonicity, bool forcePositive,
+                                    bool flatFinalPeriod = false,
+                                    const helper_map& preExistingHelpers =
+                                                               helper_map()) {
+            impl_ = boost::shared_ptr<Interpolation::Impl>(
+                   new detail::ConvexMonotoneImpl<I1,I2>(xBegin,
+                                                         xEnd,
+                                                         yBegin,
+                                                         quadraticity,
+                                                         monotonicity,
+                                                         forcePositive,
+                                                         flatFinalPeriod,
+                                                         preExistingHelpers));
+            impl_->update();
+        }
+
+        ConvexMonotoneInterpolation(Interpolation& interp)
+        : Interpolation(interp) {}
+
+        std::map<Real, boost::shared_ptr<detail::SectionHelper> >
+        getExistingHelpers() {
+            boost::shared_ptr<detail::ConvexMonotoneImpl<I1,I2> > derived =
+                boost::dynamic_pointer_cast<detail::ConvexMonotoneImpl<I1,I2>,
+                                            Interpolation::Impl>(impl_);
+            return derived->getExistingHelpers();
+        }
+    };
+
+    //! Convex-monotone interpolation factory and traits
+    class ConvexMonotone {
+      public:
+        static const bool global = true;
+        static const Size requiredPoints = 2;
+        static const Size dataSizeAdjustment = 1;
+
+        explicit ConvexMonotone(Real quadraticity = 0.3,
+                                Real monotonicity = 0.7,
+                                bool forcePositive = true)
+        : quadraticity_(quadraticity), monotonicity_(monotonicity),
+          forcePositive_(forcePositive) {}
+
+        template <class I1, class I2>
+        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
+                                  const I2& yBegin) const {
+            return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd, yBegin,
+                                                      quadraticity_,
+                                                      monotonicity_,
+                                                      forcePositive_,
+                                                      false);
+        }
+
+        template <class I1, class I2>
+        Interpolation localInterpolate(const I1& xBegin, const I1& xEnd,
+                                       const I2& yBegin, Size localisation,
+                                       Interpolation& prevInterpolation,
+                                       Size finalSize) const {
+            Size length = std::distance(xBegin, xEnd);
+            if (length - localisation == 1) { // the first time this
+                                              // function is called
+                if (length == finalSize) {
+                    return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd,
+                                                              yBegin,
+                                                              quadraticity_,
+                                                              monotonicity_,
+                                                              forcePositive_,
+                                                              false);
+                } else {
+                    return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd,
+                                                              yBegin,
+                                                              quadraticity_,
+                                                              monotonicity_,
+                                                              forcePositive_,
+                                                              true);
+                }
+            }
+
+            ConvexMonotoneInterpolation<I1,I2> interp(prevInterpolation);
+            if (length == finalSize) {
+                return ConvexMonotoneInterpolation<I1,I2>(
+                                                 xBegin, xEnd, yBegin,
+                                                 quadraticity_,
+                                                 monotonicity_,
+                                                 forcePositive_,
+                                                 false,
+                                                 interp.getExistingHelpers());
+            } else {
+                return ConvexMonotoneInterpolation<I1,I2>(
+                                                 xBegin, xEnd, yBegin,
+                                                 quadraticity_,
+                                                 monotonicity_,
+                                                 forcePositive_,
+                                                 true,
+                                                 interp.getExistingHelpers());
+            }
+        }
+      private:
+        Real quadraticity_, monotonicity_;
+        bool forcePositive_;
+    };
+
+
+    namespace detail {
 
         class SectionHelper {
           public:
@@ -60,7 +185,8 @@ namespace QuantLib {
                                bool forcePositive,
                                bool constantLastPeriod,
                                const helper_map& preExistingHelpers)
-            : Interpolation::templateImpl<I1,I2>(xBegin,xEnd,yBegin),
+            : Interpolation::templateImpl<I1,I2>(xBegin,xEnd,yBegin,
+                                                 ConvexMonotone::requiredPoints),
               preSectionHelpers_(preExistingHelpers),
               forcePositive_(forcePositive),
               constantLastPeriod_(constantLastPeriod),
@@ -733,127 +859,6 @@ namespace QuantLib {
         }
 
     }
-
-
-    //! Convex monotone yield-curve interpolation method.
-    /*! Enhances implementation of the convex monotone method
-        described in "Interpolation Methods for Curve Construction" by
-        Hagan & West AMF Vol 13, No2 2006.
-
-        A setting of monotonicity = 1 and quadraticity = 0 will
-        reproduce the basic Hagan/West method. However, this can
-        produce excessive gradients which can mean P&L swings for some
-        curves.  Setting monotonicity < 1 and/or quadraticity > 0
-        produces smoother curves.  Extra enhancement to avoid negative
-        values (if required) is in place.
-    */
-    template <class I1, class I2>
-    class ConvexMonotoneInterpolation : public Interpolation {
-        typedef std::map<Real, boost::shared_ptr<detail::SectionHelper> >
-                                                                   helper_map;
-      public:
-        ConvexMonotoneInterpolation(const I1& xBegin, const I1& xEnd,
-                                    const I2& yBegin, Real quadraticity,
-                                    Real monotonicity, bool forcePositive,
-                                    bool flatFinalPeriod = false,
-                                    const helper_map& preExistingHelpers =
-                                                               helper_map()) {
-            impl_ = boost::shared_ptr<Interpolation::Impl>(
-                   new detail::ConvexMonotoneImpl<I1,I2>(xBegin,
-                                                         xEnd,
-                                                         yBegin,
-                                                         quadraticity,
-                                                         monotonicity,
-                                                         forcePositive,
-                                                         flatFinalPeriod,
-                                                         preExistingHelpers));
-            impl_->update();
-        }
-
-        ConvexMonotoneInterpolation(Interpolation& interp)
-        : Interpolation(interp) {}
-
-        std::map<Real, boost::shared_ptr<detail::SectionHelper> >
-        getExistingHelpers() {
-            boost::shared_ptr<detail::ConvexMonotoneImpl<I1,I2> > derived =
-                boost::dynamic_pointer_cast<detail::ConvexMonotoneImpl<I1,I2>,
-                                            Interpolation::Impl>(impl_);
-            return derived->getExistingHelpers();
-        }
-    };
-
-
-    //! Convex-monotone interpolation factory and traits
-    class ConvexMonotone {
-      public:
-        static const bool global = true;
-        static const Size requiredPoints = 2;
-        static const Size dataSizeAdjustment = 1;
-
-        explicit ConvexMonotone(Real quadraticity = 0.3,
-                                Real monotonicity = 0.7,
-                                bool forcePositive = true)
-        : quadraticity_(quadraticity), monotonicity_(monotonicity),
-          forcePositive_(forcePositive) {}
-
-        template <class I1, class I2>
-        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd, yBegin,
-                                                      quadraticity_,
-                                                      monotonicity_,
-                                                      forcePositive_,
-                                                      false);
-        }
-
-        template <class I1, class I2>
-        Interpolation localInterpolate(const I1& xBegin, const I1& xEnd,
-                                       const I2& yBegin, Size localisation,
-                                       Interpolation& prevInterpolation,
-                                       Size finalSize) const {
-            Size length = std::distance(xBegin, xEnd);
-            if (length - localisation == 1) { // the first time this
-                                              // function is called
-                if (length == finalSize) {
-                    return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd,
-                                                              yBegin,
-                                                              quadraticity_,
-                                                              monotonicity_,
-                                                              forcePositive_,
-                                                              false);
-                } else {
-                    return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd,
-                                                              yBegin,
-                                                              quadraticity_,
-                                                              monotonicity_,
-                                                              forcePositive_,
-                                                              true);
-                }
-            }
-
-            ConvexMonotoneInterpolation<I1,I2> interp(prevInterpolation);
-            if (length == finalSize) {
-                return ConvexMonotoneInterpolation<I1,I2>(
-                                                 xBegin, xEnd, yBegin,
-                                                 quadraticity_,
-                                                 monotonicity_,
-                                                 forcePositive_,
-                                                 false,
-                                                 interp.getExistingHelpers());
-            } else {
-                return ConvexMonotoneInterpolation<I1,I2>(
-                                                 xBegin, xEnd, yBegin,
-                                                 quadraticity_,
-                                                 monotonicity_,
-                                                 forcePositive_,
-                                                 true,
-                                                 interp.getExistingHelpers());
-            }
-        }
-      private:
-        Real quadraticity_, monotonicity_;
-        bool forcePositive_;
-    };
 
 }
 

--- a/QuantLib/ql/math/interpolations/cubicinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/cubicinterpolation.hpp
@@ -352,7 +352,8 @@ namespace QuantLib {
                                    CubicInterpolation::BoundaryCondition rightCondition,
                                    Real rightConditionValue)
             : CoefficientHolder(xEnd-xBegin),
-              Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin),
+              Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin,
+                                                 Cubic::requiredPoints),
               da_(da),
               monotonic_(monotonic),
               leftType_(leftCondition), rightType_(rightCondition),

--- a/QuantLib/ql/math/interpolations/forwardflatinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/forwardflatinterpolation.hpp
@@ -30,6 +30,36 @@
 namespace QuantLib {
 
     namespace detail {
+        template<class I1, class I2> class ForwardFlatInterpolationImpl;
+    }
+
+    //! Forward-flat interpolation between discrete points
+    class ForwardFlatInterpolation : public Interpolation {
+      public:
+        /*! \pre the \f$ x \f$ values must be sorted. */
+        template <class I1, class I2>
+        ForwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
+                                 const I2& yBegin) {
+            impl_ = boost::shared_ptr<Interpolation::Impl>(new
+                detail::ForwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
+                                                            yBegin));
+            impl_->update();
+        }
+    };
+
+    //! Forward-flat interpolation factory and traits
+    class ForwardFlat {
+      public:
+        template <class I1, class I2>
+        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
+                                  const I2& yBegin) const {
+            return ForwardFlatInterpolation(xBegin, xEnd, yBegin);
+        }
+        static const bool global = false;
+        static const Size requiredPoints = 2;
+    };
+
+    namespace detail {
 
         template <class I1, class I2>
         class ForwardFlatInterpolationImpl
@@ -37,7 +67,8 @@ namespace QuantLib {
           public:
             ForwardFlatInterpolationImpl(const I1& xBegin, const I1& xEnd,
                                          const I2& yBegin)
-            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin),
+            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin,
+                                                 ForwardFlat::requiredPoints),
               primitive_(xEnd-xBegin), n_(xEnd-xBegin) {}
             void update() {
                 primitive_[0] = 0.0;
@@ -70,32 +101,6 @@ namespace QuantLib {
         };
 
     }
-
-    //! Forward-flat interpolation between discrete points
-    class ForwardFlatInterpolation : public Interpolation {
-      public:
-        /*! \pre the \f$ x \f$ values must be sorted. */
-        template <class I1, class I2>
-        ForwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
-                                 const I2& yBegin) {
-            impl_ = boost::shared_ptr<Interpolation::Impl>(new
-                detail::ForwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
-                                                            yBegin));
-            impl_->update();
-        }
-    };
-
-    //! Forward-flat interpolation factory and traits
-    class ForwardFlat {
-      public:
-        template <class I1, class I2>
-        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return ForwardFlatInterpolation(xBegin, xEnd, yBegin);
-        }
-        static const bool global = false;
-        static const Size requiredPoints = 2;
-    };
 
 }
 

--- a/QuantLib/ql/math/interpolations/linearinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/linearinterpolation.hpp
@@ -31,6 +31,36 @@
 namespace QuantLib {
 
     namespace detail {
+        template<class I1, class I2> class LinearInterpolationImpl;
+    }
+
+    //! %Linear interpolation between discrete points
+    class LinearInterpolation : public Interpolation {
+      public:
+        /*! \pre the \f$ x \f$ values must be sorted. */
+        template <class I1, class I2>
+        LinearInterpolation(const I1& xBegin, const I1& xEnd,
+                            const I2& yBegin) {
+            impl_ = boost::shared_ptr<Interpolation::Impl>(new
+                detail::LinearInterpolationImpl<I1,I2>(xBegin, xEnd,
+                                                       yBegin));
+            impl_->update();
+        }
+    };
+
+    //! %Linear-interpolation factory and traits
+    class Linear {
+      public:
+        template <class I1, class I2>
+        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
+                                  const I2& yBegin) const {
+            return LinearInterpolation(xBegin, xEnd, yBegin);
+        }
+        static const bool global = false;
+        static const Size requiredPoints = 2;
+    };
+
+    namespace detail {
 
         template <class I1, class I2>
         class LinearInterpolationImpl
@@ -38,7 +68,8 @@ namespace QuantLib {
           public:
             LinearInterpolationImpl(const I1& xBegin, const I1& xEnd,
                                     const I2& yBegin)
-            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin),
+            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin,
+                                                 Linear::requiredPoints),
               primitiveConst_(xEnd-xBegin), s_(xEnd-xBegin) {}
             void update() {
                 primitiveConst_[0] = 0.0;
@@ -71,32 +102,6 @@ namespace QuantLib {
         };
 
     }
-
-    //! %Linear interpolation between discrete points
-    class LinearInterpolation : public Interpolation {
-      public:
-        /*! \pre the \f$ x \f$ values must be sorted. */
-        template <class I1, class I2>
-        LinearInterpolation(const I1& xBegin, const I1& xEnd,
-                            const I2& yBegin) {
-            impl_ = boost::shared_ptr<Interpolation::Impl>(new
-                detail::LinearInterpolationImpl<I1,I2>(xBegin, xEnd,
-                                                       yBegin));
-            impl_->update();
-        }
-    };
-
-    //! %Linear-interpolation factory and traits
-    class Linear {
-      public:
-        template <class I1, class I2>
-        Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return LinearInterpolation(xBegin, xEnd, yBegin);
-        }
-        static const bool global = false;
-        static const Size requiredPoints = 2;
-    };
 
 }
 

--- a/QuantLib/ql/math/interpolations/loginterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/loginterpolation.hpp
@@ -205,7 +205,7 @@ namespace QuantLib {
                                  const I2& yBegin,
                                  const Interpolator& factory = Interpolator())
             : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin,
-                                                 LogLinear::requiredPoints),
+                                                 Interpolator::requiredPoints),
               logY_(xEnd-xBegin) {
                 interpolation_ = factory.interpolate(this->xBegin_,
                                                      this->xEnd_,

--- a/QuantLib/ql/math/interpolations/loginterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/loginterpolation.hpp
@@ -32,47 +32,7 @@
 namespace QuantLib {
 
     namespace detail {
-
-        template <class I1, class I2, class Interpolator>
-        class LogInterpolationImpl
-            : public Interpolation::templateImpl<I1,I2> {
-          public:
-            LogInterpolationImpl(const I1& xBegin, const I1& xEnd,
-                                 const I2& yBegin,
-                                 const Interpolator& factory = Interpolator())
-            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin),
-              logY_(xEnd-xBegin) {
-                interpolation_ = factory.interpolate(this->xBegin_,
-                                                     this->xEnd_,
-                                                     logY_.begin());
-            }
-            void update() {
-                for (Size i=0; i<logY_.size(); ++i) {
-                    QL_REQUIRE(this->yBegin_[i]>0.0,
-                               "invalid value (" << this->yBegin_[i]
-                               << ") at index " << i);
-                    logY_[i] = std::log(this->yBegin_[i]);
-                }
-                interpolation_.update();
-            }
-            Real value(Real x) const {
-                return std::exp(interpolation_(x, true));
-            }
-            Real primitive(Real) const {
-                QL_FAIL("LogInterpolation primitive not implemented");
-            }
-            Real derivative(Real x) const {
-                return value(x)*interpolation_.derivative(x, true);
-            }
-            Real secondDerivative(Real x) const {
-                return derivative(x)*interpolation_.derivative(x, true) +
-                            value(x)*interpolation_.secondDerivative(x, true);
-            }
-          private:
-            std::vector<Real> logY_;
-            Interpolation interpolation_;
-        };
-
+        template<class I1, class I2, class I> class LogInterpolationImpl;
     }
 
     //! %log-linear interpolation between discrete points
@@ -234,6 +194,51 @@ namespace QuantLib {
                                 CubicInterpolation::SecondDerivative, 0.0,
                                 CubicInterpolation::SecondDerivative, 0.0) {}
     };
+
+    namespace detail {
+
+        template <class I1, class I2, class Interpolator>
+        class LogInterpolationImpl
+            : public Interpolation::templateImpl<I1,I2> {
+          public:
+            LogInterpolationImpl(const I1& xBegin, const I1& xEnd,
+                                 const I2& yBegin,
+                                 const Interpolator& factory = Interpolator())
+            : Interpolation::templateImpl<I1,I2>(xBegin, xEnd, yBegin,
+                                                 LogLinear::requiredPoints),
+              logY_(xEnd-xBegin) {
+                interpolation_ = factory.interpolate(this->xBegin_,
+                                                     this->xEnd_,
+                                                     logY_.begin());
+            }
+            void update() {
+                for (Size i=0; i<logY_.size(); ++i) {
+                    QL_REQUIRE(this->yBegin_[i]>0.0,
+                               "invalid value (" << this->yBegin_[i]
+                               << ") at index " << i);
+                    logY_[i] = std::log(this->yBegin_[i]);
+                }
+                interpolation_.update();
+            }
+            Real value(Real x) const {
+                return std::exp(interpolation_(x, true));
+            }
+            Real primitive(Real) const {
+                QL_FAIL("LogInterpolation primitive not implemented");
+            }
+            Real derivative(Real x) const {
+                return value(x)*interpolation_.derivative(x, true);
+            }
+            Real secondDerivative(Real x) const {
+                return derivative(x)*interpolation_.derivative(x, true) +
+                            value(x)*interpolation_.secondDerivative(x, true);
+            }
+          private:
+            std::vector<Real> logY_;
+            Interpolation interpolation_;
+        };
+
+    }
 
 }
 

--- a/QuantLib/ql/math/interpolations/xabrinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/xabrinterpolation.hpp
@@ -107,7 +107,7 @@ class XABRInterpolationImpl : public Interpolation::templateImpl<I1, I2>,
         const boost::shared_ptr<EndCriteria> &endCriteria,
         const boost::shared_ptr<OptimizationMethod> &optMethod,
         const Real errorAccept, const bool useMaxError, const Size maxGuesses)
-        : Interpolation::templateImpl<I1, I2>(xBegin, xEnd, yBegin),
+        : Interpolation::templateImpl<I1, I2>(xBegin, xEnd, yBegin, 1),
           XABRCoeffHolder<Model>(t, forward, params, paramIsFixed),
           endCriteria_(endCriteria), optMethod_(optMethod),
           errorAccept_(errorAccept), useMaxError_(useMaxError),


### PR DESCRIPTION
This change allows to calibrate the alpha of the SABR model to the atm point only while keeping beta, nu and rho fixed. This can be applied for example to readjust the model to real time movements in atm quotes. Since the `Interpolation` class by default checked for at least two points this was not possible before. With this change I also tried to unify the check with the existing information in factory classes to get a more consistent overall picture.