### PR TITLE
Add base class above CalibrationHelper.

### DIFF
--- a/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -72,7 +72,7 @@ Volatility swaptionVols[] = {
 
 void calibrateModel(
           const ext::shared_ptr<ShortRateModel>& model,
-          const std::vector<ext::shared_ptr<CalibrationHelper> >& helpers) {
+          const std::vector<ext::shared_ptr<BlackCalibrationHelper> >& helpers) {
 
     LevenbergMarquardt om;
     model->calibrate(helpers, om,
@@ -173,7 +173,7 @@ int main(int, char* []) {
         swaptionMaturities.push_back(Period(4, Years));
         swaptionMaturities.push_back(Period(5, Years));
 
-        std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
+        std::vector<ext::shared_ptr<BlackCalibrationHelper> > swaptions;
 
         // List of times that have to be included in the timegrid
         std::list<Time> times;
@@ -183,7 +183,7 @@ int main(int, char* []) {
             Size j = numCols - i -1; // 1x5, 2x4, 3x3, 4x2, 5x1
             Size k = i*numCols + j;
             ext::shared_ptr<Quote> vol(new SimpleQuote(swaptionVols[k]));
-            swaptions.push_back(ext::shared_ptr<CalibrationHelper>(new
+            swaptions.push_back(ext::shared_ptr<BlackCalibrationHelper>(new
                 SwaptionHelper(swaptionMaturities[i],
                                Period(swapLenghts[j], Years),
                                Handle<Quote>(vol),

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -60,7 +60,7 @@ Integer sessionId() { return 0; }
 // helper function that prints a basket of calibrating swaptions to std::cout
 
 void printBasket(
-    const std::vector<ext::shared_ptr<CalibrationHelper> > &basket) {
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &basket) {
     std::cout << "\n" << std::left << std::setw(20) << "Expiry" << std::setw(20)
               << "Maturity" << std::setw(20) << "Nominal" << std::setw(14)
               << "Rate" << std::setw(12) << "Pay/Rec" << std::setw(14)
@@ -94,7 +94,7 @@ void printBasket(
 // helper function that prints the result of a model calibraiton to std::cout
 
 void printModelCalibration(
-    const std::vector<ext::shared_ptr<CalibrationHelper> > &basket,
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &basket,
     const Array &volatility) {
 
     std::cout << "\n" << std::left << std::setw(20) << "Expiry" << std::setw(14)
@@ -272,7 +272,7 @@ int main(int argc, char *argv[]) {
             ext::make_shared<EuriborSwapIsdaFixA>(10 * Years, yts6m, ytsOis);
 
         timer.start();
-        std::vector<ext::shared_ptr<CalibrationHelper> > basket =
+        std::vector<ext::shared_ptr<BlackCalibrationHelper> > basket =
             swaption->calibrationBasket(swapBase, *swaptionVol,
                                         BasketGeneratingEngine::Naive);
         timer.stop();

--- a/ql/instruments/floatfloatswaption.cpp
+++ b/ql/instruments/floatfloatswaption.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
         QL_REQUIRE(exercise, "exercise not set");
     }
 
-    Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+    Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
     FloatFloatSwaption::calibrationBasket(
         ext::shared_ptr<SwapIndex> standardSwapBase,
         ext::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,

--- a/ql/instruments/floatfloatswaption.hpp
+++ b/ql/instruments/floatfloatswaption.hpp
@@ -56,7 +56,7 @@ namespace QuantLib {
             return swap_;
         }
         //@}
-        Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+        Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
         calibrationBasket(
             ext::shared_ptr<SwapIndex> standardSwapBase,
             ext::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,

--- a/ql/instruments/nonstandardswaption.cpp
+++ b/ql/instruments/nonstandardswaption.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
         QL_REQUIRE(exercise, "exercise not set");
     }
 
-    Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+    Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
     NonstandardSwaption::calibrationBasket(
         ext::shared_ptr<SwapIndex> standardSwapBase,
         ext::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,

--- a/ql/instruments/nonstandardswaption.hpp
+++ b/ql/instruments/nonstandardswaption.hpp
@@ -61,7 +61,7 @@ namespace QuantLib {
             return swap_;
         }
         //@}
-        Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+        Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
         calibrationBasket(
             ext::shared_ptr<SwapIndex> standardSwapBase,
             ext::shared_ptr<SwaptionVolatilityStructure> swaptionVolatility,

--- a/ql/models/calibrationhelper.cpp
+++ b/ql/models/calibrationhelper.cpp
@@ -23,9 +23,9 @@
 
 namespace QuantLib {
 
-    class CalibrationHelper::ImpliedVolatilityHelper {
+    class BlackCalibrationHelper::ImpliedVolatilityHelper {
       public:
-        ImpliedVolatilityHelper(const CalibrationHelper& helper,
+        ImpliedVolatilityHelper(const BlackCalibrationHelper& helper,
                                 Real value)
         : helper_(helper), value_(value) {}
 
@@ -33,15 +33,15 @@ namespace QuantLib {
             return value_ - helper_.blackPrice(x);
         }
       private:
-        const CalibrationHelper& helper_;
+        const BlackCalibrationHelper& helper_;
         Real value_;
     };
 
-    Volatility CalibrationHelper::impliedVolatility(Real targetValue,
-                                                    Real accuracy,
-                                                    Size maxEvaluations,
-                                                    Volatility minVol,
-                                                    Volatility maxVol) const {
+    Volatility BlackCalibrationHelper::impliedVolatility(Real targetValue,
+                                                         Real accuracy,
+                                                         Size maxEvaluations,
+                                                         Volatility minVol,
+                                                         Volatility maxVol) const {
 
         ImpliedVolatilityHelper f(*this,targetValue);
         Brent solver;
@@ -49,7 +49,7 @@ namespace QuantLib {
         return solver.solve(f,accuracy,volatility_->value(),minVol,maxVol);
     }
 
-    Real CalibrationHelper::calibrationError() {
+    Real BlackCalibrationHelper::calibrationError() {
         Real error;
         
         switch (calibrationErrorType_) {

--- a/ql/models/calibrationhelper.hpp
+++ b/ql/models/calibrationhelper.hpp
@@ -43,16 +43,16 @@ namespace QuantLib {
     };
 
     //! liquid Black76 market instrument used during calibration
-    class CalibrationHelper : public LazyObject, public CalibrationHelperBase {
+    class BlackCalibrationHelper : public LazyObject, public CalibrationHelperBase {
       public:
         enum CalibrationErrorType {
                             RelativePriceError, PriceError, ImpliedVolError};
-        CalibrationHelper(const Handle<Quote>& volatility,
-                          const Handle<YieldTermStructure>& termStructure,
-                          CalibrationErrorType calibrationErrorType
+        BlackCalibrationHelper(const Handle<Quote>& volatility,
+                               const Handle<YieldTermStructure>& termStructure,
+                               CalibrationErrorType calibrationErrorType
                                                          = RelativePriceError,
-                          const VolatilityType type = ShiftedLognormal,
-                          const Real shift = 0.0)
+                               const VolatilityType type = ShiftedLognormal,
+                               const Real shift = 0.0)
         : volatility_(volatility), termStructure_(termStructure),
           volatilityType_(type), shift_(shift),
           calibrationErrorType_(calibrationErrorType) {
@@ -107,6 +107,13 @@ namespace QuantLib {
         class ImpliedVolatilityHelper;
         const CalibrationErrorType calibrationErrorType_;
     };
+
+    /*! \deprecated Use BlackCalibrationHelper instead
+
+        Deprecated in version 1.14.
+    */
+    QL_DEPRECATED
+    typedef BlackCalibrationHelper CalibrationHelper;
 
 }
 

--- a/ql/models/calibrationhelper.hpp
+++ b/ql/models/calibrationhelper.hpp
@@ -35,8 +35,15 @@ namespace QuantLib {
 
     class PricingEngine;
 
-    //! liquid market instrument used during calibration
-    class CalibrationHelper : public LazyObject {
+    //! abstract base class for calibration helpers
+    class CalibrationHelperBase {
+      public:
+        //! returns the error resulting from the model valuation
+        virtual Real calibrationError() = 0;
+    };
+
+    //! liquid Black76 market instrument used during calibration
+    class CalibrationHelper : public LazyObject, public CalibrationHelperBase {
       public:
         enum CalibrationErrorType {
                             RelativePriceError, PriceError, ImpliedVolError};
@@ -70,7 +77,7 @@ namespace QuantLib {
         virtual Real modelValue() const = 0;
 
         //! returns the error resulting from the model valuation
-        virtual Real calibrationError();
+        Real calibrationError();
 
         virtual void addTimesTo(std::list<Time>& times) const = 0;
 

--- a/ql/models/equity/hestonmodelhelper.cpp
+++ b/ql/models/equity/hestonmodelhelper.cpp
@@ -37,8 +37,8 @@ namespace QuantLib {
                             const Handle<Quote>& volatility,
                             const Handle<YieldTermStructure>& riskFreeRate,
                             const Handle<YieldTermStructure>& dividendYield,
-                            CalibrationHelper::CalibrationErrorType errorType)
-    : CalibrationHelper(volatility, riskFreeRate, errorType),
+                            BlackCalibrationHelper::CalibrationErrorType errorType)
+    : BlackCalibrationHelper(volatility, riskFreeRate, errorType),
       maturity_(maturity), calendar_(calendar),
       s0_(Handle<Quote>(ext::make_shared<SimpleQuote>(s0))),
       strikePrice_(strikePrice), dividendYield_(dividendYield) {
@@ -53,8 +53,8 @@ namespace QuantLib {
                             const Handle<Quote>& volatility,
                             const Handle<YieldTermStructure>& riskFreeRate,
                             const Handle<YieldTermStructure>& dividendYield,
-                            CalibrationHelper::CalibrationErrorType errorType)
-    : CalibrationHelper(volatility, riskFreeRate, errorType),
+                            BlackCalibrationHelper::CalibrationErrorType errorType)
+    : BlackCalibrationHelper(volatility, riskFreeRate, errorType),
       maturity_(maturity), calendar_(calendar), s0_(s0),
       strikePrice_(strikePrice), dividendYield_(dividendYield) {
         registerWith(s0);
@@ -74,7 +74,7 @@ namespace QuantLib {
         ext::shared_ptr<Exercise> exercise =
             ext::make_shared<EuropeanExercise>(exerciseDate_);
         option_ = ext::make_shared<VanillaOption>(payoff, exercise);
-        CalibrationHelper::performCalculations();
+        BlackCalibrationHelper::performCalculations();
     }
 
     Real HestonModelHelper::modelValue() const {

--- a/ql/models/equity/hestonmodelhelper.hpp
+++ b/ql/models/equity/hestonmodelhelper.hpp
@@ -31,7 +31,7 @@
 namespace QuantLib {
 
     //! calibration helper for Heston model
-    class HestonModelHelper : public CalibrationHelper {
+    class HestonModelHelper : public BlackCalibrationHelper {
       public:
         HestonModelHelper(const Period& maturity,
                           const Calendar& calendar,
@@ -40,8 +40,8 @@ namespace QuantLib {
                           const Handle<Quote>& volatility,
                           const Handle<YieldTermStructure>& riskFreeRate,
                           const Handle<YieldTermStructure>& dividendYield,
-                          CalibrationHelper::CalibrationErrorType errorType
-                                    = CalibrationHelper::RelativePriceError);
+                          BlackCalibrationHelper::CalibrationErrorType errorType
+                                    = BlackCalibrationHelper::RelativePriceError);
 
         HestonModelHelper(const Period& maturity,
                           const Calendar& calendar,
@@ -50,8 +50,8 @@ namespace QuantLib {
                           const Handle<Quote>& volatility,
                           const Handle<YieldTermStructure>& riskFreeRate,
                           const Handle<YieldTermStructure>& dividendYield,
-                          CalibrationHelper::CalibrationErrorType errorType
-                                    = CalibrationHelper::RelativePriceError);
+                          BlackCalibrationHelper::CalibrationErrorType errorType
+                                    = BlackCalibrationHelper::RelativePriceError);
 
         void addTimesTo(std::list<Time>&) const {}
         void performCalculations() const;

--- a/ql/models/model.cpp
+++ b/ql/models/model.cpp
@@ -95,20 +95,26 @@ namespace QuantLib {
             const vector<Real>& weights,
             const vector<bool>& fixParameters) {
 
-        QL_REQUIRE(weights.empty() || weights.size() == instruments.size(),
-                   "mismatch between number of instruments (" <<
-                   instruments.size() << ") and weights(" <<
-                   weights.size() << ")");
+        QL_REQUIRE(!instruments.empty(), "no instruments provided");
 
         Constraint c;
         if (additionalConstraint.empty())
             c = *constraint_;
         else
             c = CompositeConstraint(*constraint_,additionalConstraint);
+
+        QL_REQUIRE(weights.empty() || weights.size() == instruments.size(),
+                   "mismatch between number of instruments (" <<
+                   instruments.size() << ") and weights (" <<
+                   weights.size() << ")");
         vector<Real> w =
             weights.empty() ? vector<Real>(instruments.size(), 1.0): weights;
 
         Array prms = params();
+        QL_REQUIRE(fixParameters.empty() || fixParameters.size() == prms.size(),
+                   "mismatch between number of parameters (" <<
+                   prms.size() << ") and fixed-parameter specs (" <<
+                   fixParameters.size() << ")");
         vector<bool> all(prms.size(), false);
         Projection proj(prms,fixParameters.size()>0 ? fixParameters : all);
         CalibrationFunction f(this,instruments,w,proj);
@@ -142,15 +148,13 @@ namespace QuantLib {
     }
 
     Disposable<Array> CalibratedModel::params() const {
-        Size size = 0, i;
-        for (i=0; i<arguments_.size(); i++)
+        Size size=0;
+        for (Size i=0; i<arguments_.size(); ++i)
             size += arguments_[i].size();
         Array params(size);
-        Size k = 0;
-        for (i=0; i<arguments_.size(); i++) {
-            for (Size j=0; j<arguments_[i].size(); j++, k++) {
+        for (Size i=0, k=0; i<arguments_.size(); ++i) {
+            for (Size j=0; j<arguments_[i].size(); ++j, ++k)
                 params[k] = arguments_[i].params()[j];
-            }
         }
         return params;
     }

--- a/ql/models/model.cpp
+++ b/ql/models/model.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
     };
 
     void CalibratedModel::calibrate(
-                    const vector<ext::shared_ptr<CalibrationHelper> >& instruments,
+                    const vector<ext::shared_ptr<BlackCalibrationHelper> >& instruments,
                     OptimizationMethod& method,
                     const EndCriteria& endCriteria,
                     const Constraint& additionalConstraint,
@@ -125,7 +125,7 @@ namespace QuantLib {
 
     Real CalibratedModel::value(
                 const Array& params,
-                const vector<ext::shared_ptr<CalibrationHelper> >& instruments) {
+                const vector<ext::shared_ptr<BlackCalibrationHelper> >& instruments) {
         vector<ext::shared_ptr<CalibrationHelperBase> > tmp(instruments.size());
         for (Size i=0; i<instruments.size(); ++i)
             tmp[i] = ext::static_pointer_cast<CalibrationHelperBase>(instruments[i]);

--- a/ql/models/model.hpp
+++ b/ql/models/model.hpp
@@ -97,6 +97,15 @@ namespace QuantLib {
             satisfied in addition to the constraints of the model.
         */
         virtual void calibrate(
+                const std::vector<ext::shared_ptr<CalibrationHelperBase> >&,
+                OptimizationMethod& method,
+                const EndCriteria& endCriteria,
+                const Constraint& constraint = Constraint(),
+                const std::vector<Real>& weights = std::vector<Real>(),
+                const std::vector<bool>& fixParameters = std::vector<bool>());
+
+        // for backward compatibility
+        virtual void calibrate(
                 const std::vector<ext::shared_ptr<CalibrationHelper> >&,
                 OptimizationMethod& method,
                 const EndCriteria& endCriteria,
@@ -104,6 +113,10 @@ namespace QuantLib {
                 const std::vector<Real>& weights = std::vector<Real>(),
                 const std::vector<bool>& fixParameters = std::vector<bool>());
 
+        Real value(const Array& params,
+                   const std::vector<ext::shared_ptr<CalibrationHelperBase> >&);
+
+        // for backward compatibility
         Real value(const Array& params,
                    const std::vector<ext::shared_ptr<CalibrationHelper> >&);
 

--- a/ql/models/model.hpp
+++ b/ql/models/model.hpp
@@ -106,7 +106,7 @@ namespace QuantLib {
 
         // for backward compatibility
         virtual void calibrate(
-                const std::vector<ext::shared_ptr<CalibrationHelper> >&,
+                const std::vector<ext::shared_ptr<BlackCalibrationHelper> >&,
                 OptimizationMethod& method,
                 const EndCriteria& endCriteria,
                 const Constraint& constraint = Constraint(),
@@ -118,7 +118,7 @@ namespace QuantLib {
 
         // for backward compatibility
         Real value(const Array& params,
-                   const std::vector<ext::shared_ptr<CalibrationHelper> >&);
+                   const std::vector<ext::shared_ptr<BlackCalibrationHelper> >&);
 
         const ext::shared_ptr<Constraint>& constraint() const;
 

--- a/ql/models/shortrate/calibrationhelpers/caphelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/caphelper.cpp
@@ -35,8 +35,8 @@ namespace QuantLib {
                          const DayCounter& fixedLegDayCounter,
                          bool includeFirstSwaplet,
                          const Handle<YieldTermStructure>& termStructure,
-                         CalibrationHelper::CalibrationErrorType errorType)
-        : CalibrationHelper(volatility,termStructure,errorType),
+                         BlackCalibrationHelper::CalibrationErrorType errorType)
+        : BlackCalibrationHelper(volatility,termStructure,errorType),
         length_(length), index_(index), fixedLegFrequency_(fixedLegFrequency),
         fixedLegDayCounter_(fixedLegDayCounter),
         includeFirstSwaplet_(includeFirstSwaplet)
@@ -127,7 +127,7 @@ namespace QuantLib {
         cap_ = ext::make_shared<Cap>(floatingLeg,
                                               std::vector<Rate>(1, fairRate));
 
-        CalibrationHelper::performCalculations();
+        BlackCalibrationHelper::performCalculations();
 
     }
 

--- a/ql/models/shortrate/calibrationhelpers/caphelper.hpp
+++ b/ql/models/shortrate/calibrationhelpers/caphelper.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
 
     //! calibration helper for ATM cap
 
-    class CapHelper : public CalibrationHelper {
+    class CapHelper : public BlackCalibrationHelper {
       public:
         CapHelper(const Period& length,
                   const Handle<Quote>& volatility,
@@ -41,8 +41,8 @@ namespace QuantLib {
                   const DayCounter& fixedLegDayCounter,
                   bool includeFirstSwaplet,
                   const Handle<YieldTermStructure>& termStructure,
-                  CalibrationHelper::CalibrationErrorType errorType
-                                    = CalibrationHelper::RelativePriceError);
+                  BlackCalibrationHelper::CalibrationErrorType errorType
+                                    = BlackCalibrationHelper::RelativePriceError);
         virtual void addTimesTo(std::list<Time>& times) const;
         virtual Real modelValue() const;
         virtual Real blackPrice(Volatility volatility) const;

--- a/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
@@ -39,10 +39,10 @@ namespace QuantLib {
                               const DayCounter& fixedLegDayCounter,
                               const DayCounter& floatingLegDayCounter,
                               const Handle<YieldTermStructure>& termStructure,
-                              CalibrationHelper::CalibrationErrorType errorType,
+                              BlackCalibrationHelper::CalibrationErrorType errorType,
                               const Real strike, const Real nominal,
                               const VolatilityType type, const Real shift)
-    : CalibrationHelper(volatility,termStructure, errorType, type, shift),
+    : BlackCalibrationHelper(volatility,termStructure, errorType, type, shift),
         exerciseDate_(Null<Date>()), endDate_(Null<Date>()),
         maturity_(maturity), length_(length), fixedLegTenor_(fixedLegTenor), index_(index),
         fixedLegDayCounter_(fixedLegDayCounter), floatingLegDayCounter_(floatingLegDayCounter),
@@ -60,10 +60,10 @@ namespace QuantLib {
                               const DayCounter& fixedLegDayCounter,
                               const DayCounter& floatingLegDayCounter,
                               const Handle<YieldTermStructure>& termStructure,
-                              CalibrationHelper::CalibrationErrorType errorType,
+                              BlackCalibrationHelper::CalibrationErrorType errorType,
                               const Real strike, const Real nominal,
                               const VolatilityType type, const Real shift)
-    : CalibrationHelper(volatility,termStructure, errorType, type, shift),
+    : BlackCalibrationHelper(volatility,termStructure, errorType, type, shift),
         exerciseDate_(exerciseDate), endDate_(Null<Date>()),
         maturity_(0*Days), length_(length), fixedLegTenor_(fixedLegTenor), index_(index),
         fixedLegDayCounter_(fixedLegDayCounter), floatingLegDayCounter_(floatingLegDayCounter),
@@ -81,10 +81,10 @@ namespace QuantLib {
                               const DayCounter& fixedLegDayCounter,
                               const DayCounter& floatingLegDayCounter,
                               const Handle<YieldTermStructure>& termStructure,
-                              CalibrationHelper::CalibrationErrorType errorType,
+                              BlackCalibrationHelper::CalibrationErrorType errorType,
                               const Real strike, const Real nominal,
                               const VolatilityType type, const Real shift)
-    : CalibrationHelper(volatility,termStructure, errorType, type, shift),
+    : BlackCalibrationHelper(volatility,termStructure, errorType, type, shift),
         exerciseDate_(exerciseDate), endDate_(endDate),
         maturity_(0*Days), length_(0*Days), fixedLegTenor_(fixedLegTenor), index_(index),
         fixedLegDayCounter_(fixedLegDayCounter), floatingLegDayCounter_(floatingLegDayCounter),
@@ -192,7 +192,7 @@ namespace QuantLib {
 
         swaption_ = ext::make_shared<Swaption>(swap_, exercise);
 
-        CalibrationHelper::performCalculations();
+        BlackCalibrationHelper::performCalculations();
 
     }
 

--- a/ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp
+++ b/ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp
@@ -33,7 +33,7 @@ namespace QuantLib {
 
     //! calibration helper for ATM swaption
 
-    class SwaptionHelper : public CalibrationHelper {
+    class SwaptionHelper : public BlackCalibrationHelper {
       public:
         SwaptionHelper(const Period& maturity,
                        const Period& length,
@@ -43,8 +43,8 @@ namespace QuantLib {
                        const DayCounter& fixedLegDayCounter,
                        const DayCounter& floatingLegDayCounter,
                        const Handle<YieldTermStructure>& termStructure,
-                       CalibrationHelper::CalibrationErrorType errorType
-                                      = CalibrationHelper::RelativePriceError,
+                       BlackCalibrationHelper::CalibrationErrorType errorType
+                                      = BlackCalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
                        const VolatilityType type = ShiftedLognormal,
@@ -58,8 +58,8 @@ namespace QuantLib {
                        const DayCounter& fixedLegDayCounter,
                        const DayCounter& floatingLegDayCounter,
                        const Handle<YieldTermStructure>& termStructure,
-                       CalibrationHelper::CalibrationErrorType errorType
-                                      = CalibrationHelper::RelativePriceError,
+                       BlackCalibrationHelper::CalibrationErrorType errorType
+                                      = BlackCalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
                        const VolatilityType type = ShiftedLognormal,
@@ -73,8 +73,8 @@ namespace QuantLib {
                        const DayCounter& fixedLegDayCounter,
                        const DayCounter& floatingLegDayCounter,
                        const Handle<YieldTermStructure>& termStructure,
-                       CalibrationHelper::CalibrationErrorType errorType
-                                      = CalibrationHelper::RelativePriceError,
+                       BlackCalibrationHelper::CalibrationErrorType errorType
+                                      = BlackCalibrationHelper::RelativePriceError,
                        const Real strike = Null<Real>(),
                        const Real nominal = 1.0,
                        const VolatilityType type = ShiftedLognormal,

--- a/ql/models/shortrate/onefactormodels/gsr.hpp
+++ b/ql/models/shortrate/onefactormodels/gsr.hpp
@@ -104,13 +104,13 @@ class Gsr : public Gaussian1dModel, public CalibratedModel {
     // we do not need a step). Also note that the endcritera reflect
     // only the status of the last calibration when using this method.
     void calibrateVolatilitiesIterative(
-        const std::vector<ext::shared_ptr<CalibrationHelper> > &helpers,
+        const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &helpers,
         OptimizationMethod &method, const EndCriteria &endCriteria,
         const Constraint &constraint = Constraint(),
         const std::vector<Real> &weights = std::vector<Real>()) {
 
         for (Size i = 0; i < helpers.size(); i++) {
-            std::vector<ext::shared_ptr<CalibrationHelper> > h(1, helpers[i]);
+            std::vector<ext::shared_ptr<CalibrationHelperBase> > h(1, helpers[i]);
             calibrate(h, method, endCriteria, constraint, weights,
                       MoveVolatility(i));
         }
@@ -120,13 +120,13 @@ class Gsr : public Gaussian1dModel, public CalibratedModel {
     // to the given helpers. In this case the step dates must be chosen
     // according to the maturities of the calibration instruments.
     void calibrateReversionsIterative(
-        const std::vector<ext::shared_ptr<CalibrationHelper> > &helpers,
+        const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &helpers,
         OptimizationMethod &method, const EndCriteria &endCriteria,
         const Constraint &constraint = Constraint(),
         const std::vector<Real> &weights = std::vector<Real>()) {
 
         for (Size i = 0; i < helpers.size(); i++) {
-            std::vector<ext::shared_ptr<CalibrationHelper> > h(1, helpers[i]);
+            std::vector<ext::shared_ptr<CalibrationHelperBase> > h(1, helpers[i]);
             calibrate(h, method, endCriteria, constraint, weights,
                       MoveReversion(i));
         }

--- a/ql/models/shortrate/onefactormodels/markovfunctional.hpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.hpp
@@ -336,7 +336,7 @@ namespace QuantLib {
         const Array &volatility() const { return sigma_.params(); }
 
         void calibrate(
-            const std::vector<ext::shared_ptr<CalibrationHelper> > &helper,
+            const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &helper,
             OptimizationMethod &method, const EndCriteria &endCriteria,
             const Constraint &constraint = Constraint(),
             const std::vector<Real> &weights = std::vector<Real>(),

--- a/ql/pricingengines/swaption/basketgeneratingengine.cpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.cpp
@@ -30,7 +30,7 @@ using std::fabs;
 
 namespace QuantLib {
 
-    Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+    Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
     BasketGeneratingEngine::calibrationBasket(
         const ext::shared_ptr<Exercise> &exercise,
         ext::shared_ptr<SwapIndex> standardSwapBase,
@@ -45,7 +45,7 @@ namespace QuantLib {
                 !standardSwapBase->discountingTermStructure().empty(),
             "standard swap base discounting term structure must not be empty.");
 
-        std::vector<ext::shared_ptr<CalibrationHelper> > result;
+        std::vector<ext::shared_ptr<BlackCalibrationHelper> > result;
 
         Date today = Settings::instance().evaluationDate();
         Size minIdxAlive = static_cast<Size>(
@@ -96,7 +96,7 @@ namespace QuantLib {
                     standardSwapBase->exogenousDiscount()
                         ? standardSwapBase->discountingTermStructure()
                         : standardSwapBase->forwardingTermStructure(),
-                    CalibrationHelper::RelativePriceError, Null<Real>(), 1.0,
+                    BlackCalibrationHelper::RelativePriceError, Null<Real>(), 1.0,
                     swaptionVolatility->volatilityType() ,shift));
 
                 break;
@@ -225,7 +225,7 @@ namespace QuantLib {
                     standardSwapBase->exogenousDiscount()
                         ? standardSwapBase->discountingTermStructure()
                         : standardSwapBase->forwardingTermStructure(),
-                    CalibrationHelper::RelativePriceError, solution[2],
+                    BlackCalibrationHelper::RelativePriceError, solution[2],
                     fabs(solution[0]), swaptionVolatility->volatilityType(), shift));
                 break;
             }

--- a/ql/pricingengines/swaption/basketgeneratingengine.hpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.hpp
@@ -62,7 +62,7 @@ namespace QuantLib {
             MaturityStrikeByDeltaGamma
         } CalibrationBasketType;
 
-        Disposable<std::vector<ext::shared_ptr<CalibrationHelper> > >
+        Disposable<std::vector<ext::shared_ptr<BlackCalibrationHelper> > >
         calibrationBasket(
             const ext::shared_ptr<Exercise> &exercise,
             ext::shared_ptr<SwapIndex> standardSwapBase,

--- a/test-suite/batesmodel.cpp
+++ b/test-suite/batesmodel.cpp
@@ -45,7 +45,7 @@ using namespace boost::unit_test_framework;
 namespace {
 
     Real getCalibrationError(
-               std::vector<ext::shared_ptr<CalibrationHelper> > & options) {
+               std::vector<ext::shared_ptr<BlackCalibrationHelper> > & options) {
         Real sse = 0;
         for (Size i = 0; i < options.size(); ++i) {
             const Real diff = options[i]->calibrationError()*100.0;
@@ -459,7 +459,7 @@ void BatesModelTest::testDAXCalibration() {
     ext::shared_ptr<PricingEngine> batesEngine(
                                             new BatesEngine(batesModel, 64));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > options;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
 
     for (Size s = 0; s < 13; ++s) {
         for (Size m = 0; m < 8; ++m) {
@@ -470,11 +470,11 @@ void BatesModelTest::testDAXCalibration() {
 
             // this is the calibration helper for the bates models
             // FLOATING_POINT_EXCEPTION
-            options.push_back(ext::shared_ptr<CalibrationHelper>(
+            options.push_back(ext::shared_ptr<BlackCalibrationHelper>(
                     new HestonModelHelper(maturity, calendar,
                                           s0->value(), strike[s], vol,
                                           riskFreeTS, dividendTS, 
-                                          CalibrationHelper::ImpliedVolError)));
+                                          BlackCalibrationHelper::ImpliedVolError)));
             options.back()->setPricingEngine(batesEngine);
         }
     }

--- a/test-suite/gjrgarchmodel.cpp
+++ b/test-suite/gjrgarchmodel.cpp
@@ -249,7 +249,7 @@ void GJRGARCHModelTest::testDAXCalibration() {
     Real strike[] = { 3400,3600,3800,4000,4200,4400,
                       4500,4600,4800,5000,5200,5400,5600 };
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > options;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
 
     for (Size s = 3; s < 10; ++s) {
         for (Size m = 0; m < 3; ++m) {
@@ -257,11 +257,11 @@ void GJRGARCHModelTest::testDAXCalibration() {
                                                   new SimpleQuote(v[s*8+m])));
 
             Period maturity((int)((t[m]+3)/7.), Weeks); // round to weeks
-            options.push_back(ext::shared_ptr<CalibrationHelper>(
+            options.push_back(ext::shared_ptr<BlackCalibrationHelper>(
                     new HestonModelHelper(maturity, calendar,
                                           s0->value(), strike[s], vol,
                                           riskFreeTS, dividendTS, 
-                                          CalibrationHelper::ImpliedVolError)));
+                                          BlackCalibrationHelper::ImpliedVolError)));
         }
     }
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -66,7 +66,7 @@ namespace {
     struct CalibrationMarketData {
         Handle<Quote> s0;
         Handle<YieldTermStructure> riskFreeTS, dividendYield;
-        std::vector<ext::shared_ptr<CalibrationHelper> > options;
+        std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
     };
 
     CalibrationMarketData getDAXCalibrationMarketData() {
@@ -119,7 +119,7 @@ namespace {
         Real strike[] = { 3400,3600,3800,4000,4200,4400,
                           4500,4600,4800,5000,5200,5400,5600 };
         
-        std::vector<ext::shared_ptr<CalibrationHelper> > options;
+        std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
         
         for (Size s = 0; s < 13; ++s) {
             for (Size m = 0; m < 8; ++m) {
@@ -129,7 +129,7 @@ namespace {
                 options.push_back(ext::make_shared<HestonModelHelper>(maturity, calendar,
                                               s0, strike[s], vol,
                                               riskFreeTS, dividendYield,
-                                          CalibrationHelper::ImpliedVolError));
+                                          BlackCalibrationHelper::ImpliedVolError));
             }
         }
         
@@ -170,7 +170,7 @@ void HestonModelTest::testBlackCalibration() {
     optionMaturities.push_back(Period(1, Years));
     optionMaturities.push_back(Period(2, Years));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > options;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
     Handle<Quote> s0(ext::make_shared<SimpleQuote>(1.0));
     Handle<Quote> vol(ext::make_shared<SimpleQuote>(0.1));
     Volatility volatility = vol->value();
@@ -255,7 +255,7 @@ void HestonModelTest::testDAXCalibration() {
     const Handle<YieldTermStructure> dividendTS = marketData.dividendYield;
     const Handle<Quote> s0 = marketData.s0;
 
-    const std::vector<ext::shared_ptr<CalibrationHelper> > options
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > options
                                                     = marketData.options;
 
     const Real v0=0.1;
@@ -1167,7 +1167,7 @@ void HestonModelTest::testDAXCalibrationOfTimeDependentModel() {
     const Handle<YieldTermStructure> dividendTS = marketData.dividendYield;
     const Handle<Quote> s0 = marketData.s0;
 
-    const std::vector<ext::shared_ptr<CalibrationHelper> > options
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > options
                                                     = marketData.options;
 
     std::vector<Time> modelTimes;

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -1281,7 +1281,7 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
         0.303219,0.291534,0.286187,0.283073,0.280239,0.276414,0.270926,0.262173
     };
     
-    std::vector<ext::shared_ptr<CalibrationHelper> > options;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
     
     for (Size i=0; i < LENGTH(maturities); ++i) {
         const Period maturity((int)(maturities[i]*12.0+0.5), Months);
@@ -1297,10 +1297,10 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
                 strikes[j]));
             RelinkableHandle<Quote> v(ext::shared_ptr<Quote>(
                                    new SimpleQuote(vol[i*LENGTH(strikes)+j])));
-            options.push_back(ext::shared_ptr<CalibrationHelper>(
+            options.push_back(ext::shared_ptr<BlackCalibrationHelper>(
                 new HestonModelHelper(maturity, calendar, s0,
                                       strikes[j], v, rTS, qTS,
-                                      CalibrationHelper::PriceError)));
+                                      BlackCalibrationHelper::PriceError)));
             const Real marketValue = options.back()->marketValue();
             
             // Improve the quality of the starting point 
@@ -1363,10 +1363,10 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
                              new PlainVanillaPayoff(Option::Call, strikes[js]));
             Handle<Quote> v(ext::shared_ptr<Quote>(
                                    new SimpleQuote(vol[i*LENGTH(strikes)+js])));
-            options.push_back(ext::shared_ptr<CalibrationHelper>(
+            options.push_back(ext::shared_ptr<BlackCalibrationHelper>(
                 new HestonModelHelper(maturity, calendar, s0,
                                       strikes[js], v, rTS, qTS,
-                                      CalibrationHelper::PriceError)));
+                                      BlackCalibrationHelper::PriceError)));
             
             options.back()->setPricingEngine(engine);
         }

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -288,7 +288,7 @@ void LiborMarketModelTest::testCalibration() {
     DayCounter dayCounter=index->forwardingTermStructure()->dayCounter();
 
     // set-up calibration helper
-    std::vector<ext::shared_ptr<CalibrationHelper> > calibrationHelper;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > calibrationHelper;
 
     Size i;
     for (i=2; i < size; ++i) {
@@ -296,10 +296,10 @@ void LiborMarketModelTest::testCalibration() {
         Handle<Quote> capVol(
             ext::shared_ptr<Quote>(new SimpleQuote(capVols[i-2])));
 
-        ext::shared_ptr<CalibrationHelper> caphelper(
+        ext::shared_ptr<BlackCalibrationHelper> caphelper(
             new CapHelper(maturity, capVol, index, Annual,
                           index->dayCounter(), true, termStructure,
-                          CalibrationHelper::ImpliedVolError));
+                          BlackCalibrationHelper::ImpliedVolError));
 
         caphelper->setPricingEngine(ext::shared_ptr<PricingEngine>(
                            new AnalyticCapFloorEngine(model, termStructure)));
@@ -314,12 +314,12 @@ void LiborMarketModelTest::testCalibration() {
                     ext::shared_ptr<Quote>(
                         new SimpleQuote(swaptionVols[swapVolIndex++])));
 
-                ext::shared_ptr<CalibrationHelper> swaptionHelper(
+                ext::shared_ptr<BlackCalibrationHelper> swaptionHelper(
                     new SwaptionHelper(maturity, len, swaptionVol, index,
                                        index->tenor(), dayCounter,
                                        index->dayCounter(),
                                        termStructure,
-                                       CalibrationHelper::ImpliedVolError));
+                                       BlackCalibrationHelper::ImpliedVolError));
 
                 swaptionHelper->setPricingEngine(
                      ext::shared_ptr<PricingEngine>(

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1455,32 +1455,32 @@ void MarkovFunctionalTest::testCalibrationTwoInstrumentSets() {
 
     ext::shared_ptr<IborIndex> iborIndex1(new Euribor(6 * Months, flatYts_));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > calibrationHelper1;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > calibrationHelper1;
     std::vector<Real> calibrationHelperVols1;
     calibrationHelperVols1.push_back(0.20);
     calibrationHelperVols1.push_back(0.20);
     calibrationHelperVols1.push_back(0.20);
     calibrationHelperVols1.push_back(0.20);
 
-    calibrationHelper1.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(1 * Years, 4 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[0]))),
                            iborIndex1, 1 * Years, Thirty360(), Actual360(),
                            flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(2 * Years, 3 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[1]))),
                            iborIndex1, 1 * Years, Thirty360(), Actual360(),
                            flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(3 * Years, 2 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[2]))),
                            iborIndex1, 1 * Years, Thirty360(), Actual360(),
                            flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(4 * Years, 1 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[3]))),
@@ -1569,7 +1569,7 @@ void MarkovFunctionalTest::testCalibrationTwoInstrumentSets() {
             .withUpperRateBound(2.0)
             .withSmileMoneynessCheckpoints(money)));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > calibrationHelper2;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > calibrationHelper2;
     std::vector<Real> calibrationHelperVols2;
     calibrationHelperVols2.push_back(md0SwaptionVts_->volatility(
         1 * Years, 4 * Years,
@@ -1588,25 +1588,25 @@ void MarkovFunctionalTest::testCalibrationTwoInstrumentSets() {
         ext::dynamic_pointer_cast<SwaptionVolatilityCube>(
             md0SwaptionVts_.currentLink())->atmStrike(4 * Years, 1 * Years)));
 
-    calibrationHelper2.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(1 * Years, 4 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[0]))),
                            iborIndex2, 1 * Years, Thirty360(), Actual360(),
                            md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(2 * Years, 3 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[1]))),
                            iborIndex2, 1 * Years, Thirty360(), Actual360(),
                            md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(3 * Years, 2 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[2]))),
                            iborIndex2, 1 * Years, Thirty360(), Actual360(),
                            md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<CalibrationHelper>(
+    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(4 * Years, 1 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[3]))),

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -76,10 +76,10 @@ void ShortRateModelTest::testCachedHullWhite() {
     ext::shared_ptr<PricingEngine> engine(
                                          new JamshidianSwaptionEngine(model));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > swaptions;
     for (Size i=0; i<LENGTH(data); i++) {
         ext::shared_ptr<Quote> vol(new SimpleQuote(data[i].volatility));
-        ext::shared_ptr<CalibrationHelper> helper(
+        ext::shared_ptr<BlackCalibrationHelper> helper(
                              new SwaptionHelper(Period(data[i].start, Years),
                                                 Period(data[i].length, Years),
                                                 Handle<Quote>(vol),
@@ -151,10 +151,10 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
     ext::shared_ptr<PricingEngine> engine(
                                          new JamshidianSwaptionEngine(model));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > swaptions;
     for (Size i=0; i<LENGTH(data); i++) {
         ext::shared_ptr<Quote> vol(new SimpleQuote(data[i].volatility));
-        ext::shared_ptr<CalibrationHelper> helper(
+        ext::shared_ptr<BlackCalibrationHelper> helper(
                              new SwaptionHelper(Period(data[i].start, Years),
                                                 Period(data[i].length, Years),
                                                 Handle<Quote>(vol),
@@ -232,10 +232,10 @@ void ShortRateModelTest::testCachedHullWhite2() {
     ext::shared_ptr<PricingEngine> engine(
                                          new JamshidianSwaptionEngine(model));
 
-    std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
+    std::vector<ext::shared_ptr<BlackCalibrationHelper> > swaptions;
     for (Size i=0; i<LENGTH(data); i++) {
         ext::shared_ptr<Quote> vol(new SimpleQuote(data[i].volatility));
-        ext::shared_ptr<CalibrationHelper> helper(
+        ext::shared_ptr<BlackCalibrationHelper> helper(
                              new SwaptionHelper(Period(data[i].start, Years),
                                                 Period(data[i].length, Years),
                                                 Handle<Quote>(vol),


### PR DESCRIPTION
Ported from the (now outdated) `tenorbasis` branch.

This allows helpers not based on the Black model.

The name `CalibrationHelper` was too generic for the existing Black-based class, and was changed to `BlackCalibrationHelper`; the old name was kept as a deprecated typedef.

In a few releases, we can retire the `CalibrationHelper` name and give it to the new base class.