### PR TITLE
LongstaffSchwartz with exercise probability

### DIFF
--- a/QuantLib/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/QuantLib/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Klaus Spanderen
  Copyright (C) 2007 StatPro Italia srl
+ Copyright (C) 2015 Thema Consulting SA
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -159,6 +160,8 @@ namespace QuantLib {
                                           requiredSamples_,
                                           maxSamples_);
         this->results_.value = this->mcModel_->sampleAccumulator().mean();
+        this->results_.additionalResults["exerciseProbability"] =
+            this->pathPricer_->exerciseProbability();
         if (RNG::allowsErrorEstimate) {
             this->results_.errorEstimate =
                 this->mcModel_->sampleAccumulator().errorEstimate();


### PR DESCRIPTION
This patch extends the MC Longstaff-Schwartz engine to calculate the
exercise probability of the option (the algorithm derives directly from
the Longstaff-Schwartz idea, and simply counts the number of paths
where exercise occurs).

The results are checked in the test suite against values calculated
with third party (commercial) product.

At this time the other methods (tree, FD) don't calculate
exercise probability, but in future they can be extended as well.


