### PR TITLE
handle case of overlapping strike regions for caps and floors

### DIFF
--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -233,13 +233,13 @@ namespace QuantLib {
 
     #endif
 
-    namespace {
+    namespace detail {
     struct CloseEnoughComparator {
         explicit CloseEnoughComparator(const Real v) : v_(v) {}
         bool operator()(const Real w) const { return close_enough(v_, w); }
         Real v_;
     };
-    } // namespace
+    } // namespace detail
 
     //! set up the interpolations for capPrice_ and floorPrice_
     //! since we know ATM, and we have single flows,
@@ -269,10 +269,10 @@ namespace QuantLib {
                 Real K_quote = cfStrikes_[i] / 100.0;
                 Real K = std::pow(1.0 + K_quote, mat.length());
                 Size indF = std::find_if(fStrikes_.begin(), fStrikes_.end(),
-                                         CloseEnoughComparator(cfStrikes_[i])) -
+                                         detail::CloseEnoughComparator(cfStrikes_[i])) -
                             fStrikes_.begin();
                 Size indC = std::find_if(cStrikes_.begin(), cStrikes_.end(),
-                                         CloseEnoughComparator(cfStrikes_[i])) -
+                                         detail::CloseEnoughComparator(cfStrikes_[i])) -
                             cStrikes_.begin();
                 bool isFloorStrike = indF < fStrikes_.size();
                 bool isCapStrike = indC < cStrikes_.size();

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -233,6 +233,14 @@ namespace QuantLib {
 
     #endif
 
+    namespace {
+    struct CloseEnoughComparator {
+        explicit CloseEnoughComparator(const Real v) : v_(v) {}
+        bool operator()(const Real w) const { return close_enough(v_, w); }
+        Real v_;
+    };
+    } // namespace
+
     //! set up the interpolations for capPrice_ and floorPrice_
     //! since we know ATM, and we have single flows,
     //! we can use put/call parity to extend the surfaces
@@ -251,12 +259,6 @@ namespace QuantLib {
         QL_REQUIRE(!zts.empty(), "Zts is empty!!!");
         QL_REQUIRE(!yts.empty(), "Yts is empty!!!");
 
-        struct closeComp {
-            closeComp(const Real v) : v_(v) {}
-            bool operator()(const Real w) const { return close_enough(v_, w); }
-            Real v_;
-        };
-
         for (Size j = 0; j < cfMaturities_.size(); ++j) {
             Period mat = cfMaturities_[j];
             Real df = yts->discount(cpiOptionDateFromTenor(mat));
@@ -267,10 +269,10 @@ namespace QuantLib {
                 Real K_quote = cfStrikes_[i] / 100.0;
                 Real K = std::pow(1.0 + K_quote, mat.length());
                 Size indF = std::find_if(fStrikes_.begin(), fStrikes_.end(),
-                                         closeComp(cfStrikes_[i])) -
+                                         CloseEnoughComparator(cfStrikes_[i])) -
                             fStrikes_.begin();
                 Size indC = std::find_if(cStrikes_.begin(), cStrikes_.end(),
-                                         closeComp(cfStrikes_[i])) -
+                                         CloseEnoughComparator(cfStrikes_[i])) -
                             cStrikes_.begin();
                 bool isFloorStrike = indF < fStrikes_.size();
                 bool isCapStrike = indC < cStrikes_.size();

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -18,20 +18,20 @@
 */
 
 /*! \file cpicapfloortermpricesurface.hpp
-    \brief cpi inflation cap and floor term price structure.  N.B. 
+    \brief cpi inflation cap and floor term price structure.  N.B.
            cpi cap/floors have a single (one) flow (unlike nominal
            caps) because they observe cumulative inflation up to
            their maturity.  Options are on CPI(T)/CPI(0) but strikes
            are quoted for yearly average inflation, so require transformation
            via (1+quote)^T to obtain actual strikes.  These are consistent
            with ZCIIS quoting conventions.
- 
+
     The single-flow property of CPI cap/floors means that no stripping
     is required.  Additionally CPI swaps, i.e. ZCIIS zero coupon inflation
     indexed swaps are usually the most liquid of all the inflation products.
     These two facts mean that we can use a Zero Inflation term structure to
     give ATM.
- 
+
 */
 
 #ifndef quantlib_cpi_capfloor_term_price_surface_hpp
@@ -47,11 +47,11 @@
 namespace QuantLib {
 
     //! Provides cpi cap/floor prices by interpolation and put/call parity (not cap/floor/swap* parity).
-    /*! 
+    /*!
         The inflation index MUST contain a ZeroInflationTermStructure as
         this is used to create ATM.  Unlike YoY price surfaces we
         assume that 1) an ATM ZeroInflationTermStructure is available
-        and 2) that it is safe to use it.  This is supported by the 
+        and 2) that it is safe to use it.  This is supported by the
         fact that no stripping is required for CPI cap/floors as they
         only give one flow.
 
@@ -61,15 +61,15 @@ namespace QuantLib {
         are quoted for yearly average inflation, so require transformation
         via (1+quote)^T to obtain actual strikes.  These are consistent
         with ZCIIS quoting conventions.
-     
+
         The observationLag is that for the referenced instrument prices.
-        Strikes are as-quoted not as-used. 
-    */    
+        Strikes are as-quoted not as-used.
+    */
     class CPICapFloorTermPriceSurface : public InflationTermStructure {
       public:
-        CPICapFloorTermPriceSurface(Real nominal, 
+        CPICapFloorTermPriceSurface(Real nominal,
                                     Real baseRate,  // avoids an uncontrolled crash if index has no TS
-                                    const Period &observationLag,   
+                                    const Period &observationLag,
                                     const Calendar &cal, // calendar in index may not be useful
                                     const BusinessDayConvention &bdc,
                                     const DayCounter &dc,
@@ -80,7 +80,7 @@ namespace QuantLib {
                                     const std::vector<Period> &cfMaturities,
                                     const Matrix &cPrice,
                                     const Matrix &fPrice);
- 
+
         //! \name InflationTermStructure interface
         //@{
         Period observationLag() const;
@@ -100,7 +100,7 @@ namespace QuantLib {
         virtual BusinessDayConvention businessDayConvention() const;
         //@}
 
-        //! \warning you MUST remind the compiler in any descendants with the using:: mechanism 
+        //! \warning you MUST remind the compiler in any descendants with the using:: mechanism
         //!          because you overload the names
         //! remember that the strikes use the quoting convention
         //@{
@@ -111,22 +111,22 @@ namespace QuantLib {
         virtual Real capPrice(const Date &d, Rate k) const = 0;
         virtual Real floorPrice(const Date &d, Rate k) const = 0;
         //@}
-        
+
         virtual std::vector<Rate> strikes() const {return cfStrikes_;}
         virtual std::vector<Rate> capStrikes() const {return cStrikes_;}
         virtual std::vector<Rate> floorStrikes() const {return fStrikes_;}
         virtual std::vector<Period> maturities() const {return cfMaturities_;}
-        
+
         virtual const Matrix &capPrices() const { return cPrice_; }
         virtual const Matrix &floorPrices() const { return fPrice_; }
-        
+
         virtual Rate minStrike() const {return cfStrikes_.front();};
         virtual Rate maxStrike() const {return cfStrikes_.back();};
         virtual Date minDate() const {return referenceDate()+cfMaturities_.front();}// \TODO deal with index interpolation
         virtual Date maxDate() const {return referenceDate()+cfMaturities_.back();}
         //@}
 
-        
+
         virtual Date cpiOptionDateFromTenor(const Period& p) const;
 
       protected:
@@ -136,8 +136,8 @@ namespace QuantLib {
         virtual bool checkMaturity(const Date& d) {
             return ( minDate() <= d && d <= maxDate() );
         }
-        
-        
+
+
 
         Handle<ZeroInflationIndex> zii_;
         // data
@@ -154,13 +154,13 @@ namespace QuantLib {
         BusinessDayConvention bdc_;
     };
 
-        
+
 
     template<class Interpolator2D>
     class InterpolatedCPICapFloorTermPriceSurface
         : public CPICapFloorTermPriceSurface {
             public:
-            InterpolatedCPICapFloorTermPriceSurface(Real nominal, 
+            InterpolatedCPICapFloorTermPriceSurface(Real nominal,
                                                 Rate startRate,
                                                 const Period &observationLag,
                                                 const Calendar &cal,
@@ -177,28 +177,26 @@ namespace QuantLib {
 
             //! \name LazyObject interface
             //@{
-            void update();
             void performCalculations() const;
             //@}
-            
+
             //! required to allow for method hiding
             //@{
             using CPICapFloorTermPriceSurface::price;
             using CPICapFloorTermPriceSurface::capPrice;
             using CPICapFloorTermPriceSurface::floorPrice;
             //@}
-            
+
             //! remember that the strikes use the quoting convention
             //@{
             virtual Real price(const Date &d, Rate k) const;
             virtual Real capPrice(const Date &d, Rate k) const;
             virtual Real floorPrice(const Date &d, Rate k) const;
             //@}
-            
+
         protected:
-        
+
             // data for surfaces and curve
-            mutable std::vector<Rate> allStrikes_;
             mutable Matrix cPriceB_;
             mutable Matrix fPriceB_;
             mutable Interpolation2D capPrice_, floorPrice_;
@@ -213,9 +211,9 @@ namespace QuantLib {
 
     template<class Interpolator2D>
     InterpolatedCPICapFloorTermPriceSurface<Interpolator2D>::
-    InterpolatedCPICapFloorTermPriceSurface(Real nominal, 
+    InterpolatedCPICapFloorTermPriceSurface(Real nominal,
                                             Rate startRate,
-                                            const Period &observationLag,   
+                                            const Period &observationLag,
                                             const Calendar &cal,
                                             const BusinessDayConvention &bdc,
                                             const DayCounter &dc,
@@ -235,15 +233,6 @@ namespace QuantLib {
 
     #endif
 
-    
-    
-    template<class I2D>
-    void InterpolatedCPICapFloorTermPriceSurface<I2D>::
-    update() {
-        notifyObservers();
-    }
-
-
     //! set up the interpolations for capPrice_ and floorPrice_
     //! since we know ATM, and we have single flows,
     //! we can use put/call parity to extend the surfaces
@@ -251,94 +240,92 @@ namespace QuantLib {
     template<class I2D>
     void InterpolatedCPICapFloorTermPriceSurface<I2D>::
     performCalculations() const {
-        
-        
-        Size nMat = cfMaturities_.size(), ncK = cStrikes_.size(), nfK = fStrikes_.size(),
-            nK = ncK + nfK;
-        Matrix cP(nK, nMat), fP(nK, nMat);
+
+        cPriceB_ =
+            Matrix(cfStrikes_.size(), cfMaturities_.size(), Null<Real>());
+        fPriceB_ =
+            Matrix(cfStrikes_.size(), cfMaturities_.size(), Null<Real>());
+
         Handle<ZeroInflationTermStructure> zts = zii_->zeroInflationTermStructure();
         Handle<YieldTermStructure> yts = this->nominalTermStructure();
-        QL_REQUIRE(!zts.empty(),"Zts is empty!!!");
-        QL_REQUIRE(!yts.empty(),"Yts is empty!!!");
-        
-        for (Size i =0; i<nfK; i++){
-            allStrikes_.push_back(fStrikes_[i]);
-            for (Size j=0; j<nMat; j++) {
-                Period mat = cfMaturities_[j];
-                Real df = yts->discount(cpiOptionDateFromTenor(mat));
-                Real atm_quote = zts->zeroRate(cpiOptionDateFromTenor(mat));
-                Real atm = std::pow(1.0+atm_quote, mat.length());
-                Real S = atm * df;
-                Real K_quote = fStrikes_[i]/100.0;
-                Real K = std::pow(1.0+K_quote, mat.length());
-                cP[i][j] = fPrice_[i][j] + S - K * df;
-                fP[i][j] = fPrice_[i][j];
+        QL_REQUIRE(!zts.empty(), "Zts is empty!!!");
+        QL_REQUIRE(!yts.empty(), "Yts is empty!!!");
+
+        struct closeComp {
+            closeComp(const Real v) : v_(v) {}
+            bool operator()(const Real w) const { return close_enough(v_, w); }
+            Real v_;
+        };
+
+        for (Size j = 0; j < cfMaturities_.size(); ++j) {
+            Period mat = cfMaturities_[j];
+            Real df = yts->discount(cpiOptionDateFromTenor(mat));
+            Real atm_quote = zts->zeroRate(cpiOptionDateFromTenor(mat));
+            Real atm = std::pow(1.0 + atm_quote, mat.length());
+            Real S = atm * df;
+            for (Size i = 0; i < cfStrikes_.size(); ++i) {
+                Real K_quote = cfStrikes_[i] / 100.0;
+                Real K = std::pow(1.0 + K_quote, mat.length());
+                Size indF = std::find_if(fStrikes_.begin(), fStrikes_.end(),
+                                         closeComp(cfStrikes_[i])) -
+                            fStrikes_.begin();
+                Size indC = std::find_if(cStrikes_.begin(), cStrikes_.end(),
+                                         closeComp(cfStrikes_[i])) -
+                            cStrikes_.begin();
+                bool isFloorStrike = indF < fStrikes_.size();
+                bool isCapStrike = indC < cStrikes_.size();
+                if (isFloorStrike) {
+                    fPriceB_[i][j] = fPrice_[indF][j];
+                    if (!isCapStrike) {
+                        cPriceB_[i][j] = fPrice_[indF][j] + S - K * df;
+                    }
+                }
+                if (isCapStrike) {
+                    cPriceB_[i][j] = cPrice_[indC][j];
+                    if (!isFloorStrike) {
+                        fPriceB_[i][j] = cPrice_[indC][j] + K * df - S;
+                    }
+                }
             }
         }
-        for (Size i =0; i<ncK; i++){
-            allStrikes_.push_back(cStrikes_[i]);
-            for (Size j=0; j<nMat; j++) {
-                Period mat = cfMaturities_[j];
-                Real df = yts->discount(cpiOptionDateFromTenor(mat));
-                Real atm_quote = zts->zeroRate(cpiOptionDateFromTenor(mat));
-                Real atm = std::pow(1.0+atm_quote, mat.length());
-                Real S = atm * df;
-                Real K_quote = cStrikes_[i]/100.0;
-                Real K = std::pow(1.0+K_quote, mat.length());
-                cP[i+nfK][j] = cPrice_[i][j];
-                fP[i+nfK][j] = cPrice_[i][j] + K * df - S;
+
+        // check that all cells are filled
+        for (Size i = 0; i < cPriceB_.rows(); ++i) {
+            for (Size j = 0; j < cPriceB_.columns(); ++j) {
+                QL_REQUIRE(cPriceB_[i][j] != Null<Real>(),
+                           "InterpolatedCPICapFloorTermPriceSurface: did not "
+                           "fill call price matrix at ("
+                               << i << "," << j << "), this is unexpected");
+                QL_REQUIRE(fPriceB_[i][j] != Null<Real>(),
+                           "InterpolatedCPICapFloorTermPriceSurface: did not "
+                           "fill floor price matrix at ("
+                               << i << "," << j << "), this is unexpected");
             }
         }
-        
-        // copy to store        
-        cPriceB_ = cP;
-        fPriceB_ = fP;
-        
+
         cfMaturityTimes_.clear();
         for (Size i=0; i<cfMaturities_.size();i++) {
             cfMaturityTimes_.push_back(timeFromReference(cpiOptionDateFromTenor(cfMaturities_[i])));
         }
-        
+
         capPrice_ = interpolator2d_.interpolate(cfMaturityTimes_.begin(),cfMaturityTimes_.end(),
-                                                allStrikes_.begin(), allStrikes_.end(),
+                                                cfStrikes_.begin(), cfStrikes_.end(),
                                                 cPriceB_
                                                 );
         capPrice_.enableExtrapolation();
-        
+
         floorPrice_ = interpolator2d_.interpolate(cfMaturityTimes_.begin(),cfMaturityTimes_.end(),
-                                                  allStrikes_.begin(), allStrikes_.end(),
+                                                  cfStrikes_.begin(), cfStrikes_.end(),
                                                   fPriceB_
                                                   );
         floorPrice_.enableExtrapolation();
-        
-        /* test code - note order of indices
-        for (Size i =0; i<nK; i++){
-            std::cout << allStrikes_[i] << ":  ";
-            Real qK = allStrikes_[i];
-            for (Size j=0; j<nMat; j++) {
-                Real t = cfMaturityTimes_[j];
-                std::cout << fP[i][j] << "," << floorPrice_(t,qK) << " | " ;
-            }
-            std::cout << std::endl;
-        }
-        
-        for (Size i =0; i<nK; i++){
-            std::cout << allStrikes_[i] << ":  ";
-            Real qK = allStrikes_[i];
-            for (Size j=0; j<nMat; j++) {
-                Real t = cfMaturityTimes_[j];
-                std::cout << cP[i][j] << "," << capPrice_(t,qK) << " | " ;
-            }
-            std::cout << std::endl;
-        }
-        */
     }
 
     //! remember that the strike uses the quoting convention
     template<class I2D>
     Real InterpolatedCPICapFloorTermPriceSurface<I2D>::
     price(const Date &d, Rate k) const {
-        
+
         Rate atm = zeroInflationIndex()->zeroInflationTermStructure()->zeroRate(d);
         return k > atm ? capPrice(d,k): floorPrice(d,k);
     }


### PR DESCRIPTION
In the current version overlapping strike regions for caps and floors (as they are usual in the actual market quotes) are not handled correctly - if extra safety checks are enabled an exception from the bilinear interpolator is thrown ("values are not sorted", which refers to the strike input); if they are not enabled the code runs, but will produce false results. This PR fixes this and also cleans up everything a bit.