### PR TITLE
Do not error when using CDS2015 rule

### DIFF
--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -106,7 +106,8 @@ namespace QuantLib {
       protectionStart_(protectionStart == Null<Date>() ? schedule[0] :
                                                          protectionStart) {
         QL_REQUIRE((protectionStart_ <= schedule[0])
-            || (schedule.rule() == DateGeneration::CDS),
+            || (schedule.rule() == DateGeneration::CDS)
+            || (schedule.rule() == DateGeneration::CDS2015),
                    "protection can not start after accrual");
 
         leg_ = FixedRateLeg(schedule)


### PR DESCRIPTION
the test was already amended in the pure running cds case.