### PR TITLE
Additional Turkey Holidays > 2014.

### DIFF
--- a/ql/time/calendars/turkey.cpp
+++ b/ql/time/calendars/turkey.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2005 Sercan Atalik
  Copyright (C) 2010 StatPro Italia srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -128,7 +129,149 @@ namespace QuantLib {
             // additional holiday for Republic Day
                 || (m == October && d == 29))
                 return false;
-        }
+		}
+		else if (y == 2015) {
+			// Ramadan
+			if ((m == July && d >= 17 && d <= 19)
+				// Kurban
+				|| (m == October && d >= 24 && d <= 27))
+				return false;
+		}
+		else if (y == 2016) {
+			// Ramadan
+			if ((m == July && d >= 5 && d <= 7)
+				// Kurban
+				|| (m == September && d >= 12 && d <= 15))
+				return false;
+		}
+		else if (y == 2017) {
+			// Ramadan
+			if ((m == June && d >= 25 && d <= 27)
+				// Kurban
+				|| (m == September && d >= 1 && d <= 4))
+				return false;
+		}
+		else if (y == 2018) {
+			// Ramadan
+			if ((m == June && d >= 15 && d <= 17)
+				// Kurban
+				|| (m == August && d >= 21 && d <= 24))
+				return false;
+		}
+		// Note: Holidays >= 2019 are not yet officially anounced by borsaistanbul.com
+		// and need further validation
+		else if (y == 2019) {
+			// Ramadan
+			if ((m == June && d >= 5 && d <= 7)
+				// Kurban
+				|| (m == August && d >= 11 && d <= 14))
+				return false;
+		}
+		else if (y == 2020) {
+			// Ramadan
+			if ((m == May && d >= 24 && d <= 26)
+				// Kurban
+				|| (m == July && d >= 30 && d <= 31))
+				return false;
+		}
+		else if (y == 2021) {
+			// Ramadan
+			if ((m == May && d >= 13 && d <= 14)
+				// Kurban
+				|| (m == July && d >= 19 && d <= 22))
+				return false;
+		}
+		else if (y == 2022) {
+			// Ramadan
+			if ((m == May && d >= 3 && d <= 5)
+				// Kurban
+				|| (m == July && d >= 9 && d <= 12))
+				return false;
+		}
+		else if (y == 2023) {
+			// Ramadan
+			if ((m == April && d >= 22 && d <= 24)
+				// Kurban
+				|| (m == June && d >= 28 && d <= 30))
+				return false;
+		}
+		else if (y == 2024) {
+			// Ramadan
+			if ((m == April && d >= 10 && d <= 12)
+				// Kurban
+				|| (m == June && d >= 17 && d <= 19))
+				return false;
+		}
+		else if (y == 2025) {
+			// Ramadan
+			if ((m == March && d == 31) || (m == April && d >= 1 && d <= 2)
+				// Kurban
+				|| (m == June && d >= 6 && d <= 9))
+				return false;
+		}
+		else if (y == 2026) {
+			// Ramadan
+			if ((m == March && d >= 20 && d <= 22)
+				// Kurban
+				|| (m == May && d >= 26 && d <= 29))
+				return false;
+		}
+		else if (y == 2027) {
+			// Ramadan
+			if ((m == March && d >= 10 && d <= 12)
+				// Kurban
+				|| (m == May && d >= 16 && d <= 19))
+				return false;
+		}
+		else if (y == 2028) {
+			// Ramadan
+			if ((m == February && d >= 27 && d <= 29)
+				// Kurban
+				|| (m == May && d >= 4 && d <= 7))
+				return false;
+		}
+		else if (y == 2029) {
+			// Ramadan
+			if ((m == February && d >= 15 && d <= 17)
+				// Kurban
+				|| (m == April && d >= 23 && d <= 26))
+				return false;
+		}
+		else if (y == 2030) {
+			// Ramadan
+			if ((m == February && d >= 5 && d <= 7)
+				// Kurban
+				|| (m == April && d >= 13 && d <= 16))
+				return false;
+		}
+		else if (y == 2031) {
+			// Ramadan
+			if ((m == January && d >= 25 && d <= 27)
+				// Kurban
+				|| (m == April && d >= 2 && d <= 5))
+				return false;
+		}
+		else if (y == 2032) {
+			// Ramadan
+			if ((m == January && d >= 14 && d <= 16)
+				// Kurban
+				|| (m == March && d >= 21 && d <= 24))
+				return false;
+		}
+		else if (y == 2033) {
+			// Ramadan
+			if ((m == January && d >= 3 && d <= 5) || (m == December && d == 23)
+				// Kurban
+				|| (m == March && d >= 11 && d <= 14))
+				return false;
+		}
+		else if (y == 2034) {
+			// Ramadan
+			if ((m == December && d >= 12 && d <= 14) 
+				// Kurban
+				|| (m == February && d == 28) || (m == March && d >= 1 && d <= 3))
+				return false;
+		}
         return true;
     }
 

--- a/ql/time/calendars/turkey.hpp
+++ b/ql/time/calendars/turkey.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2005 Sercan Atalik
  Copyright (C) 2010 StatPro Italia srl
+ Copyright (C) 2018 Matthias Lungwitz
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -32,7 +33,9 @@ namespace QuantLib {
     //! Turkish calendar
     /*! Holidays for the Istanbul Stock Exchange:
         (data from
-         <http://borsaistanbul.com/en/products-and-markets/official-holidays>):
+         <http://borsaistanbul.com/en/products-and-markets/official-holidays>
+		 and
+		 <https://feiertagskalender.ch/index.php?geo=3539&hl=en>):
         <ul>
         <li>Saturdays</li>
         <li>Sundays</li>
@@ -42,7 +45,7 @@ namespace QuantLib {
         <li>Youth and Sports Day, May 19th</li>
         <li>Victory Day, August 30th</li>
         <li>Republic Day, October 29th</li>
-        <li>Local Holidays (Kurban, Ramadan; 2004 to 2014 only) </li>
+        <li>Local Holidays (Kurban, Ramadan - dates need further validation for >= 2019) </li>
         </ul>
 
         \ingroup calendars


### PR DESCRIPTION
Holidays >= 2019 are not yet officially anounced by borsaistanbul.com and probably need further validation - however not including them at all is worse in my opinion.