### PR TITLE
Payment lag for OIS

### DIFF
--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -5,6 +5,8 @@
  Copyright (C) 2003, 2004, 2007 StatPro Italia srl
  Copyright (C) 2007 Piter Dias
  Copyright (C) 2010 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -129,7 +131,7 @@ namespace QuantLib {
     }
 
     FixedRateLeg& FixedRateLeg::withFirstPeriodDayCounter(
-                                               const DayCounter& dayCounter) {
+                                            const DayCounter& dayCounter) {
         firstPeriodDC_ = dayCounter;
         return *this;
     }
@@ -139,10 +141,10 @@ namespace QuantLib {
         return *this;
     }
 
-	FixedRateLeg& FixedRateLeg::withPaymentLag(Natural lag) {
-		paymentLag_ = lag;
-		return *this;
-	}
+    FixedRateLeg& FixedRateLeg::withPaymentLag(Natural lag) {
+        paymentLag_ = lag;
+        return *this;
+    }
 
     FixedRateLeg& FixedRateLeg::withExCouponPeriod(
                                 const Period& period,
@@ -166,7 +168,7 @@ namespace QuantLib {
 
         // first period might be short or long
         Date start = schedule_.date(0), end = schedule_.date(1);
-		Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+        Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
         Date exCouponDate;
         InterestRate rate = couponRates_[0];
         Real nominal = notionals_[0];
@@ -205,7 +207,7 @@ namespace QuantLib {
         // regular periods
         for (Size i=2; i<schedule_.size()-1; ++i) {
             start = end; end = schedule_.date(i);
-			Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+            Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
             if (exCouponPeriod_ != Period())
             {
                 exCouponDate = exCouponCalendar_.advance(paymentDate,
@@ -229,7 +231,7 @@ namespace QuantLib {
             // last period might be short or long
             Size N = schedule_.size();
             start = end; end = schedule_.date(N-1);
-			Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+            Date paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
             if (exCouponPeriod_ != Period())
             {
                 exCouponDate = exCouponCalendar_.advance(paymentDate,

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -98,6 +98,7 @@ namespace QuantLib {
         FixedRateLeg& withPaymentAdjustment(BusinessDayConvention);
         FixedRateLeg& withFirstPeriodDayCounter(const DayCounter&);
         FixedRateLeg& withPaymentCalendar(const Calendar&);
+		FixedRateLeg& withPaymentLag(Natural lag);
         FixedRateLeg& withExCouponPeriod(const Period&,
                                          const Calendar&,
                                          BusinessDayConvention,
@@ -105,11 +106,12 @@ namespace QuantLib {
         operator Leg() const;
       private:
         Schedule schedule_;
-        Calendar calendar_;
         std::vector<Real> notionals_;
         std::vector<InterestRate> couponRates_;
         DayCounter firstPeriodDC_;
         BusinessDayConvention paymentAdjustment_;
+		Natural paymentLag_;
+		Calendar paymentCalendar_;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_;

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -111,9 +111,9 @@ namespace QuantLib {
         std::vector<Real> notionals_;
         std::vector<InterestRate> couponRates_;
         DayCounter firstPeriodDC_;
+        Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_;
         Natural paymentLag_;
-        Calendar paymentCalendar_;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_;

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -5,6 +5,8 @@
  Copyright (C) 2003, 2004, 2007 StatPro Italia srl
  Copyright (C) 2007 Piter Dias
  Copyright (C) 2010 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -98,7 +100,7 @@ namespace QuantLib {
         FixedRateLeg& withPaymentAdjustment(BusinessDayConvention);
         FixedRateLeg& withFirstPeriodDayCounter(const DayCounter&);
         FixedRateLeg& withPaymentCalendar(const Calendar&);
-		FixedRateLeg& withPaymentLag(Natural lag);
+        FixedRateLeg& withPaymentLag(Natural lag);
         FixedRateLeg& withExCouponPeriod(const Period&,
                                          const Calendar&,
                                          BusinessDayConvention,
@@ -110,8 +112,8 @@ namespace QuantLib {
         std::vector<InterestRate> couponRates_;
         DayCounter firstPeriodDC_;
         BusinessDayConvention paymentAdjustment_;
-		Natural paymentLag_;
-		Calendar paymentCalendar_;
+        Natural paymentLag_;
+        Calendar paymentCalendar_;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_;

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -181,8 +181,8 @@ namespace QuantLib {
 
     OvernightLeg::OvernightLeg(const Schedule& schedule,
                                const shared_ptr<OvernightIndex>& i)
-    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following),
-      paymentLag_(0), paymentCalendar_(schedule.calendar()) {}
+    : schedule_(schedule), overnightIndex_(i), paymentCalendar_(schedule.calendar(),
+      paymentAdjustment_(Following), paymentLag_(0)) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -181,8 +181,8 @@ namespace QuantLib {
 
     OvernightLeg::OvernightLeg(const Schedule& schedule,
                                const shared_ptr<OvernightIndex>& i)
-    : schedule_(schedule), overnightIndex_(i), paymentCalendar_(schedule.calendar(),
-      paymentAdjustment_(Following), paymentLag_(0)) {}
+    : schedule_(schedule), overnightIndex_(i), paymentCalendar_(schedule.calendar()),
+      paymentAdjustment_(Following), paymentLag_(0) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -179,7 +179,7 @@ namespace QuantLib {
 
     OvernightLeg::OvernightLeg(const Schedule& schedule,
                                const shared_ptr<OvernightIndex>& i)
-    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following) {}
+    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following), paymentLag_(0), paymentCalendar_(schedule.calendar()) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);
@@ -201,6 +201,16 @@ namespace QuantLib {
         paymentAdjustment_ = convention;
         return *this;
     }
+
+	OvernightLeg& OvernightLeg::withPaymentCalendar(const Calendar& cal) {
+		paymentCalendar_ = cal;
+		return *this;
+	}
+
+	OvernightLeg& OvernightLeg::withPaymentLag(Natural lag) {
+		paymentLag_ = lag;
+		return *this;
+	}
 
     OvernightLeg& OvernightLeg::withGearings(Real gearing) {
         gearings_ = vector<Real>(1,gearing);
@@ -238,7 +248,8 @@ namespace QuantLib {
         for (Size i=0; i<n; ++i) {
             refStart = start = schedule_.date(i);
             refEnd   =   end = schedule_.date(i+1);
-            paymentDate = calendar.adjust(end, paymentAdjustment_);
+			paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+			
             if (i == 0 && !schedule_.isRegular(i+1))
                 refStart = calendar.adjust(end - schedule_.tenor(),
                                            paymentAdjustment_);

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -3,6 +3,8 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -179,7 +181,8 @@ namespace QuantLib {
 
     OvernightLeg::OvernightLeg(const Schedule& schedule,
                                const shared_ptr<OvernightIndex>& i)
-    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following), paymentLag_(0), paymentCalendar_(schedule.calendar()) {}
+    : schedule_(schedule), overnightIndex_(i), paymentAdjustment_(Following),
+      paymentLag_(0), paymentCalendar_(schedule.calendar()) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);
@@ -202,15 +205,15 @@ namespace QuantLib {
         return *this;
     }
 
-	OvernightLeg& OvernightLeg::withPaymentCalendar(const Calendar& cal) {
-		paymentCalendar_ = cal;
-		return *this;
-	}
+    OvernightLeg& OvernightLeg::withPaymentCalendar(const Calendar& cal) {
+        paymentCalendar_ = cal;
+        return *this;
+    }
 
-	OvernightLeg& OvernightLeg::withPaymentLag(Natural lag) {
-		paymentLag_ = lag;
-		return *this;
-	}
+    OvernightLeg& OvernightLeg::withPaymentLag(Natural lag) {
+        paymentLag_ = lag;
+        return *this;
+    }
 
     OvernightLeg& OvernightLeg::withGearings(Real gearing) {
         gearings_ = vector<Real>(1,gearing);
@@ -248,8 +251,8 @@ namespace QuantLib {
         for (Size i=0; i<n; ++i) {
             refStart = start = schedule_.date(i);
             refEnd   =   end = schedule_.date(i+1);
-			paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
-			
+            paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+
             if (i == 0 && !schedule_.isRegular(i+1))
                 refStart = calendar.adjust(end - schedule_.tenor(),
                                            paymentAdjustment_);

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -83,6 +83,8 @@ namespace QuantLib {
         OvernightLeg& withNotionals(const std::vector<Real>& notionals);
         OvernightLeg& withPaymentDayCounter(const DayCounter&);
         OvernightLeg& withPaymentAdjustment(BusinessDayConvention);
+		OvernightLeg& withPaymentCalendar(const Calendar&);
+		OvernightLeg& withPaymentLag(Natural lag);
         OvernightLeg& withGearings(Real gearing);
         OvernightLeg& withGearings(const std::vector<Real>& gearings);
         OvernightLeg& withSpreads(Spread spread);
@@ -93,7 +95,9 @@ namespace QuantLib {
         boost::shared_ptr<OvernightIndex> overnightIndex_;
         std::vector<Real> notionals_;
         DayCounter paymentDayCounter_;
+		Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_;
+		Natural paymentLag_;
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
     };

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -3,6 +3,8 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -83,8 +85,8 @@ namespace QuantLib {
         OvernightLeg& withNotionals(const std::vector<Real>& notionals);
         OvernightLeg& withPaymentDayCounter(const DayCounter&);
         OvernightLeg& withPaymentAdjustment(BusinessDayConvention);
-		OvernightLeg& withPaymentCalendar(const Calendar&);
-		OvernightLeg& withPaymentLag(Natural lag);
+        OvernightLeg& withPaymentCalendar(const Calendar&);
+        OvernightLeg& withPaymentLag(Natural lag);
         OvernightLeg& withGearings(Real gearing);
         OvernightLeg& withGearings(const std::vector<Real>& gearings);
         OvernightLeg& withSpreads(Spread spread);
@@ -95,9 +97,9 @@ namespace QuantLib {
         boost::shared_ptr<OvernightIndex> overnightIndex_;
         std::vector<Real> notionals_;
         DayCounter paymentDayCounter_;
-		Calendar paymentCalendar_;
+        Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_;
-		Natural paymentLag_;
+        Natural paymentLag_;
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
     };

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -38,9 +38,9 @@ namespace QuantLib {
       settlementDays_(2),
       calendar_(overnightIndex->fixingCalendar()),
       paymentFrequency_(Annual),
-      paymentLag_(0),
-      paymentAdjustment_(Following),
       paymentCalendar_(Calendar()),
+      paymentAdjustment_(Following),
+      paymentLag_(0),
       rule_(DateGeneration::Backward),
       // any value here for endOfMonth_ would not be actually used
       isDefaultEOM_(true),

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -3,6 +3,8 @@
 /*
  Copyright (C) 2009, 2014, 2015 Ferdinando Ametrano
  Copyright (C) 2015 Paolo Mazzocchi
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -36,9 +38,9 @@ namespace QuantLib {
       settlementDays_(2),
       calendar_(overnightIndex->fixingCalendar()),
       paymentFrequency_(Annual),
-	  paymentLag_(0),
-	  paymentAdjustment_(Following),
-	  paymentCalendar_(Calendar()),
+      paymentLag_(0),
+      paymentAdjustment_(Following),
+      paymentCalendar_(Calendar()),
       rule_(DateGeneration::Backward),
       // any value here for endOfMonth_ would not be actually used
       isDefaultEOM_(true),
@@ -100,7 +102,8 @@ namespace QuantLib {
                                       0.0, // fixed rate
                                       fixedDayCount_,
                                       overnightIndex_, overnightSpread_,
-									  paymentLag_, paymentAdjustment_, paymentCalendar_);
+                                      paymentLag_, paymentAdjustment_,
+                                      paymentCalendar_);
             if (engine_ == 0) {
                 Handle<YieldTermStructure> disc =
                                     overnightIndex_->forwardingTermStructure();
@@ -122,7 +125,8 @@ namespace QuantLib {
                                  schedule,
                                  usedFixedRate, fixedDayCount_,
                                  overnightIndex_, overnightSpread_,
-								 paymentLag_, paymentAdjustment_, paymentCalendar_));
+                                 paymentLag_, paymentAdjustment_,
+                                 paymentCalendar_));
 
         if (engine_ == 0) {
             Handle<YieldTermStructure> disc =
@@ -176,20 +180,20 @@ namespace QuantLib {
         return *this;
     }
 
-	MakeOIS& MakeOIS::withPaymentAdjustment(BusinessDayConvention convention) {
-		paymentAdjustment_ = convention;
-		return *this;
-	}
+    MakeOIS& MakeOIS::withPaymentAdjustment(BusinessDayConvention convention) {
+        paymentAdjustment_ = convention;
+        return *this;
+    }
 
-	MakeOIS& MakeOIS::withPaymentLag(Natural lag) {
-		paymentLag_ = lag;
-		return *this;
-	}
+    MakeOIS& MakeOIS::withPaymentLag(Natural lag) {
+        paymentLag_ = lag;
+        return *this;
+    }
 
-	MakeOIS& MakeOIS::withPaymentCalendar(const Calendar& cal) {
-		paymentCalendar_ = cal;
-		return *this;
-	}
+    MakeOIS& MakeOIS::withPaymentCalendar(const Calendar& cal) {
+        paymentCalendar_ = cal;
+        return *this;
+    }
 
     MakeOIS& MakeOIS::withRule(DateGeneration::Rule r) {
         rule_ = r;

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -36,6 +36,9 @@ namespace QuantLib {
       settlementDays_(2),
       calendar_(overnightIndex->fixingCalendar()),
       paymentFrequency_(Annual),
+	  paymentLag_(0),
+	  paymentAdjustment_(Following),
+	  paymentCalendar_(Calendar()),
       rule_(DateGeneration::Backward),
       // any value here for endOfMonth_ would not be actually used
       isDefaultEOM_(true),
@@ -68,7 +71,7 @@ namespace QuantLib {
         }
 
         // OIS end of month default
-        bool usedEndOfMonth = 
+        bool usedEndOfMonth =
             isDefaultEOM_ ? calendar_.isEndOfMonth(startDate) : endOfMonth_;
 
         Date endDate = terminationDate_;
@@ -96,7 +99,8 @@ namespace QuantLib {
                                       schedule,
                                       0.0, // fixed rate
                                       fixedDayCount_,
-                                      overnightIndex_, overnightSpread_);
+                                      overnightIndex_, overnightSpread_,
+									  paymentLag_, paymentAdjustment_, paymentCalendar_);
             if (engine_ == 0) {
                 Handle<YieldTermStructure> disc =
                                     overnightIndex_->forwardingTermStructure();
@@ -117,7 +121,8 @@ namespace QuantLib {
             OvernightIndexedSwap(type_, nominal_,
                                  schedule,
                                  usedFixedRate, fixedDayCount_,
-                                 overnightIndex_, overnightSpread_));
+                                 overnightIndex_, overnightSpread_,
+								 paymentLag_, paymentAdjustment_, paymentCalendar_));
 
         if (engine_ == 0) {
             Handle<YieldTermStructure> disc =
@@ -170,6 +175,21 @@ namespace QuantLib {
             rule_ = DateGeneration::Zero;
         return *this;
     }
+
+	MakeOIS& MakeOIS::withPaymentAdjustment(BusinessDayConvention convention) {
+		paymentAdjustment_ = convention;
+		return *this;
+	}
+
+	MakeOIS& MakeOIS::withPaymentLag(Natural lag) {
+		paymentLag_ = lag;
+		return *this;
+	}
+
+	MakeOIS& MakeOIS::withPaymentCalendar(const Calendar& cal) {
+		paymentCalendar_ = cal;
+		return *this;
+	}
 
     MakeOIS& MakeOIS::withRule(DateGeneration::Rule r) {
         rule_ = r;

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -82,8 +82,8 @@ namespace QuantLib {
 
         Frequency paymentFrequency_;
         Calendar paymentCalendar_;
-        Natural paymentLag_;
         BusinessDayConvention paymentAdjustment_;
+        Natural paymentLag_;
 
         DateGeneration::Rule rule_;
         bool endOfMonth_, isDefaultEOM_;

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -54,6 +54,10 @@ namespace QuantLib {
         MakeOIS& withRule(DateGeneration::Rule r);
 
         MakeOIS& withPaymentFrequency(Frequency f);
+    MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
+		MakeOIS& withPaymentLag(Natural lag);
+		MakeOIS& withPaymentCalendar(const Calendar& cal);
+
         MakeOIS& withEndOfMonth(bool flag = true);
 
         MakeOIS& withFixedLegDayCount(const DayCounter& dc);
@@ -75,6 +79,10 @@ namespace QuantLib {
         Calendar calendar_;
 
         Frequency paymentFrequency_;
+		Calendar paymentCalendar_;
+		Natural paymentLag_;
+		BusinessDayConvention paymentAdjustment_;
+
         DateGeneration::Rule rule_;
         bool endOfMonth_, isDefaultEOM_;
 

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -2,6 +2,8 @@
 
 /*
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -54,9 +56,9 @@ namespace QuantLib {
         MakeOIS& withRule(DateGeneration::Rule r);
 
         MakeOIS& withPaymentFrequency(Frequency f);
-    MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
-		MakeOIS& withPaymentLag(Natural lag);
-		MakeOIS& withPaymentCalendar(const Calendar& cal);
+        MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
+        MakeOIS& withPaymentLag(Natural lag);
+        MakeOIS& withPaymentCalendar(const Calendar& cal);
 
         MakeOIS& withEndOfMonth(bool flag = true);
 
@@ -79,9 +81,9 @@ namespace QuantLib {
         Calendar calendar_;
 
         Frequency paymentFrequency_;
-		Calendar paymentCalendar_;
-		Natural paymentLag_;
-		BusinessDayConvention paymentAdjustment_;
+        Calendar paymentCalendar_;
+        Natural paymentLag_;
+        BusinessDayConvention paymentAdjustment_;
 
         DateGeneration::Rule rule_;
         bool endOfMonth_, isDefaultEOM_;

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -40,10 +40,10 @@ namespace QuantLib {
     : Swap(2), type_(type),
       nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
-      fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread),
       paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
-      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag) {
+      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag),
+      fixedRate_(fixedRate), fixedDC_(fixedDC),
+      overnightIndex_(overnightIndex), spread_(spread) {
 
           initialize(schedule);
 
@@ -62,10 +62,10 @@ namespace QuantLib {
                     Calendar paymentCalendar)
     : Swap(2), type_(type), nominals_(nominals),
       paymentFrequency_(schedule.tenor().frequency()),
-      fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread),
       paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
-      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag){
+      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag),
+      fixedRate_(fixedRate), fixedDC_(fixedDC),
+      overnightIndex_(overnightIndex), spread_(spread){
 
           initialize(schedule);
 

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -42,8 +42,8 @@ namespace QuantLib {
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
       overnightIndex_(overnightIndex), spread_(spread),
-      paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
-      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar) {
+      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
+      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag) {
 
           initialize(schedule);
 
@@ -64,8 +64,8 @@ namespace QuantLib {
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
       overnightIndex_(overnightIndex), spread_(spread),
-      paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
-      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar) {
+      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
+      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag){
 
           initialize(schedule);
 

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -3,6 +3,8 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,16 +34,16 @@ namespace QuantLib {
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
                     Spread spread,
-					Natural paymentLag,
-					BusinessDayConvention paymentAdjustment,
-					Calendar paymentCalendar)
+                    Natural paymentLag,
+                    BusinessDayConvention paymentAdjustment,
+                    Calendar paymentCalendar)
     : Swap(2), type_(type),
       nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
       overnightIndex_(overnightIndex), spread_(spread),
-	  paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
-	  paymentCalendar_(paymentCalendar == Calendar() ? schedule.calendar() : paymentCalendar) {
+      paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
+      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar) {
 
           initialize(schedule);
 
@@ -55,15 +57,15 @@ namespace QuantLib {
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
                     Spread spread,
-					Natural paymentLag,
-					BusinessDayConvention paymentAdjustment,
-					Calendar paymentCalendar)
+                    Natural paymentLag,
+                    BusinessDayConvention paymentAdjustment,
+                    Calendar paymentCalendar)
     : Swap(2), type_(type), nominals_(nominals),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
       overnightIndex_(overnightIndex), spread_(spread),
-	  paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
-	  paymentCalendar_(paymentCalendar == Calendar() ? schedule.calendar() : paymentCalendar ) {
+      paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
+      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar) {
 
           initialize(schedule);
 
@@ -75,16 +77,16 @@ namespace QuantLib {
         legs_[0] = FixedRateLeg(schedule)
             .withNotionals(nominals_)
             .withCouponRates(fixedRate_, fixedDC_)
-			.withPaymentLag(paymentLag_)
-			.withPaymentAdjustment(paymentAdjustment_)
-			.withPaymentCalendar(paymentCalendar_);
+            .withPaymentLag(paymentLag_)
+            .withPaymentAdjustment(paymentAdjustment_)
+            .withPaymentCalendar(paymentCalendar_);
 
 		legs_[1] = OvernightLeg(schedule, overnightIndex_)
-			.withNotionals(nominals_)
-			.withSpreads(spread_)
-			.withPaymentLag(paymentLag_)
-			.withPaymentAdjustment(paymentAdjustment_)
-			.withPaymentCalendar(paymentCalendar_);
+            .withNotionals(nominals_)
+            .withSpreads(spread_)
+            .withPaymentLag(paymentLag_)
+            .withPaymentAdjustment(paymentAdjustment_)
+            .withPaymentCalendar(paymentCalendar_);
 
         for (Size j=0; j<2; ++j) {
             for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -31,12 +31,17 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread)
+                    Spread spread,
+					Natural paymentLag,
+					BusinessDayConvention paymentAdjustment,
+					Calendar paymentCalendar)
     : Swap(2), type_(type),
       nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread) {
+      overnightIndex_(overnightIndex), spread_(spread),
+	  paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
+	  paymentCalendar_(paymentCalendar == Calendar() ? schedule.calendar() : paymentCalendar) {
 
           initialize(schedule);
 
@@ -49,11 +54,16 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread)
+                    Spread spread,
+					Natural paymentLag,
+					BusinessDayConvention paymentAdjustment,
+					Calendar paymentCalendar)
     : Swap(2), type_(type), nominals_(nominals),
       paymentFrequency_(schedule.tenor().frequency()),
       fixedRate_(fixedRate), fixedDC_(fixedDC),
-      overnightIndex_(overnightIndex), spread_(spread) {
+      overnightIndex_(overnightIndex), spread_(spread),
+	  paymentLag_(paymentLag), paymentAdjustment_(paymentAdjustment),
+	  paymentCalendar_(paymentCalendar == Calendar() ? schedule.calendar() : paymentCalendar ) {
 
           initialize(schedule);
 
@@ -64,11 +74,17 @@ namespace QuantLib {
             fixedDC_ = overnightIndex_->dayCounter();
         legs_[0] = FixedRateLeg(schedule)
             .withNotionals(nominals_)
-            .withCouponRates(fixedRate_, fixedDC_);
+            .withCouponRates(fixedRate_, fixedDC_)
+			.withPaymentLag(paymentLag_)
+			.withPaymentAdjustment(paymentAdjustment_)
+			.withPaymentCalendar(paymentCalendar_);
 
-        legs_[1] = OvernightLeg(schedule, overnightIndex_)
-            .withNotionals(nominals_)
-            .withSpreads(spread_);
+		legs_[1] = OvernightLeg(schedule, overnightIndex_)
+			.withNotionals(nominals_)
+			.withSpreads(spread_)
+			.withPaymentLag(paymentLag_)
+			.withPaymentAdjustment(paymentAdjustment_)
+			.withPaymentCalendar(paymentCalendar_);
 
         for (Size j=0; j<2; ++j) {
             for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -27,6 +27,8 @@
 
 #include <ql/instruments/swap.hpp>
 #include <ql/time/daycounter.hpp>
+#include <ql/time/businessdayconvention.hpp>
+#include <ql/time/calendar.hpp>
 
 namespace QuantLib {
 
@@ -44,7 +46,11 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0);
+                    Spread spread = 0.0,
+					Natural paymentLag = 0,
+					BusinessDayConvention paymentAdjustment = Following,
+					Calendar paymentCalendar = Calendar());
+
         OvernightIndexedSwap(
                     Type type,
                     std::vector<Real> nominals,
@@ -52,7 +58,11 @@ namespace QuantLib {
                     Rate fixedRate,
                     const DayCounter& fixedDC,
                     const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0);
+                    Spread spread = 0.0,
+					Natural paymentLag = 0,
+					BusinessDayConvention paymentAdjustment = Following,
+					Calendar paymentCalendar = Calendar());
+
         //! \name Inspectors
         //@{
         Type type() const { return type_; }
@@ -88,6 +98,10 @@ namespace QuantLib {
         std::vector<Real> nominals_;
 
         Frequency paymentFrequency_;
+		Natural paymentLag_;
+		BusinessDayConvention paymentAdjustment_;
+		Calendar paymentCalendar_;
+
         //Schedule schedule_;
 
         Rate fixedRate_;

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -100,9 +100,9 @@ namespace QuantLib {
         std::vector<Real> nominals_;
 
         Frequency paymentFrequency_;
-        Natural paymentLag_;
-        BusinessDayConvention paymentAdjustment_;
         Calendar paymentCalendar_;
+        BusinessDayConvention paymentAdjustment_;
+        Natural paymentLag_;
 
         //Schedule schedule_;
 

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -3,6 +3,8 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2009 Ferdinando Ametrano
+ Copyright (C) 2017 Joseph Jeisman
+ Copyright (C) 2017 Fabrice Lecuyer
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -37,31 +39,31 @@ namespace QuantLib {
 
     //! Overnight indexed swap: fix vs compounded overnight rate
     class OvernightIndexedSwap : public Swap {
-      public:
+    public:
         enum Type { Receiver = -1, Payer = 1 };
         OvernightIndexedSwap(
-                    Type type,
-                    Real nominal,
-                    const Schedule& schedule,
-                    Rate fixedRate,
-                    const DayCounter& fixedDC,
-                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0,
-					Natural paymentLag = 0,
-					BusinessDayConvention paymentAdjustment = Following,
-					Calendar paymentCalendar = Calendar());
+                        Type type,
+                        Real nominal,
+                        const Schedule& schedule,
+                        Rate fixedRate,
+                        const DayCounter& fixedDC,
+                        const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                        Spread spread = 0.0,
+                        Natural paymentLag = 0,
+                        BusinessDayConvention paymentAdjustment = Following,
+                        Calendar paymentCalendar = Calendar());
 
         OvernightIndexedSwap(
-                    Type type,
-                    std::vector<Real> nominals,
-                    const Schedule& schedule,
-                    Rate fixedRate,
-                    const DayCounter& fixedDC,
-                    const boost::shared_ptr<OvernightIndex>& overnightIndex,
-                    Spread spread = 0.0,
-					Natural paymentLag = 0,
-					BusinessDayConvention paymentAdjustment = Following,
-					Calendar paymentCalendar = Calendar());
+                        Type type,
+                        std::vector<Real> nominals,
+                        const Schedule& schedule,
+                        Rate fixedRate,
+                        const DayCounter& fixedDC,
+                        const boost::shared_ptr<OvernightIndex>& overnightIndex,
+                        Spread spread = 0.0,
+                        Natural paymentLag = 0,
+                        BusinessDayConvention paymentAdjustment = Following,
+                        Calendar paymentCalendar = Calendar());
 
         //! \name Inspectors
         //@{
@@ -98,9 +100,9 @@ namespace QuantLib {
         std::vector<Real> nominals_;
 
         Frequency paymentFrequency_;
-		Natural paymentLag_;
-		BusinessDayConvention paymentAdjustment_;
-		Calendar paymentCalendar_;
+        Natural paymentLag_;
+        BusinessDayConvention paymentAdjustment_;
+        Calendar paymentCalendar_;
 
         //Schedule schedule_;
 


### PR DESCRIPTION
Adding the possibility to apply a payment lag to overnight indexed swaps.
This can be convention in some markets, such as USD where we believe a 2bd payment lag is applied.
The change is backward compatible, and default to a 0bd adjustment. The test suite has been re-run successfully after the change.