### PR TITLE
improve performance

### DIFF
--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -113,11 +113,12 @@ namespace QuantLib {
         // adjustment has to be applied, but the Black76 method only
         // applies the standard in arrears adjustment; the bivariate
         // lognormal method is more accurate in this regard.
+        if ((!coupon_->isInArrears() && timingAdjustment_ == Black76))
+            return fixing;
         Date d1 = coupon_->fixingDate();
         Date d2 = index_->valueDate(d1);
         Date d3 = index_->maturityDate(d2);
-        if ((!coupon_->isInArrears() && timingAdjustment_ == Black76) ||
-            coupon_->date() == d3)
+        if (coupon_->date() == d3)
             return fixing;
 
         QL_REQUIRE(!capletVolatility().empty(),

--- a/ql/cashflows/couponpricer.hpp
+++ b/ql/cashflows/couponpricer.hpp
@@ -205,7 +205,7 @@ namespace QuantLib {
     }
 
     inline Rate BlackIborCouponPricer::swapletRate() const {
-        return swapletPrice()/(accrualPeriod_*discount_);
+        return gearing_ * adjustedFixing() + spread_;
     }
 
     inline Real BlackIborCouponPricer::capletPrice(Rate effectiveCap) const {


### PR DESCRIPTION
it turns out that the computation of d2 and d3 can generate significant overhead (some performance tests in our open risk engine run around 50% slower), so should be avoided if not necessary

the reimplementation of swapletRate() speeds up the computation to a much lesser degree, but still a bit (around 2% in the same test) and maybe it's even more readable and direct (maybe also a matter of taste, don't know).

