### PR TITLE
updates for lazy frcs and deepUpdate() implementations

### DIFF
--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -24,7 +24,7 @@
 
 #include <ql/instruments/bond.hpp>
 #include <ql/cashflows/cashflows.hpp>
-#include <ql/cashflows/coupon.hpp>
+#include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/cashflows/simplecashflow.hpp>
 #include <ql/pricingengines/bond/discountingbondengine.hpp>
@@ -353,6 +353,16 @@ namespace QuantLib {
 
         cashflows_.push_back(redemption);
         redemptions_.push_back(redemption);
+    }
+
+    void Bond::deepUpdate() {
+        for (Size k = 0; k < cashflows_.size(); ++k) {
+            boost::shared_ptr<FloatingRateCoupon> f =
+                boost::dynamic_pointer_cast<FloatingRateCoupon>(cashflows_[k]);
+            if (f)
+                f->update();
+        }
+        update();
     }
 
     void Bond::calculateNotionalsFromCashflows() {

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -88,6 +88,10 @@ namespace QuantLib {
         //@{
         bool isExpired() const;
         //@}
+        //! \name Observable interface
+        //@{
+        void deepUpdate();
+        //@}
         //! \name Inspectors
         //@{
         Natural settlementDays() const;

--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -273,6 +273,17 @@ namespace QuantLib {
         }
     }
 
+    void CapFloor::deepUpdate() {
+        for (Size i = 0; i < floatingLeg_.size(); ++i) {
+            boost::shared_ptr<FloatingRateCoupon> f =
+                boost::dynamic_pointer_cast<FloatingRateCoupon>(
+                    floatingLeg_[i]);
+            if (f)
+                f->update();
+        }
+        update();
+    }
+
     void CapFloor::arguments::validate() const {
         QL_REQUIRE(endDates.size() == startDates.size(),
                    "number of start dates (" << startDates.size()

--- a/ql/instruments/capfloor.hpp
+++ b/ql/instruments/capfloor.hpp
@@ -64,6 +64,10 @@ namespace QuantLib {
         CapFloor(Type type,
                  const Leg& floatingLeg,
                  const std::vector<Rate>& strikes);
+        //! \name Observable interface
+        //@{
+        void deepUpdate();
+        //@}
         //! \name Instrument interface
         //@{
         bool isExpired() const;

--- a/ql/instruments/swap.cpp
+++ b/ql/instruments/swap.cpp
@@ -21,7 +21,7 @@
 
 #include <ql/instruments/swap.hpp>
 #include <ql/cashflows/cashflows.hpp>
-#include <ql/cashflows/coupon.hpp>
+#include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 
 namespace QuantLib {
@@ -156,6 +156,18 @@ namespace QuantLib {
         return d;
     }
 
+    void Swap::deepUpdate() {
+        for (Size j = 0; j < legs_.size(); ++j) {
+            for (Size k = 0; k < legs_[j].size(); ++k) {
+                boost::shared_ptr<FloatingRateCoupon> f =
+                    boost::dynamic_pointer_cast<FloatingRateCoupon>(
+                        legs_[j][k]);
+                if (f)
+                    f->update();
+            }
+        }
+        update();
+    }
 
     void Swap::arguments::validate() const {
         QL_REQUIRE(legs.size() == payer.size(),

--- a/ql/instruments/swap.hpp
+++ b/ql/instruments/swap.hpp
@@ -53,6 +53,10 @@ namespace QuantLib {
         Swap(const std::vector<Leg>& legs,
              const std::vector<bool>& payer);
         //@}
+        //! \name Observable interface
+        //@{
+        void deepUpdate();
+        //@}
         //! \name Instrument interface
         //@{
         bool isExpired() const;

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -99,11 +99,7 @@ namespace QuantLib {
     Real OISRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->recalculate();
-        for (Leg::const_iterator c = swap_->overnightLeg().begin();
-             c != swap_->overnightLeg().end(); ++c) {
-            boost::static_pointer_cast<FloatingRateCoupon>(*c)->update();
-        }
+        swap_->deepUpdate();
         return swap_->fairRate();
     }
 
@@ -167,7 +163,7 @@ namespace QuantLib {
     Real DatedOISRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->recalculate();
+        swap_->deepUpdate();
         return swap_->fairRate();
     }
 

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -829,10 +829,7 @@ namespace QuantLib {
     Real SwapRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
         // we didn't register as observers - force calculation
-        for (Leg::const_iterator c = swap_->floatingLeg().begin();
-             c != swap_->floatingLeg().end(); ++c) {
-            boost::static_pointer_cast<FloatingRateCoupon>(*c)->update();
-        }
+        swap_->deepUpdate();
         // weak implementation... to be improved
         static const Spread basisPoint = 1.0e-4;
         Real floatingLegNPV = swap_->floatingLegNPV();
@@ -941,14 +938,7 @@ namespace QuantLib {
     Real BMASwapRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
         // we didn't register as observers - force calculation
-        for (Leg::const_iterator c = swap_->bmaLeg().begin();
-             c != swap_->bmaLeg().end(); ++c) {
-            boost::static_pointer_cast<FloatingRateCoupon>(*c)->update();
-        }
-        for (Leg::const_iterator c = swap_->liborLeg().begin();
-             c != swap_->liborLeg().end(); ++c) {
-            boost::static_pointer_cast<FloatingRateCoupon>(*c)->update();
-        }
+        swap_->deepUpdate();
         return swap_->fairLiborFraction();
     }
 


### PR DESCRIPTION
in #427 we made the floating rate coupon lazy, as a result some instruments contain nested lazy objects now; therefore it makes sense to implement the deepUpdate() method for them, which is done in this PR

furthermore this allows to simplify the update within rate helpers, now just calling deepUpdate() instead of formerly recalculate(); we could think about optimising the deepUpdate() implementation by caching the indices of floating rate coupons and only update them, but for a start I would stick with this simple implementation

last but not least with the lazy coupons from #427 the exposure simulation in our open risk engine does no longer work when disabling observability, which can be fixed by calling deepUpdate(), but this requires the implementation of this method in the relevant instruments