### PR TITLE
Nearest trading day business day convention

### DIFF
--- a/QuantLib/ql/time/businessdayconvention.cpp
+++ b/QuantLib/ql/time/businessdayconvention.cpp
@@ -41,6 +41,8 @@ namespace QuantLib {
             return out << "Modified Preceding";
           case Unadjusted:
             return out << "Unadjusted";
+          case Nearest:
+            return out << "Nearest";
           default:
             QL_FAIL("unknown BusinessDayConvention (" << Integer(b) << ")");
         }

--- a/QuantLib/ql/time/businessdayconvention.hpp
+++ b/QuantLib/ql/time/businessdayconvention.hpp
@@ -56,12 +56,17 @@ namespace QuantLib {
                                           choose the first business day after
                                           the holiday. */
         Unadjusted,                  /*!< Do not adjust. */
-        HalfMonthModifiedFollowing   /*!< Choose the first business day after
+        HalfMonthModifiedFollowing,  /*!< Choose the first business day after
                                           the given holiday unless that day
                                           crosses the mid-month (15th) or the
                                           end of month, in which case choose
                                           the first business day before the
                                           holiday. */
+        Nearest                      /*!< Choose the nearest business day 
+                                          to the given holiday. If both the
+                                          preceding and following business
+                                          days are equally far away, default
+                                          to following business day. */
     };
 
     /*! \relates BusinessDayConvention */

--- a/QuantLib/ql/time/calendar.cpp
+++ b/QuantLib/ql/time/calendar.cpp
@@ -72,6 +72,17 @@ namespace QuantLib {
             if (c == ModifiedPreceding && d1.month() != d.month()) {
                 return adjust(d,Following);
             }
+        } else if (c == Nearest) {
+            Date d2 = d;
+            while (isHoliday(d1) && isHoliday(d2))
+            {
+                d1++;
+                d2--;
+            }
+            if (isHoliday(d1))
+                return d2;
+            else
+                return d1;
         } else {
             QL_FAIL("unknown business-day convention");
         }

--- a/QuantLib/ql/time/calendar.cpp
+++ b/QuantLib/ql/time/calendar.cpp
@@ -55,16 +55,16 @@ namespace QuantLib {
             || c == HalfMonthModifiedFollowing) {
             while (isHoliday(d1))
                 d1++;
-                if (c == ModifiedFollowing 
-                    || c == HalfMonthModifiedFollowing) {
-                    if (d1.month() != d.month()) {
+            if (c == ModifiedFollowing 
+                || c == HalfMonthModifiedFollowing) {
+                if (d1.month() != d.month()) {
+                    return adjust(d, Preceding);
+                }
+                if (c == HalfMonthModifiedFollowing) {
+                    if (d.dayOfMonth() <= 15 && d1.dayOfMonth() > 15) {
                         return adjust(d, Preceding);
                     }
-                    if (c == HalfMonthModifiedFollowing) {
-                        if (d.dayOfMonth() <= 15 && d1.dayOfMonth() > 15) {
-                            return adjust(d, Preceding);
-                        }
-                    }
+                }
             }
         } else if (c == Preceding || c == ModifiedPreceding) {
             while (isHoliday(d1))

--- a/QuantLib/test-suite/businessdayconventions.cpp
+++ b/QuantLib/test-suite/businessdayconventions.cpp
@@ -1,0 +1,129 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "businessdayconventions.hpp"
+#include "utilities.hpp"
+#include <ql/time/businessdayconvention.hpp>
+#include <ql/time/daycounter.hpp>
+#include <ql/time/calendars/southafrica.hpp>
+#include <ql/time/period.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+    struct SingleCase {
+        SingleCase(const Calendar& calendar,
+                   const BusinessDayConvention& convention,
+                   const Date& start,
+                   const Period& period,
+                   const bool endOfMonth,
+                   Date result)
+        : calendar(calendar), convention(convention), start(start), 
+          period(period), endOfMonth(endOfMonth), result(result) {}
+        Calendar calendar;
+        BusinessDayConvention convention;
+        Date start;
+        Period period;
+        bool endOfMonth;
+        Date result;
+    };
+
+}
+
+void BusinessDayConventionTest::testConventions() {
+
+    BOOST_TEST_MESSAGE("Testing business day conventions...");
+
+    SingleCase testCases[] = {
+        // Following
+        SingleCase(SouthAfrica(), Following, Date(3,February,2015), Period(1,Months), false, Date(3,March,2015)),
+        SingleCase(SouthAfrica(), Following, Date(3,February,2015), Period(4,Days), false, Date(9,February,2015)),
+        SingleCase(SouthAfrica(), Following, Date(31,January,2015), Period(1,Months), true, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), Following, Date(31,January,2015), Period(1,Months), false, Date(2,March,2015)),
+
+        //ModifiedFollowing
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(3,February,2015), Period(1,Months), false, Date(3,March,2015)),
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(3,February,2015), Period(4,Days), false, Date(9,February,2015)),
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(31,January,2015), Period(1,Months), true, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(31,January,2015), Period(1,Months), false, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(25,March,2015), Period(1,Months), false, Date(28,April,2015)),
+        SingleCase(SouthAfrica(), ModifiedFollowing, Date(7,February,2015), Period(1,Months), false, Date(9,March,2015)),
+
+        //Preceding
+        SingleCase(SouthAfrica(), Preceding, Date(3,March,2015), Period(-1,Months), false, Date(3,February,2015)),
+        SingleCase(SouthAfrica(), Preceding, Date(3,February,2015), Period(-2,Days), false, Date(30,January,2015)),
+        SingleCase(SouthAfrica(), Preceding, Date(1,March,2015), Period(-1,Months), true, Date(30,January,2015)),
+        SingleCase(SouthAfrica(), Preceding, Date(1,March,2015), Period(-1,Months), false, Date(30,January,2015)),
+
+        //ModifiedPreceding
+        SingleCase(SouthAfrica(), ModifiedPreceding, Date(3,March,2015), Period(-1,Months), false, Date(3,February,2015)),
+        SingleCase(SouthAfrica(), ModifiedPreceding, Date(3,February,2015), Period(-2,Days), false, Date(30,January,2015)),
+        SingleCase(SouthAfrica(), ModifiedPreceding, Date(1,March,2015), Period(-1,Months), true, Date(2,February,2015)),
+        SingleCase(SouthAfrica(), ModifiedPreceding, Date(1,March,2015), Period(-1,Months), false, Date(2,February,2015)),
+
+        //Unadjusted
+        SingleCase(SouthAfrica(), Unadjusted, Date(3,February,2015), Period(1,Months), false, Date(3,March,2015)),
+        SingleCase(SouthAfrica(), Unadjusted, Date(3,February,2015), Period(4,Days), false, Date(9,February,2015)),
+        SingleCase(SouthAfrica(), Unadjusted, Date(31,January,2015), Period(1,Months), true, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), Unadjusted, Date(31,January,2015), Period(1,Months), false, Date(28,February,2015)),
+
+        //HalfMonthModifiedFollowing
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(3,February,2015), Period(1,Months), false, Date(3,March,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(3,February,2015), Period(4,Days), false, Date(9,February,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(31,January,2015), Period(1,Months), true, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(31,January,2015), Period(1,Months), false, Date(27,February,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(3,January,2015), Period(1,Weeks), false, Date(12,January,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(21,March,2015), Period(1,Weeks), false, Date(30,March,2015)),
+        SingleCase(SouthAfrica(), HalfMonthModifiedFollowing, Date(7,February,2015), Period(1,Months), false, Date(9,March,2015)),
+
+        //Nearest
+        SingleCase(SouthAfrica(), Nearest, Date(3,February,2015), Period(1,Months), false, Date(3,March,2015)),
+        SingleCase(SouthAfrica(), Nearest, Date(3,February,2015), Period(4,Days), false, Date(9,February,2015)),
+        SingleCase(SouthAfrica(), Nearest, Date(16,April,2015), Period(1,Months), false, Date(15,May,2015)),
+        SingleCase(SouthAfrica(), Nearest, Date(17,April,2015), Period(1,Months), false, Date(18,May,2015)),
+        SingleCase(SouthAfrica(), Nearest, Date(4,March,2015), Period(1,Months), false, Date(2,April,2015)),
+        SingleCase(SouthAfrica(), Nearest, Date(2,April,2015), Period(1,Months), false, Date(4,May,2015))
+    };
+
+    Size n = sizeof(testCases)/sizeof(SingleCase);
+    for (Size i=0; i<n; i++) {
+        Calendar calendar(testCases[i].calendar);
+        Date result = calendar.advance(
+            testCases[i].start,
+            testCases[i].period,
+            testCases[i].convention,
+            testCases[i].endOfMonth);
+
+        BOOST_CHECK_MESSAGE(result == testCases[i].result,
+                            "\ncase " << i << ":\n" //<< j << " ("<< desc << "): "
+                            << "start date: " << testCases[i].start << "\n"
+                            << "calendar: " << calendar << "\n"
+                            << "period: " << testCases[i].period << ", end of month: " << testCases[i].endOfMonth << "\n"
+                            << "convention: " << testCases[i].convention << "\n"
+                            << "expected: " << testCases[i].result << " vs. actual: " << result);
+    }
+}
+
+test_suite* BusinessDayConventionTest::suite() {
+    test_suite* suite = BOOST_TEST_SUITE("Business day convention tests");
+    suite->add(QUANTLIB_TEST_CASE(&BusinessDayConventionTest::testConventions));
+    return suite;
+}
+
+
+

--- a/QuantLib/test-suite/businessdayconventions.hpp
+++ b/QuantLib/test-suite/businessdayconventions.hpp
@@ -1,0 +1,33 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_business_day_convention_hpp
+#define quantlib_test_business_day_convention_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class BusinessDayConventionTest {
+   public:
+    static void testConventions();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+
+#endif

--- a/QuantLib/test-suite/quantlibtestsuite.cpp
+++ b/QuantLib/test-suite/quantlibtestsuite.cpp
@@ -57,6 +57,7 @@
 #include "blackformula.hpp"
 #include "bonds.hpp"
 #include "brownianbridge.hpp"
+#include "businessdayconventions.hpp"
 #include "calendars.hpp"
 #include "capfloor.hpp"
 #include "capflooredcoupon.hpp"
@@ -268,6 +269,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(BlackFormulaTest::suite());
     test->add(BondTest::suite());
     test->add(BrownianBridgeTest::suite());
+    test->add(BusinessDayConventionTest::suite());
     test->add(CalendarTest::suite());
     test->add(CapFloorTest::suite());
     test->add(CapFlooredCouponTest::suite());

--- a/QuantLib/test-suite/testsuite.vcxproj
+++ b/QuantLib/test-suite/testsuite.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug (static runtime)|Win32">
@@ -641,6 +641,7 @@
     <ClCompile Include="blackformula.cpp" />
     <ClCompile Include="bonds.cpp" />
     <ClCompile Include="brownianbridge.cpp" />
+    <ClCompile Include="businessdayconventions.cpp" />
     <ClCompile Include="calendars.cpp" />
     <ClCompile Include="capfloor.cpp" />
     <ClCompile Include="capflooredcoupon.cpp" />
@@ -773,6 +774,7 @@
     <ClInclude Include="blackformula.hpp" />
     <ClInclude Include="bonds.hpp" />
     <ClInclude Include="brownianbridge.hpp" />
+    <ClInclude Include="businessdayconventions.hpp" />
     <ClInclude Include="calendars.hpp" />
     <ClInclude Include="capfloor.hpp" />
     <ClInclude Include="capflooredcoupon.hpp" />

--- a/QuantLib/test-suite/testsuite.vcxproj.filters
+++ b/QuantLib/test-suite/testsuite.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -399,6 +399,9 @@
     <ClCompile Include="binaryoption.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="businessdayconventions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="americanoption.hpp">
@@ -789,6 +792,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="binaryoption.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="businessdayconventions.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
+++ b/QuantLibAddin/gensrc/metadata/enumerations/enumeratedtypes.xml
@@ -799,6 +799,14 @@
           <string>Indifferent</string>
           <value>QuantLib::Unadjusted</value>
         </EnumeratedType>
+        <EnumeratedType>
+          <string>Nearest</string>
+          <value>QuantLib::Nearest</value>
+        </EnumeratedType>
+        <EnumeratedType>
+          <string>N</string>
+          <value>QuantLib::Nearest</value>
+        </EnumeratedType>
       </EnumeratedTypes>
     </EnumeratedTypeGroup>
 


### PR DESCRIPTION
Refer to http://quantlib.10058.n7.nabble.com/Bussiness-day-convention-td16303.html

This PR implements the 'Nearest' business day convention. It also adds some unit tests for all business day conventions. I hope I covered most of the use cases.

Finally, this PR expands the enumeration necessary for qlXL.