### PR TITLE
fixed bug: european bonds are now with 2 settlement days

### DIFF
--- a/QuantLib/ql/instruments/bonds/btp.cpp
+++ b/QuantLib/ql/instruments/bonds/btp.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                  const Handle<YieldTermStructure>& fwdCurve,
                  const Date& startDate,
                  const Date& issueDate)
-    : FloatingRateBond(3, 100.0,
+    : FloatingRateBond(2, 100.0,
                        Schedule(startDate,
                                 maturityDate, 6*Months,
                                 NullCalendar(), Unadjusted, Unadjusted,
@@ -55,7 +55,7 @@ namespace QuantLib {
              Rate fixedRate,
              const Date& startDate,
              const Date& issueDate)
-    : FixedRateBond(3, 100.0,
+    : FixedRateBond(2, 100.0,
                     Schedule(startDate,
                              maturityDate, 6*Months,
                              NullCalendar(), Unadjusted, Unadjusted,
@@ -69,7 +69,7 @@ namespace QuantLib {
              Real redemption,
              const Date& startDate,
              const Date& issueDate)
-    : FixedRateBond(3, 100.0,
+    : FixedRateBond(2, 100.0,
                     Schedule(startDate,
                              maturityDate, 6*Months,
                              NullCalendar(), Unadjusted, Unadjusted,
@@ -178,7 +178,7 @@ namespace QuantLib {
                                        basket_->weights().end(),
                                        durations_.begin(), 0.0);
 
-        Natural settlDays = 3;
+        Natural settlDays = 2;
         DayCounter fixedDayCount = swaps_[0]->fixedDayCount();
         equivalentSwapIndex_ = nSwaps_-1;
         swapRates_[0]= swaps_[0]->fairRate();


### PR DESCRIPTION
sorry for the previous confusion, now it should be coherent. If other European bonds are missing, the bottom line is the same: they are now trading with two settlement days, not three