### PR TITLE
AnalyticEuropeanEngine to support multi-curve pricing

### DIFF
--- a/ql/pricingengines/vanilla/analyticeuropeanengine.cpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanengine.cpp
@@ -25,9 +25,16 @@
 namespace QuantLib {
 
     AnalyticEuropeanEngine::AnalyticEuropeanEngine(
-              const boost::shared_ptr<GeneralizedBlackScholesProcess>&process)
-    : process_(process) {
+              const boost::shared_ptr<GeneralizedBlackScholesProcess>&process,
+              const Handle<YieldTermStructure>& discountCurve)
+    : process_(process), discountCurve_(discountCurve) {
+        // if discount curve not specified, 
+            // we default to the risk free rate curve 
+            // embedded within the GBM process
+        if (discountCurve_.empty())
+            discountCurve_ = process_->riskFreeRate();
         registerWith(process_);
+        registerWith(discountCurve_);
     }
 
     void AnalyticEuropeanEngine::calculate() const {
@@ -46,14 +53,14 @@ namespace QuantLib {
         DiscountFactor dividendDiscount =
             process_->dividendYield()->discount(
                                              arguments_.exercise->lastDate());
-        DiscountFactor riskFreeDiscount =
+        DiscountFactor df = discountCurve_->discount(arguments_.exercise->lastDate());
+        DiscountFactor riskFreeDiscountForFwdEstimation =
             process_->riskFreeRate()->discount(arguments_.exercise->lastDate());
         Real spot = process_->stateVariable()->value();
         QL_REQUIRE(spot > 0.0, "negative or null underlying given");
-        Real forwardPrice = spot * dividendDiscount / riskFreeDiscount;
+        Real forwardPrice = spot * dividendDiscount / riskFreeDiscountForFwdEstimation;
 
-        BlackCalculator black(payoff, forwardPrice, std::sqrt(variance),
-                              riskFreeDiscount);
+        BlackCalculator black(payoff, forwardPrice, std::sqrt(variance),df);
 
 
         results_.value = black.value();
@@ -62,7 +69,7 @@ namespace QuantLib {
         results_.elasticity = black.elasticity(spot);
         results_.gamma = black.gamma(spot);
 
-        DayCounter rfdc  = process_->riskFreeRate()->dayCounter();
+        DayCounter rfdc  = discountCurve_->dayCounter();
         DayCounter divdc = process_->dividendYield()->dayCounter();
         DayCounter voldc = process_->blackVolatility()->dayCounter();
         Time t = rfdc.yearFraction(process_->riskFreeRate()->referenceDate(),

--- a/ql/pricingengines/vanilla/analyticeuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanengine.hpp
@@ -61,10 +61,13 @@ namespace QuantLib {
     class AnalyticEuropeanEngine : public VanillaOption::engine {
       public:
         AnalyticEuropeanEngine(
-                    const boost::shared_ptr<GeneralizedBlackScholesProcess>&);
+                    const boost::shared_ptr<GeneralizedBlackScholesProcess>& gbsp,
+                    const Handle<YieldTermStructure>& discountCurve =
+                        Handle<YieldTermStructure>());
         void calculate() const;
       private:
         boost::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        Handle<YieldTermStructure> discountCurve_;
     };
 
 }

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1513,6 +1513,54 @@ void EuropeanOptionTest::testLocalVolatility() {
     }
 }
 
+void EuropeanOptionTest::testAnalyticEngineDisocuntCurve() {
+    BOOST_TEST_MESSAGE("Testing separate discount curve for AnalyticEuropeanEngine...");
+
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    boost::shared_ptr<SimpleQuote> spot(new SimpleQuote(1000.0));
+    boost::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.01));
+    boost::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    boost::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.015));
+    boost::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    boost::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.02));
+    boost::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+    boost::shared_ptr<SimpleQuote> discRate(new SimpleQuote(0.015));
+    boost::shared_ptr<YieldTermStructure> discTS = flatRate(today, discRate, dc);
+
+    boost::shared_ptr<BlackScholesMertonProcess> stochProcess(new
+        BlackScholesMertonProcess(Handle<Quote>(spot),
+            Handle<YieldTermStructure>(qTS),
+            Handle<YieldTermStructure>(rTS),
+            Handle<BlackVolTermStructure>(volTS)));
+    boost::shared_ptr<PricingEngine> engineSingleCurve(
+        new AnalyticEuropeanEngine(stochProcess));
+    boost::shared_ptr<PricingEngine> engineMultiCurve(
+        new AnalyticEuropeanEngine(stochProcess,
+            Handle<YieldTermStructure>(discTS)));
+
+    boost::shared_ptr<StrikedTypePayoff> payoff(new
+        PlainVanillaPayoff(Option::Call, 1025.0));
+    Date exDate = today + Period(1, Years);
+    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    EuropeanOption option(payoff, exercise);
+    Real npvSingleCurve, npvMultiCurve;
+    option.setPricingEngine(engineSingleCurve);
+    npvSingleCurve = option.NPV();
+    option.setPricingEngine(engineMultiCurve);
+    npvMultiCurve = option.NPV();
+    // check that NPV is the same regardless of engine interface
+    BOOST_CHECK_EQUAL(npvSingleCurve, npvMultiCurve);
+    // check that NPV changes if discount rate is changed
+    discRate->setValue(0.023);
+    npvMultiCurve = option.NPV();
+    BOOST_CHECK_NE(npvSingleCurve, npvMultiCurve);
+}
+
 
 test_suite* EuropeanOptionTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("European option tests");
@@ -1541,6 +1589,9 @@ test_suite* EuropeanOptionTest::suite() {
     // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testPriceCurve));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testLocalVolatility));
+
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testAnalyticEngineDisocuntCurve));
+    
 
     return suite;
 }

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1561,7 +1561,6 @@ void EuropeanOptionTest::testAnalyticEngineDisocuntCurve() {
     BOOST_CHECK_NE(npvSingleCurve, npvMultiCurve);
 }
 
-
 test_suite* EuropeanOptionTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("European option tests");
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testValues));
@@ -1591,7 +1590,6 @@ test_suite* EuropeanOptionTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testLocalVolatility));
 
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testAnalyticEngineDisocuntCurve));
-    
 
     return suite;
 }

--- a/test-suite/europeanoption.hpp
+++ b/test-suite/europeanoption.hpp
@@ -47,6 +47,7 @@ class EuropeanOptionTest {
     static void testFFTEngines();
     static void testPriceCurve();
     static void testLocalVolatility();
+    static void testAnalyticEngineDisocuntCurve();
     static boost::unit_test_framework::test_suite* suite();
     static boost::unit_test_framework::test_suite* experimental();
 };


### PR DESCRIPTION
As suggested in my email to quantlib-users on 7th December 2016, I propose updating AnalyticEuropeanEngine so that it can support separate rate curves for discounting and estimation of the forward price. My mail to quantlib-users provides a more detailed description.
The update involves enhancing the constructor for AnalyticEuropeanEngine, so that it includes an optional second argument for the discount curve. If this is left empty/null then the engine reverts to its previous behaviour (i.e. same rate curve used for discounting and estimation of forward price).