### PR TITLE
Use safer boost::function interface.

### DIFF
--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -93,7 +93,7 @@ namespace QuantLib {
             useCostFunctionsJacobian_
                 ? boost::bind(&LevenbergMarquardt::jacFcn, this, _1, _2, _3,
                               _4, _5)
-                : MINPACK::LmdifCostFunction(NULL);
+                : MINPACK::LmdifCostFunction();
         MINPACK::lmdif(m, n, xx.get(), fvec.get(),
                        endCriteria.functionEpsilon(),
                        xtol_,

--- a/ql/math/optimization/lmdif.cpp
+++ b/ql/math/optimization/lmdif.cpp
@@ -1364,7 +1364,7 @@ L30:
 *    calculate the jacobian matrix.
 */
 iflag = 2;
-if(jacFcn != 0) // use user supplied jacobian calculation
+if(!jacFcn.empty()) // use user supplied jacobian calculation
     jacFcn(m,n,x,fjac,&iflag);
 else
     fdjac2(m,n,x,fvec,fjac,ldfjac,&iflag,epsfcn,wa4, fcn);


### PR DESCRIPTION
Relying on null pointer will break if we ever use `nullptr`.