### PR TITLE
fix for ZABR test case failing with QL_EXTRA_SAFETY_CHECKS

### DIFF
--- a/QuantLib/ql/experimental/volatility/zabrsmilesection.hpp
+++ b/QuantLib/ql/experimental/volatility/zabrsmilesection.hpp
@@ -145,7 +145,7 @@ template <typename Evaluation>
 void ZabrSmileSection<Evaluation>::init(const std::vector<Real> &moneyness,
                                         ZabrLocalVolatility) {
 
-    QL_REQUIRE(params_.size() == 5,
+    QL_REQUIRE(params_.size() >= 5,
                "zabr expects 5 parameters (alpha,beta,nu,rho,gamma) but ("
                    << params_.size() << ") given");
 
@@ -171,7 +171,7 @@ void ZabrSmileSection<Evaluation>::init(const std::vector<Real> &moneyness,
         Real f = tmp[i] * forward_;
         if (f > 0.0) {
             if (!firstStrike) {
-                for (Size j = 1; j < fdRefinement_; j++) {
+                for (Size j = 1; j <= fdRefinement_; ++j) {
                     strikes_.push_back(lastF +
                                        ((double)j) * (f - lastF) /
                                            (fdRefinement_ + 1));

--- a/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/QuantLib/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -61,9 +61,16 @@ namespace QuantLib {
             if(requireCPoint) {
                 const Real z0 = - c1 / (c2-c1);
                 const Real u0 = static_cast<int>(z0*(size-1)+0.5) / ((Real)(size-1));
-                
-                u.push_back(0.0); u.push_back(u0); u.push_back(1.0);
-                z.push_back(0.0); z.push_back(z0); z.push_back(1.0);
+                if (u0 > 0.0) {
+                    u.push_back(0.0);
+                    z.push_back(0.0);
+                }
+                u.push_back(u0);
+                z.push_back(z0);
+                if (u0 < 1.0) {
+                    u.push_back(1.0);
+                    z.push_back(1.0);
+                }
                 transform = boost::shared_ptr<Interpolation>(
                     new LinearInterpolation(u.begin(), u.end(), z.begin()));
             }


### PR DESCRIPTION
the concentrating mesher was guilty for the broken case, the other commit contains two unrelated fixes