### PR TITLE
Implement CompositeZeroYieldStructure

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1213,6 +1213,7 @@
     <ClInclude Include="ql\termstructures\yield\all.hpp" />
     <ClInclude Include="ql\termstructures\yield\bondhelpers.hpp" />
     <ClInclude Include="ql\termstructures\yield\bootstraptraits.hpp" />
+    <ClInclude Include="ql\termstructures\yield\compositezeroyieldstructure.hpp" />
     <ClInclude Include="ql\termstructures\yield\discountcurve.hpp" />
     <ClInclude Include="ql\termstructures\yield\drifttermstructure.hpp" />
     <ClInclude Include="ql\termstructures\yield\fittedbonddiscountcurve.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2010,6 +2010,9 @@
     <ClInclude Include="ql\termstructures\yield\bootstraptraits.hpp">
       <Filter>termstructures\yield</Filter>
     </ClInclude>
+    <ClInclude Include="ql\termstructures\yield\compositezeroyieldstructure.hpp">
+      <Filter>termstructures\yield</Filter>
+    </ClInclude>
     <ClInclude Include="ql\termstructures\yield\discountcurve.hpp">
       <Filter>termstructures\yield</Filter>
     </ClInclude>

--- a/ql/termstructures/yield/Makefile.am
+++ b/ql/termstructures/yield/Makefile.am
@@ -6,6 +6,7 @@ this_include_HEADERS = \
     all.hpp \
     bondhelpers.hpp \
     bootstraptraits.hpp \
+    compositezeroyieldstructure.hpp \
     discountcurve.hpp \
     drifttermstructure.hpp \
     fittedbonddiscountcurve.hpp \

--- a/ql/termstructures/yield/compositezeroyieldstructure.hpp
+++ b/ql/termstructures/yield/compositezeroyieldstructure.hpp
@@ -37,8 +37,7 @@ namespace QuantLib {
                                       const Handle<YieldTermStructure>& h2,
                                       const BinaryFunction& f,
                                       Compounding comp = Continuous,
-                                      Frequency freq = NoFrequency,
-                                      const DayCounter& dc = DayCounter());
+                                      Frequency freq = NoFrequency);
 
           //! \name YieldTermStructure interface
           //@{
@@ -54,18 +53,14 @@ namespace QuantLib {
           void update();
           //@}
       protected:
-        //! returns the spreaded zero yield rate
+        //! returns the composite zero yield rate
         Rate zeroYieldImpl(Time) const;
-        //! returns the spreaded forward rate
-        /* This method must disappear should the spread become a curve */
-        Rate forwardImpl(Time) const;
       private:
         Handle<YieldTermStructure> curve1_;
         Handle<YieldTermStructure> curve2_;
         BinaryFunction f_;
         Compounding comp_;
         Frequency freq_;
-        DayCounter dc_;
     };
 
     // inline definitions
@@ -76,9 +71,8 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& h2, 
         const BinaryFunction& f,
         Compounding comp, 
-        Frequency freq, 
-        const DayCounter& dc)
-    : curve1_(h1), curve2_(h2), f_(f), comp_(comp), freq_(freq), dc_(dc) {
+        Frequency freq)
+    : curve1_(h1), curve2_(h2), f_(f), comp_(comp), freq_(freq) {
         if (!curve1_.empty() && !curve2_.empty())
             enableExtrapolation(curve1_->allowsExtrapolation() && curve2_->allowsExtrapolation());
 
@@ -139,19 +133,8 @@ namespace QuantLib {
         InterestRate zeroRate2 =
             curve2_->zeroRate(t, comp_, freq_, true);
 
-        InterestRate compositeRate(f_(zeroRate1, zeroRate2), dc_, comp_, freq_);
+        InterestRate compositeRate(f_(zeroRate1, zeroRate2), dayCounter(), comp_, freq_);
         return compositeRate.equivalentRate(Continuous, NoFrequency, t);
-    }
-
-    template <class BinaryFunction>
-    inline Rate CompositeZeroYieldStructure<BinaryFunction>::forwardImpl(Time t) const {
-        InterestRate forwardRate1 =
-            curve1_->forwardRate(t, t, comp_, freq_, true);
-
-        InterestRate forwardRate2 =
-            curve2_->forwardRate(t, t, comp_, freq_, true);
-
-        return f_(forwardRate1, forwardRate2);
     }
 }
 #endif

--- a/ql/termstructures/yield/compositezeroyieldstructure.hpp
+++ b/ql/termstructures/yield/compositezeroyieldstructure.hpp
@@ -1,0 +1,157 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+Copyright (C) 2007, 2008 StatPro Italia srl
+Copyright (C) 2017 Francois Botha
+
+This file is part of QuantLib, a free-software/open-source library
+for financial quantitative analysts and developers - http://quantlib.org/
+
+QuantLib is free software: you can redistribute it and/or modify it
+under the terms of the QuantLib license.  You should have received a
+copy of the license along with this program; if not, please email
+<quantlib-dev@lists.sf.net>. The license is also available online at
+<http://quantlib.org/license.shtml>.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file compositezeroyieldstructure.hpp
+\brief Composite zero term structure
+*/
+
+#ifndef quantlib_composite_zero_yield_structure
+#define quantlib_composite_zero_yield_structure
+
+
+#include <ql/termstructures/yield/zeroyieldstructure.hpp>
+
+namespace QuantLib {
+    template <class BinaryFunction>
+    class CompositeZeroYieldStructure : public ZeroYieldStructure {
+      public:
+          CompositeZeroYieldStructure(const Handle<YieldTermStructure>& h1,
+                                      const Handle<YieldTermStructure>& h2,
+                                      const BinaryFunction& f,
+                                      Compounding comp = Continuous,
+                                      Frequency freq = NoFrequency,
+                                      const DayCounter& dc = DayCounter());
+
+          //! \name YieldTermStructure interface
+          //@{
+          DayCounter dayCounter() const;
+          Calendar calendar() const;
+          Natural settlementDays() const;
+          const Date& referenceDate() const;
+          Date maxDate() const;
+          Time maxTime() const;
+          //@}
+          //! \name Observer interface
+          //@{
+          void update();
+          //@}
+      protected:
+        //! returns the spreaded zero yield rate
+        Rate zeroYieldImpl(Time) const;
+        //! returns the spreaded forward rate
+        /* This method must disappear should the spread become a curve */
+        Rate forwardImpl(Time) const;
+      private:
+        Handle<YieldTermStructure> curve1_;
+        Handle<YieldTermStructure> curve2_;
+        BinaryFunction f_;
+        Compounding comp_;
+        Frequency freq_;
+        DayCounter dc_;
+    };
+
+    // inline definitions
+
+    template <class BinaryFunction>
+    inline CompositeZeroYieldStructure<BinaryFunction>::CompositeZeroYieldStructure(
+        const Handle<YieldTermStructure>& h1, 
+        const Handle<YieldTermStructure>& h2, 
+        const BinaryFunction& f,
+        Compounding comp, 
+        Frequency freq, 
+        const DayCounter& dc)
+    : curve1_(h1), curve2_(h2), f_(f), comp_(comp), freq_(freq), dc_(dc) {
+        if (!curve1_.empty() && !curve2_.empty())
+            enableExtrapolation(curve1_->allowsExtrapolation() && curve2_->allowsExtrapolation());
+
+        registerWith(curve1_);
+        registerWith(curve2_);
+    }
+
+    template <class BinaryFunction>
+    inline DayCounter CompositeZeroYieldStructure<BinaryFunction>::dayCounter() const {
+        return curve1_->dayCounter();
+    }
+
+    template <class BinaryFunction>
+    inline Calendar CompositeZeroYieldStructure<BinaryFunction>::calendar() const {
+        return curve1_->calendar();
+    }
+
+    template <class BinaryFunction>
+    inline Natural CompositeZeroYieldStructure<BinaryFunction>::settlementDays() const {
+        return curve1_->settlementDays();
+    }
+
+    template <class BinaryFunction>
+    inline const Date& CompositeZeroYieldStructure<BinaryFunction>::referenceDate() const {
+        return curve1_->referenceDate();
+    }
+
+    template <class BinaryFunction>
+    inline Date CompositeZeroYieldStructure<BinaryFunction>::maxDate() const {
+        return curve1_->maxDate();
+    }
+
+    template <class BinaryFunction>
+    inline Time CompositeZeroYieldStructure<BinaryFunction>::maxTime() const {
+        return curve1_->maxTime();
+    }
+
+    template <class BinaryFunction>
+    inline void CompositeZeroYieldStructure<BinaryFunction>::update() {
+        if (!curve1_.empty() && !curve2_.empty()) {
+            YieldTermStructure::update();
+            enableExtrapolation(curve1_->allowsExtrapolation() && curve2_->allowsExtrapolation());
+        }
+        else {
+            /* The implementation inherited from YieldTermStructure
+            asks for our reference date, which we don't have since
+            the original curve is still not set. Therefore, we skip
+            over that and just call the base-class behavior. */
+            TermStructure::update();
+        }
+    }
+
+    template <class BinaryFunction>
+    inline Rate CompositeZeroYieldStructure<BinaryFunction>::zeroYieldImpl(Time t) const {
+        Rate zeroRate1 =
+            curve1_->zeroRate(t, comp_, freq_, true);
+
+        InterestRate zeroRate2 =
+            curve2_->zeroRate(t, comp_, freq_, true);
+
+        InterestRate compositeRate(f_(zeroRate1, zeroRate2), dc_, comp_, freq_);
+        return compositeRate.equivalentRate(Continuous, NoFrequency, t);
+    }
+
+    template <class BinaryFunction>
+    inline Rate CompositeZeroYieldStructure<BinaryFunction>::forwardImpl(Time t) const {
+        InterestRate forwardRate1 =
+            curve1_->forwardRate(t, t, comp_, freq_, true);
+
+        InterestRate forwardRate2 =
+            curve2_->forwardRate(t, t, comp_, freq_, true);
+
+        return f_(forwardRate1, forwardRate2);
+    }
+}
+#endif

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -337,7 +337,10 @@ void TermStructureTest::testLinkToNullUnderlying() {
 
 void TermStructureTest::testCompositeZeroYieldStructures() {
     BOOST_TEST_MESSAGE(
-        "Testing composite zero yield structure...");
+        "Testing composite zero yield structures...");
+
+    SavedSettings backup;
+    Settings::instance().evaluationDate() = Date(10, Nov, 2017);
 
     std::vector<Date> dates;
     std::vector<Rate> rates;
@@ -437,16 +440,16 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
     dates.push_back(Date(15, Dec, 2141));
 
     rates.push_back(0.00892551511527986);
-    rates.push_back(0.0412773974133423);
-    rates.push_back(0.0567251712638837);
-    rates.push_back(0.0878295160422323);
-    rates.push_back(0.0904423159037861);
-    rates.push_back(0.0998714928415959);
-    rates.push_back(0.0400900444382439);
+    rates.push_back(0.0278755322562788);
+    rates.push_back(0.0512001768603456);
+    rates.push_back(0.0729941474263546);
+    rates.push_back(0.0778333309498459);
+    rates.push_back(0.0828451659139004);
+    rates.push_back(0.0503573807521742);
 
     Real tolerance = 1.0e-10;
     for (Size i = 0; i < dates.size(); ++i) {
-        Rate actual = compoundCurve->forwardRate(dates[i], dates[i], Actual365Fixed(), Continuous).rate();
+        Rate actual = compoundCurve->zeroRate(dates[i], Actual365Fixed(), Continuous).rate();
         Rate expected = rates[i];
 
         if (std::fabs(actual - expected) > tolerance)

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -456,7 +456,7 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
 
         if (std::fabs(actual - expected) > tolerance)
             BOOST_ERROR(
-                "unable to reproduce discount from implied curve\n"
+                "unable to reproduce zero yield rate from composite input curve\n"
                 << std::fixed << std::setprecision(10)
                 << "    calculated: " << actual << "\n"
                 << "    expected:   " << expected);

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -445,7 +445,7 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
     rates.push_back(0.0400900444382439);
 
     Real tolerance = 1.0e-10;
-    for (int i = 0; i < dates.size(); ++i) {
+    for (Size i = 0; i < dates.size(); ++i) {
         Rate actual = compoundCurve->forwardRate(dates[i], dates[i], Actual365Fixed(), Continuous).rate();
         Rate expected = rates[i];
 

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -115,10 +115,7 @@ namespace {
         }
     };
 
-    Real add(Real x, Real y) { return x + y; }
-    Real mul(Real x, Real y) { return x*y; }
     Real sub(Real x, Real y) { return x - y; }
-
 }
 
 void TermStructureTest::testReferenceChange() {
@@ -344,8 +341,6 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
 
     std::vector<Date> dates;
     std::vector<Rate> rates;
-
-    Date referenceDate(10, Nov, 2017);
 
     // First curve
     dates.push_back(Date(10, Nov, 2017));

--- a/test-suite/termstructures.hpp
+++ b/test-suite/termstructures.hpp
@@ -36,6 +36,7 @@ class TermStructureTest {
     static void testZSpreadedObs();
     static void testCreateWithNullUnderlying();
     static void testLinkToNullUnderlying();
+    static void testCompositeZeroYieldStructures();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Implements a `YieldTermStructure` that is based on a binary function of two input `YieldTermStructure`s. This is analogous to `CompositeQuote`, but for yields.

Real world use case: generating an implied inflation yield term structure from a nominal curve and a real curve.