### PR TITLE
Fix Pricer Setter

### DIFF
--- a/ql/cashflows/capflooredcoupon.cpp
+++ b/ql/cashflows/capflooredcoupon.cpp
@@ -130,7 +130,6 @@ namespace QuantLib {
     void CappedFlooredCoupon::accept(AcyclicVisitor& v) {
         typedef FloatingRateCoupon super;
         Visitor<CappedFlooredCoupon>* v1 =
-
             dynamic_cast<Visitor<CappedFlooredCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);

--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -166,6 +166,8 @@ namespace QuantLib {
         class PricerSetter : public AcyclicVisitor,
                              public Visitor<CashFlow>,
                              public Visitor<Coupon>,
+                             public Visitor<FloatingRateCoupon>,
+                             public Visitor<CappedFlooredCoupon>,
                              public Visitor<IborCoupon>,
                              public Visitor<CmsCoupon>,
                              public Visitor<CmsSpreadCoupon>,
@@ -186,6 +188,8 @@ namespace QuantLib {
 
             void visit(CashFlow& c);
             void visit(Coupon& c);
+            void visit(FloatingRateCoupon& c);
+            void visit(CappedFlooredCoupon& c);
             void visit(IborCoupon& c);
             void visit(CappedFlooredIborCoupon& c);
             void visit(DigitalIborCoupon& c);
@@ -205,6 +209,14 @@ namespace QuantLib {
 
         void PricerSetter::visit(Coupon&) {
             // nothing to do
+        }
+
+        void PricerSetter::visit(FloatingRateCoupon& c) {
+            c.setPricer(pricer_);
+        }
+
+        void PricerSetter::visit(CappedFlooredCoupon& c) {
+            c.setPricer(pricer_);
         }
 
         void PricerSetter::visit(IborCoupon& c) {


### PR DESCRIPTION
I am constructing a leg containing some CappedFlooredCoupons based on an InterestRateIndex (on that general level). Then a subsequent call to setCouponPricer on that leg won't visit those coupons. This adds the visit methods required in that situation. 