### PR TITLE
Disentangle RNGs for calibration and pricing in LS engine

### DIFF
--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -3,7 +3,7 @@
 /*
  Copyright (C) 2006 Klaus Spanderen
  Copyright (C) 2007 StatPro Italia srl
- Copyright (C) 2015 Peter Caspers
+ Copyright (C) 2015, 2016 Peter Caspers
  Copyright (C) 2015 Thema Consulting SA
 
  This file is part of QuantLib, a free-software/open-source library
@@ -31,6 +31,8 @@
 #include <ql/pricingengines/mcsimulation.hpp>
 #include <ql/methods/montecarlo/longstaffschwartzpathpricer.hpp>
 
+#include <boost/make_shared.hpp>
+
 namespace QuantLib {
 
     //! Longstaff-Schwarz Monte Carlo engine for early exercise options
@@ -44,7 +46,7 @@ namespace QuantLib {
               reproducing results available in web/literature
     */
     template <class GenericEngine, template <class> class MC,
-              class RNG, class S = Statistics>
+              class RNG, class S = Statistics, class RNG_Calibration = RNG>
     class MCLongstaffSchwartzEngine : public GenericEngine,
                                       public McSimulation<MC,RNG,S> {
       public:
@@ -55,7 +57,19 @@ namespace QuantLib {
             path_pricer_type;
         typedef typename McSimulation<MC,RNG,S>::path_generator_type
             path_generator_type;
+        typedef
+            typename McSimulation<MC, RNG_Calibration, S>::path_generator_type
+                path_generator_type_calibration;
 
+        /*! If the parameters brownianBridge and antitheticVariate are
+          not given they are chosen to be identical to the respective
+          parameters for pricing; the seed for calibration is chosen
+          to be zero if the pricing seed is zero and otherwise as the
+          pricing seed plus some offset to avoid identical paths in
+          calibration and pricing; note however that this has no effect
+          for low discrepancy RNGs usually, it is therefore recommended
+          to use pseudo random generators for the calibration phase always
+          (and possibly quasi monte carlo in the subsequent pricing). */
         MCLongstaffSchwartzEngine(
             const boost::shared_ptr<StochasticProcess>& process,
             Size timeSteps,
@@ -67,7 +81,10 @@ namespace QuantLib {
             Real requiredTolerance,
             Size maxSamples,
             BigNatural seed,
-            Size nCalibrationSamples = Null<Size>());
+            Size nCalibrationSamples = Null<Size>(),
+            boost::optional<bool> brownianBridgeCalibration = boost::none,
+            boost::optional<bool> antitheticVariateCalibration = boost::none,
+            BigNatural seedCalibration = Null<Size>());
 
         void calculate() const;
 
@@ -86,16 +103,21 @@ namespace QuantLib {
         const Size requiredSamples_;
         const Real requiredTolerance_;
         const Size maxSamples_;
-        const Size seed_;
+        const BigNatural seed_;
         const Size nCalibrationSamples_;
+        const bool brownianBridgeCalibration_;
+        const bool antitheticVariateCalibration_;
+        const BigNatural seedCalibration_;
 
         mutable boost::shared_ptr<LongstaffSchwartzPathPricer<path_type> >
             pathPricer_;
+        mutable boost::shared_ptr<MonteCarloModel<MC, RNG_Calibration, S> >
+            mcModelCalibration_;
     };
 
     template <class GenericEngine, template <class> class MC,
-              class RNG, class S>
-    inline MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::
+              class RNG, class S, class RNG_Calibration>
+    inline MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S,RNG_Calibration>::
     MCLongstaffSchwartzEngine(
             const boost::shared_ptr<StochasticProcess>& process,
             Size timeSteps,
@@ -107,7 +129,10 @@ namespace QuantLib {
             Real requiredTolerance,
             Size maxSamples,
             BigNatural seed,
-            Size nCalibrationSamples)
+            Size nCalibrationSamples,
+            boost::optional<bool> brownianBridgeCalibration,
+            boost::optional<bool> antitheticVariateCalibration,
+            BigNatural seedCalibration)
     : McSimulation<MC,RNG,S> (antitheticVariate, controlVariate),
       process_            (process),
       timeSteps_          (timeSteps),
@@ -118,7 +143,14 @@ namespace QuantLib {
       maxSamples_         (maxSamples),
       seed_               (seed),
       nCalibrationSamples_( (nCalibrationSamples == Null<Size>())
-                            ? 2048 : nCalibrationSamples) {
+                            ? 2048 : nCalibrationSamples),
+      brownianBridgeCalibration_ (brownianBridgeCalibration ?
+                                  *brownianBridgeCalibration : brownianBridge),
+      antitheticVariateCalibration_(antitheticVariateCalibration ?
+                                    *antitheticVariateCalibration : antitheticVariate),
+      seedCalibration_(seedCalibration != Null<Real>() ?
+                         seedCalibration : (seed == 0 ? 0 : seed+1768237423L))
+    {
         QL_REQUIRE(timeSteps != Null<Size>() ||
                    timeStepsPerYear != Null<Size>(),
                    "no time steps provided");
@@ -134,30 +166,41 @@ namespace QuantLib {
         this->registerWith(process_);
     }
 
-    template <class GenericEngine, template <class> class MC,
-              class RNG, class S>
-    inline
-    boost::shared_ptr<typename
-        MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::path_pricer_type>
-        MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::pathPricer() const {
+    template <class GenericEngine, template <class> class MC, class RNG,
+              class S, class RNG_Calibration>
+    inline boost::shared_ptr<typename MCLongstaffSchwartzEngine<
+        GenericEngine, MC, RNG, S, RNG_Calibration>::path_pricer_type>
+    MCLongstaffSchwartzEngine<GenericEngine, MC, RNG, S,
+                              RNG_Calibration>::pathPricer() const {
 
         QL_REQUIRE(pathPricer_, "path pricer unknown");
         return pathPricer_;
     }
 
-    template <class GenericEngine, template <class> class MC,
-              class RNG, class S>
-    inline
-    void MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::calculate() const {
+    template <class GenericEngine, template <class> class MC, class RNG,
+              class S, class RNG_Calibration>
+    inline void MCLongstaffSchwartzEngine<GenericEngine, MC, RNG, S,
+                                          RNG_Calibration>::calculate() const {
+        // calibration
         pathPricer_ = this->lsmPathPricer();
-        this->mcModel_ = boost::shared_ptr<MonteCarloModel<MC,RNG,S> >(
-                          new MonteCarloModel<MC,RNG,S>
-                              (pathGenerator(), pathPricer_,
-                               stats_type(), this->antitheticVariate_));
+        Size dimensions = process_->factors();
+        TimeGrid grid = this->timeGrid();
+        typename RNG_Calibration::rsg_type generator =
+            RNG_Calibration::make_sequence_generator(
+                dimensions * (grid.size() - 1), seedCalibration_);
+        boost::shared_ptr<path_generator_type_calibration>
+            pathGeneratorCalibration =
+                boost::make_shared<path_generator_type_calibration>(
+                    process_, grid, generator, brownianBridgeCalibration_);
+        mcModelCalibration_ =
+            boost::shared_ptr<MonteCarloModel<MC, RNG_Calibration, S> >(
+                new MonteCarloModel<MC, RNG_Calibration, S>(
+                    pathGeneratorCalibration, pathPricer_, stats_type(),
+                    this->antitheticVariateCalibration_));
 
-        this->mcModel_->addSamples(nCalibrationSamples_);
-        this->pathPricer_->calibrate();
-
+        mcModelCalibration_->addSamples(nCalibrationSamples_);
+        pathPricer_->calibrate();
+        // pricing
         McSimulation<MC,RNG,S>::calculate(requiredTolerance_,
                                           requiredSamples_,
                                           maxSamples_);
@@ -170,11 +213,11 @@ namespace QuantLib {
         }
     }
 
-    template <class GenericEngine, template <class> class MC,
-              class RNG, class S>
-    inline
-    TimeGrid MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::timeGrid()
-        const {
+    template <class GenericEngine, template <class> class MC, class RNG,
+              class S, class RNG_Calibration>
+    inline TimeGrid
+    MCLongstaffSchwartzEngine<GenericEngine, MC, RNG, S,
+                              RNG_Calibration>::timeGrid() const {
         std::vector<Time> requiredTimes;
         if (this->arguments_.exercise->type() == Exercise::American) {
             Date lastExerciseDate = this->arguments_.exercise->lastDate();
@@ -200,12 +243,12 @@ namespace QuantLib {
         }
     }
 
-    template <class GenericEngine, template <class> class MC,
-              class RNG, class S>
-    inline
-    boost::shared_ptr<typename
-    MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::path_generator_type>
-    MCLongstaffSchwartzEngine<GenericEngine,MC,RNG,S>::pathGenerator() const {
+    template <class GenericEngine, template <class> class MC, class RNG,
+              class S, class RNG_Calibration>
+    inline boost::shared_ptr<typename MCLongstaffSchwartzEngine<
+        GenericEngine, MC, RNG, S, RNG_Calibration>::path_generator_type>
+    MCLongstaffSchwartzEngine<GenericEngine, MC, RNG, S,
+                              RNG_Calibration>::pathGenerator() const {
 
         Size dimensions = process_->factors();
         TimeGrid grid = this->timeGrid();

--- a/ql/pricingengines/vanilla/mcamericanengine.hpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Klaus Spanderen
  Copyright (C) 2007 StatPro Italia srl
+ Copyright (C) 2016 Peter Caspers
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -44,10 +45,11 @@ namespace QuantLib {
         \test the correctness of the returned value is tested by
               reproducing results available in web/literature
     */
-    template <class RNG = PseudoRandom, class S = Statistics>
+    template <class RNG = PseudoRandom, class S = Statistics,
+              class RNG_Calibration = RNG>
     class MCAmericanEngine
         : public MCLongstaffSchwartzEngine<VanillaOption::engine,
-                                           SingleVariate,RNG,S>{
+                                           SingleVariate,RNG,S,RNG_Calibration> {
       public:
         MCAmericanEngine(
              const boost::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -61,7 +63,9 @@ namespace QuantLib {
              BigNatural seed,
              Size polynomOrder,
              LsmBasisSystem::PolynomType polynomType,
-             Size nCalibrationSamples = Null<Size>());
+             Size nCalibrationSamples = Null<Size>(),
+             boost::optional<bool> antitheticVariateCalibration = boost::none,
+             BigNatural seedCalibration = Null<Size>());
 
         void calculate() const;
         
@@ -99,7 +103,8 @@ namespace QuantLib {
 
 
     //! Monte Carlo American engine factory
-    template <class RNG = PseudoRandom, class S = Statistics>
+    template <class RNG = PseudoRandom, class S = Statistics,
+              class RNG_Calibration = RNG>
     class MakeMCAmericanEngine {
       public:
         MakeMCAmericanEngine(
@@ -116,6 +121,8 @@ namespace QuantLib {
         MakeMCAmericanEngine& withPolynomOrder(Size polynomOrer);
         MakeMCAmericanEngine& withBasisSystem(LsmBasisSystem::PolynomType);
         MakeMCAmericanEngine& withCalibrationSamples(Size calibrationSamples);
+        MakeMCAmericanEngine& withAntitheticVariateCalibration(bool b = true);
+        MakeMCAmericanEngine& withSeedCalibration(BigNatural seed);
 
         // conversion to pricing engine
         operator boost::shared_ptr<PricingEngine>() const;
@@ -128,41 +135,41 @@ namespace QuantLib {
         BigNatural seed_;
         Size polynomOrder_;
         LsmBasisSystem::PolynomType polynomType_;
+        boost::optional<bool> antitheticCalibration_;
+        BigNatural seedCalibration_;
     };
 
-    template <class RNG, class S> inline
-    MCAmericanEngine<RNG,S>::MCAmericanEngine(
-        const boost::shared_ptr<GeneralizedBlackScholesProcess>& process,
-        Size timeSteps, Size timeStepsPerYear,
-        bool antitheticVariate, bool controlVariate,
-        Size requiredSamples, Real requiredTolerance,
-        Size maxSamples,BigNatural seed,
-        Size polynomOrder, LsmBasisSystem::PolynomType polynomType,
-        Size nCalibrationSamples)
-    : MCLongstaffSchwartzEngine<VanillaOption::engine,
-                                SingleVariate,RNG,S>(
-                                         process, timeSteps, timeStepsPerYear,
-                                         false, antitheticVariate,
-                                         controlVariate, requiredSamples,
-                                         requiredTolerance, maxSamples,
-                                         seed, nCalibrationSamples),
-      polynomOrder_(polynomOrder),
-      polynomType_(polynomType) {}
+    template <class RNG, class S, class RNG_Calibration>
+    inline MCAmericanEngine<RNG, S, RNG_Calibration>::MCAmericanEngine(
+        const boost::shared_ptr<GeneralizedBlackScholesProcess> &process,
+        Size timeSteps, Size timeStepsPerYear, bool antitheticVariate,
+        bool controlVariate, Size requiredSamples, Real requiredTolerance,
+        Size maxSamples, BigNatural seed, Size polynomOrder,
+        LsmBasisSystem::PolynomType polynomType, Size nCalibrationSamples,
+        boost::optional<bool> antitheticVariateCalibration,
+        BigNatural seedCalibration)
+        : MCLongstaffSchwartzEngine<VanillaOption::engine, SingleVariate, RNG,
+                                    S, RNG_Calibration>(
+              process, timeSteps, timeStepsPerYear, false, antitheticVariate,
+              controlVariate, requiredSamples, requiredTolerance, maxSamples,
+              seed, nCalibrationSamples, false, antitheticVariateCalibration,
+              seedCalibration),
+          polynomOrder_(polynomOrder), polynomType_(polynomType) {}
 
-    template <class RNG, class S>
-    inline void MCAmericanEngine<RNG,S>::calculate() const {
-        MCLongstaffSchwartzEngine<VanillaOption::engine,
-                                  SingleVariate,RNG,S>::calculate();
+    template <class RNG, class S, class RNG_Calibration>
+    inline void MCAmericanEngine<RNG, S, RNG_Calibration>::calculate() const {
+        MCLongstaffSchwartzEngine<VanillaOption::engine, SingleVariate, RNG, S,
+                                  RNG_Calibration>::calculate();
         if (this->controlVariate_) {
             // control variate might lead to small negative
             // option values for deep OTM options
             this->results_.value = std::max(0.0, this->results_.value);
         }
     }
-        
-    template <class RNG, class S>
+
+    template <class RNG, class S, class RNG_Calibration>
     inline boost::shared_ptr<LongstaffSchwartzPathPricer<Path> >
-    MCAmericanEngine<RNG,S>::lsmPathPricer() const {
+    MCAmericanEngine<RNG, S, RNG_Calibration>::lsmPathPricer() const {
         boost::shared_ptr<GeneralizedBlackScholesProcess> process =
             boost::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
                                                               this->process_);
@@ -186,9 +193,9 @@ namespace QuantLib {
                                       *(process->riskFreeRate())));
     }
 
-    template <class RNG, class S>
+    template <class RNG, class S, class RNG_Calibration>
     inline boost::shared_ptr<PathPricer<Path> >
-    MCAmericanEngine<RNG,S>::controlPathPricer() const {
+    MCAmericanEngine<RNG, S, RNG_Calibration>::controlPathPricer() const {
         boost::shared_ptr<StrikedTypePayoff> payoff =
             boost::dynamic_pointer_cast<StrikedTypePayoff>(
                 this->arguments_.payoff);
@@ -207,9 +214,9 @@ namespace QuantLib {
             );
     }
 
-    template <class RNG, class S>
+    template <class RNG, class S, class RNG_Calibration>
     inline boost::shared_ptr<PricingEngine>
-    MCAmericanEngine<RNG,S>::controlPricingEngine() const {
+    MCAmericanEngine<RNG, S, RNG_Calibration>::controlPricingEngine() const {
         boost::shared_ptr<GeneralizedBlackScholesProcess> process =
             boost::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
                                                               this->process_);
@@ -219,8 +226,9 @@ namespace QuantLib {
                                          new AnalyticEuropeanEngine(process));
     }
 
-    template <class RNG, class S>
-    inline Real MCAmericanEngine<RNG,S>::controlVariateValue() const {
+    template <class RNG, class S, class RNG_Calibration>
+    inline Real
+    MCAmericanEngine<RNG, S, RNG_Calibration>::controlVariateValue() const {
         boost::shared_ptr<PricingEngine> controlPE =
             this->controlPricingEngine();
 
@@ -243,58 +251,60 @@ namespace QuantLib {
         return controlResults->value;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>::MakeMCAmericanEngine(
-             const boost::shared_ptr<GeneralizedBlackScholesProcess>& process)
-    : process_(process), antithetic_(false), controlVariate_(false),
-      steps_(Null<Size>()), stepsPerYear_(Null<Size>()),
-      samples_(Null<Size>()), maxSamples_(Null<Size>()),
-      calibrationSamples_(2048),
-      tolerance_(Null<Real>()), seed_(0),
-      polynomOrder_(2),
-      polynomType_ (LsmBasisSystem::Monomial) {}
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration>::MakeMCAmericanEngine(
+        const boost::shared_ptr<GeneralizedBlackScholesProcess> &process)
+        : process_(process), antithetic_(false), controlVariate_(false),
+          steps_(Null<Size>()), stepsPerYear_(Null<Size>()),
+          samples_(Null<Size>()), maxSamples_(Null<Size>()),
+          calibrationSamples_(2048), tolerance_(Null<Real>()), seed_(0),
+          polynomOrder_(2), polynomType_(LsmBasisSystem::Monomial),
+          antitheticCalibration_(boost::none), seedCalibration_(Null<Real>()) {}
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withPolynomOrder(Size polynomOrder) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withPolynomOrder(
+        Size polynomOrder) {
         polynomOrder_ = polynomOrder;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withBasisSystem(
-                                    LsmBasisSystem::PolynomType polynomType) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withBasisSystem(
+        LsmBasisSystem::PolynomType polynomType) {
         polynomType_ = polynomType;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withSteps(Size steps) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withSteps(Size steps) {
         steps_ = steps;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withStepsPerYear(Size steps) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withStepsPerYear(
+        Size steps) {
         stepsPerYear_ = steps;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withSamples(Size samples) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withSamples(Size samples) {
         QL_REQUIRE(tolerance_ == Null<Real>(),
                    "tolerance already set");
         samples_ = samples;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withAbsoluteTolerance(Real tolerance) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withAbsoluteTolerance(
+        Real tolerance) {
         QL_REQUIRE(samples_ == Null<Size>(),
                    "number of samples already set");
         QL_REQUIRE(RNG::allowsErrorEstimate,
@@ -304,52 +314,68 @@ namespace QuantLib {
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withMaxSamples(Size samples) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withMaxSamples(
+        Size samples) {
         maxSamples_ = samples;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withCalibrationSamples(Size samples) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withCalibrationSamples(
+        Size samples) {
         calibrationSamples_ = samples;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withSeed(BigNatural seed) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withSeed(BigNatural seed) {
         seed_ = seed;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withAntitheticVariate(bool b) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withAntitheticVariate(
+        bool b) {
         antithetic_ = b;
         return *this;
     }
 
-    template <class RNG, class S>
-    inline MakeMCAmericanEngine<RNG,S>&
-    MakeMCAmericanEngine<RNG,S>::withControlVariate(bool b) {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withControlVariate(bool b) {
         controlVariate_ = b;
         return *this;
     }
 
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &MakeMCAmericanEngine<
+        RNG, S, RNG_Calibration>::withAntitheticVariateCalibration(bool b) {
+        antitheticCalibration_ = b;
+        return *this;
+    }
 
-    template <class RNG, class S>
-    inline
-    MakeMCAmericanEngine<RNG,S>::operator boost::shared_ptr<PricingEngine>()
-                                                                      const {
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration> &
+    MakeMCAmericanEngine<RNG, S, RNG_Calibration>::withSeedCalibration(
+        BigNatural seed) {
+        seedCalibration_ = seed;
+        return *this;
+    }
+
+    template <class RNG, class S, class RNG_Calibration>
+    inline MakeMCAmericanEngine<RNG, S, RNG_Calibration>::
+    operator boost::shared_ptr<PricingEngine>() const {
         QL_REQUIRE(steps_ != Null<Size>() || stepsPerYear_ != Null<Size>(),
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
         return boost::shared_ptr<PricingEngine>(new
-            MCAmericanEngine<RNG, S>(process_,
+           MCAmericanEngine<RNG, S, RNG_Calibration>(process_,
                                      steps_,
                                      stepsPerYear_,
                                      antithetic_,
@@ -359,7 +385,9 @@ namespace QuantLib {
                                      seed_,
                                      polynomOrder_,
                                      polynomType_,
-                                     calibrationSamples_));
+                                     calibrationSamples_,
+                                     antitheticCalibration_,
+                                     seedCalibration_));
     }
 
 }


### PR DESCRIPTION
@klausspanderen, this is the change we discussed, may you have a look at what I came up with ?

This fixes the current behavior of reusing the paths for calibration in pricing (except zero seed (and PseudoRandom) is used), which implies a high biased MC estimator. One can also use different RNG traits for calibration (e.g. PseudoRandom) and pricing (e.g. LowDiscrepancy) now. The interface is kept backward compatible.

I think there are three engines deriving from ```MCLongstaffSchwartzEngine```. I amended ```MCAmericanEngine``` such that it fully uses the extended interface. If you like this extension, I can do the same with ```MCAmericanBasketEngine```. The third engine is the experimental ```MCAmericanPathEngine```. This one bascially copies the code of ```MCLongstaffSchwartzEngine``` with a tiny change in it, so we should first think of refactor this instead of copying the extensions as well.