### PR TITLE
allow non-striked payoffs and check time

### DIFF
--- a/QuantLib/ql/pricingengines/vanilla/fdvanillaengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/fdvanillaengine.cpp
@@ -43,12 +43,11 @@ namespace QuantLib {
         QL_REQUIRE(args, "incorrect argument type");
         exerciseDate_ = args->exercise->lastDate();
         payoff_ = args->payoff;
-        requiredGridValue_ =
-            boost::dynamic_pointer_cast<StrikedTypePayoff>(payoff_)->strike();
     }
 
     void FDVanillaEngine::setGridLimits(Real center, Time t) const {
         QL_REQUIRE(center > 0.0, "negative or null underlying given");
+        QL_REQUIRE(t > 0.0, "negative or zero residual time");
         center_ = center;
         Size newGridPoints = safeGridPoints(gridPoints_, t);
         if (newGridPoints > intrinsicValues_.size()) {

--- a/QuantLib/ql/pricingengines/vanilla/fdvanillaengine.hpp
+++ b/QuantLib/ql/pricingengines/vanilla/fdvanillaengine.hpp
@@ -68,7 +68,6 @@ namespace QuantLib {
         boost::shared_ptr<GeneralizedBlackScholesProcess> process_;
         Size timeSteps_, gridPoints_;
         bool timeDependent_;
-        mutable Real requiredGridValue_;
         mutable Date exerciseDate_;
         mutable boost::shared_ptr<Payoff> payoff_;
         mutable TridiagonalOperator finiteDifferenceOperator_;


### PR DESCRIPTION
This removed an unnecessary check that restricts fd to strike type payoffs.  With these changes, fd can be used with non-strike type payoffs.  This also includes a check for time calculations.