### PR TITLE
Allow arbitrary bond yield solver

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -743,96 +743,6 @@ namespace QuantLib {
                                  settlementDate, npvDate);
         }
 
-        class IrrFinder : public std::unary_function<Rate, Real> {
-          public:
-            IrrFinder(const Leg& leg,
-                      Real npv,
-                      const DayCounter& dayCounter,
-                      Compounding comp,
-                      Frequency freq,
-                      bool includeSettlementDateFlows,
-                      Date settlementDate,
-                      Date npvDate)
-            : leg_(leg), npv_(npv),
-              dayCounter_(dayCounter), compounding_(comp), frequency_(freq),
-              includeSettlementDateFlows_(includeSettlementDateFlows),
-              settlementDate_(settlementDate),
-              npvDate_(npvDate) {
-
-
-            if (settlementDate == Date())
-                settlementDate = Settings::instance().evaluationDate();
-
-                if (npvDate == Date())
-                    npvDate = settlementDate;
-
-                checkSign();
-            }
-            Real operator()(Rate y) const {
-                InterestRate yield(y, dayCounter_, compounding_, frequency_);
-                Real NPV = CashFlows::npv(leg_, yield,
-                                          includeSettlementDateFlows_,
-                                          settlementDate_, npvDate_);
-                return npv_ - NPV;
-            }
-            Real derivative(Rate y) const {
-                InterestRate yield(y, dayCounter_, compounding_, frequency_);
-                return modifiedDuration(leg_, yield,
-                                        includeSettlementDateFlows_,
-                                        settlementDate_, npvDate_);
-            }
-          private:
-            void checkSign() const {
-                // depending on the sign of the market price, check that cash
-                // flows of the opposite sign have been specified (otherwise
-                // IRR is nonsensical.)
-
-                Integer lastSign = sign(-npv_),
-                        signChanges = 0;
-                for (Size i = 0; i < leg_.size(); ++i) {
-                    if (!leg_[i]->hasOccurred(settlementDate_,
-                                              includeSettlementDateFlows_) &&
-                        !leg_[i]->tradingExCoupon(settlementDate_)) {
-                        Integer thisSign = sign(leg_[i]->amount());
-                        if (lastSign * thisSign < 0) // sign change
-                            signChanges++;
-
-                        if (thisSign != 0)
-                            lastSign = thisSign;
-                    }
-                }
-                QL_REQUIRE(signChanges > 0,
-                           "the given cash flows cannot result in the given market "
-                           "price due to their sign");
-
-                /* The following is commented out due to the lack of a QL_WARN macro
-                if (signChanges > 1) {    // Danger of non-unique solution
-                                          // Check the aggregate cash flows (Norstrom)
-                    Real aggregateCashFlow = npv;
-                    signChanges = 0;
-                    for (Size i = 0; i < leg.size(); ++i) {
-                        Real nextAggregateCashFlow =
-                            aggregateCashFlow + leg[i]->amount();
-
-                        if (aggregateCashFlow * nextAggregateCashFlow < 0.0)
-                            signChanges++;
-
-                        aggregateCashFlow = nextAggregateCashFlow;
-                    }
-                    if (signChanges > 1)
-                        QL_WARN( "danger of non-unique solution");
-                };
-                */
-            }
-            const Leg& leg_;
-            Real npv_;
-            DayCounter dayCounter_;
-            Compounding compounding_;
-            Frequency frequency_;
-            bool includeSettlementDateFlows_;
-            Date settlementDate_, npvDate_;
-        };
-
         struct CashFlowLater {
             bool operator()(const boost::shared_ptr<CashFlow> &c,
                             const boost::shared_ptr<CashFlow> &d) {
@@ -841,6 +751,85 @@ namespace QuantLib {
         };
 
     } // anonymous namespace ends here
+
+    CashFlows::IrrFinder::IrrFinder(const Leg& leg,
+          Real npv,
+          const DayCounter& dayCounter,
+          Compounding comp,
+          Frequency freq,
+          bool includeSettlementDateFlows,
+          Date settlementDate,
+          Date npvDate)
+    : leg_(leg), npv_(npv),
+      dayCounter_(dayCounter), compounding_(comp), frequency_(freq),
+      includeSettlementDateFlows_(includeSettlementDateFlows),
+      settlementDate_(settlementDate),
+      npvDate_(npvDate) {
+
+
+    if (settlementDate == Date())
+        settlementDate = Settings::instance().evaluationDate();
+
+        if (npvDate == Date())
+            npvDate = settlementDate;
+
+        checkSign();
+    }
+    Real CashFlows::IrrFinder::operator()(Rate y) const {
+        InterestRate yield(y, dayCounter_, compounding_, frequency_);
+        Real NPV = CashFlows::npv(leg_, yield,
+                                  includeSettlementDateFlows_,
+                                  settlementDate_, npvDate_);
+        return npv_ - NPV;
+    }
+    Real CashFlows::IrrFinder::derivative(Rate y) const {
+        InterestRate yield(y, dayCounter_, compounding_, frequency_);
+        return modifiedDuration(leg_, yield,
+                                includeSettlementDateFlows_,
+                                settlementDate_, npvDate_);
+    }
+    void CashFlows::IrrFinder::checkSign() const {
+        // depending on the sign of the market price, check that cash
+        // flows of the opposite sign have been specified (otherwise
+        // IRR is nonsensical.)
+
+        Integer lastSign = sign(-npv_),
+                signChanges = 0;
+        for (Size i = 0; i < leg_.size(); ++i) {
+            if (!leg_[i]->hasOccurred(settlementDate_,
+                                      includeSettlementDateFlows_) &&
+                !leg_[i]->tradingExCoupon(settlementDate_)) {
+                Integer thisSign = sign(leg_[i]->amount());
+                if (lastSign * thisSign < 0) // sign change
+                    signChanges++;
+
+                if (thisSign != 0)
+                    lastSign = thisSign;
+            }
+        }
+        QL_REQUIRE(signChanges > 0,
+                   "the given cash flows cannot result in the given market "
+                   "price due to their sign");
+
+        /* The following is commented out due to the lack of a QL_WARN macro
+        if (signChanges > 1) {    // Danger of non-unique solution
+                                  // Check the aggregate cash flows (Norstrom)
+            Real aggregateCashFlow = npv;
+            signChanges = 0;
+            for (Size i = 0; i < leg.size(); ++i) {
+                Real nextAggregateCashFlow =
+                    aggregateCashFlow + leg[i]->amount();
+
+                if (aggregateCashFlow * nextAggregateCashFlow < 0.0)
+                    signChanges++;
+
+                aggregateCashFlow = nextAggregateCashFlow;
+            }
+            if (signChanges > 1)
+                QL_WARN( "danger of non-unique solution");
+        };
+        */
+    }
 
     Real CashFlows::npv(const Leg& leg,
                         const InterestRate& y,
@@ -964,14 +953,12 @@ namespace QuantLib {
                           Real accuracy,
                           Size maxIterations,
                           Rate guess) {
-        //Brent solver;
         NewtonSafe solver;
-        solver.setMaxEvaluations(maxIterations);
-        IrrFinder objFunction(leg, npv,
-                              dayCounter, compounding, frequency,
-                              includeSettlementDateFlows,
-                              settlementDate, npvDate);
-        return solver.solve(objFunction, accuracy, guess, guess/10.0);
+        return CashFlows::yield<NewtonSafe>(solver, leg, npv, dayCounter,
+                                            compounding, frequency,
+                                            includeSettlementDateFlows,
+                                            settlementDate, npvDate, accuracy,
+                                            maxIterations, guess);
     }
 
 

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -42,6 +42,31 @@ namespace QuantLib {
       private:
         CashFlows();
         CashFlows(const CashFlows&);
+
+        class IrrFinder : public std::unary_function<Rate, Real> {
+          public:
+            IrrFinder(const Leg& leg,
+                      Real npv,
+                      const DayCounter& dayCounter,
+                      Compounding comp,
+                      Frequency freq,
+                      bool includeSettlementDateFlows,
+                      Date settlementDate,
+                      Date npvDate);
+
+            Real operator()(Rate y) const;
+            Real derivative(Rate y) const;
+          private:
+            void checkSign() const;
+
+            const Leg& leg_;
+            Real npv_;
+            DayCounter dayCounter_;
+            Compounding compounding_;
+            Frequency frequency_;
+            bool includeSettlementDateFlows_;
+            Date settlementDate_, npvDate_;
+        };
       public:
         //! \name Date functions
         //@{
@@ -246,6 +271,26 @@ namespace QuantLib {
                           Real accuracy = 1.0e-10,
                           Size maxIterations = 100,
                           Rate guess = 0.05);
+
+        template <typename Solver>
+        static Rate yield(Solver solver,
+                          const Leg& leg,
+                          Real npv,
+                          const DayCounter& dayCounter,
+                          Compounding compounding,
+                          Frequency frequency,
+                          bool includeSettlementDateFlows,
+                          Date settlementDate = Date(),
+                          Date npvDate = Date(),
+                          Real accuracy = 1.0e-10,
+                          Size maxIterations = 100,
+                          Rate guess = 0.05) {
+            solver.setMaxEvaluations(maxIterations);
+            IrrFinder objFunction(leg, npv, dayCounter, compounding,
+                                  frequency, includeSettlementDateFlows,
+                                  settlementDate, npvDate);
+            return solver.solve(objFunction, accuracy, guess, guess/10.0);
+        }
 
         //! Cash-flow duration.
         /*! The simple duration of a string of cash flows is defined as

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -23,9 +23,8 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+#include <ql/math/solvers1d/newtonsafe.hpp>
 #include <ql/pricingengines/bond/bondfunctions.hpp>
-#include <ql/instruments/bond.hpp>
-#include <ql/cashflows/cashflows.hpp>
 
 using boost::shared_ptr;
 
@@ -369,20 +368,10 @@ namespace QuantLib {
                               Real accuracy,
                               Size maxIterations,
                               Rate guess) {
-        if (settlement == Date())
-            settlement = bond.settlementDate();
-
-        QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
-
-        Real dirtyPrice = cleanPrice + bond.accruedAmount(settlement);
-        dirtyPrice /= 100.0 / bond.notional(settlement);
-
-        return CashFlows::yield(bond.cashflows(), dirtyPrice,
-                                dayCounter, compounding, frequency,
-                                false, settlement, settlement,
-                                accuracy, maxIterations, guess);
+        NewtonSafe solver;
+        return yield<NewtonSafe>(solver, bond, cleanPrice, dayCounter,
+                                 compounding, frequency, settlement, accuracy,
+                                 maxIterations, guess);
     }
 
     Time BondFunctions::duration(const Bond& bond,

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -27,9 +27,11 @@
 #ifndef quantlib_bond_functions_hpp
 #define quantlib_bond_functions_hpp
 
+#include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/duration.hpp>
 #include <ql/cashflow.hpp>
 #include <ql/interestrate.hpp>
+#include <ql/instruments/bond.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace QuantLib {
@@ -153,6 +155,33 @@ namespace QuantLib {
                           Real accuracy = 1.0e-10,
                           Size maxIterations = 100,
                           Rate guess = 0.05);
+        template <typename Solver>
+        static Rate yield(Solver solver,
+                          const Bond& bond,
+                          Real cleanPrice,
+                          const DayCounter& dayCounter,
+                          Compounding compounding,
+                          Frequency frequency,
+                          Date settlementDate = Date(),
+                          Real accuracy = 1.0e-10,
+                          Size maxIterations = 100,
+                          Rate guess = 0.05) {
+            if (settlementDate == Date())
+                settlementDate = bond.settlementDate();
+
+            QL_REQUIRE(BondFunctions::isTradable(bond, settlementDate),
+                       "non tradable at " << settlementDate <<
+                       " (maturity being " << bond.maturityDate() << ")");
+
+            Real dirtyPrice = cleanPrice + bond.accruedAmount(settlementDate);
+            dirtyPrice /= 100.0 / bond.notional(settlementDate);
+
+            return CashFlows::yield<Solver>(solver, bond.cashflows(),
+                                            dirtyPrice, dayCounter, compounding,
+                                            frequency, false, settlementDate,
+                                            settlementDate, accuracy,
+                                            maxIterations, guess);
+        }
         static Time duration(const Bond& bond,
                              const InterestRate& yield,
                              Duration::Type type = Duration::Modified,


### PR DESCRIPTION
This PR adds a template parameter to CashFlows and BondFunctions to allow them to take an arbitrary solver, instead of the default NewtonSafe solver (such as the Brent solver). These changes are backwards compatible due to the change involving a function template overload.

I am willing to make any requested further changes and can squash them if requested.
