### PR TITLE
Fix leg creation not respecting endOfMonth flag

### DIFF
--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -186,8 +186,8 @@ namespace QuantLib {
                                 start, end, start, end, exCouponDate));
             leg.push_back(temp);
         } else {
-            Date ref = end - schedule_.tenor();
-            ref = schCalendar.adjust(ref, schedule_.businessDayConvention());
+						BusinessDayConvention bdc = schedule_.businessDayConvention();
+						Date ref = schedule_.calendar().advance(end, -schedule_.tenor(), bdc, schedule_.endOfMonth());
             InterestRate r(rate.rate(),
                            firstPeriodDC_.empty() ? rate.dayCounter()
                                                   : firstPeriodDC_,

--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -186,8 +186,8 @@ namespace QuantLib {
                                 start, end, start, end, exCouponDate));
             leg.push_back(temp);
         } else {
-						BusinessDayConvention bdc = schedule_.businessDayConvention();
-						Date ref = schedule_.calendar().advance(end, -schedule_.tenor(), bdc, schedule_.endOfMonth());
+            BusinessDayConvention bdc = schedule_.businessDayConvention();
+            Date ref = schedule_.calendar().advance(end, -schedule_.tenor(), bdc, schedule_.endOfMonth());
             InterestRate r(rate.rate(),
                            firstPeriodDC_.empty() ? rate.dayCounter()
                                                   : firstPeriodDC_,

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -264,6 +264,28 @@ void CashFlowsTest::testNullFixingDays() {
         .withFixingDays(Null<Natural>());
 }
 
+void CashFlowsTest::testReferenceDatesAtEndOfMonth() {
+    BOOST_TEST_MESSAGE("Testing reference dates with end of month enabled...");
+    Schedule schedule =
+        MakeSchedule()
+        .from(Date(17, January, 2017)).to(Date(28, February, 2018))
+        .withFrequency(Semiannual)
+        .withConvention(Unadjusted)
+        .endOfMonth()
+        .backwards();
+
+    Leg leg = FixedRateLeg(schedule)
+        .withNotionals(100.0)
+        .withCouponRates(0.01, Actual360());
+
+    boost::shared_ptr<Coupon> firstCoupon =
+        boost::dynamic_pointer_cast<Coupon>(leg.front());
+
+    if (firstCoupon->referencePeriodStart() != Date(31, August, 2016))
+        BOOST_ERROR("Expected reference start date at end of month, "
+                    "got " << firstCoupon->referencePeriodStart());
+}
+
 test_suite* CashFlowsTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Cash flows tests");
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testSettings));
@@ -272,6 +294,8 @@ test_suite* CashFlowsTest::suite() {
     #ifndef QL_USE_INDEXED_COUPON
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testNullFixingDays));
     #endif
+    suite->add(QUANTLIB_TEST_CASE(
+                             &CashFlowsTest::testReferenceDatesAtEndOfMonth));
     return suite;
 }
 

--- a/test-suite/cashflows.hpp
+++ b/test-suite/cashflows.hpp
@@ -28,6 +28,7 @@ class CashFlowsTest {
     static void testAccessViolation();
     static void testDefaultSettlementDate();
     static void testNullFixingDays();
+    static void testReferenceDatesAtEndOfMonth();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
See #210 for an overview of the problem this PR addresses.

This is a simple fix for the one case that I need working right now, but I also noticed the same potential issue in a few other places:

```
cashflowvectors.hpp
cpicoupon.cpp
rangeaccrual.cpp
yoyinflationcoupon.cpp
```
I know very little about what these files handle, so I limited the scope of this PR to the code I do understand and have tested.

Speaking of testing, I couldn't find any tests for FixedRateCoupon, so I didn't add any tests to cover this issue. Any guidance on that front would be appreciated.