### PR TITLE
added normal implied volatility calculation

### DIFF
--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2006 François du Vignaud
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
  Copyright (C) 2006, 2007 StatPro Italia srl
+ Copyright (C) 2016 Paolo Mazzocchi
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -22,6 +23,7 @@
 
 #include <ql/instruments/capfloor.hpp>
 #include <ql/pricingengines/capfloor/blackcapfloorengine.hpp>
+#include <ql/pricingengines/capfloor/bacheliercapfloorengine.hpp>
 #include <ql/math/solvers1d/newtonsafe.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/cashflows/cashflows.hpp>
@@ -39,7 +41,8 @@ namespace QuantLib {
             ImpliedVolHelper(const CapFloor&,
                              const Handle<YieldTermStructure>& discountCurve,
                              Real targetValue,
-                             Real displacement);
+                             Real displacement,
+                             VolatilityType type);
             Real operator()(Volatility x) const;
             Real derivative(Volatility x) const;
           private:
@@ -54,16 +57,31 @@ namespace QuantLib {
                               const CapFloor& cap,
                               const Handle<YieldTermStructure>& discountCurve,
                               Real targetValue,
-                              Real displacement)
+                              Real displacement,
+                              VolatilityType type)
         : discountCurve_(discountCurve), targetValue_(targetValue) {
 
             // set an implausible value, so that calculation is forced
             // at first ImpliedVolHelper::operator()(Volatility x) call
             vol_ = boost::shared_ptr<SimpleQuote>(new SimpleQuote(-1));
             Handle<Quote> h(vol_);
-            engine_ = boost::shared_ptr<PricingEngine>(new
-                                    BlackCapFloorEngine(discountCurve_, h,
-                                    Actual365Fixed(), displacement));
+
+            switch (type) {
+            case ShiftedLognormal:
+                engine_ = boost::shared_ptr<PricingEngine>(new
+                    BlackCapFloorEngine(discountCurve_, h, Actual365Fixed(),
+                                                                displacement));
+                break;
+            case Normal:
+                engine_ = boost::shared_ptr<PricingEngine>(new
+                    BachelierCapFloorEngine(discountCurve_, h, 
+                                                            Actual365Fixed()));
+                break;
+            default:
+                QL_FAIL("unknown VolatilityType (" << type << ")");
+                break;
+            }
+
             cap.setupArguments(engine_->getArguments());
 
             results_ =
@@ -307,15 +325,15 @@ namespace QuantLib {
                                            Natural maxEvaluations,
                                            Volatility minVol,
                                            Volatility maxVol,
-                                           Real displacement) const {
+                                           Real displacement,
+                                           VolatilityType type) const {
         //calculate();
         QL_REQUIRE(!isExpired(), "instrument expired");
 
-        ImpliedVolHelper f(*this, d, targetValue, displacement);
+        ImpliedVolHelper f(*this, d, targetValue, displacement, type);
         //Brent solver;
         NewtonSafe solver;
         solver.setMaxEvaluations(maxEvaluations);
         return solver.solve(f, accuracy, guess, minVol, maxVol);
     }
-
 }

--- a/ql/instruments/capfloor.hpp
+++ b/ql/instruments/capfloor.hpp
@@ -30,6 +30,7 @@
 #include <ql/instrument.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/handle.hpp>
+#include <ql/termstructures/volatility/volatilitytype.hpp>
 
 namespace QuantLib {
 
@@ -83,14 +84,16 @@ namespace QuantLib {
         //@}
         Rate atmRate(const YieldTermStructure& discountCurve) const;
         //! implied term volatility
-        Volatility impliedVolatility(Real price,
-                                     const Handle<YieldTermStructure>& disc,
-                                     Volatility guess,
-                                     Real accuracy = 1.0e-4,
-                                     Natural maxEvaluations = 100,
-                                     Volatility minVol = 1.0e-7,
-                                     Volatility maxVol = 4.0,
-                                     Real displacement = 0.0) const;
+        Volatility impliedVolatility(
+                                 Real price,
+                                 const Handle<YieldTermStructure>& disc,
+                                 Volatility guess,
+                                 Real accuracy = 1.0e-4,
+                                 Natural maxEvaluations = 100,
+                                 Volatility minVol = 1.0e-7,
+                                 Volatility maxVol = 4.0,
+                                 Real displacement = 0.0,
+                                 VolatilityType type = ShiftedLognormal) const;
       private:
         Type type_;
         Leg floatingLeg_;

--- a/ql/instruments/swaption.cpp
+++ b/ql/instruments/swaption.cpp
@@ -63,12 +63,19 @@ namespace QuantLib {
             // at first ImpliedVolHelper::operator()(Volatility x) call
             vol_ = boost::shared_ptr<SimpleQuote>(new SimpleQuote(-1.0));
             Handle<Quote> h(vol_);
-            if (type == Normal) {
-                engine_ = boost::make_shared<BachelierSwaptionEngine>(
-                    discountCurve_, h, Actual365Fixed());
-            } else {
+
+            switch (type) {
+            case ShiftedLognormal:
                 engine_ = boost::make_shared<BlackSwaptionEngine>(
                     discountCurve_, h, Actual365Fixed(), displacement);
+                break;
+            case Normal:
+                engine_ = boost::make_shared<BachelierSwaptionEngine>(
+                    discountCurve_, h, Actual365Fixed());
+                break;
+            default:
+                QL_FAIL("unknown VolatilityType (" << type << ")");
+                break;
             }
             swaption.setupArguments(engine_->getArguments());
             results_ = dynamic_cast<const Instrument::results *>(


### PR DESCRIPTION
this is a solution in order to have normal implied volatility for cap/floor. 
Maybe a better solution is to add the pricing engine directly in impliedVolatility(..), @pcaspers what do you think? 