### PR TITLE
Resolves Issue 518

### DIFF
--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -117,10 +117,10 @@ namespace QuantLib {
 		std::vector<Date> couponDates = getListOfPeriodDatesIncludingQuasiPayments();
 
 		Real yearFractionSum = 0;
-		for (int i = 0; i < couponDates.size() - 2; i++) {
+		for (int i = 0; i < couponDates.size() - 1; i++) {
 			Date startReferencePeriod = couponDates[i];
 			Date endReferencePeriod = couponDates[i + 1];
-			if (endReferencePeriod > start && end >= startReferencePeriod) {
+			if (endReferencePeriod > start && end > startReferencePeriod) {
 				yearFractionSum += yearFractionWithReferenceDates(
 					(start > startReferencePeriod) ? start : startReferencePeriod,
 					(end < endReferencePeriod) ? end : endReferencePeriod,

--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -102,7 +102,6 @@ namespace QuantLib {
 
 	/*! \An ISMA day counter either needs a schedule or to have been explicitly passed a reference period. This usuage leads to innaccurate year fractions.
 	*/
-	QL_DEPRECATED
 	Time ActualActual::ISMA_Impl::yearFractionGuess(
 		const Date& start,
 		const Date& end

--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -44,6 +44,13 @@ namespace QuantLib {
         }
     }
 
+	int ActualActual::ISMA_Impl::findCouponsPerYear(Date refStart, Date refEnd) const {
+		// This will only work for day counts longer than 15 days.
+		Integer months = Integer(0.5 + 12 * Real(dayCount(refStart, refEnd))/365.0);
+		return (int)round(12.0 / Real(months));
+
+	}
+
 	Time ActualActual::ISMA_Impl::yearFractionWithReferenceDates(
 		const Date& d1,
 		const Date& d2,
@@ -54,9 +61,17 @@ namespace QuantLib {
 			d1 <= d2, 
 			"This function is only correct if d1 <= d2 \n d1: " << d1 << " d2: " << d2
 		);
+		//
 		Real referenceDayCount = Real(dayCount(d3, d4));
 		//guess how many coupon periods per year:
-		int couponsPerYear = (int) round(365.0 / referenceDayCount);
+		int couponsPerYear;
+		if (referenceDayCount < 16) {
+			couponsPerYear = 1;
+			referenceDayCount = dayCount(d1, d1 + 1 * Years);
+		}
+		else {
+			couponsPerYear = findCouponsPerYear(d3, d4);
+		}
 		return Real(dayCount(d1, d2)) / (referenceDayCount*couponsPerYear);
 
 	}

--- a/ql/time/daycounters/actualactual.hpp
+++ b/ql/time/daycounters/actualactual.hpp
@@ -67,6 +67,24 @@ namespace QuantLib {
                               const Date& refPeriodEnd) const;
           private:
             Schedule schedule_;
+			Time yearFractionWithReferenceDates(
+				const Date& d1,
+				const Date& d2,
+				const Date& refPeriodStart,
+				const Date& refPeriodEnd
+			) const;
+			Time yearFractionUsingSchedule(
+				const Date& d1,
+				const Date& d2
+			) const;
+			Time yearFractionGuess(
+				const Date& d1,
+				const Date& d2
+			) const;
+			std::vector<Date> getListOfPeriodDatesIncludingQuasiPayments() const;
+			bool isReferencePeriodSpecified(const Date& refPeriodStart, const Date& refPeriodEnd) const;
+
+
         };
         class ISDA_Impl : public DayCounter::Impl {
           public:

--- a/ql/time/daycounters/actualactual.hpp
+++ b/ql/time/daycounters/actualactual.hpp
@@ -67,6 +67,7 @@ namespace QuantLib {
                               const Date& refPeriodEnd) const;
           private:
             Schedule schedule_;
+			int findCouponsPerYear(Date refStart, Date refEnd) const;
 			Time yearFractionWithReferenceDates(
 				const Date& d1,
 				const Date& d2,

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -1168,12 +1168,14 @@ void BondTest::testExCouponGilt() {
 
     Compounding comp = Compounded;
     Frequency freq   = Semiannual;
-    DayCounter dc = ActualActual(ActualActual::ISMA);
+    
+	Schedule schedule = Schedule(startDate, maturityDate, tenor,
+		NullCalendar(), Unadjusted, Unadjusted,
+		DateGeneration::Forward, true, firstCouponDate);
+	DayCounter dc = ActualActual(ActualActual::ISMA, schedule);
 
     FixedRateBond bond(settlementDays, 100.0,
-                       Schedule(startDate, maturityDate, tenor,
-                                NullCalendar(), Unadjusted, Unadjusted,
-                                DateGeneration::Forward, true, firstCouponDate),
+                       schedule,
                        std::vector<Rate>(1, coupon),
                        dc, Unadjusted, 100.0,
                        issueDate, calendar, exCouponPeriod, calendar);
@@ -1306,12 +1308,14 @@ void BondTest::testExCouponAustralianBond() {
 
     Compounding comp = Compounded;
     Frequency freq   = Semiannual;
-    DayCounter dc = ActualActual(ActualActual::ISMA);
+    
+	Schedule schedule = Schedule(startDate, maturityDate, tenor,
+		NullCalendar(), Unadjusted, Unadjusted,
+		DateGeneration::Forward, true, firstCouponDate);
+	DayCounter dc = ActualActual(ActualActual::ISMA, schedule);
 
     FixedRateBond bond(settlementDays, 100.0,
-                       Schedule(startDate, maturityDate, tenor,
-                                NullCalendar(), Unadjusted, Unadjusted,
-                                DateGeneration::Forward, true, firstCouponDate),
+                       schedule,
                        std::vector<Rate>(1, coupon),
                        dc, Unadjusted, 100.0,
                        issueDate, calendar, exCouponPeriod, NullCalendar());
@@ -1393,10 +1397,9 @@ void BondTest::testBondFromScheduleWithDateVector()
     Rate coupon = 0.0875;
     Compounding comp = Compounded;
     Frequency freq = Semiannual;
-    DayCounter dc = ActualActual(ActualActual::Bond);
+    
 
-    // Yield as quoted in market
-    InterestRate yield(0.09185, dc, comp, freq);
+    
     
     Period tenor = 6 * Months;
     Period exCouponPeriod = 10 * Days;
@@ -1427,7 +1430,7 @@ void BondTest::testBondFromScheduleWithDateVector()
                         schedule.rule(),
                         schedule.endOfMonth(),
                         schedule.isRegular());
-
+	DayCounter dc = ActualActual(ActualActual::Bond, schedule);
     FixedRateBond bond(
         0, 
         100.0,
@@ -1436,6 +1439,9 @@ void BondTest::testBondFromScheduleWithDateVector()
         dc, Following, 100.0,
         issueDate, calendar, 
         exCouponPeriod, calendar, Unadjusted, false);
+
+	// Yield as quoted in market
+	InterestRate yield(0.09185, dc, comp, freq);
 
     Real calculatedPrice = BondFunctions::dirtyPrice(bond, yield, settlementDate);
     Real expectedPrice = 95.75706;

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -176,7 +176,10 @@ void DayCounterTest::testActualActual() {
 }
 
 void DayCounterTest::testActualActualWithScheduleAgainstSemiAnnualReferencePeriod() {
-	Calendar calendar = UnitedStates();
+
+    BOOST_TEST_MESSAGE("Testing actual/actual with schedule for undefined semi reference periods...");
+
+    Calendar calendar = UnitedStates();
 	Schedule schedule = MakeSchedule()
 		.from(Date(10, January, 2017))
 		.withFirstDate(Date(31, August, 2017))
@@ -205,6 +208,9 @@ void DayCounterTest::testActualActualWithScheduleAgainstSemiAnnualReferencePerio
 }
 
 void DayCounterTest::testActualActualWithScheduleAgainstAnnualReferencePeriod(){
+
+    BOOST_TEST_MESSAGE("Testing actual/actual with schedule for undefined annual reference periods...");
+
 	//Now do an annual schedule
 	Calendar calendar = UnitedStates();
 	Schedule schedule = MakeSchedule()
@@ -602,6 +608,8 @@ void DayCounterTest::testIntraday() {
 test_suite* DayCounterTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Day counter tests");
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActual));
+    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActualWithScheduleAgainstSemiAnnualReferencePeriod));
+    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActualWithScheduleAgainstAnnualReferencePeriod));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActualWithSchedule));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testSimple));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testOne));

--- a/test-suite/daycounters.hpp
+++ b/test-suite/daycounters.hpp
@@ -29,6 +29,8 @@ class DayCounterTest {
    public:
     static void testActualActual();
     static void testActualActualWithSchedule();
+	static void testActualActualWithScheduleAgainstSemiAnnualReferencePeriod();
+	static void testActualActualWithScheduleAgainstAnnualReferencePeriod();
     static void testSimple();
     static void testOne();
     static void testBusiness252();

--- a/test-suite/daycounters.hpp
+++ b/test-suite/daycounters.hpp
@@ -30,6 +30,9 @@ class DayCounterTest {
     static void testActualActual();
     static void testActualActualWithSchedule();
 	static void testActualActualWithScheduleAgainstSemiAnnualReferencePeriod();
+	//static void testScheduleCorrectlyDefinesNextDateAndPreviousDate();
+	static void testScheduleAlwaysHasAStartDate();
+	static void testActualActualWithScheduleAgainstSemiAnnualReferencePeriodMultipleReferencePeriods();
 	static void testActualActualWithScheduleAgainstAnnualReferencePeriod();
     static void testSimple();
     static void testOne();


### PR DESCRIPTION
I believe that this pull request resolves all outstanding issues with the ActualActual ISMA implelmentation described in issue 518.

The only remaining failing tests are regression tests. Differences are to be expected due to the fact that these were previously incorrect.

Further tests that should be added:
1) bondPrices cacluated from the pricing engine should now be consistent with prices from the bondYield(cleanPrice ....) functions for Actual Actual bonds. A test should be created to make sure that this si always true.
2) Explicit tests of a bond accrual tested against known good values to make sure that when using a schedule all the values feed through correctly to bond accrual valuations.
3) We must resolve the broken regression tests. I suspect this means that they may have been wrong before when using the actual actual without a schedule.

Phil

