### PR TITLE
add  some missing calendar methods in swig

### DIFF
--- a/QuantLib-SWIG/SWIG/calendars.i
+++ b/QuantLib-SWIG/SWIG/calendars.i
@@ -77,6 +77,8 @@ class Calendar {
   protected:
     Calendar();
   public:
+    bool isWeekend(Weekday w);
+    Date endOfMonth(const Date&);
     bool isBusinessDay(const Date&);
     bool isHoliday(const Date&);
     bool isEndOfMonth(const Date&);


### PR DESCRIPTION
related to this question : http://quant.stackexchange.com/questions/20924/quantlib-python-missing-methods
I hope I didn't screw up, it seems to work fine in python code at least