### PR TITLE
new (stub) CVAIRS manual page

### DIFF
--- a/man/BasketLosses.1
+++ b/man/BasketLosses.1
@@ -1,13 +1,13 @@
 .\" Man page contributed by Dirk Eddelbuettel <edd@debian.org>
 .\" and released under the Quantlib license
-.TH MARKETMODEL 1 "27 April 2016" QuantLib
+.TH BASKETLOSSES 1 "27 April 2016" QuantLib
 .SH NAME
-MarketModel - Example of Interst Rate Derivative Pricing
+BasketLosses - Example of Modeling Losses Across Correlated Assets
 .SH SYNOPSIS
-.B MarketModel
+.B BasketLosses
 .SH DESCRIPTION
 .PP
-.B MarketModel
+.B BasketLosses
 is an example of using \fIQuantLib\fP.
 
 .SH SEE ALSO

--- a/man/CVAIRS.1
+++ b/man/CVAIRS.1
@@ -1,0 +1,37 @@
+.\" Man page contributed by Dirk Eddelbuettel <edd@debian.org>
+.\" and released under the Quantlib license
+.TH CVAIRS 1 "26 April 2016" QuantLib
+.SH NAME
+CVAIRS - Example of Credit Value Adjustment for Interest Rate Swap
+.SH SYNOPSIS
+.B CVAIRS
+.SH DESCRIPTION
+.PP
+.B CVAIRS
+is an example of using \fIQuantLib\fP.
+
+.SH SEE ALSO
+The source code
+.IR CDS.cpp ,
+.BR BermudanSwaption (1),
+.BR Bonds (1),
+.BR CallableBonds (1),
+.BR ConvertibleBonds (1),
+.BR DiscreteHedging (1),
+.BR EquityOption (1),
+.BR FittedBondCurve (1),
+.BR FRA (1),
+.BR MarketModels (1),
+.BR Replication (1),
+.BR Repo (1),
+.BR SwapValuation (1),
+the QuantLib documentation and website at
+.IR http://quantlib.org .
+
+.SH AUTHORS
+The QuantLib Group (see
+.IR Authors.txt ).
+
+This manual page was added by Dirk Eddelbuettel <edd@debian.org>,
+the Debian GNU/Linux maintainer for
+.BR QuantLib .

--- a/man/Gaussian1dModels.1
+++ b/man/Gaussian1dModels.1
@@ -1,13 +1,13 @@
 .\" Man page contributed by Dirk Eddelbuettel <edd@debian.org>
 .\" and released under the Quantlib license
-.TH MARKETMODEL 1 "27 April 2016" QuantLib
+.TH GAUSSIAN1DMODELS 1 "27 April 2016" QuantLib
 .SH NAME
-MarketModel - Example of Interst Rate Derivative Pricing
+Gaussian1dModels - Example of Gaussian Short Rate Model for Interest Rate Derivatives
 .SH SYNOPSIS
-.B MarketModel
+.B Gaussian1dModels
 .SH DESCRIPTION
 .PP
-.B MarketModel
+.B Gaussian1dModels
 is an example of using \fIQuantLib\fP.
 
 .SH SEE ALSO

--- a/man/LatentModel.1
+++ b/man/LatentModel.1
@@ -1,13 +1,13 @@
 .\" Man page contributed by Dirk Eddelbuettel <edd@debian.org>
 .\" and released under the Quantlib license
-.TH MARKETMODEL 1 "27 April 2016" QuantLib
+.TH LatentModel 1 "27 April 2016" QuantLib
 .SH NAME
-MarketModel - Example of Interst Rate Derivative Pricing
+LatentModel - Example of Modeling Correlated Defaults
 .SH SYNOPSIS
-.B MarketModel
+.B LatentModel
 .SH DESCRIPTION
 .PP
-.B MarketModel
+.B LatentModel
 is an example of using \fIQuantLib\fP.
 
 .SH SEE ALSO

--- a/man/MultidimIntegral.1
+++ b/man/MultidimIntegral.1
@@ -1,13 +1,13 @@
 .\" Man page contributed by Dirk Eddelbuettel <edd@debian.org>
 .\" and released under the Quantlib license
-.TH MARKETMODEL 1 "27 April 2016" QuantLib
+.TH MULTIDIMINTEGRAL 1 "27 April 2016" QuantLib
 .SH NAME
-MarketModel - Example of Interst Rate Derivative Pricing
+MultidimIntegral - Example of Multi-dimensional Numerical Integration
 .SH SYNOPSIS
-.B MarketModel
+.B MultidimIntegral
 .SH DESCRIPTION
 .PP
-.B MarketModel
+.B MultidimIntegral
 is an example of using \fIQuantLib\fP.
 
 .SH SEE ALSO


### PR DESCRIPTION
Usual motivation: as we'll have a binary in the Debian package, we ought to have a manual page for the binary.  