### PR TITLE
Federal Reserve calendar addition; fixed bug in US Government Bond calendar

### DIFF
--- a/ql/indexes/ibor/fedfunds.cpp
+++ b/ql/indexes/ibor/fedfunds.cpp
@@ -27,7 +27,7 @@ namespace QuantLib {
     FedFunds::FedFunds(const Handle<YieldTermStructure>& h)
     : OvernightIndex("FedFunds", 0,
                      USDCurrency(),
-                     UnitedStates(UnitedStates::Settlement),
+                     UnitedStates(UnitedStates::FederalReserve),
                      Actual360(), h) {}
 
 }

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -73,7 +73,16 @@ namespace QuantLib {
                 return (d >= 22 && d <= 28) && w == Monday && m == October;
             }
         }
-
+     
+        bool isVeteransDayNoSaturday(Day d, Month m, Year y, Weekday w) {
+            if (y <= 1970 || y >= 1978) {
+                // November 11th, adjusted, but no Saturday to Friday
+                return (d == 11 || (d == 12 && w == Monday)) && m == November;
+            } else {
+                // fourth Monday in October
+                return (d >= 22 && d <= 28) && w == Monday && m == October;
+            }
+        }
     }
     
     UnitedStates::UnitedStates(UnitedStates::Market market) {
@@ -89,6 +98,8 @@ namespace QuantLib {
                                         new UnitedStates::GovernmentBondImpl);
         static boost::shared_ptr<Calendar::Impl> nercImpl(
                                         new UnitedStates::NercImpl);
+        static boost::shared_ptr<Calendar::Impl> FederalReserveImpl(
+                                        new UnitedStates::FederalReserveImpl);
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;
@@ -104,6 +115,9 @@ namespace QuantLib {
             break;
           case NERC:
             impl_ = nercImpl;
+            break;
+          case FederalReserve:
+            impl_ = FederalReserveImpl;
             break;
           default:
             QL_FAIL("unknown market");
@@ -268,8 +282,8 @@ namespace QuantLib {
             || isLaborDay(d, m, y, w)
             // Columbus Day (second Monday in October)
             || isColumbusDay(d, m, y, w)
-            // Veteran's Day (Monday if Sunday or Friday if Saturday)
-            || isVeteransDay(d, m, y, w)
+            // Veteran's Day (Monday if Sunday)
+            || isVeteransDayNoSaturday(d, m, y, w)
             // Thanksgiving Day (fourth Thursday in November)
             || ((d >= 22 && d <= 28) && w == Thursday && m == November)
             // Christmas (Monday if Sunday or Friday if Saturday)
@@ -294,6 +308,38 @@ namespace QuantLib {
             || ((d == 4 || (d == 5 && w == Monday)) && m == July)
             // Labor Day (first Monday in September)
             || isLaborDay(d, m, y, w)
+            // Thanksgiving Day (fourth Thursday in November)
+            || ((d >= 22 && d <= 28) && w == Thursday && m == November)
+            // Christmas (Monday if Sunday)
+            || ((d == 25 || (d == 26 && w == Monday)) && m == December))
+            return false;
+        return true;
+    }
+ 
+    bool UnitedStates::FederalReserveImpl::isBusinessDay(const Date& date) const {
+        // see https://www.frbservices.org/holidayschedules/ for details
+        Weekday w = date.weekday();
+        Day d = date.dayOfMonth();
+        Month m = date.month();
+        Year y = date.year();
+        if (isWeekend(w)
+            // New Year's Day (possibly moved to Monday if on Sunday)
+            || ((d == 1 || (d == 2 && w == Monday)) && m == January)
+            // Martin Luther King's birthday (third Monday in January)
+            || ((d >= 15 && d <= 21) && w == Monday && m == January
+                && y >= 1983)
+            // Washington's birthday (third Monday in February)
+            || isWashingtonBirthday(d, m, y, w)
+            // Memorial Day (last Monday in May)
+            || isMemorialDay(d, m, y, w)
+            // Independence Day (Monday if Sunday)
+            || ((d == 4 || (d == 5 && w == Monday)
+            // Labor Day (first Monday in September)
+            || isLaborDay(d, m, y, w)
+            // Columbus Day (second Monday in October)
+            || isColumbusDay(d, m, y, w)
+            // Veteran's Day (Monday if Sunday)
+            || isVeteransDayNoSaturday(d, m, y, w)
             // Thanksgiving Day (fourth Thursday in November)
             || ((d >= 22 && d <= 28) && w == Thursday && m == November)
             // Christmas (Monday if Sunday)

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -333,7 +333,7 @@ namespace QuantLib {
             // Memorial Day (last Monday in May)
             || isMemorialDay(d, m, y, w)
             // Independence Day (Monday if Sunday)
-            || ((d == 4 || (d == 5 && w == Monday)
+            || ((d == 4 || (d == 5 && w == Monday)) && m == July)
             // Labor Day (first Monday in September)
             || isLaborDay(d, m, y, w)
             // Columbus Day (second Monday in October)

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -98,7 +98,7 @@ namespace QuantLib {
                                         new UnitedStates::GovernmentBondImpl);
         static boost::shared_ptr<Calendar::Impl> nercImpl(
                                         new UnitedStates::NercImpl);
-        static boost::shared_ptr<Calendar::Impl> FederalReserveImpl(
+        static boost::shared_ptr<Calendar::Impl> federalreserveImpl(
                                         new UnitedStates::FederalReserveImpl);
         switch (market) {
           case Settlement:
@@ -117,7 +117,7 @@ namespace QuantLib {
             impl_ = nercImpl;
             break;
           case FederalReserve:
-            impl_ = FederalReserveImpl;
+            impl_ = federalreserveImpl;
             break;
           default:
             QL_FAIL("unknown market");
@@ -256,8 +256,7 @@ namespace QuantLib {
     }
 
 
-    bool UnitedStates::GovernmentBondImpl::isBusinessDay(const Date& date)
-                                                                      const {
+    bool UnitedStates::GovernmentBondImpl::isBusinessDay(const Date& date) const {
         Weekday w = date.weekday();
         Day d = date.dayOfMonth(), dd = date.dayOfYear();
         Month m = date.month();
@@ -315,6 +314,7 @@ namespace QuantLib {
             return false;
         return true;
     }
+ 
  
     bool UnitedStates::FederalReserveImpl::isBusinessDay(const Date& date) const {
         // see https://www.frbservices.org/holidayschedules/ for details

--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -152,16 +152,12 @@ namespace QuantLib {
         };
         class NercImpl : public Calendar::WesternImpl {
           public:
-            std::string name() const {
-                return "North American Energy Reliability Council";
-            }
+            std::string name() const { return "North American Energy Reliability Council"; }
             bool isBusinessDay(const Date&) const;
         };
         class FederalReserveImpl : public Calendar::WesternImpl {
           public:
-            std::string name() const {
-                return "Federal Reserve Bankwire System";
-            }
+            std::string name() const { return "Federal Reserve Bankwire System"; }
             bool isBusinessDay(const Date&) const;
         };
       public:

--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -157,13 +157,21 @@ namespace QuantLib {
             }
             bool isBusinessDay(const Date&) const;
         };
+        class FederalReserveImpl : public Calendar::WesternImpl {
+          public:
+            std::string name() const {
+                return "Federal Reserve Bankwire System";
+            }
+            bool isBusinessDay(const Date&) const;
+        };
       public:
         //! US calendars
         enum Market { Settlement,     //!< generic settlement calendar
                       NYSE,           //!< New York stock exchange calendar
                       GovernmentBond, //!< government-bond calendar
                       NERC,           //!< off-peak days for NERC
-                      LiborImpact     //!< Libor impact calendar
+                      LiborImpact,    //!< Libor impact calendar
+                      FederalReserve  //!< Federal Reserve Bankwire System
         };
         UnitedStates(Market market = Settlement);
     };


### PR DESCRIPTION
A few calendar issues:
1) US Government Bond market does not observe Veteran's Day on Friday if it falls on Saturday.  See SIFMA website for verification (specifically the 2006 archive, and current 2017 as well).  Not sure the most elegant way to implement, so just created a generic VeteransDayNoSaturday method that can be used by all calendars.
2) In the US, OIS instruments follow the Federal Reserve bankwire calendar (https://www.frbservices.org/holidayschedules/), which have most holidays not observed if they fall on a Saturday.  Created a new calendar for this, and updated the default calendar for fedfunds.cpp

This is my first time contributing, and I am not a C++ developer by any means, so I hope I didn't butcher the process, and apologize in advance if I did.