### PR TITLE
Don't query the curve in the ForwardRateAgreement constructor

### DIFF
--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -59,6 +59,11 @@ namespace QuantLib {
                                  settlementDays_, Days);
     }
 
+    Date ForwardRateAgreement::fixingDate() const {
+        return calendar_.advance(valueDate_,
+                                 -static_cast<Integer>(settlementDays_), Days);
+    }
+
     bool ForwardRateAgreement::isExpired() const {
         return detail::simple_event(valueDate_).hasOccurred(settlementDate());
     }
@@ -86,10 +91,15 @@ namespace QuantLib {
         return forwardRate_;
     }
 
+    void ForwardRateAgreement::setupExpired() const {
+        Forward::setupExpired();
+        forwardRate_ = InterestRate(index_->fixing(fixingDate()),
+                                    index_->dayCounter(),
+                                    Simple, Once);
+    }
+
     void ForwardRateAgreement::performCalculations() const {
-        Date fixingDate = calendar_.advance(valueDate_,
-            -static_cast<Integer>(settlementDays_), Days);
-        forwardRate_ = InterestRate(index_->fixing(fixingDate),
+        forwardRate_ = InterestRate(index_->fixing(fixingDate()),
                                     index_->dayCounter(),
                                     Simple, Once);
         underlyingSpotValue_ = spotValue();

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -39,13 +39,6 @@ namespace QuantLib {
 
         QL_REQUIRE(notionalAmount > 0.0, "notionalAmount must be positive");
 
-        // do I adjust this ?
-        // valueDate_ = calendar_.adjust(valueDate_,businessDayConvention_);
-        Date fixingDate = calendar_.advance(valueDate_,
-            -static_cast<Integer>(settlementDays_), Days);
-        forwardRate_ = InterestRate(index->fixing(fixingDate),
-                                    index->dayCounter(),
-                                    Simple, Once);
         strikeForwardRate_ = InterestRate(strikeForwardRate,
                                           index->dayCounter(),
                                           Simple, Once);

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -91,6 +91,7 @@ namespace QuantLib {
             valueDate).
         */
         Date settlementDate() const;
+        Date fixingDate() const;
         /*!  Income is zero for a FRA */
         Real spotIncome(const Handle<YieldTermStructure>& incomeDiscountCurve)
             const;
@@ -102,6 +103,7 @@ namespace QuantLib {
         //@}
 
       protected:
+        void setupExpired() const;
         void performCalculations() const;
         Position::Type fraType_;
         //! aka FRA rate (the market forward rate)

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -54,6 +54,7 @@ QL_TESTS = \
 	fdheston.hpp fdheston.cpp \
 	fdmlinearop.hpp fdmlinearop.cpp \
 	forwardoption.hpp forwardoption.cpp \
+	forwardrateagreement.hpp forwardrateagreement.cpp \
 	functions.hpp functions.cpp \
 	garch.hpp garch.cpp \
 	gaussianquadratures.hpp gaussianquadratures.cpp \

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -38,21 +38,19 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
 
         // set up the index
         RelinkableHandle<YieldTermStructure> curveHandle;
-        boost::shared_ptr<IborIndex> index = boost::make_shared<USDLibor>(Period(3, TimeUnit::Months), curveHandle);
+        boost::shared_ptr<IborIndex> index = boost::make_shared<USDLibor>(Period(3, Months), curveHandle);
 
         // set up quotes with no values
-        std::vector<boost::shared_ptr<SimpleQuote> > quotes = {
-                boost::make_shared<SimpleQuote>(),
-                boost::make_shared<SimpleQuote>(),
-                boost::make_shared<SimpleQuote>()
-        };
+        std::vector<boost::shared_ptr<SimpleQuote> > quotes;
+        quotes.push_back(boost::make_shared<SimpleQuote>());
+        quotes.push_back(boost::make_shared<SimpleQuote>());
+        quotes.push_back(boost::make_shared<SimpleQuote>());
 
         // set up the curve (this bit is a very rough sketch - i'm actually using swaps !)
-        std::vector<boost::shared_ptr<RateHelper> > helpers = {
-                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[0]), Period(1, TimeUnit::Years), index),
-                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]), Period(2, TimeUnit::Years), index),
-                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]), Period(3, TimeUnit::Years), index)
-        };
+        std::vector<boost::shared_ptr<RateHelper> > helpers;
+        helpers.push_back(boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[0]), Period(1, Years), index));
+        helpers.push_back(boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]), Period(2, Years), index));
+        helpers.push_back(boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]), Period(3, Years), index));
 
         boost::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve = boost::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(spotDate,
                                                                                                                                                              helpers,
@@ -61,9 +59,9 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
         curveHandle.linkTo(curve);
 
         // set up the instrument to price
-        ForwardRateAgreement fra(spotDate + Period(6, TimeUnit::Months),
-                                 spotDate + Period(18, TimeUnit::Months),
-                                 Position::Type::Long,
+        ForwardRateAgreement fra(spotDate + Period(6, Months),
+                                 spotDate + Period(18, Months),
+                                 Position::Long,
                                  0,
                                  1,
                                  index,

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -1,0 +1,87 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+   Copyright (C) 2018 Tom Anderson
+
+   This file is part of QuantLib, a free-software/open-source library
+   for financial quantitative analysts and developers - http://quantlib.org/
+
+   QuantLib is free software: you can redistribute it and/or modify it
+   under the terms of the QuantLib license.  You should have received a
+   copy of the license along with this program; if not, please email
+   <quantlib-dev@lists.sf.net>. The license is also available online at
+   <http://quantlib.org/license.shtml>.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+   FOR A PARTICULAR PURPOSE.  See the license for more details.
+ */
+
+#include "forwardrateagreement.hpp"
+#include "utilities.hpp"
+#include <ql/handle.hpp>
+#include <ql/indexes/ibor/usdlibor.hpp>
+#include <ql/instruments/forwardrateagreement.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/termstructures/yield/ratehelpers.hpp>
+
+#include <boost/make_shared.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+void ForwardRateAgreementTest::testConstructionWithoutACurve() {
+        BOOST_TEST_MESSAGE("Testing forward rate agreement construction...");
+
+        Date spotDate = QuantLib::Settings::instance().evaluationDate();
+
+        // set up the index
+        RelinkableHandle<YieldTermStructure> curveHandle;
+        boost::shared_ptr<IborIndex> index = boost::make_shared<USDLibor>(Period(3, TimeUnit::Months), curveHandle);
+
+        // set up quotes with no values
+        std::vector<boost::shared_ptr<SimpleQuote> > quotes = {
+                boost::make_shared<SimpleQuote>(),
+                boost::make_shared<SimpleQuote>(),
+                boost::make_shared<SimpleQuote>()
+        };
+
+        // set up the curve (this bit is a very rough sketch - i'm actually using swaps !)
+        std::vector<boost::shared_ptr<RateHelper> > helpers = {
+                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[0]), Period(1, TimeUnit::Years), index),
+                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]), Period(2, TimeUnit::Years), index),
+                boost::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]), Period(3, TimeUnit::Years), index)
+        };
+
+        boost::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve = boost::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(spotDate,
+                                                                                                                                                             helpers,
+                                                                                                                                                             index->dayCounter());
+
+        curveHandle.linkTo(curve);
+
+        // set up the instrument to price
+        ForwardRateAgreement fra(spotDate + Period(6, TimeUnit::Months),
+                                 spotDate + Period(18, TimeUnit::Months),
+                                 Position::Type::Long,
+                                 0,
+                                 1,
+                                 index,
+                                 curveHandle);
+
+        // finally put values in the quotes
+        quotes[0]->setValue(0.01);
+        quotes[1]->setValue(0.02);
+        quotes[2]->setValue(0.03);
+
+        double rate = fra.forwardRate();
+        if (std::fabs(rate - 0.0100006) > 1e-6) {
+                BOOST_ERROR("grid creation failed");
+        }
+}
+
+test_suite* ForwardRateAgreementTest::suite() {
+        test_suite* suite = BOOST_TEST_SUITE("forward rate agreement");
+        suite->add(QUANTLIB_TEST_CASE(&ForwardRateAgreementTest::testConstructionWithoutACurve));
+        return suite;
+}

--- a/test-suite/forwardrateagreement.hpp
+++ b/test-suite/forwardrateagreement.hpp
@@ -1,0 +1,34 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2018 Tom Anderson
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_forward_rate_agreement_hpp
+#define quantlib_test_forward_rate_agreement_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class ForwardRateAgreementTest {
+  public:
+    static void testConstructionWithoutACurve();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -105,6 +105,7 @@
 #include "fdheston.hpp"
 #include "fdmlinearop.hpp"
 #include "forwardoption.hpp"
+#include "forwardrateagreement.hpp"
 #include "functions.hpp"
 #include "gaussianquadratures.hpp"
 #include "garch.hpp"
@@ -269,7 +270,7 @@ QuantLib::Date evaluation_date(int argc, char** argv) {
     return knownGoodDefault;
 }
 
-    
+
 SpeedLevel speed_level(int argc, char** argv) {
     /*! Again, dead simple parser:
         - passing --slow causes all tests to be run;
@@ -390,6 +391,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(FdHestonTest::suite(speed));
     test->add(FdmLinearOpTest::suite());
     test->add(ForwardOptionTest::suite());
+    test->add(ForwardRateAgreementTest::suite());
     test->add(FunctionsTest::suite());
     test->add(GARCHTest::suite());
     test->add(GaussianQuadraturesTest::suite());


### PR DESCRIPTION
This is an attempt at fixing #371. I don't really understand how the tests work, so i cargo-culted heavily.

Closes #371.