### PR TITLE
fix default implementation of lower bound

### DIFF
--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
             //! Returns lower bound for given parameters
             virtual Array lowerBound(const Array& params) const {
                 return Array(params.size(),
-                             std::numeric_limits < Array::value_type > ::min());
+                             -std::numeric_limits < Array::value_type > ::max());
             }
         };
         boost::shared_ptr<Impl> impl_;


### PR DESCRIPTION
minor thing, but if you for example combine NoConstraint() with BoundaryConstraint() and the lower bound in the latter is negative, the lower bound of the composite will be (close to) zero