### PR TITLE
add initializers for arrays and matrices

### DIFF
--- a/ql/math/initializers.hpp
+++ b/ql/math/initializers.hpp
@@ -1,0 +1,91 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2018 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file initializers.hpp
+    \brief array and matrix initializers
+*/
+
+#ifndef quantlib_initializers_hpp
+#define quantlib_initializers_hpp
+
+#include <ql/math/array.hpp>
+#include <ql/math/matrix.hpp>
+
+namespace QuantLib {
+
+namespace initializers {
+
+class ArrayProxy {
+public:
+    ArrayProxy& operator,(const Real x) {
+        QL_REQUIRE(a_.size() > idx_,
+                   "ArrayProxy: too many initializers, array has size "
+                       << a_.size());
+        a_[idx_++] = x;
+        return *this;
+    }
+
+private:
+    ArrayProxy(Array& a, const Real x) : a_(a) {
+        QL_REQUIRE(a_.size() > 0, "ArrayProxy: array has size 0");
+        a_[0] = x;
+        idx_ = 1;
+    }
+    friend ArrayProxy operator<<(Array&, const Real);
+    Size idx_;
+    Array& a_;
+};
+
+class MatrixProxy {
+public:
+    MatrixProxy& operator,(const Real x) {
+        QL_REQUIRE(m_.rows() * m_.columns() > idx_,
+                   "MatrixProxy: too many initializers, matrix has size "
+                       << m_.rows() << "x" << m_.columns());
+        *(m_.begin() + idx_++) = x;
+        return *this;
+    }
+
+private:
+    MatrixProxy(Matrix& m, const Real x) : m_(m) {
+        QL_REQUIRE(m_.rows() * m_.columns() > 0,
+                   "MatrixProxy: matrix has size 0");
+        *m_.begin() = x;
+        idx_ = 1;
+    }
+    friend MatrixProxy operator<<(Matrix&, const Real);
+    Size idx_;
+    Matrix& m_;
+};
+
+inline ArrayProxy operator<<(Array& a, const Real x) {
+    return ArrayProxy(a, x);
+}
+
+inline MatrixProxy operator<<(Matrix& m, const Real x) {
+    return MatrixProxy(m, x);
+}
+
+} // namespace initializers
+
+using initializers::operator<<;
+
+} // namespace QuantLib
+
+#endif

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -22,6 +22,7 @@
 
 #include "matrices.hpp"
 #include "utilities.hpp"
+#include <ql/math/initializers.hpp>
 #include <ql/math/matrix.hpp>
 #include <ql/math/matrixutilities/choleskydecomposition.hpp>
 #include <ql/math/matrixutilities/pseudosqrt.hpp>
@@ -681,6 +682,51 @@ void MatricesTest::testIterativeSolvers() {
     #endif
 }
 
+void MatricesTest::testInitializers() {
+    BOOST_TEST_MESSAGE("Testing matrix and array initializers...");
+
+    Array a1(0);
+    BOOST_CHECK_THROW({ a1 << 1.0; }, QuantLib::Error);
+
+    Array a2(1);
+    BOOST_CHECK_NO_THROW({ a2 << 1.0; });
+    BOOST_CHECK_THROW(({ a2 << 1.0, 2.0; }), QuantLib::Error);
+
+    Array a3(1);
+    a3 << 1.0;
+    BOOST_REQUIRE(a3.size() == 1);
+    BOOST_CHECK_EQUAL(a3[0], 1.0);
+
+    Array a4(5);
+    a4 << 1.0, 2.2, 3.3, 4.4, 5.5;
+    BOOST_REQUIRE(a4.size() == 5);
+    BOOST_CHECK_EQUAL(a4[0], 1.0);
+    BOOST_CHECK_EQUAL(a4[1], 2.2);
+    BOOST_CHECK_EQUAL(a4[2], 3.3);
+    BOOST_CHECK_EQUAL(a4[3], 4.4);
+    BOOST_CHECK_EQUAL(a4[4], 5.5);
+
+    Matrix m1(0, 0);
+    BOOST_CHECK_THROW({ m1 << 1.0; }, QuantLib::Error);
+
+    Matrix m2(2, 2);
+    BOOST_CHECK_NO_THROW(({ m2 << 1.0, 2.0,
+                                  3.0, 4.0; }));
+    BOOST_CHECK_THROW(({ m2 << 1.0, 2.0, 3.0,
+                               4.0, 5.0, 6.0,
+                               7.0, 8.0, 9.0; }), QuantLib::Error);
+
+    Matrix m3(2,2);
+    m3 << 1.0, 2.0,
+          3.0, 4.0;
+    BOOST_REQUIRE(m3.rows() == 2);
+    BOOST_REQUIRE(m3.columns() == 2);
+    BOOST_CHECK_EQUAL(m3(0, 0), 1.0);
+    BOOST_CHECK_EQUAL(m3(0, 1), 2.0);
+    BOOST_CHECK_EQUAL(m3(1, 0), 3.0);
+    BOOST_CHECK_EQUAL(m3(1, 1), 4.0);
+}
+
 test_suite* MatricesTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Matrix tests");
 
@@ -698,6 +744,7 @@ test_suite* MatricesTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testCholeskyDecomposition));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testMoorePenroseInverse));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testIterativeSolvers));
+    suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testInitializers));
     return suite;
 }
 

--- a/test-suite/matrices.hpp
+++ b/test-suite/matrices.hpp
@@ -41,6 +41,7 @@ class MatricesTest {
     static void testCholeskyDecomposition();
     static void testMoorePenroseInverse();
     static void testIterativeSolvers();
+    static void testInitializers();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Libraries like Eigen or dlib offer convenience initializers for matrices, in Eigen you can for example write

```
Matrix3d m;
m << 1,2,3,
     4,5,6,
     7,8,9;
```

This pull request aims at providing similar initializers for ```Matrix``` and ```Array```. They do not add any overhead to the existing classes and work "in place". By including the additional header you can then write

```
Array a(5);
a << 1,2,3,4,5;
```

or

```
Matrix m(3,3);
m << 1,2,3,
     4,5,6,
     7,8,9;
```