### PR TITLE
Fix for numerical "0/0" in Cholesky Decomposition

### DIFF
--- a/ql/math/matrixutilities/choleskydecomposition.cpp
+++ b/ql/math/matrixutilities/choleskydecomposition.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2003, 2004 Ferdinando Ametrano
+ Copyright (C) 2016 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -18,6 +19,7 @@
 */
 
 #include <ql/math/matrixutilities/choleskydecomposition.hpp>
+#include <ql/math/comparison.hpp>
 
 namespace QuantLib {
 
@@ -52,8 +54,9 @@ namespace QuantLib {
                     // With positive semi-definite matrices is possible
                     // to have result[i][i]==0.0
                     // In this case sum happens to be zero as well
-                    result[j][i] =
-                        (sum==0.0 ? 0.0 : sum/result[i][i]);
+                    result[j][i] = close_enough(result[i][i], 0.0)
+                                       ? 0.0
+                                       : sum / result[i][i];
                 }
             }
         }

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -4,6 +4,7 @@
  Copyright (C) 2003 Ferdinando Ametrano
  Copyright (C) 2007, 2008 Klaus Spanderen
  Copyright (C) 2007 Neil Firth
+ Copyright (C) 2016 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -22,12 +23,15 @@
 #include "matrices.hpp"
 #include "utilities.hpp"
 #include <ql/math/matrix.hpp>
+#include <ql/math/matrixutilities/choleskydecomposition.hpp>
 #include <ql/math/matrixutilities/pseudosqrt.hpp>
 #include <ql/math/matrixutilities/svd.hpp>
 #include <ql/math/matrixutilities/symmetricschurdecomposition.hpp>
 #include <ql/math/randomnumbers/mt19937uniformrng.hpp>
 #include <ql/math/matrixutilities/qrdecomposition.hpp>
 #include <ql/math/matrixutilities/basisincompleteordered.hpp>
+
+#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -479,7 +483,76 @@ void MatricesTest::testOrthogonalProjection() {
 
 }
 
+void MatricesTest::testCholeskyDecomposition() {
 
+    BOOST_TEST_MESSAGE("Testing Cholesky Decomposition...");
+
+    // This test case fails prior to release 1.8
+
+    // The eigenvalues of this matrix are
+    // 0.0438523; 0.0187376; 0.000245617; 0.000127656; 8.35899e-05; 6.14215e-05;
+    // 1.94241e-05; 1.14417e-06; 9.79481e-18; 1.31141e-18; 5.81155e-19
+
+    Real tmp[11][11] = {
+        {6.4e-05, 5.28e-05, 2.28e-05, 0.00032, 0.00036, 6.4e-05,
+         6.3968010664e-06, 7.2e-05, 7.19460269899e-06, 1.2e-05,
+         1.19970004999e-06},
+        {5.28e-05, 0.000121, 1.045e-05, 0.00044, 0.000165, 2.2e-05,
+         2.19890036657e-06, 1.65e-05, 1.64876311852e-06, 1.1e-05,
+         1.09972504583e-06},
+        {2.28e-05, 1.045e-05, 9.025e-05, 0, 0.0001425, 9.5e-06,
+         9.49525158294e-07, 2.85e-05, 2.84786356835e-06, 4.75e-06,
+         4.74881269789e-07},
+        {0.00032, 0.00044, 0, 0.04, 0.009, 0.0008, 7.996001333e-05, 0.0006,
+         5.99550224916e-05, 0.0001, 9.99750041661e-06},
+        {0.00036, 0.000165, 0.0001425, 0.009, 0.0225, 0.0003, 2.99850049987e-05,
+         0.001125, 0.000112415667172, 0.000225, 2.24943759374e-05},
+        {6.4e-05, 2.2e-05, 9.5e-06, 0.0008, 0.0003, 0.0001, 9.99500166625e-06,
+         7.5e-05, 7.49437781145e-06, 2e-05, 1.99950008332e-06},
+        {6.3968010664e-06, 2.19890036657e-06, 9.49525158294e-07,
+         7.996001333e-05, 2.99850049987e-05, 9.99500166625e-06,
+         9.99000583083e-07, 7.49625124969e-06, 7.49063187129e-07,
+         1.99900033325e-06, 1.99850066645e-07},
+        {7.2e-05, 1.65e-05, 2.85e-05, 0.0006, 0.001125, 7.5e-05,
+         7.49625124969e-06, 0.000225, 2.24831334343e-05, 1.5e-05,
+         1.49962506249e-06},
+        {7.19460269899e-06, 1.64876311852e-06, 2.84786356835e-06,
+         5.99550224916e-05, 0.000112415667172, 7.49437781145e-06,
+         7.49063187129e-07, 2.24831334343e-05, 2.24662795123e-06,
+         1.49887556229e-06, 1.49850090584e-07},
+        {1.2e-05, 1.1e-05, 4.75e-06, 0.0001, 0.000225, 2e-05, 1.99900033325e-06,
+         1.5e-05, 1.49887556229e-06, 2.5e-05, 2.49937510415e-06},
+        {1.19970004999e-06, 1.09972504583e-06, 4.74881269789e-07,
+         9.99750041661e-06, 2.24943759374e-05, 1.99950008332e-06,
+         1.99850066645e-07, 1.49962506249e-06, 1.49850090584e-07,
+         2.49937510415e-06, 2.49875036451e-07}};
+
+    Matrix m(11,11);
+    for(Size i=0;i<11;++i) {
+        for(Size j=0;j<11;++j) {
+            m[i][j] = tmp[i][j];
+        }
+    }
+
+    Matrix c = CholeskyDecomposition(m,true);
+    Matrix m2 = c * transpose(c);
+
+    Real tol = 1.0E-12;
+    for(Size i=0;i<11;++i) {
+        for(Size j=0;j<11;++j) {
+            if(boost::math::isnan(m2[i][j])) {
+                BOOST_FAIL("Faield to verify Cholesky decomposition at (i,j)=("
+                           << i << "," << j << "), replicated value is nan");
+            }
+            // this does not detect nan values
+            if(std::abs(m[i][j]-m2[i][j]) > tol) {
+                BOOST_FAIL("Failed to verify Cholesky decomposition at (i,j)=("
+                           << i << "," << j << "), original value is "
+                           << m[i][j] << ", replicated value is " << m2[i][j]);
+            }
+        }
+    }
+}
 
 test_suite* MatricesTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Matrix tests");
@@ -495,6 +568,7 @@ test_suite* MatricesTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testInverse));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testDeterminant));
     #endif
+    suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testCholeskyDecomposition));
     return suite;
 }
 

--- a/test-suite/matrices.hpp
+++ b/test-suite/matrices.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 Ferdinando Ametrano
  Copyright (C) 2004, 2007 Neil Firth
+ Copyright (C) 2016 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -37,6 +38,7 @@ class MatricesTest {
     static void testInverse();
     static void testDeterminant();
     static void testOrthogonalProjection();
+    static void testCholeskyDecomposition();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
For a semi definite matrix with Eigenvalues

```eigenvalues=[ 0.0287076; 0.0121878; 0.00704268; 0.00179693; 0.00030437; 5.60751e-05; 2.74717e-05; 6.6124e-07; 7.58951e-20; 1.10105e-20; 5.35378e-21 ]```

  I got ```inf``` - entries in the result, where ```0``` is expected. This PR fixes that problem.