### PR TITLE
fix test case for indexed coupons

### DIFF
--- a/QuantLib/test-suite/inflationcpiswap.cpp
+++ b/QuantLib/test-suite/inflationcpiswap.cpp
@@ -361,7 +361,7 @@ void CPISwapTest::consistency() {
                testInfLegNPV << " vs " << zisV.legNPV(0));
 
     Real diff = fabs(1-zisV.NPV()/4191660.0);
-    QL_REQUIRE(diff<1e-5,
+    QL_REQUIRE(diff<3e-5,
                "failed stored consistency value test, ratio = " << diff);
 
     // remove circular refernce


### PR DESCRIPTION
we increase the tolerance for the check against the hard coded reference
value so that it is passed with indexed coupons too