### PR TITLE
Moving rate helper sort algorithm ...

### DIFF
--- a/ql/termstructures/bootstraphelper.hpp
+++ b/ql/termstructures/bootstraphelper.hpp
@@ -240,20 +240,6 @@ namespace QuantLib {
         }
     }
 
-    namespace detail {
-
-        class BootstrapHelperSorter {
-          public:
-            template <class Helper>
-            bool operator()(
-                    const boost::shared_ptr<Helper>& h1,
-                    const boost::shared_ptr<Helper>& h2) const {
-                return (h1->pillarDate() < h2->pillarDate());
-            }
-        };
-
-    }
-
 }
 
 #endif

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -80,9 +80,6 @@ namespace QuantLib {
 
     template <class Curve>
     void IterativeBootstrap<Curve>::initialize() const {
-        // ensure helpers are sorted
-        std::sort(ts_->instruments_.begin(), ts_->instruments_.end(),
-                  detail::BootstrapHelperSorter());
         // skip expired helpers
         Date firstDate = Traits::initialDate(ts_);
         QL_REQUIRE(ts_->instruments_[n_-1]->pillarDate()>firstDate,

--- a/ql/termstructures/localbootstrap.hpp
+++ b/ql/termstructures/localbootstrap.hpp
@@ -135,10 +135,6 @@ namespace QuantLib {
         validCurve_ = false;
         Size nInsts = ts_->instruments_.size();
 
-        // ensure rate helpers are sorted
-        std::sort(ts_->instruments_.begin(), ts_->instruments_.end(),
-                  detail::BootstrapHelperSorter());
-
         // check that there is no instruments with the same maturity
         for (Size i=1; i<nInsts; ++i) {
             Date m1 = ts_->instruments_[i-1]->pillarDate(),

--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -4,6 +4,7 @@
  Copyright (C) 2005, 2006, 2007, 2008 StatPro Italia srl
  Copyright (C) 2007, 2008, 2009 Ferdinando Ametrano
  Copyright (C) 2007 Chris Kenyon
+ Copyright (C) 2016 Michael von den Driesch
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -81,6 +82,7 @@ namespace QuantLib {
         : base_curve(referenceDate, dayCounter, jumps, jumpDates, i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         PiecewiseYieldCurve(
@@ -95,6 +97,7 @@ namespace QuantLib {
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         PiecewiseYieldCurve(
@@ -108,6 +111,7 @@ namespace QuantLib {
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
           accuracy_(1.0e-12), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         PiecewiseYieldCurve(
@@ -124,6 +128,7 @@ namespace QuantLib {
         : base_curve(settlementDays, calendar, dayCounter, jumps, jumpDates, i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         PiecewiseYieldCurve(
@@ -139,6 +144,7 @@ namespace QuantLib {
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         PiecewiseYieldCurve(
@@ -153,6 +159,7 @@ namespace QuantLib {
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
           accuracy_(1.0e-12), bootstrap_(bootstrap) {
+            initialize();
             bootstrap_.setup(this);
         }
         //@}
@@ -178,6 +185,16 @@ namespace QuantLib {
         //@}
         // methods
         DiscountFactor discountImpl(Time) const;
+        struct InstrumentCompare {
+          bool operator()(const boost::shared_ptr< typename Traits::helper > &c,
+                          const boost::shared_ptr< typename Traits::helper > &d) const {
+            return c->pillarDate() < d->pillarDate();
+          }
+        };
+        void initialize() {
+          InstrumentCompare instLess;
+          std::sort(instruments_.begin(), instruments_.end(), instLess);
+        }
         // data members
         std::vector<boost::shared_ptr<typename Traits::helper> > instruments_;
         Real accuracy_;


### PR DESCRIPTION
into `PiecewiseYieldCurve` constructor. In the original code the helper instruments were only sorted after an initial stripping of the curve (within the bootstrap algorithm). Therefore, if you accessed the instruments before any initial stripping, the helpers were unsorted (if not sorted already in the argument of the constructor).