### PR TITLE
GeneralizedHullWhite

### DIFF
--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -19,18 +19,18 @@
 */
 
 #include <ql/experimental/shortrate/generalizedhullwhite.hpp>
-#include <ql/termstructures/interpolatedcurve.hpp>
-#include <ql/math/interpolations/linearinterpolation.hpp>
+//#include <ql/termstructures/interpolatedcurve.hpp>
+//#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
 #include <ql/methods/lattices/trinomialtree.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/blackformula.hpp>
-#include <ql/math/interpolations/backwardflatinterpolation.hpp>
-#include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/math/integrals/simpsonintegral.hpp>
 
 namespace QuantLib {
 
-    namespace {
-
+  namespace {
+      /*
         class PiecewiseLinearCurve : public InterpolatedCurve<Linear> {
           public:
             PiecewiseLinearCurve(const std::vector<Time>& times,
@@ -72,9 +72,16 @@ namespace QuantLib {
                         constraint)
             {}
         };
+        */
 
-        Real identity(Real x) {
-            return x;
+
+        // integral of mean reversion
+        Real integrateMeanReversion(const Interpolation &a,Real t,Real T){
+          if ((T-t) < QL_EPSILON)
+            return 0.0;
+          SimpsonIntegral integrator(1e-5, 1000);
+          Real mr = integrator(a,t,T);
+          return mr;
         }
 
     }
@@ -105,7 +112,6 @@ namespace QuantLib {
                 value -= statePrices_[j]*discount;
                 x += dx_;
             }
-
             return value;
         };
 
@@ -117,53 +123,6 @@ namespace QuantLib {
         Real discountBondPrice_;
         boost::function<Real(Real)> fInverse_;
     };
-
-
-    GeneralizedHullWhite::GeneralizedHullWhite(
-        const Handle<YieldTermStructure>& yieldtermStructure,
-        const std::vector<Date>& speedstructure,
-        const std::vector<Date>& volstructure,
-        const boost::function<Real(Real)>& f,
-        const boost::function<Real(Real)>& fInverse)
-    : OneFactorAffineModel(2), TermStructureConsistentModel(yieldtermStructure),
-      speedstructure_(speedstructure), volstructure_(volstructure),
-      a_(arguments_[0]), sigma_(arguments_[1]),
-      f_(f), fInverse_(fInverse) {
-
-        if (f_.empty())
-            f_ = identity;
-        if (fInverse_.empty())
-            fInverse_ = identity;
-
-        DayCounter dc = yieldtermStructure->dayCounter();
-
-        speedperiods_.push_back(0.0);
-        for (Size i=0;i<speedstructure.size()-1;i++)
-            speedperiods_.push_back(dc.yearFraction(speedstructure[0],
-                                                    speedstructure[i+1]));
-
-        a_ = PiecewiseConstantParameter2(speedperiods_, PositiveConstraint());
-
-        volperiods_.push_back(0.0);
-        for (Size i=0;i<volstructure.size()-1;i++)
-            volperiods_.push_back(dc.yearFraction(volstructure[0],
-                                                  volstructure[i+1]));
-
-        sigma_ = PiecewiseConstantParameter2(volperiods_, PositiveConstraint());
-
-        a_.setParam(0,0.001);
-        sigma_.setParam(0,0.001);
-
-        for (Size i=1; i< a_.size();i++){
-            a_.setParam(i,0.01*i+0.07);
-        }
-
-        for (Size i=1; i< sigma_.size();i++){
-            sigma_.setParam(i,0.01*i+0.01);
-        }
-
-        registerWith(yieldtermStructure);
-    }
 
     GeneralizedHullWhite::GeneralizedHullWhite(
         const Handle<YieldTermStructure>& yieldtermStructure,
@@ -179,51 +138,9 @@ namespace QuantLib {
       a_(arguments_[0]), sigma_(arguments_[1]),
       f_(f), fInverse_(fInverse) {
 
-        Linear linearTraits;
-        BackwardFlat pwcTraits;
-
-        if (speed.size()==1 && vol.size()==1){
-          initialize(yieldtermStructure,speedstructure,volstructure,
-            speed,vol, pwcTraits, pwcTraits, f, fInverse);
-        }
-        else if (speed.size()==1 && vol.size()>1){
-          initialize(yieldtermStructure,speedstructure,volstructure,
-            speed,vol, pwcTraits, linearTraits, f, fInverse);
-        }
-        else if (speed.size()==1 && vol.size()>1){
-          initialize(yieldtermStructure,speedstructure,volstructure,
-            speed,vol, pwcTraits, linearTraits, f, fInverse);
-        }
-        /*
-        if (f_.empty())
-            f_ = identity;
-        if (fInverse_.empty())
-            fInverse_ = identity;
-
-        DayCounter dc = yieldtermStructure->dayCounter();
-        Date ref = yieldtermStructure->referenceDate();
-
-        for (Size i=0;i<speedstructure.size();i++)
-            speedperiods_.push_back(dc.yearFraction(ref,
-                                                    speedstructure[i]));
-
-        a_ = PiecewiseConstantParameter2(speedperiods_, PositiveConstraint());
-
-        for (Size i=0;i<volstructure.size();i++)
-            volperiods_.push_back(dc.yearFraction(ref,
-                                                  volstructure[i]));
-
-        sigma_ = PiecewiseConstantParameter2(volperiods_, PositiveConstraint());
-
-        for (Size i=0; i< sigma_.size();i++) {
-            sigma_.setParam(i,vol[i]);
-        }
-        for (Size i=0; i< a_.size();i++) {
-            a_.setParam(i,speed[i]);
-        }
-
-        registerWith(yieldtermStructure);
-        */
+        LinearFlat traits;
+        initialize(yieldtermStructure,speedstructure,volstructure,
+          speed, vol, traits, traits, f, fInverse);
     }
 
     //classical HW
@@ -235,66 +152,108 @@ namespace QuantLib {
       a_(arguments_[0]),
       sigma_(arguments_[1]) {
 
-        a_ = ConstantParameter(a, PositiveConstraint());
-        sigma_ = ConstantParameter(sigma, PositiveConstraint());
-        a_.setParam(0,a);
-        sigma_.setParam(0,sigma);
-
-        f_ = identity;
-        fInverse_ = identity;
-
         Date ref = yieldtermStructure->referenceDate();
-
-        speedperiods_.push_back(0.0);
-        volperiods_.push_back(0.0);
-        speedstructure_.push_back(ref);
-        volstructure_.push_back(ref);
-
-        generateArguments();
-
-        registerWith(yieldtermStructure);
-    }
-
-    Real GeneralizedHullWhite::B(Time t, Time T) const {
-        Real _a = a();
-        if (_a < std::sqrt(QL_EPSILON))
-            return (T - t);
-        else
-            return (1.0 - std::exp(-_a*(T - t)))/_a;
+        std::vector<Date> speedstructure,volstructure;
+        std::vector<Real> _a, _sigma;
+        _a.push_back(a);
+        _sigma.push_back(sigma);
+        speedstructure.push_back(ref);
+        volstructure.push_back(ref);
+        BackwardFlat traits;
+        initialize(yieldtermStructure,speedstructure,volstructure,
+          _a, _sigma, traits, traits, identity, identity);
     }
 
     void GeneralizedHullWhite::generateArguments() {
-        InterpolationParameter::update(a_);
-        InterpolationParameter::update(sigma_);
+        speed_.update();
+        vol_.update();
         phi_ = FittingParameter(termStructure(), a(), sigma());
+    }
+
+    Real GeneralizedHullWhite::B(Time t, Time T) const {
+      // Gurrieri et al, equations (30) and (31)
+      Real lnEt = integrateMeanReversion(speed_,0,t);
+      Real Et = exp(lnEt);
+      Real B = 0;
+      Size N = std::min<Size>((T-t)*365, 2000);
+      if (N==0) N=1;
+      Real dt = 0.5*(T-t)/N;
+      Real a,b,c,_t,total=0;
+      _t = t;
+      c = speed_(_t);
+      _t += dt;
+      for (Size i=0; i<N; i++){
+        a = c;
+        b = speed_(_t);
+        c = speed_(_t+dt);
+        total += (dt*(2.0/6.0))*(a+4*b+c);
+        B += (2*dt) / exp(lnEt+total);
+        _t += 2*dt;
+      }
+      B *= Et;
+      return B;
+    }
+
+    Real GeneralizedHullWhite::V(Time t, Time T) const{
+      // Gurrieri et al, equation (37)
+      Real lnEt = integrateMeanReversion(speed_,0,t);
+      Real V = 0,Eu;
+      Size N = std::min<Size>((T-t)*365, 2000);
+      if (N==0) N=1;
+      Real dt = 0.5*(T-t)/N;
+      Real a,b,c,_t,lnE=lnEt;
+      _t = t;
+      Real vol = vol_(_t);
+      Eu = exp(lnE);
+      c = Eu*Eu*vol*vol;
+      _t += dt;
+      for (Size i=0; i<N; i++){
+        a = c;
+        vol = vol_(_t);
+        lnE += speed_(_t)*dt;
+        Eu = exp(lnE);
+        b = Eu*Eu*vol*vol;
+        vol = vol_(_t+dt);
+        lnE += speed_(_t+dt)*dt;
+        Eu = exp(lnE);
+        c = Eu*Eu*vol*vol;
+        V += (dt*(2.0/6.0))*(a+4*b+c);
+        _t += 2*dt;
+      }
+      return V / (Eu*Eu);
     }
 
     Real GeneralizedHullWhite::discountBondOption(Option::Type type, Real strike,
                                                   Time maturity,
-                                                  Time bondMaturity) const {
-
-        Real _a = a();
-        Real v;
-        if (_a < std::sqrt(QL_EPSILON)) {
-            v = sigma()*B(maturity, bondMaturity)* std::sqrt(maturity);
-        } else {
-            v = sigma()*B(maturity, bondMaturity)*
-                std::sqrt(0.5*(1.0 - std::exp(-2.0*_a*maturity))/_a);
-        }
-        Real f = termStructure()->discount(bondMaturity);
-        Real k = termStructure()->discount(maturity)*strike;
-
-        return blackFormula(type, k, f, v);
+                                                  Time bondMaturity) const
+    {
+      /*
+      Hull-White bond option pricing with time varying sigma and mean reversion.
+      Based on Gurrieri, Nakabayashi & Wong (2009) "Calibration Methods of
+      Hull-White Model", https://ssrn.com/abstract=1514192
+      */
+      DiscountFactor discount1 = termStructure()->discount(maturity);
+      DiscountFactor discount2 = termStructure()->discount(bondMaturity);
+      Rate forward = termStructure()->forwardRate(maturity, maturity,
+        Continuous, NoFrequency);
+      Real BtT = B(maturity,bondMaturity);
+      Real Vr = V(0,maturity);
+      Real Vp = Vr*BtT*BtT;
+      Real vol = sqrt(Vp);
+      Real f = termStructure()->discount(bondMaturity);
+      Real k = termStructure()->discount(maturity)*strike;
+      return blackFormula(type, k, f, vol);
     }
 
     Real GeneralizedHullWhite::A(Time t, Time T) const {
+        // Gurrieri et al, equation (43)
         DiscountFactor discount1 = termStructure()->discount(t);
         DiscountFactor discount2 = termStructure()->discount(T);
-        Rate forward = termStructure()->forwardRate(t, t,
-                                                    Continuous, NoFrequency);
-        Real temp = sigma()*B(t,T);
-        Real value = B(t,T)*forward - 0.25*temp*temp*B(0.0,2.0*t);
-        return std::exp(value)*discount2/discount1;
+        Rate forward = termStructure()->forwardRate(t, t, Continuous, NoFrequency);
+        Real BtT = B(t,T);
+        Real Vr = V(0,t);
+        Real AtT = log(discount2/discount1) + BtT*forward - 0.5*BtT*BtT*Vr;
+        return exp(AtT);
     }
 
 
@@ -332,51 +291,11 @@ namespace QuantLib {
     }
 
     boost::function<Real (Time)> GeneralizedHullWhite::speed() const {
-        return a_;
-
-        std::vector<Real> speedvals;
-        speedvals.push_back(a_(0.001));
-
-        if (a_.size()==1) {
-            std::vector<Time> speedper;
-            speedper.push_back(0.0);
-            speedper.push_back(200); // 200 years to match the
-                                     // constant a and sigma case
-            speedvals.push_back(a_(0.001));
-            return PiecewiseLinearCurve(speedper, speedvals);
-        }
-
-        for (Size i=0;i<a_.size()-1;i++)
-            speedvals.push_back(
-            a_(
-            (speedstructure_[i+1]- Settings::instance().evaluationDate() )/365.0
-            - 0.001));
-
-        return PiecewiseLinearCurve(speedperiods_, speedvals);
+        return speed_;
     }
 
     boost::function<Real (Time)> GeneralizedHullWhite::vol() const {
-        return sigma_;
-
-        std::vector<Real> volvals;
-        volvals.push_back(sigma_(0.001));
-
-        if (sigma_.size()==1) {
-            std::vector<Time> volper;
-            volper.push_back(0.0);
-            volper.push_back(200); //200 years to approximate the
-                                   //constant coefficient model
-            volvals.push_back(sigma_(0.001));
-            return PiecewiseLinearCurve(volper, volvals);
-        }
-
-        for (Size i=0;i<sigma_.size()-1;i++)
-            volvals.push_back(
-            sigma_(
-            (speedstructure_[i+1]-Settings::instance().evaluationDate() )/365.0
-            - 0.001));
-
-        return PiecewiseLinearCurve(volperiods_, volvals);
+        return vol_;
     }
 
 }

--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -232,10 +232,6 @@ namespace QuantLib {
       Based on Gurrieri, Nakabayashi & Wong (2009) "Calibration Methods of
       Hull-White Model", https://ssrn.com/abstract=1514192
       */
-      DiscountFactor discount1 = termStructure()->discount(maturity);
-      DiscountFactor discount2 = termStructure()->discount(bondMaturity);
-      Rate forward = termStructure()->forwardRate(maturity, maturity,
-        Continuous, NoFrequency);
       Real BtT = B(maturity,bondMaturity);
       Real Vr = V(0,maturity);
       Real Vp = Vr*BtT*BtT;

--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -24,6 +24,8 @@
 #include <ql/methods/lattices/trinomialtree.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/blackformula.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
+#include <ql/math/interpolations/linearinterpolation.hpp>
 
 namespace QuantLib {
 
@@ -177,6 +179,22 @@ namespace QuantLib {
       a_(arguments_[0]), sigma_(arguments_[1]),
       f_(f), fInverse_(fInverse) {
 
+        Linear linearTraits;
+        BackwardFlat pwcTraits;
+
+        if (speed.size()==1 && vol.size()==1){
+          initialize(yieldtermStructure,speedstructure,volstructure,
+            speed,vol, pwcTraits, pwcTraits, f, fInverse);
+        }
+        else if (speed.size()==1 && vol.size()>1){
+          initialize(yieldtermStructure,speedstructure,volstructure,
+            speed,vol, pwcTraits, linearTraits, f, fInverse);
+        }
+        else if (speed.size()==1 && vol.size()>1){
+          initialize(yieldtermStructure,speedstructure,volstructure,
+            speed,vol, pwcTraits, linearTraits, f, fInverse);
+        }
+        /*
         if (f_.empty())
             f_ = identity;
         if (fInverse_.empty())
@@ -205,6 +223,7 @@ namespace QuantLib {
         }
 
         registerWith(yieldtermStructure);
+        */
     }
 
     //classical HW
@@ -245,6 +264,8 @@ namespace QuantLib {
     }
 
     void GeneralizedHullWhite::generateArguments() {
+        InterpolationParameter::update(a_);
+        InterpolationParameter::update(sigma_);
         phi_ = FittingParameter(termStructure(), a(), sigma());
     }
 
@@ -311,6 +332,7 @@ namespace QuantLib {
     }
 
     boost::function<Real (Time)> GeneralizedHullWhite::speed() const {
+        return a_;
 
         std::vector<Real> speedvals;
         speedvals.push_back(a_(0.001));
@@ -334,6 +356,7 @@ namespace QuantLib {
     }
 
     boost::function<Real (Time)> GeneralizedHullWhite::vol() const {
+        return sigma_;
 
         std::vector<Real> volvals;
         volvals.push_back(sigma_(0.001));

--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -298,4 +298,13 @@ namespace QuantLib {
         return vol_;
     }
 
+    //! vector to pass to 'calibrate' to fit only volatility
+    std::vector<bool> GeneralizedHullWhite::fixedReversion() const{
+      Size na = a_.params().size();
+      Size nsigma = sigma_.params().size();
+      std::vector<bool> fixr(na+nsigma,false);
+      std::fill(fixr.begin(),fixr.begin()+na,true);
+      return fixr;
+    }
+
 }

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -55,8 +55,7 @@ namespace QuantLib {
         constraint)
     { }
     void reset(const Interpolation &interp){
-      boost::dynamic_pointer_cast<InterpolationParameter::Impl>(
-        impl_)->reset(interp);
+      boost::dynamic_pointer_cast<InterpolationParameter::Impl>(impl_)->reset(interp);
     }
   };
 
@@ -128,6 +127,9 @@ namespace QuantLib {
                                 Time maturity,
                                 Time bondMaturity) const;
 
+        //! vector to pass to 'calibrate' to fit only volatility
+        std::vector<bool> fixedReversion() const;
+
       protected:
         //Analytical calibration of HW
         Real a() const { return a_(0.0); }
@@ -191,6 +193,8 @@ namespace QuantLib {
           for (Size i=0;i<volstructure.size();i++)
             volperiods_.push_back(dc.yearFraction(ref,volstructure[i]));
 
+          // interpolator x points to *periods_ vector, y points to
+          // the internal Array in the parameter
           InterpolationParameter atemp(speedperiods_.size(), NoConstraint());
           a_ = atemp;
           for (Size i=0; i<speedperiods_.size(); i++)
@@ -254,7 +258,7 @@ namespace QuantLib {
             _fInverse_=identity();
         }
 
-        Real variable(Time t, Rate r=0.01) const {
+        Real variable(Time t, Rate r) const {
             return _f_(r) - fitting_(t);
         }
 
@@ -310,7 +314,7 @@ namespace QuantLib {
     inline boost::shared_ptr<OneFactorModel::ShortRateDynamics>
     GeneralizedHullWhite::HWdynamics() const {
         return boost::shared_ptr<ShortRateDynamics>(
-                                            new Dynamics(phi_, a(), sigma()));
+          new Dynamics(phi_, a(), sigma()));
     }
 
     // todo: move to interpolations


### PR DESCRIPTION
Some work on the GHW class. This will change the behaviour of existing programs that use the class. The main constructor will now use linear interpolation with flat extrapolation which is how most of the commercial code I've seen works. The previous default involved some hand coded approximations.

The class now supports the Jamshidian pricing engine (under Hull-White only!) and agrees well with tree prices when the number of time steps is set very large. Calibration of model parameters in a typical fashion is supported. Some significant work will need to be done to get finite difference support.

The code could use a little cleaning up. I've commented out dead code which should be removed and added a few utility classes that would be better placed elsewhere.

Sample program that uses almost all features below.

```C++
/*
Simplified volatility calibration.
This program is slowwwww. Run a release build and enable OpenMP.

Roy Zywina, 2018, QuantLib license
*/
#include <boost/bind.hpp>
#include <iostream>
#include <vector>
#include <iomanip>
using namespace std;

#include <ql/indexes/ibor/usdlibor.hpp>
#include <ql/math/interpolations/all.hpp>
#include <ql/termstructures/yield/all.hpp>
#include <ql/models/shortrate/all.hpp>
#include <ql/pricingengines/swaption/treeswaptionengine.hpp>
#include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
#include <ql/experimental/shortrate/generalizedhullwhite.hpp>
using namespace QuantLib;

Real blackKarasinskiConv(Real r,Real shift){
  return log(r+shift);
}
Real blackKarasinskiConvInv(Real x,Real shift){
  return exp(x)-shift;
}
// HW is same in both directions
Real hullWhiteConv(Real x){
  return x;
}

class GenHullWhiteCalibTest{
public:
  bool useBK, useJamshidian;
  bool linearVols;
  Real bkShift;
  Date valuation;
  vector<Date> curveDates;
  vector<Real> curveVals;
  vector<Date> mrDates;
  vector<Real> mrVals;
  vector<Date> volDates;
  vector<Real> volVals;
  Handle<YieldTermStructure> zeroCurve;
  vector<boost::shared_ptr<CalibrationHelper> > helpers;
  boost::shared_ptr<IborIndex> liborIdx;
  int nTreeSteps;

  GenHullWhiteCalibTest(){
    // true for Black-Karasinski, false for Hull-White
    useBK = false;
    // lognormal shift in BK mode
    bkShift = 0.01;
    // true for linear interpolation, false for piecewise constant
    linearVols = true;
    // under Hull-White we can use trees or the faster Jamshidian model
    useJamshidian = true;
    nTreeSteps = 300;
    valuation = Date(1,January,2018);
    Settings::instance().evaluationDate() = valuation;
    curveDates.push_back(valuation+Period(1,Years));
    curveDates.push_back(valuation+Period(5,Years));
    curveDates.push_back(valuation+Period(10,Years));
    curveDates.push_back(valuation+Period(30,Years));
    curveVals.push_back(0.02);
    curveVals.push_back(0.03);
    curveVals.push_back(0.035);
    curveVals.push_back(0.04);
    mrDates.push_back(valuation);
    //mrDates.push_back(valuation+Period(2,Years));
    //mrDates.push_back(valuation+Period(4,Years));
    mrVals.push_back(0.02);
    //mrVals.push_back(0.03);
    //mrVals.push_back(-0.01);
    volDates.push_back(valuation+Period(1,Years));
    volDates.push_back(valuation+Period(2,Years));
    volDates.push_back(valuation+Period(4,Years));
    volDates.push_back(valuation+Period(6,Years));
    volDates.push_back(valuation+Period(10,Years));
    volVals.resize(volDates.size(), 0.2);
    Actual365Fixed dc;
    zeroCurve = Handle<YieldTermStructure>(
      boost::shared_ptr<YieldTermStructure>(
        new InterpolatedZeroCurve<Linear>(curveDates,curveVals,dc)));

    // portfolio of swaptions to fit volatility to
    const int N = 5;
    const int swaptionTerms[N] = {1,2,4,6,10};
    const Real swaptionVols[N] = {0.28, 0.26, 0.24, 0.22, 0.20};
    const Real swaptionStrike[N] = {0.02, 0.025, 0.025, 0.03, 0.04};

    Frequency swapFreq = Semiannual;
    Period swapTenor(swapFreq);
    liborIdx.reset(new USDLibor(swapTenor));
    liborIdx = liborIdx->clone(zeroCurve);
    BusinessDayConvention bdc = ModifiedFollowing;

    for (int i=0; i<N; i++){
      volVals[i] = swaptionVols[i];
      Handle<Quote> vol(boost::shared_ptr<Quote>(
        new SimpleQuote(swaptionVols[i])));
      boost::shared_ptr<CalibrationHelper> sh(
        new SwaptionHelper(
          Period(swaptionTerms[i],Years),
          Period(5,Years),
          vol,
          liborIdx,
          swapTenor,
          dc,dc,
          zeroCurve,
          CalibrationHelper::RelativePriceError,
          swaptionStrike[i]));
      helpers.push_back(sh);
    }
  }

  void run(){
    boost::function<Real(Real)> conv = hullWhiteConv;
    boost::function<Real(Real)> convInv = hullWhiteConv;

    vector<Real> volStart = volVals;

    if (useBK){
      conv = boost::bind(blackKarasinskiConv, _1, bkShift);
      convInv = boost::bind(blackKarasinskiConvInv, _1, bkShift);
      // in BK the Blacks vols are a good starting guess.
      // when shifted we should scale them a bit
      if (bkShift>0){
        for (Size i=0; i<volStart.size(); i++)
          volStart[i] *= (0.02/(0.02+bkShift));
      }
    }else{
      // use flat 1% vol for HW
      for (Size i=0; i<volStart.size(); i++)
        volStart[i] = 0.01;
    }

    BackwardFlat flatTraits;
    LinearFlat linearTraits;
    boost::shared_ptr<GeneralizedHullWhite> model;
    if (linearVols){
      // linear interpolated vols
      model.reset(new GeneralizedHullWhite(
        zeroCurve,
        mrDates, volDates,
        mrVals, volStart,
        flatTraits, linearTraits,
        conv, convInv));
    }else{
      // piecewise constant vols
      model.reset(new GeneralizedHullWhite(
        zeroCurve,
        mrDates, volDates,
        mrVals, volStart,
        flatTraits, flatTraits,
        conv, convInv));
    }

    boost::shared_ptr<PricingEngine> engine, engine2;
    string smodel="Tree", smodel2="Jamshidian";
    engine.reset(new TreeSwaptionEngine(model, nTreeSteps));
    if (!useBK){
      // Hull-White only
      engine2.reset(new JamshidianSwaptionEngine(model));
      if (useJamshidian){
        engine.swap(engine2);
        smodel.swap(smodel2);
      }
    }
    for (Size i=0; i<helpers.size(); i++){
      helpers[i]->setPricingEngine(engine);
    }

    EndCriteria criteria(1000,20,1e-4,1e-4,0);
    // Simplex is slow but it's the only no-derivative algorithm in QL
    Simplex solver( volStart[0]/10 );
    // I don't want to fit mean reversion
    vector<bool> fixParameters = model->fixedReversion();

    cout << "Calibrating Volatility Curve. Plase wait." << endl;

    model->calibrate(helpers, solver, criteria,
      NoConstraint(), vector<Real>(), fixParameters);

    cout << "Optimization Returns: " << model->endCriteria() << endl;
    cout << "Portfolio Valuations: " << model->functionEvaluation() << endl;
    cout << "Pricing Error: " << model->problemValues() << endl;
    cout << "Fitted Parameters: " << model->params() << endl;

    cout << endl << "Swaption Portfolio" << endl;
    cout << setw(3) << "N" << setw(20) << "Black Price" <<
      setw(20) << smodel+" Price" << setw(20) << "Error";
    if (engine2)
      cout << setw(20) << smodel2+" Price";
    cout << endl;
    for (Size i=0; i<helpers.size(); i++){
      Real bp = helpers[i]->blackPrice(volVals[i]);
      Real tp = helpers[i]->modelValue();
      cout << setw(3) << i+1 <<
        setw(20) << setprecision(9) << bp*100 <<
        setw(20) << setprecision(9) << tp*100 <<
        setw(20) << setprecision(9) << (tp-bp)*100;
      if (engine2){
        helpers[i]->setPricingEngine(engine2);
        Real p2 = helpers[i]->modelValue();
        cout << setw(20) << setprecision(9) << p2*100;
      }
      cout << endl;
    }
  }
};

int main(){
  try{
    GenHullWhiteCalibTest test;
    test.run();
  }catch(exception &ex){
    cout << "Error: " << ex.what() << endl;
  }
  return 0;
}
```