### PR TITLE
OAS calculation implemented by adding an additional apread to the short rate model

### DIFF
--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -251,7 +251,8 @@ namespace QuantLib {
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
-                                         Frequency frequency)
+                                         Frequency frequency,
+                                         Real bump)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -267,7 +268,7 @@ namespace QuantLib {
             return 0;
         else
             {
-                NumericalDifferentiation dFdOAS(f, 1, 1e-6,
+                NumericalDifferentiation dFdOAS(f, 1, bump,
                                                 3,
                                                 NumericalDifferentiation::Central);
                 return -1*dFdOAS(oas)/P;
@@ -278,7 +279,8 @@ namespace QuantLib {
                                           RelinkableHandle<YieldTermStructure>& engineTS,
                                           const DayCounter& dayCounter,
                                           Compounding compounding,
-                                          Frequency frequency)
+                                          Frequency frequency,
+                                          Real bump)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -296,7 +298,7 @@ namespace QuantLib {
             {
                 NumericalDifferentiation dFdOAS(f,
                                                 2, 
-                                                1e-6,
+                                                bump,
                                                 3,
                                                 NumericalDifferentiation::Central);
                 return dFdOAS(oas)/P;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -224,6 +224,29 @@ namespace QuantLib {
         return res;
     }
 
+    Real CallableBond::cleanPrice(Real oas,
+                                  RelinkableHandle<YieldTermStructure>& engineTS,
+                                  const DayCounter& dayCounter,
+                                  Compounding compounding,
+                                  Frequency frequency,
+                                  Date settlement)
+    {
+        if (settlement == Date())
+            settlement = settlementDate();
+
+        EngSpreadHelper s(engineTS,
+                          dayCounter,
+                          compounding,
+                          frequency);
+
+        boost::function<Real(Real)> f = NPVSpreadHelper(*this,
+                                                        s.sqSpread);
+
+        Real P = f(oas) - accruedAmount(settlement);
+
+        return P;
+    }
+
     Real CallableBond::effectiveDuration(Real oas,
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -116,7 +116,7 @@ namespace QuantLib {
         double ospread;
         CallableBond::arguments*  args;
     public:
-        EngSpreadHelper(CallableBond::arguments* args):
+        explicit EngSpreadHelper(CallableBond::arguments* args):
             args(args),
             ospread(args->spread)
         {

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -270,7 +270,7 @@ namespace QuantLib {
                 NumericalDifferentiation dFdOAS(f, 1, 1e-6,
                                                 3,
                                                 NumericalDifferentiation::Central);
-                return dFdOAS(oas)/P;
+                return -1*dFdOAS(oas)/P;
             }
     }
 

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2008 Allen Kuo
+ Copyright (C) 2017 BN Algorithms Ltd
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -113,8 +113,8 @@ namespace QuantLib {
        clean clean up when the object is destroyed
      */
     class EngSpreadHelper {
-        double ospread;
         CallableBond::arguments*  args;
+        double ospread;
     public:
         explicit EngSpreadHelper(CallableBond::arguments* args):
             args(args),

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -314,27 +314,28 @@ namespace QuantLib {
                                          Frequency frequency,
                                          Real bump)
     {
-        oas=convToContinuous(oas,
-                             *this,
-                             engineTS,
-                             dayCounter,
-                             compounding,
-                             frequency);
-        EngSpreadHelper s(dynamic_cast<CallableBond::arguments*>(engine_->getArguments()));
+        Real P = cleanPriceOAS(oas,
+                               engineTS,
+                               dayCounter,
+                               compounding,
+                               frequency);
 
-        boost::function<Real(Real)> f = NPVSpreadHelper(*this, s);
-
-        Real P = f(oas);
-
+        Real Ppp = cleanPriceOAS(oas+bump,
+                                 engineTS,
+                                 dayCounter,
+                                 compounding,
+                                 frequency);
+        Real Pmm = cleanPriceOAS(oas-bump,
+                                 engineTS,
+                                 dayCounter,
+                                 compounding,
+                                 frequency);
+            
         if ( P == 0.0 )
             return 0;
         else
             {
-                NumericalDifferentiation dFdOAS(f, 1,
-                                                bump,
-                                                3,
-                                                NumericalDifferentiation::Central);
-                return -1*dFdOAS(oas)/P;
+                return (Pmm-Ppp)/(2*P*bump);
             }
     }
 
@@ -345,29 +346,30 @@ namespace QuantLib {
                                           Frequency frequency,
                                           Real bump)
     {
-        oas=convToContinuous(oas,
-                             *this,
-                             engineTS,
-                             dayCounter,
-                             compounding,
-                             frequency);
-        EngSpreadHelper s(dynamic_cast<CallableBond::arguments*>(engine_->getArguments()));
+        Real P = cleanPriceOAS(oas,
+                               engineTS,
+                               dayCounter,
+                               compounding,
+                               frequency);
 
-        boost::function<Real(Real)> f = NPVSpreadHelper(*this, s);
-
-        Real P = f(oas);
-
+        Real Ppp = cleanPriceOAS(oas+bump,
+                                 engineTS,
+                                 dayCounter,
+                                 compounding,
+                                 frequency);
+        Real Pmm = cleanPriceOAS(oas-bump,
+                                 engineTS,
+                                 dayCounter,
+                                 compounding,
+                                 frequency);
+            
         if ( P == 0.0 )
             return 0;
         else
             {
-                NumericalDifferentiation dFdOAS(f,
-                                                2,
-                                                bump,
-                                                3,
-                                                NumericalDifferentiation::Central);
-                return dFdOAS(oas)/P;
-            }
+                return (Ppp + Pmm - 2*P) / ( std::pow(bump,2) * P);
+            }        
+
     }
 
 

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -224,12 +224,12 @@ namespace QuantLib {
         return res;
     }
 
-    Real CallableBond::cleanPrice(Real oas,
-                                  RelinkableHandle<YieldTermStructure>& engineTS,
-                                  const DayCounter& dayCounter,
-                                  Compounding compounding,
-                                  Frequency frequency,
-                                  Date settlement)
+    Real CallableBond::cleanPriceOAS(Real oas,
+                                     RelinkableHandle<YieldTermStructure>& engineTS,
+                                     const DayCounter& dayCounter,
+                                     Compounding compounding,
+                                     Frequency frequency,
+                                     Date settlement) const
     {
         if (settlement == Date())
             settlement = settlementDate();
@@ -251,8 +251,7 @@ namespace QuantLib {
                                          RelinkableHandle<YieldTermStructure>& engineTS,
                                          const DayCounter& dayCounter,
                                          Compounding compounding,
-                                         Frequency frequency,
-                                         Date settlementDate)
+                                         Frequency frequency)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -279,8 +278,7 @@ namespace QuantLib {
                                           RelinkableHandle<YieldTermStructure>& engineTS,
                                           const DayCounter& dayCounter,
                                           Compounding compounding,
-                                          Frequency frequency,
-                                          Date settlementDate)
+                                          Frequency frequency)
     {
         EngSpreadHelper s(engineTS,
                           dayCounter,
@@ -297,7 +295,7 @@ namespace QuantLib {
         else
             {
                 NumericalDifferentiation dFdOAS(f,
-                                                2,
+                                                2, 
                                                 1e-6,
                                                 3,
                                                 NumericalDifferentiation::Central);

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -96,6 +96,16 @@ namespace QuantLib {
                    Size maxIterations = 100,
                    Rate guess = 0.0);
 
+        //! Calculate the clean price based on the given
+        //! option-adjust-spread (oas) over the given yield term
+        //! structure (engineTS)
+        Real cleanPrice(Real oas,
+                        RelinkableHandle<YieldTermStructure>& engineTS,
+                        const DayCounter& dayCounter,
+                        Compounding compounding,
+                        Frequency frequency,
+                        Date settlementDate = Date());
+
         //! Calculate the effective duration, i.e., the first
         //! differential of the dirty price w.r.t. a parallel shift of
         //! the yield term structure divided by current dirty price

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -163,7 +163,7 @@ namespace QuantLib {
             public std::unary_function<Real, Real>
         {
         public:
-            NPVSpreadHelper(CallableBond& bond);
+            explicit NPVSpreadHelper(CallableBond& bond);
             Real operator()(Spread x) const;
         private:
             CallableBond& bond_;

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -113,7 +113,8 @@ namespace QuantLib {
                                RelinkableHandle<YieldTermStructure>& engineTS,
                                const DayCounter& dayCounter,
                                Compounding compounding,
-                               Frequency frequency);
+                               Frequency frequency,
+                               Real bump=2e-4);
 
         //! Calculate the effective convexity, i.e., the second
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -122,7 +123,8 @@ namespace QuantLib {
                                 RelinkableHandle<YieldTermStructure>& engineTS,
                                 const DayCounter& dayCounter,
                                 Compounding compounding,
-                                Frequency frequency);
+                                Frequency frequency,
+                                Real bump=2e-4);
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2008 Allen Kuo
+ Copyright (C) 2017 BN Algorithms Ltd
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -86,11 +86,15 @@ namespace QuantLib {
             YieldTermStructure handle used by engine should be the
             same as engineTS
          */
-        Spread OAS(Real marketPrice,
+        Spread OAS(Real cleanPrice,
                    RelinkableHandle<YieldTermStructure>& engineTS,
-                   Real accuracy,
-                   Size maxIterations,
-                   Spread guess);
+                   const DayCounter& dayCounter,
+                   Compounding compounding,
+                   Frequency frequency,
+                   Date settlementDate = Date(),
+                   Real accuracy = 1.0e-10,
+                   Size maxIterations = 100,
+                   Rate guess = 0.0);
 
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -99,12 +99,12 @@ namespace QuantLib {
         //! Calculate the clean price based on the given
         //! option-adjust-spread (oas) over the given yield term
         //! structure (engineTS)
-        Real cleanPrice(Real oas,
-                        RelinkableHandle<YieldTermStructure>& engineTS,
-                        const DayCounter& dayCounter,
-                        Compounding compounding,
-                        Frequency frequency,
-                        Date settlementDate = Date());
+        Real cleanPriceOAS(Real oas,
+                           RelinkableHandle<YieldTermStructure>& engineTS,
+                           const DayCounter& dayCounter,
+                           Compounding compounding,
+                           Frequency frequency,
+                           Date settlementDate = Date()) const;
 
         //! Calculate the effective duration, i.e., the first
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -113,8 +113,7 @@ namespace QuantLib {
                                RelinkableHandle<YieldTermStructure>& engineTS,
                                const DayCounter& dayCounter,
                                Compounding compounding,
-                               Frequency frequency,
-                               Date settlementDate = Date());
+                               Frequency frequency);
 
         //! Calculate the effective convexity, i.e., the second
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -123,8 +122,7 @@ namespace QuantLib {
                                 RelinkableHandle<YieldTermStructure>& engineTS,
                                 const DayCounter& dayCounter,
                                 Compounding compounding,
-                                Frequency frequency,
-                                Date settlementDate = Date());
+                                Frequency frequency);
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -75,6 +75,22 @@ namespace QuantLib {
                               Size maxEvaluations,
                               Volatility minVol,
                               Volatility maxVol) const;
+
+        //! Calculate the Option Adjusted Spread (OAS)
+        /*! Calculates the spread that needs to be added to the the
+            reference (engineTS risk-free) curve so that the
+            theoretical model value matches the marketPrice.
+
+            \note a pricing engine should be set on the bond and the
+            YieldTermStructure handle used by engine should be the
+            same as engineTS
+         */
+        Spread OAS(Real marketPrice,
+                   RelinkableHandle<YieldTermStructure>& engineTS,
+                   Real accuracy,
+                   Size maxIterations,
+                   Spread guess);
+
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 
@@ -108,6 +124,21 @@ namespace QuantLib {
             Real targetValue_;
             boost::shared_ptr<SimpleQuote> vol_;
             const Instrument::results* results_;
+        };
+
+
+        class OASHelper;
+        friend class OASHelper;
+        class OASHelper {
+          public:
+            OASHelper(const CallableBond& bond,
+                      Handle<SimpleQuote>& spread,
+                      Real targetValue);
+            Real operator()(Spread x) const;
+          private:
+            const CallableBond& bond_;
+            Handle<SimpleQuote>& spread_;
+            Real targetValue_;
         };
     };
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -79,12 +79,9 @@ namespace QuantLib {
 
         //! Calculate the Option Adjusted Spread (OAS)
         /*! Calculates the spread that needs to be added to the the
-            reference (engineTS risk-free) curve so that the
-            theoretical model value matches the marketPrice.
+            reference curve so that the theoretical model value
+            matches the marketPrice.
 
-            \note a pricing engine should be set on the bond and the
-            YieldTermStructure handle used by engine should be the
-            same as engineTS
          */
         Spread OAS(Real cleanPrice,
                    RelinkableHandle<YieldTermStructure>& engineTS,
@@ -104,7 +101,7 @@ namespace QuantLib {
                            const DayCounter& dayCounter,
                            Compounding compounding,
                            Frequency frequency,
-                           Date settlementDate = Date()) const;
+                           Date settlementDate = Date());
 
         //! Calculate the effective duration, i.e., the first
         //! differential of the dirty price w.r.t. a parallel shift of
@@ -161,19 +158,6 @@ namespace QuantLib {
         };
 
 
-        class OASHelper;
-        friend class OASHelper;
-        class OASHelper {
-          public:
-            OASHelper(const CallableBond& bond,
-                      Handle<SimpleQuote>& spread,
-                      Real targetValue);
-            Real operator()(Spread x) const;
-          private:
-            const CallableBond& bond_;
-            Handle<SimpleQuote>& spread_;
-            Real targetValue_;
-        };
     };
 
     class CallableBond::arguments : public Bond::arguments {
@@ -190,6 +174,10 @@ namespace QuantLib {
         //! bond full/dirty/cash prices
         std::vector<Real> callabilityPrices;
         std::vector<Date> callabilityDates;
+        //! Spread to apply to the valuation. This is a continuously
+        //! componded rate added to the model. Currently only applied
+        //! by the TreeCallableFixedRateBondEngine
+        Real spread;
         void validate() const;
     };
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -96,6 +96,25 @@ namespace QuantLib {
                    Size maxIterations = 100,
                    Rate guess = 0.0);
 
+        //! Calculate the effective duration, i.e., the first
+        //! differential of the dirty price w.r.t. a parallel shift of
+        //! the yield term structure divided by current dirty price
+        Real effectiveDuration(Real oas,
+                               RelinkableHandle<YieldTermStructure>& engineTS,
+                               const DayCounter& dayCounter,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+
+        //! Calculate the effective convexity, i.e., the second
+        //! differential of the dirty price w.r.t. a parallel shift of
+        //! the yield term structure divided by current dirty price
+        Real effectiveConvexity(Real oas,
+                                RelinkableHandle<YieldTermStructure>& engineTS,
+                                const DayCounter& dayCounter,
+                                Compounding compounding,
+                                Frequency frequency,
+                                Date settlementDate = Date());
         //@}
         virtual void setupArguments(PricingEngine::arguments*) const {}
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -84,7 +84,7 @@ namespace QuantLib {
 
          */
         Spread OAS(Real cleanPrice,
-                   RelinkableHandle<YieldTermStructure>& engineTS,
+                   const Handle<YieldTermStructure>& engineTS,
                    const DayCounter& dayCounter,
                    Compounding compounding,
                    Frequency frequency,
@@ -97,7 +97,7 @@ namespace QuantLib {
         //! option-adjust-spread (oas) over the given yield term
         //! structure (engineTS)
         Real cleanPriceOAS(Real oas,
-                           RelinkableHandle<YieldTermStructure>& engineTS,
+                           const Handle<YieldTermStructure>& engineTS,
                            const DayCounter& dayCounter,
                            Compounding compounding,
                            Frequency frequency,
@@ -107,7 +107,7 @@ namespace QuantLib {
         //! differential of the dirty price w.r.t. a parallel shift of
         //! the yield term structure divided by current dirty price
         Real effectiveDuration(Real oas,
-                               RelinkableHandle<YieldTermStructure>& engineTS,
+                               const Handle<YieldTermStructure>& engineTS,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
@@ -117,7 +117,7 @@ namespace QuantLib {
         //! differential of the dirty price w.r.t. a parallel shift of
         //! the yield term structure divided by current dirty price
         Real effectiveConvexity(Real oas,
-                                RelinkableHandle<YieldTermStructure>& engineTS,
+                                const Handle<YieldTermStructure>& engineTS,
                                 const DayCounter& dayCounter,
                                 Compounding compounding,
                                 Frequency frequency,
@@ -156,8 +156,19 @@ namespace QuantLib {
             boost::shared_ptr<SimpleQuote> vol_;
             const Instrument::results* results_;
         };
-
-
+        //! Helper class for option adjusted spread calculations
+        class NPVSpreadHelper;
+        friend class NPVSpreadHelper;
+        class NPVSpreadHelper :
+            public std::unary_function<Real, Real>
+        {
+        public:
+            NPVSpreadHelper(CallableBond& bond);
+            Real operator()(Spread x) const;
+        private:
+            CallableBond& bond_;
+            const Instrument::results* results_;
+        };
     };
 
     class CallableBond::arguments : public Bond::arguments {

--- a/ql/experimental/callablebonds/treecallablebondengine.cpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.cpp
@@ -90,7 +90,8 @@ namespace QuantLib {
         callableBond.initialize(lattice, redemptionTime);
         callableBond.rollback(0.0);
         results_.value = results_.settlementValue = callableBond.presentValue();
-        sr->setSpread(0.0);
+        if (sr)
+            sr->setSpread(0.0);
     }
 
 }

--- a/ql/experimental/callablebonds/treecallablebondengine.cpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.cpp
@@ -44,10 +44,10 @@ namespace QuantLib {
     }
 
     void TreeCallableFixedRateBondEngine::calculate() const {
-        return calculateSpread(arguments_.spread);
+        return calculateWithSpread(arguments_.spread);
     }
 
-    void TreeCallableFixedRateBondEngine::calculateSpread(double s) const {
+    void TreeCallableFixedRateBondEngine::calculateWithSpread(Spread s) const {
         QL_REQUIRE(!model_.empty(), "no model specified");
 
         Date referenceDate;
@@ -76,13 +76,13 @@ namespace QuantLib {
             lattice = model_->tree(timeGrid);
         }
 
-        OneFactorModel::ShortRateTree *sr=
-            dynamic_cast<OneFactorModel::ShortRateTree*>(&(*lattice));
-        if (sr)
+        if (s != 0.0) {
+            OneFactorModel::ShortRateTree *sr=
+                dynamic_cast<OneFactorModel::ShortRateTree*>(&(*lattice));
+            QL_REQUIRE(sr,
+                       "Spread is not supported for trees other than OneFactorModel");
             sr->setSpread(s);
-        else
-            QL_REQUIRE( s==0.0,
-                        "Spread is not supported for trees other than OneFactorModel");
+        }
 
         Time redemptionTime =
             dayCounter.yearFraction(referenceDate,
@@ -90,8 +90,6 @@ namespace QuantLib {
         callableBond.initialize(lattice, redemptionTime);
         callableBond.rollback(0.0);
         results_.value = results_.settlementValue = callableBond.presentValue();
-        if (sr)
-            sr->setSpread(0.0);
     }
 
 }

--- a/ql/experimental/callablebonds/treecallablebondengine.hpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.hpp
@@ -52,8 +52,8 @@ namespace QuantLib {
                                                  Handle<YieldTermStructure>()) ;
         //@}
         void calculate() const;
-        void calculateSpread(double s) const;        
       private:
+        void calculateWithSpread(Spread s) const;
         Handle<YieldTermStructure> termStructure_;
     };
 

--- a/ql/experimental/callablebonds/treecallablebondengine.hpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.hpp
@@ -52,6 +52,7 @@ namespace QuantLib {
                                                  Handle<YieldTermStructure>()) ;
         //@}
         void calculate() const;
+        void calculateSpread(double s) const;        
       private:
         Handle<YieldTermStructure> termStructure_;
     };

--- a/ql/models/shortrate/onefactormodel.cpp
+++ b/ql/models/shortrate/onefactormodel.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
                          const boost::shared_ptr<ShortRateDynamics>& dynamics,
                          const TimeGrid& timeGrid)
     : TreeLattice1D<OneFactorModel::ShortRateTree>(timeGrid, tree->size(1)),
-      tree_(tree), dynamics_(dynamics) {}
+        tree_(tree), dynamics_(dynamics), spread_() {}
 
     OneFactorModel::OneFactorModel(Size nArguments)
     : ShortRateModel(nArguments) {}

--- a/ql/models/shortrate/onefactormodel.cpp
+++ b/ql/models/shortrate/onefactormodel.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
                 <TermStructureFittingParameter::NumericalImpl>& theta,
             const TimeGrid& timeGrid)
     : TreeLattice1D<OneFactorModel::ShortRateTree>(timeGrid, tree->size(1)),
-      tree_(tree), dynamics_(dynamics) {
+      tree_(tree), dynamics_(dynamics), spread_(0.0) {
 
         theta->reset();
         Real value = 1.0;
@@ -87,7 +87,7 @@ namespace QuantLib {
                          const boost::shared_ptr<ShortRateDynamics>& dynamics,
                          const TimeGrid& timeGrid)
     : TreeLattice1D<OneFactorModel::ShortRateTree>(timeGrid, tree->size(1)),
-        tree_(tree), dynamics_(dynamics), spread_() {}
+      tree_(tree), dynamics_(dynamics), spread_(0.0) {}
 
     OneFactorModel::OneFactorModel(Size nArguments)
     : ShortRateModel(nArguments) {}

--- a/ql/models/shortrate/onefactormodel.hpp
+++ b/ql/models/shortrate/onefactormodel.hpp
@@ -91,7 +91,7 @@ namespace QuantLib {
         }
         DiscountFactor discount(Size i, Size index) const {
             Real x = tree_->underlying(i, index);
-            Rate r = dynamics_->shortRate(timeGrid()[i], x);
+            Rate r = dynamics_->shortRate(timeGrid()[i], x) +spread_;
             return std::exp(-r*timeGrid().dt(i));
         }
         Real underlying(Size i, Size index) const {
@@ -103,10 +103,15 @@ namespace QuantLib {
         Real probability(Size i, Size index, Size branch) const {
             return tree_->probability(i, index, branch);
         }
+        void setSpread(double spread)
+        {
+            spread_=spread;
+        }
       private:
         boost::shared_ptr<TrinomialTree> tree_;
         boost::shared_ptr<ShortRateDynamics> dynamics_;
         class Helper;
+        double spread_;
     };
 
     //! Single-factor affine base class

--- a/ql/models/shortrate/onefactormodel.hpp
+++ b/ql/models/shortrate/onefactormodel.hpp
@@ -103,7 +103,7 @@ namespace QuantLib {
         Real probability(Size i, Size index, Size branch) const {
             return tree_->probability(i, index, branch);
         }
-        void setSpread(double spread)
+        void setSpread(Spread spread)
         {
             spread_=spread;
         }
@@ -111,7 +111,7 @@ namespace QuantLib {
         boost::shared_ptr<TrinomialTree> tree_;
         boost::shared_ptr<ShortRateDynamics> dynamics_;
         class Helper;
-        double spread_;
+        Spread spread_;
     };
 
     //! Single-factor affine base class


### PR DESCRIPTION
This approach correctly reproduces the market convention for OAS calculation for log-normal models, where the spread is after the dynamics have been determined, i.e.,  the volatility is relative to the un-spreaded yield curve not the spreaded yield curve.  For this reason this approach is preferred to the approach in #250 