### PR TITLE
allow for user defined jacobian in optimization

### DIFF
--- a/QuantLib/ql/math/optimization/levenbergmarquardt.hpp
+++ b/QuantLib/ql/math/optimization/levenbergmarquardt.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2006 Klaus Spanderen
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,12 +33,23 @@ namespace QuantLib {
     /*! This implementation is based on MINPACK
         (<http://www.netlib.org/minpack>,
         <http://www.netlib.org/cephes/linalg.tgz>)
+        It has a built in fd scheme to compute
+        the jacobian, which is used by default.
+        If useCostFunctionsJacobian is true the
+        corresponding method in the cost function
+        of the problem is used instead. Note that
+        the default implementation of the jacobian
+        in CostFunction uses a central difference
+        (oder 2, but requiring more function
+        evaluations) compared to the forward
+        difference implemented here (order 1).
     */
     class LevenbergMarquardt : public OptimizationMethod {
       public:
         LevenbergMarquardt(Real epsfcn = 1.0e-8,
                            Real xtol = 1.0e-8,
-                           Real gtol = 1.0e-8);
+                           Real gtol = 1.0e-8,
+                           bool useCostFunctionsJacobian = false);
         virtual EndCriteria::Type minimize(Problem& P,
                                            const EndCriteria& endCriteria //= EndCriteria()
                                            );
@@ -48,11 +60,19 @@ namespace QuantLib {
                  Real* x,
                  Real* fvec,
                  int* iflag);
+        void jacFcn(int m,
+                 int n,
+                 Real* x,
+                 Real* fjac,
+                 int* iflag);
+
       private:
         Problem* currentProblem_;
         Array initCostValues_;
+        Matrix initJacobian_;
         mutable Integer info_;
         const Real epsfcn_, xtol_, gtol_;
+        bool useCostFunctionsJacobian_;
     };
 
 }

--- a/QuantLib/ql/math/optimization/lmdif.cpp
+++ b/QuantLib/ql/math/optimization/lmdif.cpp
@@ -1123,7 +1123,8 @@ void lmdif(int m,int n,Real* x,Real* fvec,Real ftol,
       int nprint, int* info,int* nfev,Real* fjac,
       int ldfjac,int* ipvt,Real* qtf,
       Real* wa1,Real* wa2,Real* wa3,Real* wa4,
-      const QuantLib::MINPACK::LmdifCostFunction& fcn)
+      const QuantLib::MINPACK::LmdifCostFunction& fcn,
+      const QuantLib::MINPACK::LmdifCostFunction& jacFcn)
 {
 /*
 *     **********
@@ -1296,7 +1297,7 @@ void lmdif(int m,int n,Real* x,Real* fvec,Real ftol,
 *
 *     subprograms called
 *
-*   user-supplied ...... fcn
+*   user-supplied ...... fcn, jacFcn
 *
 *   minpack-supplied ... dpmpar,enorm,fdjac2,lmpar,qrfac
 *
@@ -1363,7 +1364,10 @@ L30:
 *    calculate the jacobian matrix.
 */
 iflag = 2;
-fdjac2(m,n,x,fvec,fjac,ldfjac,&iflag,epsfcn,wa4, fcn);
+if(jacFcn != 0) // use user supplied jacobian calculation
+    jacFcn(m,n,x,fjac,&iflag);
+else
+    fdjac2(m,n,x,fvec,fjac,ldfjac,&iflag,epsfcn,wa4, fcn);
 *nfev += n;
 if(iflag < 0)
     goto L300;

--- a/QuantLib/ql/math/optimization/lmdif.hpp
+++ b/QuantLib/ql/math/optimization/lmdif.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2006 Klaus Spanderen
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -42,7 +43,8 @@ namespace QuantLib {
                    int nprint, int* info,int* nfev,Real* fjac,
                    int ldfjac,int* ipvt,Real* qtf,
                    Real* wa1,Real* wa2,Real* wa3,Real* wa4,
-                   const LmdifCostFunction& fcn);
+                   const LmdifCostFunction& fcn,
+                   const LmdifCostFunction& jacFcn);
         
         void qrsolv(int n,Real* r,int ldr,int* ipvt,
                     Real* diag,Real* qtb, Real* x,

--- a/QuantLib/test-suite/optimizers.cpp
+++ b/QuantLib/test-suite/optimizers.cpp
@@ -108,6 +108,7 @@ namespace {
 
     enum OptimizationMethodType {simplex,
                                  levenbergMarquardt,
+                                 levenbergMarquardt2,
                                  conjugateGradient,
                                  steepestDescent,
                                  bfgs};
@@ -118,6 +119,8 @@ namespace {
             return "Simplex";
           case levenbergMarquardt:
             return "Levenberg Marquardt";
+          case levenbergMarquardt2:
+            return "Levenberg Marquardt (cost function's jacbobian)";
           case conjugateGradient:
             return "Conjugate Gradient";
           case steepestDescent:
@@ -150,6 +153,12 @@ namespace {
                 new LevenbergMarquardt(levenbergMarquardtEpsfcn,
                                        levenbergMarquardtXtol,
                                        levenbergMarquardtGtol));
+          case levenbergMarquardt2:
+            return boost::shared_ptr<OptimizationMethod>(
+                new LevenbergMarquardt(levenbergMarquardtEpsfcn,
+                                       levenbergMarquardtXtol,
+                                       levenbergMarquardtGtol,
+                                       true));
           case conjugateGradient:
             return boost::shared_ptr<OptimizationMethod>(new ConjugateGradient);
           case steepestDescent:
@@ -225,7 +234,8 @@ namespace {
                             gradientNormEpsilons_.back())));
         // Set optimization methods for optimizer
         OptimizationMethodType optimizationMethodTypes[] = {
-            simplex, levenbergMarquardt, conjugateGradient, bfgs//, steepestDescent
+            simplex, levenbergMarquardt, levenbergMarquardt2, conjugateGradient,
+            bfgs //, steepestDescent
         };
         Real simplexLambda = 0.1;                   // characteristic search length for simplex
         Real levenbergMarquardtEpsfcn = 1.0e-8;     // parameters specific for Levenberg-Marquardt


### PR DESCRIPTION
extend the cost function to allow for a user defined jacobian implementation and provide a central difference default implementation - this is in parallel to the gradient method which is already customizable

extend the levenberg marquardt optimizer by an option to use the cost function's jacobian implementation, this is done is a way wich keeps backward compatibility

a customizable jacobian is particularly interesting in connection with automatic differentiation
