### PR TITLE
Elimination of incompatibilities that prevent redefining Real as a class globally

### DIFF
--- a/QuantLib/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/QuantLib/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -382,7 +382,7 @@ int main(int, char* []) {
         std::cout << "BK:              " << itmBermudanSwaption.NPV()
                   << std::endl;
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/Bonds/Bonds.cpp
+++ b/QuantLib/Examples/Bonds/Bonds.cpp
@@ -558,7 +558,7 @@ int main(int, char* []) {
          /* "Yield to Price"
             "Price to Yield" */
 
-         Real seconds = timer.elapsed();
+         double seconds = timer.elapsed();
          Integer hours = int(seconds/3600);
          seconds -= hours * 3600;
          Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/CallableBonds/CallableBonds.cpp
+++ b/QuantLib/Examples/CallableBonds/CallableBonds.cpp
@@ -322,7 +322,7 @@ int main(int, char* [])
              << endl
              << endl;
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/QuantLib/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -312,7 +312,7 @@ int main(int, char* []) {
 
         std::cout << dblrule << std::endl;
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/DiscreteHedging/DiscreteHedging.cpp
+++ b/QuantLib/Examples/DiscreteHedging/DiscreteHedging.cpp
@@ -193,7 +193,7 @@ int main(int, char* []) {
         hedgesNum = 84;
         rp.compute(hedgesNum, scenarios);
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/EquityOption/EquityOption.cpp
+++ b/QuantLib/Examples/EquityOption/EquityOption.cpp
@@ -390,7 +390,7 @@ int main(int, char* []) {
                   << std::endl;
 
         // End test
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/FRA/FRA.cpp
+++ b/QuantLib/Examples/FRA/FRA.cpp
@@ -340,7 +340,7 @@ int main(int, char* []) {
                  << endl;
         }
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -604,7 +604,7 @@ int main(int, char* []) {
         }
 
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/Replication/Replication.cpp
+++ b/QuantLib/Examples/Replication/Replication.cpp
@@ -367,7 +367,7 @@ int main(int, char* []) {
             << "the example and contribute a patch if you spot any errors."
             << std::endl;
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/Repo/Repo.cpp
+++ b/QuantLib/Examples/Repo/Repo.cpp
@@ -226,7 +226,7 @@ int main(int, char* []) {
              << endl;
 
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/Examples/Swap/swapvaluation.cpp
+++ b/QuantLib/Examples/Swap/swapvaluation.cpp
@@ -761,7 +761,7 @@ int main(int, char* []) {
                   << io::rate(fairRate) << separator;
         std::cout << std::endl;
 
-        Real seconds = timer.elapsed();
+        double seconds = timer.elapsed();
         Integer hours = int(seconds/3600);
         seconds -= hours * 3600;
         Integer minutes = int(seconds/60);

--- a/QuantLib/ql/cashflows/conundrumpricer.cpp
+++ b/QuantLib/ql/cashflows/conundrumpricer.cpp
@@ -268,7 +268,7 @@ namespace QuantLib {
 
     Real NumericHaganPricer::integrate(Real a,
         Real b, const ConundrumIntegrand& integrand) const {
-            double result =.0;
+            Real result =.0;
             //double abserr =.0;
             //double alpha = 1.0;
 

--- a/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1450,7 +1450,7 @@ namespace QuantLib {
             integr_adapter(
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())) {}
-            double operator()(double t1,double t2) const {
+            Real operator()(double t1,double t2) const {
                 return r->forwardRate(t1,t2,Continuous) * (t2-t1);
             }
         };
@@ -1476,7 +1476,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())),
               q(*(process->dividendYield())) {}
-            double operator()(double t) const {
+            Real operator()(double t) const {
                 return r->forwardRate(t,t,Continuous)
                      - q->forwardRate(t,t,Continuous);
             }

--- a/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1462,7 +1462,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())),
               q(*(process->dividendYield())) {}
-            double operator()(double t1,double t2) const {
+            Real operator()(double t1,double t2) const {
                 Real alpha = r->forwardRate(t1,t2,Continuous)
                            - q->forwardRate(t1,t2,Continuous);
                 return alpha * (t2-t1);
@@ -1502,7 +1502,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : v(*(process->blackVolatility())),
               s(process->x0()) {}
-            double operator()(double t1,double t2) const {
+            Real operator()(double t1,double t2) const {
                 return v->blackForwardVariance(t1,t2,s,true);
             }
         };

--- a/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -23,6 +23,7 @@
 #include <ql/experimental/barrieroption/perturbativebarrieroptionengine.hpp>
 #include <ql/exercise.hpp>
 #include <ql/errors.hpp>
+#include <ql/types.hpp>
 #include <boost/function.hpp>
 #include <cmath>
 #include <algorithm>
@@ -31,58 +32,58 @@ using namespace std;
 
 #define SIGN(a,b) ((b) >= 0.0 ? fabs(a) : -fabs(a))
 #define ABS(x) (((x) < 0) ? -(x) : (x))
-#define POW(x,y) pow( (double) (x), (double) (y))
+#define POW(x,y) pow( (Real) (x), (Real) (y))
 #define PI 3.14159265358979324
 
-namespace {
+namespace QuantLib {
 
-    double ND2(double a, double b, double rho);
+    Real ND2(Real a, Real b, Real rho);
 
-    double H1, H2,  H3, R23, RUA, RUB, AR, RUC;
+    Real H1, H2,  H3, R23, RUA, RUB, AR, RUC;
     int NUC;
 
     // standard normal cumulative distribution function
-    double PHID(double Z);
+    Real PHID(Real Z);
 
     // Functions used to compute the first order approximation
-    double ff(double p,double tt,double a, double b, double gm);
-    double v(double p, double tt,double a,double b,double gm);
-    double llold(double p,double tt, double a, double b,
-                 double c, double gm);
+    Real ff(Real p,Real tt,Real a, Real b, Real gm);
+    Real v(Real p, Real tt,Real a,Real b,Real gm);
+    Real llold(Real p,Real tt, Real a, Real b,
+                 Real c, Real gm);
 
     // Functions used to compute the second order approximation
-    double derivn3(double limit[4],double sigmarho[4], int idx);
-    double ddvv(double s, double p, double tt, double a,
-                double b, double gm);
-    double ddff(double s, double p,double tt,double a,double b,double gm);
-    double dll(double s,double p,double tt,double a,double b,
-               double c,double gm);
-    double ddll(double s,double p,double tt, double ax, double bx,
-                double c, double gm);
-    double dvv(double s,double p,double tt,double a,double b,double gm);
-    double dff(double s, double p,double tt,double a,double b,double gm);
-    double tvtl(int jj,double limit[4],double sigmarho[4],double epsi);
+    Real derivn3(Real limit[4],Real sigmarho[4], int idx);
+    Real ddvv(Real s, Real p, Real tt, Real a,
+                Real b, Real gm);
+    Real ddff(Real s, Real p,Real tt,Real a,Real b,Real gm);
+    Real dll(Real s,Real p,Real tt,Real a,Real b,
+               Real c,Real gm);
+    Real ddll(Real s,Real p,Real tt, Real ax, Real bx,
+                Real c, Real gm);
+    Real dvv(Real s,Real p,Real tt,Real a,Real b,Real gm);
+    Real dff(Real s, Real p,Real tt,Real a,Real b,Real gm);
+    Real tvtl(int jj,Real limit[4],Real sigmarho[4],Real epsi);
 
-    double BarrierUPD(double kprice, double stock, double hbarr,
-                      double taumin, double taumax, int iord, int igm,
-                      boost::function<double(double, double)> integr,
-                      boost::function<double(double, double)> integalpha,
-                      boost::function<double(double, double)> integs,
-                      boost::function<double(double)> alpha,
-                      boost::function<double(double)> sigmaq)
+    Real BarrierUPD(Real kprice, Real stock, Real hbarr,
+                      Real taumin, Real taumax, int iord, int igm,
+                      boost::function<Real(Real, Real)> integr,
+                      boost::function<Real(Real, Real)> integalpha,
+                      boost::function<Real(Real, Real)> integs,
+                      boost::function<Real(Real)> alpha,
+                      boost::function<Real(Real)> sigmaq)
     {
-        double v0=0.0, v1=0.0, v1p=0.0, v2p=0.0, v2pp=0.0, gm=0.0;
+        Real v0=0.0, v1=0.0, v1p=0.0, v2p=0.0, v2pp=0.0, gm=0.0;
         int i=0,j=0;
-        double tmp=0.0, e1=0.0, e2=0.0, e3=0.0, e4=0.0;
-        double xstar=0.0, s0=0.0;
-        double sigmat=0.0, disc=0.0, d1=0.0,d2=0.0,d3=0.0,d4=0.0;
-        double et=0.0,tt=0.0, dt=0.0,p=0.0;
+        Real tmp=0.0, e1=0.0, e2=0.0, e3=0.0, e4=0.0;
+        Real xstar=0.0, s0=0.0;
+        Real sigmat=0.0, disc=0.0, d1=0.0,d2=0.0,d3=0.0,d4=0.0;
+        Real et=0.0,tt=0.0, dt=0.0,p=0.0;
         int npoint,npoint2;
         static double pi= 3.14159265358979324;
-        double dsqpi;
-        double caux=0.0,ccaux=0.0;
-        double auxnew=0.0;
-        double x=0.0,b=0.0,c=0.0;
+        Real dsqpi;
+        Real caux=0.0,ccaux=0.0;
+        Real auxnew=0.0;
+        Real x=0.0,b=0.0,c=0.0;
 
         if(igm==0) {
             gm=0.0;
@@ -221,7 +222,7 @@ namespace {
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         */
 
-        double v2,dtp, tmp1,s,caux2;
+        Real v2,dtp, tmp1,s,caux2;
         v2=0.0;
 
         for(i=1;i<=npoint;i++) {
@@ -291,7 +292,7 @@ namespace {
     }
 
 
-    double PHID(double Z){
+    Real PHID(Real Z){
         /*
          *     Normal distribution probabilities accurate to 1D-15.
          *     Z = number of standard deviations from the mean.
@@ -303,9 +304,9 @@ namespace {
          *     Hart, J.F. et al, 'Computer Approximations', Wiley, 1968
          *
          */
-        double P0, P1, P2, P3, P4, P5, P6;
-        double Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7;
-        double P, EXPNTL, CUTOFF, ROOTPI, ZABS;
+        Real P0, P1, P2, P3, P4, P5, P6;
+        Real Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7;
+        Real P, EXPNTL, CUTOFF, ROOTPI, ZABS;
 
         P0 = 220.2068679123761;
         P1 = 221.2135961699311;
@@ -369,10 +370,10 @@ namespace {
       !! Function F(p,tt,a,b,gm)
       !!
     */
-    double ff(double p,double tt,double a, double b, double gm) {
-        double phid;
-        double aa, caux;
-        double ppi= 3.14159265358979324;
+    Real ff(Real p,Real tt,Real a, Real b, Real gm) {
+        Real phid;
+        Real aa, caux;
+        Real ppi= 3.14159265358979324;
 
         aa=-(b*p-b*tt+a)/POW(2.0*(tt-p),0.5);
 
@@ -389,10 +390,10 @@ namespace {
       !! Function  E(p,tt,a,b,gm)
       !!
     */
-    double v(double p, double tt,double a,double b,double gm)
+    Real v(Real p, Real tt,Real a,Real b,Real gm)
     {
-        double result;
-        double aa,caux;
+        Real result;
+        Real aa,caux;
 
         aa=-(p*(a-b)+b*tt)/POW(2.0*p*tt*(tt-p),0.5);
         caux=PHID(aa);
@@ -408,11 +409,11 @@ namespace {
       !! Fuction L(p,tt,a,b,c,gm)
       !!
     */
-    double llold(double p,double tt, double a, double b,double c, double gm){
-        double bvnd;
-        double xx,yy,rho,caux;
-        double ppi= 3.14159265358979324;
-        double aa;
+    Real llold(Real p,Real tt, Real a, Real b,Real c, Real gm){
+        Real bvnd;
+        Real xx,yy,rho,caux;
+        Real ppi= 3.14159265358979324;
+        Real aa;
 
         xx=(-a+b*(tt-p))/POW(2.0*(tt-p),0.5);
         yy=(-a+b*tt+c)/POW(2.0*tt,0.5);
@@ -438,12 +439,12 @@ namespace {
       !! Function  D_E(s,p,tt,a,b,gm)
       !!
     */
-    double dvv(double s,double p,double tt,double a,double b,double gm)
+    Real dvv(Real s,Real p,Real tt,Real a,Real b,Real gm)
     {
         double ppi= 3.14159265358979324;
-        double result;
-        double aa,caux,caux1,caux2;
-        double xx,yy,rho;
+        Real result;
+        Real aa,caux,caux1,caux2;
+        Real xx,yy,rho;
 
         aa=(a*p+b*(tt-p))/POW(2.0*p*tt*(tt-p),0.5);
         caux=PHID(aa);
@@ -474,11 +475,11 @@ namespace {
       !! Function D_F(s,p,tt,a,b,gm)
       !!
     */
-    double dff(double s, double p,double tt,double a,double b,double gm)
+    Real dff(Real s, Real p,Real tt,Real a,Real b,Real gm)
     {
-        double result;
-        double aa,caux,caux1,caux2;
-        double xx,yy,rho;
+        Real result;
+        Real aa,caux,caux1,caux2;
+        Real xx,yy,rho;
 
         xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
         caux=-PHID(xx)*exp(-0.5*a*b);
@@ -507,11 +508,11 @@ namespace {
       !! Function D_L(s,p,a,b,c,gm)
       !!
     */
-    double dll(double s,double p,double tt,double a,double b,double c,double gm)
+    Real dll(Real s,Real p,Real tt,Real a,Real b,Real c,Real gm)
     {
-        double result;
-        double aa,caux,caux1;
-        double sigmarho[4],limit[4],epsi;
+        Real result;
+        Real aa,caux,caux1;
+        Real sigmarho[4],limit[4],epsi;
 
         epsi=1.e-12;
         limit[1]=(a+b*(tt-p))/POW(2.0*(tt-p),0.5);
@@ -545,11 +546,11 @@ namespace {
       !! Derivative with respect to a of the function D_F(s,p,tt,a,b,gm)
       !!
     */
-    double ddff(double s, double p,double tt,double a,double b,double gm)
+    Real ddff(Real s, Real p,Real tt,Real a,Real b,Real gm)
     {
-        double aa,caux,caux1,caux2,caux3,caux4;
-        double xx,yy,rho;
-        double result;
+        Real aa,caux,caux1,caux2,caux3,caux4;
+        Real xx,yy,rho;
+        Real result;
         double ppi= 3.14159265358979324;
 
         xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
@@ -601,13 +602,13 @@ namespace {
       !! Derivative with respect to a of the function D_L(s,p,tt,a,b,c,gm)
       !!
     */
-    double ddll(double s,double p,double tt, double ax, double bx,double c, double gm)
+    Real ddll(Real s,Real p,Real tt, Real ax, Real bx,Real c, Real gm)
     {
-        static double result;
-        static double aa,caux,caux1;
-        static double sigmarho[4],limit[4];
+        static Real result;
+        static Real aa,caux,caux1;
+        static Real sigmarho[4],limit[4];
         static int idx;
-        double epsi;
+        Real epsi;
 
         epsi=1.e-12;
         limit[1]=(ax+bx*(tt-p))/POW(2.0*(tt-p),0.5);
@@ -664,12 +665,12 @@ namespace {
       !!   Derivative with respect to a of the function D_E(s,p,tt,a,b,gm)
       !!
     */
-    double ddvv(double s, double p, double tt, double a, double b, double gm)
+    Real ddvv(Real s, Real p, Real tt, Real a, Real b, Real gm)
     {
-        static double result;
-        static double aa,caux,caux1,caux2,caux6;
-        static double caux3,caux4,caux5,aux;
-        static double xx,yy,rho;
+        static Real result;
+        static Real aa,caux,caux1,caux2,caux6;
+        static Real caux3,caux4,caux5,aux;
+        static Real xx,yy,rho;
         static double ppi= 3.14159265358979324;
 
         aa=(a*p+b*(tt-p))/POW(2.0*p*tt*(tt-p),0.5);
@@ -729,12 +730,12 @@ namespace {
       !! distribution with respect to one of the integration limits
       !!
     */
-    double derivn3(double limit[4],double sigmarho[4], int idx)
+    Real derivn3(Real limit[4],Real sigmarho[4], int idx)
     {
-        static double aa;
-        static double xx,yy,rho,sc;
+        static Real aa;
+        static Real xx,yy,rho,sc;
         static double  ppi= 3.14159265358979324;
-        static double deriv;
+        static Real deriv;
         sc=POW(2.0*ppi,0.5);
 
         if(idx==1)
@@ -773,17 +774,17 @@ namespace {
     }
 
 
-    double BVTL(int NU, double DH, double DK, double RRR );
-    double TVTMFN(double X, double H1, double H2, double H3,
-                  double R23, double RUA, double RUB, double AR,
-                  double RUC, int NUC);
-    double ADONET(double ZRO,double ONE,double EPS,
-                  double(*TVTMFN)(double X, double H1, double H2,
-                                  double H3, double R23, double RUA,
-                                  double RUB, double AR, double RUC,
+    Real BVTL(int NU, Real DH, Real DK, Real RRR );
+    Real TVTMFN(Real X, Real H1, Real H2, Real H3,
+                  Real R23, Real RUA, Real RUB, Real AR,
+                  Real RUC, int NUC);
+    Real ADONET(Real ZRO,Real ONE,Real EPS,
+                  Real(*TVTMFN)(Real X, Real H1, Real H2,
+                                  Real H3, Real R23, Real RUA,
+                                  Real RUB, Real AR, Real RUC,
                                   int NUC));
 
-    double tvtl(int NU, double limit[], double sigmarho[],double epsi)
+    Real tvtl(int NU, Real limit[], Real sigmarho[],Real epsi)
     {
         /*
           A function for computing trivariate normal and t-probabilities.
@@ -823,9 +824,9 @@ namespace {
 
         */
 
-        static double result;
-        static double  ONE=1.0, ZRO=0.0, EPS,  TVT;
-        static double PT, R12, R13;
+        static Real result;
+        static Real  ONE=1.0, ZRO=0.0, EPS,  TVT;
+        static Real PT, R12, R13;
         static double ppi= 3.14159265358979324;
         EPS = max( 1.e-14, epsi );
         PT=ppi/2.0;
@@ -893,19 +894,19 @@ namespace {
         return(result);
     }
 
-    void SINCS(double v1,double& v2, double& v3);
-    double PNTGND(int , double ,double ,double ,
-                  double ,double ,double ,double );
+    void SINCS(Real v1,Real& v2, Real& v3);
+    Real PNTGND(int , Real ,Real ,Real ,
+                  Real ,Real ,Real ,Real );
 
-    double TVTMFN(double X, double H1, double H2, double H3, double R23,
-                  double RUA, double RUB, double AR,double RUC, int NUC ){
+    Real TVTMFN(Real X, Real H1, Real H2, Real H3, Real R23,
+                  Real RUA, Real RUB, Real AR,Real RUC, int NUC ){
         /*
           Computes Plackett formula integrands
         */
 
-        static double R12=0.0, RR2=0, R13=0.0, RR3=0.0, R=0.0, RR=0.0;
-        const double ZRO = 0.0;
-        double result = 0.0;
+        static Real R12=0.0, RR2=0, R13=0.0, RR3=0.0, R=0.0, RR=0.0;
+        const Real ZRO = 0.0;
+        Real result = 0.0;
 
         SINCS( RUA*X, R12, RR2 );
         SINCS( RUB*X, R13, RR3 );
@@ -922,12 +923,12 @@ namespace {
     //
 
 
-    void SINCS(double X, double& SX, double& CS )
+    void SINCS(Real X, Real& SX, Real& CS )
     {
         /*
           Computes SIN(X), COS(X)^2, with series approx. for |X| near PI/2
         */
-        static double PT, EE;
+        static Real PT, EE;
         PT = 1.57079632679489661923132169163975;
         EE = POW(( PT - fabs(X) ),2);
 
@@ -945,18 +946,18 @@ namespace {
     }
     //
 
-    double KRNRDT(double, double,
-                  double(*TVTMFN)(double, double, double, double,
-                                  double, double, double, double, double, int),
-                  double& );
+    Real KRNRDT(Real, Real,
+                  Real(*TVTMFN)(Real, Real, Real, Real,
+                                  Real, Real, Real, Real, Real, int),
+                  Real& );
 
-    double ADONET(double A,double B, double TOL,double(*TVTMFN)(double X, double H1, double H2, double H3, double R23, double RUA, double RUB, double AR, double RUC, int NUC)){
+    Real ADONET(Real A,Real B, Real TOL,Real(*TVTMFN)(Real X, Real H1, Real H2, Real H3, Real R23, Real RUA, Real RUB, Real AR, Real RUC, int NUC)){
         //
         //     One Dimensional Globally Adaptive Integration Function
         //
         int NL=100, I, IM, IP;
-        static double EI[101], AI[101], BI[101], FI[101], FIN;
-        static double result,ERR;
+        static Real EI[101], AI[101], BI[101], FI[101], FIN;
+        static Real result,ERR;
 
 
         AI[1] = A;
@@ -989,14 +990,14 @@ namespace {
     }
     //
 
-    double KRNRDT(double A, double B,double(*TVTMFN)(double X, double H1, double H2, double H3, double R23, double RUA, double RUB, double AR, double RUC, int NUC),double& ERR ){
+    Real KRNRDT(Real A, Real B,Real(*TVTMFN)(Real X, Real H1, Real H2, Real H3, Real R23, Real RUA, Real RUB, Real AR, Real RUC, int NUC),Real& ERR ){
 
         //
         //     Kronrod Rule
         //
-        static double  T, CEN, FC, WID, RESG, RESK;
+        static Real  T, CEN, FC, WID, RESG, RESK;
 
-        static double result;
+        static Real result;
         //
         //        The abscissae and weights are given for the interval (-1,1);
         //        only positive abscissae and corresponding weights are given.
@@ -1009,7 +1010,7 @@ namespace {
         //
         int J, N=11;
 
-        static double  WG[7], WGK[13], XGK[13];
+        static Real  WG[7], WGK[13], XGK[13];
 
         WG[1]= 0.2729250867779007;
         WG[2]=0.05566856711617449;
@@ -1074,15 +1075,15 @@ namespace {
     }
 
     //
-    double  STUDNT(int NU, double T )
+    Real  STUDNT(int NU, Real T )
     {
         /*
           Student t Distribution Function
         */
         static int J;
-        static double  ZRO=0.0, ONE=1.0;
-        static double  CSSTHE, SNTHE, POLYN, TT, TS, RN;
-        static double result;
+        static Real  ZRO=0.0, ONE=1.0;
+        static Real  CSSTHE, SNTHE, POLYN, TT, TS, RN;
+        static Real result;
 
 
         if ( NU < 1 ) result= PHID( T );
@@ -1114,7 +1115,7 @@ namespace {
     }
 
     //
-    double BVTL(int NU, double DH, double DK, double R )
+    Real BVTL(int NU, Real DH, Real DK, Real R )
     {
         /*
           A function for computing bivariate t probabilities.
@@ -1144,10 +1145,10 @@ namespace {
           R   correlation coefficient
         */
         static int  J, HS, KS;
-        static double  TPI, ORS, HRK, KRH, BVT, SNU;
-        static double  GMPH, GMPK, XNKH, XNHK, QHRK, HKN, HPK, HKRN;
-        static double  BTNCKH, BTNCHK, BTPDKH, BTPDHK, ONE, EPS;
-        static double result;
+        static Real  TPI, ORS, HRK, KRH, BVT, SNU;
+        static Real  GMPH, GMPK, XNKH, XNHK, QHRK, HKN, HPK, HKRN;
+        static Real  BTNCKH, BTNCHK, BTPDKH, BTPDHK, ONE, EPS;
+        static Real result;
         ONE = 1;
         EPS = 1e-15;
         if ( NU <1 ) result = ND2( -DH, -DK, R );
@@ -1238,11 +1239,11 @@ namespace {
 
 
 
-      double PNTGND(int NUC, double BA, double BB, double BC, double RA, double RB, double R, double RR) {
+      Real PNTGND(int NUC, Real BA, Real BB, Real BC, Real RA, Real RB, Real R, Real RR) {
           /*
             Computes Plackett formula integrand
           */
-          static double DT, FT, BT,result;
+          static Real DT, FT, BT,result;
 
           result = 0.0;
           DT = RR*( RR - POW(( RA - RB ),2) - 2*RA*RB*( 1 - R ) );
@@ -1265,7 +1266,7 @@ namespace {
 
 
     //***********************************************************
-    double ND2(double a, double b, double rho ){
+    Real ND2(Real a, Real b, Real rho ){
         /*
          *     A function for computing bivariate normal probabilities.
          *     This function is based on the method described by
@@ -1294,11 +1295,11 @@ namespace {
          *   R   DOUBLE PRECISION, correlation coefficient
          */
         static double TWOPI = 6.283185307179586;
-        static double result, DK, DH, R;
+        static Real result, DK, DH, R;
         static int I, IS, LG, NG;
 
-        static double XL[11][4], WL[11][4], AS, AA, BB, C, D, RS, XS, BVN;
-        static double SN, ASR, H, K, BS, HS, HK;
+        static Real XL[11][4], WL[11][4], AS, AA, BB, C, D, RS, XS, BVN;
+        static Real SN, ASR, H, K, BS, HS, HK;
         //  Gauss Legendre Points and Weights, N =  6
         //  DATA ( W(I,1), X(I,1), I = 1,3) /
         WL[1][1]=0.1713244923791705;
@@ -1450,7 +1451,7 @@ namespace QuantLib {
             integr_adapter(
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())) {}
-            Real operator()(double t1,double t2) const {
+            Real operator()(Real t1,Real t2) const {
                 return r->forwardRate(t1,t2,Continuous) * (t2-t1);
             }
         };
@@ -1462,7 +1463,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())),
               q(*(process->dividendYield())) {}
-            Real operator()(double t1,double t2) const {
+            Real operator()(Real t1,Real t2) const {
                 Real alpha = r->forwardRate(t1,t2,Continuous)
                            - q->forwardRate(t1,t2,Continuous);
                 return alpha * (t2-t1);
@@ -1476,7 +1477,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : r(*(process->riskFreeRate())),
               q(*(process->dividendYield())) {}
-            Real operator()(double t) const {
+            Real operator()(Real t) const {
                 return r->forwardRate(t,t,Continuous)
                      - q->forwardRate(t,t,Continuous);
             }
@@ -1489,7 +1490,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : v(*(process->blackVolatility())),
               s(process->x0()) {}
-            Real operator()(double t) const {
+            Real operator()(Real t) const {
                 Real sigma = v->blackForwardVol(t,t,s,true);
                 return sigma*sigma;
             }
@@ -1502,7 +1503,7 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : v(*(process->blackVolatility())),
               s(process->x0()) {}
-            Real operator()(double t1,double t2) const {
+            Real operator()(Real t1,Real t2) const {
                 return v->blackForwardVariance(t1,t2,s,true);
             }
         };

--- a/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1489,8 +1489,8 @@ namespace QuantLib {
                     boost::shared_ptr<GeneralizedBlackScholesProcess> process)
             : v(*(process->blackVolatility())),
               s(process->x0()) {}
-            double operator()(double t) const {
-                double sigma = v->blackForwardVol(t,t,s,true);
+            Real operator()(double t) const {
+                Real sigma = v->blackForwardVol(t,t,s,true);
                 return sigma*sigma;
             }
         };

--- a/QuantLib/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
@@ -31,6 +31,7 @@
 
 using std::pow;
 using std::log;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
@@ -29,6 +29,9 @@
 #include <ql/time/calendars/nullcalendar.hpp>
 #include <boost/make_shared.hpp>
 
+using std::pow;
+using std::log;
+
 namespace QuantLib {
 
     VannaVolgaBarrierEngine::VannaVolgaBarrierEngine(

--- a/QuantLib/ql/experimental/barrieroption/vannavolgadoublebarrierengine.cpp
+++ b/QuantLib/ql/experimental/barrieroption/vannavolgadoublebarrierengine.cpp
@@ -29,6 +29,8 @@
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 
+using std::sqrt;
+
 namespace QuantLib {
 
     VannaVolgaDoubleBarrierEngine::VannaVolgaDoubleBarrierEngine(

--- a/QuantLib/ql/experimental/barrieroption/vannavolgainterpolation.hpp
+++ b/QuantLib/ql/experimental/barrieroption/vannavolgainterpolation.hpp
@@ -62,14 +62,14 @@ namespace QuantLib {
             }
             Real value(Real k) const {
                 Real x1 = vega(k)/vegas[0] 
-                    * (log(this->xBegin_[1]/k) * log(this->xBegin_[2]/k))
-                    / (log(this->xBegin_[1]/this->xBegin_[0]) * log(this->xBegin_[2]/this->xBegin_[0]));
+                    * (std::log(this->xBegin_[1]/k) * std::log(this->xBegin_[2]/k))
+                    / (std::log(this->xBegin_[1]/this->xBegin_[0]) * std::log(this->xBegin_[2]/this->xBegin_[0]));
                 Real x2 = vega(k)/vegas[1]
-                    * (log(k/this->xBegin_[0]) * log(this->xBegin_[2]/k))
-                    / (log(this->xBegin_[1]/this->xBegin_[0]) * log(this->xBegin_[2]/this->xBegin_[1]));
+                    * (std::log(k/this->xBegin_[0]) * std::log(this->xBegin_[2]/k))
+                    / (std::log(this->xBegin_[1]/this->xBegin_[0]) * std::log(this->xBegin_[2]/this->xBegin_[1]));
                 Real x3 = vega(k)/vegas[2]
-                    * (log(k/this->xBegin_[0]) * log(k/this->xBegin_[1]))
-                    / (log(this->xBegin_[2]/this->xBegin_[0]) * log(this->xBegin_[2]/this->xBegin_[1]));
+                    * (std::log(k/this->xBegin_[0]) * std::log(k/this->xBegin_[1]))
+                    / (std::log(this->xBegin_[2]/this->xBegin_[0]) * std::log(this->xBegin_[2]/this->xBegin_[1]));
 
                 Real cBS = blackFormula(Option::Call, k, fwd_, atmVol_ * std::sqrt(T_), dDiscount_);
                 Real c = cBS + x1*(premiaMKT[0] - premiaBS[0]) + x2*(premiaMKT[1] - premiaBS[1]) + x3*(premiaMKT[2] - premiaBS[2]);

--- a/QuantLib/ql/experimental/catbonds/catrisk.cpp
+++ b/QuantLib/ql/experimental/catbonds/catrisk.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     namespace {
         Integer round(Real r) {
-            return (r > 0.0) ? Integer(floor(r + 0.5)) : Integer(ceil(r - 0.5));
+            return (r > 0.0) ? Integer(std::floor(r + 0.5)) : Integer(std::ceil(r - 0.5));
         }
     }
 

--- a/QuantLib/ql/experimental/coupons/lineartsrpricer.hpp
+++ b/QuantLib/ql/experimental/coupons/lineartsrpricer.hpp
@@ -136,7 +136,7 @@ namespace QuantLib {
           public:
             VegaRatioHelper(const SmileSection *section, const Real targetVega)
                 : section_(section), targetVega_(targetVega) {}
-            double operator()(double strike) const {
+            Real operator()(Real strike) const {
                 return section_->vega(strike) - targetVega_;
             };
             const SmileSection *section_;
@@ -148,7 +148,7 @@ namespace QuantLib {
             PriceHelper(const SmileSection *section, const Option::Type type,
                         const Real targetPrice)
                 : section_(section), targetPrice_(targetPrice), type_(type) {}
-            double operator()(double strike) const {
+            Real operator()(Real strike) const {
                 return section_->optionPrice(strike, type_) - targetPrice_;
             };
             const SmileSection *section_;

--- a/QuantLib/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/QuantLib/ql/experimental/coupons/subperiodcoupons.cpp
@@ -161,7 +161,7 @@ namespace QuantLib {
         // past or future fixing is managed in InterestRateIndex::fixing()
 
         Size nCount = initialValues_.size();
-        double dAvgRate = 0.0, dTotalCvg = 0.0, dTotalPayment = 0.0;
+        Real dAvgRate = 0.0, dTotalCvg = 0.0, dTotalPayment = 0.0;
         for (Size i=0; i<nCount; i++) {
             dTotalPayment += initialValues_[i] * observationCvg_[i];
             dTotalCvg += observationCvg_[i];
@@ -176,10 +176,10 @@ namespace QuantLib {
     Real CompoundingRatePricer::swapletPrice() const {
         // past or future fixing is managed in InterestRateIndex::fixing()
 
-        double dNotional = 1.0;
+        Real dNotional = 1.0;
 
         Size nCount = initialValues_.size();
-        double dCompRate = 0.0, dTotalCvg = 0.0, dTotalPayment = 0.0;
+        Real dCompRate = 0.0, dTotalCvg = 0.0, dTotalPayment = 0.0;
         for (Size i=0; i<nCount; i++) {
             dTotalPayment = initialValues_[i] * observationCvg_[i]*dNotional;
             dNotional += dTotalPayment;

--- a/QuantLib/ql/experimental/credit/binomiallossmodel.hpp
+++ b/QuantLib/ql/experimental/credit/binomiallossmodel.hpp
@@ -182,7 +182,7 @@ namespace QuantLib {
             bsktNots.begin(), std::back_inserter(lgdsLeft), 
             std::multiplies<Real>());
         Real avgLgd = 
-            std::accumulate(lgdsLeft.begin(), lgdsLeft.end(), 0.) / bsktSize;
+            std::accumulate(lgdsLeft.begin(), lgdsLeft.end(), Real(0.)) / bsktSize;
 
         std::vector<Probability> condDefProb(bsktSize, 0.);
         for(Size j=0; j<bsktSize; j++)//transform
@@ -272,12 +272,12 @@ namespace QuantLib {
         */
         std::vector<Real> fractionalEL = expConditionalLgd(d, mktFctrs);
         Real notBskt = std::accumulate(reminingNots.begin(), 
-            reminingNots.end(), 0.);
+            reminingNots.end(), Real(0.));
         std::vector<Real> lgdsLeft;
         std::transform(fractionalEL.begin(), fractionalEL.end(), 
             reminingNots.begin(), std::back_inserter(lgdsLeft),
             boost::lambda::_1 * boost::lambda::_2 / notBskt);
-        return std::accumulate(lgdsLeft.begin(), lgdsLeft.end(), 0.) 
+        return std::accumulate(lgdsLeft.begin(), lgdsLeft.end(), Real(0.)) 
             / bsktSize;
     }
 

--- a/QuantLib/ql/experimental/credit/binomiallossmodel.hpp
+++ b/QuantLib/ql/experimental/credit/binomiallossmodel.hpp
@@ -196,7 +196,7 @@ namespace QuantLib {
                 / (avgLgd * bsktSize);
         // model parameters:
         Real m = avgProb * bsktSize;
-        Real floorAveProb = std::min(Real(bsktSize-1), floor(Real(m)));
+        Real floorAveProb = std::min(Real(bsktSize-1), std::floor(Real(m)));
         Real ceilAveProb = floorAveProb + 1.;
         // nu_A
         Real varianceBinom = avgProb * (1. - avgProb)/bsktSize;

--- a/QuantLib/ql/experimental/credit/gaussianlhplossmodel.cpp
+++ b/QuantLib/ql/experimental/credit/gaussianlhplossmodel.cpp
@@ -22,6 +22,8 @@
 
 #include <boost/make_shared.hpp>
 
+using std::sqrt;
+
 namespace QuantLib {
 
     CumulativeNormalDistribution const GaussianLHPLossModel::phi_ = 

--- a/QuantLib/ql/experimental/credit/gaussianlhplossmodel.hpp
+++ b/QuantLib/ql/experimental/credit/gaussianlhplossmodel.hpp
@@ -73,8 +73,8 @@ namespace QuantLib {
             const std::vector<Real>& recoveries);
 
         void update() {
-            sqrt1minuscorrel_ = sqrt(1.-correl_->value());
-            beta_ = sqrt(correl_->value());
+            sqrt1minuscorrel_ = std::sqrt(1.-correl_->value());
+            beta_ = std::sqrt(correl_->value());
             biphi_ = BivariateCumulativeNormalDistribution(
                 -beta_);
             // tell basket to notify instruments, etc, we are invalid

--- a/QuantLib/ql/experimental/credit/integralntdengine.cpp
+++ b/QuantLib/ql/experimental/credit/integralntdengine.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
                         d);
                 Probability defaultProb = 
                     std::accumulate(probsTriggering.begin(), 
-                    probsTriggering.end(), 0.);
+                    probsTriggering.end(), Real(0.));
                 // OVERKILL???? 1-probAtleastNevents is enough
 
 */
@@ -87,7 +87,7 @@ namespace QuantLib {
                         d0);
                 Probability defProb0 = std::accumulate(probsTriggering.begin(), 
                 ///OVERKILL????
-                    probsTriggering.end(), 0.);
+                    probsTriggering.end(), Real(0.));
 */
                 Probability defProb0 = arguments_.basket->probAtLeastNEvents(
                         arguments_.ntdOrder, d0);
@@ -110,7 +110,7 @@ namespace QuantLib {
                             arguments_.basket->probsBeingNthEvent(
                                 arguments_.ntdOrder, d);
                         defProb1 = std::accumulate(probsTriggering1.begin(), 
-                            probsTriggering1.end(), 0.);
+                            probsTriggering1.end(), Real(0.));
                         /*Recoveries might differ along names, depending on 
                         which name is triggering the contract the loss will be 
                         different  

--- a/QuantLib/ql/experimental/credit/lossdistribution.cpp
+++ b/QuantLib/ql/experimental/credit/lossdistribution.cpp
@@ -307,7 +307,7 @@ namespace QuantLib {
         // LecuyerUniformRng rng(seed_);
         MersenneTwisterUniformRng rng(seed_);
         for (Size i = 0; i < simulations_; i++) {
-            double e = 0;
+            Real e = 0;
             for (Size j = 0; j < nominals.size(); j++) {
                 Real r = rng.next().value;
                 if (r <= probabilities[j])

--- a/QuantLib/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/QuantLib/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -490,7 +490,7 @@ namespace QuantLib {
                 losses.end())) / static_cast<Real>(nSims_);
 
         return ( perctlInf * (1.-percent-probOverQ) +//<-correction term
-            std::accumulate(losses.begin() + position, losses.end(), 0.)/nSims_
+            std::accumulate(losses.begin() + position, losses.end(), Real(0.))/nSims_
                 )/(1.-percent);
 
         /* Alternative ESF definition; find the first loss larger than the

--- a/QuantLib/ql/experimental/credit/riskyassetswap.cpp
+++ b/QuantLib/ql/experimental/credit/riskyassetswap.cpp
@@ -122,7 +122,7 @@ namespace QuantLib {
             do {
                 Real disc = yieldTS_->discount (d);
                 Real dd   = defaultTS_->defaultDensity (d, true);
-                double dcf  = defaultTS_->dayCounter().yearFraction (d0, d);
+                Real dcf  = defaultTS_->dayCounter().yearFraction (d0, d);
 
                 recoveryValue  += disc * dd * dcf;
 

--- a/QuantLib/ql/experimental/credit/riskyassetswap.cpp
+++ b/QuantLib/ql/experimental/credit/riskyassetswap.cpp
@@ -120,8 +120,8 @@ namespace QuantLib {
                 d = defaultTS_->referenceDate();
             Date d0 = d;
             do {
-                double disc = yieldTS_->discount (d);
-                double dd   = defaultTS_->defaultDensity (d, true);
+                Real disc = yieldTS_->discount (d);
+                Real dd   = defaultTS_->defaultDensity (d, true);
                 double dcf  = defaultTS_->dayCounter().yearFraction (d0, d);
 
                 recoveryValue  += disc * dd * dcf;

--- a/QuantLib/ql/experimental/exoticoptions/analyticcomplexchooserengine.cpp
+++ b/QuantLib/ql/experimental/exoticoptions/analyticcomplexchooserengine.cpp
@@ -22,6 +22,10 @@
 #include <ql/exercise.hpp>
 #include <boost/make_shared.hpp>
 
+using std::pow;
+using std::log;
+using std::exp;
+
 namespace QuantLib {
 
     AnalyticComplexChooserEngine::AnalyticComplexChooserEngine(

--- a/QuantLib/ql/experimental/exoticoptions/analyticcomplexchooserengine.cpp
+++ b/QuantLib/ql/experimental/exoticoptions/analyticcomplexchooserengine.cpp
@@ -25,6 +25,7 @@
 using std::pow;
 using std::log;
 using std::exp;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/QuantLib/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -25,6 +25,7 @@
 using std::pow;
 using std::log;
 using std::exp;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/QuantLib/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -22,6 +22,10 @@
 #include <ql/exercise.hpp>
 #include <boost/make_shared.hpp>
 
+using std::pow;
+using std::log;
+using std::exp;
+
 namespace QuantLib {
 
     AnalyticHolderExtensibleOptionEngine::AnalyticHolderExtensibleOptionEngine(

--- a/QuantLib/ql/experimental/exoticoptions/analytictwoassetcorrelationengine.cpp
+++ b/QuantLib/ql/experimental/exoticoptions/analytictwoassetcorrelationengine.cpp
@@ -21,6 +21,8 @@
 #include <ql/math/distributions/bivariatenormaldistribution.hpp>
 #include <ql/exercise.hpp>
 
+using std::log;
+
 namespace QuantLib {
 
     AnalyticTwoAssetCorrelationEngine::AnalyticTwoAssetCorrelationEngine(

--- a/QuantLib/ql/experimental/math/adaptiverungekutta.hpp
+++ b/QuantLib/ql/experimental/math/adaptiverungekutta.hpp
@@ -104,7 +104,7 @@ namespace QuantLib {
         const Real a2,a3,a4,a5,a6,
                    b21,b31,b32,b41,b42,b43,b51,b52,b53,b54,b61,b62,b63,b64,b65,
                    c1,c3,c4,c6,dc1,dc3,dc4,dc5,dc6;
-        const Real ADAPTIVERK_MAXSTP, ADAPTIVERK_TINY, ADAPTIVERK_SAFETY,
+        const double ADAPTIVERK_MAXSTP, ADAPTIVERK_TINY, ADAPTIVERK_SAFETY,
                    ADAPTIVERK_PGROW, ADAPTIVERK_PSHRINK, ADAPTIVERK_ERRCON;
     };
 

--- a/QuantLib/ql/experimental/math/adaptiverungekutta.hpp
+++ b/QuantLib/ql/experimental/math/adaptiverungekutta.hpp
@@ -192,7 +192,7 @@ namespace QuantLib {
                 errmax=std::max(errmax,std::abs(yerr[i]/yScale[i]));
             errmax/=eps;
             if (errmax>1.0) {
-                htemp=ADAPTIVERK_SAFETY*h*pow(errmax,ADAPTIVERK_PSHRINK);
+                htemp=ADAPTIVERK_SAFETY*h*std::pow(errmax,ADAPTIVERK_PSHRINK);
                 h = (h>=0.0 ? std::max(htemp,h/10) : std::min(htemp,h/10));
                 xnew=x+h;
                 if (xnew==x)
@@ -201,7 +201,7 @@ namespace QuantLib {
                 continue;
             } else {
                 if (errmax>ADAPTIVERK_ERRCON)
-                    hnext=ADAPTIVERK_SAFETY*h*pow(errmax,ADAPTIVERK_PGROW);
+                    hnext=ADAPTIVERK_SAFETY*h*std::pow(errmax,ADAPTIVERK_PGROW);
                 else
                     hnext=5.0*h;
                 x+=(hdid=h);

--- a/QuantLib/ql/experimental/math/gaussiancopulapolicy.hpp
+++ b/QuantLib/ql/experimental/math/gaussiancopulapolicy.hpp
@@ -87,7 +87,7 @@ namespace QuantLib {
           depending on those values.
         */
         Probability density(const std::vector<Real>& m) const {
-            return std::accumulate(m.begin(), m.end(), 1., 
+            return std::accumulate(m.begin(), m.end(), Real(1.), 
                 boost::bind(std::multiplies<Real>(), _1, 
                     boost::bind(density_, _2)));
         }

--- a/QuantLib/ql/experimental/mcbasket/longstaffschwartzmultipathpricer.cpp
+++ b/QuantLib/ql/experimental/mcbasket/longstaffschwartzmultipathpricer.cpp
@@ -230,9 +230,9 @@ namespace QuantLib {
                always is absolute: regardless of the lowerBoundContinuationValue_ (this could be changed)
                but it still honours "canExercise"
              */
-            double sumOptimized = 0.0;
-            double sumNoExercise = 0.0;
-            double sumAlwaysExercise = 0.0; // always, if allowed
+            Real sumOptimized = 0.0;
+            Real sumNoExercise = 0.0;
+            Real sumAlwaysExercise = 0.0; // always, if allowed
 
             for (Size j = 0, k = 0; j < n; ++j) {
                 sumNoExercise += prices[j];

--- a/QuantLib/ql/experimental/models/basketgeneratingengine.cpp
+++ b/QuantLib/ql/experimental/models/basketgeneratingengine.cpp
@@ -26,6 +26,9 @@
 #include <ql/quotes/simplequote.hpp>
 #include <boost/make_shared.hpp>
 
+using std::exp;
+using std::fabs;
+
 namespace QuantLib {
 
     Disposable<std::vector<boost::shared_ptr<CalibrationHelper> > >

--- a/QuantLib/ql/experimental/models/basketgeneratingengine.hpp
+++ b/QuantLib/ql/experimental/models/basketgeneratingengine.hpp
@@ -151,10 +151,10 @@ namespace QuantLib {
                 // transformations
                 int type = type_; // start with same type as non standard
                                   // underlying (1 means payer, -1 receiver)
-                Real nominal = fabs(v[0]);
+                Real nominal = std::fabs(v[0]);
                 if (v[0] < 0.0)
                     type *= -1;
-                Real maturity = std::min(fabs(v[1]), maxMaturity_);
+                Real maturity = std::min(std::fabs(v[1]), maxMaturity_);
 
                 Real fixedRate = v[2]; // allow for negative rates explicitly
                 // (though it might not be reasonable for calibration depending

--- a/QuantLib/ql/experimental/models/gaussian1dmodel.cpp
+++ b/QuantLib/ql/experimental/models/gaussian1dmodel.cpp
@@ -20,6 +20,8 @@
 
 #include <ql/experimental/models/gaussian1dmodel.hpp>
 
+using std::exp;
+
 namespace QuantLib {
 
     const Real

--- a/QuantLib/ql/experimental/models/gaussian1dnonstandardswaptionengine.cpp
+++ b/QuantLib/ql/experimental/models/gaussian1dnonstandardswaptionengine.cpp
@@ -23,6 +23,8 @@
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/quotes/simplequote.hpp>
 
+using std::exp;
+
 namespace QuantLib {
 
     const Real

--- a/QuantLib/ql/experimental/models/gsr.cpp
+++ b/QuantLib/ql/experimental/models/gsr.cpp
@@ -198,7 +198,7 @@ namespace QuantLib {
                                    termStructure()->discount(t, true)
                              : yts->discount(T, true) / yts->discount(t, true);
 
-        return d * exp(-x * gtT - 0.5 * p->y(t) * gtT * gtT);
+        return d * std::exp(-x * gtT - 0.5 * p->y(t) * gtT * gtT);
     }
 
     const Real Gsr::numeraireImpl(const Time t, const Real y,

--- a/QuantLib/ql/experimental/models/gsrprocess.cpp
+++ b/QuantLib/ql/experimental/models/gsrprocess.cpp
@@ -19,6 +19,9 @@
 
 #include <ql/experimental/models/gsrprocess.hpp>
 
+using std::exp;
+using std::pow;
+
 namespace QuantLib {
 
     GsrProcess::GsrProcess(const Array &times, const Array &vols,

--- a/QuantLib/ql/experimental/models/gsrprocess.cpp
+++ b/QuantLib/ql/experimental/models/gsrprocess.cpp
@@ -21,6 +21,7 @@
 
 using std::exp;
 using std::pow;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/experimental/models/kahalesmilesection.cpp
+++ b/QuantLib/ql/experimental/models/kahalesmilesection.cpp
@@ -19,6 +19,8 @@
 
 #include <ql/experimental/models/kahalesmilesection.hpp>
 
+using std::sqrt;
+
 namespace QuantLib {
 
     KahaleSmileSection::KahaleSmileSection(

--- a/QuantLib/ql/experimental/models/kahalesmilesection.hpp
+++ b/QuantLib/ql/experimental/models/kahalesmilesection.hpp
@@ -69,7 +69,7 @@ namespace QuantLib {
                 if (s_ < QL_EPSILON)
                     return std::max(f_ - k, 0.0) + a_ * k + b_;
                 boost::math::normal normal;
-                Real d1 = log(f_ / k) / s_ + s_ / 2.0;
+                Real d1 = std::log(f_ / k) / s_ + s_ / 2.0;
                 Real d2 = d1 - s_;
                 return f_ * boost::math::cdf(normal, d1) -
                        k * boost::math::cdf(normal, d2) + a_ * k + b_;
@@ -85,10 +85,10 @@ namespace QuantLib {
                 boost::math::normal normal;
                 Real d20 = boost::math::quantile(normal, -c0p_ + a);
                 Real d21 = boost::math::quantile(normal, -c1p_ + a);
-                Real alpha = (d20 - d21) / (log(k0_) - log(k1_));
-                Real beta = d20 - alpha * log(k0_);
+                Real alpha = (d20 - d21) / (std::log(k0_) - std::log(k1_));
+                Real beta = d20 - alpha * std::log(k0_);
                 s_ = -1.0 / alpha;
-                f_ = exp(s_ * (beta + s_ / 2.0));
+                f_ = std::exp(s_ * (beta + s_ / 2.0));
                 QL_REQUIRE(f_ < QL_KAHALE_FMAX, "dummy"); // this is caught
                 cFunction cTmp(f_, s_, a, 0.0);
                 b_ = c0_ - cTmp(k0_);
@@ -105,7 +105,7 @@ namespace QuantLib {
                 s = std::max(s, 0.0);
                 boost::math::normal normal;
                 Real d20 = boost::math::quantile(normal, -c0p_);
-                f_ = k0_ * exp(s * d20 + s * s / 2.0);
+                f_ = k0_ * std::exp(s * d20 + s * s / 2.0);
                 QL_REQUIRE(f_ < QL_KAHALE_FMAX, "dummy"); // this is caught
                 cFunction c(f_, s, 0.0, 0.0);
                 return c(k0_) - c0_;
@@ -121,7 +121,7 @@ namespace QuantLib {
                 s = std::max(s, 0.0);
                 boost::math::normal normal;
                 Real d21 = boost::math::quantile(normal, -c1p_);
-                f_ = k1_ * exp(s * d21 + s * s / 2.0);
+                f_ = k1_ * std::exp(s * d21 + s * s / 2.0);
                 QL_REQUIRE(f_ < QL_KAHALE_FMAX, "dummy"); // this is caught
                 b_ = c0_ - f_;
                 cFunction c(f_, s, 0.0, b_);

--- a/QuantLib/ql/experimental/models/markovfunctional.cpp
+++ b/QuantLib/ql/experimental/models/markovfunctional.cpp
@@ -144,7 +144,7 @@ namespace QuantLib {
         normalIntegralW_ = gaussHermite.weights();
         for (Size i = 0; i < normalIntegralX_.size(); i++) {
             normalIntegralW_[i] *=
-                exp(-normalIntegralX_[i] * normalIntegralX_[i]) * M_1_SQRTPI;
+                std::exp(-normalIntegralX_[i] * normalIntegralX_[i]) * M_1_SQRTPI;
             normalIntegralX_[i] *= M_SQRT2;
         }
 

--- a/QuantLib/ql/experimental/models/markovfunctional.hpp
+++ b/QuantLib/ql/experimental/models/markovfunctional.hpp
@@ -423,7 +423,7 @@ namespace QuantLib {
                        const CalibrationPoint &p, const Real marketPrice)
                 : model_(model), marketPrice_(marketPrice), expiry_(expiry),
                   p_(p) {}
-            double operator()(double strike) const {
+            Real operator()(Real strike) const {
                 Real modelPrice = model_->marketDigitalPrice(
                     expiry_, p_, Option::Call, strike);
                 return modelPrice - marketPrice_;

--- a/QuantLib/ql/experimental/models/mfstateprocess.cpp
+++ b/QuantLib/ql/experimental/models/mfstateprocess.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
         Size j = std::upper_bound(times_.begin(), times_.end(), t + dt) -
                  times_.begin();
 
-        double v = 0.0;
+        Real v = 0.0;
 
         for (Size k = i; k < j; k++) {
             if (reversionZero_)

--- a/QuantLib/ql/experimental/models/mfstateprocess.cpp
+++ b/QuantLib/ql/experimental/models/mfstateprocess.cpp
@@ -21,7 +21,7 @@
 
 namespace QuantLib {
 
-    MfStateProcess::MfStateProcess(double reversion, const Array &times,
+    MfStateProcess::MfStateProcess(Real reversion, const Array &times,
                                    const Array &vols)
         : reversion_(reversion), reversionZero_(false), times_(times),
           vols_(vols) {

--- a/QuantLib/ql/experimental/models/mfstateprocess.hpp
+++ b/QuantLib/ql/experimental/models/mfstateprocess.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
     */
     class MfStateProcess : public StochasticProcess1D {
       public:
-        MfStateProcess(double reversion, const Array &times, const Array &vols);
+        MfStateProcess(Real reversion, const Array &times, const Array &vols);
 
         //! \name StochasticProcess interface
         //@{

--- a/QuantLib/ql/experimental/risk/creditriskplus.cpp
+++ b/QuantLib/ql/experimental/risk/creditriskplus.cpp
@@ -121,7 +121,7 @@ namespace QuantLib {
         std::map<unsigned long, Real, std::less<unsigned long> >::iterator iter;
 
         for (Size k = 0; k < m_; ++k) {
-            unsigned long exUnit = (unsigned long)(floor(0.5 + exposure_[k] / unit_)); // round
+            unsigned long exUnit = (unsigned long)(std::floor(0.5 + exposure_[k] / unit_)); // round
             if (exposure_[k] > 0 && exUnit == 0)
                 exUnit = 1; // but avoid zero exposure
             if (exUnit > maxNu_)

--- a/QuantLib/ql/experimental/risk/creditriskplus.cpp
+++ b/QuantLib/ql/experimental/risk/creditriskplus.cpp
@@ -20,6 +20,8 @@
 #include <ql/experimental/risk/creditriskplus.hpp>
 #include <map>
 
+using std::sqrt;
+
 namespace QuantLib {
 
     CreditRiskPlus::CreditRiskPlus(

--- a/QuantLib/ql/experimental/risk/creditriskplus.cpp
+++ b/QuantLib/ql/experimental/risk/creditriskplus.cpp
@@ -211,7 +211,7 @@ namespace QuantLib {
         // compute loss distribution
 
         loss_.clear();
-        loss_.push_back(pow(1.0 - pC_, alphaC_)); // A(0)
+        loss_.push_back(std::pow(1.0 - pC_, alphaC_)); // A(0)
 
         Real res;
         for (unsigned long n = 0; n < upperIndex_ - 1; ++n) { // compute A(n+1)

--- a/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
     typedef std::complex<Real> Complex;
 
     Real IvopOneDim(Real eps, Real chi, Real theta, Real /*rho*/,
-                      Real v0, Real eprice, double tau, Real rtax)
+                      Real v0, Real eprice, Time tau, Real rtax)
     {
         Real ss=0.0;
         boost::scoped_array<double> xiv(new double[2048*2048+1]);

--- a/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -347,7 +347,7 @@ namespace {
         boost::shared_ptr<QuantLib::Payoff> payoff;
         payoff_adapter(boost::shared_ptr<QuantLib::Payoff> payoff)
         : payoff(payoff) {}
-        double operator()(double S) const {
+        Real operator()(double S) const {
             return (*payoff)(S);
         }
     };

--- a/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -196,7 +196,7 @@ namespace QuantLib {
 
 
     Real IvopTwoDim(Real eps, Real chi, Real theta, Real /*rho*/,
-                    Real v0, double tau, Real rtax,
+                    Real v0, Time tau, Real rtax,
                     const boost::function<Real(Real)>& payoff) {
 
         Real ss=0.0;

--- a/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/QuantLib/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -27,7 +27,7 @@
 #include <boost/scoped_array.hpp>
 #include <complex>
 
-namespace {
+namespace QuantLib {
 
     /*
      *****************************************************************
@@ -49,18 +49,18 @@ namespace {
      ****************************************************************
      */
 
-    typedef std::complex<double> Complex;
+    typedef std::complex<Real> Complex;
 
-    double IvopOneDim(double eps, double chi, double theta, double /*rho*/,
-                      double v0, double eprice, double tau, double rtax)
+    Real IvopOneDim(Real eps, Real chi, Real theta, Real /*rho*/,
+                      Real v0, Real eprice, double tau, Real rtax)
     {
-        double ss=0.0;
+        Real ss=0.0;
         boost::scoped_array<double> xiv(new double[2048*2048+1]);
         double nris=0.0;
         int j=0,mm=0;
         double pi=0,pi2=0;
         double dstep=0;
-        double option=0, impart=0;
+        Real option=0, impart=0;
 
         boost::scoped_array<Complex> ff(new Complex[2048*2048]);
         Complex xi;
@@ -74,7 +74,7 @@ namespace {
          **   i0: initial integrated variance i0=0
          **********************************************************
          */
-        double i0=0.0;
+        Real i0=0.0;
         //s=2.0*chi*theta/(eps*eps)-1.0;
 
         //s=s+1;
@@ -87,7 +87,7 @@ namespace {
 
         pi= 3.14159265358979324;
         pi2=2.0*pi;
-        double s=2.0*chi*theta/(eps*eps)-1.0;
+        Real s=2.0*chi*theta/(eps*eps)-1.0;
         /*
          ****************************************
          ** Note that s must be greater than zero
@@ -195,23 +195,23 @@ namespace {
 
 
 
-    double IvopTwoDim(double eps, double chi, double theta, double /*rho*/,
-                    double v0, double tau, double rtax,
-                    const boost::function<double(double)>& payoff) {
+    Real IvopTwoDim(Real eps, Real chi, Real theta, Real /*rho*/,
+                    Real v0, double tau, Real rtax,
+                    const boost::function<Real(Real)>& payoff) {
 
-        double ss=0.0;
+        Real ss=0.0;
         boost::scoped_array<double> xiv(new double[2048*2048+1]);
-        boost::scoped_array<double> ivet(new double[2048*2048+1]);
+        boost::scoped_array<double> ivet(new double[2048 * 2048 + 1]);
         double nris=0.0;
         int j=0,mm=0,k=0;
         double pi=0,pi2=0;
 
         double dstep=0;
-        double ip=0;
-        double payoffval=0;
-        double option=0/*, impart=0*/;
+        Real ip=0;
+        Real payoffval=0;
+        Real option=0/*, impart=0*/;
 
-        double sumr=0;//,sumi=0;
+        Real sumr=0;//,sumi=0;
         Complex dxi,z;
 
         boost::scoped_array<Complex> ff(new Complex[2048*2048]);
@@ -226,7 +226,7 @@ namespace {
          **   i0: initial integrated variance i0=0
          **********************************************************
          */
-        double i0=0.0;
+        Real i0=0.0;
 
         /*
          *************************************************
@@ -237,7 +237,7 @@ namespace {
         pi= 3.14159265358979324;
         pi2=2.0*pi;
 
-        double s=2.0*chi*theta/(eps*eps)-1.0;
+        Real s=2.0*chi*theta/(eps*eps)-1.0;
         /*
          ****************************************
          ** Note that s must be greater than zero
@@ -347,7 +347,7 @@ namespace {
         boost::shared_ptr<QuantLib::Payoff> payoff;
         payoff_adapter(boost::shared_ptr<QuantLib::Payoff> payoff)
         : payoff(payoff) {}
-        Real operator()(double S) const {
+        Real operator()(Real S) const {
             return (*payoff)(S);
         }
     };

--- a/QuantLib/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
+++ b/QuantLib/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
         const std::vector<Date> fixingDates = process->fixingDates();
 
         for (Size i = 1; i < size_; ++i) {
-            double cumVar = 0.0;
+            Real cumVar = 0.0;
             for (Size j = 1; j < i; ++j) {
                 cumVar +=  lambda[i-j-1] * lambda[i-j-1]
                          * (fixingTimes[j+1] - fixingTimes[j]);

--- a/QuantLib/ql/math/copulas/plackettcopula.cpp
+++ b/QuantLib/ql/math/copulas/plackettcopula.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
         QL_REQUIRE(y >= 0.0 && y <=1.0 ,
                    "2nd argument (" << y << ") must be in [0,1]");
         using namespace std;
-        return ((1.0+(theta_-1.0)*(x+y))-sqrt(pow(1.0+(theta_-1.0)*(x+y),2.0)-4.0*x*y*theta_*(theta_-1.0)))/(2.0*(theta_-1.0));
+        return ((1.0+(theta_-1.0)*(x+y))-sqrt(std::pow(1.0+(theta_-1.0)*(x+y),2.0)-4.0*x*y*theta_*(theta_-1.0)))/(2.0*(theta_-1.0));
     }
 
 }

--- a/QuantLib/ql/math/curve.hpp
+++ b/QuantLib/ql/math/curve.hpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
     class TestCurve : public Curve {
     public:
-        Real operator()(Real x) const { return sin(x); }
+        Real operator()(Real x) const { return std::sin(x); }
     };
 
 }

--- a/QuantLib/ql/math/integrals/gaussianorthogonalpolynomial.cpp
+++ b/QuantLib/ql/math/integrals/gaussianorthogonalpolynomial.cpp
@@ -107,7 +107,7 @@ namespace QuantLib {
         Real denom = (2.0*i+alpha_+beta_)*(2.0*i+alpha_+beta_+2);
 
         if (!denom) {
-            if (num) {
+            if (num != 0.0) {
                 QL_FAIL("can't compute a_k for jacobi integration\n");
             }
             else {
@@ -128,7 +128,7 @@ namespace QuantLib {
                    * ((2.0*i+alpha_+beta_)*(2.0*i+alpha_+beta_)-1);
 
         if (!denom) {
-            if (num) {
+            if (num != 0.0) {
                 QL_FAIL("can't compute b_k for jacobi integration\n");
             } else {
                 // l'Hospital

--- a/QuantLib/ql/math/integrals/gausslobattointegral.cpp
+++ b/QuantLib/ql/math/integrals/gausslobattointegral.cpp
@@ -138,7 +138,7 @@ namespace QuantLib {
         
         // avoid 80 bit logic on x86 cpu
         volatile Real dist = acc + (integral1-integral2);
-        if(dist==acc || mll<=a || b<=mrr) {
+        if(Real(dist)==acc || mll<=a || b<=mrr) {
             QL_REQUIRE(m>a && b>m,"Interval contains no more machine number");
             return integral1;
         }

--- a/QuantLib/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/QuantLib/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -411,7 +411,7 @@ namespace QuantLib {
                     Real dAv = bAv*bAv - 4.0*aAv*cAv;
                     if (dAv >= 0.0) {
                         splitRegion_ = true;
-                        Real avRoot = (-bAv - sqrt(dAv))/(2*aAv);
+                        Real avRoot = (-bAv - std::sqrt(dAv))/(2*aAv);
 
                         xRatio_ = fAverage_ / avRoot;
                         xScaling_ *= xRatio_;

--- a/QuantLib/ql/math/linearleastsquaresregression.hpp
+++ b/QuantLib/ql/math/linearleastsquaresregression.hpp
@@ -52,7 +52,7 @@ namespace QuantLib {
           public:
             typedef typename xContainer::value_type ArgumentType;
             LinearFcts (const xContainer &x, Real intercept) {
-                if (intercept)
+                if (intercept != 0.0)
                     v.push_back(constant<ArgumentType, Real>(intercept));
                 v.push_back(identity<ArgumentType>());
             }
@@ -71,7 +71,7 @@ namespace QuantLib {
           public:
             typedef typename xContainer::value_type ArgumentType;
             LinearFcts (const xContainer &x, Real intercept) {
-                if (intercept)
+                if (intercept != 0.0)
                     v.push_back(constant<ArgumentType, Real>(intercept));
                 Size m = x.begin()->size();
                 for (Size i = 0; i < m; ++i)

--- a/QuantLib/ql/math/matrixutilities/pseudosqrt.cpp
+++ b/QuantLib/ql/math/matrixutilities/pseudosqrt.cpp
@@ -489,7 +489,7 @@ namespace QuantLib {
         // factor reduction
         Real enough = componentRetainedPercentage *
                       std::accumulate(eigenValues.begin(),
-                                      eigenValues.end(), 0.0);
+                                      eigenValues.end(), Real(0.0));
         if (componentRetainedPercentage == 1.0) {
             // numerical glitches might cause some factors to be discarded
             enough *= 1.1;

--- a/QuantLib/ql/math/matrixutilities/qrdecomposition.cpp
+++ b/QuantLib/ql/math/matrixutilities/qrdecomposition.cpp
@@ -34,8 +34,8 @@ namespace QuantLib {
         const Size n = M.columns();
 
         boost::scoped_array<int> lipvt(new int[n]);
-        boost::scoped_array<double> rdiag(new double[n]);
-        boost::scoped_array<double> wa(new double[n]);
+        boost::scoped_array<Real> rdiag(new Real[n]);
+        boost::scoped_array<Real> wa(new Real[n]);
 
         MINPACK::qrfac(m, n, mT.begin(), 0, (pivot)?1:0,
                        lipvt.get(), n, rdiag.get(), rdiag.get(), wa.get());
@@ -108,8 +108,8 @@ namespace QuantLib {
         Matrix aT = transpose(a);
         Matrix rT = transpose(r);
 
-        boost::scoped_array<double> sdiag(new double[n]);
-        boost::scoped_array<double> wa(new double[n]);
+        boost::scoped_array<Real> sdiag(new Real[n]);
+        boost::scoped_array<Real> wa(new Real[n]);
 
         Array ld(n, 0.0);
         if (!d.empty()) {

--- a/QuantLib/ql/math/optimization/bfgs.cpp
+++ b/QuantLib/ql/math/optimization/bfgs.cpp
@@ -43,8 +43,8 @@ namespace QuantLib {
             for (Size j = 0; j < P.currentValue().size(); ++j)
                 diffGradientWithHessianApplied[i] += inverseHessian_[i][j] * diffGradient[j];
 
-        double fac, fae, fad;
-        double sumdg, sumxi;
+        Real fac, fae, fad;
+        Real sumdg, sumxi;
 
         fac = fae = sumdg = sumxi = 0.;
         for (Size i = 0; i < P.currentValue().size(); ++i)

--- a/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
+++ b/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
         initCostValues_ = P.costFunction().values(x_);
         int m = initCostValues_.size();
         int n = x_.size();
-        boost::scoped_array<double> xx(new double[n]);
+        boost::scoped_array<double> xx(new Real[n]);
         std::copy(x_.begin(), x_.end(), xx.get());
         boost::scoped_array<double> fvec(new double[m]);
         boost::scoped_array<double> diag(new double[n]);
@@ -83,11 +83,11 @@ namespace QuantLib {
         MINPACK::LmdifCostFunction lmdifCostFunction = 
             boost::bind(&LevenbergMarquardt::fcn, this, _1, _2, _3, _4, _5);
         MINPACK::lmdif(m, n, xx.get(), fvec.get(),
-                       static_cast<double>(endCriteria.functionEpsilon()),
-                       static_cast<double>(xtol_),
-                       static_cast<double>(gtol_),
-                       static_cast<int>(endCriteria.maxIterations()),
-                       static_cast<double>(epsfcn_),
+                       endCriteria.functionEpsilon(),
+                       xtol_,
+                       gtol_,
+                       endCriteria.maxIterations(),
+                       epsfcn_,
                        diag.get(), mode, factor,
                        nprint, &info, &nfev, fjac.get(),
                        ldfjac, ipvt.get(), qtf.get(),

--- a/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
+++ b/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
         initCostValues_ = P.costFunction().values(x_);
         int m = initCostValues_.size();
         int n = x_.size();
-        boost::scoped_array<double> xx(new Real[n]);
+        boost::scoped_array<Real> xx(new Real[n]);
         std::copy(x_.begin(), x_.end(), xx.get());
         boost::scoped_array<double> fvec(new double[m]);
         boost::scoped_array<double> diag(new double[n]);

--- a/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
+++ b/QuantLib/ql/math/optimization/levenbergmarquardt.cpp
@@ -51,21 +51,21 @@ namespace QuantLib {
         int n = x_.size();
         boost::scoped_array<Real> xx(new Real[n]);
         std::copy(x_.begin(), x_.end(), xx.get());
-        boost::scoped_array<double> fvec(new double[m]);
-        boost::scoped_array<double> diag(new double[n]);
+        boost::scoped_array<Real> fvec(new Real[m]);
+        boost::scoped_array<Real> diag(new Real[n]);
         int mode = 1;
-        double factor = 1;
+        Real factor = 1;
         int nprint = 0;
         int info = 0;
         int nfev =0;
-        boost::scoped_array<double> fjac(new double[m*n]);
+        boost::scoped_array<Real> fjac(new Real[m*n]);
         int ldfjac = m;
         boost::scoped_array<int> ipvt(new int[n]);
-        boost::scoped_array<double> qtf(new double[n]);
-        boost::scoped_array<double> wa1(new double[n]);
-        boost::scoped_array<double> wa2(new double[n]);
-        boost::scoped_array<double> wa3(new double[n]);
-        boost::scoped_array<double> wa4(new double[m]);
+        boost::scoped_array<Real> qtf(new Real[n]);
+        boost::scoped_array<Real> wa1(new Real[n]);
+        boost::scoped_array<Real> wa2(new Real[n]);
+        boost::scoped_array<Real> wa3(new Real[n]);
+        boost::scoped_array<Real> wa4(new Real[m]);
         // requirements; check here to get more detailed error messages.
         QL_REQUIRE(n > 0, "no variables given");
         QL_REQUIRE(m >= n,
@@ -117,7 +117,7 @@ namespace QuantLib {
         return ecType;
     }
 
-    void LevenbergMarquardt::fcn(int, int n, double* x, double* fvec, int*) {
+    void LevenbergMarquardt::fcn(int, int n, Real* x, Real* fvec, int*) {
         Array xt(n);
         std::copy(x, x+n, xt.begin());
         // constraint handling needs some improvement in the future:

--- a/QuantLib/ql/math/optimization/levenbergmarquardt.hpp
+++ b/QuantLib/ql/math/optimization/levenbergmarquardt.hpp
@@ -45,8 +45,8 @@ namespace QuantLib {
         virtual Integer getInfo() const;
         void fcn(int m,
                  int n,
-                 double* x,
-                 double* fvec,
+                 Real* x,
+                 Real* fvec,
                  int* iflag);
       private:
         Problem* currentProblem_;

--- a/QuantLib/ql/math/optimization/lmdif.cpp
+++ b/QuantLib/ql/math/optimization/lmdif.cpp
@@ -77,7 +77,7 @@ double DWARF = 1.0e-38;
 
 
 
-double enorm(int n,double* x)
+Real enorm(int n,Real* x)
 {
 /*
 *     **********
@@ -119,8 +119,8 @@ double enorm(int n,double* x)
 *     **********
 */
 int i;
-double agiant,floatn,s1,s2,s3,xabs,x1max,x3max;
-double ans, temp;
+Real agiant,floatn,s1,s2,s3,xabs,x1max,x3max;
+Real ans, temp;
 static double rdwarf = 3.834e-20;
 static double rgiant = 1.304e19;
 static double zero = 0.0;
@@ -210,7 +210,7 @@ return(ans);
 }
 /************************lmmisc.c*************************/
 
-double dmax1(double a,double b)
+Real dmax1(Real a,Real b)
 {
 if( a >= b )
     return(a);
@@ -218,7 +218,7 @@ else
     return(b);
 }
 
-double dmin1(double a,double b)
+Real dmin1(Real a,Real b)
 {
 if( a <= b )
     return(a);
@@ -248,14 +248,14 @@ return( k % m );
  * fvec = vector of function values
  * iflag = error return variable
  */
-//void fcn(int m,int n, double* x, double* fvec,int *iflag)
+//void fcn(int m,int n, Real* x, Real* fvec,int *iflag)
 //{
 //  QuantLib::LevenbergMarquardt::fcn(m, n, x, fvec, iflag);
 //}
 
 void
-fdjac2(int m,int n,double* x,double* fvec,double* fjac,int,
-       int* iflag,double epsfcn,double* wa,
+fdjac2(int m,int n,Real* x,Real* fvec,Real* fjac,int,
+       int* iflag,Real epsfcn,Real* wa,
        const QuantLib::MINPACK::LmdifCostFunction& fcn)
 {
 /*
@@ -336,7 +336,7 @@ fdjac2(int m,int n,double* x,double* fvec,double* fjac,int,
       **********
 */
 int i,j,ij;
-double eps,h,temp;
+Real eps,h,temp;
 static double zero = 0.0;
 
 
@@ -368,8 +368,8 @@ for( j=0; j<n; j++ )
 
 
 void
-qrfac(int m,int n,double* a,int,int pivot,int* ipvt,
-      int,double* rdiag,double* acnorm,double* wa)
+qrfac(int m,int n,Real* a,int,int pivot,int* ipvt,
+      int,Real* rdiag,Real* acnorm,Real* wa)
 {
 /*
 *     **********
@@ -449,7 +449,7 @@ qrfac(int m,int n,double* a,int,int pivot,int* ipvt,
 *     **********
 */
 int i,ij,jj,j,jp1,k,kmax,minmn;
-double ajnorm,sum,temp;
+Real ajnorm,sum,temp;
 static double zero = 0.0;
 static double one = 1.0;
 static double p05 = 0.05;
@@ -575,8 +575,8 @@ L100:
 
 
 void
-qrsolv(int n,double* r,int ldr,int* ipvt,double* diag,double* qtb,
-       double* x,double* sdiag,double* wa)
+qrsolv(int n,Real* r,int ldr,int* ipvt,Real* diag,Real* qtb,
+       Real* x,Real* sdiag,Real* wa)
 {
 /*
 *     **********
@@ -658,7 +658,7 @@ qrsolv(int n,double* r,int ldr,int* ipvt,double* diag,double* qtb,
 *     **********
 */
 int i,ij,ik,kk,j,jp1,k,kp1,l,nsing;
-double cos,cotan,qtbpj,sin,sum,tan,temp;
+Real cos,cotan,qtbpj,sin,sum,tan,temp;
 static double zero = 0.0;
 static double p25 = 0.25;
 static double p5 = 0.5;
@@ -806,9 +806,9 @@ for( j=0; j<n; j++ )
 
 
 void
-lmpar(int n,double* r,int ldr,int* ipvt,double* diag,
-      double* qtb,double delta,double* par,double* x,double* sdiag,
-      double* wa1,double* wa2)
+lmpar(int n,Real* r,int ldr,int* ipvt,Real* diag,
+      Real* qtb,Real delta,Real* par,Real* x,Real* sdiag,
+      Real* wa1,Real* wa2)
 {
 /*     **********
 *
@@ -906,8 +906,8 @@ lmpar(int n,double* r,int ldr,int* ipvt,double* diag,
 *     **********
 */
 int i,iter,ij,jj,j,jm1,jp1,k,l,nsing;
-double dxnorm,fp,gnorm,parc,parl,paru;
-double sum,temp;
+Real dxnorm,fp,gnorm,parc,parl,paru;
+Real sum,temp;
 static double zero = 0.0;
 static double p1 = 0.1;
 static double p001 = 0.001;
@@ -1117,12 +1117,12 @@ if(iter == 0)
 
 
 
-void lmdif(int m,int n,double* x,double* fvec,double ftol,
-      double xtol,double gtol,int maxfev,double epsfcn,
-      double* diag, int mode, double factor,
-      int nprint, int* info,int* nfev,double* fjac,
-      int ldfjac,int* ipvt,double* qtf,
-      double* wa1,double* wa2,double* wa3,double* wa4,
+void lmdif(int m,int n,Real* x,Real* fvec,Real ftol,
+      Real xtol,Real gtol,int maxfev,Real epsfcn,
+      Real* diag, int mode, Real factor,
+      int nprint, int* info,int* nfev,Real* fjac,
+      int ldfjac,int* ipvt,Real* qtf,
+      Real* wa1,Real* wa2,Real* wa3,Real* wa4,
       const QuantLib::MINPACK::LmdifCostFunction& fcn)
 {
 /*
@@ -1308,9 +1308,9 @@ void lmdif(int m,int n,double* x,double* fvec,double ftol,
 *     **********
 */
 int i,iflag,ij,jj,iter,j,l;
-double actred,delta=0,dirder,fnorm,fnorm1,gnorm;
-double par,pnorm,prered,ratio;
-double sum,temp,temp1,temp2,temp3,xnorm=0;
+Real actred,delta=0,dirder,fnorm,fnorm1,gnorm;
+Real par,pnorm,prered,ratio;
+Real sum,temp,temp1,temp2,temp3,xnorm=0;
 static double one = 1.0;
 static double p1 = 0.1;
 static double p5 = 0.5;

--- a/QuantLib/ql/math/optimization/lmdif.hpp
+++ b/QuantLib/ql/math/optimization/lmdif.hpp
@@ -24,7 +24,7 @@
 #ifndef quantlib_optimization_lmdif_hpp
 #define quantlib_optimization_lmdif_hpp
 
-#include <ql/qldefines.hpp>
+#include <ql/types.hpp>
 #include <boost/function.hpp>
 
 namespace QuantLib {
@@ -32,23 +32,23 @@ namespace QuantLib {
     namespace MINPACK {
         typedef boost::function<void (int,
                                       int, 
-                                      double*,
-                                      double*,
+                                      Real*,
+                                      Real*,
                                       int*)> LmdifCostFunction;
 
-        void lmdif(int m,int n,double* x,double* fvec,double ftol,
-                   double xtol,double gtol,int maxfev,double epsfcn,
-                   double* diag, int mode, double factor,
-                   int nprint, int* info,int* nfev,double* fjac,
-                   int ldfjac,int* ipvt,double* qtf,
-                   double* wa1,double* wa2,double* wa3,double* wa4,
+        void lmdif(int m,int n,Real* x,Real* fvec,Real ftol,
+                   Real xtol,Real gtol,int maxfev,Real epsfcn,
+                   Real* diag, int mode, Real factor,
+                   int nprint, int* info,int* nfev,Real* fjac,
+                   int ldfjac,int* ipvt,Real* qtf,
+                   Real* wa1,Real* wa2,Real* wa3,Real* wa4,
                    const LmdifCostFunction& fcn);
         
-        void qrsolv(int n,double* r,int ldr,int* ipvt,
-                    double* diag,double* qtb, double* x,
-                    double* sdiag,double* wa);
-        void qrfac(int m,int n,double* a,int, int pivot,int* ipvt,
-                   int,double* rdiag,double* acnorm,double* wa);
+        void qrsolv(int n,Real* r,int ldr,int* ipvt,
+                    Real* diag,Real* qtb, Real* x,
+                    Real* sdiag,Real* wa);
+        void qrfac(int m,int n,Real* a,int, int pivot,int* ipvt,
+                   int,Real* rdiag,Real* acnorm,Real* wa);
     }
 }
 #endif

--- a/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp
+++ b/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         Concentrating1dMesher(
             Real start, Real end, Size size,
             const std::pair<Real, Real>& cPoints
-                     = (std::pair<double, double>(Null<Real>(), Null<Real>())),
+                     = (std::pair<Real, Real>(Null<Real>(), Null<Real>())),
             const bool requireCPoint = false);
     };
 }

--- a/QuantLib/ql/models/calibrationhelper.cpp
+++ b/QuantLib/ql/models/calibrationhelper.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
     }
 
     Real CalibrationHelper::calibrationError() {
-        double error;
+        Real error;
         
         switch (calibrationErrorType_) {
           case RelativePriceError:

--- a/QuantLib/ql/models/marketmodels/callability/upperboundengine.cpp
+++ b/QuantLib/ql/models/marketmodels/callability/upperboundengine.cpp
@@ -262,7 +262,7 @@ namespace QuantLib {
 
                     const std::vector<Real>& values = innerStats.mean();
                     unexercisedHedgeValue =
-                        std::accumulate(values.begin(), values.end(), 0.0)
+                        std::accumulate(values.begin(), values.end(), Real(0.0))
                         / principalInNumerairePortfolio;
 
                     callable.disableCallability();

--- a/QuantLib/ql/models/marketmodels/driftcomputation/cmsmmdriftcalculator.cpp
+++ b/QuantLib/ql/models/marketmodels/driftcomputation/cmsmmdriftcalculator.cpp
@@ -90,7 +90,7 @@ namespace QuantLib {
             for (Integer j=static_cast<Integer>(numberOfRates_)-2;
                  j>=static_cast<Integer>(alive_)-1; --j)
             {
-                double sr = cs.cmSwapRate(j+1,spanningFwds_);
+                Real sr = cs.cmSwapRate(j+1,spanningFwds_);
                 Integer endIndex =
                     std::min<Integer>(j + static_cast<Integer>(spanningFwds_) + 1,
                              static_cast<Integer>(numberOfRates_));

--- a/QuantLib/ql/models/marketmodels/driftcomputation/smmdriftcalculator.cpp
+++ b/QuantLib/ql/models/marketmodels/driftcomputation/smmdriftcalculator.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
           }
 
 
-        double numeraireRatio = cs.discountRatio(numberOfRates_,numeraire_);
+        Real numeraireRatio = cs.discountRatio(numberOfRates_, numeraire_);
 
 // change to work for general numeraire
         for (Size k=0; k<numberOfFactors_; ++k) {

--- a/QuantLib/ql/models/marketmodels/models/capletcoterminalswaptioncalibration.cpp
+++ b/QuantLib/ql/models/marketmodels/models/capletcoterminalswaptioncalibration.cpp
@@ -232,7 +232,7 @@ namespace QuantLib {
             }
 
             // we also get an extra linear part, this corresponds to row i, and columns j>i+1, and transpose
-            double extraLinearPart=0.0;
+            Real extraLinearPart=0.0;
             for (Size k = i+1; k < numberOfSteps; ++k)
             {
                     extraLinearPart+=invertedZedMatrix[i-1][k] *

--- a/QuantLib/ql/models/marketmodels/models/piecewiseconstantvariance.cpp
+++ b/QuantLib/ql/models/marketmodels/models/piecewiseconstantvariance.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
         QL_REQUIRE(i<variances().size(),
                    "invalid step index");
         return std::accumulate(variances().begin(),
-                               variances().begin()+i+1, 0.0);
+                               variances().begin()+i+1, Real(0.0));
     }
 
     Volatility PiecewiseConstantVariance::totalVolatility(Size i) const {

--- a/QuantLib/ql/models/marketmodels/pathwisegreeks/swaptionpseudojacobian.cpp
+++ b/QuantLib/ql/models/marketmodels/pathwisegreeks/swaptionpseudojacobian.cpp
@@ -91,7 +91,7 @@ namespace QuantLib
                 Size zIndex = rate -startIndex;
                 for (Size f =0; f < factors; ++f)
                 {
-                    double sum=0.0;
+                    Real sum=0.0;
                     for (Size rate2 = startIndex; rate2<endIndex; ++rate2)
                     {
                         Size zIndex2 = rate2-startIndex;

--- a/QuantLib/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
+++ b/QuantLib/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
         const std::vector<Real>& fixedAccruals,
         const std::vector<Real>& floatingAccruals,
         const std::vector<Time>& paymentTimes,
-        double fixedRate)
+        Real fixedRate)
     : MultiProductMultiStep(rateTimes),
       fixedAccruals_(fixedAccruals), floatingAccruals_(floatingAccruals),
       paymentTimes_(paymentTimes), fixedRate_(fixedRate) {

--- a/QuantLib/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.hpp
+++ b/QuantLib/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
                                  const std::vector<Real>& fixedAccruals,
                                  const std::vector<Real>& floatingAccruals,
                                  const std::vector<Time>& paymentTimes,
-                                 double fixedRate);
+                                 Real fixedRate);
         //! \name MarketModelMultiProduct interface
         //@{
         std::vector<Time> possibleCashFlowTimes() const;
@@ -47,7 +47,7 @@ namespace QuantLib {
       private:
         std::vector<Real> fixedAccruals_, floatingAccruals_;
         std::vector<Time> paymentTimes_;
-        double fixedRate_;
+        Real fixedRate_;
         Size lastIndex_;
         // things that vary in a path
         Size currentIndex_;

--- a/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -86,10 +86,10 @@ namespace QuantLib {
     if (currentIndex_ >=offset_ && (currentIndex_ - offset_) % period_ ==0)
     {
         // caplet first
-        double df = currentState.discountRatio(currentIndex_+period_,currentIndex_);
+        Real df = currentState.discountRatio(currentIndex_ + period_, currentIndex_);
         double tau = rateTimes_[currentIndex_+period_]- rateTimes_[currentIndex_];
         double forward = (1.0/df-1.0)/tau;
-        double value = (*forwardPayOffs_[productIndex_])(forward);
+        Real value = (*forwardPayOffs_[productIndex_])(forward);
         value *= tau*currentState.discountRatio(currentIndex_+period_,currentIndex_);
 
         if (value >0)
@@ -102,9 +102,9 @@ namespace QuantLib {
         // now swaption
 
         unsigned long numberPeriods = numberBigFRAs_ - productIndex_;
-        double B=0.0;
+        Real B = 0.0;
         double P0 = 1.0; // i.e currentState.discountRatio(currentIndex_,currentIndex_);
-        double Pn = currentState.discountRatio(currentIndex_+numberPeriods*period_,currentIndex_);
+        Real Pn = currentState.discountRatio(currentIndex_ + numberPeriods*period_, currentIndex_);
         for (unsigned long i=0; i < numberPeriods; ++i)
         {
             double tau = rateTimes_[currentIndex_+(i+1)*period_]- rateTimes_[currentIndex_+i*period_];

--- a/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -88,7 +88,7 @@ namespace QuantLib {
         // caplet first
         Real df = currentState.discountRatio(currentIndex_ + period_, currentIndex_);
         double tau = rateTimes_[currentIndex_+period_]- rateTimes_[currentIndex_];
-        double forward = (1.0/df-1.0)/tau;
+        Real forward = (1.0/df-1.0)/tau;
         Real value = (*forwardPayOffs_[productIndex_])(forward);
         value *= tau*currentState.discountRatio(currentIndex_+period_,currentIndex_);
 

--- a/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/QuantLib/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
     {
         // caplet first
         Real df = currentState.discountRatio(currentIndex_ + period_, currentIndex_);
-        double tau = rateTimes_[currentIndex_+period_]- rateTimes_[currentIndex_];
+        Time tau = rateTimes_[currentIndex_+period_]- rateTimes_[currentIndex_];
         Real forward = (1.0/df-1.0)/tau;
         Real value = (*forwardPayOffs_[productIndex_])(forward);
         value *= tau*currentState.discountRatio(currentIndex_+period_,currentIndex_);
@@ -107,7 +107,7 @@ namespace QuantLib {
         Real Pn = currentState.discountRatio(currentIndex_ + numberPeriods*period_, currentIndex_);
         for (unsigned long i=0; i < numberPeriods; ++i)
         {
-            double tau = rateTimes_[currentIndex_+(i+1)*period_]- rateTimes_[currentIndex_+i*period_];
+            Time tau = rateTimes_[currentIndex_+(i+1)*period_]- rateTimes_[currentIndex_+i*period_];
             B+= tau*currentState.discountRatio(currentIndex_+(i+1)*period_,currentIndex_);
         }
 

--- a/QuantLib/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/QuantLib/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -23,6 +23,8 @@
 #include <ql/methods/lattices/trinomialtree.hpp>
 #include <ql/pricingengines/blackformula.hpp>
 
+using std::exp;
+
 namespace QuantLib {
 
     HullWhite::HullWhite(const Handle<YieldTermStructure>& termStructure,

--- a/QuantLib/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/QuantLib/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -24,6 +24,7 @@
 #include <ql/pricingengines/blackformula.hpp>
 
 using std::exp;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/models/volatility/garch.cpp
+++ b/QuantLib/ql/models/volatility/garch.cpp
@@ -417,7 +417,7 @@ namespace QuantLib {
         Array acf(maxLag+1);
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        std::bind2nd(std::minus<double>(), mean_r2));
+                        std::bind2nd(std::minus<Real>(), mean_r2));
         autocovariances (tmp.begin(), tmp.end(), acf.begin(), maxLag);
         QL_REQUIRE (acf[0] > 0, "Data series is constant");
 
@@ -519,7 +519,7 @@ namespace QuantLib {
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        std::bind2nd(std::minus<double>(), mean_r2));
+                        std::bind2nd(std::minus<Real>(), mean_r2));
         return calibrate_r2(tmp, method, endCriteria, initGuess,
                             alpha, beta, omega);
     }
@@ -552,7 +552,7 @@ namespace QuantLib {
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        std::bind2nd(std::minus<double>(), mean_r2));
+                        std::bind2nd(std::minus<Real>(), mean_r2));
         return calibrate_r2(tmp, method, constraints, endCriteria,
                             initGuess, alpha, beta, omega);
     }

--- a/QuantLib/ql/models/volatility/garch.cpp
+++ b/QuantLib/ql/models/volatility/garch.cpp
@@ -466,7 +466,7 @@ namespace QuantLib {
                 opt1[1] = alpha;
                 opt1[2] = beta;
                 opt1[0] = omega;
-                double fCost = QL_MAX_REAL;
+                Real fCost = QL_MAX_REAL;
                 if (constraints.test(opt1) && (fCost = cost.value(opt1)) < fCost1)
                     fCost1 = fCost;
             } catch (const std::exception &) {

--- a/QuantLib/ql/models/volatility/garch.cpp
+++ b/QuantLib/ql/models/volatility/garch.cpp
@@ -479,7 +479,7 @@ namespace QuantLib {
                 opt2[1] = alpha;
                 opt2[2] = beta;
                 opt2[0] = omega;
-                double fCost = QL_MAX_REAL;
+                Real fCost = QL_MAX_REAL;
                 if (constraints.test(opt2) && (fCost = cost.value(opt2)) < fCost2)
                     fCost2 = fCost;
             } catch (const std::exception &) {

--- a/QuantLib/ql/pricingengines/asian/analytic_discr_geom_av_price.cpp
+++ b/QuantLib/ql/pricingengines/asian/analytic_discr_geom_av_price.cpp
@@ -86,7 +86,7 @@ namespace QuantLib {
         Real futureWeight = 1.0-pastWeight;
 
         Time timeSum = std::accumulate(fixingTimes.begin(),
-                                       fixingTimes.end(), 0.0);
+                                       fixingTimes.end(), Real(0.0));
 
         Volatility vola = process_->blackVolatility()->blackVol(
                                               arguments_.exercise->lastDate(),

--- a/QuantLib/ql/pricingengines/asian/analytic_discr_geom_av_strike.cpp
+++ b/QuantLib/ql/pricingengines/asian/analytic_discr_geom_av_strike.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
         Real futureWeight = 1.0-pastWeight;
 
         Time timeSum = std::accumulate(fixingTimes.begin(),
-                                       fixingTimes.end(), 0.0);
+                                       fixingTimes.end(), Real(0.0));
 
         Time residualTime = rfdc.yearFraction(arguments_.fixingDates[pastFixings],
                                               arguments_.exercise->lastDate());

--- a/QuantLib/ql/pricingengines/barrier/discretizedbarrieroption.cpp
+++ b/QuantLib/ql/pricingengines/barrier/discretizedbarrieroption.cpp
@@ -177,9 +177,9 @@ namespace QuantLib {
                   if (grid[j]<=barrier && grid[j+1] > barrier) {
                       // grid[j+1] above barrier, grid[j] under (out),
                       // interpolate optvalues[j+1]
-                      double a = (barrier-grid[j])*rebate;
-                      double b = (grid[j+1]-barrier)*unenhanced_.values()[j+1];
-                      double c = (grid[j+1]-grid[j]);
+                      Real a = (barrier-grid[j])*rebate;
+                      Real b = (grid[j+1]-barrier)*unenhanced_.values()[j+1];
+                      Real c = (grid[j+1]-grid[j]);
                       optvalues[j+1] = std::max(0.0, (a+b)/c);
                   }
               }
@@ -203,9 +203,9 @@ namespace QuantLib {
                   if (grid[j] < barrier && grid[j+1] >= barrier) {
                       // grid[j+1] above barrier (out), grid[j] under, 
                       // interpolate optvalues[j]
-                      double a = (barrier-grid[j])*unenhanced_.values()[j];
-                      double b = (grid[j+1]-barrier)*rebate;
-                      double c = (grid[j+1]-grid[j]);
+                      Real a = (barrier-grid[j])*unenhanced_.values()[j];
+                      Real b = (grid[j+1]-barrier)*rebate;
+                      Real c = (grid[j+1]-grid[j]);
                       optvalues[j] = std::max(0.0, (a+b)/c);
                   }
               }

--- a/QuantLib/ql/pricingengines/mcsimulation.hpp
+++ b/QuantLib/ql/pricingengines/mcsimulation.hpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         }
 
         Size nextBatch;
-        double order;
+        Real order;
         result_type error(mcModel_->sampleAccumulator().errorEstimate());
         while (maxError(error) > tolerance) {
             QL_REQUIRE(sampleNumber<maxSamples,

--- a/QuantLib/ql/pricingengines/mcsimulation.hpp
+++ b/QuantLib/ql/pricingengines/mcsimulation.hpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         }
 
         Size nextBatch;
-        Real order;
+        double order;
         result_type error(mcModel_->sampleAccumulator().errorEstimate());
         while (maxError(error) > tolerance) {
             QL_REQUIRE(sampleNumber<maxSamples,
@@ -125,8 +125,8 @@ namespace QuantLib {
             // conservative estimate of how many samples are needed
             order = maxError(error*error)/tolerance/tolerance;
             nextBatch =
-                Size(std::max<Real>(static_cast<Real>(sampleNumber)*order*0.8-static_cast<Real>(sampleNumber),
-                                    static_cast<Real>(minSamples)));
+                Size(std::max<double>(static_cast<double>(sampleNumber)*order*0.8 - static_cast<double>(sampleNumber),
+                                    static_cast<double>(minSamples)));
 
             // do not exceed maxSamples
             nextBatch = std::min(nextBatch, maxSamples-sampleNumber);

--- a/QuantLib/ql/pricingengines/mcsimulation.hpp
+++ b/QuantLib/ql/pricingengines/mcsimulation.hpp
@@ -125,8 +125,8 @@ namespace QuantLib {
             // conservative estimate of how many samples are needed
             order = maxError(error*error)/tolerance/tolerance;
             nextBatch =
-                Size(std::max<double>(static_cast<double>(sampleNumber)*order*0.8 - static_cast<double>(sampleNumber),
-                                    static_cast<double>(minSamples)));
+                Size(std::max<Real>(static_cast<Real>(sampleNumber)*order*0.8 - static_cast<Real>(sampleNumber),
+                                    static_cast<Real>(minSamples)));
 
             // do not exceed maxSamples
             nextBatch = std::min(nextBatch, maxSamples-sampleNumber);

--- a/QuantLib/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
@@ -26,6 +26,9 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/instruments/payoffs.hpp>
 
+using std::exp;
+using std::pow;
+
 namespace QuantLib {
 
 

--- a/QuantLib/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
@@ -120,7 +120,7 @@ namespace QuantLib {
                 *(9*la*la*n+8*n+15*la*N+pow<4>(la)*n+pow<5>(la)*N
                   +10*pow<3>(la)*N)
                 - 6*b1*b1*b2*la - 6*b3*b1*b1*(n+la*N)
-                - 12*b2*b2*b1*(3*la+::pow(la,3)); // ok
+                - 12*b2*b2*b1*(3*la+std::pow(la,3)); // ok
             z1 = b1 + b2*(3+la*la) + b3*(la*n+3*N+la*la*N); // ok
             z2 = b1*b1 + b2*b2*(15+pow<4>(la)+18*la*la)
                 + (b3*b3+2*b2*b3)*(pow<3>(la)*n+17*la*n+15*N

--- a/QuantLib/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -214,7 +214,7 @@ namespace QuantLib {
                       *std::complex<Real>(-phi, (j_== 1)? 1 : -1));
         const std::complex<Real> ex = std::exp(-d*term_);
         const std::complex<Real> addOnTerm
-            = engine_ > 0 ? engine_->addOnTerm(phi, term_, j_) : 0.0;
+            = engine_ > 0 ? engine_->addOnTerm(phi, term_, j_) : Real(0.0);
 
         if (cpxLog_ == Gatheral) {
             if (phi != 0.0) {

--- a/QuantLib/ql/pricingengines/vanilla/hestonexpansionengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/hestonexpansionengine.cpp
@@ -47,6 +47,7 @@ using namespace boost::lambda;
 using std::exp;
 using std::pow;
 using std::log;
+using std::sqrt;
 
 namespace QuantLib {
 

--- a/QuantLib/ql/pricingengines/vanilla/hestonexpansionengine.cpp
+++ b/QuantLib/ql/pricingengines/vanilla/hestonexpansionengine.cpp
@@ -44,6 +44,10 @@
 
 using namespace boost::lambda;
 
+using std::exp;
+using std::pow;
+using std::log;
+
 namespace QuantLib {
 
     HestonExpansionEngine::HestonExpansionEngine(

--- a/QuantLib/ql/processes/hestonprocess.cpp
+++ b/QuantLib/ql/processes/hestonprocess.cpp
@@ -490,7 +490,7 @@ namespace QuantLib {
                 - 0.5*vds + rho_*vdw;
 
             const Volatility sig = std::sqrt((1-rho_*rho_)*vds);
-            const Real s = x0[0]*exp(mu + sig*dw[0]);
+            const Real s = x0[0]*std::exp(mu + sig*dw[0]);
 
             retVal[0] = s;
             retVal[1] = nu_t;

--- a/QuantLib/ql/qldefines.hpp
+++ b/QuantLib/ql/qldefines.hpp
@@ -50,6 +50,10 @@
 #define QL_BIG_INTEGER long
 #define QL_REAL double
 
+/* In AD mode, QL_REAL_VALUE is the underlying value type of QL_REAL;
+   in non-AD mode, QL_REAL_VALUE is the QL_REAL type itself
+*/
+#define QL_REAL_VALUE double
 
 /*! \defgroup macros QuantLib macros
 

--- a/QuantLib/ql/termstructures/volatility/smilesection.cpp
+++ b/QuantLib/ql/termstructures/volatility/smilesection.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
                    "smile section must provide atm level to compute option price");
         // for zero strike, return option price even if outside
         // minstrike, maxstrike interval
-        return blackFormula(type,strike,atm, fabs(strike) < QL_EPSILON ?
+        return blackFormula(type,strike,atm, std::fabs(strike) < QL_EPSILON ?
                             0.2 : sqrt(variance(strike)),discount);
     }
 

--- a/QuantLib/ql/termstructures/volatility/smilesection.cpp
+++ b/QuantLib/ql/termstructures/volatility/smilesection.cpp
@@ -22,6 +22,8 @@
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/settings.hpp>
 
+using std::sqrt;
+
 namespace QuantLib {
 
     void SmileSection::update() {

--- a/QuantLib/test-suite/barrieroption.cpp
+++ b/QuantLib/test-suite/barrieroption.cpp
@@ -50,6 +50,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::sqrt;
+
 #define REPORT_FAILURE(greekName, barrierType, barrier, rebate, payoff, \
                        exercise, s, q, r, today, v, expected, calculated, \
                        error, tolerance) \

--- a/QuantLib/test-suite/blackdeltacalculator.cpp
+++ b/QuantLib/test-suite/blackdeltacalculator.cpp
@@ -32,6 +32,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::sqrt;
+
 namespace {
 
     Integer timeToDays(Time t) {

--- a/QuantLib/test-suite/catbonds.cpp
+++ b/QuantLib/test-suite/catbonds.cpp
@@ -156,9 +156,9 @@ void CatBondTest::testBetaRisk() {
         poissonSumSquares+=path.size()*path.size();
     }
     Real poissonMean = poissonSum/PATHS;
-    BOOST_CHECK_CLOSE(3.0/100.0, poissonMean, 2);
+    BOOST_CHECK_CLOSE(Real(3.0/100.0), poissonMean, 2);
     Real poissonVar = poissonSumSquares/PATHS - poissonMean*poissonMean;
-    BOOST_CHECK_CLOSE(3.0/100.0, poissonVar, 5);
+    BOOST_CHECK_CLOSE(Real(3.0/100.0), poissonVar, 5);
     
     Real expectedMean = 3.0*10.0/100.0;
     Real actualMean = sum/PATHS;
@@ -426,9 +426,9 @@ void CatBondTest::testCatBondInDoomScenario() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(1.0, lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(1.0, exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(1.0, expectedLoss, tolerance);
+    BOOST_CHECK_CLOSE(Real(1.0), lossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(1.0), exhaustionProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(1.0), expectedLoss, tolerance);
 }
 
 
@@ -492,9 +492,9 @@ void CatBondTest::testCatBondWithDoomOnceInTenYears() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(0.1, lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(0.1, exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(0.1, expectedLoss, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.1), exhaustionProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.1), expectedLoss, tolerance);
 
     shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
     catBond.setPricingEngine(catBondEngineRF);
@@ -505,8 +505,8 @@ void CatBondTest::testCatBondWithDoomOnceInTenYears() {
     Real riskFreeExhaustionProbability = catBond.exhaustionProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(0.0, riskFreeLossProbability, tolerance);
-    BOOST_CHECK_CLOSE(0.0, riskFreeExhaustionProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.0), riskFreeExhaustionProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
     BOOST_CHECK_CLOSE(riskFreePrice*0.9, price, tolerance);
@@ -573,9 +573,9 @@ void CatBondTest::testCatBondWithDoomOnceInTenYearsProportional() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(0.1, lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(0.0, exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(0.05, expectedLoss, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.0), exhaustionProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.05), expectedLoss, tolerance);
 
     shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
     catBond.setPricingEngine(catBondEngineRF);
@@ -585,7 +585,7 @@ void CatBondTest::testCatBondWithDoomOnceInTenYearsProportional() {
     Real riskFreeLossProbability = catBond.lossProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(0.0, riskFreeLossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
     BOOST_CHECK_CLOSE(riskFreePrice*0.95, price, tolerance);
@@ -661,7 +661,7 @@ void CatBondTest::testCatBondWithGeneratedEventsProportional() {
     Real riskFreeLossProbability = catBond.lossProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(0.0, riskFreeLossProbability, tolerance);
+    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
     BOOST_CHECK_GT(riskFreePrice, price);

--- a/QuantLib/test-suite/creditdefaultswap.cpp
+++ b/QuantLib/test-suite/creditdefaultswap.cpp
@@ -272,8 +272,8 @@ void CreditDefaultSwapTest::testCachedMarketValue() {
                           new MidPointCdsEngine(piecewiseFlatHazardRate,
                                                 recoveryRate,discountCurve)));
 
-    double calculatedNpv = cds.NPV();
-    double calculatedFairRate = cds.fairSpread();
+    Real calculatedNpv = cds.NPV();
+    Real calculatedFairRate = cds.fairSpread();
 
     double npv = -1.364048777;        // from Bloomberg we have 98.15598868 - 100.00;
     double fairRate =  0.0248429452; // from Bloomberg we have 0.0258378;

--- a/QuantLib/test-suite/distributions.cpp
+++ b/QuantLib/test-suite/distributions.cpp
@@ -182,7 +182,7 @@ namespace {
         for (int i = 0; i<10;i++) {
             Real cdf0 = bvn(x,y);
             y = y + tolerance;
-            double cdf1 = bvn(x,y);
+            Real cdf1 = bvn(x,y);
             if (cdf0 > cdf1) {
                 BOOST_ERROR(tag << " cdf must be decreasing in the tails\n"
                             << QL_SCIENTIFIC

--- a/QuantLib/test-suite/functions.cpp
+++ b/QuantLib/test-suite/functions.cpp
@@ -27,6 +27,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::exp;
+
 void FunctionsTest::testFactorial() {
 
     BOOST_TEST_MESSAGE("Testing factorial numbers...");

--- a/QuantLib/test-suite/gsr.cpp
+++ b/QuantLib/test-suite/gsr.cpp
@@ -44,6 +44,8 @@
 using namespace QuantLib;
 using boost::unit_test_framework::test_suite;
 
+using std::fabs;
+
 void GsrTest::testGsrProcess() {
 
     BOOST_MESSAGE("Testing GSR process...");

--- a/QuantLib/test-suite/inflation.cpp
+++ b/QuantLib/test-suite/inflation.cpp
@@ -47,6 +47,9 @@ using boost::unit_test_framework::test_suite;
 
 using namespace QuantLib;
 
+using std::fabs;
+using std::pow;
+
 namespace {
 
     struct Datum {

--- a/QuantLib/test-suite/inflationcapfloor.cpp
+++ b/QuantLib/test-suite/inflationcapfloor.cpp
@@ -52,6 +52,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+
 namespace {
 
     struct Datum {

--- a/QuantLib/test-suite/inflationcapflooredcoupon.cpp
+++ b/QuantLib/test-suite/inflationcapflooredcoupon.cpp
@@ -56,6 +56,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+
 namespace {
     struct Datum {
         Date date;

--- a/QuantLib/test-suite/inflationcpiswap.cpp
+++ b/QuantLib/test-suite/inflationcpiswap.cpp
@@ -45,6 +45,7 @@ using namespace boost::unit_test_framework;
 
 #include <iostream>
 
+using std::fabs;
 
 namespace {
     struct Datum {

--- a/QuantLib/test-suite/linearleastsquaresregression.cpp
+++ b/QuantLib/test-suite/linearleastsquaresregression.cpp
@@ -168,7 +168,7 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
     }
 
     // much simpler
-    LinearRegression m1(x, y, 1.0);
+    LinearRegression m1(x, y, Real(1.0));
 
     for (Size i=0; i < m1.dim(); ++i) {
         if (m1.standardErrors()[i] > tolerance) {

--- a/QuantLib/test-suite/lowdiscrepancysequences.cpp
+++ b/QuantLib/test-suite/lowdiscrepancysequences.cpp
@@ -43,6 +43,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+
 void LowDiscrepancyTest::testSeedGenerator() {
     BOOST_TEST_MESSAGE("Testing random-seed generator...");
     SeedGenerator::instance().get();

--- a/QuantLib/test-suite/marketmodel.cpp
+++ b/QuantLib/test-suite/marketmodel.cpp
@@ -119,6 +119,9 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+using std::sqrt;
+
 #define BEGIN(x) (x+0)
 #define END(x) (x+LENGTH(x))
 

--- a/QuantLib/test-suite/marketmodel_smmcaplethomocalibration.cpp
+++ b/QuantLib/test-suite/marketmodel_smmcaplethomocalibration.cpp
@@ -76,6 +76,9 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+using std::sqrt;
+
 #define BEGIN(x) (x+0)
 #define END(x) (x+LENGTH(x))
 

--- a/QuantLib/test-suite/markovfunctional.cpp
+++ b/QuantLib/test-suite/markovfunctional.cpp
@@ -54,6 +54,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+
 void MarkovFunctionalTest::testMfStateProcess() {
 
     const Real tolerance = 1E-10;

--- a/QuantLib/test-suite/matrices.cpp
+++ b/QuantLib/test-suite/matrices.cpp
@@ -32,6 +32,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+
 namespace {
 
     Size N;

--- a/QuantLib/test-suite/mersennetwister.cpp
+++ b/QuantLib/test-suite/mersennetwister.cpp
@@ -450,7 +450,7 @@ void MersenneTwisterTest::testValues() {
         }
     }
     for (i=0; i<1000; i++) {
-        double e = std::fabs(referenceValues[i] -
+        Real e = std::fabs(referenceValues[i] -
                              mt19937.next().value);
         if (e > 1.0e-8) {
             BOOST_FAIL("Mersenne Twister test failed at index: " << i << "\n"

--- a/QuantLib/test-suite/ode.cpp
+++ b/QuantLib/test-suite/ode.cpp
@@ -27,6 +27,9 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::exp;
+using std::sin;
+
 namespace {
 
     struct ode1 {

--- a/QuantLib/test-suite/optimizers.cpp
+++ b/QuantLib/test-suite/optimizers.cpp
@@ -375,7 +375,7 @@ namespace {
         Real value(const Array& x) const {
             Real fx = 0.0;
             for (Size i=0; i<x.size(); ++i) {
-                fx += floor(x[i])*floor(x[i]);
+                fx += std::floor(x[i])*std::floor(x[i]);
             }
             return fx;
         }

--- a/QuantLib/test-suite/optimizers.cpp
+++ b/QuantLib/test-suite/optimizers.cpp
@@ -36,6 +36,9 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::pow;
+using std::cos;
+
 namespace {
 
     struct NamedOptimizationMethod;

--- a/QuantLib/test-suite/overnightindexedswap.cpp
+++ b/QuantLib/test-suite/overnightindexedswap.cpp
@@ -46,6 +46,8 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::exp;
+
 using boost::shared_ptr;
 
 typedef PiecewiseYieldCurve<Discount,LogLinear> PiecewiseFlatForward;

--- a/QuantLib/test-suite/piecewisezerospreadedtermstructure.cpp
+++ b/QuantLib/test-suite/piecewisezerospreadedtermstructure.cpp
@@ -404,7 +404,7 @@ void PiecewiseZeroSpreadedTermStructureTest::testSetInterpolationFactory() {
 
     Real tolerance = 1e-9;
     Real expectedRate = vars.termStructure->zeroRate(t,vars.compounding) +
-                        0.026065770863;
+                        Real(0.026065770863);
 
     if (std::fabs(interpolatedZeroRate - expectedRate) > tolerance)
         BOOST_ERROR(
@@ -476,7 +476,7 @@ void PiecewiseZeroSpreadedTermStructureTest::testQuoteChanging() {
     Rate interpolatedZeroRate = spreadedTermStructure->zeroRate(t,vars.compounding);
     Real tolerance = 1e-9;
     Real expectedRate = vars.termStructure->zeroRate(t,vars.compounding) +
-                        0.03;
+                        Real(0.03);
 
     if (std::fabs(interpolatedZeroRate - expectedRate) > tolerance)
         BOOST_ERROR(
@@ -489,7 +489,7 @@ void PiecewiseZeroSpreadedTermStructureTest::testQuoteChanging() {
 
     interpolatedZeroRate = spreadedTermStructure->zeroRate(t,vars.compounding);
     expectedRate = vars.termStructure->zeroRate(t,vars.compounding) +
-                   0.025;
+                   Real(0.025);
 
     if (std::fabs(interpolatedZeroRate - expectedRate) > tolerance)
         BOOST_ERROR(

--- a/QuantLib/test-suite/riskstats.cpp
+++ b/QuantLib/test-suite/riskstats.cpp
@@ -83,7 +83,7 @@ void RiskStatisticsTest::testResults() {
 
             // weightSum()
             tolerance = 1e-10;
-            expected = std::accumulate(weights.begin(),weights.end(),0.0);
+            expected = std::accumulate(weights.begin(),weights.end(),Real(0.0));
             calculated = igs.weightSum();
             if (std::fabs(calculated-expected) > tolerance)
                 BOOST_FAIL("IncrementalGaussianStatistics: "

--- a/QuantLib/test-suite/stats.cpp
+++ b/QuantLib/test-suite/stats.cpp
@@ -51,7 +51,7 @@ namespace {
                        << "    calculated: " << s.samples() << "\n"
                        << "    expected:   " << LENGTH(data));
 
-        expected = std::accumulate(weights,weights+LENGTH(weights),0.0);
+        expected = std::accumulate(weights,weights+LENGTH(weights),Real(0.0));
         calculated = s.weightSum();
         if (calculated != expected)
             BOOST_FAIL(name << ": wrong sum of weights\n"
@@ -143,7 +143,7 @@ namespace {
                        << "    calculated: " << ss.samples() << "\n"
                        << "    expected:   " << LENGTH(data));
 
-        expected = std::accumulate(weights,weights+LENGTH(weights),0.0);
+        expected = std::accumulate(weights,weights+LENGTH(weights),Real(0.0));
         if (ss.weightSum() != expected)
             BOOST_FAIL("SequenceStatistics<" << name << ">: "
                        << "wrong sum of weights\n"

--- a/QuantLib/test-suite/swapforwardmappings.cpp
+++ b/QuantLib/test-suite/swapforwardmappings.cpp
@@ -47,6 +47,9 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
+using std::fabs;
+using std::sqrt;
+
 #define BEGIN(x) (x+0)
 #define END(x) (x+LENGTH(x))
 

--- a/QuantLib/test-suite/swingoption.cpp
+++ b/QuantLib/test-suite/swingoption.cpp
@@ -438,7 +438,7 @@ void SwingOptionTest::testExtOUJumpSwingOption() {
 
             Real npCashFlows
                 = std::accumulate(exerciseValues.begin(),
-                                  exerciseValues.begin()+exerciseRights, 0.0);
+                                  exerciseValues.begin()+exerciseRights, Real(0.0));
             npv.add(npCashFlows);
         }
 

--- a/QuantLib/test-suite/utilities.hpp
+++ b/QuantLib/test-suite/utilities.hpp
@@ -157,7 +157,7 @@ namespace QuantLib {
         std::transform(begin,end,begin,f2.begin(),
                        std::multiplies<Real>());
         // numeric integral of f^2
-        Real I = h * (std::accumulate(f2.begin(),f2.end(),0.0)
+        Real I = h * (std::accumulate(f2.begin(),f2.end(),Real(0.0))
                       - 0.5*f2.front() - 0.5*f2.back());
         return std::sqrt(I);
     }


### PR DESCRIPTION
This pull request eliminates incompatibilities that prevent redefining Real as a class. Such redefinition is required for using operator overloading to introduce AD to QuantLib, which can be done with moderate changes to the core code by making Real a lightweight, mostly inline class containing an AD variable such as AD<double> (CppAD) or adouble (ADOL-C). 

A typical example of an error fixed by this pull request is mixing up double and Real, for example using Real for a timer, or double for a calculated value. The pull request does not contain code that actually redefines Real, which remains defined as double; it only makes code changes that would result in compilation errors if Real were defined as a class.
