### PR TITLE
add missing registration

### DIFF
--- a/ql/instruments/nonstandardswaption.cpp
+++ b/ql/instruments/nonstandardswaption.cpp
@@ -40,6 +40,7 @@ namespace QuantLib {
           settlementType_(delivery) {
 
         registerWith(swap_);
+        registerWithObservables(swap_);
     }
 
     bool NonstandardSwaption::isExpired() const {


### PR DESCRIPTION
Swaption and FloatFloatSwaption were fixed in 1.6, but NonstandardSwaption was forgotten