### PR TITLE
Minor fix for man page generation.

### DIFF
--- a/Docs/Makefile.am
+++ b/Docs/Makefile.am
@@ -42,11 +42,7 @@ docs-html-dist: docs-html
 	    | GZIP=--best gzip -c > QuantLib-docs-$(VERSION)-html.tar.gz
 	rm QuantLib-docs-$(VERSION)-html
 
-docs-man: .time-stamp-man
-.time-stamp-man: .time-stamp
-	$(SED) -e "s/index/QuantLib/" man/man3/index.3 > man/man3/QuantLib.3
-	rm man/man3/index.3
-	touch .time-stamp-man
+docs-man: .time-stamp
 
 docs-man-dist: docs-man
 	ln -s man QuantLib-docs-$(VERSION)-man


### PR DESCRIPTION
There is no requirement for sed command in Makefile.am as QuantLib.3 is
generated by Doxygen (version >= 1.8.5) already.

Closes #340.