### PR TITLE
Fixed compilation error introduced with commit 224a0e6.

### DIFF
--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -37,6 +37,9 @@
 
 namespace QuantLib {
 
+   const Real LinearTsrPricer::defaultLowerBound = 0.0001,
+             LinearTsrPricer::defaultUpperBound = 2.0000;
+
     LinearTsrPricer::LinearTsrPricer(
         const Handle<SwaptionVolatilityStructure> &swaptionVol,
         const Handle<Quote> &meanReversion,

--- a/ql/cashflows/lineartsrpricer.hpp
+++ b/ql/cashflows/lineartsrpricer.hpp
@@ -62,8 +62,8 @@ namespace QuantLib {
     class LinearTsrPricer : public CmsCouponPricer, public MeanRevertingPricer {
 
       private:
-        static const Real defaultLowerBound = 0.0001,
-                          defaultUpperBound = 2.0000;
+        static const Real defaultLowerBound,
+                          defaultUpperBound;
 
       public:
 

--- a/ql/math/interpolations/lagrangeinterpolation.hpp
+++ b/ql/math/interpolations/lagrangeinterpolation.hpp
@@ -24,6 +24,7 @@
 #include <ql/math/interpolation.hpp>
 
 #include <boost/make_shared.hpp>
+#include<set>
 
 namespace QuantLib {
     /*! References: J-P. Berrut and L.N. Trefethen,


### PR DESCRIPTION
I got error C2864: 'QuantLib::LinearTsrPricer::defaultLowerBound' : only static const integral data members can be initialized within a class. This fix the compilation