### PR TITLE
Iceland calendar doesn't adjust New Year's Day to Monday.

### DIFF
--- a/ql/time/calendars/iceland.cpp
+++ b/ql/time/calendars/iceland.cpp
@@ -34,9 +34,8 @@ namespace QuantLib {
         Year y = date.year();
         Day em = easterMonday(y);
         if (isWeekend(w)
-            // New Year's Day (possibly moved to Monday)
-            || ((d == 1 || ((d == 2 || d == 3) && w == Monday))
-                && m == January)
+            // New Year's Day
+            || (d == 1 && m == January)
             // Holy Thursday
             || (dd == em-4)
             // Good Friday

--- a/ql/time/calendars/iceland.hpp
+++ b/ql/time/calendars/iceland.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
         <ul>
         <li>Saturdays</li>
         <li>Sundays</li>
-        <li>New Year's Day, January 1st (possibly moved to Monday)</li>
+        <li>New Year's Day, January 1st</li>
         <li>Holy Thursday</li>
         <li>Good Friday</li>
         <li>Easter Monday</li>


### PR DESCRIPTION
Closes #194.