### PR TITLE
create copy of calibration instrument in Andreasen-Huge Volatility interpolation

### DIFF
--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -272,7 +272,8 @@ namespace QuantLib {
             calibrationSet_.push_back(
                 std::make_pair(
                     boost::make_shared<VanillaOption>(payoff, exercise),
-                    calibrationSet[i].second));
+                    calibrationSet[i].second)
+            );
 
             registerWith(calibrationSet[i].second);
         }

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -232,8 +232,7 @@ namespace QuantLib {
         Real _maxStrike,
         const boost::shared_ptr<OptimizationMethod>& optimizationMethod,
         const EndCriteria& endCriteria)
-    : calibrationSet_(calibrationSet),
-      spot_(spot),
+    : spot_(spot),
       rTS_(rTS),
       qTS_(qTS),
       interpolationType_(interplationType),
@@ -243,13 +242,13 @@ namespace QuantLib {
       maxStrike_(_maxStrike),
       optimizationMethod_(optimizationMethod),
       endCriteria_(endCriteria) {
-
         QL_REQUIRE(nGridPoints > 2 && calibrationSet.size() > 0,
                 "undefined grid or calibration set");
 
         std::set<Real> strikes;
         std::set<Date> expiries;
 
+        calibrationSet_.reserve(calibrationSet.size());
         for (Size i=0; i < calibrationSet.size(); ++i) {
 
             const boost::shared_ptr<Exercise> exercise =
@@ -269,6 +268,11 @@ namespace QuantLib {
 
             const Real strike = payoff->strike();
             strikes.insert(strike);
+
+            calibrationSet_.push_back(
+                std::make_pair(
+                    boost::make_shared<VanillaOption>(payoff, exercise),
+                    calibrationSet[i].second));
 
             registerWith(calibrationSet[i].second);
         }
@@ -623,7 +627,7 @@ namespace QuantLib {
         calculate();
 
         const boost::shared_ptr<Array> localVol(
-            boost::make_shared<Array>(gridPoints_));
+            boost::make_shared<Array>(gridPoints_.size()));
 
         switch (calibrationType_) {
           case CallPut: {

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
@@ -124,7 +124,7 @@ namespace QuantLib {
         Disposable<Array>
             getLocalVolSlice(Time t, Option::Type optionType) const;
 
-        const CalibrationSet calibrationSet_;
+        CalibrationSet calibrationSet_;
         const Handle<Quote> spot_;
         const Handle<YieldTermStructure> rTS_;
         const Handle<YieldTermStructure> qTS_;
@@ -137,7 +137,6 @@ namespace QuantLib {
         const boost::shared_ptr<OptimizationMethod> optimizationMethod_;
         const EndCriteria endCriteria_;
 
-
         std::vector<Real> strikes_;
         std::vector<Date> expiries_;
         mutable std::vector<Time> expiryTimes_, dT_;
@@ -149,7 +148,6 @@ namespace QuantLib {
         mutable Array gridPoints_, gridInFwd_;
 
         mutable std::vector<SingleStepCalibrationResult> calibrationResults_;
-
 
         mutable TimeValueCacheType localVolCache_, priceCache_;
     };


### PR DESCRIPTION
to avoid a circular reference in case the calibration instrument is priced based on the same Andreasen-Huge volatility surface later on.