### PR TITLE
Replaced "unsigned long" with "uint32_t" in SobolRsg. 

### DIFF
--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -115,13 +115,14 @@ namespace QuantLib {
             Kuo, Kuo2, Kuo3 };
         /*! \pre dimensionality must be <= PPMT_MAX_DIM */
         SobolRsg(Size dimensionality,
-                 unsigned long seed = 0,
+                 uint32_t seed = 0,
                  DirectionIntegers directionIntegers = Jaeckel);
         /*! skip to the n-th sample in the low-discrepancy sequence */
-        void skipTo(unsigned long n);
-        const std::vector<unsigned long>& nextInt32Sequence() const;
+        void skipTo(uint32_t n);
+        const std::vector<uint32_t>& nextInt32Sequence() const;
+
         const SobolRsg::sample_type& nextSequence() const {
-            const std::vector<unsigned long>& v = nextInt32Sequence();
+            const std::vector<uint32_t>& v = nextInt32Sequence();
             // normalize to get a double in (0,1)
             for (Size k=0; k<dimensionality_; ++k)
                 sequence_.value[k] = v[k] * normalizationFactor_;
@@ -133,11 +134,11 @@ namespace QuantLib {
         static const int bits_;
         static const double normalizationFactor_;
         Size dimensionality_;
-        mutable unsigned long sequenceCounter_;
+        mutable uint32_t sequenceCounter_;
         mutable bool firstDraw_;
         mutable sample_type sequence_;
-        mutable std::vector<unsigned long> integerSequence_;
-        std::vector<std::vector<unsigned long> > directionIntegers_;
+        mutable std::vector<uint32_t> integerSequence_;
+        std::vector<std::vector<uint32_t> > directionIntegers_;
     };
 
 }

--- a/test-suite/lowdiscrepancysequences.cpp
+++ b/test-suite/lowdiscrepancysequences.cpp
@@ -1075,8 +1075,8 @@ void LowDiscrepancyTest::testSobolSkipping() {
 
             // compare next 100 samples
             for (Size m=0; m<100; m++) {
-                std::vector<unsigned long> s1 = rsg1.nextInt32Sequence();
-                std::vector<unsigned long> s2 = rsg2.nextInt32Sequence();
+                std::vector<uint32_t> s1 = rsg1.nextInt32Sequence();
+                std::vector<uint32_t> s2 = rsg2.nextInt32Sequence();
                 for (Size n=0; n<s1.size(); n++) {
                     if (s1[n] != s2[n]) {
                         BOOST_ERROR("Mismatch after skipping:"


### PR DESCRIPTION
Due to differing definitions by compiler/OS unsigned long can be either a 32 or 64 bit integer. Given the huge number of constants used in the algorithm, this cuts executable size by about 2.5 megabytes on 64 bit Mac and Linux.
