### PR TITLE
add check for non-empty calendar implementation

### DIFF
--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -26,6 +26,7 @@
 namespace QuantLib {
 
     void Calendar::addHoliday(const Date& d) {
+        QL_REQUIRE(impl_, "no implementation provided");
         // if d was a genuine holiday previously removed, revert the change
         impl_->removedHolidays.erase(d);
         // if it's already a holiday, leave the calendar alone.
@@ -35,6 +36,7 @@ namespace QuantLib {
     }
 
     void Calendar::removeHoliday(const Date& d) {
+        QL_REQUIRE(impl_, "no implementation provided");
         // if d was an artificially-added holiday, revert the change
         impl_->addedHolidays.erase(d);
         // if it's already a business day, leave the calendar alone.

--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -26,6 +26,7 @@
 #ifndef quantlib_calendar_hpp
 #define quantlib_calendar_hpp
 
+#include <ql/errors.hpp>
 #include <ql/time/date.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <boost/shared_ptr.hpp>
@@ -189,10 +190,12 @@ namespace QuantLib {
     }
 
     inline std::string Calendar::name() const {
+        QL_REQUIRE(impl_, "no implementation provided");
         return impl_->name();
     }
 
     inline bool Calendar::isBusinessDay(const Date& d) const {
+        QL_REQUIRE(impl_, "no implementation provided");
         if (impl_->addedHolidays.find(d) != impl_->addedHolidays.end())
             return false;
         if (impl_->removedHolidays.find(d) != impl_->removedHolidays.end())
@@ -213,6 +216,7 @@ namespace QuantLib {
     }
 
     inline bool Calendar::isWeekend(Weekday w) const {
+        QL_REQUIRE(impl_, "no implementation provided");
         return impl_->isWeekend(w);
     }
 


### PR DESCRIPTION
otherwise a lonely message like "boost assertion failed px!=0" may be thrown with no further hint