### PR TITLE
Make the ownership transfer clear [low priority]

### DIFF
--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
       public:
         Helper(const Size i, const Real xMin, const Real dx,
                const Real discountBondPrice,
-               const boost::shared_ptr<ShortRateTree>& tree,
+               const std::auto_ptr<ShortRateTree>& tree,
                const boost::function<Real(Real)>& fInv)
         : size_(tree->size(i)),
           dt_(tree->timeGrid().dt(i)),
@@ -277,7 +277,7 @@ namespace QuantLib {
     }
 
 
-    boost::shared_ptr<Lattice> GeneralizedHullWhite::tree(
+    std::auto_ptr<Lattice> GeneralizedHullWhite::tree(
                                                   const TimeGrid& grid) const{
 
         TermStructureFittingParameter phi(termStructure());
@@ -285,7 +285,7 @@ namespace QuantLib {
             new Dynamics(phi, speed(), vol(), f_, fInverse_));
         boost::shared_ptr<TrinomialTree> trinomial(
             new TrinomialTree(numericDynamics->process(), grid));
-        boost::shared_ptr<ShortRateTree> numericTree(
+        std::auto_ptr<ShortRateTree> numericTree(
             new ShortRateTree(trinomial, numericDynamics, grid));
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
         boost::shared_ptr<NumericalImpl> impl =
@@ -307,7 +307,7 @@ namespace QuantLib {
             impl->set(grid[i], value);
         }
 
-        return numericTree;
+        return std::auto_ptr<Lattice> (numericTree);
     }
 
     boost::function<Real (Time)> GeneralizedHullWhite::speed() const {

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -69,7 +69,7 @@ namespace QuantLib {
                     "use HWdynamics()");
         }
 
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid)const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid)const;
 
         //Analytical calibration of HW
 

--- a/ql/models/model.hpp
+++ b/ql/models/model.hpp
@@ -26,6 +26,8 @@
 #ifndef quantlib_interest_rate_model_hpp
 #define quantlib_interest_rate_model_hpp
 
+#include <memory>
+
 #include <ql/option.hpp>
 #include <ql/methods/lattices/lattice.hpp>
 #include <ql/models/parameter.hpp>
@@ -142,7 +144,7 @@ namespace QuantLib {
     class ShortRateModel : public CalibratedModel {
       public:
         ShortRateModel(Size nArguments);
-        virtual boost::shared_ptr<Lattice> tree(const TimeGrid&) const = 0;
+        virtual std::auto_ptr<Lattice> tree(const TimeGrid&) const = 0;
     };
 
 

--- a/ql/models/shortrate/onefactormodel.cpp
+++ b/ql/models/shortrate/onefactormodel.cpp
@@ -92,11 +92,11 @@ namespace QuantLib {
     OneFactorModel::OneFactorModel(Size nArguments)
     : ShortRateModel(nArguments) {}
 
-    boost::shared_ptr<Lattice>
+    std::auto_ptr<Lattice>
     OneFactorModel::tree(const TimeGrid& grid) const {
         boost::shared_ptr<TrinomialTree> trinomial(
                               new TrinomialTree(dynamics()->process(), grid));
-        return boost::shared_ptr<Lattice>(
+        return std::auto_ptr<Lattice>(
                               new ShortRateTree(trinomial, dynamics(), grid));
     }
 

--- a/ql/models/shortrate/onefactormodel.hpp
+++ b/ql/models/shortrate/onefactormodel.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
         virtual boost::shared_ptr<ShortRateDynamics> dynamics() const = 0;
 
         //! Return by default a trinomial recombining tree
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
     };
 
     //! Base class describing the short-rate dynamics

--- a/ql/models/shortrate/onefactormodels/blackkarasinski.cpp
+++ b/ql/models/shortrate/onefactormodels/blackkarasinski.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
       public:
         Helper(Size i, Real xMin, Real dx,
                Real discountBondPrice,
-               const boost::shared_ptr<ShortRateTree>& tree)
+               const std::auto_ptr<ShortRateTree>& tree)
         : size_(tree->size(i)),
           dt_(tree->timeGrid().dt(i)),
           xMin_(xMin), dx_(dx),
@@ -65,7 +65,7 @@ namespace QuantLib {
         registerWith(termStructure);
     }
 
-    boost::shared_ptr<Lattice>
+    std::auto_ptr<Lattice>
     BlackKarasinski::tree(const TimeGrid& grid) const {
 
         TermStructureFittingParameter phi(termStructure());
@@ -75,7 +75,7 @@ namespace QuantLib {
 
         boost::shared_ptr<TrinomialTree> trinomial(
                          new TrinomialTree(numericDynamics->process(), grid));
-        boost::shared_ptr<ShortRateTree> numericTree(
+        std::auto_ptr<ShortRateTree> numericTree(
                          new ShortRateTree(trinomial, numericDynamics, grid));
 
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
@@ -97,7 +97,7 @@ namespace QuantLib {
             // vMin = value - 10.0;
             // vMax = value + 10.0;
         }
-        return numericTree;
+        return std::auto_ptr<Lattice>(numericTree);
     }
 
 }

--- a/ql/models/shortrate/onefactormodels/blackkarasinski.hpp
+++ b/ql/models/shortrate/onefactormodels/blackkarasinski.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
             QL_FAIL("no defined process for Black-Karasinski");
         }
 
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
 
       private:
         class Dynamics;

--- a/ql/models/shortrate/onefactormodels/coxingersollross.cpp
+++ b/ql/models/shortrate/onefactormodels/coxingersollross.cpp
@@ -122,11 +122,11 @@ namespace QuantLib {
             return call - discountS + strike*discountT;
     }
 
-    boost::shared_ptr<Lattice>
+    std::auto_ptr<Lattice>
     CoxIngersollRoss::tree(const TimeGrid& grid) const {
         boost::shared_ptr<TrinomialTree> trinomial(
                         new TrinomialTree(dynamics()->process(), grid, true));
-        return boost::shared_ptr<Lattice>(
+        return std::auto_ptr<Lattice>(
                               new ShortRateTree(trinomial, dynamics(), grid));
     }
 

--- a/ql/models/shortrate/onefactormodels/coxingersollross.hpp
+++ b/ql/models/shortrate/onefactormodels/coxingersollross.hpp
@@ -56,7 +56,7 @@ namespace QuantLib {
 
         virtual boost::shared_ptr<ShortRateDynamics> dynamics() const;
 
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
 
         class Dynamics;
       protected:

--- a/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
+++ b/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
         generateArguments();
     }
 
-    boost::shared_ptr<Lattice> ExtendedCoxIngersollRoss::tree(
+    std::auto_ptr<Lattice> ExtendedCoxIngersollRoss::tree(
                                                  const TimeGrid& grid) const {
         TermStructureFittingParameter phi(termStructure());
         boost::shared_ptr<Dynamics> numericDynamics(
@@ -45,7 +45,7 @@ namespace QuantLib {
         boost::shared_ptr<NumericalImpl> impl =
             boost::dynamic_pointer_cast<NumericalImpl>(phi.implementation());
 
-        return boost::shared_ptr<Lattice>(
+        return std::auto_ptr<Lattice>(
                    new ShortRateTree(trinomial, numericDynamics, impl, grid));
     }
 

--- a/ql/models/shortrate/onefactormodels/extendedcoxingersollross.hpp
+++ b/ql/models/shortrate/onefactormodels/extendedcoxingersollross.hpp
@@ -51,7 +51,7 @@ namespace QuantLib {
                               Real x0 = 0.05,
                               bool withFellerConstraint = true);
 
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
 
         boost::shared_ptr<ShortRateDynamics> dynamics() const;
 

--- a/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -40,14 +40,14 @@ namespace QuantLib {
         registerWith(termStructure);
     }
 
-    boost::shared_ptr<Lattice> HullWhite::tree(const TimeGrid& grid) const {
+    std::auto_ptr<Lattice> HullWhite::tree(const TimeGrid& grid) const {
 
         TermStructureFittingParameter phi(termStructure());
         boost::shared_ptr<ShortRateDynamics> numericDynamics(
                                              new Dynamics(phi, a(), sigma()));
         boost::shared_ptr<TrinomialTree> trinomial(
                          new TrinomialTree(numericDynamics->process(), grid));
-        boost::shared_ptr<ShortRateTree> numericTree(
+        std::auto_ptr<ShortRateTree> numericTree(
                          new ShortRateTree(trinomial, numericDynamics, grid));
 
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
@@ -69,7 +69,7 @@ namespace QuantLib {
             value = std::log(value/discountBond)/dt;
             impl->set(grid[i], value);
         }
-        return numericTree;
+        return std::auto_ptr<Lattice> (numericTree);
     }
 
     Real HullWhite::A(Time t, Time T) const {

--- a/ql/models/shortrate/onefactormodels/hullwhite.hpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.hpp
@@ -50,7 +50,7 @@ namespace QuantLib {
         HullWhite(const Handle<YieldTermStructure>& termStructure,
                   Real a = 0.1, Real sigma = 0.01);
 
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
 
         boost::shared_ptr<ShortRateDynamics> dynamics() const;
 

--- a/ql/models/shortrate/twofactormodel.cpp
+++ b/ql/models/shortrate/twofactormodel.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
     TwoFactorModel::TwoFactorModel(Size nArguments)
     : ShortRateModel(nArguments) {}
 
-    boost::shared_ptr<Lattice>
+    std::auto_ptr<Lattice>
     TwoFactorModel::tree(const TimeGrid& grid) const {
         boost::shared_ptr<ShortRateDynamics> dyn = dynamics();
 
@@ -35,7 +35,7 @@ namespace QuantLib {
         boost::shared_ptr<TrinomialTree> tree2(
                                     new TrinomialTree(dyn->yProcess(), grid));
 
-        return boost::shared_ptr<Lattice>(
+        return std::auto_ptr<Lattice>(
                         new TwoFactorModel::ShortRateTree(tree1, tree2, dyn));
     }
 

--- a/ql/models/shortrate/twofactormodel.hpp
+++ b/ql/models/shortrate/twofactormodel.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         virtual boost::shared_ptr<ShortRateDynamics> dynamics() const = 0;
 
         //! Returns a two-dimensional trinomial tree
-        boost::shared_ptr<Lattice> tree(const TimeGrid& grid) const;
+        std::auto_ptr<Lattice> tree(const TimeGrid& grid) const;
 
     };
 


### PR DESCRIPTION
Use auto_ptr instead of shared_ptr to show that the Lattice created by
tree() is not retained in ShortRateModel derived classes.

(I realise this is not a commonly used in QL, but anyway something to consider perhaps)