### PR TITLE
Adaptive successive over-relaxation method for implied volatility calculation

### DIFF
--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -9,6 +9,7 @@
  Copyright (C) 2007 Chiara Fornarola
  Copyright (C) 2013 Gary Kennedy
  Copyright (C) 2015 Peter Caspers
+ Copyright (C) 2017 Klaus Spanderen
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -95,12 +96,12 @@ namespace QuantLib {
         method.
     */
     Real blackFormulaImpliedStdDevChambers(Option::Type optionType,
-                                                Real strike,
-                                                Real forward,
-                                                Real blackPrice,
-                                                Real blackAtmPrice,
-                                                Real discount = 1.0,
-                                                Real displacement = 0.0);
+                                           Real strike,
+                                           Real forward,
+                                           Real blackPrice,
+                                           Real blackAtmPrice,
+                                           Real discount = 1.0,
+                                           Real displacement = 0.0);
 
     /*! Approximated Black 1976 implied standard deviation,
         i.e. volatility*sqrt(timeToMaturity).
@@ -117,6 +118,35 @@ namespace QuantLib {
         Real blackAtmPrice,
         Real discount = 1.0,
         Real displacement = 0.0);
+
+    /*! Approximated Black 1976 implied standard deviation,
+        i.e. volatility*sqrt(timeToMaturity).
+
+        It is calculated using
+
+        "An Explicit Implicit Volatility Formula"
+        R. Radoicic, D. Stefanica,
+        https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2908494
+
+        "Tighter Bounds for Implied Volatility",
+        J. Gatheral, I. Matic, R. Radoicic, D. Stefanica
+        https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2922742
+    */
+    Real blackFormulaImpliedStdDevRS(
+        Option::Type optionType,
+        Real strike,
+        Real forward,
+        Real blackPrice,
+        Real discount = 1.0,
+        Real displacement = 0.0);
+
+    Real blackFormulaImpliedStdDevRS(
+        const boost::shared_ptr<PlainVanillaPayoff> &payoff,
+        Real forward,
+        Real blackPrice,
+        Real discount = 1.0,
+        Real displacement = 0.0);
+
 
     /*! Black 1976 implied standard deviation,
         i.e. volatility*sqrt(timeToMaturity)

--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -132,7 +132,7 @@ namespace QuantLib {
         J. Gatheral, I. Matic, R. Radoicic, D. Stefanica
         https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2922742
     */
-    Real blackFormulaImpliedStdDevRS(
+    Real blackFormulaImpliedStdDevApproximationRS(
         Option::Type optionType,
         Real strike,
         Real forward,
@@ -140,7 +140,7 @@ namespace QuantLib {
         Real discount = 1.0,
         Real displacement = 0.0);
 
-    Real blackFormulaImpliedStdDevRS(
+    Real blackFormulaImpliedStdDevApproximationRS(
         const boost::shared_ptr<PlainVanillaPayoff> &payoff,
         Real forward,
         Real blackPrice,
@@ -174,6 +174,42 @@ namespace QuantLib {
                         Real accuracy = 1.0e-6,
                         Natural maxIterations = 100);
 
+    /*! Black 1976 implied standard deviation,
+         i.e. volatility*sqrt(timeToMaturity)
+
+        "An Adaptive Successive Over-relaxation Method for Computing the
+        Black-Scholes Implied Volatility"
+        M. Li, http://mpra.ub.uni-muenchen.de/6867/
+
+
+        Starting point of the iteration is calculated based on
+
+        "An Explicit Implicit Volatility Formula"
+        R. Radoicic, D. Stefanica,
+        https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2908494
+    */
+    Real blackFormulaImpliedStdDevLiRS(
+        Option::Type optionType,
+        Real strike,
+        Real forward,
+        Real blackPrice,
+        Real discount = 1.0,
+        Real displacement = 0.0,
+        Real guess = Null<Real>(),
+        Real omega = 1.0,
+        Real accuracy = 1.0e-6,
+        Natural maxIterations = 100);
+
+    Real blackFormulaImpliedStdDevLiRS(
+        const boost::shared_ptr<PlainVanillaPayoff>& payoff,
+        Real forward,
+        Real blackPrice,
+        Real discount = 1.0,
+        Real displacement = 0.0,
+        Real guess = Null<Real>(),
+        Real omega = 1.0,
+        Real accuracy = 1.0e-6,
+        Natural maxIterations = 100);
 
     /*! Black 1976 probability of being in the money (in the bond martingale
         measure), i.e. N(d2).

--- a/test-suite/blackformula.cpp
+++ b/test-suite/blackformula.cpp
@@ -151,7 +151,7 @@ void BlackFormulaTest::testRadoicicStefanicaImpliedVol() {
 
             const Real marketValue = blackFormula(payoff, forward, stdDev, df);
 
-            const Real estVol = blackFormulaImpliedStdDevRS(
+            const Real estVol = blackFormulaImpliedStdDevApproximationRS(
                 payoff, forward, marketValue, df) / std::sqrt(T);
 
             const Real error = std::fabs(estVol - vol);
@@ -187,7 +187,7 @@ void BlackFormulaTest::testRadoicicStefanicaLowerBound() {
     for (Real s=0.17; s < 2.9; s+=0.01) {
         const Real strike = std::exp(k)*forward;
         const Real c = blackFormula(Option::Call, strike, forward, s);
-        const Real estimate = blackFormulaImpliedStdDevRS(
+        const Real estimate = blackFormulaImpliedStdDevApproximationRS(
             Option::Call, strike, forward, c);
 
         const Real error = s - estimate;
@@ -202,13 +202,79 @@ void BlackFormulaTest::testRadoicicStefanicaLowerBound() {
 
         }
 
-        if (c > 1e-5 && error < 0.0) {
+        if (c > 1e-6 && error < 0.0) {
             BOOST_ERROR("Failed to verify Radoicic-Stefanica is lower bound"
                     << "\n forward     :" << forward
                     << "\n strike      :" << k
                     << "\n stdDev      :" << s
                     << "\n result      :" << estimate
                     << "\n error       :" << error);
+        }
+    }
+}
+
+void BlackFormulaTest::testImpliedVolAdaptiveSuccessiveOverRelaxation() {
+    BOOST_TEST_MESSAGE("Testing implied volatility calculation via "
+        "adaptive successive over-relaxation...");
+
+    SavedSettings backup;
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(12, July, 2017);
+    Settings::instance().evaluationDate() = today;
+
+    const Date exerciseDate = today + Period(15, Months);
+    const Time exerciseTime = dc.yearFraction(today, exerciseDate);
+
+    const boost::shared_ptr<YieldTermStructure> rTS = flatRate(0.10, dc);
+    const boost::shared_ptr<YieldTermStructure> qTS = flatRate(0.06, dc);
+
+    const DiscountFactor df = rTS->discount(exerciseDate);
+
+    const Volatility vol = 0.20;
+    const Real stdDev = vol * std::sqrt(exerciseTime);
+
+    const Real s0     = 100;
+    const Real forward= s0 * qTS->discount(exerciseDate)/df;
+
+    const Option::Type types[] = { Option::Call, Option::Put };
+    const Real strikes[] = { 50, 60, 70, 80, 90, 100, 110, 125, 150, 200 };
+    const Real displacements[] = { 0, 25, 50, 100};
+
+    const Real tol = 1e-8;
+
+    for (Size i=0; i < LENGTH(strikes); ++i) {
+        const Real strike = strikes[i];
+
+        for (Size j=0; j < LENGTH(types); ++j) {
+            const Option::Type type = types[j];
+
+            const boost::shared_ptr<PlainVanillaPayoff> payoff(
+                boost::make_shared<PlainVanillaPayoff>(type, strike));
+
+            for (Size k=0; k < LENGTH(displacements); ++k) {
+
+                const Real displacement = displacements[k];
+                const Real marketValue = blackFormula(
+                    payoff, forward, stdDev, df, displacement);
+
+                const Real impliedStdDev = blackFormulaImpliedStdDevLiRS(
+                    payoff, forward, marketValue, df, displacement,
+                    Null<Real>(), 1.0, tol, 100);
+
+                const Real error = std::fabs(impliedStdDev - stdDev);
+                if (error > 10*tol) {
+                    BOOST_ERROR("Failed to calculated implied volatility"
+                                " with adaptive successive over-relaxation"
+                            << "\n forward     :" << forward
+                            << "\n strike      :" << strike
+                            << "\n stdDev      :" << stdDev
+                            << "\n displacement:" << displacement
+                            << "\n result      :" << impliedStdDev
+                            << "\n error       :" << error
+                            << "\n tolerance   :" << tol);
+                }
+            }
         }
     }
 }
@@ -225,6 +291,8 @@ test_suite* BlackFormulaTest::suite() {
         &BlackFormulaTest::testRadoicicStefanicaImpliedVol));
     suite->add(QUANTLIB_TEST_CASE(
         &BlackFormulaTest::testRadoicicStefanicaLowerBound));
+    suite->add(QUANTLIB_TEST_CASE(
+        &BlackFormulaTest::testImpliedVolAdaptiveSuccessiveOverRelaxation));
 
     return suite;
 }

--- a/test-suite/blackformula.hpp
+++ b/test-suite/blackformula.hpp
@@ -31,6 +31,8 @@ class BlackFormulaTest {
     static void testChambersImpliedVol();
     static void testRadoicicStefanicaImpliedVol();
     static void testRadoicicStefanicaLowerBound();
+    static void testImpliedVolAdaptiveSuccessiveOverRelaxation();
+
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/blackformula.hpp
+++ b/test-suite/blackformula.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2013 Gary Kennedy
  Copyright (C) 2015 Peter Caspers
+ Copyright (C) 2017 Klaus Spanderen
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,6 +29,8 @@ class BlackFormulaTest {
   public:
     static void testBachelierImpliedVol();
     static void testChambersImpliedVol();
+    static void testRadoicicStefanicaImpliedVol();
+    static void testRadoicicStefanicaLowerBound();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
"An Adaptive Successive Over-relaxation Method for Computing the Black-Scholes Implied Volatility"
M. Li, http://mpra.ub.uni-muenchen.de/6867/

Starting point of the iteration is calculated based on
"An Explicit Implicit Volatility Formula",  R. Radoicic, D. Stefanica,
https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2908494

See also: http://chasethedevil.github.io/post/implied-volatility-from-black-scholes-price/
