### PR TITLE
Put builddir before srcdir in AM_CPPFLAGS

### DIFF
--- a/Examples/BasketLosses/Makefile.am
+++ b/Examples/BasketLosses/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = BasketLosses

--- a/Examples/BermudanSwaption/Makefile.am
+++ b/Examples/BermudanSwaption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = BermudanSwaption

--- a/Examples/Bonds/Makefile.am
+++ b/Examples/Bonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = Bonds

--- a/Examples/CDS/Makefile.am
+++ b/Examples/CDS/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = CDS

--- a/Examples/CVAIRS/Makefile.am
+++ b/Examples/CVAIRS/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = CVAIRS

--- a/Examples/CallableBonds/Makefile.am
+++ b/Examples/CallableBonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = CallableBonds

--- a/Examples/ConvertibleBonds/Makefile.am
+++ b/Examples/ConvertibleBonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = ConvertibleBonds

--- a/Examples/DiscreteHedging/Makefile.am
+++ b/Examples/DiscreteHedging/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = DiscreteHedging

--- a/Examples/EquityOption/Makefile.am
+++ b/Examples/EquityOption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = EquityOption

--- a/Examples/FRA/Makefile.am
+++ b/Examples/FRA/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = FRA

--- a/Examples/FittedBondCurve/Makefile.am
+++ b/Examples/FittedBondCurve/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = FittedBondCurve

--- a/Examples/Gaussian1dModels/Makefile.am
+++ b/Examples/Gaussian1dModels/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = Gaussian1dModels

--- a/Examples/GlobalOptimizer/Makefile.am
+++ b/Examples/GlobalOptimizer/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = GlobalOptimizer

--- a/Examples/LatentModel/Makefile.am
+++ b/Examples/LatentModel/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = LatentModel

--- a/Examples/Makefile.am
+++ b/Examples/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 SUBDIRS = \
     BasketLosses \

--- a/Examples/MarketModels/Makefile.am
+++ b/Examples/MarketModels/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = MarketModels

--- a/Examples/MultidimIntegral/Makefile.am
+++ b/Examples/MultidimIntegral/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = MultidimIntegral

--- a/Examples/Replication/Makefile.am
+++ b/Examples/Replication/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = Replication

--- a/Examples/Repo/Makefile.am
+++ b/Examples/Repo/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = Repo

--- a/Examples/Swap/Makefile.am
+++ b/Examples/Swap/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 if AUTO_EXAMPLES
 bin_PROGRAMS = SwapValuation

--- a/ql/Makefile.am
+++ b/ql/Makefile.am
@@ -17,7 +17,7 @@ SUBDIRS = \
     time \
     utilities
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/cashflows/Makefile.am
+++ b/ql/cashflows/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/currencies/Makefile.am
+++ b/ql/currencies/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/Makefile.am
+++ b/ql/experimental/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = amortizingbonds averageois barrieroption callablebonds \
           math mcbasket models processes risk shortrate swaptions \
           termstructures variancegamma varianceoption volatility
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/amortizingbonds/Makefile.am
+++ b/ql/experimental/amortizingbonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/averageois/Makefile.am
+++ b/ql/experimental/averageois/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/barrieroption/Makefile.am
+++ b/ql/experimental/barrieroption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/callablebonds/Makefile.am
+++ b/ql/experimental/callablebonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/catbonds/Makefile.am
+++ b/ql/experimental/catbonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/commodities/Makefile.am
+++ b/ql/experimental/commodities/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/convertiblebonds/Makefile.am
+++ b/ql/experimental/convertiblebonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/coupons/Makefile.am
+++ b/ql/experimental/coupons/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/credit/Makefile.am
+++ b/ql/experimental/credit/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/exoticoptions/Makefile.am
+++ b/ql/experimental/exoticoptions/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/finitedifferences/Makefile.am
+++ b/ql/experimental/finitedifferences/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/fx/Makefile.am
+++ b/ql/experimental/fx/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/inflation/Makefile.am
+++ b/ql/experimental/inflation/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/lattices/Makefile.am
+++ b/ql/experimental/lattices/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/math/Makefile.am
+++ b/ql/experimental/math/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/mcbasket/Makefile.am
+++ b/ql/experimental/mcbasket/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/models/Makefile.am
+++ b/ql/experimental/models/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/processes/Makefile.am
+++ b/ql/experimental/processes/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/risk/Makefile.am
+++ b/ql/experimental/risk/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/shortrate/Makefile.am
+++ b/ql/experimental/shortrate/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/swaptions/Makefile.am
+++ b/ql/experimental/swaptions/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/termstructures/Makefile.am
+++ b/ql/experimental/termstructures/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/variancegamma/Makefile.am
+++ b/ql/experimental/variancegamma/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/varianceoption/Makefile.am
+++ b/ql/experimental/varianceoption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/experimental/volatility/Makefile.am
+++ b/ql/experimental/volatility/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/indexes/Makefile.am
+++ b/ql/indexes/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = ibor inflation swap
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/indexes/inflation/Makefile.am
+++ b/ql/indexes/inflation/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/indexes/swap/Makefile.am
+++ b/ql/indexes/swap/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/instruments/Makefile.am
+++ b/ql/instruments/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = bonds
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/instruments/bonds/Makefile.am
+++ b/ql/instruments/bonds/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/legacy/Makefile.am
+++ b/ql/legacy/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = libormarketmodels
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/legacy/libormarketmodels/Makefile.am
+++ b/ql/legacy/libormarketmodels/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/Makefile.am
+++ b/ql/math/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = copulas distributions integrals interpolations \
           matrixutilities ode optimization randomnumbers solvers1d \
           statistics
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/copulas/Makefile.am
+++ b/ql/math/copulas/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/distributions/Makefile.am
+++ b/ql/math/distributions/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/integrals/Makefile.am
+++ b/ql/math/integrals/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/interpolations/Makefile.am
+++ b/ql/math/interpolations/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/matrixutilities/Makefile.am
+++ b/ql/math/matrixutilities/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/ode/Makefile.am
+++ b/ql/math/ode/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/optimization/Makefile.am
+++ b/ql/math/optimization/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/randomnumbers/Makefile.am
+++ b/ql/math/randomnumbers/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/solvers1d/Makefile.am
+++ b/ql/math/solvers1d/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/math/statistics/Makefile.am
+++ b/ql/math/statistics/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/Makefile.am
+++ b/ql/methods/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = finitedifferences lattices montecarlo
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/Makefile.am
+++ b/ql/methods/finitedifferences/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = meshers operators schemes solvers stepconditions utilities
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/meshers/Makefile.am
+++ b/ql/methods/finitedifferences/meshers/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/operators/Makefile.am
+++ b/ql/methods/finitedifferences/operators/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/schemes/Makefile.am
+++ b/ql/methods/finitedifferences/schemes/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/solvers/Makefile.am
+++ b/ql/methods/finitedifferences/solvers/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/stepconditions/Makefile.am
+++ b/ql/methods/finitedifferences/stepconditions/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/finitedifferences/utilities/Makefile.am
+++ b/ql/methods/finitedifferences/utilities/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/lattices/Makefile.am
+++ b/ql/methods/lattices/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/methods/montecarlo/Makefile.am
+++ b/ql/methods/montecarlo/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/Makefile.am
+++ b/ql/models/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = equity marketmodels shortrate volatility
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/equity/Makefile.am
+++ b/ql/models/equity/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/Makefile.am
+++ b/ql/models/marketmodels/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = browniangenerators callability correlations curvestates \
           driftcomputation evolvers models products pathwisegreeks 
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/browniangenerators/Makefile.am
+++ b/ql/models/marketmodels/browniangenerators/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/callability/Makefile.am
+++ b/ql/models/marketmodels/callability/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/correlations/Makefile.am
+++ b/ql/models/marketmodels/correlations/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/curvestates/Makefile.am
+++ b/ql/models/marketmodels/curvestates/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/driftcomputation/Makefile.am
+++ b/ql/models/marketmodels/driftcomputation/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/evolvers/Makefile.am
+++ b/ql/models/marketmodels/evolvers/Makefile.am
@@ -1,6 +1,6 @@
 SUBDIRS = volprocesses
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/evolvers/volprocesses/Makefile.am
+++ b/ql/models/marketmodels/evolvers/volprocesses/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/models/Makefile.am
+++ b/ql/models/marketmodels/models/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 

--- a/ql/models/marketmodels/pathwisegreeks/Makefile.am
+++ b/ql/models/marketmodels/pathwisegreeks/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/products/Makefile.am
+++ b/ql/models/marketmodels/products/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = onestep multistep pathwise
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/products/multistep/Makefile.am
+++ b/ql/models/marketmodels/products/multistep/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/products/onestep/Makefile.am
+++ b/ql/models/marketmodels/products/onestep/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/marketmodels/products/pathwise/Makefile.am
+++ b/ql/models/marketmodels/products/pathwise/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/shortrate/Makefile.am
+++ b/ql/models/shortrate/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = calibrationhelpers onefactormodels twofactormodels
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/shortrate/calibrationhelpers/Makefile.am
+++ b/ql/models/shortrate/calibrationhelpers/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/shortrate/onefactormodels/Makefile.am
+++ b/ql/models/shortrate/onefactormodels/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/shortrate/twofactormodels/Makefile.am
+++ b/ql/models/shortrate/twofactormodels/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/models/volatility/Makefile.am
+++ b/ql/models/volatility/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/patterns/Makefile.am
+++ b/ql/patterns/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/Makefile.am
+++ b/ql/pricingengines/Makefile.am
@@ -2,7 +2,7 @@
 SUBDIRS = asian barrier basket bond capfloor cliquet credit \
           forward inflation lookback quanto swap swaption vanilla
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/asian/Makefile.am
+++ b/ql/pricingengines/asian/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/barrier/Makefile.am
+++ b/ql/pricingengines/barrier/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/basket/Makefile.am
+++ b/ql/pricingengines/basket/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/bond/Makefile.am
+++ b/ql/pricingengines/bond/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/capfloor/Makefile.am
+++ b/ql/pricingengines/capfloor/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/cliquet/Makefile.am
+++ b/ql/pricingengines/cliquet/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/credit/Makefile.am
+++ b/ql/pricingengines/credit/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/forward/Makefile.am
+++ b/ql/pricingengines/forward/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/inflation/Makefile.am
+++ b/ql/pricingengines/inflation/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/lookback/Makefile.am
+++ b/ql/pricingengines/lookback/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/quanto/Makefile.am
+++ b/ql/pricingengines/quanto/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/swap/Makefile.am
+++ b/ql/pricingengines/swap/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/swaption/Makefile.am
+++ b/ql/pricingengines/swaption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/pricingengines/vanilla/Makefile.am
+++ b/ql/pricingengines/vanilla/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/processes/Makefile.am
+++ b/ql/processes/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/quotes/Makefile.am
+++ b/ql/quotes/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/Makefile.am
+++ b/ql/termstructures/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = credit inflation volatility yield
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/credit/Makefile.am
+++ b/ql/termstructures/credit/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/inflation/Makefile.am
+++ b/ql/termstructures/inflation/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/Makefile.am
+++ b/ql/termstructures/volatility/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = equityfx capfloor inflation optionlet swaption
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/capfloor/Makefile.am
+++ b/ql/termstructures/volatility/capfloor/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/equityfx/Makefile.am
+++ b/ql/termstructures/volatility/equityfx/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/inflation/Makefile.am
+++ b/ql/termstructures/volatility/inflation/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/optionlet/Makefile.am
+++ b/ql/termstructures/volatility/optionlet/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/volatility/swaption/Makefile.am
+++ b/ql/termstructures/volatility/swaption/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/termstructures/yield/Makefile.am
+++ b/ql/termstructures/yield/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/time/Makefile.am
+++ b/ql/time/Makefile.am
@@ -1,7 +1,7 @@
 
 SUBDIRS = calendars daycounters
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/time/calendars/Makefile.am
+++ b/ql/time/calendars/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/time/daycounters/Makefile.am
+++ b/ql/time/daycounters/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/ql/utilities/Makefile.am
+++ b/ql/utilities/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -175,7 +175,7 @@ dist-hook:
 
 if BOOST_UNIT_TEST_FOUND
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_builddir}
+AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 
 noinst_LTLIBRARIES = libUnitMain.la
 libUnitMain_la_SOURCES = main.cpp


### PR DESCRIPTION
The top_srcdir/ql/config.hpp would be found before the top_builddir/ql/config.hpp when srcdir is before builddir in the include path and QuantLib is built outside the source tree.

Fixes #379.