### PR TITLE
Correct parameter transformation 2.5 -> 0.5

### DIFF
--- a/ql/math/interpolations/sabrinterpolation.hpp
+++ b/ql/math/interpolations/sabrinterpolation.hpp
@@ -3,7 +3,7 @@
 /*
  Copyright (C) 2006 Ferdinando Ametrano
  Copyright (C) 2007 Marco Bianchetti
- Copyright (C) 2007 François du Vignaud
+ Copyright (C) 2007 FranÃ§ois du Vignaud
  Copyright (C) 2007 Giorgio Facchinetti
  Copyright (C) 2006 Mario Pucci
  Copyright (C) 2006 StatPro Italia srl
@@ -128,7 +128,7 @@ struct SABRSpecs {
                    : eps1();
         y[2] = std::fabs(x[2]) < 5.0 ? x[2] * x[2] + eps1()
                                      : (10.0 * std::fabs(x[2]) - 25.0) + eps1();
-        y[3] = std::fabs(x[3]) < 2.5 * M_PI
+        y[3] = std::fabs(x[3]) < 0.5 * M_PI
                    ? eps2() * std::sin(x[3])
                    : eps2() * (x[3] > 0.0 ? 1.0 : (-1.0));
         return y;


### PR DESCRIPTION
We are trying to reverse the transformation into parameters used to optimize, where the function used was asin. To reverse this, we only need for check for x between -pi/2 and pi2.

Unless I have completely missed something about this code the bound should 0.5 * M_PI. I am chasing calibration problems where rho 'gets stuck' at 0.9999. I don't think this is a bug caused by this typo, but it seems like it is a little confusing, and *might* affect the calibration?

I will go into this code in more detail, and find a test case for the calibration problems, but I thought it was worth posting this as someone may be able to immediately confirm that it is a typo or else let me know what I am missing. Cheers.