### PR TITLE
Recompute switchstrike for caplets #328

### DIFF
--- a/test-suite/optionletstripper.hpp
+++ b/test-suite/optionletstripper.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2008 Ferdinando Ametrano
  Copyright (C) 2007, 2008 Laurent Hoffmann
+ Copyright (C) 2016 Michael von den Driesch
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,6 +33,7 @@ class OptionletStripperTest {
     static void testTermVolatilityStripping1();
     static void testFlatTermVolatilityStripping2();
     static void testTermVolatilityStripping2();
+    static void testSwitchStrike();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
So ... here is the missing test case for the switch strike calculation (I hope, this nicely fits into the existing PR #16. Not to sure, if I got everything right with the new repo.). 