### PR TITLE
Projected constraint bug fix

### DIFF
--- a/ql/math/optimization/projectedconstraint.hpp
+++ b/ql/math/optimization/projectedconstraint.hpp
@@ -46,10 +46,10 @@ namespace QuantLib {
                 return constraint_.test(projection_.include(params));
             }
             Array upperBound(const Array &params) const {
-                return constraint_.upperBound(projection_.include(params));
+				return projection_.project(constraint_.upperBound(projection_.include(params)));
             }
             Array lowerBound(const Array &params) const {
-                return constraint_.lowerBound(projection_.include(params));
+				return projection_.project(constraint_.lowerBound(projection_.include(params)));
             }
 
           private:


### PR DESCRIPTION
The upperBound and lowerBound vectors were not matching the size of projected currentValue() vector when a parameter is fixed.

Was raising an error in Constraint class (upperBound and lowerBound functions).