### PR TITLE
Avoid GNU-specific syntax in Makefiles.

### DIFF
--- a/Docs/Makefile.am
+++ b/Docs/Makefile.am
@@ -13,13 +13,6 @@ DOXYGEN_INPUT := $(shell find ${top_srcdir} -name *.hpp) \
 
 BASEPATH = @abs_top_srcdir@
 
-%.gz: %
-	rm -f $@
-	gzip --best $<
-%.tar: %
-	tar chf $@ $<
-	rm $<
-
 .PHONY: docs-all docs-html docs-clean
 .PHONY: docs-dist
 

--- a/Examples/Makefile.am
+++ b/Examples/Makefile.am
@@ -26,10 +26,7 @@ SUBDIR_CHECKS = $(SUBDIRS:%=%.check)
 
 EXTRA_DIST = CMakeLists.txt README.txt
 
-%.check:
-	$(MAKE) -C $* check-examples
-
-.PHONY: examples check-examples $(SUBDIRS)
+.PHONY: examples check-examples $(SUBDIRS) $(SUBDIR_CHECKS)
 
 examples: $(SUBDIRS)
 
@@ -37,3 +34,6 @@ check-examples: $(SUBDIR_CHECKS)
 
 $(SUBDIRS):
 	$(MAKE) -C $@ examples
+
+$(SUBDIR_CHECKS):
+	$(MAKE) -C ${@:.check=} check-examples


### PR DESCRIPTION
Thanks to UnitedMarsupials.

Closes #501.