### PR TITLE
Add missing OneFactorAffineSurvivalStructure constructor.

### DIFF
--- a/ql/experimental/credit/onefactoraffinesurvival.hpp
+++ b/ql/experimental/credit/onefactoraffinesurvival.hpp
@@ -61,6 +61,18 @@ namespace QuantLib {
         : HazardRateStructure(referenceDate, Calendar(), dayCounter, jumps, 
             jumpDates), model_(model) {}
 
+        OneFactorAffineSurvivalStructure(
+            boost::shared_ptr<OneFactorAffineModel> model,
+            Natural settlementDays,
+            const Calendar& calendar,
+            const DayCounter& dayCounter = DayCounter(),
+            const std::vector<Handle<Quote> >& jumps
+                                          = std::vector<Handle<Quote> >(),
+            const std::vector<Date>& jumpDates = std::vector<Date>())
+        : HazardRateStructure(settlementDays, calendar,
+                              dayCounter, jumps, jumpDates),
+          model_(model) {}
+
         //! \name TermStructure interface
         //@{
         // overwrite on mkt models (e.g. bootstraps)


### PR DESCRIPTION
It was used by `InterpolatedAffineHazardRateCurve`, but not declared.