### PR TITLE
OptionletStripper1: Local CapFloorMatrix

### DIFF
--- a/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -95,13 +95,6 @@ OptionletStripper1::OptionletStripper1(
                 discount_;
 
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
-        // initialize CapFloorMatrix
-
-		CapFloorMatrix capFloors = CapFloorMatrix(nOptionletTenors_);
-
-        for (Size i = 0; i < nOptionletTenors_; ++i) {
-            capFloors[i].resize(nStrikes_);
-        }
 
         boost::shared_ptr<PricingEngine> capFloorEngine;
         boost::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
@@ -133,11 +126,11 @@ OptionletStripper1::OptionletStripper1(
                 capFloorVols_[i][j] = termVolSurface_->volatility(
                     capFloorLengths_[i], strikes[j], true);
                 volQuote->setValue(capFloorVols_[i][j]);
-                capFloors[i][j] =
+                boost::shared_ptr<CapFloor> capFloor =
                     MakeCapFloor(capFloorType, capFloorLengths_[i],
                                  iborIndex_, strikes[j], -0 * Days)
                         .withPricingEngine(capFloorEngine);
-                capFloorPrices_[i][j] = capFloors[i][j]->NPV();
+                capFloorPrices_[i][j] = capFloor->NPV();
                 optionletPrices_[i][j] = capFloorPrices_[i][j] -
                                                         previousCapFloorPrice;
                 previousCapFloorPrice = capFloorPrices_[i][j];

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -45,7 +45,7 @@ OptionletStripper1::OptionletStripper1(
       volQuotes_(nOptionletTenors_,
                  std::vector< shared_ptr< SimpleQuote > >(nStrikes_)),
       floatingSwitchStrike_(switchStrike == Null< Rate >() ? true : false),
-      capFlooMatrixNotInitialized_(true), switchStrike_(switchStrike),
+      switchStrike_(switchStrike),
       accuracy_(accuracy), maxIter_(maxIter), dontThrow_(dontThrow) {
 
         capFloorPrices_ = Matrix(nOptionletTenors_, nStrikes_);
@@ -56,7 +56,6 @@ OptionletStripper1::OptionletStripper1(
         Real firstGuess = 0.14; // guess is only used for shifted lognormal vols
         optionletStDevs_ = Matrix(nOptionletTenors_, nStrikes_, firstGuess);
 
-        capFloors_ = CapFloorMatrix(nOptionletTenors_);
         capFloorEngines_ = std::vector<std::vector<boost::shared_ptr<PricingEngine> > >(nOptionletTenors_);
     }
 
@@ -101,33 +100,34 @@ OptionletStripper1::OptionletStripper1(
 
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
         // initialize CapFloorMatrix
-        if (capFlooMatrixNotInitialized_) {
-            for (Size i = 0; i < nOptionletTenors_; ++i) {
-                capFloors_[i].resize(nStrikes_);
-                capFloorEngines_[i].resize(nStrikes_);
-            }
-            // construction might go here
-            for (Size j=0; j<nStrikes_; ++j) {
-                for (Size i=0; i<nOptionletTenors_; ++i) {
-                    volQuotes_[i][j] = shared_ptr<SimpleQuote>(new
-                                                                SimpleQuote());
-                    if (volatilityType_ == ShiftedLognormal) {
-                        capFloorEngines_[i][j]=boost::shared_ptr<BlackCapFloorEngine>(
-                          new BlackCapFloorEngine(
-                              discountCurve, Handle<Quote>(volQuotes_[i][j]),
-                              dc, displacement_));
-                    } else if (volatilityType_ == Normal) {
-                        capFloorEngines_[i][j]=boost::shared_ptr<BachelierCapFloorEngine>(
-                          new BachelierCapFloorEngine(
-                              discountCurve, Handle<Quote>(volQuotes_[i][j]),
-                              dc));
-                    } else {
-                      QL_FAIL("unknown volatility type: " << volatilityType_);
-                    }
+
+		CapFloorMatrix capFloors = CapFloorMatrix(nOptionletTenors_);
+
+        for (Size i = 0; i < nOptionletTenors_; ++i) {
+            capFloors[i].resize(nStrikes_);
+            capFloorEngines_[i].resize(nStrikes_);
+        }
+        // construction might go here
+        for (Size j=0; j<nStrikes_; ++j) {
+            for (Size i=0; i<nOptionletTenors_; ++i) {
+                volQuotes_[i][j] = shared_ptr<SimpleQuote>(new
+                                                            SimpleQuote());
+                if (volatilityType_ == ShiftedLognormal) {
+                    capFloorEngines_[i][j]=boost::shared_ptr<BlackCapFloorEngine>(
+                        new BlackCapFloorEngine(
+                            discountCurve, Handle<Quote>(volQuotes_[i][j]),
+                            dc, displacement_));
+                } else if (volatilityType_ == Normal) {
+                    capFloorEngines_[i][j]=boost::shared_ptr<BachelierCapFloorEngine>(
+                        new BachelierCapFloorEngine(
+                            discountCurve, Handle<Quote>(volQuotes_[i][j]),
+                            dc));
+                } else {
+                    QL_FAIL("unknown volatility type: " << volatilityType_);
                 }
             }
-            capFlooMatrixNotInitialized_ = false;
         }
+
 
         for (Size j=0; j<nStrikes_; ++j) {
             // using out-of-the-money options
@@ -142,11 +142,11 @@ OptionletStripper1::OptionletStripper1(
                 capFloorVols_[i][j] = termVolSurface_->volatility(
                     capFloorLengths_[i], strikes[j], true);
                 volQuotes_[i][j]->setValue(capFloorVols_[i][j]);
-                capFloors_[i][j] =
+                capFloors[i][j] =
                     MakeCapFloor(capFloorType, capFloorLengths_[i],
                                  iborIndex_, strikes[j], -0 * Days)
                         .withPricingEngine(capFloorEngines_[i][j]);
-                capFloorPrices_[i][j] = capFloors_[i][j]->NPV();
+                capFloorPrices_[i][j] = capFloors[i][j]->NPV();
                 optionletPrices_[i][j] = capFloorPrices_[i][j] -
                                                         previousCapFloorPrice;
                 previousCapFloorPrice = capFloorPrices_[i][j];

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -70,8 +70,6 @@ namespace QuantLib {
         mutable Matrix capFloorVols_;
         mutable Matrix optionletStDevs_, capletVols_;
 
-        mutable std::vector<std::vector<boost::shared_ptr<SimpleQuote> > > volQuotes_;
-        mutable std::vector<std::vector<boost::shared_ptr<PricingEngine> > > capFloorEngines_;
         bool floatingSwitchStrike_;
 
         mutable Rate switchStrike_;

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -70,11 +70,10 @@ namespace QuantLib {
         mutable Matrix capFloorVols_;
         mutable Matrix optionletStDevs_, capletVols_;
 
-        mutable CapFloorMatrix capFloors_;
         mutable std::vector<std::vector<boost::shared_ptr<SimpleQuote> > > volQuotes_;
         mutable std::vector<std::vector<boost::shared_ptr<PricingEngine> > > capFloorEngines_;
         bool floatingSwitchStrike_;
-        mutable bool capFlooMatrixNotInitialized_;
+
         mutable Rate switchStrike_;
         Real accuracy_;
         Natural maxIter_;

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -37,6 +37,7 @@ namespace QuantLib {
     class CapFloor;
     class PricingEngine;
 
+    QL_DEPRECATED
     typedef std::vector<std::vector<boost::shared_ptr<CapFloor> > > CapFloorMatrix;
 
     /*! Helper class to strip optionlet (i.e. caplet/floorlet) volatilities


### PR DESCRIPTION
I suggest to remove the CapFloorMatrix class member variable of OptionletStripper1 and use a local variable within OptionletStripper1::performCalculations instead in order to save memory. These matrices tends to get rather large when using several different optionlet surfaces in parallel in order to price different currencies and option tenors. Apparently there hasn't been any use case for the initialized matrix and the corresponding bool in the last ten years, and the matrix currently would be recreated anyway whenever performCalculations is called in the current implementation.