### PR TITLE
 adapt parallel unit test runner for the upcoming boost 1.66 release 

### DIFF
--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -33,7 +33,14 @@
 #include <ql/math/comparison.hpp>
 #include <ql/math/functional.hpp>
 
+#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/math/distributions/non_central_chi_squared.hpp>
+#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
+#pragma GCC diagnostic pop
+#endif
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;

--- a/test-suite/paralleltestrunner.hpp
+++ b/test-suite/paralleltestrunner.hpp
@@ -438,6 +438,7 @@ int main( int argc, char* argv[] )
                         framework::impl::s_frk_state().m_observers )
                         to->test_finish();
                 #else
+                    // works for BOOST_VERSION > 106100, needed for >106500
                     framework::run(id.id, false);
                 #endif
 

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -62,7 +62,15 @@
 
 #include <boost/make_shared.hpp>
 #include <boost/assign/std/vector.hpp>
+
+#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/math/distributions/non_central_chi_squared.hpp>
+#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
+#pragma GCC diagnostic pop
+#endif
 
 #include <set>
 


### PR DESCRIPTION
+ avoid gcc warnings