### PR TITLE
move some boost::shared_ptr construction to boost::make_shared

### DIFF
--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -51,16 +51,16 @@ namespace QuantLib {
       rTS_  (process->riskFreeRate().currentLink()),
       qTS_  (process->dividendYield().currentLink()),
       varianceValues_(0.5*mesher->locations(1)),
-      dxMap_ (new FirstDerivativeOp(0, mesher)),
-      dxxMap_(new ModTripleBandLinearOp(TripleBandLinearOp(
+      dxMap_ (boost::make_shared<FirstDerivativeOp>(0, mesher)),
+      dxxMap_(boost::make_shared<ModTripleBandLinearOp>(TripleBandLinearOp(
           type == FdmSquareRootFwdOp::Log ?
             SecondDerivativeOp(0, mesher).mult(0.5*Exp(mesher->locations(1)))
           : SecondDerivativeOp(0, mesher).mult(0.5*mesher->locations(1))
           ))),
-      boundary_(new ModTripleBandLinearOp(TripleBandLinearOp(SecondDerivativeOp(0, mesher).mult(Array(mesher->locations(0).size(), 0.0))))),
-      mapX_  (new TripleBandLinearOp(0, mesher)),
-      mapY_  (new FdmSquareRootFwdOp(mesher,kappa_,theta_,sigma_, 1, type)),
-      correlation_(new NinePointLinearOp(
+      boundary_(boost::make_shared<ModTripleBandLinearOp>(TripleBandLinearOp(SecondDerivativeOp(0, mesher).mult(Array(mesher->locations(0).size(), 0.0))))),
+      mapX_  (boost::make_shared<TripleBandLinearOp>(0, mesher)),
+      mapY_  (boost::make_shared<FdmSquareRootFwdOp>(mesher,kappa_,theta_,sigma_, 1, type)),
+      correlation_(boost::make_shared<NinePointLinearOp>(
           type == FdmSquareRootFwdOp::Log ?
               SecondOrderMixedDerivativeOp(0, 1, mesher)
               .mult(Array(mesher->layout()->size(), rho_*sigma_))

--- a/ql/experimental/finitedifferences/hestonrndcalculator.cpp
+++ b/ql/experimental/finitedifferences/hestonrndcalculator.cpp
@@ -27,6 +27,8 @@
 #include <ql/experimental/finitedifferences/bsmrndcalculator.hpp>
 #include <ql/experimental/finitedifferences/hestonrndcalculator.hpp>
 
+#include <boost/make_shared.hpp>
+
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
@@ -138,7 +140,7 @@ namespace {
             CpxPv_Helper(getHestonParams(hestonProcess_), x_t(x, t), t),
             0.0, 1.0)/M_TWOPI;
     }
-
+	
     Real HestonRNDCalculator::cdf(Real x, Time t) const {
         return GaussLobattoIntegral(
             maxIntegrationIterations_, 0.1*integrationEps_)(
@@ -156,17 +158,16 @@ namespace {
             = std::sqrt(theta + (v0-theta)*(1-std::exp(-kappa*t))/(t*kappa));
 
         const boost::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-            new BlackScholesMertonProcess(
+            boost::make_shared<BlackScholesMertonProcess>(
                 hestonProcess_->s0(),
                 hestonProcess_->dividendYield(),
                 hestonProcess_->riskFreeRate(),
                 Handle<BlackVolTermStructure>(
-                    boost::shared_ptr<BlackVolTermStructure>(
-                        new BlackConstantVol(
+                    boost::make_shared<BlackConstantVol>(
                             hestonProcess_->riskFreeRate()->referenceDate(),
                             NullCalendar(),
                             expVol,
-                            hestonProcess_->riskFreeRate()->dayCounter())))));
+                            hestonProcess_->riskFreeRate()->dayCounter()))));
 
         const Real guess = BSMRNDCalculator(bsmProcess).invcdf(p, t);
 

--- a/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
       theta_(hestonProcess->theta()),
       sigma_(hestonProcess->sigma()),
       rho_(hestonProcess->rho()),
-      hwModel_(new HullWhite(hestonProcess->riskFreeRate(),
+      hwModel_(boost::make_shared<HullWhite>(hestonProcess->riskFreeRate(),
                              hwProcess->a(), hwProcess->sigma())),
       hestonCorrMap_(SecondOrderMixedDerivativeOp(0, 1, mesher)
                      .mult(rho_*sigma_*mesher->locations(1))),

--- a/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
     : solverDesc_(solverDesc),
       schemeDesc_(schemeDesc),
       op_(op),
-      thetaCondition_(new FdmSnapshotCondition(
+      thetaCondition_(boost::make_shared<FdmSnapshotCondition>(
         0.99*std::min(1.0/365.0,
            solverDesc.condition->stoppingTimes().empty()
                     ? solverDesc.maturity
@@ -69,9 +69,8 @@ namespace QuantLib {
                       solverDesc_.timeSteps, solverDesc_.dampingSteps);
 
         std::copy(rhs.begin(), rhs.end(), resultValues_.begin());
-        interpolation_ = boost::shared_ptr<CubicInterpolation>(new
-            MonotonicCubicNaturalSpline(x_.begin(), x_.end(),
-                                        resultValues_.begin()));
+        interpolation_ = boost::make_shared<MonotonicCubicNaturalSpline>(x_.begin(), x_.end(),
+                                        resultValues_.begin());
     }
 
     Real Fdm1DimSolver::interpolateAt(Real x) const {

--- a/ql/methods/finitedifferences/solvers/fdm2dblackscholessolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm2dblackscholessolver.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
     void Fdm2dBlackScholesSolver::performCalculations() const {
         
         boost::shared_ptr<Fdm2dBlackScholesOp> op(
-                new Fdm2dBlackScholesOp(solverDesc_.mesher,
+			boost::make_shared<Fdm2dBlackScholesOp>(solverDesc_.mesher,
                                         p1_.currentLink(), 
                                         p2_.currentLink(), 
                                         correlation_,
@@ -57,8 +57,7 @@ namespace QuantLib {
                                         localVol_,
                                         illegalLocalVolOverwrite_));
 
-        solver_ = boost::shared_ptr<Fdm2DimSolver>(
-                            new Fdm2DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm2DimSolver>(solverDesc_, schemeDesc_, op);
     }
 
     Real Fdm2dBlackScholesSolver::valueAt(Real u, Real v) const {

--- a/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
     : solverDesc_(solverDesc),
       schemeDesc_(schemeDesc),
       op_(op),
-      thetaCondition_(new FdmSnapshotCondition(
+      thetaCondition_(boost::make_shared<FdmSnapshotCondition>(
         0.99*std::min(1.0/365.0,
            solverDesc.condition->stoppingTimes().empty()
                     ? solverDesc.maturity
@@ -78,10 +78,9 @@ namespace QuantLib {
                       solverDesc_.timeSteps, solverDesc_.dampingSteps);
 
         std::copy(rhs.begin(), rhs.end(), resultValues_.begin());
-        interpolation_ = boost::shared_ptr<BicubicSpline> (
-            new BicubicSpline(x_.begin(), x_.end(),
+        interpolation_ = boost::make_shared<BicubicSpline>(x_.begin(), x_.end(),
                               y_.begin(), y_.end(),
-                              resultValues_));
+                              resultValues_);
     }
 
     Real Fdm2DimSolver::interpolateAt(Real x, Real y) const {

--- a/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
     : solverDesc_(solverDesc),
       schemeDesc_(schemeDesc),
       op_(op),
-      thetaCondition_(new FdmSnapshotCondition(
+      thetaCondition_(boost::make_shared<FdmSnapshotCondition>(
         0.99*std::min(1.0/365.0,
                 solverDesc.condition->stoppingTimes().empty()
                 ? solverDesc.maturity :
@@ -90,10 +90,9 @@ namespace QuantLib {
                       rhs.begin()+(i+1)*y_.size()*x_.size(),
                       resultValues_[i].begin());
 
-            interpolation_[i] = boost::shared_ptr<BicubicSpline> (
-                new BicubicSpline(x_.begin(), x_.end(),
+            interpolation_[i] = boost::make_shared<BicubicSpline>(x_.begin(), x_.end(),
                                   y_.begin(), y_.end(),
-                                  resultValues_[i]));
+                                  resultValues_[i]);
         }
     }
 

--- a/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
@@ -75,10 +75,9 @@ namespace QuantLib {
         const FdmSchemeDesc& schemeDesc)
     : map_(map), bcSet_(bcSet),
       condition_((condition) ? condition 
-                             : boost::shared_ptr<FdmStepConditionComposite>(
-                                 new FdmStepConditionComposite(
+                             : boost::make_shared<FdmStepConditionComposite>(
                                      std::list<std::vector<Time> >(),
-                                     FdmStepConditionComposite::Conditions()))),
+                                     FdmStepConditionComposite::Conditions())),
       schemeDesc_(schemeDesc) {
      }
         

--- a/ql/methods/finitedifferences/solvers/fdmblackscholessolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmblackscholessolver.cpp
@@ -44,12 +44,11 @@ namespace QuantLib {
     }
 
     void FdmBlackScholesSolver::performCalculations() const {
-        const boost::shared_ptr<FdmBlackScholesOp> op(new FdmBlackScholesOp(
+        const boost::shared_ptr<FdmBlackScholesOp> op(boost::make_shared<FdmBlackScholesOp>(
                 solverDesc_.mesher, process_.currentLink(), strike_,
                 localVol_, illegalLocalVolOverwrite_));
 
-        solver_ = boost::shared_ptr<Fdm1DimSolver>(
-            new Fdm1DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm1DimSolver>(solverDesc_, schemeDesc_, op);
     }
 
     Real FdmBlackScholesSolver::valueAt(Real s) const {

--- a/ql/methods/finitedifferences/solvers/fdmhestonhullwhitesolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmhestonhullwhitesolver.cpp
@@ -42,13 +42,12 @@ namespace QuantLib {
 
     void FdmHestonHullWhiteSolver::performCalculations() const {
         const boost::shared_ptr<FdmLinearOpComposite> op(
-            new FdmHestonHullWhiteOp(solverDesc_.mesher,
+			boost::make_shared<FdmHestonHullWhiteOp>(solverDesc_.mesher,
                                      hestonProcess_.currentLink(),
                                      hwProcess_.currentLink(), 
                                      corrEquityShortRate_));
 
-        solver_ = boost::shared_ptr<Fdm3DimSolver>(
-                                new Fdm3DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm3DimSolver>(solverDesc_, schemeDesc_, op);
     }
 
     Real FdmHestonHullWhiteSolver::valueAt(Real s, Real v, Rate r) const {

--- a/ql/methods/finitedifferences/solvers/fdmhestonsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmhestonsolver.cpp
@@ -45,14 +45,13 @@ namespace QuantLib {
 
     void FdmHestonSolver::performCalculations() const {
         boost::shared_ptr<FdmLinearOpComposite> op(
-            new FdmHestonOp(
+			boost::make_shared<FdmHestonOp>(
                 solverDesc_.mesher, process_.currentLink(),
                 (!quantoHelper_.empty()) ? quantoHelper_.currentLink()
                              : boost::shared_ptr<FdmQuantoHelper>(),
                 leverageFct_));
 
-        solver_ = boost::shared_ptr<Fdm2DimSolver>(
-                               new Fdm2DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm2DimSolver>(solverDesc_, schemeDesc_, op);
     }
 
     Real FdmHestonSolver::valueAt(Real s, Real v) const {

--- a/ql/methods/finitedifferences/solvers/fdmhullwhitesolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmhullwhitesolver.cpp
@@ -41,10 +41,9 @@ namespace QuantLib {
 
     void FdmHullWhiteSolver::performCalculations() const {
         const boost::shared_ptr<FdmHullWhiteOp> op(
-            new FdmHullWhiteOp(solverDesc_.mesher, model_.currentLink(), 0));
+			boost::make_shared<FdmHullWhiteOp>(solverDesc_.mesher, model_.currentLink(), 0));
 
-        solver_ = boost::shared_ptr<Fdm1DimSolver>(
-            new Fdm1DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm1DimSolver>(solverDesc_, schemeDesc_, op));
     }
 
     Real FdmHullWhiteSolver::valueAt(Real r) const {

--- a/ql/methods/finitedifferences/solvers/fdmsimple2dbssolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmsimple2dbssolver.cpp
@@ -41,11 +41,10 @@ namespace QuantLib {
     }
 
     void FdmSimple2dBSSolver::performCalculations() const {
-        boost::shared_ptr<FdmBlackScholesOp> op(new FdmBlackScholesOp(
+        boost::shared_ptr<FdmBlackScholesOp> op(boost::make_shared<FdmBlackScholesOp>(
                 solverDesc_.mesher, process_.currentLink(), strike_));
 
-        solver_ = boost::shared_ptr<Fdm2DimSolver>(
-                            new Fdm2DimSolver(solverDesc_, schemeDesc_, op));
+        solver_ = boost::make_shared<Fdm2DimSolver>(solverDesc_, schemeDesc_, op);
     }
 
     Real FdmSimple2dBSSolver::valueAt(Real s, Real a) const {

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -66,15 +66,15 @@ namespace QuantLib {
         }
 
         const boost::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(xGrid_, process_, maturity,
+			boost::make_shared<FdmBlackScholesMesher>(xGrid_, process_, maturity,
                                       payoff->strike(), xMin, xMax));
         
         const boost::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher));
+			boost::make_shared<FdmMesherComposite>(equityMesher));
 
         // 2. Calculator
         boost::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 0));
+			boost::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
 
         // 3. Step conditions
         std::list<boost::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -82,7 +82,7 @@ namespace QuantLib {
 
         // 3.1 Step condition if discrete dividends
         boost::shared_ptr<FdmDividendHandler> dividendCondition(
-            new FdmDividendHandler(arguments_.cashFlow, mesher,
+			boost::make_shared<FdmDividendHandler>(arguments_.cashFlow, mesher,
                                    process_->riskFreeRate()->referenceDate(),
                                    process_->riskFreeRate()->dayCounter(), 0));
 
@@ -95,23 +95,23 @@ namespace QuantLib {
                    "only european style option are supported");
 
         boost::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+			boost::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions));
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
         if (   arguments_.barrierType == Barrier::DownIn
             || arguments_.barrierType == Barrier::DownOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Lower)));
+            boundaries.push_back(
+				boost::make_shared<FdmDirichletBoundary>(mesher, arguments_.rebate, 0,
+                                         FdmDirichletBoundary::Lower));
 
         }
 
         if (   arguments_.barrierType == Barrier::UpIn
             || arguments_.barrierType == Barrier::UpOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Upper)));
+            boundaries.push_back(
+				boost::make_shared<FdmDirichletBoundary>(mesher, arguments_.rebate, 0,
+                                         FdmDirichletBoundary::Upper));
         }
 
         // 5. Solver
@@ -119,7 +119,7 @@ namespace QuantLib {
                                      maturity, tGrid_, dampingSteps_ };
 
         boost::shared_ptr<FdmBlackScholesSolver> solver(
-                new FdmBlackScholesSolver(
+			boost::make_shared<FdmBlackScholesSolver>(
                                Handle<GeneralizedBlackScholesProcess>(process_),
                                payoff->strike(), solverDesc, schemeDesc_,
                                localVol_, illegalLocalVolOverwrite_));
@@ -140,19 +140,19 @@ namespace QuantLib {
             // Calculate the vanilla option
             
             boost::shared_ptr<DividendVanillaOption> vanillaOption(
-                new DividendVanillaOption(payoff,arguments_.exercise,
+				boost::make_shared<DividendVanillaOption>(payoff,arguments_.exercise,
                                           dividendCondition->dividendDates(), 
                                           dividendCondition->dividends()));
             
-            vanillaOption->setPricingEngine(boost::shared_ptr<PricingEngine>(
-                new FdBlackScholesVanillaEngine(
+            vanillaOption->setPricingEngine(
+				boost::make_shared<FdBlackScholesVanillaEngine>(
                         process_, tGrid_, xGrid_,
                         0, // dampingSteps
-                        schemeDesc_, localVol_, illegalLocalVolOverwrite_)));
+                        schemeDesc_, localVol_, illegalLocalVolOverwrite_));
 
             // Calculate the rebate value
             boost::shared_ptr<DividendBarrierOption> rebateOption(
-                new DividendBarrierOption(arguments_.barrierType,
+				boost::make_shared<DividendBarrierOption>(arguments_.barrierType,
                                           arguments_.barrier,
                                           arguments_.rebate,
                                           payoff, arguments_.exercise,
@@ -163,11 +163,10 @@ namespace QuantLib {
             const Size rebateDampingSteps 
                 = (dampingSteps_ > 0) ? std::min(Size(1), dampingSteps_/2) : 0; 
 
-            rebateOption->setPricingEngine(boost::shared_ptr<PricingEngine>(
-                    new FdBlackScholesRebateEngine(
+            rebateOption->setPricingEngine(boost::make_shared<FdBlackScholesRebateEngine>(
                             process_, tGrid_, std::max(min_grid_size, xGrid_/5), 
                             rebateDampingSteps, schemeDesc_, localVol_, 
-                            illegalLocalVolOverwrite_)));
+                            illegalLocalVolOverwrite_));
 
             results_.value = vanillaOption->NPV()   + rebateOption->NPV()
                                                     - results_.value;

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
         // 1.1 The variance mesher
         const Size tGridMin = 5;
         const boost::shared_ptr<FdmHestonVarianceMesher> varianceMesher(
-            new FdmHestonVarianceMesher(vGrid_, process, maturity,
+			boost::make_shared<FdmHestonVarianceMesher>(vGrid_, process, maturity,
                                         std::max(tGridMin, tGrid_/50)));
 
         // 1.2 The equity mesher
@@ -75,7 +75,7 @@ namespace QuantLib {
         }
 
         const boost::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+			boost::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(), 
@@ -83,11 +83,11 @@ namespace QuantLib {
                 maturity, payoff->strike(), xMin, xMax));
         
         const boost::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, varianceMesher));
+			boost::make_shared<FdmMesherComposite>(equityMesher, varianceMesher));
 
         // 2. Calculator
         boost::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 0));
+			boost::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
 
         // 3. Step conditions
         std::list<boost::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -95,7 +95,7 @@ namespace QuantLib {
 
         // 3.1 Step condition if discrete dividends
         boost::shared_ptr<FdmDividendHandler> dividendCondition(
-            new FdmDividendHandler(arguments_.cashFlow, mesher,
+			boost::make_shared<FdmDividendHandler>(arguments_.cashFlow, mesher,
                                    process->riskFreeRate()->referenceDate(),
                                    process->riskFreeRate()->dayCounter(), 0));
 
@@ -108,22 +108,22 @@ namespace QuantLib {
                    "only european style option are supported");
 
         boost::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+			boost::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions));
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
         if (   arguments_.barrierType == Barrier::DownIn
             || arguments_.barrierType == Barrier::DownOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Lower)));
+            boundaries.push_back(
+				boost::make_shared<FdmDirichletBoundary>(mesher, arguments_.rebate, 0,
+                                         FdmDirichletBoundary::Lower));
 
         }
         if (   arguments_.barrierType == Barrier::UpIn
             || arguments_.barrierType == Barrier::UpOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Upper)));
+            boundaries.push_back(
+				boost::make_shared<FdmDirichletBoundary>(mesher, arguments_.rebate, 0,
+                                         FdmDirichletBoundary::Upper));
         }
 
         // 5. Solver
@@ -131,7 +131,7 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        boost::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        boost::shared_ptr<FdmHestonSolver> solver(boost::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
                     Handle<FdmQuantoHelper>(), leverageFct_));
 
@@ -150,16 +150,16 @@ namespace QuantLib {
                                                             arguments_.payoff);
             // Calculate the vanilla option
             boost::shared_ptr<DividendVanillaOption> vanillaOption(
-                new DividendVanillaOption(payoff,arguments_.exercise,
+				boost::make_shared<DividendVanillaOption>(payoff,arguments_.exercise,
                                           dividendCondition->dividendDates(), 
                                           dividendCondition->dividends()));
             vanillaOption->setPricingEngine(boost::shared_ptr<PricingEngine>(
-                    new FdHestonVanillaEngine(*model_, tGrid_, xGrid_, 
+				boost::make_shared<FdHestonVanillaEngine>(*model_, tGrid_, xGrid_,
                                               vGrid_, dampingSteps_,
                                               schemeDesc_)));
             // Calculate the rebate value
             boost::shared_ptr<DividendBarrierOption> rebateOption(
-                new DividendBarrierOption(arguments_.barrierType,
+				boost::make_shared<DividendBarrierOption>(arguments_.barrierType,
                                           arguments_.barrier,
                                           arguments_.rebate,
                                           payoff, arguments_.exercise,
@@ -169,12 +169,12 @@ namespace QuantLib {
             const Size vGridMin = 10;
             const Size rebateDampingSteps 
                 = (dampingSteps_ > 0) ? std::min(Size(1), dampingSteps_/2) : 0; 
-            rebateOption->setPricingEngine(boost::shared_ptr<PricingEngine>(
-                    new FdHestonRebateEngine(*model_, tGrid_, 
+            rebateOption->setPricingEngine(
+				boost::make_shared<FdHestonRebateEngine>(*model_, tGrid_,
                                              std::max(xGridMin, xGrid_/4), 
                                              std::max(vGridMin, vGrid_/4),
                                              rebateDampingSteps,
-                                             schemeDesc_)));
+                                             schemeDesc_));
 
             results_.value = vanillaOption->NPV()   + rebateOption->NPV()
                                                     - results_.value;

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -93,8 +93,7 @@ namespace {
         }
         // FLOATING_POINT_EXCEPTION
         Handle<YieldTermStructure> riskFreeTS(
-                           boost::shared_ptr<YieldTermStructure>(
-                                      new ZeroCurve(dates, rates, dayCounter)));
+			boost::make_shared<ZeroCurve>(dates, rates, dayCounter));
         
         Handle<YieldTermStructure> dividendYield(
                                     flatRate(settlementDate, 0.0, dayCounter));
@@ -114,7 +113,7 @@ namespace {
             0.3857,0.2860,0.2578,0.2399,0.2357,0.2327,0.2312,0.2351,
             0.3976,0.2860,0.2607,0.2356,0.2297,0.2268,0.2241,0.2320 };
         
-        Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(4468.17)));
+        Handle<Quote> s0(boost::make_shared<SimpleQuote>(4468.17));
         Real strike[] = { 3400,3600,3800,4000,4200,4400,
                           4500,4600,4800,5000,5200,5400,5600 };
         
@@ -122,15 +121,13 @@ namespace {
         
         for (Size s = 0; s < 13; ++s) {
             for (Size m = 0; m < 8; ++m) {
-                Handle<Quote> vol(boost::shared_ptr<Quote>(
-                                                    new SimpleQuote(v[s*8+m])));
+                Handle<Quote> vol(boost::make_shared<SimpleQuote>(v[s*8+m]));
         
                 Period maturity((int)((t[m]+3)/7.), Weeks); // round to weeks
-                options.push_back(boost::shared_ptr<CalibrationHelper>(
-                        new HestonModelHelper(maturity, calendar,
+                options.push_back(boost::make_shared<HestonModelHelper>(maturity, calendar,
                                               s0, strike[s], vol,
                                               riskFreeTS, dividendYield,
-                                          CalibrationHelper::ImpliedVolError)));
+                                          CalibrationHelper::ImpliedVolError));
             }
         }
         
@@ -172,8 +169,8 @@ void HestonModelTest::testBlackCalibration() {
     optionMaturities.push_back(Period(2, Years));
 
     std::vector<boost::shared_ptr<CalibrationHelper> > options;
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.0)));
-    Handle<Quote> vol(boost::shared_ptr<Quote>(new SimpleQuote(0.1)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.0));
+    Handle<Quote> vol(boost::make_shared<SimpleQuote>(0.1));
     Volatility volatility = vol->value();
 
     for (Size i = 0; i < optionMaturities.size(); ++i) {
@@ -188,10 +185,9 @@ void HestonModelTest::testBlackCalibration() {
         const Real strikePrice = fwdPrice * std::exp(-moneyness * volatility
                                                      * std::sqrt(tau));
 
-        options.push_back(boost::shared_ptr<CalibrationHelper>(
-                          new HestonModelHelper(optionMaturities[i], calendar,
+        options.push_back(boost::make_shared<HestonModelHelper>(optionMaturities[i], calendar,
                                                 s0, strikePrice, vol,
-                                                riskFreeTS, dividendTS)));
+                                                riskFreeTS, dividendTS));
         }
     }
 
@@ -202,12 +198,12 @@ void HestonModelTest::testBlackCalibration() {
         const Real rho=-0.75;
 
         boost::shared_ptr<HestonProcess> process(
-            new HestonProcess(riskFreeTS, dividendTS,
+			boost::make_shared<HestonProcess>(riskFreeTS, dividendTS,
                               s0, v0, kappa, theta, sigma, rho));
 
-        boost::shared_ptr<HestonModel> model(new HestonModel(process));
+        boost::shared_ptr<HestonModel> model(boost::make_shared<HestonModel>(process));
         boost::shared_ptr<PricingEngine> engine(
-                                         new AnalyticHestonEngine(model, 96));
+			boost::make_shared<AnalyticHestonEngine>(model, 96));
 
         for (Size i = 0; i < options.size(); ++i)
             options[i]->setPricingEngine(engine);
@@ -313,13 +309,14 @@ void HestonModelTest::testAnalyticVsBlack() {
     Date exerciseDate = settlementDate + 6*Months;
 
     boost::shared_ptr<StrikedTypePayoff> payoff(
-                                     new PlainVanillaPayoff(Option::Put, 30));
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+		boost::make_shared<PlainVanillaPayoff>(Option::Put, 30));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.1, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.04, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(32.0)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(32.0));
 
     const Real v0=0.05;
     const Real kappa=5.0;
@@ -327,13 +324,14 @@ void HestonModelTest::testAnalyticVsBlack() {
     const Real sigma=1.0e-4;
     const Real rho=0.0;
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(boost::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho));
 
     VanillaOption option(payoff, exercise);
     // FLOATING_POINT_EXCEPTION
-    boost::shared_ptr<PricingEngine> engine(new AnalyticHestonEngine(
-              boost::shared_ptr<HestonModel>(new HestonModel(process)), 144));
+    boost::shared_ptr<PricingEngine> engine(
+		boost::make_shared<AnalyticHestonEngine>(
+			boost::make_shared<HestonModel>(process), 144));
 
     option.setPricingEngine(engine);
     Real calculated = option.NPV();
@@ -352,9 +350,10 @@ void HestonModelTest::testAnalyticVsBlack() {
                    << "\n    error:      " << QL_SCIENTIFIC << error);
     }
 
-    engine = boost::shared_ptr<PricingEngine>(new FdHestonVanillaEngine(
-              boost::shared_ptr<HestonModel>(new HestonModel(process)),
-              200,200,100));
+    engine = 
+		boost::make_shared<FdHestonVanillaEngine>(
+			boost::make_shared<HestonModel>(process),
+              200,200,100);
     option.setPricingEngine(engine);
 
     calculated = option.NPV();
@@ -381,26 +380,28 @@ void HestonModelTest::testAnalyticVsCached() {
     Date exerciseDate(28, March, 2005);
 
     boost::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Call, 1.05));
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+		boost::make_shared<PlainVanillaPayoff>(Option::Call, 1.05));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.0225, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.02, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.0)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.0));
     const Real v0 = 0.1;
     const Real kappa = 3.16;
     const Real theta = 0.09;
     const Real sigma = 0.4;
     const Real rho = -0.2;
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(boost::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho));
 
     VanillaOption option(payoff, exercise);
 
-    boost::shared_ptr<AnalyticHestonEngine> engine(new AnalyticHestonEngine(
-               boost::shared_ptr<HestonModel>(new HestonModel(process)), 64));
+    boost::shared_ptr<AnalyticHestonEngine> engine(
+		boost::make_shared<AnalyticHestonEngine>(
+			boost::make_shared<HestonModel>(process), 64));
 
     option.setPricingEngine(engine);
 
@@ -427,23 +428,25 @@ void HestonModelTest::testAnalyticVsCached() {
         Date exerciseDate(8+i/3, September, 2005);
 
         boost::shared_ptr<StrikedTypePayoff> payoff(
-                                new PlainVanillaPayoff(Option::Call, K[i%3]));
+			boost::make_shared<PlainVanillaPayoff>(Option::Call, K[i%3]));
         boost::shared_ptr<Exercise> exercise(
-                                          new EuropeanExercise(exerciseDate));
+			boost::make_shared<EuropeanExercise>(exerciseDate));
 
         Handle<YieldTermStructure> riskFreeTS(flatRate(0.05, dayCounter));
         Handle<YieldTermStructure> dividendTS(flatRate(0.02, dayCounter));
 
         Real s = riskFreeTS->discount(0.7)/dividendTS->discount(0.7);
-        Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(s)));
+        Handle<Quote> s0(boost::make_shared<SimpleQuote>(s));
 
-        boost::shared_ptr<HestonProcess> process(new HestonProcess(
+        boost::shared_ptr<HestonProcess> process(
+			boost::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, 0.09, 1.2, 0.08, 1.8, -0.45));
 
         VanillaOption option(payoff, exercise);
 
-        boost::shared_ptr<PricingEngine> engine(new AnalyticHestonEngine(
-                   boost::shared_ptr<HestonModel>(new HestonModel(process))));
+        boost::shared_ptr<PricingEngine> engine(
+			boost::make_shared<AnalyticHestonEngine>(
+				boost::make_shared<HestonModel>(process)));
 
         option.setPricingEngine(engine);
         calculated2[i] = option.NPV();
@@ -479,15 +482,17 @@ void HestonModelTest::testMcVsCached() {
     Date exerciseDate(28, March, 2005);
 
     boost::shared_ptr<StrikedTypePayoff> payoff(
-                                   new PlainVanillaPayoff(Option::Put, 1.05));
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+		boost::make_shared<PlainVanillaPayoff>(Option::Put, 1.05));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.7, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.4, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.05)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.05));
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(
+		boost::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, 0.3, 1.16, 0.2, 0.8, 0.8,
                    HestonProcess::QuadraticExponentialMartingale));
 
@@ -529,23 +534,25 @@ void HestonModelTest::testFdBarrierVsCached() {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
     Handle<YieldTermStructure> rTS(flatRate(today, 0.08, dc));
     Handle<YieldTermStructure> qTS(flatRate(today, 0.04, dc));
 
     Date exDate = today + Integer(0.5*360+0.5);
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exDate));
 
-    boost::shared_ptr<StrikedTypePayoff> payoff(new
-            PlainVanillaPayoff(Option::Call, 90.0));
+    boost::shared_ptr<StrikedTypePayoff> payoff(
+		boost::make_shared<PlainVanillaPayoff>(Option::Call, 90.0));
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(
+		boost::make_shared<HestonProcess>(
             rTS, qTS, s0, 0.25*0.25, 1.0, 0.25*0.25, 0.001, 0.0));
 
     boost::shared_ptr<PricingEngine> engine;
-    engine = boost::shared_ptr<PricingEngine>(new FdHestonBarrierEngine(
-                    boost::shared_ptr<HestonModel>(new HestonModel(process)),
-                    200,400,100));
+    engine = boost::make_shared<FdHestonBarrierEngine>(
+				boost::make_shared<HestonModel>(process),
+                    200,400,100);
 
     BarrierOption option(Barrier::DownOut, 95.0, 3.0, payoff, exercise);
     option.setPricingEngine(engine);
@@ -586,23 +593,25 @@ void HestonModelTest::testFdVanillaVsCached() {
     Date exerciseDate(28, March, 2005);
 
     boost::shared_ptr<StrikedTypePayoff> payoff(
-                                   new PlainVanillaPayoff(Option::Put, 1.05));
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+		boost::make_shared<PlainVanillaPayoff>(Option::Put, 1.05));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.7, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.4, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.05)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.05));
 
     VanillaOption option(payoff, exercise);
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(
+		boost::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, 0.3, 1.16, 0.2, 0.8, 0.8));
 
     boost::shared_ptr<PricingEngine> engine;
-    engine = boost::shared_ptr<PricingEngine>(new FdHestonVanillaEngine(
-                    boost::shared_ptr<HestonModel>(new HestonModel(process)),
-                    100,200,100));
+    engine = boost::make_shared<FdHestonVanillaEngine>(
+				boost::make_shared<HestonModel>(process),
+                    100,200,100);
     option.setPricingEngine(engine);
 
     Real expected = 0.06325;
@@ -619,15 +628,14 @@ void HestonModelTest::testFdVanillaVsCached() {
 
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for discrete dividends...");
 
-    payoff = boost::shared_ptr<StrikedTypePayoff>(
-                          new PlainVanillaPayoff(Option::Call, 95.0));
-    s0 = Handle<Quote>(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    payoff = boost::make_shared<PlainVanillaPayoff>(Option::Call, 95.0);
+    s0 = Handle<Quote>(boost::make_shared<SimpleQuote>(100.0));
 
     riskFreeTS = Handle<YieldTermStructure>(flatRate(0.05, dayCounter));
     dividendTS = Handle<YieldTermStructure>(flatRate(0.0, dayCounter));
 
     exerciseDate = Date(28, March, 2006);
-    exercise = boost::shared_ptr<Exercise>(new EuropeanExercise(exerciseDate));
+    exercise = boost::make_shared<EuropeanExercise>(exerciseDate);
 
     std::vector<Date> dividendDates;
     std::vector<Real> dividends;
@@ -640,11 +648,11 @@ void HestonModelTest::testFdVanillaVsCached() {
 
     DividendVanillaOption divOption(payoff, exercise,
                                     dividendDates, dividends);
-    process = boost::shared_ptr<HestonProcess>(new HestonProcess(
-                   riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0));
-    engine = boost::shared_ptr<PricingEngine>(new FdHestonVanillaEngine(
-                    boost::shared_ptr<HestonModel>(new HestonModel(process)),
-                    200,400,100));
+    process = boost::make_shared<HestonProcess>(
+                   riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0);
+    engine = boost::make_shared<FdHestonVanillaEngine>(
+				boost::make_shared<HestonModel>(process),
+                    200,400,100);
     divOption.setPricingEngine(engine);
     calculated = divOption.NPV();
     // Value calculated with an independent FD framework, validated with
@@ -663,15 +671,14 @@ void HestonModelTest::testFdVanillaVsCached() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for american exercise...");
 
     dividendTS = Handle<YieldTermStructure>(flatRate(0.03, dayCounter));
-    process = boost::shared_ptr<HestonProcess>(new HestonProcess(
-                   riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0));
-    engine = boost::shared_ptr<PricingEngine>(new FdHestonVanillaEngine(
-                    boost::shared_ptr<HestonModel>(new HestonModel(process)),
-                    200,400,100));
-    payoff = boost::shared_ptr<StrikedTypePayoff>(
-                          new PlainVanillaPayoff(Option::Put, 95.0));
-    exercise = boost::shared_ptr<Exercise>(new AmericanExercise(
-            settlementDate, exerciseDate));
+    process = boost::make_shared<HestonProcess>(
+                   riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0);
+    engine = boost::make_shared<FdHestonVanillaEngine>(
+				boost::make_shared<HestonModel>(process),
+                    200,400,100);
+    payoff = boost::make_shared<PlainVanillaPayoff>(Option::Put, 95.0);
+    exercise = boost::make_shared<AmericanExercise>(
+            settlementDate, exerciseDate);
     option = VanillaOption(payoff, exercise);
     option.setPricingEngine(engine);
     calculated = option.NPV();
@@ -679,9 +686,9 @@ void HestonModelTest::testFdVanillaVsCached() {
     Handle<BlackVolTermStructure> volTS(flatVol(settlementDate, 0.2,
                                                   dayCounter));
     boost::shared_ptr<BlackScholesMertonProcess> ref_process(
-        new BlackScholesMertonProcess(s0, dividendTS, riskFreeTS, volTS));
+		boost::make_shared<BlackScholesMertonProcess>(s0, dividendTS, riskFreeTS, volTS));
     boost::shared_ptr<PricingEngine> ref_engine(
-                  new FDAmericanEngine<CrankNicolson>(ref_process, 200, 400));
+		boost::make_shared<FDAmericanEngine<CrankNicolson> >(ref_process, 200, 400));
     option.setPricingEngine(ref_engine);
     expected = option.NPV();
 
@@ -723,9 +730,9 @@ void HestonModelTest::testKahlJaeckelCase() {
     Date exerciseDate(30, March, 2017);
 
     const boost::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(Option::Call, 200));
+		boost::make_shared<PlainVanillaPayoff>(Option::Call, 200));
     const boost::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(exerciseDate));
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     VanillaOption option(payoff, exercise);
 
@@ -733,7 +740,7 @@ void HestonModelTest::testKahlJaeckelCase() {
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.0, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.0, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(100));
 
     const Real v0    = 0.16;
     const Real theta = v0;
@@ -754,7 +761,7 @@ void HestonModelTest::testKahlJaeckelCase() {
 
     for (Size i=0; i < LENGTH(descriptions); ++i) {
         const boost::shared_ptr<HestonProcess> process(
-            new HestonProcess(riskFreeTS, dividendTS, s0, v0,
+			boost::make_shared<HestonProcess>(riskFreeTS, dividendTS, s0, v0,
                               kappa, theta, sigma, rho,
                               descriptions[i].discretization));
 
@@ -787,10 +794,9 @@ void HestonModelTest::testKahlJaeckelCase() {
 
     option.setPricingEngine(
         MakeMCEuropeanHestonEngine<LowDiscrepancy>(
-            boost::shared_ptr<HestonProcess>(
-                new HestonProcess(
+			boost::make_shared<HestonProcess>(
                     riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho,
-                    HestonProcess::BroadieKayaExactSchemeLaguerre)))
+                    HestonProcess::BroadieKayaExactSchemeLaguerre))
         .withSteps(1)
         .withSamples(1023));
 
@@ -805,13 +811,13 @@ void HestonModelTest::testKahlJaeckelCase() {
 
 
     const boost::shared_ptr<HestonModel> hestonModel(
-         new HestonModel(
-             boost::shared_ptr<HestonProcess>(new HestonProcess(
+		boost::make_shared<HestonModel>(
+			boost::make_shared<HestonProcess>(
                 riskFreeTS, dividendTS, s0, v0,
-                kappa, theta, sigma, rho))));
+                kappa, theta, sigma, rho)));
 
-    option.setPricingEngine(boost::shared_ptr<PricingEngine>(
-        new FdHestonVanillaEngine(hestonModel, 200, 400, 100)));
+    option.setPricingEngine(
+		boost::make_shared<FdHestonVanillaEngine>(hestonModel, 200, 400, 100));
 
     calculated = option.NPV();
     Real error = std::fabs(calculated - expected);
@@ -823,8 +829,7 @@ void HestonModelTest::testKahlJaeckelCase() {
     }
 
     option.setPricingEngine(
-        boost::shared_ptr<AnalyticHestonEngine>(
-            new AnalyticHestonEngine(hestonModel, 1e-6, 1000)));
+		boost::make_shared<AnalyticHestonEngine>(hestonModel, 1e-6, 1000));
 
     calculated = option.NPV();
     error = std::fabs(calculated - expected);
@@ -892,29 +897,31 @@ void HestonModelTest::testDifferentIntegrals() {
     for (std::vector<HestonParameter>::const_iterator iter = params.begin();
          iter != params.end(); ++iter) {
 
-        Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.0)));
-        boost::shared_ptr<HestonProcess> process(new HestonProcess(
+        Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.0));
+        boost::shared_ptr<HestonProcess> process(
+			boost::make_shared<HestonProcess>(
             riskFreeTS, dividendTS,
             s0, iter->v0, iter->kappa,
             iter->theta, iter->sigma, iter->rho));
 
-        boost::shared_ptr<HestonModel> model(new HestonModel(process));
+        boost::shared_ptr<HestonModel> model(
+			boost::make_shared<HestonModel>(process));
 
         boost::shared_ptr<AnalyticHestonEngine> lobattoEngine(
-                              new AnalyticHestonEngine(model, 1e-10,
+			boost::make_shared<AnalyticHestonEngine>(model, 1e-10,
                                                        1000000));
         boost::shared_ptr<AnalyticHestonEngine> laguerreEngine(
-                                        new AnalyticHestonEngine(model, 128));
+			boost::make_shared<AnalyticHestonEngine>(model, 128));
         boost::shared_ptr<AnalyticHestonEngine> legendreEngine(
-            new AnalyticHestonEngine(
+			boost::make_shared<AnalyticHestonEngine>(
                 model, AnalyticHestonEngine::Gatheral,
                 AnalyticHestonEngine::Integration::gaussLegendre(512)));
         boost::shared_ptr<AnalyticHestonEngine> chebyshevEngine(
-            new AnalyticHestonEngine(
+			boost::make_shared<AnalyticHestonEngine>(
                 model, AnalyticHestonEngine::Gatheral,
                 AnalyticHestonEngine::Integration::gaussChebyshev(512)));
         boost::shared_ptr<AnalyticHestonEngine> chebyshev2ndEngine(
-            new AnalyticHestonEngine(
+			boost::make_shared<AnalyticHestonEngine>(
                 model, AnalyticHestonEngine::Gatheral,
                 AnalyticHestonEngine::Integration::gaussChebyshev2nd(512)));
 
@@ -925,14 +932,14 @@ void HestonModelTest::testDifferentIntegrals() {
 
         for (Size i=0; i < LENGTH(maturities); ++i) {
             boost::shared_ptr<Exercise> exercise(
-                new EuropeanExercise(settlementDate
+				boost::make_shared<EuropeanExercise>(settlementDate
                                      + Period(maturities[i], Months)));
 
             for (Size j=0; j < LENGTH(strikes); ++j) {
                 for (Size k=0; k < LENGTH(types); ++k) {
 
                     boost::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(types[k], strikes[j]));
+						boost::make_shared<PlainVanillaPayoff>(types[k], strikes[j]));
 
                     VanillaOption option(payoff, exercise);
 
@@ -992,31 +999,34 @@ void HestonModelTest::testMultipleStrikesEngine() {
     DayCounter dayCounter = ActualActual();
     Date exerciseDate(28, March, 2006);
 
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.06, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.02, dayCounter));
 
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.05)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.05));
 
-    boost::shared_ptr<HestonProcess> process(new HestonProcess(
+    boost::shared_ptr<HestonProcess> process(
+		boost::make_shared<HestonProcess>(
                      riskFreeTS, dividendTS, s0, 0.16, 2.5, 0.09, 0.8, -0.8));
-    boost::shared_ptr<HestonModel> model(new HestonModel(process));
+    boost::shared_ptr<HestonModel> model(
+		boost::make_shared<HestonModel>(process));
 
     std::vector<Real> strikes;
     strikes.push_back(1.0);  strikes.push_back(0.5);
     strikes.push_back(0.75); strikes.push_back(1.5); strikes.push_back(2.0);
 
     boost::shared_ptr<FdHestonVanillaEngine> singleStrikeEngine(
-                             new FdHestonVanillaEngine(model, 20, 400, 50));
+		boost::make_shared<FdHestonVanillaEngine>(model, 20, 400, 50));
     boost::shared_ptr<FdHestonVanillaEngine> multiStrikeEngine(
-                             new FdHestonVanillaEngine(model, 20, 400, 50));
+		boost::make_shared<FdHestonVanillaEngine>(model, 20, 400, 50));
     multiStrikeEngine->enableMultipleStrikesCaching(strikes);
 
     Real relTol = 5e-3;
     for (Size i=0; i < strikes.size(); ++i) {
         boost::shared_ptr<StrikedTypePayoff> payoff(
-                           new PlainVanillaPayoff(Option::Put, strikes[i]));
+			boost::make_shared<PlainVanillaPayoff>(Option::Put, strikes[i]));
 
         VanillaOption aOption(payoff, exercise);
         aOption.setPricingEngine(multiStrikeEngine);
@@ -1072,26 +1082,25 @@ void HestonModelTest::testAnalyticPiecewiseTimeDependent() {
     Date exerciseDate(28, March, 2005);
 
     boost::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Call, 1.0));
-    boost::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+		boost::make_shared<PlainVanillaPayoff>(Option::Call, 1.0));
+    boost::shared_ptr<Exercise> exercise(
+		boost::make_shared<EuropeanExercise>(exerciseDate));
 
     std::vector<Date> dates; 
     dates.push_back(settlementDate); dates.push_back(Date(01, January, 2007));
     std::vector<Rate> irates;
     irates.push_back(0.0); irates.push_back(0.2);
     Handle<YieldTermStructure> riskFreeTS(
-            boost::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, irates, dayCounter)));
+		boost::make_shared<ZeroCurve>(dates, irates, dayCounter));
 
     std::vector<Rate> qrates;
     qrates.push_back(0.0); qrates.push_back(0.3);
     Handle<YieldTermStructure> dividendTS(
-            boost::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, qrates, dayCounter)));
+		boost::make_shared<ZeroCurve>(dates, qrates, dayCounter));
     
 
     const Real v0 = 0.1;
-    Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(1.0)));
+    Handle<Quote> s0(boost::make_shared<SimpleQuote>(1.0));
 
     ConstantParameter theta(0.09, PositiveConstraint());
     ConstantParameter kappa(3.16, PositiveConstraint());
@@ -1099,21 +1108,19 @@ void HestonModelTest::testAnalyticPiecewiseTimeDependent() {
     ConstantParameter rho  (-0.8, BoundaryConstraint(-1.0, 1.0));
 
     boost::shared_ptr<PiecewiseTimeDependentHestonModel> model(
-        new PiecewiseTimeDependentHestonModel(riskFreeTS, dividendTS,
+		boost::make_shared<PiecewiseTimeDependentHestonModel>(riskFreeTS, dividendTS,
                                               s0, v0, theta, kappa, 
                                               sigma, rho, TimeGrid(20.0, 2)));
     
     VanillaOption option(payoff, exercise);
-    option.setPricingEngine(boost::shared_ptr<PricingEngine>(
-                                           new AnalyticPTDHestonEngine(model)));
+    option.setPricingEngine(boost::make_shared<AnalyticPTDHestonEngine>(model));
 
     const Real calculated = option.NPV();
     boost::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(riskFreeTS, dividendTS, s0, v0,
+		boost::make_shared<HestonProcess>(riskFreeTS, dividendTS, s0, v0,
                           kappa(0.0), theta(0.0), sigma(0.0), rho(0.0)));
-    boost::shared_ptr<HestonModel> hestonModel(new HestonModel(hestonProcess));
-    option.setPricingEngine(boost::shared_ptr<PricingEngine>(
-                                    new AnalyticHestonEngine(hestonModel)));
+    boost::shared_ptr<HestonModel> hestonModel(boost::make_shared<HestonModel>(hestonProcess));
+    option.setPricingEngine(boost::make_shared<AnalyticHestonEngine>(hestonModel));
     
     const Real expected = option.NPV();
     
@@ -1160,11 +1167,12 @@ void HestonModelTest::testDAXCalibrationOfTimeDependentModel() {
     }
 
     boost::shared_ptr<PiecewiseTimeDependentHestonModel> model(
-        new PiecewiseTimeDependentHestonModel(riskFreeTS, dividendTS,
+		boost::make_shared<PiecewiseTimeDependentHestonModel>(riskFreeTS, dividendTS,
                                               s0, v0, theta, kappa, 
                                               sigma, rho, modelGrid));
     
-    boost::shared_ptr<PricingEngine> engine(new AnalyticPTDHestonEngine(model));
+    boost::shared_ptr<PricingEngine> engine(
+		boost::make_shared<AnalyticPTDHestonEngine>(model));
     for (Size i = 0; i < options.size(); ++i)
         options[i]->setPricingEngine(engine);
 
@@ -1200,13 +1208,13 @@ void HestonModelTest::testAlanLewisReferencePrices() {
 
     const Date maturityDate(5, July, 2003);
     const boost::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(maturityDate));
+		boost::make_shared<EuropeanExercise>(maturityDate));
 
     const DayCounter dayCounter = Actual365Fixed();
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.01, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.02, dayCounter));
 
-    const Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.04;
     const Real rho   = -0.5;
@@ -1214,18 +1222,20 @@ void HestonModelTest::testAlanLewisReferencePrices() {
     const Real kappa =  4.0;
     const Real theta =  0.25;
 
-    const boost::shared_ptr<HestonProcess> process(new HestonProcess(
-        riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho));
-    const boost::shared_ptr<HestonModel> model(new HestonModel(process));
+    const boost::shared_ptr<HestonProcess> process(
+		boost::make_shared<HestonProcess>(
+			riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho));
+    const boost::shared_ptr<HestonModel> model(
+		boost::make_shared<HestonModel>(process));
 
     const boost::shared_ptr<PricingEngine> laguerreEngine(
-        new AnalyticHestonEngine(model, 128u));
+		boost::make_shared<AnalyticHestonEngine>(model, 128u));
 
     const boost::shared_ptr<PricingEngine> gaussLobattoEngine(
-        new AnalyticHestonEngine(model, QL_EPSILON, 100000u));
+		boost::make_shared<AnalyticHestonEngine>(model, QL_EPSILON, 100000u));
 
     const boost::shared_ptr<PricingEngine> cosEngine(
-        new COSHestonEngine(model, 20, 400));
+		boost::make_shared<COSHestonEngine>(model, 20, 400));
 
     const Real strikes[] = { 80, 90, 100, 110, 120 };
     const Option::Type types[] = { Option::Put, Option::Call };
@@ -1258,7 +1268,7 @@ void HestonModelTest::testAlanLewisReferencePrices() {
                 const boost::shared_ptr<PricingEngine> engine = engines[k];
 
                 const boost::shared_ptr<StrikedTypePayoff> payoff(
-                    new PlainVanillaPayoff(type, strike));
+					boost::make_shared<PlainVanillaPayoff>(type, strike));
 
                 VanillaOption option(payoff, exercise);
                 option.setPricingEngine(engine);
@@ -1292,7 +1302,7 @@ void HestonModelTest::testAnalyticPDFHestonEngine() {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.07, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.185, dayCounter));
 
-    const Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   = -0.5;
@@ -1301,26 +1311,26 @@ void HestonModelTest::testAnalyticPDFHestonEngine() {
     const Real theta =  0.05;
 
     const boost::shared_ptr<HestonModel> model(
-        new HestonModel(boost::shared_ptr<HestonProcess>(
-            new HestonProcess(riskFreeTS, dividendTS,
-                              s0, v0, kappa, theta, sigma, rho))));
+        boost::make_shared<HestonModel>(
+			boost::make_shared<HestonProcess>(riskFreeTS, dividendTS,
+                              s0, v0, kappa, theta, sigma, rho)));
 
     const Real tol = 1e-6;
     const boost::shared_ptr<AnalyticPDFHestonEngine> pdfEngine(
-        new AnalyticPDFHestonEngine(model, tol));
+		boost::make_shared<AnalyticPDFHestonEngine>(model, tol));
 
     const boost::shared_ptr<PricingEngine> analyticEngine(
-        new AnalyticHestonEngine(model, 192));
+		boost::make_shared<AnalyticHestonEngine>(model, 192));
 
     const Date maturityDate(5, July, 2014);
     const Time maturity = dayCounter.yearFraction(settlementDate, maturityDate);
     const boost::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(maturityDate));
+		boost::make_shared<EuropeanExercise>(maturityDate));
 
     // 1. check a plain vanilla call option
     for (Real strike=40; strike < 190; strike+=20) {
         const boost::shared_ptr<StrikedTypePayoff> vanillaPayoff(
-            new PlainVanillaPayoff(Option::Call, strike));
+			boost::make_shared<PlainVanillaPayoff>(Option::Call, strike));
 
         VanillaOption planVanillaOption(vanillaPayoff, exercise);
 
@@ -1345,22 +1355,19 @@ void HestonModelTest::testAnalyticPDFHestonEngine() {
     // 2. digital call option (approx. with a call spread)
     for (Real strike=40; strike < 190; strike+=10) {
         VanillaOption digitalOption(
-            boost::shared_ptr<StrikedTypePayoff>(
-                new CashOrNothingPayoff(Option::Call, strike, 1.0)),
+			boost::make_shared<CashOrNothingPayoff>(Option::Call, strike, 1.0),
             exercise);
         digitalOption.setPricingEngine(pdfEngine);
         const Real calculated = digitalOption.NPV();
 
         const Real eps = 0.01;
         VanillaOption longCall(
-            boost::shared_ptr<StrikedTypePayoff>(
-                new PlainVanillaPayoff(Option::Call, strike-eps)),
+			boost::make_shared<PlainVanillaPayoff>(Option::Call, strike-eps),
             exercise);
         longCall.setPricingEngine(analyticEngine);
 
         VanillaOption shortCall(
-            boost::shared_ptr<StrikedTypePayoff>(
-                new PlainVanillaPayoff(Option::Call, strike+eps)),
+			boost::make_shared<PlainVanillaPayoff>(Option::Call, strike+eps),
             exercise);
         shortCall.setPricingEngine(analyticEngine);
 
@@ -1604,7 +1611,7 @@ void HestonModelTest::testAllIntegrationMethods() {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.05, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.075, dayCounter));
 
-    const Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   = -0.75;
@@ -1771,7 +1778,7 @@ void HestonModelTest::testCosHestonCumulants() {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.15, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.075, dayCounter));
 
-    const Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   = -0.75;
@@ -1864,7 +1871,7 @@ void HestonModelTest::testCosHestonEngine() {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.15, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.07, dayCounter));
 
-    const Handle<Quote> s0(boost::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(boost::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   = -0.75;

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -187,49 +187,49 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation() {
     const Size xGrid = 2*100+1;
     const Size tGrid = 400;
 
-    const Handle<Quote> spot(boost::shared_ptr<Quote>(new SimpleQuote(s0)));
+    const Handle<Quote> spot(boost::make_shared<SimpleQuote>(s0));
     const Handle<YieldTermStructure> qTS(flatRate(q, dc));
     const Handle<YieldTermStructure> rTS(flatRate(r, dc));
     const Handle<BlackVolTermStructure> vTS(flatVol(v, dc));
 
     const boost::shared_ptr<GeneralizedBlackScholesProcess> process(
-        new GeneralizedBlackScholesProcess(spot, qTS, rTS, vTS));
+		boost::make_shared<GeneralizedBlackScholesProcess>(spot, qTS, rTS, vTS));
 
     const boost::shared_ptr<PricingEngine> engine(
-        new AnalyticEuropeanEngine(process));
+		boost::make_shared<AnalyticEuropeanEngine>(process));
 
     const boost::shared_ptr<FdmMesher> uniformMesher(
-        new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-            new FdmBlackScholesMesher(xGrid, process, maturity, s0))));
+		boost::make_shared<FdmMesherComposite>(
+			boost::make_shared<FdmBlackScholesMesher>(xGrid, process, maturity, s0)));
 
     const boost::shared_ptr<FdmLinearOpComposite> uniformBSFwdOp(
-        new FdmBlackScholesFwdOp(uniformMesher, process, s0, 0));
+		boost::make_shared<FdmBlackScholesFwdOp>(uniformMesher, process, s0, 0));
 
     const boost::shared_ptr<FdmMesher> concentratedMesher(
-        new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-            new FdmBlackScholesMesher(xGrid, process, maturity, s0,
+		boost::make_shared<FdmMesherComposite>(
+			boost::make_shared<FdmBlackScholesMesher>(xGrid, process, maturity, s0,
                                       Null<Real>(), Null<Real>(), 0.0001, 1.5,
-                                      std::pair<Real, Real>(s0, 0.1)))));
+                                      std::pair<Real, Real>(s0, 0.1))));
 
     const boost::shared_ptr<FdmLinearOpComposite> concentratedBSFwdOp(
-        new FdmBlackScholesFwdOp(concentratedMesher, process, s0, 0));
+		boost::make_shared<FdmBlackScholesFwdOp>(concentratedMesher, process, s0, 0));
 
     const boost::shared_ptr<FdmMesher> shiftedMesher(
-        new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-            new FdmBlackScholesMesher(xGrid, process, maturity, s0,
+		boost::make_shared<FdmMesherComposite>(
+			boost::make_shared<FdmBlackScholesMesher>(xGrid, process, maturity, s0,
                                       Null<Real>(), Null<Real>(), 0.0001, 1.5,
-                                      std::pair<Real, Real>(s0*1.1, 0.2)))));
+                                      std::pair<Real, Real>(s0*1.1, 0.2))));
 
     const boost::shared_ptr<FdmLinearOpComposite> shiftedBSFwdOp(
-        new FdmBlackScholesFwdOp(shiftedMesher, process, s0, 0));
+		boost::make_shared<FdmBlackScholesFwdOp>(shiftedMesher, process, s0, 0));
 
     const boost::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(maturityDate));
+		boost::make_shared<EuropeanExercise>(maturityDate));
     const Real strikes[] = { 50, 80, 100, 130, 150 };
 
     for (Size i=0; i < LENGTH(strikes); ++i) {
         const boost::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(Option::Call, strikes[i]));
+			boost::make_shared<PlainVanillaPayoff>(Option::Call, strikes[i]));
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -373,8 +373,8 @@ namespace {
         }
 
         return boost::shared_ptr<FdmMesher>(
-            new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-                new Predefined1dMesher(v))));
+			boost::make_shared<FdmMesherComposite>(
+				boost::make_shared<Predefined1dMesher>(v)));
     }
 }
 
@@ -430,7 +430,7 @@ namespace {
       public:
         q_fct(const Array& v, const Array& p, const Real alpha)
         : v_(v), q_(Pow(v, alpha)*p), alpha_(alpha),
-          spline_(new CubicNaturalSpline(v_.begin(), v_.end(), q_.begin())) {
+          spline_(boost::make_shared<CubicNaturalSpline>(v_.begin(), v_.end(), q_.begin())) {
         }
 
         Real operator()(Real v) const {
@@ -464,8 +464,8 @@ void HestonSLVModelTest::testSquareRootEvolveWithStationaryDensity() {
         const Real vMax = rnd.stationary_invcdf(1-eps);
 
         const boost::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-                    new Uniform1dMesher(vMin, vMax, vGrid))));
+			boost::make_shared<FdmMesherComposite>(
+				boost::make_shared<Uniform1dMesher>(vMin, vMax, vGrid)));
 
         const Array v = mesher->locations(0);
         const FdmSquareRootFwdOp::TransformationType transform =
@@ -487,7 +487,7 @@ void HestonSLVModelTest::testSquareRootEvolveWithStationaryDensity() {
         }
 
         const boost::shared_ptr<FdmSquareRootFwdOp> op(
-            new FdmSquareRootFwdOp(mesher, kappa, theta,
+			boost::make_shared<FdmSquareRootFwdOp>(mesher, kappa, theta,
                                    sigma, 0, transform));
 
         const Array eP = p;
@@ -550,8 +550,8 @@ void HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity() {
         const Real vMax = rnd.stationary_invcdf(1-eps);
 
         const boost::shared_ptr<FdmMesherComposite> mesher(
-            new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-                new Uniform1dMesher(log(vMin), log(vMax), vGrid))));
+			boost::make_shared<FdmMesherComposite>(
+				boost::make_shared<Uniform1dMesher>(log(vMin), log(vMax), vGrid)));
 
         const Array v = mesher->locations(0);
 
@@ -560,7 +560,7 @@ void HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity() {
             p[i] =  stationaryLogProbabilityFct(kappa, theta, sigma, v[i]);
 
         const boost::shared_ptr<FdmSquareRootFwdOp> op(
-            new FdmSquareRootFwdOp(mesher, kappa, theta,
+			boost::make_shared<FdmSquareRootFwdOp>(mesher, kappa, theta,
                                    sigma, 0,
                                    FdmSquareRootFwdOp::Log));
 
@@ -610,13 +610,13 @@ void HestonSLVModelTest::testSquareRootFokkerPlanckFwdEquation() {
     const Real lowerBound = std::max(0.0002, theta-6*vol);
 
     const boost::shared_ptr<FdmMesher> mesher(
-        new FdmMesherComposite(boost::shared_ptr<Fdm1dMesher>(
-                new Uniform1dMesher(lowerBound, upperBound, xGrid))));
+		boost::make_shared<FdmMesherComposite>(
+			boost::make_shared<Uniform1dMesher>(lowerBound, upperBound, xGrid)));
 
     const Array x(mesher->locations(0));
 
     const boost::shared_ptr<FdmSquareRootFwdOp> op(
-        new FdmSquareRootFwdOp(mesher, kappa, theta, sigma, 0)); //!
+		boost::make_shared<FdmSquareRootFwdOp>(mesher, kappa, theta, sigma, 0)); //!
 
     const Time dt = maturity/tGrid;
     const Size n = 5;
@@ -734,17 +734,17 @@ namespace {
         const Real v0    = testCase.v0;
         const Real alpha = 1.0 - 2*kappa*theta/(sigma*sigma);
 
-        const Handle<Quote> spot(boost::shared_ptr<Quote>(new SimpleQuote(s0)));
+        const Handle<Quote> spot(boost::make_shared<SimpleQuote>(s0));
         const Handle<YieldTermStructure> rTS(flatRate(r, dc));
         const Handle<YieldTermStructure> qTS(flatRate(q, dc));
 
         const boost::shared_ptr<HestonProcess> process(
-            new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+			boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
-        const boost::shared_ptr<HestonModel> model(new HestonModel(process));
+        const boost::shared_ptr<HestonModel> model(boost::make_shared<HestonModel>(process));
 
         const boost::shared_ptr<PricingEngine> engine(
-            new AnalyticHestonEngine(model));
+			boost::make_shared<AnalyticHestonEngine>(model));
 
         const Size xGrid = testCase.xGrid;
         const Size vGrid = testCase.vGrid;
@@ -800,7 +800,7 @@ namespace {
         }
 
         const boost::shared_ptr<Fdm1dMesher> varianceMesher(
-            new Concentrating1dMesher(lowerBound, upperBound,
+			boost::make_shared<Concentrating1dMesher>(lowerBound, upperBound,
                                       vGrid, cPoints, 1e-12));
 
         const Real sEps = 1e-4;
@@ -810,14 +810,14 @@ namespace {
             = std::log(hestonPxBoundary(maturity, 1-sEps,model));
 
         const boost::shared_ptr<Fdm1dMesher> spotMesher(
-            new Concentrating1dMesher(sLowerBound, sUpperBound, xGrid,
+			boost::make_shared<Concentrating1dMesher>(sLowerBound, sUpperBound, xGrid,
                 std::make_pair(x0, 0.1), true));
 
         const boost::shared_ptr<FdmMesherComposite>
-            mesher(new FdmMesherComposite(spotMesher, varianceMesher));
+            mesher(boost::make_shared<FdmMesherComposite>(spotMesher, varianceMesher));
 
         const boost::shared_ptr<FdmLinearOpComposite> hestonFwdOp(
-            new FdmHestonFwdOp(mesher, process, transformationType));
+			boost::make_shared<FdmHestonFwdOp>(mesher, process, transformationType));
 
         ModifiedCraigSneydScheme evolver(
             FdmSchemeDesc::ModifiedCraigSneyd().theta,
@@ -851,7 +851,7 @@ namespace {
             for (Size i=0; i < LENGTH(strikes); ++i) {
                 const Real strike = strikes[i];
                 const boost::shared_ptr<StrikedTypePayoff> payoff(
-                    new PlainVanillaPayoff((strike > s0) ? Option::Call :
+					boost::make_shared<PlainVanillaPayoff>((strike > s0) ? Option::Call :
                                                            Option::Put, strike));
 
                 Array pd(p.size());
@@ -871,7 +871,7 @@ namespace {
                     * rTS->discount(nextMaturityDate);
 
                 const boost::shared_ptr<Exercise> exercise(
-                    new EuropeanExercise(nextMaturityDate));
+					boost::make_shared<EuropeanExercise>(nextMaturityDate));
 
                 VanillaOption option(payoff, exercise);
                 option.setPricingEngine(engine);
@@ -997,7 +997,7 @@ namespace {
         }
 
         boost::shared_ptr<Matrix> surface(
-            new Matrix(strikes.size(), dates.size()));
+			boost::make_shared<Matrix>(strikes.size(), dates.size()));
 
         for (Size i=0; i < strikes.size(); ++i) {
             for (Size j=0; j < dates.size(); ++j) {
@@ -1059,7 +1059,7 @@ namespace {
             }
 
         const boost::shared_ptr<BlackVarianceSurface> volTS(
-            new BlackVarianceSurface(todaysDate, cal,
+			boost::make_shared<BlackVarianceSurface>(todaysDate, cal,
                                      dates,
                                      surfaceStrikes, blackVolMatrix,
                                      dc,
@@ -1101,12 +1101,12 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     const DayCounter dayCounter = Actual365Fixed();
     const Calendar calendar = TARGET();
 
-    const Handle<Quote> spot(boost::shared_ptr<Quote>(new SimpleQuote(s0)));
+    const Handle<Quote> spot(boost::make_shared<SimpleQuote>(s0));
     const Handle<YieldTermStructure> rTS(flatRate(todaysDate, r, dayCounter));
     const Handle<YieldTermStructure> qTS(flatRate(todaysDate, q, dayCounter));
 
     boost::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+		boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
     const Size xGrid = 201;
     const Size vGrid = 401;
@@ -1123,20 +1123,20 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     critPoints.push_back(boost::tuple<Real, Real, bool>(v0, beta/100, true));
     critPoints.push_back(boost::tuple<Real, Real, bool>(upperBound, beta, true));
     const boost::shared_ptr<Fdm1dMesher> varianceMesher(
-            new Concentrating1dMesher(lowerBound, upperBound, vGrid, critPoints));
+		boost::make_shared<Concentrating1dMesher>(lowerBound, upperBound, vGrid, critPoints));
 
     const boost::shared_ptr<Fdm1dMesher> equityMesher(
-        new Concentrating1dMesher(std::log(2.0), std::log(600.0), xGrid,
+		boost::make_shared<Concentrating1dMesher>(std::log(2.0), std::log(600.0), xGrid,
             std::make_pair(x0+0.005, 0.1), true));
 
     const boost::shared_ptr<FdmMesherComposite>
-        mesher(new FdmMesherComposite(equityMesher, varianceMesher));
+        mesher(boost::make_shared<FdmMesherComposite>(equityMesher, varianceMesher));
 
     const boost::tuple<std::vector<Real>, std::vector<Date>,
                  boost::shared_ptr<BlackVarianceSurface> > smoothSurface =
         createSmoothImpliedVol(dayCounter, calendar);
     const boost::shared_ptr<BlackScholesMertonProcess> lvProcess(
-        new BlackScholesMertonProcess(spot, qTS, rTS,
+		boost::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS,
             Handle<BlackVolTermStructure>(smoothSurface.get<2>())));
 
     // step two days using non-correlated process
@@ -1180,13 +1180,13 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
         lvProcess, ds, dates, times);
 
     const boost::shared_ptr<FixedLocalVolSurface> leverage(
-        new FixedLocalVolSurface(todaysDate, dates, ds, m, dc));
+		boost::make_shared<FixedLocalVolSurface>(todaysDate, dates, ds, m, dc));
 
     const boost::shared_ptr<PricingEngine> lvEngine(
-        new AnalyticEuropeanEngine(lvProcess));
+		boost::make_shared<AnalyticEuropeanEngine>(lvProcess));
 
     const boost::shared_ptr<FdmLinearOpComposite> hestonFwdOp(
-        new FdmHestonFwdOp(mesher, hestonProcess, transform, leverage));
+		boost::make_shared<FdmHestonFwdOp>(mesher, hestonProcess, transform, leverage));
 
     HundsdorferScheme evolver(FdmSchemeDesc::Hundsdorfer().theta,
                               FdmSchemeDesc::Hundsdorfer().mu,
@@ -1200,15 +1200,15 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     }
 
     const boost::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(maturityDate));
+		boost::make_shared<EuropeanExercise>(maturityDate));
 
     const boost::shared_ptr<PricingEngine> fdmEngine(
-        new FdBlackScholesVanillaEngine(lvProcess, 50, 201, 0,
+		boost::make_shared<FdBlackScholesVanillaEngine>(lvProcess, 50, 201, 0,
                                         FdmSchemeDesc::Douglas(), true,0.2));
 
     for (Size strike=5; strike < 200; strike+=10) {
         const boost::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(Option::Put, Real(strike), 1.0));
+			boost::make_shared<CashOrNothingPayoff>(Option::Put, Real(strike), 1.0));
 
         Array pd(p.size());
         for (FdmLinearOpIterator iter = layout->begin();
@@ -1276,13 +1276,13 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol() {
 
     const Handle<Quote> spot(boost::make_shared<SimpleQuote>(s0));
     const boost::shared_ptr<BlackScholesMertonProcess> process(
-        new BlackScholesMertonProcess(spot, qTS, rTS, vTS));
+		boost::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS, vTS));
 
     const boost::shared_ptr<LocalVolTermStructure> localVol(
         boost::make_shared<NoExceptLocalVolSurface>(vTS, rTS, qTS, spot, 0.2));
 
     const boost::shared_ptr<PricingEngine> engine(
-            new AnalyticEuropeanEngine(process));
+		boost::make_shared<AnalyticEuropeanEngine>(process));
 
     for (Size i = 1; i < dates.size(); i += 2) {
         for (Size j = 3; j < strikes.size() - 3; j += 2) {
@@ -1290,48 +1290,45 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol() {
             const Date maturityDate = exDate;
             const Time maturity = dc.yearFraction(todaysDate, maturityDate);
             const boost::shared_ptr<Exercise> exercise(
-                    new EuropeanExercise(exDate));
+				boost::make_shared<EuropeanExercise>(exDate));
 
             const boost::shared_ptr<FdmMesher> uniformMesher(
-                new FdmMesherComposite(
-                    boost::shared_ptr<Fdm1dMesher>(
-                        new FdmBlackScholesMesher(xGrid, process,
-                            maturity, s0))));
+				boost::make_shared<FdmMesherComposite>(
+					boost::make_shared<FdmBlackScholesMesher>(xGrid, process,
+                            maturity, s0)));
 
             //-- operator --
             const boost::shared_ptr<FdmLinearOpComposite> uniformBSFwdOp(
-                new FdmLocalVolFwdOp(
+				boost::make_shared<FdmLocalVolFwdOp>(
                     uniformMesher, *spot, *rTS, *qTS, localVol));
 
             const boost::shared_ptr<FdmMesher> concentratedMesher(
-                new FdmMesherComposite(
-                    boost::shared_ptr<Fdm1dMesher>(
-                        new FdmBlackScholesMesher(xGrid, process,
+				boost::make_shared<FdmMesherComposite>(
+					boost::make_shared<FdmBlackScholesMesher>(xGrid, process,
                                 maturity, s0, Null<Real>(),
                                 Null<Real>(), 0.0001, 1.5,
-                                std::pair<Real, Real>(s0, 0.1)))));
+                                std::pair<Real, Real>(s0, 0.1))));
 
             //-- operator --
             const boost::shared_ptr<FdmLinearOpComposite> concentratedBSFwdOp(
-                new FdmLocalVolFwdOp(
+				boost::make_shared<FdmLocalVolFwdOp>(
                     concentratedMesher, *spot, *rTS, *qTS, localVol));
 
             const boost::shared_ptr<FdmMesher> shiftedMesher(
-                new FdmMesherComposite(
-                    boost::shared_ptr<Fdm1dMesher>(
-                        new FdmBlackScholesMesher(xGrid, process,
+				boost::make_shared<FdmMesherComposite>(
+					boost::make_shared<FdmBlackScholesMesher>(xGrid, process,
                             maturity, s0, Null<Real>(),
                             Null<Real>(), 0.0001, 1.5,
                             std::pair<Real, Real>(s0 * 1.1,
-                                    0.2)))));
+                                    0.2))));
 
             //-- operator --
             const boost::shared_ptr<FdmLinearOpComposite> shiftedBSFwdOp(
-                new FdmLocalVolFwdOp(
+				boost::make_shared<FdmLocalVolFwdOp>(
                     shiftedMesher, *spot, *rTS, *qTS, localVol));
 
             const boost::shared_ptr<StrikedTypePayoff> payoff(
-                    new PlainVanillaPayoff(Option::Call, strikes[j]));
+				boost::make_shared<PlainVanillaPayoff>(Option::Call, strikes[j]));
 
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(engine);
@@ -1402,7 +1399,7 @@ namespace {
         const Handle<YieldTermStructure> qTS(flatRate(q, dc));
 
         const boost::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+			boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
         const Handle<HestonModel> hestonModel(
             boost::make_shared<HestonModel>(hestonProcess));
@@ -1418,11 +1415,11 @@ namespace {
             l = slvModel.leverageFunction();
 
         const boost::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-            new GeneralizedBlackScholesProcess(spot, qTS, rTS,
+			boost::make_shared<GeneralizedBlackScholesProcess>(spot, qTS, rTS,
                 Handle<BlackVolTermStructure>(flatVol(lv, dc))));
 
         const boost::shared_ptr<PricingEngine> analyticEngine(
-            new AnalyticEuropeanEngine(bsProcess));
+			boost::make_shared<AnalyticEuropeanEngine>(bsProcess));
 
         const Real strikes[] = { 50, 75, 80, 90, 100, 110, 125, 150 };
         const Size times[] = { 3, 6, 9, 12, 24, 36, 60 };
@@ -1430,14 +1427,14 @@ namespace {
         for (Size t=0; t < LENGTH(times); ++t) {
             const Date expiry = todaysDate +  Period(times[t], Months);
             const boost::shared_ptr<Exercise> exercise(
-                new EuropeanExercise(expiry));
+				boost::make_shared<EuropeanExercise>(expiry));
 
             const boost::shared_ptr<PricingEngine> slvEngine(
                 (times[t] <= 3) ?
-                    new FdHestonVanillaEngine(hestonModel.currentLink(),
+				boost::make_shared<FdHestonVanillaEngine>(hestonModel.currentLink(),
                         Size(std::max(101.0, 51*times[t]/12.0)), 401, 101, 0,
                             FdmSchemeDesc::ModifiedCraigSneyd(), l)
-                :   new FdHestonVanillaEngine(hestonModel.currentLink(),
+                : boost::make_shared<FdHestonVanillaEngine>(hestonModel.currentLink(),
                         Size(std::max(51.0, 51*times[t]/12.0)), 201, 101, 0,
                             FdmSchemeDesc::ModifiedCraigSneyd(), l));
 
@@ -1445,7 +1442,7 @@ namespace {
                 const Real strike = strikes[s];
 
                 const boost::shared_ptr<StrikedTypePayoff> payoff(
-                    new PlainVanillaPayoff(
+					boost::make_shared<PlainVanillaPayoff>(
                         (strike > s0) ? Option::Call : Option::Put, strike));
 
                 VanillaOption option(payoff, exercise);
@@ -1458,7 +1455,7 @@ namespace {
                 const Real vega = option.vega();
 
                 const boost::shared_ptr<GeneralizedBlackScholesProcess> bp(
-                    new GeneralizedBlackScholesProcess(spot, qTS, rTS,
+					boost::make_shared<GeneralizedBlackScholesProcess>(spot, qTS, rTS,
                         Handle<BlackVolTermStructure>(flatVol(lv,
                                                       dc))));
 
@@ -1562,7 +1559,7 @@ void HestonSLVModelTest::testLocalVolsvSLVPropDensity() {
     const Real v0    =  0.1974;
 
     const boost::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+		boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
     const Handle<HestonModel> hestonModel(
         boost::make_shared<HestonModel>(hestonProcess));
@@ -1652,7 +1649,7 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
     const Handle<YieldTermStructure> qTS(flatRate(q, dc));
 
     const boost::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+		boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
     const Handle<HestonModel> hestonModel(
         boost::make_shared<HestonModel>(hestonProcess));
@@ -1670,10 +1667,10 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
         Period(3, Years), Period(5, Years) };
 
     const boost::shared_ptr<LocalVolSurface> localVolSurface(
-        new LocalVolSurface(surf, rTS, qTS, spot));
+		boost::make_shared<LocalVolSurface>(surf, rTS, qTS, spot));
 
     const boost::shared_ptr<PricingEngine> hestonEngine(
-        new AnalyticHestonEngine(hestonModel.currentLink(), 164));
+		boost::make_shared<AnalyticHestonEngine>(hestonModel.currentLink(), 164));
 
     for (Size i=0; i < LENGTH(strikeValues); ++i) {
         for (Size j=0; j < LENGTH(maturities); ++j) {
@@ -1684,22 +1681,22 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
             const Volatility impliedVol = surf->blackVol(t, strike, true);
 
             const boost::shared_ptr<GeneralizedBlackScholesProcess>
-                bsProcess(new GeneralizedBlackScholesProcess(
+                bsProcess(boost::make_shared<GeneralizedBlackScholesProcess>(
                     spot, qTS, rTS,
                     Handle<BlackVolTermStructure>(flatVol(impliedVol, dc))));
 
             const boost::shared_ptr<PricingEngine> analyticEngine(
-                new AnalyticEuropeanEngine(bsProcess));
+				boost::make_shared<AnalyticEuropeanEngine>(bsProcess));
 
             const boost::shared_ptr<Exercise> exercise(
-                new EuropeanExercise(exerciseDate));
+				boost::make_shared<EuropeanExercise>(exerciseDate));
             const boost::shared_ptr<StrikedTypePayoff> payoff(
-                new PlainVanillaPayoff(
+				boost::make_shared<PlainVanillaPayoff>(
                     spot->value() < strike ? Option::Call : Option::Put,
                     strike));
 
             const boost::shared_ptr<PricingEngine> localVolEngine(
-                new FdBlackScholesVanillaEngine(bsProcess, 201, 801, 0,
+				boost::make_shared<FdBlackScholesVanillaEngine>(bsProcess, 201, 801, 0,
                     FdmSchemeDesc::Douglas(), true));
 
             VanillaOption option(payoff, exercise);
@@ -1755,7 +1752,7 @@ void HestonSLVModelTest::testBarrierPricingMixedModels() {
     const Handle<YieldTermStructure> qTS(flatRate(q, dc));
 
     const boost::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
+		boost::make_shared<HestonProcess>(rTS, qTS, spot, v0, kappa, theta, sigma, rho));
 
     const Handle<HestonModel> hestonModel(
         boost::make_shared<HestonModel>(hestonProcess));
@@ -2213,7 +2210,7 @@ void HestonSLVModelTest::testForwardSkewSLV() {
     const Handle<BlackVolTermStructure> volTS(flatVol(todaysDate, vol, dc));
 
     const boost::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-        new GeneralizedBlackScholesProcess(spot, qTS, rTS, volTS));
+		boost::make_shared<GeneralizedBlackScholesProcess>(spot, qTS, rTS, volTS));
 
     const boost::shared_ptr<PricingEngine> fwdEngine(
         boost::make_shared<ForwardVanillaEngine<AnalyticEuropeanEngine> >(

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug (static runtime)|Win32">
@@ -87,27 +87,35 @@
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (static runtime)|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release (static runtime)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug (static runtime)|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug (static runtime)|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\boost\boost.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>


### PR DESCRIPTION
boost suggests to use make_shared for the construction of shared_ptr for efficiency reasons. This is done in this pull request for some code I have been involved in. 