### PR TITLE
Fix inconsistent strike units in CPI cap/floor term price surface

### DIFF
--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -266,7 +266,7 @@ namespace QuantLib {
             Real atm = std::pow(1.0 + atm_quote, mat.length());
             Real S = atm * df;
             for (Size i = 0; i < cfStrikes_.size(); ++i) {
-                Real K_quote = cfStrikes_[i] / 100.0;
+                Real K_quote = cfStrikes_[i];
                 Real K = std::pow(1.0 + K_quote, mat.length());
                 Size indF = std::find_if(fStrikes_.begin(), fStrikes_.end(),
                                          detail::CloseEnoughComparator(cfStrikes_[i])) -

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -376,6 +376,18 @@ void InflationCPICapFloorTest::cpicapfloorpricesurface() {
         }
     }
 
+    // Test the price method also i.e. does it pick out the correct premium?
+    // Look up premium from surface at 3 years and strike of 1%
+    // Expect, as 1% < ATM, to get back floor premium at 1% i.e. 53.61 bps
+    // Instead we get back cap premium at 1% because price method compares
+    // 1 with atm of 0.03059
+    Real premium = cpiSurf.price(3 * Years, 1.0);
+    Real expPremium = (*common.fPriceUK)[2][0];
+    if (fabs(premium - expPremium) > 1e-12) {
+        BOOST_ERROR("The requested premium, " << premium
+            << ", does not equal the expected premium, " << expPremium << ".");
+    }
+
     // remove circular refernce
     common.hcpi.linkTo(boost::shared_ptr<ZeroInflationTermStructure>());
 }

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -277,8 +277,8 @@ namespace {
 
             // cpi CF price surf data
             Period cfMat[] = {3*Years, 5*Years, 7*Years, 10*Years, 15*Years, 20*Years, 30*Years};
-            Real cStrike[] = {3, 4, 5, 6};
-            Real fStrike[] = {-1, 0, 1, 2};
+            Real cStrike[] = {0.03, 0.04, 0.05, 0.06};
+            Real fStrike[] = {-0.01, 0, 0.01, 0.02};
             Size ncStrikes = 4, nfStrikes = 4, ncfMaturities = 7;
 
             Real cPrice[7][4] = {
@@ -379,9 +379,7 @@ void InflationCPICapFloorTest::cpicapfloorpricesurface() {
     // Test the price method also i.e. does it pick out the correct premium?
     // Look up premium from surface at 3 years and strike of 1%
     // Expect, as 1% < ATM, to get back floor premium at 1% i.e. 53.61 bps
-    // Instead we get back cap premium at 1% because price method compares
-    // 1 with atm of 0.03059
-    Real premium = cpiSurf.price(3 * Years, 1.0);
+    Real premium = cpiSurf.price(3 * Years, 0.01);
     Real expPremium = (*common.fPriceUK)[2][0];
     if (fabs(premium - expPremium) > 1e-12) {
         BOOST_ERROR("The requested premium, " << premium
@@ -445,12 +443,7 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
 
     Date d = common.cpiCFsurfUK->cpiOptionDateFromTenor(Period(3,Years));
 
-    // Error is just being masked with following line of commented code
-    // You should really get back the cap premium at strike 0.03 i.e. 227.6 bps
-    // Instead the units of strike for the CPI surface are in percent and to find 
-    // premium for the 0.03 strike cap, an interpolation is done between 0 and 1 i.e. 
-    // the 0 and 0.01 strikes to obtain an incorrect NPV of 913.6 bps
-    // Real cached = cpiCFsurfUKh->capPrice(d, strike);
+    // We should get back the cap premium at strike 0.03 i.e. 227.6 bps
     Real cached = (*common.cPriceUK)[0][0];
 
     QL_REQUIRE(fabs(cached - aCap.NPV())<1e-10,"InterpolatingCPICapFloorEngine does not reproduce cached price: "

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -433,8 +433,14 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
 
     Date d = common.cpiCFsurfUK->cpiOptionDateFromTenor(Period(3,Years));
 
+    // Error is just being masked with following line of commented code
+    // You should really get back the cap premium at strike 0.03 i.e. 227.6 bps
+    // Instead the units of strike for the CPI surface are in percent and to find 
+    // premium for the 0.03 strike cap, an interpolation is done between 0 and 1 i.e. 
+    // the 0 and 0.01 strikes to obtain an incorrect NPV of 913.6 bps
+    // Real cached = cpiCFsurfUKh->capPrice(d, strike);
+    Real cached = (*common.cPriceUK)[0][0];
 
-    Real cached = cpiCFsurfUKh->capPrice(d, strike);
     QL_REQUIRE(fabs(cached - aCap.NPV())<1e-10,"InterpolatingCPICapFloorEngine does not reproduce cached price: "
                << cached << " vs " << aCap.NPV());
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -441,8 +441,6 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
 
     aCap.setPricingEngine(engine);
 
-    Date d = common.cpiCFsurfUK->cpiOptionDateFromTenor(Period(3,Years));
-
     // We should get back the cap premium at strike 0.03 i.e. 227.6 bps
     Real cached = (*common.cPriceUK)[0][0];
 


### PR DESCRIPTION
The `CPICapFloorTermPriceSurface` class' constructor takes cap and floor strikes in percentage e.g. 1 for 0.01. The underlying interpolation on strikes is set up in these units also so that the various methods for querying a premium expect the strike in the same units. However, in the `price` method [here](https://github.com/lballabio/QuantLib/blob/612027233c953cfbbe57c3f2b0537ce0b54b28dc/ql/experimental/inflation/cpicapfloortermpricesurface.hpp#L332), entering a strike `k` in percentage units leads to an error.

Commits e9ee6cd381fd7c61c922d63e2a2ba3855fe5b556 and a294761c1ef7bd6cc323ef4b1490a54f41919c56 in this pull request show in the unit tests how this leads to errors.

This pull request fixes this by expecting the strike values in the constructor to be entered without any assumed units. 