### PR TITLE
fix interpolation of shift

### DIFF
--- a/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
@@ -320,10 +320,9 @@ namespace QuantLib {
                                                Time swapLength) const {
         // dummy strike
         Volatility atmVol = volatilityImpl(optionTime, swapLength, 0.05);
-        Real shift = interpolationShifts_(optionTime, swapLength,true);
-        return boost::shared_ptr<SmileSection>(
-            new FlatSmileSection(optionTime, atmVol, dayCounter(), Null<Real>(),
-                                 volatilityType(), shift));
+        return boost::shared_ptr<SmileSection>(new FlatSmileSection(
+            optionTime, atmVol, dayCounter(), Null<Real>(), volatilityType(),
+            shift(optionTime, swapLength, true)));
     }
 
 }


### PR DESCRIPTION
optionTime and swapLength are swapped when computing the smile section's shift, better rely on the public shift method anyway instead on the internal interpolation object