### PR TITLE
avoid signal fp exception 8

### DIFF
--- a/ql/termstructures/inflation/seasonality.cpp
+++ b/ql/termstructures/inflation/seasonality.cpp
@@ -48,6 +48,7 @@ namespace QuantLib {
             case Biweekly:          // etc.
             case Weekly:
             case Daily:
+                QL_REQUIRE(this->seasonalityFactors().empty(), "no seasonality factors given");
                 QL_REQUIRE( (this->seasonalityFactors().size() %
                              this->frequency()) == 0,
                            "For frequency " << this->frequency()

--- a/ql/termstructures/inflation/seasonality.cpp
+++ b/ql/termstructures/inflation/seasonality.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
             case Biweekly:          // etc.
             case Weekly:
             case Daily:
-                QL_REQUIRE(this->seasonalityFactors().empty(), "no seasonality factors given");
+                QL_REQUIRE(!this->seasonalityFactors().empty(), "no seasonality factors given");
                 QL_REQUIRE( (this->seasonalityFactors().size() %
                              this->frequency()) == 0,
                            "For frequency " << this->frequency()


### PR DESCRIPTION
If seasonalityFactors_ is an empty vector it still passes the
validate() checks. Later in isConsistent() the call to
seasonalityFactor() will calculate x % nFactors with nFactors = 0
which will produce a fp exception 8 signal.