### PR TITLE
Minor fix in caplet stripping

### DIFF
--- a/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/QuantLib/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2007 François du Vignaud
  Copyright (C) 2007 Katiuscia Manzoni
  Copyright (C) 2007 Giorgio Facchinetti
+ Copyright (C) 2015 Michael von den Driesch
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -83,7 +84,7 @@ namespace QuantLib {
             optionletAccrualPeriods_[i] = lFRC->accrualPeriod();
             optionletTimes_[i] = dc.yearFraction(referenceDate,
                                                  optionletDates_[i]);
-            atmOptionletRate_[i] = iborIndex_->fixing(optionletDates_[i]);
+            atmOptionletRate_[i] = lFRC->indexFixing();
         }
 
         if (floatingSwitchStrike_ && capFlooMatrixNotInitialized_) {

--- a/QuantLib/test-suite/optionletstripper.cpp
+++ b/QuantLib/test-suite/optionletstripper.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2008 Ferdinando Ametrano
  Copyright (C) 2007, 2008 Laurent Hoffmann
+ Copyright (C) 2015 Michael von den Driesch
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -65,7 +66,7 @@ namespace {
 
         CommonVars() {
             accuracy = 1.0e-6;
-            tolerance = 2.5e-5;
+            tolerance = 2.5e-8;
         }
 
         void setTermStructure() {


### PR DESCRIPTION
This fix ensures consistent forward rates between optionlet stripping (the "vol imply part" of it) and actual caplet pricing. As a result the error tolerance can be improved in the corresponding test-suite class.

An additional test case for the normal vol stripping will be provided shortly with an additional PR.