### PR TITLE
South Africa calendar updated for election day holiday 3 Aug

### DIFF
--- a/ql/time/calendars/southafrica.cpp
+++ b/ql/time/calendars/southafrica.cpp
@@ -71,6 +71,8 @@ namespace QuantLib {
                 && m == December)
             // one-shot: Election day 2009
             || (d == 22 && m == April && y == 2009)
+			// one-shot: Election day 2016
+			|| (d == 3 && m == August && y == 2016)
             )
             return false;
         return true;


### PR DESCRIPTION
Hi, another one shot holiday for election day Wednesday 3 Aug 2016. Thanks, Jasen