### PR TITLE
canonical operator overloading

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -83,14 +83,14 @@ namespace QuantLib {
             the same size.
         */
         //@{
-        const Array& operator+=(const Array&);
-        const Array& operator+=(Real);
-        const Array& operator-=(const Array&);
-        const Array& operator-=(Real);
-        const Array& operator*=(const Array&);
-        const Array& operator*=(Real);
-        const Array& operator/=(const Array&);
-        const Array& operator/=(Real);
+        Array& operator+=(const Array&);
+        Array& operator+=(Real);
+        Array& operator-=(const Array&);
+        Array& operator-=(Real);
+        Array& operator*=(const Array&);
+        Array& operator*=(Real);
+        Array& operator/=(const Array&);
+        Array& operator/=(Real);
         //@}
         //! \name Element access
         //@{
@@ -157,47 +157,47 @@ namespace QuantLib {
 
     // unary operators
     /*! \relates Array */
-    const Disposable<Array> operator+(const Array& v);
+    Disposable<Array> operator+(const Array& v);
     /*! \relates Array */
-    const Disposable<Array> operator-(const Array& v);
+    Disposable<Array> operator-(const Array& v);
 
     // binary operators
     /*! \relates Array */
-    const Disposable<Array> operator+(const Array&, const Array&);
+    Disposable<Array> operator+(Array, const Array&);
     /*! \relates Array */
-    const Disposable<Array> operator+(const Array&, Real);
+    Disposable<Array> operator+(Array, Real);
     /*! \relates Array */
-    const Disposable<Array> operator+(Real, const Array&);
+    Disposable<Array> operator+(Real, Array);
     /*! \relates Array */
-    const Disposable<Array> operator-(const Array&, const Array&);
+    Disposable<Array> operator-(Array, const Array&);
     /*! \relates Array */
-    const Disposable<Array> operator-(const Array&, Real);
+    Disposable<Array> operator-(Array, Real);
     /*! \relates Array */
-    const Disposable<Array> operator-(Real, const Array&);
+    Disposable<Array> operator-(Real, Array);
     /*! \relates Array */
-    const Disposable<Array> operator*(const Array&, const Array&);
+    Disposable<Array> operator*(Array, const Array&);
     /*! \relates Array */
-    const Disposable<Array> operator*(const Array&, Real);
+    Disposable<Array> operator*(Array, Real);
     /*! \relates Array */
-    const Disposable<Array> operator*(Real, const Array&);
+    Disposable<Array> operator*(Real, Array);
     /*! \relates Array */
-    const Disposable<Array> operator/(const Array&, const Array&);
+    Disposable<Array> operator/(Array, const Array&);
     /*! \relates Array */
-    const Disposable<Array> operator/(const Array&, Real);
+    Disposable<Array> operator/(Array, Real);
     /*! \relates Array */
-    const Disposable<Array> operator/(Real, const Array&);
+    Disposable<Array> operator/(Real, Array);
 
     // math functions
     /*! \relates Array */
-    const Disposable<Array> Abs(const Array&);
+    Disposable<Array> Abs(const Array&);
     /*! \relates Array */
-    const Disposable<Array> Sqrt(const Array&);
+    Disposable<Array> Sqrt(const Array&);
     /*! \relates Array */
-    const Disposable<Array> Log(const Array&);
+    Disposable<Array> Log(const Array&);
     /*! \relates Array */
-    const Disposable<Array> Exp(const Array&);
+    Disposable<Array> Exp(const Array&);
     /*! \relates Array */
-    const Disposable<Array> Pow(const Array&, Real);
+    Disposable<Array> Pow(const Array&, Real);
 
     // utilities
     /*! \relates Array */
@@ -302,7 +302,7 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Array& Array::operator+=(const Array& v) {
+    inline Array& Array::operator+=(const Array& v) {
         QL_REQUIRE(n_ == v.n_,
                    "arrays with different sizes (" << n_ << ", "
                    << v.n_ << ") cannot be added");
@@ -312,13 +312,13 @@ namespace QuantLib {
     }
 
 
-    inline const Array& Array::operator+=(Real x) {
+    inline Array& Array::operator+=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::plus<Real>(),x));
         return *this;
     }
 
-    inline const Array& Array::operator-=(const Array& v) {
+    inline Array& Array::operator-=(const Array& v) {
         QL_REQUIRE(n_ == v.n_,
                    "arrays with different sizes (" << n_ << ", "
                    << v.n_ << ") cannot be subtracted");
@@ -327,13 +327,13 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Array& Array::operator-=(Real x) {
+    inline Array& Array::operator-=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::minus<Real>(),x));
         return *this;
     }
 
-    inline const Array& Array::operator*=(const Array& v) {
+    inline Array& Array::operator*=(const Array& v) {
         QL_REQUIRE(n_ == v.n_,
                    "arrays with different sizes (" << n_ << ", "
                    << v.n_ << ") cannot be multiplied");
@@ -342,13 +342,13 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Array& Array::operator*=(Real x) {
+    inline Array& Array::operator*=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::multiplies<Real>(),x));
         return *this;
     }
 
-    inline const Array& Array::operator/=(const Array& v) {
+    inline Array& Array::operator/=(const Array& v) {
         QL_REQUIRE(n_ == v.n_,
                    "arrays with different sizes (" << n_ << ", "
                    << v.n_ << ") cannot be divided");
@@ -357,7 +357,7 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Array& Array::operator/=(Real x) {
+    inline Array& Array::operator/=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::divides<Real>(),x));
         return *this;
@@ -486,12 +486,12 @@ namespace QuantLib {
 
     // unary
 
-    inline const Disposable<Array> operator+(const Array& v) {
+    inline Disposable<Array> operator+(const Array& v) {
         Array result = v;
         return result;
     }
 
-    inline const Disposable<Array> operator-(const Array& v) {
+    inline Disposable<Array> operator-(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
                        std::negate<Real>());
@@ -501,137 +501,93 @@ namespace QuantLib {
 
     // binary operators
 
-    inline const Disposable<Array> operator+(const Array& v1,
-                                             const Array& v2) {
-        QL_REQUIRE(v1.size() == v2.size(),
-                   "arrays with different sizes (" << v1.size() << ", "
-                   << v2.size() << ") cannot be added");
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),v2.begin(),result.begin(),
-                       std::plus<Real>());
-        return result;
+    inline Disposable<Array> operator+(Array v1, const Array& v2) {
+        return v1 += v2;
     }
 
-    inline const Disposable<Array> operator+(const Array& v1, Real a) {
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       std::bind2nd(std::plus<Real>(),a));
-        return result;
+    inline Disposable<Array> operator+(Array v1, Real a) {
+        return v1 += a;
     }
 
-    inline const Disposable<Array> operator+(Real a, const Array& v2) {
-        Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
+    inline Disposable<Array> operator+(Real a, Array v2) {
+        std::transform(v2.begin(),v2.end(),v2.begin(),
                        std::bind1st(std::plus<Real>(),a));
-        return result;
+        return v2;
     }
 
-    inline const Disposable<Array> operator-(const Array& v1,
-                                             const Array& v2) {
-        QL_REQUIRE(v1.size() == v2.size(),
-                   "arrays with different sizes (" << v1.size() << ", "
-                   << v2.size() << ") cannot be subtracted");
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),v2.begin(),result.begin(),
-                       std::minus<Real>());
-        return result;
+    inline Disposable<Array> operator-(Array v1, const Array& v2) {
+        return v1 -= v2;
     }
 
-    inline const Disposable<Array> operator-(const Array& v1, Real a) {
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       std::bind2nd(std::minus<Real>(),a));
-        return result;
+    inline Disposable<Array> operator-(Array v1, Real a) {
+        return v1 -= a;
     }
 
-    inline const Disposable<Array> operator-(Real a, const Array& v2) {
-        Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       std::bind1st(std::minus<Real>(),a));
-        return result;
+    inline Disposable<Array> operator-(Real a, Array v2) {
+        std::transform(v2.begin(), v2.end(), v2.begin(),
+                       std::bind1st(std::minus<Real>(), a));
+        return v2;
     }
 
-    inline const Disposable<Array> operator*(const Array& v1,
-                                             const Array& v2) {
-        QL_REQUIRE(v1.size() == v2.size(),
-                   "arrays with different sizes (" << v1.size() << ", "
-                   << v2.size() << ") cannot be multiplied");
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),v2.begin(),result.begin(),
-                       std::multiplies<Real>());
-        return result;
+    inline Disposable<Array> operator*(Array v1, const Array& v2) {
+        return v1 *= v2;
     }
 
-    inline const Disposable<Array> operator*(const Array& v1, Real a) {
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       std::bind2nd(std::multiplies<Real>(),a));
-        return result;
+    inline Disposable<Array> operator*(Array v1, Real a) {
+        return v1 *= a;
     }
 
-    inline const Disposable<Array> operator*(Real a, const Array& v2) {
-        Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
+    inline Disposable<Array> operator*(Real a, Array v2) {
+        std::transform(v2.begin(),v2.end(),v2.begin(),
                        std::bind1st(std::multiplies<Real>(),a));
-        return result;
+        return v2;
     }
 
-    inline const Disposable<Array> operator/(const Array& v1,
-                                             const Array& v2) {
-        QL_REQUIRE(v1.size() == v2.size(),
-                   "arrays with different sizes (" << v1.size() << ", "
-                   << v2.size() << ") cannot be divided");
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),v2.begin(),result.begin(),
-                       std::divides<Real>());
-        return result;
+    inline Disposable<Array> operator/(Array v1, const Array& v2) {
+        return v1 /= v2;
     }
 
-    inline const Disposable<Array> operator/(const Array& v1, Real a) {
-        Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       std::bind2nd(std::divides<Real>(),a));
-        return result;
+    inline Disposable<Array> operator/(Array v1, Real a) {
+        return v1 /= a;
     }
 
-    inline const Disposable<Array> operator/(Real a, const Array& v2) {
-        Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       std::bind1st(std::divides<Real>(),a));
-        return result;
+    inline Disposable<Array> operator/(Real a, Array v2) {
+        std::transform(v2.begin(), v2.end(), v2.begin(),
+                       std::bind1st(std::divides<Real>(), a));
+        return v2;
     }
 
     // functions
 
-    inline const Disposable<Array> Abs(const Array& v) {
+    inline Disposable<Array> Abs(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
                        std::ptr_fun<Real,Real>(std::fabs));
         return result;
     }
 
-    inline const Disposable<Array> Sqrt(const Array& v) {
+    inline Disposable<Array> Sqrt(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
                        std::ptr_fun<Real,Real>(std::sqrt));
         return result;
     }
 
-    inline const Disposable<Array> Log(const Array& v) {
+    inline Disposable<Array> Log(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
                        std::ptr_fun<Real,Real>(std::log));
         return result;
     }
 
-    inline const Disposable<Array> Exp(const Array& v) {
+    inline Disposable<Array> Exp(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
                        std::ptr_fun<Real,Real>(std::exp));
         return result;
     }
 
-    inline const Disposable<Array> Pow(const Array& v, Real alpha) {
+    inline Disposable<Array> Pow(const Array& v, Real alpha) {
         Array result(v.size());
         std::transform(v.begin(), v.end(), result.begin(),
             std::bind2nd(std::ptr_fun<Real, Real, Real>(std::pow), alpha));

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -64,10 +64,10 @@ namespace QuantLib {
                  the same size.
         */
         //@{
-        const Matrix& operator+=(const Matrix&);
-        const Matrix& operator-=(const Matrix&);
-        const Matrix& operator*=(Real);
-        const Matrix& operator/=(Real);
+        Matrix& operator+=(const Matrix&);
+        Matrix& operator-=(const Matrix&);
+        Matrix& operator*=(Real);
+        Matrix& operator/=(Real);
         //@}
 
         typedef Real* iterator;
@@ -144,37 +144,37 @@ namespace QuantLib {
     // algebraic operators
 
     /*! \relates Matrix */
-    const Disposable<Matrix> operator+(const Matrix&, const Matrix&);
+    Disposable<Matrix> operator+(Matrix, const Matrix&);
     /*! \relates Matrix */
-    const Disposable<Matrix> operator-(const Matrix&, const Matrix&);
+    Disposable<Matrix> operator-(Matrix, const Matrix&);
     /*! \relates Matrix */
-    const Disposable<Matrix> operator*(const Matrix&, Real);
+    Disposable<Matrix> operator*(Matrix, Real);
     /*! \relates Matrix */
-    const Disposable<Matrix> operator*(Real, const Matrix&);
+    Disposable<Matrix> operator*(Real, Matrix);
     /*! \relates Matrix */
-    const Disposable<Matrix> operator/(const Matrix&, Real);
+    Disposable<Matrix> operator/(Matrix, Real);
 
 
     // vectorial products
 
     /*! \relates Matrix */
-    const Disposable<Array> operator*(const Array&, const Matrix&);
+    Disposable<Array> operator*(const Array&, const Matrix&);
     /*! \relates Matrix */
-    const Disposable<Array> operator*(const Matrix&, const Array&);
+    Disposable<Array> operator*(const Matrix&, const Array&);
     /*! \relates Matrix */
-    const Disposable<Matrix> operator*(const Matrix&, const Matrix&);
+    Disposable<Matrix> operator*(const Matrix&, const Matrix&);
 
     // misc. operations
 
     /*! \relates Matrix */
-    const Disposable<Matrix> transpose(const Matrix&);
+    Disposable<Matrix> transpose(const Matrix&);
 
     /*! \relates Matrix */
-    const Disposable<Matrix> outerProduct(const Array& v1, const Array& v2);
+    Disposable<Matrix> outerProduct(const Array& v1, const Array& v2);
 
     /*! \relates Matrix */
     template<class Iterator1, class Iterator2>
-    const Disposable<Matrix> outerProduct(Iterator1 v1begin, Iterator1 v1end,
+    Disposable<Matrix> outerProduct(Iterator1 v1begin, Iterator1 v1end,
                                           Iterator2 v2begin, Iterator2 v2end);
 
     /*! \relates Matrix */
@@ -245,7 +245,7 @@ namespace QuantLib {
         swap(columns_,from.columns_);
     }
 
-    inline const Matrix& Matrix::operator+=(const Matrix& m) {
+    inline Matrix& Matrix::operator+=(const Matrix& m) {
         QL_REQUIRE(rows_ == m.rows_ && columns_ == m.columns_,
                    "matrices with different sizes (" <<
                    m.rows_ << "x" << m.columns_ << ", " <<
@@ -256,7 +256,7 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Matrix& Matrix::operator-=(const Matrix& m) {
+    inline Matrix& Matrix::operator-=(const Matrix& m) {
         QL_REQUIRE(rows_ == m.rows_ && columns_ == m.columns_,
                    "matrices with different sizes (" <<
                    m.rows_ << "x" << m.columns_ << ", " <<
@@ -267,13 +267,13 @@ namespace QuantLib {
         return *this;
     }
 
-    inline const Matrix& Matrix::operator*=(Real x) {
+    inline Matrix& Matrix::operator*=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::multiplies<Real>(),x));
         return *this;
     }
 
-    inline const Matrix& Matrix::operator/=(Real x) {
+    inline Matrix& Matrix::operator/=(Real x) {
         std::transform(begin(),end(),begin(),
                        std::bind2nd(std::divides<Real>(),x));
         return *this;
@@ -476,56 +476,29 @@ namespace QuantLib {
         return rows_ == 0 || columns_ == 0;
     }
 
-    inline const Disposable<Matrix> operator+(const Matrix& m1,
-                                              const Matrix& m2) {
-        QL_REQUIRE(m1.rows() == m2.rows() &&
-                   m1.columns() == m2.columns(),
-                   "matrices with different sizes (" <<
-                   m1.rows() << "x" << m1.columns() << ", " <<
-                   m2.rows() << "x" << m2.columns() << ") cannot be "
-                   "added");
-        Matrix temp(m1.rows(),m1.columns());
-        std::transform(m1.begin(),m1.end(),m2.begin(),temp.begin(),
-                       std::plus<Real>());
-        return temp;
+    inline Disposable<Matrix> operator+(Matrix m1, const Matrix& m2) {
+        return m1 += m2;
     }
 
-    inline const Disposable<Matrix> operator-(const Matrix& m1,
-                                              const Matrix& m2) {
-        QL_REQUIRE(m1.rows() == m2.rows() &&
-                   m1.columns() == m2.columns(),
-                   "matrices with different sizes (" <<
-                   m1.rows() << "x" << m1.columns() << ", " <<
-                   m2.rows() << "x" << m2.columns() << ") cannot be "
-                   "subtracted");
-        Matrix temp(m1.rows(),m1.columns());
-        std::transform(m1.begin(),m1.end(),m2.begin(),temp.begin(),
-                       std::minus<Real>());
-        return temp;
+    inline Disposable<Matrix> operator-(Matrix m1, const Matrix& m2) {
+        return m1 -= m2;
     }
 
-    inline const Disposable<Matrix> operator*(const Matrix& m, Real x) {
-        Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
+    inline Disposable<Matrix> operator*(Matrix m, Real x) {
+        return m *= x;
+    }
+
+    inline Disposable<Matrix> operator*(Real x, Matrix m) {
+        std::transform(m.begin(),m.end(),m.begin(),
                        std::bind2nd(std::multiplies<Real>(),x));
-        return temp;
+        return m;
     }
 
-    inline const Disposable<Matrix> operator*(Real x, const Matrix& m) {
-        Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
-                       std::bind2nd(std::multiplies<Real>(),x));
-        return temp;
+    inline Disposable<Matrix> operator/(Matrix m, Real x) {
+        return m /= x;
     }
 
-    inline const Disposable<Matrix> operator/(const Matrix& m, Real x) {
-        Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
-                       std::bind2nd(std::divides<Real>(),x));
-        return temp;
-    }
-
-    inline const Disposable<Array> operator*(const Array& v, const Matrix& m) {
+    inline Disposable<Array> operator*(const Array& v, const Matrix& m) {
         QL_REQUIRE(v.size() == m.rows(),
                    "vectors and matrices with different sizes ("
                    << v.size() << ", " << m.rows() << "x" << m.columns() <<
@@ -538,7 +511,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline const Disposable<Array> operator*(const Matrix& m, const Array& v) {
+    inline Disposable<Array> operator*(const Matrix& m, const Array& v) {
         QL_REQUIRE(v.size() == m.columns(),
                    "vectors and matrices with different sizes ("
                    << v.size() << ", " << m.rows() << "x" << m.columns() <<
@@ -550,8 +523,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline const Disposable<Matrix> operator*(const Matrix& m1,
-                                              const Matrix& m2) {
+    inline Disposable<Matrix> operator*(const Matrix& m1, const Matrix& m2) {
         QL_REQUIRE(m1.columns() == m2.rows(),
                    "matrices with different sizes (" <<
                    m1.rows() << "x" << m1.columns() << ", " <<
@@ -568,7 +540,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline const Disposable<Matrix> transpose(const Matrix& m) {
+    inline Disposable<Matrix> transpose(const Matrix& m) {
         Matrix result(m.columns(),m.rows());
         #if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
         if (!m.empty())
@@ -578,13 +550,13 @@ namespace QuantLib {
         return result;
     }
 
-    inline const Disposable<Matrix> outerProduct(const Array& v1,
+    inline Disposable<Matrix> outerProduct(const Array& v1,
                                                  const Array& v2) {
         return outerProduct(v1.begin(), v1.end(), v2.begin(), v2.end());
     }
 
     template<class Iterator1, class Iterator2>
-    inline const Disposable<Matrix> outerProduct(Iterator1 v1begin,
+    inline Disposable<Matrix> outerProduct(Iterator1 v1begin,
                                                  Iterator1 v1end,
                                                  Iterator2 v2begin,
                                                  Iterator2 v2end) {

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -175,6 +175,84 @@ void ArrayTest::testConstruction() {
     }
 }
 
+void ArrayTest::testArrayOperators() {
+    BOOST_TEST_MESSAGE("Testing array operators...");
+
+    Real tol = 1.0E-14 * 100.0;
+
+    Array a(2), b(2);
+    a[0] = 1.0;
+    a[1] = 2.0;
+    b[0] = 3.0;
+    b[1] = 4.0;
+
+    b += a;
+    BOOST_CHECK_CLOSE(b[0], 4.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 6.0, tol);
+
+    b += 1.0;
+    BOOST_CHECK_CLOSE(b[0], 5.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 7.0, tol);
+
+    b -= a;
+    BOOST_CHECK_CLOSE(b[0], 4.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 5.0, tol);
+
+    b -= 1.0;
+    BOOST_CHECK_CLOSE(b[0], 3.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 4.0, tol);
+
+    b *= a;
+    BOOST_CHECK_CLOSE(b[0], 3.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 8.0, tol);
+
+    b *= 2.0;
+    BOOST_CHECK_CLOSE(b[0], 6.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 16.0, tol);
+
+    b /= a;
+    BOOST_CHECK_CLOSE(b[0], 6.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 8.0, tol);
+
+    b /= 2.0;
+    BOOST_CHECK_CLOSE(b[0], 3.0, tol);
+    BOOST_CHECK_CLOSE(b[1], 4.0, tol);
+
+    Array c(2);
+
+    c = a + b;
+    BOOST_CHECK_CLOSE(c[0], 4.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 6.0, tol);
+
+    c = a * b;
+    BOOST_CHECK_CLOSE(c[0], 3.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 8.0, tol);
+
+    c = a - b;
+    BOOST_CHECK_CLOSE(c[0], -2.0, tol);
+    BOOST_CHECK_CLOSE(c[1], -2.0, tol);
+
+    c = a / b;
+    BOOST_CHECK_CLOSE(c[0], 1.0 / 3.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 2.0 / 4.0, tol);
+
+    c = a + 1.0;
+    BOOST_CHECK_CLOSE(c[0], 2.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 3.0, tol);
+
+    c = a * 2.0;
+    BOOST_CHECK_CLOSE(c[0], 2.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 4.0, tol);
+
+    c = a - 1.0;
+    BOOST_CHECK_CLOSE(c[0], 0.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 1.0, tol);
+
+    c = a / 2.0;
+    BOOST_CHECK_CLOSE(c[0], 1.0 / 2.0, tol);
+    BOOST_CHECK_CLOSE(c[1], 2.0 / 2.0, tol);
+}
+
 void ArrayTest::testArrayFunctions() {
 
     BOOST_TEST_MESSAGE("Testing array functions...");
@@ -212,6 +290,7 @@ test_suite* ArrayTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("array tests");
     suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testConstruction));
     suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testArrayFunctions));
+    suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testArrayOperators));
     return suite;
 }
 

--- a/test-suite/array.hpp
+++ b/test-suite/array.hpp
@@ -29,6 +29,7 @@ class ArrayTest {
   public:
     static void testConstruction();
     static void testArrayFunctions();
+    static void testArrayOperators();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
I am not sure about the changes proposed here, so please rather take the PR as a base for discussion than a solution to an obvious issue:

I am trying to follow the "canonical implementation" for operator overloading suggested in http://en.cppreference.com/w/cpp/language/operators. The actual changes are:

- Implement ```operator+()``` etc. in terms of the compound operators ```+=``` etc. This simplifies and shortens the code.

- Instead of creating a temporary result variable within ```operator+()``` etc. use a copy of the LHS input. For expressions like ```x+y+z``` this avoids allocating a new object, since the LHS variable can be moved (this also works essentially with the QL disposable workaround for move semantics. see https://github.com/lballabio/QuantLib/issues/372). On the other hand when computing ```x=y+z``` I think the old implementation is slightly more efficient, since it involves only the allocation of a new object while the new implementation will do a full copy of the argument ```y```. When running the test suite I don't notice any difference in the running time though. The memory footprint should be slightly better with the new implementation.

- Remove const qualifiers from return types. Currently expressions like ```(x+=y)+=z``` won't compile, with the change they will. Although there does not seem to be much practical use of allowing these kind of expressions, this is in line with e.g. the ```complex<T>``` implementation in the std lib (and with the reference above for what it's worth).
