### PR TITLE
Perform Travis build in Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ env:
   global:
     - DOCKER_OPTS="--rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build"
     - DOCKER_IMAGE=lballabio/quantlib-devenv
+    - CXXFLAGS="-O2 -Wall -Wno-unknown-pragmas -Werror -std=c++03"
 
 before_install:
   - docker pull ${DOCKER_IMAGE}
 
 script:
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./autogen.sh
-  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./configure --disable-static CXXFLAGS='-O2'
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./configure --disable-static CXXFLAGS="${CXXFLAGS}"
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --zero-stats
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --max-size=2.5G
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --show-stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,21 @@ language: cpp
 
 os: linux
 dist: trusty
-sudo: false
+sudo: required
 compiler: gcc
+services: docker
 
 cache: ccache
 
-addons:
-  apt:
-    packages:
-      - libboost-dev
-      - libboost-test-dev
+before_install:
+  - docker pull lballabio/boost
 
 script:
   - ./autogen.sh
-  - ./configure --disable-static CXXFLAGS='-O2'
-  - ccache --zero-stats
-  - ccache --max-size=2.5G
-  - make -j 2
-  - ccache --show-stats
-  - ./test-suite/quantlib-test-suite --log_level=message -- --faster
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ./configure --disable-static CXXFLAGS='-O2'
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --zero-stats
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --max-size=2.5G
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost make -j 2
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --show-stats
+  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ./test-suite/quantlib-test-suite --log_level=message -- --faster
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,20 @@ services: docker
 
 cache: ccache
 
+env:
+  global:
+    - DOCKER_OPTS="--rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build"
+    - DOCKER_IMAGE=lballabio/boost
+
 before_install:
-  - docker pull lballabio/boost
+  - docker pull ${DOCKER_IMAGE}
 
 script:
   - ./autogen.sh
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ./configure --disable-static CXXFLAGS='-O2'
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --zero-stats
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --max-size=2.5G
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost make -j 2
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ccache --show-stats
-  - docker run --rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build lballabio/boost ./test-suite/quantlib-test-suite --log_level=message -- --faster
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./configure --disable-static CXXFLAGS='-O2'
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --zero-stats
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --max-size=2.5G
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} make -j 2
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --show-stats
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./test-suite/quantlib-test-suite --log_level=message -- --faster
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./configure --disable-static CXXFLAGS='-O2'
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --zero-stats
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --max-size=2.5G
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --show-stats
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} make -j 2
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --show-stats
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./test-suite/quantlib-test-suite --log_level=message -- --faster

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ cache: ccache
 env:
   global:
     - DOCKER_OPTS="--rm -ti -v ${HOME}/.ccache:/root/.ccache -v ${TRAVIS_BUILD_DIR}:/build -w /build"
-    - DOCKER_IMAGE=lballabio/boost
+    - DOCKER_IMAGE=lballabio/quantlib-devenv
 
 before_install:
   - docker pull ${DOCKER_IMAGE}
 
 script:
-  - ./autogen.sh
+  - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./autogen.sh
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ./configure --disable-static CXXFLAGS='-O2'
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --zero-stats
   - docker run ${DOCKER_OPTS} ${DOCKER_IMAGE} ccache --max-size=2.5G


### PR DESCRIPTION
The image is stored on the Docker Hub; the current one contains an installation of the latest Boost version in the latest long-term Ubuntu release.

The approach should be easily extended to multiple jobs, each in a different image; in turn, this would allow to use different Boost releases (to check compatibility with older ones) or different Ubuntu releases (to try out older or newer gcc versions).