### PR TITLE
Move inclusion of specific header from base class to derived.

### DIFF
--- a/ql/experimental/commodities/commoditycurve.hpp
+++ b/ql/experimental/commodities/commoditycurve.hpp
@@ -30,6 +30,7 @@
 #include <ql/experimental/commodities/exchangecontract.hpp>
 #include <ql/currency.hpp>
 #include <ql/math/interpolations/forwardflatinterpolation.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 
 namespace QuantLib {
 

--- a/ql/experimental/volatility/abcdatmvolcurve.hpp
+++ b/ql/experimental/volatility/abcdatmvolcurve.hpp
@@ -28,6 +28,7 @@
 #include <ql/experimental/volatility/blackatmvolcurve.hpp>
 #include <ql/patterns/lazyobject.hpp>
 #include <ql/math/interpolations/abcdinterpolation.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 
 namespace QuantLib {
 

--- a/ql/termstructure.hpp
+++ b/ql/termstructure.hpp
@@ -25,7 +25,7 @@
 #define quantlib_term_structure_hpp
 
 #include <ql/time/calendar.hpp>
-#include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/time/daycounter.hpp>
 #include <ql/settings.hpp>
 #include <ql/handle.hpp>
 #include <ql/math/interpolations/extrapolation.hpp>

--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
@@ -31,6 +31,7 @@
 #include <ql/math/interpolation.hpp>
 #include <ql/quote.hpp>
 #include <ql/patterns/lazyobject.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <boost/noncopyable.hpp>
 #include <vector>
 

--- a/ql/termstructures/volatility/capfloor/capfloortermvolsurface.hpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolsurface.hpp
@@ -29,6 +29,7 @@
 #include <ql/math/interpolations/interpolation2d.hpp>
 #include <ql/quote.hpp>
 #include <ql/patterns/lazyobject.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <vector>
 
 namespace QuantLib {

--- a/ql/termstructures/volatility/interpolatedsmilesection.hpp
+++ b/ql/termstructures/volatility/interpolatedsmilesection.hpp
@@ -31,6 +31,7 @@
 #include <ql/patterns/lazyobject.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/termstructures/volatility/smilesection.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 
 namespace QuantLib {
 


### PR DESCRIPTION
The header ql/time/daycounters/actual365fixed.hpp was included in ql/termstructure.hpp but not used in the interface of the base class.