### PR TITLE
CMake: generate and install config.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,3 +46,11 @@ endif (Boost_FOUND)
 add_subdirectory(ql)
 add_subdirectory(Examples)
 add_subdirectory(test-suite)
+
+#
+# Copy across the ANSI config file into the build directory. Users
+# need to change userconfig.hpp if they require different settings.
+#
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ql/config.ansi.hpp
+  ${PROJECT_BINARY_DIR}/config.hpp COPYONLY)
+install(FILES ${PROJECT_BINARY_DIR}/config.hpp DESTINATION include/ql)


### PR DESCRIPTION
CMake builds are broken at present because they are not generating config.hpp. This is done as part of 
configure, and cannot be easily replicated in CMake without some duplication. This patch takes the easy approach and simply copies across the ANSI configuration and installs it as part of make install. For details on the discussion, see [1].

[1] https://github.com/lballabio/QuantLib/issues/396