### PR TITLE
Added possibility to fit spread over a discount curve

### DIFF
--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -464,7 +464,7 @@ int main(int, char* []) {
         printOutput("(e) Svensson", ts5);
 
         Handle<YieldTermStructure> discountCurve = getDiscountCurve();
-        NelsonSiegelFitting nelsonSiegelSpread(Array(), discountCurve);
+        SpreadFittingMethod nelsonSiegelSpread(make_shared<NelsonSiegelFitting>(), discountCurve);
         boost::shared_ptr<FittedBondDiscountCurve> ts6 (
                         new FittedBondDiscountCurve(curveSettlementDays,
                                                     calendar,

--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -42,6 +42,7 @@
 #include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
+#include <boost/make_shared.hpp>
 
 #define LENGTH(a) (sizeof(a)/sizeof(a[0]))
 
@@ -464,7 +465,7 @@ int main(int, char* []) {
         printOutput("(e) Svensson", ts5);
 
         Handle<YieldTermStructure> discountCurve = getDiscountCurve();
-        SpreadFittingMethod nelsonSiegelSpread(make_shared<NelsonSiegelFitting>(), discountCurve);
+        SpreadFittingMethod nelsonSiegelSpread(boost::make_shared<NelsonSiegelFitting>(), discountCurve);
         boost::shared_ptr<FittedBondDiscountCurve> ts6 (
                         new FittedBondDiscountCurve(curveSettlementDays,
                                                     calendar,

--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -2,6 +2,7 @@
 
 /*!
  Copyright (C) 2007 Allen Kuo
+ Copyright (C) 2015 Andres Hernandez
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -81,6 +82,209 @@ void printOutput(const std::string& tag,
          << endl;
 }
 
+Handle<YieldTermStructure> getDiscountCurve(){
+
+
+    /*********************
+     ***  MARKET DATA  ***
+     *********************/
+
+    Calendar calendar = TARGET();
+    Integer fixingDays = 0;
+    Date todaysDate = Settings::instance().evaluationDate();
+    Date settlementDate = calendar.advance(todaysDate, fixingDays, Days);
+
+    std::cout << "Today: " << todaysDate.weekday()
+              << ", " << todaysDate << std::endl;
+
+    std::cout << "Settlement date: " << settlementDate.weekday()
+              << ", " << settlementDate << std::endl;
+
+    // deposits
+    Rate d1wQuote=0.0382;
+    Rate d1mQuote=0.0372;
+    Rate d3mQuote=0.0363;
+    Rate d6mQuote=0.0353;
+    Rate d9mQuote=0.0348;
+    Rate d1yQuote=0.0345;
+    // FRAs
+    Rate fra3x6Quote=0.037125;
+    Rate fra6x9Quote=0.037125;
+    Rate fra6x12Quote=0.037125;
+    // futures
+    Real fut1Quote=96.2875;
+    Real fut2Quote=96.7875;
+    Real fut3Quote=96.9875;
+    Real fut4Quote=96.6875;
+    Real fut5Quote=96.4875;
+    Real fut6Quote=96.3875;
+    Real fut7Quote=96.2875;
+    Real fut8Quote=96.0875;
+    // swaps
+    Rate s2yQuote=0.037125;
+    Rate s3yQuote=0.0398;
+    Rate s5yQuote=0.0443;
+    Rate s10yQuote=0.05165;
+    Rate s15yQuote=0.055175;
+
+
+    /********************
+     ***    QUOTES    ***
+     ********************/
+
+    // SimpleQuote stores a value which can be manually changed;
+    // other Quote subclasses could read the value from a database
+    // or some kind of data feed.
+
+    // deposits
+    boost::shared_ptr<Quote> d1wRate(new SimpleQuote(d1wQuote));
+    boost::shared_ptr<Quote> d1mRate(new SimpleQuote(d1mQuote));
+    boost::shared_ptr<Quote> d3mRate(new SimpleQuote(d3mQuote));
+    boost::shared_ptr<Quote> d6mRate(new SimpleQuote(d6mQuote));
+    boost::shared_ptr<Quote> d9mRate(new SimpleQuote(d9mQuote));
+    boost::shared_ptr<Quote> d1yRate(new SimpleQuote(d1yQuote));
+    // FRAs
+    boost::shared_ptr<Quote> fra3x6Rate(new SimpleQuote(fra3x6Quote));
+    boost::shared_ptr<Quote> fra6x9Rate(new SimpleQuote(fra6x9Quote));
+    boost::shared_ptr<Quote> fra6x12Rate(new SimpleQuote(fra6x12Quote));
+    // futures
+    boost::shared_ptr<Quote> fut1Price(new SimpleQuote(fut1Quote));
+    boost::shared_ptr<Quote> fut2Price(new SimpleQuote(fut2Quote));
+    boost::shared_ptr<Quote> fut3Price(new SimpleQuote(fut3Quote));
+    boost::shared_ptr<Quote> fut4Price(new SimpleQuote(fut4Quote));
+    boost::shared_ptr<Quote> fut5Price(new SimpleQuote(fut5Quote));
+    boost::shared_ptr<Quote> fut6Price(new SimpleQuote(fut6Quote));
+    boost::shared_ptr<Quote> fut7Price(new SimpleQuote(fut7Quote));
+    boost::shared_ptr<Quote> fut8Price(new SimpleQuote(fut8Quote));
+    // swaps
+    boost::shared_ptr<Quote> s2yRate(new SimpleQuote(s2yQuote));
+    boost::shared_ptr<Quote> s3yRate(new SimpleQuote(s3yQuote));
+    boost::shared_ptr<Quote> s5yRate(new SimpleQuote(s5yQuote));
+    boost::shared_ptr<Quote> s10yRate(new SimpleQuote(s10yQuote));
+    boost::shared_ptr<Quote> s15yRate(new SimpleQuote(s15yQuote));
+
+
+    /*********************
+     ***  RATE HELPERS ***
+     *********************/
+
+    // RateHelpers are built from the above quotes together with
+    // other instrument dependant infos.  Quotes are passed in
+    // relinkable handles which could be relinked to some other
+    // data source later.
+
+    // deposits
+    DayCounter depositDayCounter = Actual360();
+
+    boost::shared_ptr<RateHelper> d1w(new DepositRateHelper(
+        Handle<Quote>(d1wRate),
+        1*Weeks, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> d1m(new DepositRateHelper(
+        Handle<Quote>(d1mRate),
+        1*Months, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> d3m(new DepositRateHelper(
+        Handle<Quote>(d3mRate),
+        3*Months, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> d6m(new DepositRateHelper(
+        Handle<Quote>(d6mRate),
+        6*Months, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> d9m(new DepositRateHelper(
+        Handle<Quote>(d9mRate),
+        9*Months, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> d1y(new DepositRateHelper(
+        Handle<Quote>(d1yRate),
+        1*Years, fixingDays,
+        calendar, ModifiedFollowing,
+        true, depositDayCounter));
+
+
+    // setup FRAs
+    boost::shared_ptr<RateHelper> fra3x6(new FraRateHelper(
+        Handle<Quote>(fra3x6Rate),
+        3, 6, fixingDays, calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> fra6x9(new FraRateHelper(
+        Handle<Quote>(fra6x9Rate),
+        6, 9, fixingDays, calendar, ModifiedFollowing,
+        true, depositDayCounter));
+    boost::shared_ptr<RateHelper> fra6x12(new FraRateHelper(
+        Handle<Quote>(fra6x12Rate),
+        6, 12, fixingDays, calendar, ModifiedFollowing,
+        true, depositDayCounter));
+
+    // setup swaps
+    Frequency swFixedLegFrequency = Annual;
+    BusinessDayConvention swFixedLegConvention = Unadjusted;
+    DayCounter swFixedLegDayCounter = Thirty360(Thirty360::European);
+    boost::shared_ptr<IborIndex> swFloatingLegIndex(new Euribor6M);
+
+    boost::shared_ptr<RateHelper> s2y(new SwapRateHelper(
+        Handle<Quote>(s2yRate), 2*Years,
+        calendar, swFixedLegFrequency,
+        swFixedLegConvention, swFixedLegDayCounter,
+        swFloatingLegIndex));
+    boost::shared_ptr<RateHelper> s3y(new SwapRateHelper(
+        Handle<Quote>(s3yRate), 3*Years,
+        calendar, swFixedLegFrequency,
+        swFixedLegConvention, swFixedLegDayCounter,
+        swFloatingLegIndex));
+    boost::shared_ptr<RateHelper> s5y(new SwapRateHelper(
+        Handle<Quote>(s5yRate), 5*Years,
+        calendar, swFixedLegFrequency,
+        swFixedLegConvention, swFixedLegDayCounter,
+        swFloatingLegIndex));
+    boost::shared_ptr<RateHelper> s10y(new SwapRateHelper(
+        Handle<Quote>(s10yRate), 10*Years,
+        calendar, swFixedLegFrequency,
+        swFixedLegConvention, swFixedLegDayCounter,
+        swFloatingLegIndex));
+    boost::shared_ptr<RateHelper> s15y(new SwapRateHelper(
+        Handle<Quote>(s15yRate), 15*Years,
+        calendar, swFixedLegFrequency,
+        swFixedLegConvention, swFixedLegDayCounter,
+        swFloatingLegIndex));
+
+
+    /*********************
+     **  CURVE BUILDING **
+     *********************/
+
+    // Any DayCounter would be fine.
+    // ActualActual::ISDA ensures that 30 years is 30.0
+    DayCounter termStructureDayCounter =
+        ActualActual(ActualActual::ISDA);
+
+
+    double tolerance = 1.0e-15;
+
+    // A depo-FRA-swap curve
+    std::vector<boost::shared_ptr<RateHelper> > depoFRASwapInstruments;
+    depoFRASwapInstruments.push_back(d1w);
+    depoFRASwapInstruments.push_back(d1m);
+    depoFRASwapInstruments.push_back(d3m);
+    depoFRASwapInstruments.push_back(fra3x6);
+    depoFRASwapInstruments.push_back(fra6x9);
+    depoFRASwapInstruments.push_back(fra6x12);
+    depoFRASwapInstruments.push_back(s2y);
+    depoFRASwapInstruments.push_back(s3y);
+    depoFRASwapInstruments.push_back(s5y);
+    depoFRASwapInstruments.push_back(s10y);
+    depoFRASwapInstruments.push_back(s15y);
+    return Handle<YieldTermStructure>(boost::make_shared<PiecewiseYieldCurve<Discount,LogLinear> >(
+                                       settlementDate, depoFRASwapInstruments,
+                                       termStructureDayCounter,
+                                       tolerance));
+}
 
 int main(int, char* []) {
 
@@ -118,7 +322,7 @@ int main(int, char* []) {
         BusinessDayConvention convention = ModifiedFollowing;
         Real redemption = 100.0;
 
-        Calendar calendar = NullCalendar();
+        Calendar calendar = TARGET();
         Date today = calendar.adjust(Date::todaysDate());
         Date origToday = today;
         Settings::instance().evaluationDate() = today;
@@ -259,6 +463,19 @@ int main(int, char* []) {
 
         printOutput("(e) Svensson", ts5);
 
+        Handle<YieldTermStructure> discountCurve = getDiscountCurve();
+        NelsonSiegelFitting nelsonSiegelSpread(Array(), discountCurve);
+        boost::shared_ptr<FittedBondDiscountCurve> ts6 (
+                        new FittedBondDiscountCurve(curveSettlementDays,
+                                                    calendar,
+                                                    instrumentsA,
+                                                    dc,
+                                                    nelsonSiegelSpread,
+                                                    tolerance,
+                                                    max));
+
+        printOutput("(f) Nelson-Siegel spreaded", ts6);
+
 
         cout << "Output par rates for each curve. In this case, "
              << endl
@@ -273,7 +490,8 @@ int main(int, char* []) {
              << setw(6) << "(b)" << " | "
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
-             << setw(6) << "(e)" << endl;
+             << setw(6) << "(e)" << " | "
+             << setw(6) << "(f)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -313,7 +531,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts4,keyDates,dc) << " | "
                  // Svensson
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts5,keyDates,dc) << endl;
+                 << 100.*parRate(*ts5,keyDates,dc)  << " | "
+                 // Nelson-Siegel Spreaded
+                 << setw(6) << fixed << setprecision(3)
+                 << 100.*parRate(*ts3,keyDates,dc) << endl;
         }
 
         cout << endl << endl << endl;

--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -535,7 +535,7 @@ int main(int, char* []) {
                  << 100.*parRate(*ts5,keyDates,dc)  << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts3,keyDates,dc) << endl;
+                 << 100.*parRate(*ts6,keyDates,dc) << endl;
         }
 
         cout << endl << endl << endl;

--- a/QuantLib/Examples/FittedBondCurve/FittedBondCurve.vcxproj
+++ b/QuantLib/Examples/FittedBondCurve/FittedBondCurve.vcxproj
@@ -445,7 +445,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>..\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..;C:\boost_1_57_0\path\include\boost-1_57;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WIN32;_CONSOLE;_SCL_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>

--- a/QuantLib/QuantLib.vcxproj
+++ b/QuantLib/QuantLib.vcxproj
@@ -228,7 +228,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;C:\boost_1_57_0\path\include\boost-1_57;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;_SCL_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -249,6 +249,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -136,14 +136,6 @@ namespace QuantLib {
 
 
     void FittedBondDiscountCurve::FittingMethod::init() {
-        //In case discount curve is given and has a different reference date,
-        //discount to this curve's reference date
-        if(!discountingCurve_.empty() && curve_->referenceDate() != discountingCurve_->referenceDate()){
-            rebase_ = discountingCurve_->discount(curve_->referenceDate());
-        } else{
-            rebase_ = 1.0;
-        }
-
         // yield conventions
         DayCounter yieldDC = curve_->dayCounter();
         Compounding yieldComp = Compounded;

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -189,7 +189,11 @@ namespace QuantLib {
 
 		if(curve_->maxEvaluations_ == 0)
 		{
-			//don't calculate, simply use given parameters to provide a fitted curve
+			//Don't calculate, simply use given parameters to provide a fitted curve.
+			//This turns the fittedbonddiscountcurve into an evaluator of the parametric
+			//curve, for example allowing to use the parameters for a credit spread curve
+			//calculated with bonds in one currency to be coupled to a discount curve in 
+			//another currency. 
 			return;
 		}
 		

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -209,30 +209,30 @@ namespace QuantLib {
             x = curve_->guessSolution_;
         }
 
-        //workaround for backwards compatibility
-        boost::shared_ptr<OptimizationMethod> optimization = optimizationMethod_;
-        if(!optimization)
-        {
-            optimization = boost::make_shared<Simplex>(curve_->simplexLambda_);
+        if(curve_->maxEvaluations_ > 0){
+            //workaround for backwards compatibility
+            boost::shared_ptr<OptimizationMethod> optimization = optimizationMethod_;
+            if(!optimization){
+                optimization = boost::make_shared<Simplex>(curve_->simplexLambda_);
+            }
+            Problem problem(costFunction, constraint, x);
+
+            Real rootEpsilon = curve_->accuracy_;
+            Real functionEpsilon =  curve_->accuracy_;
+            Real gradientNormEpsilon = curve_->accuracy_;
+
+            EndCriteria endCriteria(curve_->maxEvaluations_,
+                                    curve_->maxStationaryStateIterations_,
+                                    rootEpsilon,
+                                    functionEpsilon,
+                                    gradientNormEpsilon);
+
+            optimization->minimize(problem,endCriteria);
+            solution_ = problem.currentValue();
+
+            numberOfIterations_ = problem.functionEvaluation();
+            costValue_ = problem.functionValue();
         }
-        Problem problem(costFunction, constraint, x);
-
-        Real rootEpsilon = curve_->accuracy_;
-        Real functionEpsilon =  curve_->accuracy_;
-        Real gradientNormEpsilon = curve_->accuracy_;
-
-        EndCriteria endCriteria(curve_->maxEvaluations_,
-                                curve_->maxStationaryStateIterations_,
-                                rootEpsilon,
-                                functionEpsilon,
-                                gradientNormEpsilon);
-
-        optimization->minimize(problem,endCriteria);
-        solution_ = problem.currentValue();
-
-        numberOfIterations_ = problem.functionEvaluation();
-        costValue_ = problem.functionValue();
-
         // save the results as the guess solution, in case of recalculation
         curve_->guessSolution_ = solution_;
     }

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -203,6 +203,8 @@ namespace QuantLib {
 		Array weights() const;
 		//! return optimization method being used
 		boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
+		//! open discountFunction to public
+		DiscountFactor discount(const Array& x, Time t) const;
       protected:
         //! constructor
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
@@ -298,6 +300,11 @@ namespace QuantLib {
 	inline boost::shared_ptr<OptimizationMethod> 
 	FittedBondDiscountCurve::FittingMethod::optimizationMethod() const {
 		return optimizationMethod_;
+	}
+
+	inline DiscountFactor 
+	FittedBondDiscountCurve::FittingMethod::discount(const Array& x, Time t) const {
+		return discountFunction(x, t);
 	}
 }
 

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -153,7 +153,7 @@ namespace QuantLib {
     //! Base fitting method used to construct a fitted bond discount curve
     /*! This base class provides the specific methodology/strategy
         used to construct a FittedBondDiscountCurve.  Derived classes
-        need only define the virtual function discountFunctionImpl() based
+        need only define the virtual function discountFunction() based
         on the particular fitting method to be implemented, as well as
         size(), the number of variables to be solved for/optimized. The
         generic fitting methodology implemented here can be termed

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -306,6 +306,7 @@ namespace QuantLib {
 	FittedBondDiscountCurve::FittingMethod::discount(const Array& x, Time t) const {
 		return discountFunction(x, t);
 	}
+
 }
 
 #endif

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -164,11 +164,6 @@ namespace QuantLib {
         weights, which will be used as weights to each bond. If not given
         or empty, then the bonds will be weighted by inverse duration
 
-        To fit a spread curve, provide a discount curve as an input
-        parameter. The discount factor calculated by this curve then
-        becomes the discount factor from the underlying curve times the
-        discount factor of the spread curve.
-
         \todo derive the special-case class LinearFittingMethods from
               FittingMethod. A linear fitting to a set of basis
               functions \f$ b_i(t) \f$ is any fitting of the form
@@ -202,24 +197,22 @@ namespace QuantLib {
         Real minimumCostValue() const;
         //! clone of the current object
         virtual std::auto_ptr<FittingMethod> clone() const = 0;
+		//! return whether there is a constraint at zero
+		bool constrainAtZero() const;
+		//! return weights being used
+		Array weights() const;
+		//! return optimization method being used
+		boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
       protected:
         //! constructor
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
-                      const Handle<YieldTermStructure>& discountingCurve
-                                          = Handle<YieldTermStructure>(),
                       boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         //! rerun every time instruments/referenceDate changes
         virtual void init();
         //! discount function called by FittedBondDiscountCurve
-        DiscountFactor discountFunction(const Array& x,
-                                        Time t) const;
-        //! derived classes must set this
-        /*! user-defined discount curve, as a function of time and an
-            array of unknown fitting coefficients \f$ x_i \f$.
-        */
-        virtual DiscountFactor discountFunctionImpl(const Array& x,
-                                                    Time t) const = 0;
+        virtual DiscountFactor discountFunction(const Array& x,
+                                                Time t) const = 0;
 
         //! constrains discount function to unity at \f$ T=0 \f$, if true
         bool constrainAtZero_;
@@ -244,10 +237,6 @@ namespace QuantLib {
         Integer numberOfIterations_;
         // final value for the minimized cost function
         Real costValue_;
-        // adjustment in case underlying discount curve has different reference date
-        DiscountFactor rebase_;
-        // discount curve from on top of which the spread will be calculated
-        Handle<YieldTermStructure> discountingCurve_;
         // optimization method to be used, if none provided use Simplex
         boost::shared_ptr<OptimizationMethod> optimizationMethod_;
     };
@@ -297,7 +286,19 @@ namespace QuantLib {
     inline Array FittedBondDiscountCurve::FittingMethod::solution() const {
         return solution_;
     }
+	
+	inline bool FittedBondDiscountCurve::FittingMethod::constrainAtZero() const {
+		return constrainAtZero_;
+	}
+	
+	inline Array FittedBondDiscountCurve::FittingMethod::weights() const {
+		return weights_;
+	}
 
+	inline boost::shared_ptr<OptimizationMethod> 
+	FittedBondDiscountCurve::FittingMethod::optimizationMethod() const {
+		return optimizationMethod_;
+	}
 }
 
 #endif

--- a/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/QuantLib/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -1,8 +1,9 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2009 Ferdinando Ametrano
  Copyright (C) 2007 Allen Kuo
+ Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2015 Andres Hernandez
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -26,6 +27,7 @@
 #define quantlib_fitted_bond_discount_curve_hpp
 
 #include <ql/termstructures/yield/bondhelpers.hpp>
+#include <ql/math/optimization/method.hpp>
 #include <ql/patterns/lazyobject.hpp>
 #include <ql/math/array.hpp>
 #include <ql/utilities/clone.hpp>
@@ -98,7 +100,8 @@ namespace QuantLib {
                  Real accuracy = 1.0e-10,
                  Size maxEvaluations = 10000,
                  const Array& guess = Array(),
-                 Real simplexLambda = 1.0);
+                 Real simplexLambda = 1.0,
+                 Size maxStationaryStateIterations = 100);
         //! curve reference date fixed for life of curve
         FittedBondDiscountCurve(
                  const Date &referenceDate,
@@ -108,7 +111,8 @@ namespace QuantLib {
                  Real accuracy = 1.0e-10,
                  Size maxEvaluations = 10000,
                  const Array &guess = Array(),
-                 Real simplexLambda = 1.0);
+                 Real simplexLambda = 1.0,
+                 Size maxStationaryStateIterations = 100);
         //@}
 
         //! \name Inspectors
@@ -136,6 +140,8 @@ namespace QuantLib {
         Size maxEvaluations_;
         // sets the scale in the (Simplex) optimization routine
         Real simplexLambda_;
+        // max number of evaluations where no improvement to solution is made
+        Size maxStationaryStateIterations_;
         // a guess solution may be passed into the constructor to speed calcs
         Array guessSolution_;
         mutable Date maxDate_;
@@ -147,12 +153,21 @@ namespace QuantLib {
     //! Base fitting method used to construct a fitted bond discount curve
     /*! This base class provides the specific methodology/strategy
         used to construct a FittedBondDiscountCurve.  Derived classes
-        need only define the virtual function discountFunction() based
+        need only define the virtual function discountFunctionImpl() based
         on the particular fitting method to be implemented, as well as
         size(), the number of variables to be solved for/optimized. The
         generic fitting methodology implemented here can be termed
         nonlinear, in contrast to (typically faster, computationally)
         linear fitting method.
+
+        Optional parameters for FittingMethod include an Array of
+        weights, which will be used as weights to each bond. If not given
+        or empty, then the bonds will be weighted by inverse duration
+
+        To fit a spread curve, provide a discount curve as an input
+        parameter. The discount factor calculated by this curve then
+        becomes the discount factor from the underlying curve times the
+        discount factor of the spread curve.
 
         \todo derive the special-case class LinearFittingMethods from
               FittingMethod. A linear fitting to a set of basis
@@ -189,15 +204,22 @@ namespace QuantLib {
         virtual std::auto_ptr<FittingMethod> clone() const = 0;
       protected:
         //! constructor
-        FittingMethod(bool constrainAtZero = true);
+        FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
+                      const Handle<YieldTermStructure>& discountingCurve
+                                          = Handle<YieldTermStructure>(),
+                      boost::shared_ptr<OptimizationMethod> optimizationMethod
+                                          = boost::shared_ptr<OptimizationMethod>());
         //! rerun every time instruments/referenceDate changes
-        void init();
+        virtual void init();
+        //! discount function called by FittedBondDiscountCurve
+        DiscountFactor discountFunction(const Array& x,
+                                        Time t) const;
         //! derived classes must set this
         /*! user-defined discount curve, as a function of time and an
             array of unknown fitting coefficients \f$ x_i \f$.
         */
-        virtual DiscountFactor discountFunction(const Array& x,
-                                                Time t) const = 0;
+        virtual DiscountFactor discountFunctionImpl(const Array& x,
+                                                    Time t) const = 0;
 
         //! constrains discount function to unity at \f$ T=0 \f$, if true
         bool constrainAtZero_;
@@ -222,6 +244,12 @@ namespace QuantLib {
         Integer numberOfIterations_;
         // final value for the minimized cost function
         Real costValue_;
+        // adjustment in case underlying discount curve has different reference date
+        DiscountFactor rebase_;
+        // discount curve from on top of which the spread will be calculated
+        Handle<YieldTermStructure> discountingCurve_;
+        // optimization method to be used, if none provided use Simplex
+        boost::shared_ptr<OptimizationMethod> optimizationMethod_;
     };
 
     // inline

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -230,13 +230,6 @@ namespace QuantLib {
       method_(method), discountingCurve_(discountCurve) {
 		QL_REQUIRE(method, "Fitting method is empty");
 		QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");
-		//In case discount curve is given and has a different reference date,
-        //discount to this curve's reference date
-        if(curve_->referenceDate() != discountingCurve_->referenceDate()){
-            rebase_ = discountingCurve_->discount(curve_->referenceDate());
-        } else{
-            rebase_ = 1.0;
-        }
 	}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
@@ -252,5 +245,18 @@ namespace QuantLib {
 	DiscountFactor SpreadFittingMethod::discountFunction(const Array& x, Time t) const{
         return method_->discount(x, t)*discountingCurve_->discount(t, true)/rebase_;
     }
+
+	void SpreadFittingMethod::init(){
+		//In case discount curve has a different reference date,
+		//discount to this curve's reference date
+		if (curve_->referenceDate() != discountingCurve_->referenceDate()){
+			rebase_ = discountingCurve_->discount(curve_->referenceDate());
+		}
+		else{
+			rebase_ = 1.0;
+		}
+		//Call regular init
+		FittedBondDiscountCurve::FittingMethod::init();
+	}
 }
 

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2007 Allen Kuo
  Copyright (C) 2010 Alessandro Roveda
+ Copyright (C) 2015 Andres Hernandez
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -23,8 +24,11 @@
 
 namespace QuantLib {
 
-    ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero) {}
+    ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
+                                                         const Array& weights,
+                                                         const Handle<YieldTermStructure>& discountingCurve,
+                                                         boost::shared_ptr<OptimizationMethod> optimizationMethod)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, discountingCurve, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     ExponentialSplinesFitting::clone() const {
@@ -36,7 +40,7 @@ namespace QuantLib {
         return constrainAtZero_ ? 9 : 10;
     }
 
-    DiscountFactor ExponentialSplinesFitting::discountFunction(const Array& x,
+    DiscountFactor ExponentialSplinesFitting::discountFunctionImpl(const Array& x,
                                                                Time t) const {
         DiscountFactor d = 0.0;
         Size N = size();
@@ -63,8 +67,10 @@ namespace QuantLib {
 
 
 
-    NelsonSiegelFitting::NelsonSiegelFitting()
-    : FittedBondDiscountCurve::FittingMethod(true) {}
+    NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
+                                             const Handle<YieldTermStructure>& discountingCurve,
+                                             boost::shared_ptr<OptimizationMethod> optimizationMethod)
+    : FittedBondDiscountCurve::FittingMethod(true, weights, discountingCurve, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     NelsonSiegelFitting::clone() const {
@@ -76,7 +82,7 @@ namespace QuantLib {
         return 4;
     }
 
-    DiscountFactor NelsonSiegelFitting::discountFunction(const Array& x,
+    DiscountFactor NelsonSiegelFitting::discountFunctionImpl(const Array& x,
                                                          Time t) const {
         Real kappa = x[size()-1];
         Real zeroRate = x[0] + (x[1] + x[2])*
@@ -88,8 +94,10 @@ namespace QuantLib {
     }
 
 
-    SvenssonFitting::SvenssonFitting()
-    : FittedBondDiscountCurve::FittingMethod(true) {}
+    SvenssonFitting::SvenssonFitting(const Array& weights,
+                                     const Handle<YieldTermStructure>& discountingCurve,
+                                     boost::shared_ptr<OptimizationMethod> optimizationMethod)
+    : FittedBondDiscountCurve::FittingMethod(true, weights, discountingCurve, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     SvenssonFitting::clone() const {
@@ -101,7 +109,7 @@ namespace QuantLib {
         return 6;
     }
 
-    DiscountFactor SvenssonFitting::discountFunction(const Array& x,
+    DiscountFactor SvenssonFitting::discountFunctionImpl(const Array& x,
                                                      Time t) const {
         Real kappa = x[size()-2];
         Real kappa_1 = x[size()-1];
@@ -118,8 +126,11 @@ namespace QuantLib {
 
 
     CubicBSplinesFitting::CubicBSplinesFitting(const std::vector<Time>& knots,
-                                               bool constrainAtZero)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero),
+                                               bool constrainAtZero,
+                                               const Array& weights,
+                                               const Handle<YieldTermStructure>& discountingCurve,
+                                               boost::shared_ptr<OptimizationMethod> optimizationMethod)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, discountingCurve, optimizationMethod),
       splines_(3, knots.size()-5, knots) {
 
         QL_REQUIRE(knots.size() >= 8,
@@ -155,7 +166,7 @@ namespace QuantLib {
         return size_;
     }
 
-    DiscountFactor CubicBSplinesFitting::discountFunction(const Array& x,
+    DiscountFactor CubicBSplinesFitting::discountFunctionImpl(const Array& x,
                                                           Time t) const {
         DiscountFactor d = 0.0;
 
@@ -185,8 +196,11 @@ namespace QuantLib {
 
 
     SimplePolynomialFitting::SimplePolynomialFitting(Natural degree,
-                                                     bool constrainAtZero)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero),
+                                                     bool constrainAtZero,
+                                                     const Array& weights,
+                                                     const Handle<YieldTermStructure>& discountingCurve,
+                                                     boost::shared_ptr<OptimizationMethod> optimizationMethod)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, discountingCurve, optimizationMethod),
       size_(constrainAtZero ? degree : degree+1) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
@@ -199,7 +213,7 @@ namespace QuantLib {
         return size_;
     }
 
-    DiscountFactor SimplePolynomialFitting::discountFunction(const Array& x,
+    DiscountFactor SimplePolynomialFitting::discountFunctionImpl(const Array& x,
                                                              Time t) const {
         DiscountFactor d = 0.0;
 

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -223,12 +223,12 @@ namespace QuantLib {
         return d;
     }
 	
-	SpreadFittingMethod::SpreadFittingMethod(shared_ptr<FittingMethod> method,
+	SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve)
     : FittedBondDiscountCurve::FittingMethod(method ? method->constrainAtZero() : true, method ? method->weights() : Array(), 
 											 method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>()),
       method_(method), discountingCurve_(discountCurve) {
-		QL_REQUIRE(!method, "Fitting method is empty");
+		QL_REQUIRE(method, "Fitting method is empty");
 		QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");
 		//In case discount curve is given and has a different reference date,
         //discount to this curve's reference date
@@ -250,7 +250,7 @@ namespace QuantLib {
     }
 
 	DiscountFactor SpreadFittingMethod::discountFunction(const Array& x, Time t) const{
-        return method_->discountFunction(x, t)*discountingCurve_->discount(t, true)/rebase_;
+        return method_->discount(x, t)*discountingCurve_->discount(t, true)/rebase_;
     }
 }
 

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -27,6 +27,7 @@
 
 #include <ql/termstructures/yield/fittedbonddiscountcurve.hpp>
 #include <ql/math/bspline.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace QuantLib {
 
@@ -176,14 +177,14 @@ namespace QuantLib {
     class SpreadFittingMethod
         : public FittedBondDiscountCurve::FittingMethod {
       public:
-         SpreadFittingMethod(shared_ptr<FittingMethod> method,
+         SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
 		// underlying parametric method
-		shared_ptr<FittingMethod> method_;
+		boost::shared_ptr<FittingMethod> method_;
         // adjustment in case underlying discount curve has different reference date
         DiscountFactor rebase_;
         // discount curve from on top of which the spread will be calculated

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -47,14 +47,12 @@ namespace QuantLib {
       public:
         ExponentialSplinesFitting(bool constrainAtZero = true,
                                   const Array& weights = Array(),
-                                  const Handle<YieldTermStructure>& discountingCurve
-                                          = Handle<YieldTermStructure>(),
                                   boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
     };
 
 
@@ -72,14 +70,12 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         NelsonSiegelFitting(const Array& weights = Array(),
-                            const Handle<YieldTermStructure>& discountingCurve
-                                   = Handle<YieldTermStructure>(),
                             boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
     };
 
 
@@ -99,14 +95,12 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         SvenssonFitting(const Array& weights = Array(),
-                        const Handle<YieldTermStructure>& discountingCurve
-                               = Handle<YieldTermStructure>(),
                         boost::shared_ptr<OptimizationMethod> optimizationMethod
                                = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
     };
 
 
@@ -135,8 +129,6 @@ namespace QuantLib {
         CubicBSplinesFitting(const std::vector<Time>& knotVector,
                              bool constrainAtZero = true,
                              const Array& weights = Array(),
-                             const Handle<YieldTermStructure>& discountingCurve
-                                     = Handle<YieldTermStructure>(),
                              boost::shared_ptr<OptimizationMethod> optimizationMethod
                                      = boost::shared_ptr<OptimizationMethod>());
         //! cubic B-spline basis functions
@@ -144,7 +136,7 @@ namespace QuantLib {
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
         BSpline splines_;
         Size size_;
         //! N_th basis function coefficient to solve for when d(0)=1
@@ -168,17 +160,35 @@ namespace QuantLib {
         SimplePolynomialFitting(Natural degree,
                                 bool constrainAtZero = true,
                                 const Array& weights = Array(),
-                                const Handle<YieldTermStructure>& discountingCurve
-                                       = Handle<YieldTermStructure>(),
                                 boost::shared_ptr<OptimizationMethod> optimizationMethod
                                        = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
         Size size_;
     };
 
+
+    //! Spread fitting method helper
+    /*  Fits a spread curve on top of a discount function according to given parametric method
+    */
+    class SpreadFittingMethod
+        : public FittedBondDiscountCurve::FittingMethod {
+      public:
+         SpreadFittingMethod(shared_ptr<FittingMethod> method,
+                        Handle<YieldTermStructure> discountCurve);
+        std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
+      private:
+        Size size() const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
+		// underlying parametric method
+		shared_ptr<FittingMethod> method_;
+        // adjustment in case underlying discount curve has different reference date
+        DiscountFactor rebase_;
+        // discount curve from on top of which the spread will be calculated
+        Handle<YieldTermStructure> discountingCurve_;
+    };
 }
 
 

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -45,11 +45,16 @@ namespace QuantLib {
     class ExponentialSplinesFitting
         : public FittedBondDiscountCurve::FittingMethod {
       public:
-        ExponentialSplinesFitting(bool constrainAtZero = true);
+        ExponentialSplinesFitting(bool constrainAtZero = true,
+                                  const Array& weights = Array(),
+                                  const Handle<YieldTermStructure>& discountingCurve
+                                          = Handle<YieldTermStructure>(),
+                                  boost::shared_ptr<OptimizationMethod> optimizationMethod
+                                          = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunction(const Array& x, Time t) const;
+        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
     };
 
 
@@ -66,11 +71,15 @@ namespace QuantLib {
     class NelsonSiegelFitting
         : public FittedBondDiscountCurve::FittingMethod {
       public:
-        NelsonSiegelFitting();
+        NelsonSiegelFitting(const Array& weights = Array(),
+                            const Handle<YieldTermStructure>& discountingCurve
+                                   = Handle<YieldTermStructure>(),
+                            boost::shared_ptr<OptimizationMethod> optimizationMethod
+                                          = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunction(const Array& x, Time t) const;
+        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
     };
 
 
@@ -89,11 +98,15 @@ namespace QuantLib {
     class SvenssonFitting
         : public FittedBondDiscountCurve::FittingMethod {
       public:
-        SvenssonFitting();
+        SvenssonFitting(const Array& weights = Array(),
+                        const Handle<YieldTermStructure>& discountingCurve
+                               = Handle<YieldTermStructure>(),
+                        boost::shared_ptr<OptimizationMethod> optimizationMethod
+                               = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunction(const Array& x, Time t) const;
+        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
     };
 
 
@@ -120,13 +133,18 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         CubicBSplinesFitting(const std::vector<Time>& knotVector,
-                             bool constrainAtZero = true);
+                             bool constrainAtZero = true,
+                             const Array& weights = Array(),
+                             const Handle<YieldTermStructure>& discountingCurve
+                                     = Handle<YieldTermStructure>(),
+                             boost::shared_ptr<OptimizationMethod> optimizationMethod
+                                     = boost::shared_ptr<OptimizationMethod>());
         //! cubic B-spline basis functions
         Real basisFunction(Integer i, Time t) const;
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunction(const Array& x, Time t) const;
+        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
         BSpline splines_;
         Size size_;
         //! N_th basis function coefficient to solve for when d(0)=1
@@ -148,11 +166,16 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         SimplePolynomialFitting(Natural degree,
-                                bool constrainAtZero = true);
+                                bool constrainAtZero = true,
+                                const Array& weights = Array(),
+                                const Handle<YieldTermStructure>& discountingCurve
+                                       = Handle<YieldTermStructure>(),
+                                boost::shared_ptr<OptimizationMethod> optimizationMethod
+                                       = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
-        DiscountFactor discountFunction(const Array& x, Time t) const;
+        DiscountFactor discountFunctionImpl(const Array& x, Time t) const;
         Size size_;
     };
 

--- a/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/QuantLib/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -180,7 +180,9 @@ namespace QuantLib {
          SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
-      private:
+	protected:
+		void init();
+	  private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
 		// underlying parametric method


### PR DESCRIPTION
These changes make the previous class more general:
- One can now specify the weights to be used, it defaults to the old method
of weighted by inverse duration if an empty weight Array is given (or skipped)
- One can now give an externally initiated optimization method, e.g. a global 
optimizer like simulated annealing. If none is provided, then the old Simplex 
method is used.

The real change is to allow for an extra parameter to specify an underlying discount curve upon which the spread curve will be calculated. If no curve is given, then the full curve is fitted as before. Furthermore, if one sets the maxIteratoins to zero, then no calculation at all is made. This allows to calculate a credit spread curve in one currency, and apply it on top of a discount curve from another currency to price bonds from the same issuer but in a different currency. 

The changes are almost completely backwards compatible, as the extra parameters are optional parameters that default to the previous functionality. The only place, where the changes would cause problems, is for people who have made classes deriving from FittedBondDiscountCurve::FittingMethod. In that case it will break at compilation time, as the function that should be overloaded is now discountFunctionImpl, instead of discountFunction. The old discountFunction, is now the place where the spread and the underliyng discount curve come together. 