### PR TITLE
Oas experimental

### DIFF
--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -251,7 +251,8 @@ namespace QuantLib {
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
-                                         Frequency frequency)
+                                         Frequency frequency,
+                                         Real bump)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -267,7 +268,7 @@ namespace QuantLib {
             return 0;
         else
             {
-                NumericalDifferentiation dFdOAS(f, 1, 1e-6,
+                NumericalDifferentiation dFdOAS(f, 1, bump,
                                                 3,
                                                 NumericalDifferentiation::Central);
                 return -1*dFdOAS(oas)/P;
@@ -278,7 +279,8 @@ namespace QuantLib {
                                           RelinkableHandle<YieldTermStructure>& engineTS,
                                           const DayCounter& dayCounter,
                                           Compounding compounding,
-                                          Frequency frequency)
+                                          Frequency frequency,
+                                          Real bump)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -296,7 +298,7 @@ namespace QuantLib {
             {
                 NumericalDifferentiation dFdOAS(f,
                                                 2, 
-                                                1e-6,
+                                                bump,
                                                 3,
                                                 NumericalDifferentiation::Central);
                 return dFdOAS(oas)/P;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -224,6 +224,29 @@ namespace QuantLib {
         return res;
     }
 
+    Real CallableBond::cleanPrice(Real oas,
+                                  RelinkableHandle<YieldTermStructure>& engineTS,
+                                  const DayCounter& dayCounter,
+                                  Compounding compounding,
+                                  Frequency frequency,
+                                  Date settlement)
+    {
+        if (settlement == Date())
+            settlement = settlementDate();
+
+        EngSpreadHelper s(engineTS,
+                          dayCounter,
+                          compounding,
+                          frequency);
+
+        boost::function<Real(Real)> f = NPVSpreadHelper(*this,
+                                                        s.sqSpread);
+
+        Real P = f(oas) - accruedAmount(settlement);
+
+        return P;
+    }
+
     Real CallableBond::effectiveDuration(Real oas,
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -270,7 +270,7 @@ namespace QuantLib {
                 NumericalDifferentiation dFdOAS(f, 1, 1e-6,
                                                 3,
                                                 NumericalDifferentiation::Central);
-                return dFdOAS(oas)/P;
+                return -1*dFdOAS(oas)/P;
             }
     }
 

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2008 Allen Kuo
+ Copyright (C) 2017 BN Algorithms Ltd
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -224,12 +224,12 @@ namespace QuantLib {
         return res;
     }
 
-    Real CallableBond::cleanPrice(Real oas,
-                                  RelinkableHandle<YieldTermStructure>& engineTS,
-                                  const DayCounter& dayCounter,
-                                  Compounding compounding,
-                                  Frequency frequency,
-                                  Date settlement)
+    Real CallableBond::cleanPriceOAS(Real oas,
+                                     RelinkableHandle<YieldTermStructure>& engineTS,
+                                     const DayCounter& dayCounter,
+                                     Compounding compounding,
+                                     Frequency frequency,
+                                     Date settlement) const
     {
         if (settlement == Date())
             settlement = settlementDate();
@@ -251,8 +251,7 @@ namespace QuantLib {
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
-                                         Frequency frequency,
-                                         Date settlementDate)
+                                         Frequency frequency)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -279,8 +278,7 @@ namespace QuantLib {
                                           RelinkableHandle<YieldTermStructure>& engineTS,
                                           const DayCounter& dayCounter,
                                           Compounding compounding,
-                                          Frequency frequency,
-                                          Date settlementDate)
+                                          Frequency frequency)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -297,7 +295,7 @@ namespace QuantLib {
         else
             {
                 NumericalDifferentiation dFdOAS(f,
-                                                2,
+                                                2, 
                                                 1e-6,
                                                 3,
                                                 NumericalDifferentiation::Central);

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -96,6 +96,16 @@ namespace QuantLib {
                    Size maxIterations = 100,
                    Rate guess = 0.0);
 
+        //! Calculate the clean price based on the given
+        //! option-adjust-spread (oas) over the given yield term
+        //! structure (engineTS)
+        Real cleanPrice(Real oas,
+                        RelinkableHandle<YieldTermStructure>& engineTS,
+                        const DayCounter& dayCounter,
+                        Compounding compounding,
+                        Frequency frequency,
+                        Date settlementDate = Date());
+
         //! Calculate the effective duration, i.e., the first
         //! differential of the dirty price w.r.t. a parallel shift of
         //! the yield term structure divided by current dirty price

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -113,7 +113,8 @@ namespace QuantLib {
                                RelinkableHandle<YieldTermStructure>& engineTS,
                                const DayCounter& dayCounter,
                                Compounding compounding,
-                               Frequency frequency);
+                               Frequency frequency,
+                               Real bump=2e-4);
 
         //! Calculate the effective convexity, i.e., the second
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -122,7 +123,8 @@ namespace QuantLib {
                                 RelinkableHandle<YieldTermStructure>& engineTS,
                                 const DayCounter& dayCounter,
                                 Compounding compounding,
-                                Frequency frequency);
+                                Frequency frequency,
+                                Real bump=2e-4);
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2008 Allen Kuo
+ Copyright (C) 2017 BN Algorithms Ltd
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -86,11 +86,15 @@ namespace QuantLib {
             YieldTermStructure handle used by engine should be the
             same as engineTS
          */
-        Spread OAS(Real marketPrice,
+        Spread OAS(Real cleanPrice,
                    RelinkableHandle<YieldTermStructure>& engineTS,
-                   Real accuracy,
-                   Size maxIterations,
-                   Spread guess);
+                   const DayCounter& dayCounter,
+                   Compounding compounding,
+                   Frequency frequency,
+                   Date settlementDate = Date(),
+                   Real accuracy = 1.0e-10,
+                   Size maxIterations = 100,
+                   Rate guess = 0.0);
 
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -99,12 +99,12 @@ namespace QuantLib {
         //! Calculate the clean price based on the given
         //! option-adjust-spread (oas) over the given yield term
         //! structure (engineTS)
-        Real cleanPrice(Real oas,
-                        RelinkableHandle<YieldTermStructure>& engineTS,
-                        const DayCounter& dayCounter,
-                        Compounding compounding,
-                        Frequency frequency,
-                        Date settlementDate = Date());
+        Real cleanPriceOAS(Real oas,
+                           RelinkableHandle<YieldTermStructure>& engineTS,
+                           const DayCounter& dayCounter,
+                           Compounding compounding,
+                           Frequency frequency,
+                           Date settlementDate = Date()) const;
 
         //! Calculate the effective duration, i.e., the first
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -113,8 +113,7 @@ namespace QuantLib {
                                RelinkableHandle<YieldTermStructure>& engineTS,
                                const DayCounter& dayCounter,
                                Compounding compounding,
-                               Frequency frequency,
-                               Date settlementDate = Date());
+                               Frequency frequency);
 
         //! Calculate the effective convexity, i.e., the second
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -123,8 +122,7 @@ namespace QuantLib {
                                 RelinkableHandle<YieldTermStructure>& engineTS,
                                 const DayCounter& dayCounter,
                                 Compounding compounding,
-                                Frequency frequency,
-                                Date settlementDate = Date());
+                                Frequency frequency);
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -75,6 +75,22 @@ namespace QuantLib {
                               Size maxEvaluations,
                               Volatility minVol,
                               Volatility maxVol) const;
+
+        //! Calculate the Option Adjusted Spread (OAS)
+        /*! Calculates the spread that needs to be added to the the
+            reference (engineTS risk-free) curve so that the
+            theoretical model value matches the marketPrice.
+
+            \note a pricing engine should be set on the bond and the
+            YieldTermStructure handle used by engine should be the
+            same as engineTS
+         */
+        Spread OAS(Real marketPrice,
+                   RelinkableHandle<YieldTermStructure>& engineTS,
+                   Real accuracy,
+                   Size maxIterations,
+                   Spread guess);
+
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 
@@ -108,6 +124,21 @@ namespace QuantLib {
             Real targetValue_;
             boost::shared_ptr<SimpleQuote> vol_;
             const Instrument::results* results_;
+        };
+
+
+        class OASHelper;
+        friend class OASHelper;
+        class OASHelper {
+          public:
+            OASHelper(const CallableBond& bond,
+                      Handle<SimpleQuote>& spread,
+                      Real targetValue);
+            Real operator()(Spread x) const;
+          private:
+            const CallableBond& bond_;
+            Handle<SimpleQuote>& spread_;
+            Real targetValue_;
         };
     };
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -96,6 +96,25 @@ namespace QuantLib {
                    Size maxIterations = 100,
                    Rate guess = 0.0);
 
+        //! Calculate the effective duration, i.e., the first
+        //! differential of the dirty price w.r.t. a parallel shift of
+        //! the yield term structure divided by current dirty price
+        Real effectiveDuration(Real oas,
+                               RelinkableHandle<YieldTermStructure>& engineTS,
+                               const DayCounter& dayCounter,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+
+        //! Calculate the effective convexity, i.e., the second
+        //! differential of the dirty price w.r.t. a parallel shift of
+        //! the yield term structure divided by current dirty price
+        Real effectiveConvexity(Real oas,
+                                RelinkableHandle<YieldTermStructure>& engineTS,
+                                const DayCounter& dayCounter,
+                                Compounding compounding,
+                                Frequency frequency,
+                                Date settlementDate = Date());
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 


### PR DESCRIPTION
Add functions to calculate OAS from clean price and vice versa, effective duration and effective convexity for callable fixed rate bonds. (This enhancement to QuantLib was sponsored by TMC Bonds LLC)