### PR TITLE
use boost accumulators for incremental statistics

### DIFF
--- a/QuantLib/ql/math/statistics/incrementalstatistics.cpp
+++ b/QuantLib/ql/math/statistics/incrementalstatistics.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 Ferdinando Ametrano
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,162 +29,112 @@ namespace QuantLib {
     }
 
     Size IncrementalStatistics::samples() const {
-        return sampleNumber_;
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::count>(acc_);
     }
 
     Real IncrementalStatistics::weightSum() const {
-        return sampleWeight_;
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::sum_of_weights_kahan>(acc_);
     }
 
     Real IncrementalStatistics::mean() const {
-        QL_REQUIRE(sampleWeight_>0.0,
-                   "sampleWeight_=0, unsufficient");
-        return sum_/sampleWeight_;
+        QL_REQUIRE(weightSum() > 0.0, "sampleWeight_= 0, unsufficient");
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::weighted_mean>(acc_);
     }
 
     Real IncrementalStatistics::variance() const {
-        QL_REQUIRE(sampleWeight_>0.0,
-                   "sampleWeight_=0, unsufficient");
-        QL_REQUIRE(sampleNumber_>1,
-                   "sample number <=1, unsufficient");
-
-        Real m = mean();
-        Real v = quadraticSum_/sampleWeight_;
-        v -= m*m;
-        v *= sampleNumber_/(sampleNumber_-1.0);
-
-
-        QL_ENSURE(v >= 0.0,
-                  "negative variance (" << std::scientific << v << ")");
-
-        return v;
+        QL_REQUIRE(weightSum() > 0.0, "sampleWeight_= 0, unsufficient");
+        QL_REQUIRE(samples() > 1, "sample number <= 1, unsufficient");
+        Real n = static_cast<Real>(samples());
+        return n / (n - 1.0) *
+               boost::accumulators::extract_result<
+                   boost::accumulators::tag::weighted_variance>(acc_);
     }
 
     Real IncrementalStatistics::standardDeviation() const {
         return std::sqrt(variance());
     }
 
+    Real IncrementalStatistics::errorEstimate() const {
+        return std::sqrt(variance() / (samples()));
+    }
+
+    Real IncrementalStatistics::skewness() const {
+        QL_REQUIRE(samples() > 2, "sample number <= 2, unsufficient");
+        Real n = static_cast<Real>(samples());
+        Real r1 = n / (n - 2.0);
+        Real r2 = (n - 1.0) / (n - 2.0);
+        return std::sqrt(r1 * r2) * 
+               boost::accumulators::extract_result<
+                   boost::accumulators::tag::weighted_skewness>(acc_);
+    }
+
+    Real IncrementalStatistics::kurtosis() const {
+        QL_REQUIRE(samples() > 3,
+                   "sample number <= 3, unsufficient");
+        boost::accumulators::extract_result<
+            boost::accumulators::tag::weighted_kurtosis>(acc_);
+        Real n = static_cast<Real>(samples());
+        Real r1 = (n - 1.0) / (n - 2.0);
+        Real r2 = (n + 1.0) / (n - 3.0);
+        Real r3 = (n - 1.0) / (n - 3.0);
+        return ((3.0 + boost::accumulators::extract_result<
+                           boost::accumulators::tag::weighted_kurtosis>(acc_)) *
+                    r2 -
+                3.0 * r3) *
+               r1;
+    }
+
+    Real IncrementalStatistics::min() const {
+        QL_REQUIRE(samples() > 0, "empty sample set");
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::min>(acc_);
+    }
+
+    Real IncrementalStatistics::max() const {
+        QL_REQUIRE(samples() > 0, "empty sample set");
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::max>(acc_);
+    }
+
+    Size IncrementalStatistics::downsideSamples() const {
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::count>(downsideAcc_);
+    }
+
+    Real IncrementalStatistics::downsideWeightSum() const {
+        return boost::accumulators::extract_result<
+            boost::accumulators::tag::sum_of_weights_kahan>(downsideAcc_);
+    }
+
     Real IncrementalStatistics::downsideVariance() const {
-        if (downsideSampleWeight_==0.0) {
-            QL_REQUIRE(sampleWeight_>0.0,
-                       "sampleWeight_=0, unsufficient");
-            return 0.0;
-        }
-
-        QL_REQUIRE(downsideSampleNumber_>1,
-                   "sample number below zero <=1, unsufficient");
-
-        return (downsideSampleNumber_/(downsideSampleNumber_-1.0))*
-            (downsideQuadraticSum_ /downsideSampleWeight_);
+        QL_REQUIRE(downsideWeightSum() > 0.0, "sampleWeight_= 0, unsufficient");
+        QL_REQUIRE(downsideSamples() > 1, "sample number <= 1, unsufficient");
+        Real n = static_cast<Real>(downsideSamples());
+        Real r1 = n / (n - 1.0);
+        Real r2 = n / downsideWeightSum();
+        return r1 *
+               boost::accumulators::extract_result<
+                   boost::accumulators::tag::moment<2> >(downsideAcc_);
     }
 
     Real IncrementalStatistics::downsideDeviation() const {
         return std::sqrt(downsideVariance());
     }
 
-    Real IncrementalStatistics::errorEstimate() const {
-        Real var = variance();
-        QL_REQUIRE(samples() > 0, "empty sample set");
-        return std::sqrt(var/samples());
-    }
-
-    Real IncrementalStatistics::skewness() const {
-        QL_REQUIRE(sampleNumber_>2,
-                   "sample number <=2, unsufficient");
-        Real s = standardDeviation();
-
-        if (s==0.0) return 0.0;
-
-        Real m = mean();
-        Real result = cubicSum_/sampleWeight_;
-        result -= 3.0*m*(quadraticSum_/sampleWeight_);
-        result += 2.0*m*m*m;
-        result /= s*s*s;
-        result *= sampleNumber_/(sampleNumber_-1.0);
-        result *= sampleNumber_/(sampleNumber_-2.0);
-        return result;
-    }
-
-    Real IncrementalStatistics::kurtosis() const {
-        QL_REQUIRE(sampleNumber_>3,
-                   "sample number <=3, unsufficient");
-
-        Real m = mean();
-        Real v = variance();
-
-        Real c = (sampleNumber_-1.0)/(sampleNumber_-2.0);
-        c *= (sampleNumber_-1.0)/(sampleNumber_-3.0);
-        c *= 3.0;
-
-        if (v==0) return c;
-
-        Real result = fourthPowerSum_/sampleWeight_;
-        result -= 4.0*m*(cubicSum_/sampleWeight_);
-        result += 6.0*m*m*(quadraticSum_/sampleWeight_);
-        result -= 3.0*m*m*m*m;
-        result /= v*v;
-        result *= sampleNumber_/(sampleNumber_-1.0);
-        result *= sampleNumber_/(sampleNumber_-2.0);
-        result *= (sampleNumber_+1.0)/(sampleNumber_-3.0);
-
-
-        return result-c;
-    }
-
-    Real IncrementalStatistics::min() const {
-        QL_REQUIRE(samples() > 0, "empty sample set");
-        return min_;
-    }
-
-    Real IncrementalStatistics::max() const {
-        QL_REQUIRE(samples() > 0, "empty sample set");
-        return max_;
-    }
-
-    void IncrementalStatistics::add(Real value, Real weight) {
-        QL_REQUIRE(weight>=0.0,
-                   "negative weight (" << weight << ") not allowed");
-
-        Size oldSamples = sampleNumber_;
-        sampleNumber_++;
-        QL_ENSURE(sampleNumber_ > oldSamples,
-                  "maximum number of samples reached");
-
-        sampleWeight_ += weight;
-
-        Real temp = weight*value;
-        sum_ += temp;
-        temp *= value;
-        quadraticSum_ += temp;
-        if (value<0.0) {
-            downsideQuadraticSum_ += temp;
-            downsideSampleNumber_++;
-            downsideSampleWeight_ += weight;
-        }
-        temp *= value;
-        cubicSum_ += temp;
-        temp *= value;
-        fourthPowerSum_ += temp;
-        if (oldSamples == 0) {
-            min_ = max_ = value;
-        } else {
-            min_ = std::min(value, min_);
-            max_ = std::max(value, max_);
-        }
+    void IncrementalStatistics::add(Real value, Real valueWeight) {
+        QL_REQUIRE(valueWeight >= 0.0, "negative weight (" << valueWeight
+                                                           << ") not allowed");
+        acc_(value, boost::accumulators::weight = valueWeight);
+        if(value < 0.0)
+            downsideAcc_(value, boost::accumulators::weight = valueWeight);
     }
 
     void IncrementalStatistics::reset() {
-        min_ = QL_MAX_REAL;
-        max_ = QL_MIN_REAL;
-        sampleNumber_ = 0;
-        downsideSampleNumber_ = 0;
-        sampleWeight_ = 0.0;
-        downsideSampleWeight_ = 0.0;
-        sum_ = 0.0;
-        quadraticSum_ = 0.0;
-        downsideQuadraticSum_ = 0.0;
-        cubicSum_ = 0.0;
-        fourthPowerSum_ = 0.0;
+        acc_ = acc0_;
+        downsideAcc_ = downsideAcc0_;
     }
 
 }

--- a/QuantLib/ql/math/statistics/incrementalstatistics.cpp
+++ b/QuantLib/ql/math/statistics/incrementalstatistics.cpp
@@ -114,7 +114,6 @@ namespace QuantLib {
         QL_REQUIRE(downsideSamples() > 1, "sample number <= 1, unsufficient");
         Real n = static_cast<Real>(downsideSamples());
         Real r1 = n / (n - 1.0);
-        Real r2 = n / downsideWeightSum();
         return r1 *
                boost::accumulators::extract_result<
                    boost::accumulators::tag::moment<2> >(downsideAcc_);
@@ -133,8 +132,8 @@ namespace QuantLib {
     }
 
     void IncrementalStatistics::reset() {
-        acc_ = acc0_;
-        downsideAcc_ = downsideAcc0_;
+        acc_ = accumulator_set();
+        downsideAcc_ = downside_accumulator_set();
     }
 
 }

--- a/QuantLib/ql/math/statistics/incrementalstatistics.hpp
+++ b/QuantLib/ql/math/statistics/incrementalstatistics.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 Ferdinando Ametrano
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -20,6 +21,8 @@
 
 /*! \file incrementalstatistics.hpp
     \brief statistics tool based on incremental accumulation
+           in the meantime, this is just a wrapper to the boost
+           accumulator library, kept for backward compatibility
 */
 
 #ifndef quantlib_incremental_statistics_hpp
@@ -28,15 +31,27 @@
 #include <ql/utilities/null.hpp>
 #include <ql/errors.hpp>
 
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/count.hpp>
+#include <boost/accumulators/statistics/sum.hpp>
+#include <boost/accumulators/statistics/sum_kahan.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/weighted_mean.hpp>
+#include <boost/accumulators/statistics/weighted_variance.hpp>
+#include <boost/accumulators/statistics/weighted_skewness.hpp>
+#include <boost/accumulators/statistics/weighted_kurtosis.hpp>
+#include <boost/accumulators/statistics/weighted_moment.hpp>
+
 namespace QuantLib {
 
     //! Statistics tool based on incremental accumulation
     /*! It can accumulate a set of data and return statistics (e.g: mean,
-        variance, skewness, kurtosis, error estimation, etc.)
-
-        \warning high moments are numerically unstable for high
-                 average/standardDeviation ratios.
+        variance, skewness, kurtosis, error estimation, etc.).
+        This class is a wrapper to the boost accumulator library.
     */
+
     class IncrementalStatistics {
       public:
         typedef Real value_type;
@@ -92,6 +107,12 @@ namespace QuantLib {
         /*! returns the maximum sample value */
         Real max() const;
 
+        //! number of negative samples collected
+        Size downsideSamples() const;
+
+        //! sum of data weights for negative samples
+        Real downsideWeightSum() const;
+
         /*! returns the downside variance, defined as
             \f[ \frac{N}{N-1} \times \frac{ \sum_{i=1}^{N}
                 \theta \times x_i^{2}}{ \sum_{i=1}^{N} w_i} \f],
@@ -129,12 +150,26 @@ namespace QuantLib {
         //! resets the data to a null set
         void reset();
         //@}
-      protected:
-        Size sampleNumber_, downsideSampleNumber_;
-        Real sampleWeight_, downsideSampleWeight_;
-        Real sum_, quadraticSum_, downsideQuadraticSum_,
-            cubicSum_, fourthPowerSum_;
-        Real min_, max_;
+     private:
+       boost::accumulators::accumulator_set<
+           Real,
+           boost::accumulators::stats<
+               boost::accumulators::tag::count, boost::accumulators::tag::min,
+               boost::accumulators::tag::max,
+               boost::accumulators::tag::weighted_mean,
+               boost::accumulators::tag::weighted_variance,
+               boost::accumulators::tag::weighted_skewness,
+               boost::accumulators::tag::weighted_kurtosis,
+               boost::accumulators::tag::sum_of_weights_kahan>,
+           Real> acc_,
+           acc0_;
+       boost::accumulators::accumulator_set<
+           Real, boost::accumulators::stats<
+                     boost::accumulators::tag::count,
+                     boost::accumulators::tag::weighted_moment<2>,
+                     boost::accumulators::tag::sum_of_weights_kahan>,
+           Real> downsideAcc_,
+           downsideAcc0_;
     };
 
 }

--- a/QuantLib/ql/math/statistics/incrementalstatistics.hpp
+++ b/QuantLib/ql/math/statistics/incrementalstatistics.hpp
@@ -151,7 +151,7 @@ namespace QuantLib {
         void reset();
         //@}
      private:
-       boost::accumulators::accumulator_set<
+       typedef boost::accumulators::accumulator_set<
            Real,
            boost::accumulators::stats<
                boost::accumulators::tag::count, boost::accumulators::tag::min,
@@ -161,15 +161,15 @@ namespace QuantLib {
                boost::accumulators::tag::weighted_skewness,
                boost::accumulators::tag::weighted_kurtosis,
                boost::accumulators::tag::sum_of_weights_kahan>,
-           Real> acc_,
-           acc0_;
-       boost::accumulators::accumulator_set<
-           Real, boost::accumulators::stats<
-                     boost::accumulators::tag::count,
-                     boost::accumulators::tag::weighted_moment<2>,
-                     boost::accumulators::tag::sum_of_weights_kahan>,
-           Real> downsideAcc_,
-           downsideAcc0_;
+           Real> accumulator_set;
+        accumulator_set acc_;
+        typedef boost::accumulators::accumulator_set<
+            Real, boost::accumulators::stats<
+                      boost::accumulators::tag::count,
+                      boost::accumulators::tag::weighted_moment<2>,
+                      boost::accumulators::tag::sum_of_weights_kahan>,
+            Real> downside_accumulator_set;
+        downside_accumulator_set downsideAcc_;
     };
 
 }

--- a/QuantLib/test-suite/stats.hpp
+++ b/QuantLib/test-suite/stats.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 RiskMap srl
  Copyright (C) 2005 Gary Kennedy
+ Copyright (C) 2015 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,6 +32,7 @@ class StatisticsTest {
     static void testStatistics();
     static void testSequenceStatistics();
     static void testConvergenceStatistics();
+    static void testIncrementalStatistics();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
add test cases with reference values from the old implementation, add
test cases which tests the numerical stability of the new implementation
where the old one fails