### PR TITLE
Add boost-style element access and size

### DIFF
--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -113,6 +113,7 @@ namespace QuantLib {
         row_iterator operator[](Size);
         row_iterator at(Size);
         Disposable<Array> diagonal(void) const;
+        Real& operator()(Size i, Size j) const;
         //@}
 
         //! \name Inspectors
@@ -120,6 +121,8 @@ namespace QuantLib {
         Size rows() const;
         Size columns() const;
         bool empty() const;
+        Size size1() const;
+        Size size2() const;
         //@}
 
         //! \name Utilities
@@ -426,12 +429,16 @@ namespace QuantLib {
         return row_begin(i);
     }
 
-    inline Disposable<Array> Matrix::diagonal(void) const{
+    inline Disposable<Array> Matrix::diagonal(void) const {
         Size arraySize = std::min<Size>(rows(), columns());
         Array tmp(arraySize);
         for(Size i = 0; i < arraySize; i++)
             tmp[i] = (*this)[i][i];
         return tmp;
+    }
+
+    inline Real &Matrix::operator()(Size i, Size j) const {
+        return data_[i*columns()+j];
     }
 
     inline Size Matrix::rows() const {
@@ -440,6 +447,14 @@ namespace QuantLib {
 
     inline Size Matrix::columns() const {
         return columns_;
+    }
+
+    inline Size Matrix::size1() const {
+        return rows();
+    }
+
+    inline Size Matrix::size2() const {
+        return columns();
     }
 
     inline bool Matrix::empty() const {


### PR DESCRIPTION
Migrated from https://github.com/lballabio/quantlib-old/pull/358 by @pcaspers 