### PR TITLE
Resolve NaN issue when data to fit is identical

### DIFF
--- a/ql/math/interpolations/cubicinterpolation.hpp
+++ b/ql/math/interpolations/cubicinterpolation.hpp
@@ -575,7 +575,7 @@ namespace QuantLib {
                                 for (Size i=1; i<n_-1; ++i) {
                                     Real Smin = std::min(S_[i-1], S_[i]);
                                     Real Smax = std::max(S_[i-1], S_[i]);
-                                    tmp_[i] = 3.0*Smin*Smax/(Smax+2.0*Smin);
+                                    tmp_[i] = Smin == 0 || Smax == 0 ? 0 : 3.0*Smin*Smax/(Smax+2.0*Smin);
                                 }
                                 // end points
                                 tmp_[0]    = ((2.0*dx_[   0]+dx_[   1])*S_[   0] - dx_[   0]*S_[   1]) / (dx_[   0]+dx_[   1]);

--- a/ql/math/interpolations/cubicinterpolation.hpp
+++ b/ql/math/interpolations/cubicinterpolation.hpp
@@ -289,7 +289,7 @@ namespace QuantLib {
                             const I1& xEnd,
                             const I2& yBegin)
         : CubicInterpolation(xBegin, xEnd, yBegin,
-                             FritschButland, false,
+                             FritschButland, true,
                              SecondDerivative, 0.0,
                              SecondDerivative, 0.0) {}
     };
@@ -575,7 +575,16 @@ namespace QuantLib {
                                 for (Size i=1; i<n_-1; ++i) {
                                     Real Smin = std::min(S_[i-1], S_[i]);
                                     Real Smax = std::max(S_[i-1], S_[i]);
-                                    tmp_[i] = Smin == 0 || Smax == 0 ? 0 : 3.0*Smin*Smax/(Smax+2.0*Smin);
+                                    if(Smax+2.0*Smin == 0){
+                                        if (Smin*Smax < 0)
+                                            tmp_[i] = QL_MIN_REAL;
+                                        else if (Smin*Smax == 0)
+                                            tmp_[i] = 0;
+                                        else
+                                            tmp_[i] = QL_MAX_REAL;
+                                    }
+                                    else
+                                        tmp_[i] = 3.0*Smin*Smax/(Smax+2.0*Smin);
                                 }
                                 // end points
                                 tmp_[0]    = ((2.0*dx_[   0]+dx_[   1])*S_[   0] - dx_[   0]*S_[   1]) / (dx_[   0]+dx_[   1]);

--- a/test-suite/interpolations.hpp
+++ b/test-suite/interpolations.hpp
@@ -40,6 +40,7 @@ class InterpolationTest {
     static void testSplineErrorOnGaussianValues();
     static void testMultiSpline();
     static void testAsFunctor();
+    static void testFritschButland();
     // other interpolations
     static void testBackwardFlat();
     static void testForwardFlat();


### PR DESCRIPTION
Fixes #377 

NaN is originally from Line 578. When either of the min or max slope is zero, we'll see it's divided by zero. Here I added a pre-check, if that's the case, make tmp_[i] zero directly.

Sorry for replicate PR for typo in branch name.