### PR TITLE
change date's serial number type to fast32

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -333,7 +333,7 @@ namespace QuantLib {
         return 0;
     }
 
-    BigInteger CashFlows::accrualDays(const Leg& leg,
+    int_fast32_t CashFlows::accrualDays(const Leg& leg,
                                       bool includeSettlementDateFlows,
                                       Date settlementDate) {
         Leg::const_iterator cf = nextCashFlow(leg,
@@ -370,7 +370,7 @@ namespace QuantLib {
         return 0;
     }
 
-    BigInteger CashFlows::accruedDays(const Leg& leg,
+    int_fast32_t CashFlows::accruedDays(const Leg& leg,
                                       bool includeSettlementDateFlows,
                                       Date settlementDate) {
         if (settlementDate == Date())

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -333,7 +333,7 @@ namespace QuantLib {
         return 0;
     }
 
-    int_fast32_t CashFlows::accrualDays(const Leg& leg,
+    Date::serial_type CashFlows::accrualDays(const Leg& leg,
                                       bool includeSettlementDateFlows,
                                       Date settlementDate) {
         Leg::const_iterator cf = nextCashFlow(leg,
@@ -370,7 +370,7 @@ namespace QuantLib {
         return 0;
     }
 
-    int_fast32_t CashFlows::accruedDays(const Leg& leg,
+    Date::serial_type CashFlows::accruedDays(const Leg& leg,
                                       bool includeSettlementDateFlows,
                                       Date settlementDate) {
         if (settlementDate == Date())

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
         accrualPeriod(const Leg& leg,
                       bool includeSettlementDateFlows,
                       Date settlementDate = Date());
-        static int_fast32_t
+        static Date::serial_type
         accrualDays(const Leg& leg,
                     bool includeSettlementDateFlows,
                     Date settlementDate = Date());
@@ -125,7 +125,7 @@ namespace QuantLib {
         accruedPeriod(const Leg& leg,
                       bool includeSettlementDateFlows,
                       Date settlementDate = Date());
-        static int_fast32_t
+        static Date::serial_type
         accruedDays(const Leg& leg,
                     bool includeSettlementDateFlows,
                     Date settlementDate = Date());

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
         accrualPeriod(const Leg& leg,
                       bool includeSettlementDateFlows,
                       Date settlementDate = Date());
-        static BigInteger
+        static int_fast32_t
         accrualDays(const Leg& leg,
                     bool includeSettlementDateFlows,
                     Date settlementDate = Date());
@@ -125,7 +125,7 @@ namespace QuantLib {
         accruedPeriod(const Leg& leg,
                       bool includeSettlementDateFlows,
                       Date settlementDate = Date());
-        static BigInteger
+        static int_fast32_t
         accruedDays(const Leg& leg,
                     bool includeSettlementDateFlows,
                     Date settlementDate = Date());

--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
         return accrualPeriod_;
     }
 
-    BigInteger Coupon::accrualDays() const {
+    int_fast32_t Coupon::accrualDays() const {
         return dayCounter().dayCount(accrualStartDate_,
                                      accrualEndDate_);
     }
@@ -65,7 +65,7 @@ namespace QuantLib {
         }
     }
 
-    BigInteger Coupon::accruedDays(const Date& d) const {
+    int_fast32_t Coupon::accruedDays(const Date& d) const {
         if (d <= accrualStartDate_ || d > paymentDate_) {
             return 0;
         } else {

--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
         return accrualPeriod_;
     }
 
-    int_fast32_t Coupon::accrualDays() const {
+    Date::serial_type Coupon::accrualDays() const {
         return dayCounter().dayCount(accrualStartDate_,
                                      accrualEndDate_);
     }
@@ -65,7 +65,7 @@ namespace QuantLib {
         }
     }
 
-    int_fast32_t Coupon::accruedDays(const Date& d) const {
+    Date::serial_type Coupon::accruedDays(const Date& d) const {
         if (d <= accrualStartDate_ || d > paymentDate_) {
             return 0;
         } else {

--- a/ql/cashflows/coupon.hpp
+++ b/ql/cashflows/coupon.hpp
@@ -70,7 +70,7 @@ namespace QuantLib {
         //! accrual period as fraction of year
         Time accrualPeriod() const;
         //! accrual period in days
-        BigInteger accrualDays() const;
+        int_fast32_t accrualDays() const;
         //! accrued rate
         virtual Rate rate() const = 0;
         //! day counter for accrual calculation
@@ -78,7 +78,7 @@ namespace QuantLib {
         //! accrued period as fraction of year at the given date
         Time accruedPeriod(const Date&) const;
         //! accrued days at the given date
-        BigInteger accruedDays(const Date&) const;
+        int_fast32_t accruedDays(const Date&) const;
         //! accrued amount at the given date
         virtual Real accruedAmount(const Date&) const = 0;
         //@}

--- a/ql/cashflows/coupon.hpp
+++ b/ql/cashflows/coupon.hpp
@@ -70,7 +70,7 @@ namespace QuantLib {
         //! accrual period as fraction of year
         Time accrualPeriod() const;
         //! accrual period in days
-        int_fast32_t accrualDays() const;
+        Date::serial_type accrualDays() const;
         //! accrued rate
         virtual Rate rate() const = 0;
         //! day counter for accrual calculation
@@ -78,7 +78,7 @@ namespace QuantLib {
         //! accrued period as fraction of year at the given date
         Time accruedPeriod(const Date&) const;
         //! accrued days at the given date
-        int_fast32_t accruedDays(const Date&) const;
+        Date::serial_type accruedDays(const Date&) const;
         //! accrued amount at the given date
         virtual Real accruedAmount(const Date&) const = 0;
         //@}

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -350,7 +350,7 @@ namespace QuantLib {
     {
         calculate();
         Date today = Settings::instance().evaluationDate();
-        BigInteger val = d.serialNumber() - today.serialNumber();
+        int_fast32_t val = d.serialNumber() - today.serialNumber();
 
         Real attachAmount = basket_->attachmentAmount();
         Real detachAmount = basket_->detachmentAmount();
@@ -363,7 +363,7 @@ namespace QuantLib {
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
                 // if event is within time horizon...
-                if(val > static_cast<BigInteger>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                     // ...and is contained in the basket.
                         portfSimLoss +=
@@ -406,7 +406,7 @@ namespace QuantLib {
         std::set<Real> keys;// attainable loss values
         keys.insert(0.);
         Date today = Settings::instance().evaluationDate();
-        BigInteger val = d.serialNumber() - today.serialNumber();
+        int_fast32_t val = d.serialNumber() - today.serialNumber();
         // redundant test? should have been tested by the basket caller?
         QL_REQUIRE(d >= today,
             "Requested percentile date must lie after computation date.");
@@ -420,7 +420,7 @@ namespace QuantLib {
 
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<BigInteger>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
           // test needed (here and the others) to reuse simulations:
           //          if(basket_->pool()->has(copula_->pool()->names()[iName]))
@@ -453,7 +453,7 @@ namespace QuantLib {
         Real attachAmount = basket_->attachmentAmount();
         Real detachAmount = basket_->detachmentAmount();
 
-        BigInteger val = d.serialNumber() - today.serialNumber();
+        int_fast32_t val = d.serialNumber() - today.serialNumber();
         if(val <= 0) return 0.;// plus basket realized losses
 
         //GenericRiskStatistics<GeneralStatistics> statsX;
@@ -462,7 +462,7 @@ namespace QuantLib {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<BigInteger>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                     // ...and is contained in the basket.
                     //if(basket_->pool()->has(copula_->pool()->names()[iName]))
@@ -548,12 +548,12 @@ namespace QuantLib {
 
         std::vector<Real> rankLosses;
         Date today = Settings::instance().evaluationDate();
-        BigInteger val = d.serialNumber() - today.serialNumber();
+        int_fast32_t val = d.serialNumber() - today.serialNumber();
         for(Size iSim=0; iSim < nSims_; iSim++) {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<BigInteger>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                  //   if(basket_->pool()->has(copula_->pool()->names()[iName]))
                         portfSimLoss +=
@@ -650,7 +650,7 @@ namespace QuantLib {
         std::vector<GeneralStatistics> splitStats(numLiveNames,
             GeneralStatistics());
         Date today = Settings::instance().evaluationDate();
-        BigInteger val = date.serialNumber() - today.serialNumber();
+        int_fast32_t val = date.serialNumber() - today.serialNumber();
 
         for(Size iSim=0; iSim < nSims_; iSim++) {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
@@ -659,7 +659,7 @@ namespace QuantLib {
             std::vector<simEvent<D<C, URNG> > > splitEventsBuffer;
 
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<BigInteger>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                 // if(basket_->pool()->has(copula_->pool()->names()[iName])) {
                         portfSimLoss +=

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -350,7 +350,7 @@ namespace QuantLib {
     {
         calculate();
         Date today = Settings::instance().evaluationDate();
-        int_fast32_t val = d.serialNumber() - today.serialNumber();
+        Date::serial_type val = d.serialNumber() - today.serialNumber();
 
         Real attachAmount = basket_->attachmentAmount();
         Real detachAmount = basket_->detachmentAmount();
@@ -363,7 +363,7 @@ namespace QuantLib {
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
                 // if event is within time horizon...
-                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<Date::serial_type>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                     // ...and is contained in the basket.
                         portfSimLoss +=
@@ -406,7 +406,7 @@ namespace QuantLib {
         std::set<Real> keys;// attainable loss values
         keys.insert(0.);
         Date today = Settings::instance().evaluationDate();
-        int_fast32_t val = d.serialNumber() - today.serialNumber();
+        Date::serial_type val = d.serialNumber() - today.serialNumber();
         // redundant test? should have been tested by the basket caller?
         QL_REQUIRE(d >= today,
             "Requested percentile date must lie after computation date.");
@@ -420,7 +420,7 @@ namespace QuantLib {
 
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<Date::serial_type>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
           // test needed (here and the others) to reuse simulations:
           //          if(basket_->pool()->has(copula_->pool()->names()[iName]))
@@ -453,7 +453,7 @@ namespace QuantLib {
         Real attachAmount = basket_->attachmentAmount();
         Real detachAmount = basket_->detachmentAmount();
 
-        int_fast32_t val = d.serialNumber() - today.serialNumber();
+        Date::serial_type val = d.serialNumber() - today.serialNumber();
         if(val <= 0) return 0.;// plus basket realized losses
 
         //GenericRiskStatistics<GeneralStatistics> statsX;
@@ -462,7 +462,7 @@ namespace QuantLib {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<Date::serial_type>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                     // ...and is contained in the basket.
                     //if(basket_->pool()->has(copula_->pool()->names()[iName]))
@@ -548,12 +548,12 @@ namespace QuantLib {
 
         std::vector<Real> rankLosses;
         Date today = Settings::instance().evaluationDate();
-        int_fast32_t val = d.serialNumber() - today.serialNumber();
+        Date::serial_type val = d.serialNumber() - today.serialNumber();
         for(Size iSim=0; iSim < nSims_; iSim++) {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
             Real portfSimLoss=0.;
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<Date::serial_type>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                  //   if(basket_->pool()->has(copula_->pool()->names()[iName]))
                         portfSimLoss +=
@@ -650,7 +650,7 @@ namespace QuantLib {
         std::vector<GeneralStatistics> splitStats(numLiveNames,
             GeneralStatistics());
         Date today = Settings::instance().evaluationDate();
-        int_fast32_t val = date.serialNumber() - today.serialNumber();
+        Date::serial_type val = date.serialNumber() - today.serialNumber();
 
         for(Size iSim=0; iSim < nSims_; iSim++) {
             const std::vector<simEvent<D<C, URNG> > >& events = getSim(iSim);
@@ -659,7 +659,7 @@ namespace QuantLib {
             std::vector<simEvent<D<C, URNG> > > splitEventsBuffer;
 
             for(Size iEvt=0; iEvt < events.size(); iEvt++) {
-                if(val > static_cast<int_fast32_t>(events[iEvt].dayFromRef)) {
+                if(val > static_cast<Date::serial_type>(events[iEvt].dayFromRef)) {
                     Size iName = events[iEvt].nameIdx;
                 // if(basket_->pool()->has(copula_->pool()->names()[iName])) {
                         portfSimLoss +=

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -185,7 +185,7 @@ namespace QuantLib {
                                         false, settlement);
     }
 
-    int_fast32_t BondFunctions::accrualDays(const Bond& bond,
+    Date::serial_type BondFunctions::accrualDays(const Bond& bond,
                                           Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
@@ -211,7 +211,7 @@ namespace QuantLib {
                                         false, settlement);
     }
 
-    int_fast32_t BondFunctions::accruedDays(const Bond& bond,
+    Date::serial_type BondFunctions::accruedDays(const Bond& bond,
                                           Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -185,7 +185,7 @@ namespace QuantLib {
                                         false, settlement);
     }
 
-    BigInteger BondFunctions::accrualDays(const Bond& bond,
+    int_fast32_t BondFunctions::accrualDays(const Bond& bond,
                                           Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
@@ -211,7 +211,7 @@ namespace QuantLib {
                                         false, settlement);
     }
 
-    BigInteger BondFunctions::accruedDays(const Bond& bond,
+    int_fast32_t BondFunctions::accruedDays(const Bond& bond,
                                           Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -91,11 +91,11 @@ namespace QuantLib {
                                        Date settlementDate = Date());
         static Time accrualPeriod(const Bond& bond,
                                   Date settlementDate = Date());
-        static int_fast32_t accrualDays(const Bond& bond,
+        static Date::serial_type accrualDays(const Bond& bond,
                                       Date settlementDate = Date());
         static Time accruedPeriod(const Bond& bond,
                                   Date settlementDate = Date());
-        static int_fast32_t accruedDays(const Bond& bond,
+        static Date::serial_type accruedDays(const Bond& bond,
                                       Date settlementDate = Date());
         static Real accruedAmount(const Bond& bond,
                                   Date settlementDate = Date());

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -91,11 +91,11 @@ namespace QuantLib {
                                        Date settlementDate = Date());
         static Time accrualPeriod(const Bond& bond,
                                   Date settlementDate = Date());
-        static BigInteger accrualDays(const Bond& bond,
+        static int_fast32_t accrualDays(const Bond& bond,
                                       Date settlementDate = Date());
         static Time accruedPeriod(const Bond& bond,
                                   Date settlementDate = Date());
-        static BigInteger accruedDays(const Bond& bond,
+        static int_fast32_t accruedDays(const Bond& bond,
                                       Date settlementDate = Date());
         static Real accruedAmount(const Bond& bond,
                                   Date settlementDate = Date());

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
@@ -48,7 +48,7 @@ Gaussian1dSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                Time swapLength) const {
     DateHelper hlp(*this, optionTime);
     NewtonSafe newton;
-    Date d(static_cast<int_fast32_t>(newton.solve(
+    Date d(static_cast<Date::serial_type>(newton.solve(
         hlp, 0.1,
         365.25 * optionTime + static_cast<Real>(referenceDate().serialNumber()),
         1.0)));

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
@@ -48,7 +48,7 @@ Gaussian1dSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                Time swapLength) const {
     DateHelper hlp(*this, optionTime);
     NewtonSafe newton;
-    Date d(static_cast<BigInteger>(newton.solve(
+    Date d(static_cast<int_fast32_t>(newton.solve(
         hlp, 0.1,
         365.25 * optionTime + static_cast<Real>(referenceDate().serialNumber()),
         1.0)));

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
@@ -73,11 +73,11 @@ class Gaussian1dSwaptionVolatility : public SwaptionVolatilityStructure {
       public:
         DateHelper(const TermStructure &ts, const Time t) : ts_(ts), t_(t) {}
         Real operator()(Real date) const {
-            Date d1(static_cast<BigInteger>(date));
-            Date d2(static_cast<BigInteger>(date) + 1);
+            Date d1(static_cast<int_fast32_t>(date));
+            Date d2(static_cast<int_fast32_t>(date) + 1);
             Real t1 = ts_.timeFromReference(d1) - t_;
             Real t2 = ts_.timeFromReference(d2) - t_;
-            Real h = date - static_cast<BigInteger>(date);
+            Real h = date - static_cast<int_fast32_t>(date);
             return h * t2 + (1.0 - h) * t1;
         }
         Real derivative(Real date) const {

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
@@ -73,11 +73,11 @@ class Gaussian1dSwaptionVolatility : public SwaptionVolatilityStructure {
       public:
         DateHelper(const TermStructure &ts, const Time t) : ts_(ts), t_(t) {}
         Real operator()(Real date) const {
-            Date d1(static_cast<int_fast32_t>(date));
-            Date d2(static_cast<int_fast32_t>(date) + 1);
+            Date d1(static_cast<Date::serial_type>(date));
+            Date d2(static_cast<Date::serial_type>(date) + 1);
             Real t1 = ts_.timeFromReference(d1) - t_;
             Real t2 = ts_.timeFromReference(d2) - t_;
-            Real h = date - static_cast<int_fast32_t>(date);
+            Real h = date - static_cast<Date::serial_type>(date);
             return h * t2 + (1.0 - h) * t1;
         }
         Real derivative(Real date) const {

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
 
     inline const Date
     SwaptionVolatilityDiscrete::optionDateFromTime(Time optionTime) const {
-        return Date(static_cast<int_fast32_t>(optionInterpolator_(optionTime)));
+        return Date(static_cast<Date::serial_type>(optionInterpolator_(optionTime)));
     }
 
 }

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
 
     inline const Date
     SwaptionVolatilityDiscrete::optionDateFromTime(Time optionTime) const {
-        return Date(static_cast<BigInteger>(optionInterpolator_(optionTime)));
+        return Date(static_cast<int_fast32_t>(optionInterpolator_(optionTime)));
     }
 
 }

--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -155,7 +155,7 @@ namespace QuantLib {
     #ifndef __DOXYGEN__
 
     // template definitions
-
+    
     template <class T>
     DiscountFactor InterpolatedDiscountCurve<T>::discountImpl(Time t) const {
         if (t <= this->times_.back())

--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -137,11 +137,11 @@ namespace QuantLib {
         return advance(d, p.length(), p.units(), c, endOfMonth);
     }
 
-    BigInteger Calendar::businessDaysBetween(const Date& from,
+    int_fast32_t Calendar::businessDaysBetween(const Date& from,
                                              const Date& to,
                                              bool includeFirst,
                                              bool includeLast) const {
-        BigInteger wd = 0;
+        int_fast32_t wd = 0;
         if (from != to) {
             if (from < to) {
                 // the last one is treated separately to avoid

--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -137,11 +137,11 @@ namespace QuantLib {
         return advance(d, p.length(), p.units(), c, endOfMonth);
     }
 
-    int_fast32_t Calendar::businessDaysBetween(const Date& from,
+    Date::serial_type Calendar::businessDaysBetween(const Date& from,
                                              const Date& to,
                                              bool includeFirst,
                                              bool includeLast) const {
-        int_fast32_t wd = 0;
+        Date::serial_type wd = 0;
         if (from != to) {
             if (from < to) {
                 // the last one is treated separately to avoid

--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -139,7 +139,7 @@ namespace QuantLib {
         /*! Calculates the number of business days between two given
             dates and returns the result.
         */
-        int_fast32_t businessDaysBetween(const Date& from,
+        Date::serial_type businessDaysBetween(const Date& from,
                                        const Date& to,
                                        bool includeFirst = true,
                                        bool includeLast = false) const;

--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -139,7 +139,7 @@ namespace QuantLib {
         /*! Calculates the number of business days between two given
             dates and returns the result.
         */
-        BigInteger businessDaysBetween(const Date& from,
+        int_fast32_t businessDaysBetween(const Date& from,
                                        const Date& to,
                                        bool includeFirst = true,
                                        bool includeLast = false) const;

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -52,9 +52,9 @@ namespace QuantLib {
 #ifndef QL_HIGH_RESOLUTION_DATE
     // constructors
     Date::Date()
-    : serialNumber_(int_fast32_t(0)) {}
+    : serialNumber_(Date::serial_type(0)) {}
 
-    Date::Date(int_fast32_t serialNumber)
+    Date::Date(Date::serial_type serialNumber)
     : serialNumber_(serialNumber) {
         checkSerialNumber(serialNumber);
     }
@@ -94,8 +94,8 @@ namespace QuantLib {
         return y;
     }
 
-    Date& Date::operator+=(int_fast32_t days) {
-        int_fast32_t serial = serialNumber_ + days;
+    Date& Date::operator+=(Date::serial_type days) {
+        Date::serial_type serial = serialNumber_ + days;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -106,8 +106,8 @@ namespace QuantLib {
         return *this;
     }
 
-    Date& Date::operator-=(int_fast32_t days) {
-        int_fast32_t serial = serialNumber_ - days;
+    Date& Date::operator-=(Date::serial_type days) {
+        Date::serial_type serial = serialNumber_ - days;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -119,14 +119,14 @@ namespace QuantLib {
     }
 
     Date& Date::operator++() {
-        int_fast32_t serial = serialNumber_ + 1;
+        Date::serial_type serial = serialNumber_ + 1;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
     }
 
     Date& Date::operator--() {
-        int_fast32_t serial = serialNumber_ - 1;
+        Date::serial_type serial = serialNumber_ - 1;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -276,10 +276,10 @@ namespace QuantLib {
         return (leapYear? MonthLeapOffset[m-1] : MonthOffset[m-1]);
     }
 
-    int_fast32_t Date::yearOffset(Year y) {
+    Date::serial_type Date::yearOffset(Year y) {
         // the list of all December 31st in the preceding year
         // e.g. for 1901 yearOffset[1] is 366, that is, December 31 1900
-        static const int_fast32_t YearOffset[] = {
+        static const Date::serial_type YearOffset[] = {
             // 1900-1909
                 0,  366,  731, 1096, 1461, 1827, 2192, 2557, 2922, 3288,
             // 1910-1919
@@ -528,7 +528,7 @@ namespace QuantLib {
                millisec*(time_duration::ticks_per_second()/1000)
              + microsec*(time_duration::ticks_per_second()/1000000))) {}
 
-    Date::Date(int_fast32_t serialNumber)
+    Date::Date(Date::serial_type serialNumber)
     : dateTime_(
          serialNumberDateReference() +
          boost::gregorian::days(serialNumber)) {
@@ -598,8 +598,8 @@ namespace QuantLib {
         return time_duration::ticks_per_second();
     }
 
-    int_fast32_t Date::serialNumber() const {
-        const int_fast32_t n = (dateTime_.date()
+    Date::serial_type Date::serialNumber() const {
+        const Date::serial_type n = (dateTime_.date()
             - serialNumberDateReference()).days();
         checkSerialNumber(n);
 
@@ -608,7 +608,7 @@ namespace QuantLib {
 
     const ptime& Date::dateTime() const { return dateTime_; }
 
-    Date& Date::operator+=(int_fast32_t d) {
+    Date& Date::operator+=(Date::serial_type d) {
         dateTime_ += boost::gregorian::days(d);
         return *this;
     }
@@ -618,7 +618,7 @@ namespace QuantLib {
         return *this;
     }
 
-    Date& Date::operator-=(int_fast32_t d) {
+    Date& Date::operator-=(Date::serial_type d) {
         dateTime_ -= boost::gregorian::days(d);
         return *this;
     }
@@ -637,14 +637,14 @@ namespace QuantLib {
         return *this;
     }
 
-    Date Date::operator+(int_fast32_t days) const {
+    Date Date::operator+(Date::serial_type days) const {
         Date retVal(*this);
         retVal+=days;
 
         return retVal;
     }
 
-    Date Date::operator-(int_fast32_t days) const {
+    Date Date::operator-(Date::serial_type days) const {
         Date retVal(*this);
         retVal-=days;
 
@@ -693,12 +693,12 @@ namespace QuantLib {
     }
 
 
-    int_fast32_t operator-(const Date& d1, const Date& d2) {
+    Date::serial_type operator-(const Date& d1, const Date& d2) {
         return (d1.dateTime().date() - d2.dateTime().date()).days();
     }
 
     Time daysBetween(const Date& d1, const Date& d2) {
-        const int_fast32_t days = d2 - d1;
+        const Date::serial_type days = d2 - d1;
         return days + d2.fractionOfDay() - d1.fractionOfDay();
     }
 
@@ -727,15 +727,15 @@ namespace QuantLib {
     }
 #endif
 
-    int_fast32_t Date::minimumSerialNumber() {
+    Date::serial_type Date::minimumSerialNumber() {
         return 367;       // Jan 1st, 1901
     }
 
-    int_fast32_t Date::maximumSerialNumber() {
+    Date::serial_type Date::maximumSerialNumber() {
         return 109574;    // Dec 31st, 2199
     }
 
-    void Date::checkSerialNumber(int_fast32_t serialNumber) {
+    void Date::checkSerialNumber(Date::serial_type serialNumber) {
         QL_REQUIRE(serialNumber >= minimumSerialNumber() &&
                    serialNumber <= maximumSerialNumber(),
                    "Date's serial number (" << serialNumber << ") outside "

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -52,9 +52,9 @@ namespace QuantLib {
 #ifndef QL_HIGH_RESOLUTION_DATE
     // constructors
     Date::Date()
-    : serialNumber_(BigInteger(0)) {}
+    : serialNumber_(int_fast32_t(0)) {}
 
-    Date::Date(BigInteger serialNumber)
+    Date::Date(int_fast32_t serialNumber)
     : serialNumber_(serialNumber) {
         checkSerialNumber(serialNumber);
     }
@@ -94,8 +94,8 @@ namespace QuantLib {
         return y;
     }
 
-    Date& Date::operator+=(BigInteger days) {
-        BigInteger serial = serialNumber_ + days;
+    Date& Date::operator+=(int_fast32_t days) {
+        int_fast32_t serial = serialNumber_ + days;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -106,8 +106,8 @@ namespace QuantLib {
         return *this;
     }
 
-    Date& Date::operator-=(BigInteger days) {
-        BigInteger serial = serialNumber_ - days;
+    Date& Date::operator-=(int_fast32_t days) {
+        int_fast32_t serial = serialNumber_ - days;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -119,14 +119,14 @@ namespace QuantLib {
     }
 
     Date& Date::operator++() {
-        BigInteger serial = serialNumber_ + 1;
+        int_fast32_t serial = serialNumber_ + 1;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
     }
 
     Date& Date::operator--() {
-        BigInteger serial = serialNumber_ - 1;
+        int_fast32_t serial = serialNumber_ - 1;
         checkSerialNumber(serial);
         serialNumber_ = serial;
         return *this;
@@ -276,10 +276,10 @@ namespace QuantLib {
         return (leapYear? MonthLeapOffset[m-1] : MonthOffset[m-1]);
     }
 
-    BigInteger Date::yearOffset(Year y) {
+    int_fast32_t Date::yearOffset(Year y) {
         // the list of all December 31st in the preceding year
         // e.g. for 1901 yearOffset[1] is 366, that is, December 31 1900
-        static const BigInteger YearOffset[] = {
+        static const int_fast32_t YearOffset[] = {
             // 1900-1909
                 0,  366,  731, 1096, 1461, 1827, 2192, 2557, 2922, 3288,
             // 1910-1919
@@ -528,7 +528,7 @@ namespace QuantLib {
                millisec*(time_duration::ticks_per_second()/1000)
              + microsec*(time_duration::ticks_per_second()/1000000))) {}
 
-    Date::Date(BigInteger serialNumber)
+    Date::Date(int_fast32_t serialNumber)
     : dateTime_(
          serialNumberDateReference() +
          boost::gregorian::days(serialNumber)) {
@@ -598,8 +598,8 @@ namespace QuantLib {
         return time_duration::ticks_per_second();
     }
 
-    BigInteger Date::serialNumber() const {
-        const BigInteger n = (dateTime_.date()
+    int_fast32_t Date::serialNumber() const {
+        const int_fast32_t n = (dateTime_.date()
             - serialNumberDateReference()).days();
         checkSerialNumber(n);
 
@@ -608,7 +608,7 @@ namespace QuantLib {
 
     const ptime& Date::dateTime() const { return dateTime_; }
 
-    Date& Date::operator+=(BigInteger d) {
+    Date& Date::operator+=(int_fast32_t d) {
         dateTime_ += boost::gregorian::days(d);
         return *this;
     }
@@ -618,7 +618,7 @@ namespace QuantLib {
         return *this;
     }
 
-    Date& Date::operator-=(BigInteger d) {
+    Date& Date::operator-=(int_fast32_t d) {
         dateTime_ -= boost::gregorian::days(d);
         return *this;
     }
@@ -637,14 +637,14 @@ namespace QuantLib {
         return *this;
     }
 
-    Date Date::operator+(BigInteger days) const {
+    Date Date::operator+(int_fast32_t days) const {
         Date retVal(*this);
         retVal+=days;
 
         return retVal;
     }
 
-    Date Date::operator-(BigInteger days) const {
+    Date Date::operator-(int_fast32_t days) const {
         Date retVal(*this);
         retVal-=days;
 
@@ -693,12 +693,12 @@ namespace QuantLib {
     }
 
 
-    BigInteger operator-(const Date& d1, const Date& d2) {
+    int_fast32_t operator-(const Date& d1, const Date& d2) {
         return (d1.dateTime().date() - d2.dateTime().date()).days();
     }
 
     Time daysBetween(const Date& d1, const Date& d2) {
-        const BigInteger days = d2 - d1;
+        const int_fast32_t days = d2 - d1;
         return days + d2.fractionOfDay() - d1.fractionOfDay();
     }
 
@@ -727,15 +727,15 @@ namespace QuantLib {
     }
 #endif
 
-    BigInteger Date::minimumSerialNumber() {
+    int_fast32_t Date::minimumSerialNumber() {
         return 367;       // Jan 1st, 1901
     }
 
-    BigInteger Date::maximumSerialNumber() {
+    int_fast32_t Date::maximumSerialNumber() {
         return 109574;    // Dec 31st, 2199
     }
 
-    void Date::checkSerialNumber(BigInteger serialNumber) {
+    void Date::checkSerialNumber(int_fast32_t serialNumber) {
         QL_REQUIRE(serialNumber >= minimumSerialNumber() &&
                    serialNumber <= maximumSerialNumber(),
                    "Date's serial number (" << serialNumber << ") outside "

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -121,12 +121,14 @@ namespace QuantLib {
 
     class Date {
       public:
+        //! serial number type
+        typedef int_fast32_t serial_type;
         //! \name constructors
         //@{
         //! Default constructor returning a null date.
         Date();
         //! Constructor taking a serial number as given by Applix or Excel.
-        explicit Date(int_fast32_t serialNumber);
+        explicit Date(Date::serial_type serialNumber);
         //! More traditional constructor.
         Date(Day d, Month m, Year y);
 
@@ -148,7 +150,7 @@ namespace QuantLib {
         Day dayOfYear() const;
         Month month() const;
         Year year() const;
-        int_fast32_t serialNumber() const;
+        Date::serial_type serialNumber() const;
 
 #ifdef QL_HIGH_RESOLUTION_DATE
         Hour hours() const;
@@ -167,11 +169,11 @@ namespace QuantLib {
         //! \name date algebra
         //@{
         //! increments date by the given number of days
-        Date& operator+=(int_fast32_t days);
+        Date& operator+=(Date::serial_type days);
         //! increments date by the given period
         Date& operator+=(const Period&);
         //! decrement date by the given number of days
-        Date& operator-=(int_fast32_t days);
+        Date& operator-=(Date::serial_type days);
         //! decrements date by the given period
         Date& operator-=(const Period&);
         //! 1-day pre-increment
@@ -183,11 +185,11 @@ namespace QuantLib {
         //! 1-day post-decrement
         Date operator--(int );
         //! returns a new date incremented by the given number of days
-        Date operator+(int_fast32_t days) const;
+        Date operator+(Date::serial_type days) const;
         //! returns a new date incremented by the given period
         Date operator+(const Period&) const;
         //! returns a new date decremented by the given number of days
-        Date operator-(int_fast32_t days) const;
+        Date operator-(Date::serial_type days) const;
         //! returns a new date decremented by the given period
         Date operator-(const Period&) const;
         //@}
@@ -238,25 +240,25 @@ namespace QuantLib {
         //@}
 
       private:
-        static int_fast32_t minimumSerialNumber();
-        static int_fast32_t maximumSerialNumber();
-        static void checkSerialNumber(int_fast32_t serialNumber);
+        static Date::serial_type minimumSerialNumber();
+        static Date::serial_type maximumSerialNumber();
+        static void checkSerialNumber(Date::serial_type serialNumber);
 
 #ifdef QL_HIGH_RESOLUTION_DATE
         boost::posix_time::ptime dateTime_;
 #else
-        int_fast32_t serialNumber_;
+        Date::serial_type serialNumber_;
         static Date advance(const Date& d, Integer units, TimeUnit);
         static Integer monthLength(Month m, bool leapYear);
         static Integer monthOffset(Month m, bool leapYear);
-        static int_fast32_t yearOffset(Year y);
+        static Date::serial_type yearOffset(Year y);
 #endif
     };
 
     /*! \relates Date
         \brief Difference in days between dates
     */
-    int_fast32_t operator-(const Date&, const Date&);
+    Date::serial_type operator-(const Date&, const Date&);
     /*! \relates Date
         \brief Difference in days (including fraction of days) between dates
     */
@@ -368,15 +370,15 @@ namespace QuantLib {
         return serialNumber_ - yearOffset(year());
     }
 
-    inline int_fast32_t Date::serialNumber() const {
+    inline Date::serial_type Date::serialNumber() const {
         return serialNumber_;
     }
 
-    inline Date Date::operator+(int_fast32_t days) const {
+    inline Date Date::operator+(Date::serial_type days) const {
         return Date(serialNumber_+days);
     }
 
-    inline Date Date::operator-(int_fast32_t days) const {
+    inline Date Date::operator-(Date::serial_type days) const {
         return Date(serialNumber_-days);
     }
 
@@ -398,7 +400,7 @@ namespace QuantLib {
        return (d.dayOfMonth() == monthLength(d.month(), isLeap(d.year())));
     }
 
-    inline int_fast32_t operator-(const Date& d1, const Date& d2) {
+    inline Date::serial_type operator-(const Date& d1, const Date& d2) {
         return d1.serialNumber()-d2.serialNumber();
     }
 

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -41,6 +41,8 @@
 #include <utility>
 #include <functional>
 
+#include <boost/cstdint.hpp>
+
 namespace QuantLib {
 
     //! Day number
@@ -124,7 +126,7 @@ namespace QuantLib {
         //! Default constructor returning a null date.
         Date();
         //! Constructor taking a serial number as given by Applix or Excel.
-        explicit Date(BigInteger serialNumber);
+        explicit Date(int_fast32_t serialNumber);
         //! More traditional constructor.
         Date(Day d, Month m, Year y);
 
@@ -146,7 +148,7 @@ namespace QuantLib {
         Day dayOfYear() const;
         Month month() const;
         Year year() const;
-        BigInteger serialNumber() const;
+        int_fast32_t serialNumber() const;
 
 #ifdef QL_HIGH_RESOLUTION_DATE
         Hour hours() const;
@@ -165,11 +167,11 @@ namespace QuantLib {
         //! \name date algebra
         //@{
         //! increments date by the given number of days
-        Date& operator+=(BigInteger days);
+        Date& operator+=(int_fast32_t days);
         //! increments date by the given period
         Date& operator+=(const Period&);
         //! decrement date by the given number of days
-        Date& operator-=(BigInteger days);
+        Date& operator-=(int_fast32_t days);
         //! decrements date by the given period
         Date& operator-=(const Period&);
         //! 1-day pre-increment
@@ -181,11 +183,11 @@ namespace QuantLib {
         //! 1-day post-decrement
         Date operator--(int );
         //! returns a new date incremented by the given number of days
-        Date operator+(BigInteger days) const;
+        Date operator+(int_fast32_t days) const;
         //! returns a new date incremented by the given period
         Date operator+(const Period&) const;
         //! returns a new date decremented by the given number of days
-        Date operator-(BigInteger days) const;
+        Date operator-(int_fast32_t days) const;
         //! returns a new date decremented by the given period
         Date operator-(const Period&) const;
         //@}
@@ -236,25 +238,25 @@ namespace QuantLib {
         //@}
 
       private:
-        static BigInteger minimumSerialNumber();
-        static BigInteger maximumSerialNumber();
-        static void checkSerialNumber(BigInteger serialNumber);
+        static int_fast32_t minimumSerialNumber();
+        static int_fast32_t maximumSerialNumber();
+        static void checkSerialNumber(int_fast32_t serialNumber);
 
 #ifdef QL_HIGH_RESOLUTION_DATE
         boost::posix_time::ptime dateTime_;
 #else
-        BigInteger serialNumber_;
+        int_fast32_t serialNumber_;
         static Date advance(const Date& d, Integer units, TimeUnit);
         static Integer monthLength(Month m, bool leapYear);
         static Integer monthOffset(Month m, bool leapYear);
-        static BigInteger yearOffset(Year y);
+        static int_fast32_t yearOffset(Year y);
 #endif
     };
 
     /*! \relates Date
         \brief Difference in days between dates
     */
-    BigInteger operator-(const Date&, const Date&);
+    int_fast32_t operator-(const Date&, const Date&);
     /*! \relates Date
         \brief Difference in days (including fraction of days) between dates
     */
@@ -366,15 +368,15 @@ namespace QuantLib {
         return serialNumber_ - yearOffset(year());
     }
 
-    inline BigInteger Date::serialNumber() const {
+    inline int_fast32_t Date::serialNumber() const {
         return serialNumber_;
     }
 
-    inline Date Date::operator+(BigInteger days) const {
+    inline Date Date::operator+(int_fast32_t days) const {
         return Date(serialNumber_+days);
     }
 
-    inline Date Date::operator-(BigInteger days) const {
+    inline Date Date::operator-(int_fast32_t days) const {
         return Date(serialNumber_-days);
     }
 
@@ -396,7 +398,7 @@ namespace QuantLib {
        return (d.dayOfMonth() == monthLength(d.month(), isLeap(d.year())));
     }
 
-    inline BigInteger operator-(const Date& d1, const Date& d2) {
+    inline int_fast32_t operator-(const Date& d1, const Date& d2) {
         return d1.serialNumber()-d2.serialNumber();
     }
 

--- a/ql/time/daycounter.hpp
+++ b/ql/time/daycounter.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
             virtual ~Impl() {}
             virtual std::string name() const = 0;
             //! to be overloaded by more complex day counters
-            virtual BigInteger dayCount(const Date& d1,
+            virtual int_fast32_t dayCount(const Date& d1,
                                         const Date& d2) const {
                 return (d2-d1);
             }
@@ -79,7 +79,7 @@ namespace QuantLib {
         */
         std::string name() const;
         //! Returns the number of days between two dates.
-        BigInteger dayCount(const Date&,
+        int_fast32_t dayCount(const Date&,
                             const Date&) const;
         //! Returns the period between two dates as a fraction of year.
         Time yearFraction(const Date&, const Date&,
@@ -117,7 +117,7 @@ namespace QuantLib {
         return impl_->name();
     }
 
-    inline BigInteger DayCounter::dayCount(const Date& d1,
+    inline int_fast32_t DayCounter::dayCount(const Date& d1,
                                            const Date& d2) const {
         QL_REQUIRE(impl_, "no implementation provided");
         return impl_->dayCount(d1,d2);

--- a/ql/time/daycounter.hpp
+++ b/ql/time/daycounter.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
             virtual ~Impl() {}
             virtual std::string name() const = 0;
             //! to be overloaded by more complex day counters
-            virtual int_fast32_t dayCount(const Date& d1,
+            virtual Date::serial_type dayCount(const Date& d1,
                                         const Date& d2) const {
                 return (d2-d1);
             }
@@ -79,7 +79,7 @@ namespace QuantLib {
         */
         std::string name() const;
         //! Returns the number of days between two dates.
-        int_fast32_t dayCount(const Date&,
+        Date::serial_type dayCount(const Date&,
                             const Date&) const;
         //! Returns the period between two dates as a fraction of year.
         Time yearFraction(const Date&, const Date&,
@@ -117,7 +117,7 @@ namespace QuantLib {
         return impl_->name();
     }
 
-    inline int_fast32_t DayCounter::dayCount(const Date& d1,
+    inline Date::serial_type DayCounter::dayCount(const Date& d1,
                                            const Date& d2) const {
         QL_REQUIRE(impl_, "no implementation provided");
         return impl_->dayCount(d1,d2);

--- a/ql/time/daycounters/actual365nl.hpp
+++ b/ql/time/daycounters/actual365nl.hpp
@@ -41,14 +41,14 @@ namespace QuantLib {
             std::string name() const { return std::string("Actual/365 (NL)"); }
 
             // Returns the exact number of days between 2 dates, excluding leap days
-            BigInteger dayCount(const Date& d1,
+            int_fast32_t dayCount(const Date& d1,
                                 const Date& d2) const {
 
                 static const Integer MonthOffset[] = {
                     0,  31,  59,  90, 120, 151,  // Jan - Jun
                   181, 212, 243, 273, 304, 334   // Jun - Dec
                 };
-                BigInteger s1, s2;
+                int_fast32_t s1, s2;
 
                 s1 = d1.dayOfMonth() + MonthOffset[d1.month()-1] + (d1.year() * 365);
                 s2 = d2.dayOfMonth() + MonthOffset[d2.month()-1] + (d2.year() * 365);

--- a/ql/time/daycounters/actual365nl.hpp
+++ b/ql/time/daycounters/actual365nl.hpp
@@ -41,14 +41,14 @@ namespace QuantLib {
             std::string name() const { return std::string("Actual/365 (NL)"); }
 
             // Returns the exact number of days between 2 dates, excluding leap days
-            int_fast32_t dayCount(const Date& d1,
+            Date::serial_type dayCount(const Date& d1,
                                 const Date& d2) const {
 
                 static const Integer MonthOffset[] = {
                     0,  31,  59,  90, 120, 151,  // Jan - Jun
                   181, 212, 243, 273, 304, 334   // Jun - Dec
                 };
-                int_fast32_t s1, s2;
+                Date::serial_type s1, s2;
 
                 s1 = d1.dayOfMonth() + MonthOffset[d1.month()-1] + (d1.year() * 365);
                 s2 = d2.dayOfMonth() + MonthOffset[d2.month()-1] + (d2.year() * 365);

--- a/ql/time/daycounters/business252.cpp
+++ b/ql/time/daycounters/business252.cpp
@@ -25,8 +25,8 @@ namespace QuantLib {
 
     namespace {
 
-        typedef std::map<Year, std::map<Month, int_fast32_t> > Cache;
-        typedef std::map<Year, int_fast32_t> OuterCache;
+        typedef std::map<Year, std::map<Month, Date::serial_type> > Cache;
+        typedef std::map<Year, Date::serial_type> OuterCache;
         
         std::map<std::string, Cache> monthlyFigures_;
         std::map<std::string, OuterCache> yearlyFigures_;
@@ -39,7 +39,7 @@ namespace QuantLib {
             return d1.year() == d2.year() && d1.month() == d2.month();
         }
 
-        int_fast32_t businessDays(Cache& cache,
+        Date::serial_type businessDays(Cache& cache,
                                 const Calendar& calendar,
                                 Month month, Year year) {
             if (cache[year][month] == 0) {
@@ -51,13 +51,13 @@ namespace QuantLib {
             return cache[year][month];
         }
 
-        int_fast32_t businessDays(OuterCache& outerCache,
+        Date::serial_type businessDays(OuterCache& outerCache,
                                 Cache& cache,
                                 const Calendar& calendar,
                                 Year year) {
             if (outerCache[year] == 0) {
                 // calculate and store.
-                int_fast32_t total = 0;
+                Date::serial_type total = 0;
                 for (Integer i=1; i<=12; ++i) {
                     total += businessDays(cache,calendar,
                                           Month(i), year);
@@ -75,7 +75,7 @@ namespace QuantLib {
         return out.str();
     }
 
-    int_fast32_t Business252::Impl::dayCount(const Date& d1,
+    Date::serial_type Business252::Impl::dayCount(const Date& d1,
                                            const Date& d2) const {
         if (sameMonth(d1,d2) || d1 >= d2) {
             // we treat the case of d1 > d2 here, since we'd need a
@@ -85,7 +85,7 @@ namespace QuantLib {
             return calendar_.businessDaysBetween(d1, d2);
         } else if (sameYear(d1,d2)) {
             Cache& cache = monthlyFigures_[calendar_.name()];
-            int_fast32_t total = 0;
+            Date::serial_type total = 0;
             Date d;
             // first, we get to the beginning of next month.
             d = Date(1,d1.month(),d1.year()) + 1*Months;
@@ -103,7 +103,7 @@ namespace QuantLib {
         } else {
             Cache& cache = monthlyFigures_[calendar_.name()];
             OuterCache& outerCache = yearlyFigures_[calendar_.name()];
-            int_fast32_t total = 0;
+            Date::serial_type total = 0;
             Date d;
             // first, we get to the beginning of next year.
             // The first bit gets us to the end of this month...

--- a/ql/time/daycounters/business252.cpp
+++ b/ql/time/daycounters/business252.cpp
@@ -25,8 +25,8 @@ namespace QuantLib {
 
     namespace {
 
-        typedef std::map<Year, std::map<Month, BigInteger> > Cache;
-        typedef std::map<Year, BigInteger> OuterCache;
+        typedef std::map<Year, std::map<Month, int_fast32_t> > Cache;
+        typedef std::map<Year, int_fast32_t> OuterCache;
         
         std::map<std::string, Cache> monthlyFigures_;
         std::map<std::string, OuterCache> yearlyFigures_;
@@ -39,7 +39,7 @@ namespace QuantLib {
             return d1.year() == d2.year() && d1.month() == d2.month();
         }
 
-        BigInteger businessDays(Cache& cache,
+        int_fast32_t businessDays(Cache& cache,
                                 const Calendar& calendar,
                                 Month month, Year year) {
             if (cache[year][month] == 0) {
@@ -51,13 +51,13 @@ namespace QuantLib {
             return cache[year][month];
         }
 
-        BigInteger businessDays(OuterCache& outerCache,
+        int_fast32_t businessDays(OuterCache& outerCache,
                                 Cache& cache,
                                 const Calendar& calendar,
                                 Year year) {
             if (outerCache[year] == 0) {
                 // calculate and store.
-                BigInteger total = 0;
+                int_fast32_t total = 0;
                 for (Integer i=1; i<=12; ++i) {
                     total += businessDays(cache,calendar,
                                           Month(i), year);
@@ -75,7 +75,7 @@ namespace QuantLib {
         return out.str();
     }
 
-    BigInteger Business252::Impl::dayCount(const Date& d1,
+    int_fast32_t Business252::Impl::dayCount(const Date& d1,
                                            const Date& d2) const {
         if (sameMonth(d1,d2) || d1 >= d2) {
             // we treat the case of d1 > d2 here, since we'd need a
@@ -85,7 +85,7 @@ namespace QuantLib {
             return calendar_.businessDaysBetween(d1, d2);
         } else if (sameYear(d1,d2)) {
             Cache& cache = monthlyFigures_[calendar_.name()];
-            BigInteger total = 0;
+            int_fast32_t total = 0;
             Date d;
             // first, we get to the beginning of next month.
             d = Date(1,d1.month(),d1.year()) + 1*Months;
@@ -103,7 +103,7 @@ namespace QuantLib {
         } else {
             Cache& cache = monthlyFigures_[calendar_.name()];
             OuterCache& outerCache = yearlyFigures_[calendar_.name()];
-            BigInteger total = 0;
+            int_fast32_t total = 0;
             Date d;
             // first, we get to the beginning of next year.
             // The first bit gets us to the end of this month...

--- a/ql/time/daycounters/business252.hpp
+++ b/ql/time/daycounters/business252.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
             Calendar calendar_;
           public:
             std::string name() const;
-            int_fast32_t dayCount(const Date& d1,
+            Date::serial_type dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,

--- a/ql/time/daycounters/business252.hpp
+++ b/ql/time/daycounters/business252.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
             Calendar calendar_;
           public:
             std::string name() const;
-            BigInteger dayCount(const Date& d1,
+            int_fast32_t dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,

--- a/ql/time/daycounters/one.hpp
+++ b/ql/time/daycounters/one.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         class Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("1/1"); }
-            BigInteger dayCount(const Date& d1, const Date& d2) const {
+            int_fast32_t dayCount(const Date& d1, const Date& d2) const {
                 // the sign is all we need
                 return (d2 >= d1 ? 1 : -1);
             };

--- a/ql/time/daycounters/one.hpp
+++ b/ql/time/daycounters/one.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         class Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("1/1"); }
-            int_fast32_t dayCount(const Date& d1, const Date& d2) const {
+            Date::serial_type dayCount(const Date& d1, const Date& d2) const {
                 // the sign is all we need
                 return (d2 >= d1 ? 1 : -1);
             };

--- a/ql/time/daycounters/simpledaycounter.cpp
+++ b/ql/time/daycounters/simpledaycounter.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     namespace { DayCounter fallback = Thirty360(); }
 
-    BigInteger SimpleDayCounter::Impl::dayCount(const Date& d1,
+    int_fast32_t SimpleDayCounter::Impl::dayCount(const Date& d1,
                                                 const Date& d2) const {
         return fallback.dayCount(d1,d2);
     }

--- a/ql/time/daycounters/simpledaycounter.cpp
+++ b/ql/time/daycounters/simpledaycounter.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     namespace { DayCounter fallback = Thirty360(); }
 
-    int_fast32_t SimpleDayCounter::Impl::dayCount(const Date& d1,
+    Date::serial_type SimpleDayCounter::Impl::dayCount(const Date& d1,
                                                 const Date& d2) const {
         return fallback.dayCount(d1,d2);
     }

--- a/ql/time/daycounters/simpledaycounter.hpp
+++ b/ql/time/daycounters/simpledaycounter.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         class Impl : public DayCounter::Impl {
           public:
             std::string name() const { return "Simple"; }
-            int_fast32_t dayCount(const Date& d1,
+            Date::serial_type dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,

--- a/ql/time/daycounters/simpledaycounter.hpp
+++ b/ql/time/daycounters/simpledaycounter.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         class Impl : public DayCounter::Impl {
           public:
             std::string name() const { return "Simple"; }
-            BigInteger dayCount(const Date& d1,
+            int_fast32_t dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,

--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
         }
     }
 
-    int_fast32_t Thirty360::US_Impl::dayCount(const Date& d1,
+    Date::serial_type Thirty360::US_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Integer mm1 = d1.month(), mm2 = d2.month();
@@ -49,7 +49,7 @@ namespace QuantLib {
             std::max(Integer(0),30-dd1) + std::min(Integer(30),dd2);
     }
 
-    int_fast32_t Thirty360::EU_Impl::dayCount(const Date& d1,
+    Date::serial_type Thirty360::EU_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Month mm1 = d1.month(), mm2 = d2.month();
@@ -59,7 +59,7 @@ namespace QuantLib {
             std::max(Integer(0),30-dd1) + std::min(Integer(30),dd2);
     }
 
-    int_fast32_t Thirty360::IT_Impl::dayCount(const Date& d1,
+    Date::serial_type Thirty360::IT_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Month mm1 = d1.month(), mm2 = d2.month();

--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
         }
     }
 
-    BigInteger Thirty360::US_Impl::dayCount(const Date& d1,
+    int_fast32_t Thirty360::US_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Integer mm1 = d1.month(), mm2 = d2.month();
@@ -49,7 +49,7 @@ namespace QuantLib {
             std::max(Integer(0),30-dd1) + std::min(Integer(30),dd2);
     }
 
-    BigInteger Thirty360::EU_Impl::dayCount(const Date& d1,
+    int_fast32_t Thirty360::EU_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Month mm1 = d1.month(), mm2 = d2.month();
@@ -59,7 +59,7 @@ namespace QuantLib {
             std::max(Integer(0),30-dd1) + std::min(Integer(30),dd2);
     }
 
-    BigInteger Thirty360::IT_Impl::dayCount(const Date& d1,
+    int_fast32_t Thirty360::IT_Impl::dayCount(const Date& d1,
                                             const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
         Month mm1 = d1.month(), mm2 = d2.month();

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         class US_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30/360 (Bond Basis)");}
-            BigInteger dayCount(const Date& d1,
+            int_fast32_t dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
@@ -71,7 +71,7 @@ namespace QuantLib {
         class EU_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30E/360 (Eurobond Basis)");}
-            BigInteger dayCount(const Date& d1,
+            int_fast32_t dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
@@ -82,7 +82,7 @@ namespace QuantLib {
         class IT_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30/360 (Italian)");}
-            BigInteger dayCount(const Date& d1, const Date& d2) const;
+            int_fast32_t dayCount(const Date& d1, const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
                               const Date&,

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         class US_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30/360 (Bond Basis)");}
-            int_fast32_t dayCount(const Date& d1,
+            Date::serial_type dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
@@ -71,7 +71,7 @@ namespace QuantLib {
         class EU_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30E/360 (Eurobond Basis)");}
-            int_fast32_t dayCount(const Date& d1,
+            Date::serial_type dayCount(const Date& d1,
                                 const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
@@ -82,7 +82,7 @@ namespace QuantLib {
         class IT_Impl : public DayCounter::Impl {
           public:
             std::string name() const { return std::string("30/360 (Italian)");}
-            int_fast32_t dayCount(const Date& d1, const Date& d2) const;
+            Date::serial_type dayCount(const Date& d1, const Date& d2) const;
             Time yearFraction(const Date& d1,
                               const Date& d2,
                               const Date&,

--- a/ql/time/ecb.cpp
+++ b/ql/time/ecb.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     const std::set<Date>& ECB::knownDates() {
 
         // one-off inizialization
-        static const int_fast32_t knownDatesArray[] = {
+        static const Date::serial_type knownDatesArray[] = {
               38371, 38391, 38420, 38455, 38483, 38511, 38546, 38574, 38602, 38637, 38665, 38692 // 2005
             , 38735, 38756, 38784, 38819, 38847, 38883, 38910, 38938, 38966, 39001, 39029, 39064 // 2006
             , 39099, 39127, 39155, 39190, 39217, 39246, 39274, 39302, 39337, 39365, 39400, 39428 // 2007
@@ -61,7 +61,7 @@ namespace QuantLib {
             , 42760 // 2017
         };
         if (knownDateSet.empty()) {
-            Size n = sizeof(knownDatesArray)/sizeof(int_fast32_t);
+            Size n = sizeof(knownDatesArray)/sizeof(Date::serial_type);
             for (Size i=0; i<n; ++i)
                 knownDateSet.insert(Date(knownDatesArray[i]));
         }

--- a/ql/time/ecb.cpp
+++ b/ql/time/ecb.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     const std::set<Date>& ECB::knownDates() {
 
         // one-off inizialization
-        static const BigInteger knownDatesArray[] = {
+        static const int_fast32_t knownDatesArray[] = {
               38371, 38391, 38420, 38455, 38483, 38511, 38546, 38574, 38602, 38637, 38665, 38692 // 2005
             , 38735, 38756, 38784, 38819, 38847, 38883, 38910, 38938, 38966, 39001, 39029, 39064 // 2006
             , 39099, 39127, 39155, 39190, 39217, 39246, 39274, 39302, 39337, 39365, 39400, 39428 // 2007
@@ -61,7 +61,7 @@ namespace QuantLib {
             , 42760 // 2017
         };
         if (knownDateSet.empty()) {
-            Size n = sizeof(knownDatesArray)/sizeof(BigInteger);
+            Size n = sizeof(knownDatesArray)/sizeof(int_fast32_t);
             for (Size i=0; i<n; ++i)
                 knownDateSet.insert(Date(knownDatesArray[i]));
         }

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -299,7 +299,7 @@ namespace QuantLib {
                 Date next20th = nextTwentieth(effectiveDate, *rule_);
                 if (*rule_ == DateGeneration::OldCDS) {
                     // distance rule inforced in natural days
-                    static const BigInteger stubDays = 30;
+                    static const int_fast32_t stubDays = 30;
                     if (next20th - effectiveDate < stubDays) {
                         // +1 will skip this one and get the next
                         next20th = nextTwentieth(next20th + 1, *rule_);

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -299,7 +299,7 @@ namespace QuantLib {
                 Date next20th = nextTwentieth(effectiveDate, *rule_);
                 if (*rule_ == DateGeneration::OldCDS) {
                     // distance rule inforced in natural days
-                    static const int_fast32_t stubDays = 30;
+                    static const Date::serial_type stubDays = 30;
                     if (next20th - effectiveDate < stubDays) {
                         // +1 will skip this one and get the next
                         next20th = nextTwentieth(next20th + 1, *rule_);

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -1580,7 +1580,7 @@ void CalendarTest::testBusinessDaysBetween() {
     testDates.push_back(Date(15,May,2006));
     testDates.push_back(Date(26,July,2006));
 
-    BigInteger expected[] = {
+    int_fast32_t expected[] = {
         1,
         321,
         152,

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -236,7 +236,7 @@ void CashFlowsTest::testDefaultSettlementDate() {
     if (accruedPeriod == 0.0)
         BOOST_ERROR("null accrued period with default settlement date");
 
-    BigInteger accruedDays = CashFlows::accruedDays(leg, false);
+    int_fast32_t accruedDays = CashFlows::accruedDays(leg, false);
     if (accruedDays == 0)
         BOOST_ERROR("no accrued days with default settlement date");
 

--- a/test-suite/dates.cpp
+++ b/test-suite/dates.cpp
@@ -228,18 +228,18 @@ void DateTest::testConsistency() {
 
     BOOST_TEST_MESSAGE("Testing dates...");
 
-    BigInteger minDate = Date::minDate().serialNumber()+1,
+    int_fast32_t minDate = Date::minDate().serialNumber()+1,
                maxDate = Date::maxDate().serialNumber();
 
-    BigInteger dyold = Date(minDate-1).dayOfYear(),
+    int_fast32_t dyold = Date(minDate-1).dayOfYear(),
                dold  = Date(minDate-1).dayOfMonth(),
                mold  = Date(minDate-1).month(),
                yold  = Date(minDate-1).year(),
                wdold = Date(minDate-1).weekday();
 
-    for (BigInteger i=minDate; i<=maxDate; i++) {
+    for (int_fast32_t i=minDate; i<=maxDate; i++) {
         Date t(i);
-        BigInteger serial = t.serialNumber();
+        int_fast32_t serial = t.serialNumber();
 
         // check serial number consistency
         if (serial != i)

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -100,7 +100,7 @@ namespace boost {
     template<>
     struct hash<Date> : std::unary_function<Date, std::size_t> {
         size_t operator()(const Date& _Keyval) const {
-            return boost::hash<BigInteger>()(_Keyval.serialNumber());
+            return boost::hash<int_fast32_t>()(_Keyval.serialNumber());
         }
     };
 


### PR DESCRIPTION
I am not 100% sure about this one, but on my system ```QuantLib::Date```'s serial number is stored using 64bit (```BigInteger``` aka ```long```), although 32bit would be enough to cover ```Date::minSerialNumber()``` to ```Date::maxSerialNumber()```. Maybe long is from the time when ```int``` was still 16bit? The type ```int_fast32_t``` is available at least since boost 1.46, the doc says

> The typedef int_fast#_t, with # replaced by the width, designates the fastest signed integer type with a width of at least # bits. Similarly, the typedef name uint_fast#_t designates the fastest unsigned integer type with a width of at least # bits.

On my system, ```int_fast32_t``` is 32bit. We could probably use an unsigned type as well, but this could produce warnings in client code like the ones on mixing unsigned and signed types in comparisons. 16bit would be too narrow in any case, so all in all ```int_fast32_t``` looks like a reasonable choice to me. Does it make sense? What about the interfaces to Python, Excel, etc.?