### PR TITLE
Small refactoring of InterpolatedSurvivalProbabilityCurve

### DIFF
--- a/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
+++ b/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
@@ -45,6 +45,17 @@ namespace QuantLib {
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
             const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
+        InterpolatedSurvivalProbabilityCurve(
+            const std::vector<Date>& dates,
+            const std::vector<Probability>& probabilities,
+            const DayCounter& dayCounter,
+            const Calendar& calendar,
+            const Interpolator& interpolator);
+        InterpolatedSurvivalProbabilityCurve(
+            const std::vector<Date>& dates,
+            const std::vector<Probability>& probabilities,
+            const DayCounter& dayCounter,
+            const Interpolator& interpolator);
         //! \name TermStructure interface
         //@{
         Date maxDate() const;
@@ -82,6 +93,8 @@ namespace QuantLib {
         Real defaultDensityImpl(Time) const;
         //@}
         mutable std::vector<Date> dates_;
+    private:
+        void initialize();
     };
 
     // inline definitions
@@ -198,6 +211,43 @@ namespace QuantLib {
       InterpolatedCurve<T>(std::vector<Time>(), probabilities, interpolator),
       dates_(dates)
     {
+        initialize();
+    }
+
+    template <class T>
+    InterpolatedSurvivalProbabilityCurve<T>::InterpolatedSurvivalProbabilityCurve(
+                                    const std::vector<Date>& dates,
+                                    const std::vector<Probability>& probabilities,
+                                    const DayCounter& dayCounter,
+                                    const Calendar& calendar,
+                                    const T& interpolator)
+    : SurvivalProbabilityStructure(dates.at(0), calendar, dayCounter),
+      InterpolatedCurve<T>(std::vector<Time>(), probabilities, interpolator),
+      dates_(dates)
+    {
+        initialize();
+    }
+
+    template <class T>
+    InterpolatedSurvivalProbabilityCurve<T>::InterpolatedSurvivalProbabilityCurve(
+                                    const std::vector<Date>& dates,
+                                    const std::vector<Probability>& probabilities,
+                                    const DayCounter& dayCounter,
+                                    const T& interpolator)
+    : SurvivalProbabilityStructure(dates.at(0), Calendar(), dayCounter),
+      InterpolatedCurve<T>(std::vector<Time>(), probabilities, interpolator),
+      dates_(dates)
+    {
+        initialize();
+    }
+
+
+    #endif
+
+
+    template <class T>
+    void InterpolatedSurvivalProbabilityCurve<T>::initialize()
+    {
         QL_REQUIRE(dates_.size() >= T::requiredPoints,
                    "not enough input dates given");
         QL_REQUIRE(this->data_.size() == dates_.size(),
@@ -212,7 +262,7 @@ namespace QuantLib {
             QL_REQUIRE(dates_[i] > dates_[i-1],
                        "invalid date (" << dates_[i] << ", vs "
                        << dates_[i-1] << ")");
-            this->times_[i] = dayCounter.yearFraction(dates_[0], dates_[i]);
+            this->times_[i] = dayCounter().yearFraction(dates_[0], dates_[i]);
             QL_REQUIRE(!close(this->times_[i],this->times_[i-1]),
                        "two dates correspond to the same time "
                        "under this curve's day count convention");
@@ -234,7 +284,6 @@ namespace QuantLib {
         this->interpolation_.update();
     }
 
-    #endif
 }
 
 #endif


### PR DESCRIPTION
Small refactoring to be in line with the classes InterpolatedHazardRateCurve and InterpolatedDefaultDensityCurve.

With a view to expose this curve in Python and call it in a simpler way. 