### PR TITLE
Speed up compilation of examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - ./autogen.sh
   - ./configure --disable-static
   - make -j 2 -C ql
+  - make -j 2 -C Examples
 

--- a/Examples/BasketLosses/BasketLosses.cpp
+++ b/Examples/BasketLosses/BasketLosses.cpp
@@ -17,7 +17,17 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/experimental/credit/gaussianlhplossmodel.hpp>
+#include <ql/experimental/credit/constantlosslatentmodel.hpp>
+#include <ql/experimental/credit/binomiallossmodel.hpp>
+#include <ql/experimental/credit/randomdefaultlatentmodel.hpp>
+#include <ql/experimental/credit/randomlosslatentmodel.hpp>
+#include <ql/experimental/credit/spotlosslatentmodel.hpp>
+#include <ql/experimental/credit/basecorrelationlossmodel.hpp>
+#include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/currencies/europe.hpp>
 
 #include <boost/timer.hpp>
 #include <boost/make_shared.hpp>
@@ -26,6 +36,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <string>
 
 using namespace std;
 using namespace QuantLib;

--- a/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -19,7 +19,23 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/instruments/swaption.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/pricingengines/swaption/treeswaptionengine.hpp>
+#include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
+#include <ql/pricingengines/swaption/g2swaptionengine.hpp>
+#include <ql/pricingengines/swaption/fdhullwhiteswaptionengine.hpp>
+#include <ql/pricingengines/swaption/fdg2swaptionengine.hpp>
+#include <ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp>
+#include <ql/models/shortrate/onefactormodels/blackkarasinski.hpp>
+#include <ql/math/optimization/levenbergmarquardt.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/cashflows/coupon.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/utilities/dataformatters.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -22,8 +22,20 @@
     computations such as "Yield to Price" or "Price to Yield"
  */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/instruments/bonds/zerocouponbond.hpp>
+#include <ql/instruments/bonds/floatingratebond.hpp>
+#include <ql/pricingengines/bond/discountingbondengine.hpp>
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/bondhelpers.hpp>
+#include <ql/termstructures/volatility/optionlet/constantoptionletvol.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/ibor/usdlibor.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
 
 #include <boost/timer.hpp>
 #include <iostream>

--- a/Examples/CDS/CDS.cpp
+++ b/Examples/CDS/CDS.cpp
@@ -17,7 +17,14 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/instruments/creditdefaultswap.hpp>
+#include <ql/pricingengines/credit/midpointcdsengine.hpp>
+#include <ql/termstructures/credit/piecewisedefaultcurve.hpp>
+#include <ql/termstructures/credit/defaultprobabilityhelpers.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/quotes/simplequote.hpp>
 
 #include <boost/timer.hpp>
 #include <iostream>

--- a/Examples/CVAIRS/CVAIRS.cpp
+++ b/Examples/CVAIRS/CVAIRS.cpp
@@ -17,9 +17,20 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/instruments/vanillaswap.hpp>
+#include <ql/instruments/makevanillaswap.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/pricingengines/swap/cvaswapengine.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/termstructures/credit/interpolatedhazardratecurve.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <ql/time/daycounters/actual360.hpp>
 
 #include <boost/timer.hpp>
+#include <boost/make_shared.hpp>
 #include <iostream>
 #include <iomanip>
 

--- a/Examples/CallableBonds/CallableBonds.cpp
+++ b/Examples/CallableBonds/CallableBonds.cpp
@@ -21,6 +21,13 @@
    engine and compares to Bloomberg's Hull White price/yield calculations.
 */
 
+#include <ql/experimental/callablebonds/callablebond.hpp>
+#include <ql/experimental/callablebonds/treecallablebondengine.hpp>
+#include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point
    exceptions. Warning: unpredictable results can arise...
@@ -32,7 +39,6 @@
 // namespace { unsigned int u = _controlfp(_EM_INEXACT, _MCW_EM); }
 #endif
 
-#include <ql/quantlib.hpp>
 #include <vector>
 #include <cmath>
 #include <iomanip>

--- a/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -18,8 +18,11 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/experimental/convertiblebonds/convertiblebond.hpp>
+#include <ql/experimental/convertiblebonds/binomialconvertibleengine.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/utilities/dataformatters.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/DiscreteHedging/DiscreteHedging.cpp
+++ b/Examples/DiscreteHedging/DiscreteHedging.cpp
@@ -45,8 +45,14 @@
     We examine the range of possibilities, computing the replication error.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/methods/montecarlo/montecarlomodel.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/pricingengines/blackcalculator.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/EquityOption/EquityOption.cpp
+++ b/Examples/EquityOption/EquityOption.cpp
@@ -17,8 +17,21 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/pricingengines/vanilla/binomialengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/analytichestonengine.hpp>
+#include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
+#include <ql/pricingengines/vanilla/bjerksundstenslandengine.hpp>
+#include <ql/pricingengines/vanilla/batesengine.hpp>
+#include <ql/pricingengines/vanilla/integralengine.hpp>
+#include <ql/pricingengines/vanilla/fdeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/fdbermudanengine.hpp>
+#include <ql/pricingengines/vanilla/fdamericanengine.hpp>
+#include <ql/pricingengines/vanilla/mceuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/mcamericanengine.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/utilities/dataformatters.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -21,8 +21,11 @@
     forward-rate agreement.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/instruments/forwardrateagreement.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -26,7 +26,14 @@
     results generated from the bootstrap fitting method.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/termstructures/yield/fittedbonddiscountcurve.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/bondhelpers.hpp>
+#include <ql/termstructures/yield/nonlinearfittingmethods.hpp>
+#include <ql/pricingengines/bond/bondfunctions.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/simpledaycounter.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -17,8 +17,33 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/instruments/floatfloatswap.hpp>
+#include <ql/instruments/floatfloatswaption.hpp>
+#include <ql/instruments/nonstandardswaption.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/pricingengines/swaption/gaussian1dswaptionengine.hpp>
+#include <ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.hpp>
+#include <ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.hpp>
+#include <ql/models/shortrate/onefactormodels/gsr.hpp>
+#include <ql/models/shortrate/onefactormodels/markovfunctional.hpp>
+#include <ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp>
+#include <ql/math/optimization/levenbergmarquardt.hpp>
+#include <ql/cashflows/lineartsrpricer.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/swap/euriborswap.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionconstantvol.hpp>
+#include <ql/rebatedexercise.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+
 #include <boost/timer.hpp>
+#include <boost/make_shared.hpp>
+
+#include <iostream>
+#include <iomanip>
 
 using namespace QuantLib;
 

--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -17,7 +17,11 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/math/optimization/differentialevolution.hpp>
+#include <ql/math/optimization/simulatedannealing.hpp>
+#include <ql/experimental/math/fireflyalgorithm.hpp>
+#include <ql/experimental/math/hybridsimulatedannealing.hpp>
+#include <ql/experimental/math/particleswarmoptimization.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/LatentModel/LatentModel.cpp
+++ b/Examples/LatentModel/LatentModel.cpp
@@ -17,7 +17,11 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/quantlib.hpp>
+#include <ql/experimental/credit/randomdefaultlatentmodel.hpp>
+#include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/currencies/europe.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 
 #include <boost/timer.hpp>
 #include <boost/make_shared.hpp>

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -1,9 +1,14 @@
-#include <iostream>
-#include <iomanip>
+
+#include <ql/experimental/math/multidimintegrator.hpp>
+#include <ql/experimental/math/multidimquadrature.hpp>
+#include <ql/math/integrals/trapezoidintegral.hpp>
+
 #include <boost/function.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/timer.hpp>
 
-#include <ql/quantlib.hpp>
+#include <iostream>
+#include <iomanip>
 
 using namespace QuantLib;
 using namespace std;

--- a/Examples/Replication/Replication.cpp
+++ b/Examples/Replication/Replication.cpp
@@ -24,8 +24,16 @@
     reader.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/instruments/compositeinstrument.hpp>
+#include <ql/instruments/barrieroption.hpp>
+#include <ql/instruments/europeanoption.hpp>
+#include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/exercise.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point

--- a/Examples/Repo/Repo.cpp
+++ b/Examples/Repo/Repo.cpp
@@ -28,8 +28,13 @@
    YieldTermStructure.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/instruments/fixedratebondforward.hpp>
+#include <ql/pricingengines/bond/discountingbondengine.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/schedule.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point
@@ -44,6 +49,7 @@
 
 #include <boost/timer.hpp>
 #include <iostream>
+#include <iomanip>
 
 using namespace std;
 using namespace QuantLib;

--- a/Examples/Swap/swapvaluation.cpp
+++ b/Examples/Swap/swapvaluation.cpp
@@ -23,8 +23,15 @@
     swap.
 */
 
-// the only header you need to use QuantLib
-#include <ql/quantlib.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/imm.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
 
 #ifdef BOOST_MSVC
 /* Uncomment the following lines to unmask floating-point


### PR DESCRIPTION
Instead of including the global `ql/quantlib.hpp` header, examples only include what they need.
This decreases the compilation time of each example by an amount going from 60% to 80%.