### PR TITLE
Detect the case when it's not possible to run a Monte Carlo simulation for Asian options

### DIFF
--- a/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
@@ -136,7 +136,7 @@ namespace QuantLib {
                     payoff->optionType(),
                     payoff->strike(),
                     this->process_->riskFreeRate()->discount(
-                                                     this->timeGrid().back()),
+                                                        exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings));
     }

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -114,7 +114,7 @@ namespace QuantLib {
                 new ArithmeticASOPathPricer(
                     payoff->optionType(),
                     this->process_->riskFreeRate()->discount(
-                                                     this->timeGrid().back()),
+                                                        exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings));
     }

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -126,7 +126,7 @@ namespace QuantLib {
                     payoff->optionType(),
                     payoff->strike(),
                     this->process_->riskFreeRate()->discount(
-                                                   this->timeGrid().back()),
+                                                        exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings));
     }

--- a/ql/timegrid.hpp
+++ b/ql/timegrid.hpp
@@ -51,6 +51,7 @@ namespace QuantLib {
         template <class Iterator>
         TimeGrid(Iterator begin, Iterator end)
         : mandatoryTimes_(begin, end) {
+            QL_REQUIRE(begin != end, "empty time sequence");
             std::sort(mandatoryTimes_.begin(),mandatoryTimes_.end());
             // We seem to assume that the grid begins at 0.
             // Let's enforce the assumption for the time being
@@ -81,6 +82,7 @@ namespace QuantLib {
         template <class Iterator>
         TimeGrid(Iterator begin, Iterator end, Size steps)
         : mandatoryTimes_(begin, end) {
+            QL_REQUIRE(begin != end, "empty time sequence");
             std::sort(mandatoryTimes_.begin(),mandatoryTimes_.end());
             // We seem to assume that the grid begins at 0.
             // Let's enforce the assumption for the time being

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1193,13 +1193,13 @@ void AsianOptionTest::testAllFixingsInThePast() {
         MakeMCDiscreteGeometricAPEngine<LowDiscrepancy>(stochProcess)
         .withSamples(2047));
 
-    // Check that NPV raises an exception instead of crashing.
+    // Check that NPV raises a specific exception instead of crashing.
     // (It used to do that.)
 
     bool raised = false;
     try {
         option1.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {
@@ -1209,7 +1209,7 @@ void AsianOptionTest::testAllFixingsInThePast() {
     raised = false;
     try {
         option1.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {
@@ -1219,7 +1219,7 @@ void AsianOptionTest::testAllFixingsInThePast() {
     raised = false;
     try {
         option2.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {
@@ -1235,7 +1235,7 @@ void AsianOptionTest::testAllFixingsInThePast() {
     raised = false;
     try {
         option1.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {
@@ -1245,7 +1245,7 @@ void AsianOptionTest::testAllFixingsInThePast() {
     raised = false;
     try {
         option1.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {
@@ -1255,7 +1255,7 @@ void AsianOptionTest::testAllFixingsInThePast() {
     raised = false;
     try {
         option2.NPV();
-    } catch (Error&) {
+    } catch (detail::PastFixingsOnly&) {
         raised = true;
     }
     if (!raised) {

--- a/test-suite/asianoptions.hpp
+++ b/test-suite/asianoptions.hpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2003, 2004 Ferdinando Ametrano
- Copyright (C) 2008 StatPro Italia srl
+ Copyright (C) 2008, 2017 StatPro Italia srl
  Copyright (C) 2009 Master IMAFA - Polytech'Nice Sophia - Université de Nice Sophia Antipolis
 
  This file is part of QuantLib, a free-software/open-source library
@@ -38,6 +38,7 @@ class AsianOptionTest {
     static void testMCDiscreteArithmeticAverageStrike();
     static void testAnalyticDiscreteGeometricAveragePriceGreeks();
     static void testPastFixings();
+    static void testAllFixingsInThePast();
     static void testLevyEngine();
     static void testVecerEngine();
     static boost::unit_test_framework::test_suite* suite();


### PR DESCRIPTION
Fixes #242.

When all fixing dates are in the past, or when today's date is the last fixing date, it's not possible to build a time grid for the simulation.  In the best case, this caused a generic exception; in the worst case, this would cause an access violation and crash the program.

The code now detects these cases and throws an exception with a proper message.

Also, the PR contains a couple of related fixes.  The `TimeGrid` constructor would crash when passed an empty iterator range, and the payoff of Asian options was discounted from the last fixing date instead of the exercise date.