### PR TITLE
relax check for parameter vector length (thanks to Jan van Heys)

### DIFF
--- a/QuantLib/ql/experimental/volatility/noarbsabrsmilesection.cpp
+++ b/QuantLib/ql/experimental/volatility/noarbsabrsmilesection.cpp
@@ -40,8 +40,8 @@ NoArbSabrSmileSection::NoArbSabrSmileSection(
 }
 
 void NoArbSabrSmileSection::init() {
-    QL_REQUIRE(params_.size() == 4,
-               "sabr expects 4 parameters (alpha,beta,nu,rho,gamma) but ("
+    QL_REQUIRE(params_.size() >= 4,
+               "sabr expects 4 parameters (alpha,beta,nu,rho) but ("
                    << params_.size() << ") given");
     model_ =
         boost::make_shared<NoArbSabrModel>(exerciseTime(), forward_, params_[0],

--- a/QuantLib/ql/experimental/volatility/zabrsmilesection.hpp
+++ b/QuantLib/ql/experimental/volatility/zabrsmilesection.hpp
@@ -145,7 +145,7 @@ template <typename Evaluation>
 void ZabrSmileSection<Evaluation>::init(const std::vector<Real> &moneyness,
                                         ZabrLocalVolatility) {
 
-    QL_REQUIRE(params_.size() == 5,
+    QL_REQUIRE(params_.size() >= 5,
                "zabr expects 5 parameters (alpha,beta,nu,rho,gamma) but ("
                    << params_.size() << ") given");
 


### PR DESCRIPTION
This is necessary, because the SwaptionVolatilityCube1 constructs its smile sections by vectors that contain more elements than only the model parameters. Since this has always been the case for the original Hagan cube, I don't change this in the cube class for now, but just amend the new smile sections accordingly.