### PR TITLE
Bug fix for instantaneous forward rate

### DIFF
--- a/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -619,8 +619,8 @@ namespace QuantLib {
             for (Size i=startPoint; i<length_-1; ++i) {
                 Real dxPrev = this->xBegin_[i] - this->xBegin_[i-1];
                 Real dx = this->xBegin_[i+1] - this->xBegin_[i];
-                f[i] = dxPrev/(dx+dxPrev) * this->yBegin_[i]
-                     + dx/(dx+dxPrev) * this->yBegin_[i+1];
+                f[i] = dxPrev/(dx+dxPrev) * this->yBegin_[i+1]
+                     + dx/(dx+dxPrev) * this->yBegin_[i];
             }
 
             if (startPoint > 1)


### PR DESCRIPTION
In the calculation of the instantaneous forward rate f[i] = ... the indeces i and i+1 of yBegin were swapped (lines 622 and 623). Compare with Hagan and West's paper.
