### PR TITLE
fixed bug: avoid to get fixings for dates later than evaluation date

### DIFF
--- a/QuantLib/ql/quotes/lastfixingquote.cpp
+++ b/QuantLib/ql/quotes/lastfixingquote.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2008 Ferdinando Ametrano
+ Copyright (C) 2008, 2014 Ferdinando Ametrano
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -18,6 +18,7 @@
 */
 
 #include <ql/quotes/lastfixingquote.hpp>
+#include <ql/settings.hpp>
 
 namespace QuantLib {
 
@@ -37,6 +38,7 @@ namespace QuantLib {
     }
 
     Date LastFixingQuote::referenceDate() const {
-        return index_->timeSeries().lastDate();
+        return std::min<Date>(index_->timeSeries().lastDate(),
+                              Settings::instance().evaluationDate());
     }
 }


### PR DESCRIPTION
when evaluationDate is in the past then fixings for dates later than evaluationDate might be available. It is relevant for lastFixing() to return a fixing for a date <= evaluationDate 