### PR TITLE
Fix leg creation not respecting endOfMonth flag

### DIFF
--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -186,8 +186,8 @@ namespace QuantLib {
                                 start, end, start, end, exCouponDate));
             leg.push_back(temp);
         } else {
-            Date ref = end - schedule_.tenor();
-            ref = schCalendar.adjust(ref, schedule_.businessDayConvention());
+						BusinessDayConvention bdc = schedule_.businessDayConvention();
+						Date ref = schedule_.calendar().advance(end, -schedule_.tenor(), bdc, schedule_.endOfMonth());
             InterestRate r(rate.rate(),
                            firstPeriodDC_.empty() ? rate.dayCounter()
                                                   : firstPeriodDC_,


### PR DESCRIPTION
See #210 for an overview of the problem this PR addresses.

This is a simple fix for the one case that I need working right now, but I also noticed the same potential issue in a few other places:

```
cashflowvectors.hpp
cpicoupon.cpp
rangeaccrual.cpp
yoyinflationcoupon.cpp
```
I know very little about what these files handle, so I limited the scope of this PR to the code I do understand and have tested.

Speaking of testing, I couldn't find any tests for FixedRateCoupon, so I didn't add any tests to cover this issue. Any guidance on that front would be appreciated.