### PR TITLE
Check if isRegular is empty before popping elements

### DIFF
--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -463,9 +463,10 @@ namespace QuantLib {
                    result.dates_[0]);
         if (truncationDate<result.dates_.back()) {
             // remove later dates
-            while (!result.isRegular_.empty() && result.dates_.back()>truncationDate) {
+            while (result.dates_.back()>truncationDate) {
                 result.dates_.pop_back();
-                result.isRegular_.pop_back();
+                if(!result.isRegular_.empty())
+                    result.isRegular_.pop_back();
             }
 
             // add truncationDate if missing

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -463,7 +463,7 @@ namespace QuantLib {
                    result.dates_[0]);
         if (truncationDate<result.dates_.back()) {
             // remove later dates
-            while (!isRegular_.empty() && result.dates_.back()>truncationDate) {
+            while (!result.isRegular_.empty() && result.dates_.back()>truncationDate) {
                 result.dates_.pop_back();
                 result.isRegular_.pop_back();
             }

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -463,7 +463,7 @@ namespace QuantLib {
                    result.dates_[0]);
         if (truncationDate<result.dates_.back()) {
             // remove later dates
-            while (result.dates_.back()>truncationDate) {
+            while (!isRegular_.empty() && result.dates_.back()>truncationDate) {
                 result.dates_.pop_back();
                 result.isRegular_.pop_back();
             }


### PR DESCRIPTION
Fixes #360.

Added pre-check before popping the back elements from isRegular. Since isRegular is regarding intervals between dates. Its size is always dates.size() - 1. So it's unnecessary to check dates's length as long as we confirm isRegular is not empty.