### PR TITLE
 Replaced "unsigned long" with "uint32_t" in SobolRsg

### DIFF
--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/methods/montecarlo/sample.hpp>
 #include <vector>
+#include <stdint.h>
 
 namespace QuantLib {
 
@@ -115,7 +116,7 @@ namespace QuantLib {
             Kuo, Kuo2, Kuo3 };
         /*! \pre dimensionality must be <= PPMT_MAX_DIM */
         SobolRsg(Size dimensionality,
-                 uint32_t seed = 0,
+                 unsigned long seed = 0,
                  DirectionIntegers directionIntegers = Jaeckel);
         /*! skip to the n-th sample in the low-discrepancy sequence */
         void skipTo(uint32_t n);

--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -115,13 +115,14 @@ namespace QuantLib {
             Kuo, Kuo2, Kuo3 };
         /*! \pre dimensionality must be <= PPMT_MAX_DIM */
         SobolRsg(Size dimensionality,
-                 unsigned long seed = 0,
+                 uint32_t seed = 0,
                  DirectionIntegers directionIntegers = Jaeckel);
         /*! skip to the n-th sample in the low-discrepancy sequence */
-        void skipTo(unsigned long n);
-        const std::vector<unsigned long>& nextInt32Sequence() const;
+        void skipTo(uint32_t n);
+        const std::vector<uint32_t>& nextInt32Sequence() const;
+
         const SobolRsg::sample_type& nextSequence() const {
-            const std::vector<unsigned long>& v = nextInt32Sequence();
+            const std::vector<uint32_t>& v = nextInt32Sequence();
             // normalize to get a double in (0,1)
             for (Size k=0; k<dimensionality_; ++k)
                 sequence_.value[k] = v[k] * normalizationFactor_;
@@ -133,11 +134,11 @@ namespace QuantLib {
         static const int bits_;
         static const double normalizationFactor_;
         Size dimensionality_;
-        mutable unsigned long sequenceCounter_;
+        mutable uint32_t sequenceCounter_;
         mutable bool firstDraw_;
         mutable sample_type sequence_;
-        mutable std::vector<unsigned long> integerSequence_;
-        std::vector<std::vector<unsigned long> > directionIntegers_;
+        mutable std::vector<uint32_t> integerSequence_;
+        std::vector<std::vector<uint32_t> > directionIntegers_;
     };
 
 }

--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -28,7 +28,7 @@
 
 #include <ql/methods/montecarlo/sample.hpp>
 #include <vector>
-#include <stdint.h>
+#include <boost/cstdint.hpp>
 
 namespace QuantLib {
 
@@ -119,11 +119,11 @@ namespace QuantLib {
                  unsigned long seed = 0,
                  DirectionIntegers directionIntegers = Jaeckel);
         /*! skip to the n-th sample in the low-discrepancy sequence */
-        void skipTo(uint32_t n);
-        const std::vector<uint32_t>& nextInt32Sequence() const;
+        void skipTo(boost::uint_least32_t n);
+        const std::vector<boost::uint_least32_t>& nextInt32Sequence() const;
 
         const SobolRsg::sample_type& nextSequence() const {
-            const std::vector<uint32_t>& v = nextInt32Sequence();
+            const std::vector<boost::uint_least32_t>& v = nextInt32Sequence();
             // normalize to get a double in (0,1)
             for (Size k=0; k<dimensionality_; ++k)
                 sequence_.value[k] = v[k] * normalizationFactor_;
@@ -135,11 +135,11 @@ namespace QuantLib {
         static const int bits_;
         static const double normalizationFactor_;
         Size dimensionality_;
-        mutable uint32_t sequenceCounter_;
+        mutable boost::uint_least32_t sequenceCounter_;
         mutable bool firstDraw_;
         mutable sample_type sequence_;
-        mutable std::vector<uint32_t> integerSequence_;
-        std::vector<std::vector<uint32_t> > directionIntegers_;
+        mutable std::vector<boost::uint_least32_t> integerSequence_;
+        std::vector<std::vector<boost::uint_least32_t> > directionIntegers_;
     };
 
 }

--- a/test-suite/lowdiscrepancysequences.cpp
+++ b/test-suite/lowdiscrepancysequences.cpp
@@ -1075,8 +1075,8 @@ void LowDiscrepancyTest::testSobolSkipping() {
 
             // compare next 100 samples
             for (Size m=0; m<100; m++) {
-                std::vector<uint32_t> s1 = rsg1.nextInt32Sequence();
-                std::vector<uint32_t> s2 = rsg2.nextInt32Sequence();
+                std::vector<boost::uint_least32_t> s1 = rsg1.nextInt32Sequence();
+                std::vector<boost::uint_least32_t> s2 = rsg2.nextInt32Sequence();
                 for (Size n=0; n<s1.size(); n++) {
                     if (s1[n] != s2[n]) {
                         BOOST_ERROR("Mismatch after skipping:"

--- a/test-suite/lowdiscrepancysequences.cpp
+++ b/test-suite/lowdiscrepancysequences.cpp
@@ -1075,8 +1075,8 @@ void LowDiscrepancyTest::testSobolSkipping() {
 
             // compare next 100 samples
             for (Size m=0; m<100; m++) {
-                std::vector<unsigned long> s1 = rsg1.nextInt32Sequence();
-                std::vector<unsigned long> s2 = rsg2.nextInt32Sequence();
+                std::vector<uint32_t> s1 = rsg1.nextInt32Sequence();
+                std::vector<uint32_t> s2 = rsg2.nextInt32Sequence();
                 for (Size n=0; n<s1.size(); n++) {
                     if (s1[n] != s2[n]) {
                         BOOST_ERROR("Mismatch after skipping:"


### PR DESCRIPTION
Some 64 bit systems (mac, linux) define unsigned long as 64 bit. With the huge number of constants the Sobol sequence requires this results in code bloat with no improvement in performance. The analysis done on the constants was all done assuming 32 bit integers as well, there is no benefit to going to 64 bit until someone publishes some direction integers for it.