### PR TITLE
boost 1.67 (beta 1) does not allow to register the same test case name multiple times

### DIFF
--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1470,7 +1470,7 @@ test_suite* AsianOptionTest::suite() {
 }
 
 test_suite* AsianOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Asian option tests");
+    test_suite* suite = BOOST_TEST_SUITE("Asian option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testLevyEngine));
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testVecerEngine));
     return suite;

--- a/test-suite/barrieroption.cpp
+++ b/test-suite/barrieroption.cpp
@@ -1196,7 +1196,7 @@ test_suite* BarrierOptionTest::suite() {
 }
 
 test_suite* BarrierOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Barrier option tests");
+    test_suite* suite = BOOST_TEST_SUITE("Barrier option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&BarrierOptionTest::testPerturbative));
     suite->add(QUANTLIB_TEST_CASE(
                       &BarrierOptionTest::testVannaVolgaSimpleBarrierValues));

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -41,6 +41,7 @@
 #include <boost/make_shared.hpp>
 #include <boost/bind.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/preprocessor/iteration/local.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -1105,13 +1106,15 @@ test_suite* BasketOptionTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&BasketOptionTest::test2DPDEGreeks));
 
     if (speed <= Fast) {
-        const Size nTestCases = std::min(Size(5), LENGTH(oneDataValues));
-        for (Size i=0; i < nTestCases; ++i) {
-            suite->add(QUANTLIB_TEST_CASE(
-                boost::bind(&BasketOptionTest::testOneDAmericanValues,
-                    (i    *LENGTH(oneDataValues))/nTestCases,
-                    ((i+1)*LENGTH(oneDataValues))/nTestCases)));
-        }
+        #define N_TEST_CASES 5
+        #define BOOST_PP_LOCAL_MACRO(n)                                \
+            suite->add(QUANTLIB_TEST_CASE(                             \
+                boost::bind(&BasketOptionTest::testOneDAmericanValues, \
+                    (n    *LENGTH(oneDataValues))/N_TEST_CASES,        \
+                    ((n+1)*LENGTH(oneDataValues))/N_TEST_CASES)));
+
+        #define BOOST_PP_LOCAL_LIMITS (0, N_TEST_CASES-1)
+        #include BOOST_PP_LOCAL_ITERATE()
     }
 
     if (speed == Slow) {

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -37,6 +37,8 @@
 #include <ql/currencies/europe.hpp>
 
 #include <boost/bind.hpp>
+#include <boost/preprocessor/iteration/local.hpp>
+
 #include <iomanip>
 #include <iostream>
 
@@ -373,9 +375,11 @@ test_suite* CdoTest::suite(SpeedLevel speed) {
     test_suite* suite = BOOST_TEST_SUITE("CDO tests");
     #ifndef QL_PATCH_SOLARIS
     if (speed == Slow) {
-        for (unsigned i=0; i < LENGTH(hwData7); ++i)
-            suite->add(QUANTLIB_TEST_CASE(
-                boost::bind(&CdoTest::testHW, i)));
+        #define BOOST_PP_LOCAL_MACRO(n) \
+            suite->add(QUANTLIB_TEST_CASE(boost::bind(&CdoTest::testHW, n)));
+
+        #define BOOST_PP_LOCAL_LIMITS (0, 4)
+        #include BOOST_PP_LOCAL_ITERATE()
     }
     #endif
     return suite;

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1724,7 +1724,7 @@ test_suite* EuropeanOptionTest::suite() {
 }
 
 test_suite* EuropeanOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("European option tests");
+    test_suite* suite = BOOST_TEST_SUITE("European option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testFFTEngines));
     return suite;
 }

--- a/test-suite/extendedtrees.cpp
+++ b/test-suite/extendedtrees.cpp
@@ -362,7 +362,7 @@ void ExtendedTreesTest::testJOSHIBinomialEngines() {
 }
 
 test_suite* ExtendedTreesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("European option tests");
+    test_suite* suite = BOOST_TEST_SUITE("European option extended trees tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ExtendedTreesTest::testJRBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&ExtendedTreesTest::testCRRBinomialEngines));

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -2723,7 +2723,7 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
 }
 
 test_suite* HestonModelTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Heston model tests");
+    test_suite* suite = BOOST_TEST_SUITE("Heston model experimental tests");
     suite->add(QUANTLIB_TEST_CASE(
         &HestonModelTest::testAnalyticPDFHestonEngine));
     return suite;

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -109,6 +109,7 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/models/marketmodels/products/multistep/multisteppathwisewrapper.hpp>
 
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/preprocessor/iteration/local.hpp>
 #include <boost/bind.hpp>
 #include <sstream>
 
@@ -4891,19 +4892,22 @@ test_suite* MarketModelTest::suite(SpeedLevel speed) {
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testPathwiseVegas));
 
+        setup();
+
         MarketModelType marketModels[] = {
             ExponentialCorrelationFlatVolatility,
-            ExponentialCorrelationAbcdVolatility };
+            ExponentialCorrelationAbcdVolatility
+        };
 
-        setup();
-        for (Size j=0; j<LENGTH(marketModels); j++) {
-            Size testedFactors[] = { 4, 8, todaysForwards.size()};
-            for (Size m=0; m<LENGTH(testedFactors); ++m) {
-                suite->add(QUANTLIB_TEST_CASE(
-                    boost::bind(&MarketModelTest::testCallableSwapAnderson,
-                        marketModels[j],testedFactors[m])));
-            }
-        }
+        Size testedFactors[] = { 4, 8, todaysForwards.size() };
+        #define BOOST_PP_LOCAL_MACRO(n)                                 \
+            suite->add(QUANTLIB_TEST_CASE(                              \
+                boost::bind(&MarketModelTest::testCallableSwapAnderson, \
+                    marketModels[n/LENGTH(testedFactors)],              \
+                    testedFactors[n%LENGTH(testedFactors)])));
+
+        #define BOOST_PP_LOCAL_LIMITS (0, 5)
+        #include BOOST_PP_LOCAL_ITERATE()
     }
 
     if (speed == Slow) {

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -838,9 +838,8 @@ test_suite* OptionletStripperTest::suite() {
     #if defined(QL_NEGATIVE_RATES)
     suite->add(QUANTLIB_TEST_CASE(
         &OptionletStripperTest::testTermVolatilityStrippingNormalVol));
-    suite->add(
-        QUANTLIB_TEST_CASE(&OptionletStripperTest::
-                               testTermVolatilityStrippingShiftedLogNormalVol));
+    suite->add(QUANTLIB_TEST_CASE(
+        &OptionletStripperTest::testTermVolatilityStrippingShiftedLogNormalVol));
     #endif
 
     return suite;

--- a/test-suite/paralleltestrunner.hpp
+++ b/test-suite/paralleltestrunner.hpp
@@ -150,7 +150,7 @@ namespace {
     void output_logstream(
         std::ostream& out, std::streambuf* outBuf, std::stringstream& s) {
 
-        static named_mutex mutex(open_or_create, "namesLogMutexName");
+        static named_mutex mutex(open_or_create, namesLogMutexName);
         scoped_lock<named_mutex> lock(mutex);
 
         out.flush();
@@ -163,7 +163,7 @@ namespace {
         for (std::vector<std::string>::const_iterator iter = tok.begin();
             iter != tok.end(); ++iter) {
             if (iter->length() && iter->compare("Running 1 test case...")) {
-                out << *iter << std::endl;
+                out << *iter  << std::endl;
             }
         }
 
@@ -273,19 +273,6 @@ int main( int argc, char* argv[] )
                     ? tcc.map().find(tcc.testSuiteId())->second
                     : std::list<test_unit_id>();
 
-            std::stringstream logBuf;
-            std::streambuf* const oldBuf = log_stream().rdbuf();
-            log_stream().rdbuf(logBuf.rdbuf());
-
-            for (std::list<test_unit_id>::const_iterator iter = qlRoot.begin();
-                std::distance(qlRoot.begin(), iter) < int(qlRoot.size())-1;
-                ++iter) {
-
-                framework::impl::s_frk_state().execute_test_tree(*iter);
-            }
-            output_logstream(log_stream(), oldBuf, logBuf);
-            log_stream().rdbuf(oldBuf);
-
             // fork worker processes
             boost::thread_group threadGroup;
             for (unsigned i=0; i < nProc; ++i) {
@@ -364,17 +351,6 @@ int main( int argc, char* argv[] )
 
                 boost::unit_test::s_rc_impl().m_results_store[remoteResults.id]
                     = remoteResults.results;
-            }
-
-            if (!qlRoot.empty()) {
-                std::streambuf* const oldBuf = log_stream().rdbuf();
-                log_stream().rdbuf(logBuf.rdbuf());
-
-                const test_unit_id id = qlRoot.back();
-                framework::impl::s_frk_state().execute_test_tree(id);
-
-                output_logstream(log_stream(), oldBuf, logBuf);
-                log_stream().rdbuf(oldBuf);
             }
 
             TestCaseReportAggregator tca;

--- a/test-suite/zabr.cpp
+++ b/test-suite/zabr.cpp
@@ -89,7 +89,7 @@ void ZabrTest::testConsistency() {
 }
 
 test_suite *ZabrTest::suite(SpeedLevel speed) {
-    test_suite *suite = BOOST_TEST_SUITE("NoArbSabrModel tests");
+    test_suite *suite = BOOST_TEST_SUITE("Zabr model tests");
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&ZabrTest::testConsistency));


### PR DESCRIPTION
Change log Boost.Test v3.7 / boost 1.67:
Breaking changes: Adding test cases with the same name to the same test suite is reported as an error. This impacts template and parametrized test cases, as well as manually registered tests. Make sure you have no duplicate names. 