### PR TITLE
provide better error message than px != 0

### DIFF
--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -52,9 +52,9 @@ namespace QuantLib {
         boost::shared_ptr<Impl> impl_;
       public:
         bool empty() const { return !impl_; }
-        bool test(const Array& p) const { return impl_->test(p); }
+        bool test(const Array& p) const { return impl()->test(p); }
         Array upperBound(const Array& params) const {
-            Array result = impl_->upperBound(params);
+            Array result = impl()->upperBound(params);
             QL_REQUIRE(params.size() == result.size(),
                        "upper bound size (" << result.size()
                                             << ") not equal to params size ("
@@ -62,7 +62,7 @@ namespace QuantLib {
             return result;
         }
         Array lowerBound(const Array& params) const {
-            Array result = impl_->lowerBound(params);
+            Array result = impl()->lowerBound(params);
             QL_REQUIRE(params.size() == result.size(),
                        "lower bound size (" << result.size()
                                             << ") not equal to params size ("
@@ -74,6 +74,11 @@ namespace QuantLib {
                     Real beta);
         Constraint(const boost::shared_ptr<Impl>& impl =
                                                    boost::shared_ptr<Impl>());
+      private:
+        boost::shared_ptr<Impl> impl() const {
+            QL_REQUIRE(!empty(), "Constraint: no implementation given");
+            return impl_;
+        }
     };
 
     //! No constraint

--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -52,9 +52,9 @@ namespace QuantLib {
         boost::shared_ptr<Impl> impl_;
       public:
         bool empty() const { return !impl_; }
-        bool test(const Array& p) const { return impl()->test(p); }
+        bool test(const Array& p) const { return impl_->test(p); }
         Array upperBound(const Array& params) const {
-            Array result = impl()->upperBound(params);
+            Array result = impl_->upperBound(params);
             QL_REQUIRE(params.size() == result.size(),
                        "upper bound size (" << result.size()
                                             << ") not equal to params size ("
@@ -62,7 +62,7 @@ namespace QuantLib {
             return result;
         }
         Array lowerBound(const Array& params) const {
-            Array result = impl()->lowerBound(params);
+            Array result = impl_->lowerBound(params);
             QL_REQUIRE(params.size() == result.size(),
                        "lower bound size (" << result.size()
                                             << ") not equal to params size ("
@@ -74,11 +74,6 @@ namespace QuantLib {
                     Real beta);
         Constraint(const boost::shared_ptr<Impl>& impl =
                                                    boost::shared_ptr<Impl>());
-      private:
-        boost::shared_ptr<Impl> impl() const {
-            QL_REQUIRE(!empty(), "Constraint: no implementation given");
-            return impl_;
-        }
     };
 
     //! No constraint

--- a/ql/math/optimization/problem.hpp
+++ b/ql/math/optimization/problem.hpp
@@ -27,11 +27,10 @@
 #define quantlib_optimization_problem_h
 
 #include <ql/math/optimization/method.hpp>
+#include <ql/math/optimization/constraint.hpp>
 #include <ql/math/optimization/costfunction.hpp>
 
 namespace QuantLib {
-
-    class Constraint;
 
     //! Constrained optimization problem
     /*! \warning The passed CostFunction and Constraint instances are
@@ -46,7 +45,9 @@ namespace QuantLib {
                 Constraint& constraint,
                 const Array& initialValue = Array())
         : costFunction_(costFunction), constraint_(constraint),
-          currentValue_(initialValue) {}
+          currentValue_(initialValue) {
+            QL_REQUIRE(!constraint.empty(), "empty constraint given");
+        }
 
         /*! \warning it does not reset the current minumum to any initial value
         */


### PR DESCRIPTION
I used an instance of Constraint (instead of NoConstraint) for an optimisation and got a px != 0 runtime error. These are brutal to locate sometimes ...