### PR TITLE
Updated LIBOR docs.

### DIFF
--- a/ql/indexes/ibor/audlibor.hpp
+++ b/ql/indexes/ibor/audlibor.hpp
@@ -33,9 +33,7 @@
 namespace QuantLib {
 
     //! %AUD %LIBOR rate
-    /*! Australian Dollar LIBOR fixed by BBA.
-
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+    /*! Australian Dollar LIBOR discontinued as of 2013.
     */
     class AUDLibor : public Libor {
       public:

--- a/ql/indexes/ibor/cadlibor.hpp
+++ b/ql/indexes/ibor/cadlibor.hpp
@@ -33,10 +33,7 @@
 namespace QuantLib {
 
     //! %CAD LIBOR rate
-    /*! Canadian Dollar LIBOR fixed by BBA.
-
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
-
+    /*! Canadian Dollar LIBOR discontinued as of 2013.
         \warning This is the rate fixed in London by BBA. Use CDOR if
                  you're interested in the Canadian fixing by IDA.
     */

--- a/ql/indexes/ibor/chflibor.hpp
+++ b/ql/indexes/ibor/chflibor.hpp
@@ -33,9 +33,9 @@
 namespace QuantLib {
 
     //! %CHF %LIBOR rate
-    /*! Swiss Franc LIBOR fixed by BBA.
+    /*! Swiss Franc LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
 
         \warning This is the rate fixed in London by BBA. Use ZIBOR if
                  you're interested in the Zurich fixing.

--- a/ql/indexes/ibor/dkklibor.hpp
+++ b/ql/indexes/ibor/dkklibor.hpp
@@ -33,9 +33,7 @@
 namespace QuantLib {
 
     //! %DKK %LIBOR rate
-    /*! Danish Krona LIBOR fixed by BBA.
-
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+    /*! Danish Krona LIBOR discontinued as of 2013.
     */
     class DKKLibor : public Libor {
       public:

--- a/ql/indexes/ibor/eurlibor.hpp
+++ b/ql/indexes/ibor/eurlibor.hpp
@@ -31,10 +31,10 @@
 
 namespace QuantLib {
 
-    //! base class for all BBA %EUR %LIBOR indexes but the O/N
-    /*! Euro LIBOR fixed by BBA.
+    //! base class for all ICE %EUR %LIBOR indexes but the O/N
+    /*! Euro LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
 
         \warning This is the rate fixed in London by BBA. Use Euribor if
                  you're interested in the fixing by the ECB.
@@ -46,7 +46,7 @@ namespace QuantLib {
                                     Handle<YieldTermStructure>());
         /*! \name Date calculations
 
-            see http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1412
+            See <https://www.theice.com/marketdata/reports/170>.
             @{
         */
         Date valueDate(const Date& fixingDate) const;
@@ -56,13 +56,13 @@ namespace QuantLib {
         Calendar target_;
     };
 
-    //! base class for the one day deposit BBA %EUR %LIBOR indexes
-    /*! Euro O/N LIBOR fixed by BBA. It can be also used for T/N and S/N
-        indexes, even if such indexes do not have BBA fixing.
+    //! base class for the one day deposit ICE %EUR %LIBOR indexes
+    /*! Euro O/N LIBOR fixed by ICE. It can be also used for T/N and S/N
+        indexes, even if such indexes do not have ICE fixing.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
 
-        \warning This is the rate fixed in London by BBA. Use Eonia if
+        \warning This is the rate fixed in London by ICE. Use Eonia if
                  you're interested in the fixing by the ECB.
     */
     class DailyTenorEURLibor : public IborIndex {

--- a/ql/indexes/ibor/gbplibor.hpp
+++ b/ql/indexes/ibor/gbplibor.hpp
@@ -33,9 +33,9 @@
 namespace QuantLib {
 
     //! %GBP %LIBOR rate
-    /*! Pound Sterling LIBOR fixed by BBA.
+    /*! Pound Sterling LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
     */
     class GBPLibor : public Libor {
       public:
@@ -49,7 +49,7 @@ namespace QuantLib {
                 Actual365Fixed(), h) {}
     };
 
-    //! base class for the one day deposit BBA %GBP %LIBOR indexes
+    //! Base class for the one day deposit ICE %GBP %LIBOR indexes
     class DailyTenorGBPLibor : public DailyTenorLibor {
       public:
         DailyTenorGBPLibor(Natural settlementDays,

--- a/ql/indexes/ibor/jpylibor.hpp
+++ b/ql/indexes/ibor/jpylibor.hpp
@@ -34,11 +34,11 @@
 namespace QuantLib {
 
     //! %JPY %LIBOR rate
-    /*! Japanese Yen LIBOR fixed by BBA.
+    /*! Japanese Yen LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
 
-        \warning This is the rate fixed in London by BBA. Use TIBOR if
+        \warning This is the rate fixed in London by ICE. Use TIBOR if
                  you're interested in the Tokio fixing.
     */
     class JPYLibor : public Libor {
@@ -53,7 +53,7 @@ namespace QuantLib {
                 Actual360(), h) {}
     };
 
-    //! base class for the one day deposit BBA %JPY %LIBOR indexes
+    //! base class for the one day deposit ICE %JPY %LIBOR indexes
     class DailyTenorJPYLibor : public DailyTenorLibor {
       public:
         DailyTenorJPYLibor(Natural settlementDays,

--- a/ql/indexes/ibor/libor.hpp
+++ b/ql/indexes/ibor/libor.hpp
@@ -30,10 +30,10 @@
 
 namespace QuantLib {
 
-    //! base class for all BBA LIBOR indexes but the EUR, O/N, and S/N ones
-    /*! LIBOR fixed by BBA.
+    //! base class for all ICE LIBOR indexes but the EUR, O/N, and S/N ones
+    /*! LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
     */
     class Libor : public IborIndex {
       public:
@@ -47,7 +47,7 @@ namespace QuantLib {
                                     Handle<YieldTermStructure>());
         /*! \name Date calculations
 
-            see http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1412
+            See <https://www.theice.com/marketdata/reports/170>.
             @{
         */
         Date valueDate(const Date& fixingDate) const;
@@ -68,9 +68,9 @@ namespace QuantLib {
     };
 
     //! base class for all O/N-S/N BBA LIBOR indexes but the EUR ones
-    /*! One day deposit LIBOR fixed by BBA.
+    /*! One day deposit LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
     */
     class DailyTenorLibor : public IborIndex {
       public:

--- a/ql/indexes/ibor/nzdlibor.hpp
+++ b/ql/indexes/ibor/nzdlibor.hpp
@@ -33,9 +33,7 @@
 namespace QuantLib {
 
     //! %NZD %LIBOR rate
-    /*! New Zealand Dollar LIBOR fixed by BBA.
-
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+    /*! New Zealand Dollar LIBOR discontinued as of 2013.
     */
     class NZDLibor : public Libor {
       public:

--- a/ql/indexes/ibor/seklibor.hpp
+++ b/ql/indexes/ibor/seklibor.hpp
@@ -34,9 +34,7 @@
 namespace QuantLib {
 
     //! %SEK %LIBOR rate
-    /*! Sweden Krone LIBOR fixed by BBA.
-
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+    /*! Sweden Krone LIBOR discontinued as of 2013.
     */
     class SEKLibor : public Libor {
       public:

--- a/ql/indexes/ibor/trlibor.hpp
+++ b/ql/indexes/ibor/trlibor.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     //! %TRY %LIBOR rate
     /*! TRY LIBOR fixed by TBA.
 
-        See <http://www.trlibor.org/trlibor/english/default.asp>
+        See <http://www.trlibor.org/trlibor/english/>
 
         \todo check end-of-month adjustment.
     */

--- a/ql/indexes/ibor/usdlibor.hpp
+++ b/ql/indexes/ibor/usdlibor.hpp
@@ -33,9 +33,9 @@
 namespace QuantLib {
 
     //! %USD %LIBOR rate
-    /*! US Dollar LIBOR fixed by BBA.
+    /*! US Dollar LIBOR fixed by ICE.
 
-        See <http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1414>.
+        See <https://www.theice.com/marketdata/reports/170>.
     */
     class USDLibor : public Libor {
       public:
@@ -49,7 +49,7 @@ namespace QuantLib {
                 Actual360(), h) {}
     };
 
-    //! base class for the one day deposit BBA %USD %LIBOR indexes
+    //! base class for the one day deposit ICE %USD %LIBOR indexes
     class DailyTenorUSDLibor : public DailyTenorLibor {
       public:
         DailyTenorUSDLibor(Natural settlementDays,


### PR DESCRIPTION
Fixes for transfer from BBA LIBOR to ICE LIBOR and discontinuation of NZD, SEK, DKK, AUD and CAD LIBOR as of 2013.

Fixes #66.