### PR TITLE
enable extrapolation on local adapters

### DIFF
--- a/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
@@ -95,6 +95,7 @@ namespace QuantLib {
         spreadsVolImplied_ = spreadsVolImplied();
 
         StrippedOptionletAdapter adapter(stripper1_);
+        adapter.enableExtrapolation();
 
         Volatility unadjustedVol, adjustedVol;
         for (Size j=0; j<nOptionExpiries_; ++j) {
@@ -165,6 +166,7 @@ namespace QuantLib {
     {
         boost::shared_ptr<OptionletVolatilityStructure> adapter(new
             StrippedOptionletAdapter(optionletStripper1));
+        adapter->enableExtrapolation();
 
         // set an implausible value, so that calculation is forced
         // at first operator()(Volatility x) call


### PR DESCRIPTION
if the atm strike lies outside the domain given by the OptionletStripper1's fixed strikes, an exception is thrown in OptionletStripper2; if this is not intentional (i.e. if we do not want to enforce atm to fall into this range for some reason), I'd propose to enable extrapolation on the local adapters