### PR TITLE
Ukraine data

### DIFF
--- a/ql/currencies/europe.cpp
+++ b/ql/currencies/europe.cpp
@@ -511,7 +511,18 @@ namespace QuantLib {
         data_ = skkData;
     }
 
-
+    // Ukrainian hryvnia
+    /* The ISO three-letter code is UAH; the numeric code is 980.
+       It is divided in 100 kopiykas.
+     */
+    UAHCurrency::UAHCurrency() {
+        static boost::shared_ptr<Data> uahData(
+                                     new Data("Ukrainian hryvnia", "UAH", 980,
+                                              "hrn", "", 100,
+                                              Rounding(),
+                                              "%1$.2f %3%"));
+        data_ = uahData;
+    }
 }
 
 

--- a/ql/currencies/europe.hpp
+++ b/ql/currencies/europe.hpp
@@ -469,6 +469,17 @@ namespace QuantLib {
         SKKCurrency();
     };
 
+    //! Ukrainian hryvnia
+    /*! The ISO three-letter code is UAH; the numeric code is 980.
+        It is divided in 100 kopiykas.
+
+        \ingroup currencies    
+     */
+    class UAHCurrency : public Currency {
+    public:
+        UAHCurrency();
+    };
+
 }
 
 #if defined(QL_PATCH_MSVC)

--- a/ql/time/calendars/ukraine.cpp
+++ b/ql/time/calendars/ukraine.cpp
@@ -54,7 +54,9 @@ namespace QuantLib {
             // Constitution Day
             || (d == 28 && m == June)
             // Independence Day
-            || (d == 24 && m == August))
+            || (d == 24 && m == August)
+            // Defender's Day
+            || (d == 14 && m == October))
             return false;
         return true;
     }


### PR DESCRIPTION
Added support for Ukrainian hryvnia.
```c++
class UAHCurrency : public Currency {
    public:
        UAHCurrency();
    };

UAHCurrency::UAHCurrency() {
        static boost::shared_ptr<Data> uahData(
                                     new Data("Ukrainian hryvnia", "UAH", 980,
                                              "hrn", "", 100,
                                              Rounding(),
                                              "%1$.2f %3%"));
        data_ = uahData;
    }
```
Also, Defender's Day (14 October) added to the list of non-business days according to the recent changes in legislation.
```c++
// Defender's Day
|| (d == 14 && m == October))
```