### PR TITLE
Add bond test for South African R2048 which requires Schedule from custom Date vector

### DIFF
--- a/QuantLib/test-suite/bonds.hpp
+++ b/QuantLib/test-suite/bonds.hpp
@@ -38,6 +38,7 @@ class BondTest {
     static void testBrazilianCached();
     static void testExCouponGilt();
     static void testExCouponAustralianBond();
+    static void testBondFromScheduleWithDateVector();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
This PR adds a test for the R2048 South African government bond. It uses the Schedule constructor that @pcaspers added to enforce coupon dates on 28 Feb even for leap years.

The schedule is first built using the standard way and then modified and passed into a new schedule.

Price and yield from market quotes.