### PR TITLE
Add good friday holiday to hungarian calendar.

### DIFF
--- a/ql/time/calendars/hungary.cpp
+++ b/ql/time/calendars/hungary.cpp
@@ -34,8 +34,8 @@ namespace QuantLib {
         Year y = date.year();
         Day em = easterMonday(y);
         if (isWeekend(w)
-			// Good Friday (since 2017)
-			|| (dd == em - 3 && y >= 2017)
+            // Good Friday (since 2017)
+            || (dd == em - 3 && y >= 2017)
             // Easter Monday
             || (dd == em)
             // Whit Monday

--- a/ql/time/calendars/hungary.cpp
+++ b/ql/time/calendars/hungary.cpp
@@ -34,6 +34,8 @@ namespace QuantLib {
         Year y = date.year();
         Day em = easterMonday(y);
         if (isWeekend(w)
+			// Good Friday (since 2017)
+			|| (dd == em - 3 && y >= 2017)
             // Easter Monday
             || (dd == em)
             // Whit Monday

--- a/ql/time/calendars/hungary.hpp
+++ b/ql/time/calendars/hungary.hpp
@@ -33,6 +33,7 @@ namespace QuantLib {
         <ul>
         <li>Saturdays</li>
         <li>Sundays</li>
+        <li>Good Friday (since 2017)</li>
         <li>Easter Monday</li>
         <li>Whit(Pentecost) Monday </li>
         <li>New Year's Day, January 1st</li>


### PR DESCRIPTION
Since 2017, good friday is a bank holiday in hungary:

http://abouthungary.hu/news-in-brief/hungary-to-observe-good-friday-as-a-public-holiday/
http://hungarytoday.hu/news/official-good-friday-voted-become-hungarys-eleventh-public-holiday-89938
