### PR TITLE
Amendment of day count convention and spot lag by CAD fixings

### DIFF
--- a/ql/indexes/ibor/cadlibor.hpp
+++ b/ql/indexes/ibor/cadlibor.hpp
@@ -27,7 +27,7 @@
 
 #include <ql/indexes/ibor/libor.hpp>
 #include <ql/time/calendars/canada.hpp>
-#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/currencies/america.hpp>
 
 namespace QuantLib {
@@ -36,6 +36,9 @@ namespace QuantLib {
     /*! Canadian Dollar LIBOR discontinued as of 2013.
         \warning This is the rate fixed in London by BBA. Use CDOR if
                  you're interested in the Canadian fixing by IDA.
+        \warning Actual360 changed to Actual365Fixed()
+        \warning settlement days changed from 2 to 0
+        \warning source: OpenGamma "Interest Rate Instruments and Market Conventions Guide", BBG, IKON
     */
     class CADLibor : public Libor {
       public:
@@ -43,10 +46,10 @@ namespace QuantLib {
                  const Handle<YieldTermStructure>& h =
                                     Handle<YieldTermStructure>())
         : Libor("CADLibor", tenor,
-                2,
+                0,
                 CADCurrency(),
                 Canada(),
-                Actual360(), h) {}
+                Actual365Fixed(), h) {}
     };
 
     //! Overnight %CAD %Libor index
@@ -58,7 +61,7 @@ namespace QuantLib {
                           0,
                           CADCurrency(),
                           Canada(),
-                          Actual360(), h) {}
+                          Actual365Fixed(), h) {}
     };
 
 }

--- a/ql/indexes/ibor/cdor.hpp
+++ b/ql/indexes/ibor/cdor.hpp
@@ -26,7 +26,7 @@
 
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/calendars/canada.hpp>
-#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/currencies/america.hpp>
 
 namespace QuantLib {
@@ -39,15 +39,18 @@ namespace QuantLib {
 
         \todo check settlement days, end-of-month adjustment,
               and day-count convention.
+        \warning Actual360 changed to Actual365Fixed()
+        \warning settlement days changed from 2 to 0
+        \warning source: OpenGamma "Interest Rate Instruments and Market Conventions Guide", BBG, IKON
     */
     class Cdor : public IborIndex {
       public:
         Cdor(const Period& tenor,
              const Handle<YieldTermStructure>& h =
                                     Handle<YieldTermStructure>())
-        : IborIndex("CDOR", tenor, 2, CADCurrency(),
+        : IborIndex("CDOR", tenor, 0, CADCurrency(),
                     Canada(), ModifiedFollowing, false,
-                    Actual360(), h) {}
+                    Actual365Fixed(), h) {}
     };
 
 }


### PR DESCRIPTION
Regarding to the OpenGamma "Interest Rate Instruments and Market Conventions Guide" as well as market data provider Bloomberg and IKON (Reuters) the convantion should be Act365 F and spot lag should be 0 instead of Act360 and 2 used so far in cdor.hpp and cadlibor.hpp

Best Regards