### PR TITLE
set time for finite difference operator to avoid uninitialised values 

### DIFF
--- a/QuantLib/ql/experimental/finitedifferences/fdsimpleextoustorageengine.hpp
+++ b/QuantLib/ql/experimental/finitedifferences/fdsimpleextoustorageengine.hpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         const boost::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> process_;
         const boost::shared_ptr<YieldTermStructure> rTS_;
         const Size tGrid_, xGrid_, yGrid_;
-        const boost::shared_ptr<Shape>& shape_;
+        const boost::shared_ptr<Shape> shape_;
         const FdmSchemeDesc schemeDesc_;
     };
 }

--- a/QuantLib/test-suite/vpp.cpp
+++ b/QuantLib/test-suite/vpp.cpp
@@ -909,6 +909,7 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
         new FdmKlugeExtOUOp(mesher, klugeOUProcess,
                             flatRate(today, 0.0, ActualActual()),
                             FdmBoundaryConditionSet(), 16));
+    op->setTime(0.1, 0.2);
 
     Array x(mesher->layout()->size());
 


### PR DESCRIPTION
set time for finite difference operator to avoid uninitialised values in test case VPPTest::testKlugeExtOUMatrixDecomposition()