### PR TITLE
Added gradient and jacobian calculation to FittedBondDiscountCurve::FittingMethods

### DIFF
--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -225,12 +225,12 @@ int main(int, char* []) {
 
         printOutput("(b) simple polynomial", ts2);
 
-        Array ns_l2(4, .0001);
+        Array ns_l2(4, .001);
         ns_l2[0] = 0.0;
         NelsonSiegelFitting nelsonSiegel(Array(), optimizor, ns_l2);
         Array ns_guess(4, 0.0);
         ns_guess[1] = .03;
-        ns_guess[3] = 7.0;
+        ns_guess[3] = 3.0;
 
         boost::shared_ptr<FittedBondDiscountCurve> ts3 (
                         new FittedBondDiscountCurve(curveSettlementDays,
@@ -270,13 +270,13 @@ int main(int, char* []) {
 
         printOutput("(d) cubic B-splines", ts4);
 
-        Array nss_l2(6, .0001);
+        Array nss_l2(6, .001);
         nss_l2[0] = 0.0;
         SvenssonFitting svensson(Array(), optimizor, nss_l2);
         Array nss_guess(6, 0.0);
         nss_guess[1] = .03;
-        nss_guess[4] = 7.0;
-        nss_guess[5] = 10.0;
+        nss_guess[4] = 1.0;
+        nss_guess[5] = 7.0;
 
         boost::shared_ptr<FittedBondDiscountCurve> ts5 (
                         new FittedBondDiscountCurve(curveSettlementDays,
@@ -316,7 +316,7 @@ int main(int, char* []) {
             knotVector_q.push_back(knots_q[i]);
         }
 
-        Array quad_l2(LENGTH(knots_q), .0001);
+        Array quad_l2(LENGTH(knots_q), .00001);
         quad_l2[0] = 0.0;
 
         QuadraticYieldSplinesFitting quadraticYieldSplines(knotVector_q, Array(), optimizor, quad_l2);

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -193,8 +193,8 @@ int main(int, char* []) {
                                                           calendar,
                                                           instrumentsB,
                                                           dc));
-
-        ExponentialSplinesFitting exponentialSplines(constrainAtZero, Array(), optimizor);
+        Array exp_l2(9, 0.0001);
+        ExponentialSplinesFitting exponentialSplines(constrainAtZero, Array(), optimizor, exp_l2);
 
         Array exp_guess(9, 0.0);
         exp_guess[8] = 1.0;
@@ -211,8 +211,8 @@ int main(int, char* []) {
 
         printOutput("(a) exponential splines", ts1);
 
-
-        SimplePolynomialFitting simplePolynomial(3, constrainAtZero, Array(), optimizor);
+        Array sp_l2(3, 0.0001);
+        SimplePolynomialFitting simplePolynomial(3, constrainAtZero, Array(), optimizor, sp_l2);
 
         boost::shared_ptr<FittedBondDiscountCurve> ts2 (
                     new FittedBondDiscountCurve(curveSettlementDays,
@@ -225,8 +225,9 @@ int main(int, char* []) {
 
         printOutput("(b) simple polynomial", ts2);
 
-
-        NelsonSiegelFitting nelsonSiegel(Array(), optimizor);
+        Array ns_l2(4, .0001);
+        ns_l2[0] = 0.0;
+        NelsonSiegelFitting nelsonSiegel(Array(), optimizor, ns_l2);
         Array ns_guess(4, 0.0);
         ns_guess[1] = .03;
         ns_guess[3] = 7.0;
@@ -255,7 +256,8 @@ int main(int, char* []) {
             knotVector.push_back(knots[i]);
         }
 
-        CubicBSplinesFitting cubicBSplines(knotVector, constrainAtZero, Array(), optimizor);
+        Array cub_l2(LENGTH(knots) - 5, .0001);
+        CubicBSplinesFitting cubicBSplines(knotVector, constrainAtZero, Array(), optimizor, cub_l2);
 
         boost::shared_ptr<FittedBondDiscountCurve> ts4 (
                        new FittedBondDiscountCurve(curveSettlementDays,
@@ -268,7 +270,9 @@ int main(int, char* []) {
 
         printOutput("(d) cubic B-splines", ts4);
 
-        SvenssonFitting svensson(Array(), optimizor);
+        Array nss_l2(6, .0001);
+        nss_l2[0] = 0.0;
+        SvenssonFitting svensson(Array(), optimizor, nss_l2);
         Array nss_guess(6, 0.0);
         nss_guess[1] = .03;
         nss_guess[4] = 7.0;
@@ -290,7 +294,7 @@ int main(int, char* []) {
             boost::make_shared<FlatForward>(
                                     curveSettlementDays, calendar, 0.01, dc));
         SpreadFittingMethod nelsonSiegelSpread(
-                                    boost::make_shared<NelsonSiegelFitting>(Array(), optimizor),
+                                    boost::make_shared<NelsonSiegelFitting>(Array(), optimizor, ns_l2),
                                     discountCurve);
 
         boost::shared_ptr<FittedBondDiscountCurve> ts6 (
@@ -312,7 +316,10 @@ int main(int, char* []) {
             knotVector_q.push_back(knots_q[i]);
         }
 
-        QuadraticYieldSplinesFitting quadraticYieldSplines(knotVector_q, Array(), optimizor);
+        Array quad_l2(LENGTH(knots_q), .0001);
+        quad_l2[0] = 0.0;
+
+        QuadraticYieldSplinesFitting quadraticYieldSplines(knotVector_q, Array(), optimizor, quad_l2);
 
         boost::shared_ptr<FittedBondDiscountCurve> ts7(
             new FittedBondDiscountCurve(curveSettlementDays,

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -305,6 +305,26 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts6);
 
+        Time knots_q[] = { 0.5, 1.0, 1.5, 3., 6., 9., 18., 27.};
+
+        std::vector<Time> knotVector_q;
+        for (Size i = 0; i< LENGTH(knots_q); i++) {
+            knotVector_q.push_back(knots_q[i]);
+        }
+
+        QuadraticYieldSplinesFitting quadraticYieldSplines(knotVector_q, Array(), optimizor);
+
+        boost::shared_ptr<FittedBondDiscountCurve> ts7(
+            new FittedBondDiscountCurve(curveSettlementDays,
+                calendar,
+                instrumentsA,
+                dc,
+                quadraticYieldSplines,
+                tolerance,
+                max));
+
+        printOutput("(g) quadratic yield splines", ts7);
+
 
         cout << "Output par rates for each curve. In this case, "
              << endl
@@ -320,7 +340,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -363,7 +384,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts5,keyDates,dc)  << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts6,keyDates,dc) << endl;
+                 << 100.*parRate(*ts6,keyDates,dc) << " | "
+                 // Quadratic Yield Spline
+                 << setw(6) << fixed << setprecision(3)
+                 << 100.*parRate(*ts7, keyDates, dc) << endl;
         }
 
         cout << endl << endl << endl;

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -138,8 +138,8 @@ int main(int, char* []) {
 
         // changing bondSettlementDays=3 increases calculation
         // time of exponentialsplines fitting method
-        Natural bondSettlementDays = 0;
-        Natural curveSettlementDays = 0;
+        Natural bondSettlementDays = 3;
+        Natural curveSettlementDays = 3;
 
         Date bondSettlementDate = calendar.advance(today, bondSettlementDays*Days);
 
@@ -271,7 +271,7 @@ int main(int, char* []) {
         SvenssonFitting svensson(Array(), optimizor);
         Array nss_guess(6, 0.0);
         nss_guess[1] = .03;
-        nss_guess[4] = 3.0;
+        nss_guess[4] = 7.0;
         nss_guess[5] = 10.0;
 
         boost::shared_ptr<FittedBondDiscountCurve> ts5 (
@@ -305,7 +305,7 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts6);
 
-        Time knots_q[] = { 0.5, 1.0, 1.5, 3., 6., 9., 18., 27.};
+        Time knots_q[] = {0.75, 1.5, 3., 6., 9., 18., 27.};
 
         std::vector<Time> knotVector_q;
         for (Size i = 0; i< LENGTH(knots_q); i++) {
@@ -416,6 +416,8 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts6);
 
+        printOutput("(g) Quadratic Yield Spline", ts7);
+
         cout << endl
              << endl;
 
@@ -428,7 +430,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -471,7 +474,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts5,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts6,keyDates,dc) << endl;
+                 << 100.*parRate(*ts6,keyDates,dc) << " | "
+                 // Quadratic Yield Spline
+                 << setw(6) << fixed << setprecision(3)
+                 << 100.*parRate(*ts7, keyDates, dc) << endl;
         }
 
         cout << endl << endl << endl;
@@ -570,6 +576,17 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts66);
 
+        boost::shared_ptr<FittedBondDiscountCurve> ts77(
+            new FittedBondDiscountCurve(curveSettlementDays,
+                calendar,
+                instrumentsA,
+                dc,
+                quadraticYieldSplines,
+                tolerance,
+                max));
+
+        printOutput("(g) quadratic yield splines", ts77);
+
         cout << setw(6) << "tenor" << " | "
              << setw(6) << "coupon" << " | "
              << setw(6) << "bstrap" << " | "
@@ -578,7 +595,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -621,7 +639,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts55,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts66,keyDates,dc) << endl;
+                 << 100.*parRate(*ts66,keyDates,dc) << " | "
+                 // Quadratic Yield Spline
+                 << setw(6) << fixed << setprecision(3)
+                 << 100.*parRate(*ts77, keyDates, dc) << endl;
         }
 
 
@@ -660,7 +681,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -703,7 +725,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts55,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts66,keyDates,dc) << endl;
+                 << 100.*parRate(*ts66,keyDates,dc) << " | "
+                 // Quadratic Yield Spline
+                 << setw(6) << fixed << setprecision(3)
+                 << 100.*parRate(*ts77, keyDates, dc) << endl;
         }
 
 

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -297,9 +297,15 @@ namespace QuantLib {
             values[i] = weightedError * weightedError;
         }
 
+        Array guess(x.size(), 0.0);
+        if(!fittingMethod_->curve_->guessSolution_.empty())
+        {
+            guess = fittingMethod_->curve_->guessSolution_;
+        }
+
         if (N != 0) {
             for (Size i = 0; i < N; ++i) {
-                Real error = x[i] - fittingMethod_->curve_->guessSolution_[i];
+                Real error = x[i] - guess[i];
                 values[i + n] = fittingMethod_->l2_[i] * error * error;
             }
         }
@@ -385,13 +391,19 @@ namespace QuantLib {
                 jacobian[i][l] *= 2.0 * weight * weight * error;
             }
         }
+        
+        Array guess(x.size(), 0.0);
+        if (!fittingMethod_->curve_->guessSolution_.empty())
+        {
+            guess = fittingMethod_->curve_->guessSolution_;
+        }
 
         if (N != 0) {
             for (Size i = 0; i < N; ++i) {
                 for (Size l = 0; l < m; l++) {
                     jacobian[i+n][l] = 0.0;
                 }
-                Real error = x[i] - fittingMethod_->curve_->guessSolution_[i];
+                Real error = x[i] - guess[i];
                 jacobian[i + n][i] = 2.0 * fittingMethod_->l2_[i] * error;
             }
         }

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -281,14 +281,16 @@ namespace QuantLib {
                 modelPrice += cf[k]->amount() *
                                     fittingMethod_->discountFunction(x, tenor);
             }
-            if (helper->useCleanPrice())
-                modelPrice -= bond->accruedAmount(bondSettlement);
 
             // adjust price (NPV) for forward settlement
             if (bondSettlement != refDate ) {
                 Time tenor = dc.yearFraction(refDate, bondSettlement);
                 modelPrice /= fittingMethod_->discountFunction(x, tenor);
             }
+
+            if (helper->useCleanPrice())
+                modelPrice -= bond->accruedAmount(bondSettlement);
+
             Real marketPrice = helper->quote()->value();
             Real error = modelPrice - marketPrice;
             Real weightedError = fittingMethod_->weights_[i] * error;
@@ -360,8 +362,6 @@ namespace QuantLib {
                     jacobian[i][l] += cf[k]->amount() * grads[l];
                 }
             }
-            if (helper->useCleanPrice())
-                modelPrice -= bond->accruedAmount(bondSettlement);
 
             // adjust price (NPV) for forward settlement
             if (bondSettlement != refDate) {
@@ -375,6 +375,8 @@ namespace QuantLib {
                 }
                 modelPrice /= df;
             }
+            if (helper->useCleanPrice())
+                modelPrice -= bond->accruedAmount(bondSettlement);
             Real marketPrice = helper->quote()->value();
             Real error = modelPrice - marketPrice;
             Real weight = fittingMethod_->weights_[i];

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -41,6 +41,8 @@ namespace QuantLib {
                        FittedBondDiscountCurve::FittingMethod* fittingMethod);
         Real value(const Array& x) const;
         Disposable<Array> values(const Array& x) const;
+        Disposable<Array> gradients(const Array& x) const;
+        void jacobian(Matrix& jacobian, const Array& x) const;
       private:
         FittedBondDiscountCurve::FittingMethod* fittingMethod_;
         mutable vector<Size> firstCashFlow_;
@@ -300,6 +302,73 @@ namespace QuantLib {
             }
         }
         return values;
+    }
+
+    void
+        FittedBondDiscountCurve::FittingMethod::FittingCost::jacobian(Matrix &jacobian,
+            const Array &x) const {
+        Date refDate = fittingMethod_->curve_->referenceDate();
+        const DayCounter& dc = fittingMethod_->curve_->dayCounter();
+        Size n = fittingMethod_->curve_->bondHelpers_.size();
+        Size N = fittingMethod_->l2_.size();
+        Size m = x.size();
+
+      /*  Array values(n + N);*/
+        for (Size i = 0; i<n; ++i) {
+            shared_ptr<BondHelper> helper =
+                fittingMethod_->curve_->bondHelpers_[i];
+
+            shared_ptr<Bond> bond = helper->bond();
+            Date bondSettlement = bond->settlementDate();
+
+            // CleanPrice_i = sum( cf_k * d(t_k) ) - accruedAmount
+            Real modelPrice = 0.0;
+            for (Size l = 0; l < m; l++) {
+                jacobian[i][l] = 0.0;
+            }
+            const Leg& cf = bond->cashflows();
+            for (Size k = firstCashFlow_[i]; k<cf.size(); ++k) {
+                Time tenor = dc.yearFraction(refDate, cf[k]->date());
+                modelPrice += cf[k]->amount() *
+                    fittingMethod_->discountFunction(x, tenor);
+                Array grads = fittingMethod_->gradientFunction(x, tenor);
+                for (Size l = 0; l < m; l++) {
+                    jacobian[i][l] += cf[k]->amount() * grads[l];
+                }
+            }
+            if (helper->useCleanPrice())
+                modelPrice -= bond->accruedAmount(bondSettlement);
+
+            // adjust price (NPV) for forward settlement
+            if (bondSettlement != refDate) {
+                Time tenor = dc.yearFraction(refDate, bondSettlement);
+                Array grads = fittingMethod_->gradientFunction(x, tenor);
+                DiscountFactor df = fittingMethod_->discountFunction(x, tenor);
+                for (Size l = 0; l<m; l++)
+                {
+                    jacobian[i][l] /= df;
+                    jacobian[i][l] -= modelPrice * grads[l] / df / df;
+                }
+                modelPrice /= df;
+            }
+            Real marketPrice = helper->quote()->value();
+            Real error = modelPrice - marketPrice;
+            Real weight = fittingMethod_->weights_[i];
+            for (Size l = 0; l < m; l++)
+            {
+                jacobian[i][l] *= 2.0 * weight * weight * error;
+            }
+        }
+
+        if (N != 0) {
+            for (Size i = 0; i < N; ++i) {
+                for (Size l = 0; l < m; l++) {
+                    jacobian[i+n][l] = 0.0;
+                }
+                Real error = x[i] - fittingMethod_->curve_->guessSolution_[i];
+                jacobian[i + n][i] = 2.0 * fittingMethod_->l2_[i] * error;
+            }
+        }
     }
 
 }

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
                        FittedBondDiscountCurve::FittingMethod* fittingMethod);
         Real value(const Array& x) const;
         Disposable<Array> values(const Array& x) const;
-        Disposable<Array> gradients(const Array& x) const;
+        void gradient(Array &grad_f, const Array& x) const;
         void jacobian(Matrix& jacobian, const Array& x) const;
       private:
         FittedBondDiscountCurve::FittingMethod* fittingMethod_;
@@ -302,6 +302,30 @@ namespace QuantLib {
             }
         }
         return values;
+    }
+
+    void
+        FittedBondDiscountCurve::FittingMethod::FittingCost::gradient(Array &grad_f,
+             const Array &x) const {
+        Size n = fittingMethod_->curve_->bondHelpers_.size();
+        Size N = fittingMethod_->l2_.size();
+        Size m = x.size();
+        Matrix jacobianMatrix(n + N, m);
+
+        for (Size j = 0; j<m; j++)
+        {
+            grad_f[j] += 0;
+        }
+
+        jacobian(jacobianMatrix, x);
+        for(Size i=0; i<(n+N); i++)
+        {
+            for(Size j=0; j<m; j++)
+            {
+                grad_f[j] += jacobianMatrix[i][j];
+            }
+        }
+        
     }
 
     void

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -130,11 +130,10 @@ namespace QuantLib {
     FittedBondDiscountCurve::FittingMethod::FittingMethod(
                      bool constrainAtZero,
                      const Array& weights,
-                     const Array& l2,
-                     boost::shared_ptr<OptimizationMethod> optimizationMethod)
+                     boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                     const Array& l2)
     : constrainAtZero_(constrainAtZero), weights_(weights), l2_(l2),
       calculateWeights_(weights.empty()), optimizationMethod_(optimizationMethod) {}
-
 
     void FittedBondDiscountCurve::FittingMethod::init() {
         // yield conventions

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -130,7 +130,7 @@ namespace QuantLib {
     FittedBondDiscountCurve::FittingMethod::FittingMethod(
                      bool constrainAtZero,
                      const Array& weights,
-		             const Array& l2,
+                     const Array& l2,
                      boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : constrainAtZero_(constrainAtZero), weights_(weights), l2_(l2),
       calculateWeights_(weights.empty()), optimizationMethod_(optimizationMethod) {}
@@ -186,10 +186,10 @@ namespace QuantLib {
         QL_REQUIRE(weights_.size() == n,
                    "Given weights do not cover all boostrapping helpers");
 
-		if (!l2_.empty()) {
-			QL_REQUIRE(l2_.size() == size(),
-				"Given penalty factors do not cover all parameters");
-		}
+        if (!l2_.empty()) {
+            QL_REQUIRE(l2_.size() == size(),
+                       "Given penalty factors do not cover all parameters");
+        }
     }
 
     void FittedBondDiscountCurve::FittingMethod::calculate() {
@@ -203,24 +203,24 @@ namespace QuantLib {
             x = curve_->guessSolution_;
         }
 
-		if(curve_->maxEvaluations_ == 0)
-		{
-			//Don't calculate, simply use given parameters to provide a fitted curve.
-			//This turns the fittedbonddiscountcurve into an evaluator of the parametric
-			//curve, for example allowing to use the parameters for a credit spread curve
-			//calculated with bonds in one currency to be coupled to a discount curve in 
-			//another currency. 
-			return;
-		}
-		
+        if(curve_->maxEvaluations_ == 0)
+        {
+            //Don't calculate, simply use given parameters to provide a fitted curve.
+            //This turns the fittedbonddiscountcurve into an evaluator of the parametric
+            //curve, for example allowing to use the parameters for a credit spread curve
+            //calculated with bonds in one currency to be coupled to a discount curve in 
+            //another currency. 
+            return;
+        }
+        
         //workaround for backwards compatibility
         boost::shared_ptr<OptimizationMethod> optimization = optimizationMethod_;
         if(!optimization){
-		    optimization = boost::make_shared<Simplex>(curve_->simplexLambda_);
-		}
-		Problem problem(costFunction, constraint, x);
+            optimization = boost::make_shared<Simplex>(curve_->simplexLambda_);
+        }
+        Problem problem(costFunction, constraint, x);
 
-		Real rootEpsilon = curve_->accuracy_;
+        Real rootEpsilon = curve_->accuracy_;
         Real functionEpsilon =  curve_->accuracy_;
         Real gradientNormEpsilon = curve_->accuracy_;
 
@@ -249,8 +249,8 @@ namespace QuantLib {
     Real FittedBondDiscountCurve::FittingMethod::FittingCost::value(
                                                        const Array& x) const {
         Real squaredError = 0.0;
-		Array vals = values(x);
-		for (Size i = 0; i<vals.size(); ++i) {
+        Array vals = values(x);
+        for (Size i = 0; i<vals.size(); ++i) {
             squaredError += vals[i];
         }
         return squaredError;
@@ -262,7 +262,7 @@ namespace QuantLib {
         Date refDate  = fittingMethod_->curve_->referenceDate();
         const DayCounter& dc = fittingMethod_->curve_->dayCounter();
         Size n = fittingMethod_->curve_->bondHelpers_.size();
-		Size N = fittingMethod_->l2_.size();
+        Size N = fittingMethod_->l2_.size();
 
         Array values(n + N);
         for (Size i=0; i<n; ++i) {
@@ -294,12 +294,12 @@ namespace QuantLib {
             values[i] = weightedError * weightedError;
         }
 
-		if (N != 0) {
-			for (Size i = 0; i < N; ++i) {
-				Real error = x[i] - fittingMethod_->curve_->guessSolution_[i];
-				values[i + n] = fittingMethod_->l2_[i] * error * error;
-			}
-		}
+        if (N != 0) {
+            for (Size i = 0; i < N; ++i) {
+                Real error = x[i] - fittingMethod_->curve_->guessSolution_[i];
+                values[i + n] = fittingMethod_->l2_[i] * error * error;
+            }
+        }
         return values;
     }
 

--- a/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -164,6 +164,10 @@ namespace QuantLib {
         weights, which will be used as weights to each bond. If not given
         or empty, then the bonds will be weighted by inverse duration
 
+		An optional Array may be provided as an L2 regularizor in this case
+		a L2 (gaussian) penalty is applied to each parameter starting from the 
+		initial guess. This is the same as giving a Gaussian prior on the parameters
+
         \todo derive the special-case class LinearFittingMethods from
               FittingMethod. A linear fitting to a set of basis
               functions \f$ b_i(t) \f$ is any fitting of the form
@@ -201,6 +205,8 @@ namespace QuantLib {
 		bool constrainAtZero() const;
 		//! return weights being used
 		Array weights() const;
+		//! return l2 penalties being used
+		Array l2() const;
 		//! return optimization method being used
 		boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
 		//! open discountFunction to public
@@ -208,6 +214,7 @@ namespace QuantLib {
       protected:
         //! constructor
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
+			          const Array& l2 = Array(),
                       boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         //! rerun every time instruments/referenceDate changes
@@ -234,6 +241,8 @@ namespace QuantLib {
         void calculate();
         // array of normalized (duration) weights, one for each bond helper
         Array weights_;
+		// array of l2 penalties one for each parameter
+		Array l2_;
         // whether or not the weights should be calculated internally
         bool calculateWeights_;
         // total number of iterations used in the optimization routine
@@ -297,6 +306,10 @@ namespace QuantLib {
 	
 	inline Array FittedBondDiscountCurve::FittingMethod::weights() const {
 		return weights_;
+	}
+
+	inline Array FittedBondDiscountCurve::FittingMethod::l2() const {
+		return l2_;
 	}
 
 	inline boost::shared_ptr<OptimizationMethod> 

--- a/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -212,11 +212,11 @@ namespace QuantLib {
         //! open discountFunction to public
         DiscountFactor discount(const Array& x, Time t) const;
       protected:
-        //! constructor
+        //! constructors
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
-                      const Array& l2 = Array(),
                       boost::shared_ptr<OptimizationMethod> optimizationMethod
-                                          = boost::shared_ptr<OptimizationMethod>());
+                                          = boost::shared_ptr<OptimizationMethod>(),
+                      const Array& l2 = Array());
         //! rerun every time instruments/referenceDate changes
         virtual void init();
         //! discount function called by FittedBondDiscountCurve

--- a/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -164,9 +164,9 @@ namespace QuantLib {
         weights, which will be used as weights to each bond. If not given
         or empty, then the bonds will be weighted by inverse duration
 
-		An optional Array may be provided as an L2 regularizor in this case
-		a L2 (gaussian) penalty is applied to each parameter starting from the 
-		initial guess. This is the same as giving a Gaussian prior on the parameters
+        An optional Array may be provided as an L2 regularizor in this case
+        a L2 (gaussian) penalty is applied to each parameter starting from the 
+        initial guess. This is the same as giving a Gaussian prior on the parameters
 
         \todo derive the special-case class LinearFittingMethods from
               FittingMethod. A linear fitting to a set of basis
@@ -201,20 +201,20 @@ namespace QuantLib {
         Real minimumCostValue() const;
         //! clone of the current object
         virtual std::auto_ptr<FittingMethod> clone() const = 0;
-		//! return whether there is a constraint at zero
-		bool constrainAtZero() const;
-		//! return weights being used
-		Array weights() const;
-		//! return l2 penalties being used
-		Array l2() const;
-		//! return optimization method being used
-		boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
-		//! open discountFunction to public
-		DiscountFactor discount(const Array& x, Time t) const;
+        //! return whether there is a constraint at zero
+        bool constrainAtZero() const;
+        //! return weights being used
+        Array weights() const;
+        //! return l2 penalties being used
+        Array l2() const;
+        //! return optimization method being used
+        boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
+        //! open discountFunction to public
+        DiscountFactor discount(const Array& x, Time t) const;
       protected:
         //! constructor
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
-			          const Array& l2 = Array(),
+                      const Array& l2 = Array(),
                       boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         //! rerun every time instruments/referenceDate changes
@@ -241,8 +241,8 @@ namespace QuantLib {
         void calculate();
         // array of normalized (duration) weights, one for each bond helper
         Array weights_;
-		// array of l2 penalties one for each parameter
-		Array l2_;
+        // array of l2 penalties one for each parameter
+        Array l2_;
         // whether or not the weights should be calculated internally
         bool calculateWeights_;
         // total number of iterations used in the optimization routine
@@ -299,28 +299,28 @@ namespace QuantLib {
     inline Array FittedBondDiscountCurve::FittingMethod::solution() const {
         return solution_;
     }
-	
-	inline bool FittedBondDiscountCurve::FittingMethod::constrainAtZero() const {
-		return constrainAtZero_;
-	}
-	
-	inline Array FittedBondDiscountCurve::FittingMethod::weights() const {
-		return weights_;
-	}
+    
+    inline bool FittedBondDiscountCurve::FittingMethod::constrainAtZero() const {
+        return constrainAtZero_;
+    }
+    
+    inline Array FittedBondDiscountCurve::FittingMethod::weights() const {
+        return weights_;
+    }
 
-	inline Array FittedBondDiscountCurve::FittingMethod::l2() const {
-		return l2_;
-	}
+    inline Array FittedBondDiscountCurve::FittingMethod::l2() const {
+        return l2_;
+    }
 
-	inline boost::shared_ptr<OptimizationMethod> 
-	FittedBondDiscountCurve::FittingMethod::optimizationMethod() const {
-		return optimizationMethod_;
-	}
+    inline boost::shared_ptr<OptimizationMethod> 
+    FittedBondDiscountCurve::FittingMethod::optimizationMethod() const {
+        return optimizationMethod_;
+    }
 
-	inline DiscountFactor 
-	FittedBondDiscountCurve::FittingMethod::discount(const Array& x, Time t) const {
-		return discountFunction(x, t);
-	}
+    inline DiscountFactor 
+    FittedBondDiscountCurve::FittingMethod::discount(const Array& x, Time t) const {
+        return discountFunction(x, t);
+    }
 
 }
 

--- a/ql/termstructures/yield/fittedbonddiscountcurve.hpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.hpp
@@ -211,6 +211,8 @@ namespace QuantLib {
         boost::shared_ptr<OptimizationMethod> optimizationMethod() const;
         //! open discountFunction to public
         DiscountFactor discount(const Array& x, Time t) const;
+        //! open discountFunction to public
+        Array gradients(const Array& x, Time t) const;
       protected:
         //! constructors
         FittingMethod(bool constrainAtZero = true, const Array& weights = Array(),
@@ -222,6 +224,9 @@ namespace QuantLib {
         //! discount function called by FittedBondDiscountCurve
         virtual DiscountFactor discountFunction(const Array& x,
                                                 Time t) const = 0;
+        //! gradient function called by FittedBondDiscountCurve
+        virtual Array gradientFunction(const Array& x,
+            Time t) const = 0;
 
         //! constrains discount function to unity at \f$ T=0 \f$, if true
         bool constrainAtZero_;
@@ -320,6 +325,11 @@ namespace QuantLib {
     inline DiscountFactor 
     FittedBondDiscountCurve::FittingMethod::discount(const Array& x, Time t) const {
         return discountFunction(x, t);
+    }
+
+    inline Array
+        FittedBondDiscountCurve::FittingMethod::gradients(const Array& x, Time t) const {
+        return gradientFunction(x, t);
     }
 
 }

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -26,9 +26,14 @@ namespace QuantLib {
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
                                                          const Array& weights,
-                                                         const Array& l2,
-                                                         boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod) {}
+                                                         boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                                                         const Array& l2)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod, l2) {}
+
+    ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
+        const Array& weights,
+        const Array& l2)
+        : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, boost::shared_ptr<OptimizationMethod>(), l2) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     ExponentialSplinesFitting::clone() const {
@@ -68,9 +73,13 @@ namespace QuantLib {
 
 
     NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
-                                             const Array& l2,
-                                             boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
+                                             boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                                             const Array& l2)
+    : FittedBondDiscountCurve::FittingMethod(true, weights, optimizationMethod, l2) {}
+
+    NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
+        const Array& l2)
+        : FittedBondDiscountCurve::FittingMethod(true, weights, boost::shared_ptr<OptimizationMethod>(), l2) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     NelsonSiegelFitting::clone() const {
@@ -95,9 +104,13 @@ namespace QuantLib {
 
 
     SvenssonFitting::SvenssonFitting(const Array& weights,
-                                     const Array& l2,
-                                     boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
+                                     boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                                     const Array& l2)
+    : FittedBondDiscountCurve::FittingMethod(true, weights, optimizationMethod, l2) {}
+
+    SvenssonFitting::SvenssonFitting(const Array& weights,
+        const Array& l2)
+        : FittedBondDiscountCurve::FittingMethod(true, weights, boost::shared_ptr<OptimizationMethod>(), l2) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     SvenssonFitting::clone() const {
@@ -128,9 +141,9 @@ namespace QuantLib {
     CubicBSplinesFitting::CubicBSplinesFitting(const std::vector<Time>& knots,
                                                bool constrainAtZero,
                                                const Array& weights,
-                                               const Array& l2,
-                                               boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
+                                               boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                                               const Array& l2)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod, l2),
       splines_(3, knots.size()-5, knots) {
 
         QL_REQUIRE(knots.size() >= 8,
@@ -147,6 +160,33 @@ namespace QuantLib {
             QL_REQUIRE(std::abs(splines_(N_, 0.0)) > QL_EPSILON,
                        "N_th cubic B-spline must be nonzero at t=0");
         } else {
+            size_ = basisFunctions;
+            N_ = 0;
+        }
+    }
+
+    CubicBSplinesFitting::CubicBSplinesFitting(const std::vector<Time>& knots,
+        bool constrainAtZero,
+        const Array& weights,
+        const Array& l2)
+        : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, boost::shared_ptr<OptimizationMethod>(), l2),
+        splines_(3, knots.size() - 5, knots) {
+
+        QL_REQUIRE(knots.size() >= 8,
+            "At least 8 knots are required");
+        Size basisFunctions = knots.size() - 4;
+
+        if (constrainAtZero) {
+            size_ = basisFunctions - 1;
+
+            // Note: A small but nonzero N_th basis function at t=0 may
+            // lead to an ill conditioned problem
+            N_ = 1;
+
+            QL_REQUIRE(std::abs(splines_(N_, 0.0)) > QL_EPSILON,
+                "N_th cubic B-spline must be nonzero at t=0");
+        }
+        else {
             size_ = basisFunctions;
             N_ = 0;
         }
@@ -198,10 +238,16 @@ namespace QuantLib {
     SimplePolynomialFitting::SimplePolynomialFitting(Natural degree,
                                                      bool constrainAtZero,
                                                      const Array& weights,
-                                                     const Array& l2,
-                                                     boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
+                                                     boost::shared_ptr<OptimizationMethod> optimizationMethod,
+                                                     const Array& l2)
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod, l2),
       size_(constrainAtZero ? degree : degree+1) {}
+
+    SimplePolynomialFitting::SimplePolynomialFitting(Natural degree, bool constrainAtZero,
+                                                     const Array& weights, const Array& l2)
+        : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, 
+                                                 boost::shared_ptr<OptimizationMethod>(), l2),
+        size_(constrainAtZero ? degree : degree + 1) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     SimplePolynomialFitting::clone() const {
@@ -230,9 +276,9 @@ namespace QuantLib {
     
     SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve)
-    : FittedBondDiscountCurve::FittingMethod(method ? method->constrainAtZero() : true, method ? method->weights() : Array(), 
-                                             method ? method->l2() : Array(),
-                                             method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>()),
+    : FittedBondDiscountCurve::FittingMethod(method ? method->constrainAtZero() : true, method ? method->weights() : Array(),
+                                             method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>(), 
+                                             method ? method->l2() : Array()),
       method_(method), discountingCurve_(discountCurve) {
         QL_REQUIRE(method, "Fitting method is empty");
         QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -70,6 +70,35 @@ namespace QuantLib {
         return d;
     }
 
+    Array ExponentialSplinesFitting::gradientFunction(const Array& x,
+        Time t) const {
+
+        DiscountFactor dKappa = 0.0;
+        Size N = size();
+        Array gradients(N);
+        Real kappa = x[N - 1];
+
+        if (!constrainAtZero_) {
+            for (Size i = 0; i<N - 1; ++i) {
+                gradients[i] = std::exp(-kappa * (i + 1) * t);
+                dKappa -= (i + 1) * t * x[i] * gradients[i];
+            }
+        }
+        else {
+            //  notation:
+            //  d(t) = coeff* exp(-kappa*1*t) + x[0]* exp(-kappa*2*t) +
+            //  x[1]* exp(-kappa*3*t) + ..+ x[7]* exp(-kappa*9*t)
+            for (Size i = 0; i<N - 1; i++) {
+                gradients[i] = std::exp(-kappa * (i + 2) * t);
+                dKappa -= (i + 2) * t * x[i] * gradients[i];
+                gradients[i] -= std::exp(-kappa * t);
+                dKappa += t * x[i] * std::exp(-kappa * t);
+            }
+        }
+        gradients[N - 1] = dKappa;
+        return gradients;
+    }
+
 
 
     NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
@@ -100,6 +129,25 @@ namespace QuantLib {
                         (x[2])*std::exp(-kappa*t);
         DiscountFactor d = std::exp(-zeroRate * t) ;
         return d;
+    }
+
+    Array NelsonSiegelFitting::gradientFunction(const Array& x, Time t) const {
+        Array gradients(size());
+        Real kappa = x[size() - 1];
+        Real exp = std::exp(-kappa*t);
+        Real Z = (1.0 - exp) / ((kappa + QL_EPSILON)*(t + QL_EPSILON));
+        Real zeroRate = x[0] + (x[1] + x[2]) * Z - x[2] * exp;
+        Real dDdR = -t * std::exp(-zeroRate * t);
+
+        gradients[0] = dDdR;
+        gradients[1] = dDdR * Z;
+        gradients[2] = dDdR * (Z - exp);
+        gradients[3] = (x[1] + x[2]) / t / kappa;
+        gradients[3] *= t * exp - (1 - exp) / kappa / kappa;
+        gradients[3] += x[2] * t * exp;
+        gradients[3] *= dDdR;
+
+        return gradients;
     }
 
 
@@ -134,6 +182,33 @@ namespace QuantLib {
                         x[3]* (((1.0 - std::exp(-kappa_1*t))/((kappa_1+QL_EPSILON)*(t+QL_EPSILON)))- std::exp(-kappa_1*t));
         DiscountFactor d = std::exp(-zeroRate * t) ;
         return d;
+    }
+
+    Array SvenssonFitting::gradientFunction(const Array& x, Time t) const {
+        Array gradients(size());
+        Real kappa = x[size() - 2];
+        Real kappa_1 = x[size() - 1];
+        Real exp = std::exp(-kappa*t);
+        Real exp_1 = std::exp(-kappa_1*t);
+        Real Z = (1.0 - exp) / ((kappa + QL_EPSILON)*(t + QL_EPSILON));
+        Real Z_1 = (1.0 - exp_1) / ((kappa_1 + QL_EPSILON)*(t + QL_EPSILON));
+        Real zeroRate = x[0] + (x[1] + x[2]) * Z - x[2] * exp + x[3] * (Z_1 - exp_1);
+        Real dDdR = -t * std::exp(-zeroRate * t);
+
+        gradients[0] = dDdR;
+        gradients[1] = dDdR * Z;
+        gradients[2] = dDdR * (Z - exp);
+        gradients[3] = dDdR * (Z_1 - exp_1);
+        gradients[4] = (x[1] + x[2]) / t / kappa;
+        gradients[4] *= t * exp - (1 - exp) / kappa;
+        gradients[4] += x[2] * t * exp;
+        gradients[4] *= dDdR;
+        gradients[5] = - (1 - exp_1) / t / kappa_1 / kappa_1;
+        gradients[5] += exp_1 / kappa_1;
+        gradients[5] += t * exp_1;
+        gradients[5] *= x[3] * dDdR;
+
+        return gradients;
     }
 
 
@@ -234,6 +309,32 @@ namespace QuantLib {
         return d;
     }
 
+    Array CubicBSplinesFitting::gradientFunction(const Array& x,
+        Time t) const {
+
+        Array gradients(size());
+
+        if (!constrainAtZero_) {
+            for (Size i = 0; i<size_; ++i) {
+                gradients[i] = splines_(i, t);
+            }
+        }
+        else {
+            const Real T = 0.0;
+            Real sum = 0.0;
+            for (Size i = 0; i<size_; ++i) {
+                if (i < N_) {
+                    gradients[i] = splines_(i, t) - splines_(i, T) / splines_(N_, T);
+                }
+                else {
+                    gradients[i] = splines_(i + 1, t) - splines_(i + 1, T) / splines_(N_, T);
+                }
+            }
+        }
+
+        return gradients;
+    }
+
 
     SimplePolynomialFitting::SimplePolynomialFitting(Natural degree,
                                                      bool constrainAtZero,
@@ -273,6 +374,21 @@ namespace QuantLib {
         }
         return d;
     }
+
+    Array SimplePolynomialFitting::gradientFunction(const Array& x,
+        Time t) const {
+        Array gradients(size());
+
+        if (!constrainAtZero_) {
+            for (Size i = 0; i<size_; ++i)
+                gradients[i] = BernsteinPolynomial::get(i, i, t);
+        }
+        else {
+            for (Size i = 0; i<size_; ++i)
+                gradients[i] = BernsteinPolynomial::get(i + 1, i + 1, t);
+        }
+        return gradients;
+    }
     
     SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve)
@@ -296,6 +412,18 @@ namespace QuantLib {
 
     DiscountFactor SpreadFittingMethod::discountFunction(const Array& x, Time t) const{
         return method_->discount(x, t)*discountingCurve_->discount(t, true)/rebase_;
+    }
+
+    Array SpreadFittingMethod::gradientFunction(const Array& x, Time t) const {
+        Array gradients = method_->gradients(x, t);
+        Real crv_df = discountingCurve_->discount(t, true) / rebase_;
+        Size n = size();
+
+        for(Size i=0; i<n; i++)
+        {
+            gradients[i] *= crv_df;
+        }
+        return gradients;
     }
 
     void SpreadFittingMethod::init(){

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -26,8 +26,9 @@ namespace QuantLib {
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
                                                          const Array& weights,
+		                                                 const Array& l2,
                                                          boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod) {}
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     ExponentialSplinesFitting::clone() const {
@@ -67,8 +68,9 @@ namespace QuantLib {
 
 
     NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
+		                                     const Array& l2,
                                              boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(true, weights, optimizationMethod) {}
+    : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     NelsonSiegelFitting::clone() const {
@@ -93,8 +95,9 @@ namespace QuantLib {
 
 
     SvenssonFitting::SvenssonFitting(const Array& weights,
+		                             const Array& l2,
                                      boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(true, weights, optimizationMethod) {}
+    : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     SvenssonFitting::clone() const {
@@ -125,8 +128,9 @@ namespace QuantLib {
     CubicBSplinesFitting::CubicBSplinesFitting(const std::vector<Time>& knots,
                                                bool constrainAtZero,
                                                const Array& weights,
+		                                       const Array& l2,
                                                boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod),
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
       splines_(3, knots.size()-5, knots) {
 
         QL_REQUIRE(knots.size() >= 8,
@@ -194,8 +198,9 @@ namespace QuantLib {
     SimplePolynomialFitting::SimplePolynomialFitting(Natural degree,
                                                      bool constrainAtZero,
                                                      const Array& weights,
+		                                             const Array& l2,
                                                      boost::shared_ptr<OptimizationMethod> optimizationMethod)
-    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, optimizationMethod),
+    : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
       size_(constrainAtZero ? degree : degree+1) {}
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
@@ -226,6 +231,7 @@ namespace QuantLib {
 	SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve)
     : FittedBondDiscountCurve::FittingMethod(method ? method->constrainAtZero() : true, method ? method->weights() : Array(), 
+		                                     method ? method->l2() : Array(),
 											 method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>()),
       method_(method), discountingCurve_(discountCurve) {
 		QL_REQUIRE(method, "Fitting method is empty");

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -321,7 +321,6 @@ namespace QuantLib {
         }
         else {
             const Real T = 0.0;
-            Real sum = 0.0;
             for (Size i = 0; i<size_; ++i) {
                 if (i < N_) {
                     gradients[i] = splines_(i, t) - splines_(N_, t) * 

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -73,7 +73,7 @@ namespace QuantLib {
     Array ExponentialSplinesFitting::gradientFunction(const Array& x,
         Time t) const {
 
-        DiscountFactor dKappa = 0.0;
+        Real dKappa = 0.0;
         Size N = size();
         Array gradients(N);
         Real kappa = x[N - 1];
@@ -324,10 +324,12 @@ namespace QuantLib {
             Real sum = 0.0;
             for (Size i = 0; i<size_; ++i) {
                 if (i < N_) {
-                    gradients[i] = splines_(i, t) - splines_(i, T) / splines_(N_, T);
+                    gradients[i] = splines_(i, t) - splines_(N_, t) * 
+                                   splines_(i, T) / splines_(N_, T);
                 }
                 else {
-                    gradients[i] = splines_(i + 1, t) - splines_(i + 1, T) / splines_(N_, T);
+                    gradients[i] = splines_(i + 1, t) - splines_(N_, t) * 
+                                   splines_(i + 1, T) / splines_(N_, T);
                 }
             }
         }

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
                                                          const Array& weights,
-		                                                 const Array& l2,
+                                                         const Array& l2,
                                                          boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod) {}
 
@@ -68,7 +68,7 @@ namespace QuantLib {
 
 
     NelsonSiegelFitting::NelsonSiegelFitting(const Array& weights,
-		                                     const Array& l2,
+                                             const Array& l2,
                                              boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
 
@@ -95,7 +95,7 @@ namespace QuantLib {
 
 
     SvenssonFitting::SvenssonFitting(const Array& weights,
-		                             const Array& l2,
+                                     const Array& l2,
                                      boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : FittedBondDiscountCurve::FittingMethod(true, weights, l2, optimizationMethod) {}
 
@@ -128,7 +128,7 @@ namespace QuantLib {
     CubicBSplinesFitting::CubicBSplinesFitting(const std::vector<Time>& knots,
                                                bool constrainAtZero,
                                                const Array& weights,
-		                                       const Array& l2,
+                                               const Array& l2,
                                                boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
       splines_(3, knots.size()-5, knots) {
@@ -198,7 +198,7 @@ namespace QuantLib {
     SimplePolynomialFitting::SimplePolynomialFitting(Natural degree,
                                                      bool constrainAtZero,
                                                      const Array& weights,
-		                                             const Array& l2,
+                                                     const Array& l2,
                                                      boost::shared_ptr<OptimizationMethod> optimizationMethod)
     : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, l2, optimizationMethod),
       size_(constrainAtZero ? degree : degree+1) {}
@@ -227,16 +227,16 @@ namespace QuantLib {
         }
         return d;
     }
-	
-	SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
+    
+    SpreadFittingMethod::SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve)
     : FittedBondDiscountCurve::FittingMethod(method ? method->constrainAtZero() : true, method ? method->weights() : Array(), 
-		                                     method ? method->l2() : Array(),
-											 method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>()),
+                                             method ? method->l2() : Array(),
+                                             method ? method->optimizationMethod() : boost::shared_ptr<OptimizationMethod>()),
       method_(method), discountingCurve_(discountCurve) {
-		QL_REQUIRE(method, "Fitting method is empty");
-		QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");
-	}
+        QL_REQUIRE(method, "Fitting method is empty");
+        QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");
+    }
 
     std::auto_ptr<FittedBondDiscountCurve::FittingMethod>
     SpreadFittingMethod::clone() const {
@@ -248,21 +248,21 @@ namespace QuantLib {
         return method_->size();
     }
 
-	DiscountFactor SpreadFittingMethod::discountFunction(const Array& x, Time t) const{
+    DiscountFactor SpreadFittingMethod::discountFunction(const Array& x, Time t) const{
         return method_->discount(x, t)*discountingCurve_->discount(t, true)/rebase_;
     }
 
-	void SpreadFittingMethod::init(){
-		//In case discount curve has a different reference date,
-		//discount to this curve's reference date
-		if (curve_->referenceDate() != discountingCurve_->referenceDate()){
-			rebase_ = discountingCurve_->discount(curve_->referenceDate());
-		}
-		else{
-			rebase_ = 1.0;
-		}
-		//Call regular init
-		FittedBondDiscountCurve::FittingMethod::init();
-	}
+    void SpreadFittingMethod::init(){
+        //In case discount curve has a different reference date,
+        //discount to this curve's reference date
+        if (curve_->referenceDate() != discountingCurve_->referenceDate()){
+            rebase_ = discountingCurve_->discount(curve_->referenceDate());
+        }
+        else{
+            rebase_ = 1.0;
+        }
+        //Call regular init
+        FittedBondDiscountCurve::FittingMethod::init();
+    }
 }
 

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -58,6 +58,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
     };
 
 
@@ -83,6 +84,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
     };
 
 
@@ -110,6 +112,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
     };
 
 
@@ -151,6 +154,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
         BSpline splines_;
         Size size_;
         //! N_th basis function coefficient to solve for when d(0)=1
@@ -185,6 +189,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
         Size size_;
     };
 
@@ -203,6 +208,7 @@ namespace QuantLib {
       private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
         // underlying parametric method
         boost::shared_ptr<FittingMethod> method_;
         // adjustment in case underlying discount curve has different reference date

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -162,6 +162,34 @@ namespace QuantLib {
     };
 
 
+    //! QuadraticYieldSpline fitting method
+    /*! Fits a zeroRate yield function to a set of quadratic splines
+    
+    */
+    class QuadraticYieldSplinesFitting
+        : public FittedBondDiscountCurve::FittingMethod {
+    public:
+        QuadraticYieldSplinesFitting(const std::vector<Time>& knotVector,
+            const Array& weights = Array(),
+            boost::shared_ptr<OptimizationMethod> optimizationMethod
+            = boost::shared_ptr<OptimizationMethod>(),
+            const Array& l2 = Array());
+        QuadraticYieldSplinesFitting(const std::vector<Time>& knotVector,
+            const Array& weights,
+            const Array& l2);
+        //! cubic B-spline basis functions
+        std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
+    private:
+        Size size() const;
+        DiscountFactor discountFunction(const Array& x, Time t) const;
+        Array gradientFunction(const Array& x, Time t) const;
+        std::vector<Time> knots_;
+        Size size_;
+        //! N_th basis function coefficient to solve for when d(0)=1
+        Natural N_;
+    };
+
+
     //! Simple polynomial fitting method
     /*  Fits a discount function to the simple polynomial form:
         \f[

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -48,6 +48,7 @@ namespace QuantLib {
       public:
         ExponentialSplinesFitting(bool constrainAtZero = true,
                                   const Array& weights = Array(),
+			                      const Array& l2 = Array(),
                                   boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -71,6 +72,7 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         NelsonSiegelFitting(const Array& weights = Array(),
+			                const Array& l2 = Array(),
                             boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -96,6 +98,7 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         SvenssonFitting(const Array& weights = Array(),
+			            const Array& l2 = Array(),
                         boost::shared_ptr<OptimizationMethod> optimizationMethod
                                = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -130,6 +133,7 @@ namespace QuantLib {
         CubicBSplinesFitting(const std::vector<Time>& knotVector,
                              bool constrainAtZero = true,
                              const Array& weights = Array(),
+			                 const Array& l2 = Array(),
                              boost::shared_ptr<OptimizationMethod> optimizationMethod
                                      = boost::shared_ptr<OptimizationMethod>());
         //! cubic B-spline basis functions
@@ -161,6 +165,7 @@ namespace QuantLib {
         SimplePolynomialFitting(Natural degree,
                                 bool constrainAtZero = true,
                                 const Array& weights = Array(),
+			                    const Array& l2 = Array(),
                                 boost::shared_ptr<OptimizationMethod> optimizationMethod
                                        = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
       public:
         ExponentialSplinesFitting(bool constrainAtZero = true,
                                   const Array& weights = Array(),
-			                      const Array& l2 = Array(),
+                                  const Array& l2 = Array(),
                                   boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -72,7 +72,7 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         NelsonSiegelFitting(const Array& weights = Array(),
-			                const Array& l2 = Array(),
+                            const Array& l2 = Array(),
                             boost::shared_ptr<OptimizationMethod> optimizationMethod
                                           = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -98,7 +98,7 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         SvenssonFitting(const Array& weights = Array(),
-			            const Array& l2 = Array(),
+                        const Array& l2 = Array(),
                         boost::shared_ptr<OptimizationMethod> optimizationMethod
                                = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -133,7 +133,7 @@ namespace QuantLib {
         CubicBSplinesFitting(const std::vector<Time>& knotVector,
                              bool constrainAtZero = true,
                              const Array& weights = Array(),
-			                 const Array& l2 = Array(),
+                             const Array& l2 = Array(),
                              boost::shared_ptr<OptimizationMethod> optimizationMethod
                                      = boost::shared_ptr<OptimizationMethod>());
         //! cubic B-spline basis functions
@@ -165,7 +165,7 @@ namespace QuantLib {
         SimplePolynomialFitting(Natural degree,
                                 bool constrainAtZero = true,
                                 const Array& weights = Array(),
-			                    const Array& l2 = Array(),
+                                const Array& l2 = Array(),
                                 boost::shared_ptr<OptimizationMethod> optimizationMethod
                                        = boost::shared_ptr<OptimizationMethod>());
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -185,13 +185,13 @@ namespace QuantLib {
          SpreadFittingMethod(boost::shared_ptr<FittingMethod> method,
                         Handle<YieldTermStructure> discountCurve);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
-	protected:
-		void init();
-	  private:
+    protected:
+        void init();
+      private:
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
-		// underlying parametric method
-		boost::shared_ptr<FittingMethod> method_;
+        // underlying parametric method
+        boost::shared_ptr<FittingMethod> method_;
         // adjustment in case underlying discount curve has different reference date
         DiscountFactor rebase_;
         // discount curve from on top of which the spread will be calculated

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -48,9 +48,12 @@ namespace QuantLib {
       public:
         ExponentialSplinesFitting(bool constrainAtZero = true,
                                   const Array& weights = Array(),
-                                  const Array& l2 = Array(),
                                   boost::shared_ptr<OptimizationMethod> optimizationMethod
-                                          = boost::shared_ptr<OptimizationMethod>());
+                                          = boost::shared_ptr<OptimizationMethod>(),
+                                  const Array& l2 = Array());
+        ExponentialSplinesFitting(bool constrainAtZero,
+                                  const Array& weights,
+                                  const Array& l2);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
@@ -72,9 +75,10 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         NelsonSiegelFitting(const Array& weights = Array(),
-                            const Array& l2 = Array(),
                             boost::shared_ptr<OptimizationMethod> optimizationMethod
-                                          = boost::shared_ptr<OptimizationMethod>());
+                                          = boost::shared_ptr<OptimizationMethod>(),
+                            const Array& l2 = Array());
+        NelsonSiegelFitting(const Array& weights, const Array& l2);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
@@ -98,9 +102,10 @@ namespace QuantLib {
         : public FittedBondDiscountCurve::FittingMethod {
       public:
         SvenssonFitting(const Array& weights = Array(),
-                        const Array& l2 = Array(),
                         boost::shared_ptr<OptimizationMethod> optimizationMethod
-                               = boost::shared_ptr<OptimizationMethod>());
+                               = boost::shared_ptr<OptimizationMethod>(),
+                        const Array& l2 = Array());
+        SvenssonFitting(const Array& weights, const Array& l2);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;
@@ -133,9 +138,13 @@ namespace QuantLib {
         CubicBSplinesFitting(const std::vector<Time>& knotVector,
                              bool constrainAtZero = true,
                              const Array& weights = Array(),
-                             const Array& l2 = Array(),
                              boost::shared_ptr<OptimizationMethod> optimizationMethod
-                                     = boost::shared_ptr<OptimizationMethod>());
+                                     = boost::shared_ptr<OptimizationMethod>(),
+                             const Array& l2 = Array());
+        CubicBSplinesFitting(const std::vector<Time>& knotVector,
+                             bool constrainAtZero,
+                             const Array& weights,
+                             const Array& l2);
         //! cubic B-spline basis functions
         Real basisFunction(Integer i, Time t) const;
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
@@ -165,9 +174,13 @@ namespace QuantLib {
         SimplePolynomialFitting(Natural degree,
                                 bool constrainAtZero = true,
                                 const Array& weights = Array(),
-                                const Array& l2 = Array(),
                                 boost::shared_ptr<OptimizationMethod> optimizationMethod
-                                       = boost::shared_ptr<OptimizationMethod>());
+                                       = boost::shared_ptr<OptimizationMethod>(),
+                                const Array& l2 = Array());
+        SimplePolynomialFitting(Natural degree,
+                                bool constrainAtZero,
+                                const Array& weights,
+                                const Array& l2);
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
       private:
         Size size() const;

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -548,7 +548,10 @@ test_suite* DayCounterTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testBusiness252));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_BondBasis));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_EurobondBasis));
+
+#ifdef QL_HIGH_RESOLUTION_DATE
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testIntraday));
+#endif
 
     return suite;
 }


### PR DESCRIPTION
So methods will work with optimizors requireing gradients. Would also suggest to change default optimzor to LevanbergMarquedt, requires sensible guesses st start but is much faster than simplex gradient free.