### PR TITLE
integer in '#pragma omp for' loop must be signed

### DIFF
--- a/ql/experimental/volatility/zabrsmilesection.hpp
+++ b/ql/experimental/volatility/zabrsmilesection.hpp
@@ -206,7 +206,7 @@ void ZabrSmileSection<Evaluation>::init2(ZabrLocalVolatility) {
 template <typename Evaluation>
 void ZabrSmileSection<Evaluation>::init2(ZabrFullFd) {
     callPrices_.resize(strikes_.size());
-#pragma omp parallel for
+//#pragma omp parallel for
     for (Size i = 0; i < strikes_.size(); i++) {
         callPrices_[i] = model_->fullFdPrice(strikes_[i]);
     }

--- a/ql/experimental/volatility/zabrsmilesection.hpp
+++ b/ql/experimental/volatility/zabrsmilesection.hpp
@@ -206,8 +206,8 @@ void ZabrSmileSection<Evaluation>::init2(ZabrLocalVolatility) {
 template <typename Evaluation>
 void ZabrSmileSection<Evaluation>::init2(ZabrFullFd) {
     callPrices_.resize(strikes_.size());
-//#pragma omp parallel for
-    for (Size i = 0; i < strikes_.size(); i++) {
+#pragma omp parallel for
+    for (long i = 0; i < (long)strikes_.size(); i++) {
         callPrices_[i] = model_->fullFdPrice(strikes_[i]);
     }
 }

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -218,10 +218,10 @@ namespace QuantLib {
         TripleBandLinearOp retVal(direction_, mesher_);
 
         #pragma omp parallel for
-        for (Size i=0; i < size; ++i) {
+        for (long i=0; i < (long)size; ++i) {
             const Real sm1 = i > 0? u[i-1] : 1.0;
             const Real s0 = u[i];
-            const Real sp1 = i < size-1? u[i+1] : 1.0;
+            const Real sp1 = i < (long)size-1? u[i+1] : 1.0;
             retVal.lower_[i]= lower_[i]*sm1;
             retVal.diag_[i] = diag_[i]*s0;
             retVal.upper_[i]= upper_[i]*sp1;

--- a/ql/methods/lattices/lattice.hpp
+++ b/ql/methods/lattices/lattice.hpp
@@ -166,7 +166,7 @@ namespace QuantLib {
     template <class Impl>
     void TreeLattice<Impl>::stepback(Size i, const Array& values,
                                      Array& newValues) const {
-        #pragma omp parallel for
+        //#pragma omp parallel for
         for (Size j=0; j<this->impl().size(i); j++) {
             Real value = 0.0;
             for (Size l=0; l<n_; l++) {

--- a/ql/methods/lattices/lattice.hpp
+++ b/ql/methods/lattices/lattice.hpp
@@ -166,8 +166,8 @@ namespace QuantLib {
     template <class Impl>
     void TreeLattice<Impl>::stepback(Size i, const Array& values,
                                      Array& newValues) const {
-        //#pragma omp parallel for
-        for (Size j=0; j<this->impl().size(i); j++) {
+        #pragma omp parallel for
+        for (long j=0; j<(long)this->impl().size(i); j++) {
             Real value = 0.0;
             for (Size l=0; l<n_; l++) {
                 value += this->impl().probability(i,j,l) *

--- a/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
@@ -115,7 +115,7 @@ namespace QuantLib {
 #endif
 
 #pragma omp parallel for default(shared) firstprivate(p) if(expiry0>settlement)
-            for (Size k = 0; k < (expiry0 > settlement ? npv0.size() : 1);
+            for (long k = 0; k < (expiry0 > settlement ? (long)npv0.size() : 1);
                  k++) {
 
                 Real price = 0.0;


### PR DESCRIPTION
please see http://www.openmp.org/wp-content/uploads/cspec20.pdf page 12.
Only MSVC seems to enforce this. I've only commented out the ones in
.hpp files. there is one remaining instance in
gaussian1dswaptionengine.cpp, which works fine as I only compile
QuantLib with default options.