### PR TITLE
make past fixing virtual

### DIFF
--- a/ql/indexes/interestrateindex.hpp
+++ b/ql/indexes/interestrateindex.hpp
@@ -80,7 +80,7 @@ namespace QuantLib {
         //@{
         //! It can be overridden to implement particular conventions
         virtual Rate forecastFixing(const Date& fixingDate) const = 0;
-        Rate pastFixing(const Date& fixingDate) const;
+        virtual Rate pastFixing(const Date& fixingDate) const;
         // @}
       protected:
         std::string familyName_;


### PR DESCRIPTION
Looking at the implementation of SwapSpreadIndex (in ql/experimental/coupons), the fixing method won't work properly unless we make InterestRateIndex::pastFixing() virtual.

This extends to other custom indices which rely on historical fixings for some underlying indices instead of providing native fixings themselves.