### PR TITLE
Remove deprecated std::unary_function and std::binary_function.

### DIFF
--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -73,8 +73,11 @@ namespace QuantLib {
     typedef std::vector<ext::shared_ptr<CashFlow> > Leg;
 
     template <>
-    struct earlier_than<CashFlow>
-            : public std::binary_function<CashFlow,CashFlow,bool> {
+    struct earlier_than<CashFlow> {
+        typedef CashFlow first_argument_type;
+        typedef CashFlow second_argument_type;
+        typedef bool result_type;
+
         bool operator()(const CashFlow& c1,
                         const CashFlow& c2) const {
             return c1.date() < c2.date();

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -1163,7 +1163,7 @@ namespace QuantLib {
     // Z-spread utility functions
     namespace {
 
-        class ZSpreadFinder : public std::unary_function<Rate, Real> {
+        class ZSpreadFinder {
           public:
             ZSpreadFinder(const Leg& leg,
                           const ext::shared_ptr<YieldTermStructure>& discountCurve,

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
         CashFlows();
         CashFlows(const CashFlows&);
 
-        class IrrFinder : public std::unary_function<Rate, Real> {
+        class IrrFinder {
           public:
             IrrFinder(const Leg& leg,
                       Real npv,

--- a/ql/cashflows/conundrumpricer.hpp
+++ b/ql/cashflows/conundrumpricer.hpp
@@ -149,7 +149,7 @@ namespace QuantLib {
 
             class ObjectiveFunction;
             friend class ObjectiveFunction;
-            class ObjectiveFunction : public std::unary_function<Real, Real> {
+            class ObjectiveFunction {
                 const GFunctionWithShifts& o_;
                 Real Rs_;
                 mutable Real derivative_;
@@ -261,8 +261,10 @@ namespace QuantLib {
        Real stdDeviations() { return stdDeviationsForUpperLimit_; }
 
       //private:
-        class Function : public std::unary_function<Real, Real> {
+        class Function {
           public:
+            typedef Real argument_type;
+            typedef Real result_type;
             virtual ~Function() {}
             virtual Real operator()(Real x) const = 0;
         };

--- a/ql/currencies/exchangeratemanager.cpp
+++ b/ql/currencies/exchangeratemanager.cpp
@@ -27,8 +27,7 @@ namespace QuantLib {
 
     namespace {
 
-        struct valid_at
-            : public std::unary_function<ExchangeRateManager::Entry,bool> {
+        struct valid_at {
             Date d;
             explicit valid_at(const Date& d) : d(d) {}
             bool operator()(const ExchangeRateManager::Entry& e) {

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -159,9 +159,7 @@ namespace QuantLib {
         //! Helper class for option adjusted spread calculations
         class NPVSpreadHelper;
         friend class NPVSpreadHelper;
-        class NPVSpreadHelper :
-            public std::unary_function<Real, Real>
-        {
+        class NPVSpreadHelper {
         public:
             explicit NPVSpreadHelper(CallableBond& bond);
             Real operator()(Spread x) const;

--- a/ql/experimental/credit/defaultevent.hpp
+++ b/ql/experimental/credit/defaultevent.hpp
@@ -185,8 +185,7 @@ namespace QuantLib {
     }
 
     template<>
-    struct earlier_than<DefaultEvent>
-        : public std::binary_function<DefaultEvent, DefaultEvent, bool> {
+    struct earlier_than<DefaultEvent> {
         bool operator()(const DefaultEvent& e1,
                         const DefaultEvent& e2) const {
             return e1.date() < e2.date();

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -174,8 +174,7 @@ namespace QuantLib {
         Real CumGen4thDerivative(const Date& date, Real s) const;
         
         // -------- Saddle point search functions ---------------------------
-        class SaddleObjectiveFunction : 
-            public std::unary_function<Real, Real> {
+        class SaddleObjectiveFunction {
             const SaddlePointLossModel& me_;
             Real targetValue_;
             const std::vector<Real>& mktFactor_;
@@ -224,7 +223,7 @@ namespace QuantLib {
             Natural maxEvaluations = 50
             ) const;
 
-        class SaddlePercObjFunction : public std::unary_function<Real, Real> {
+        class SaddlePercObjFunction {
             const SaddlePointLossModel& me_;
             Real targetValue_;
             Date date_;

--- a/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
+++ b/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
@@ -61,8 +61,7 @@ namespace QuantLib {
 
         };
 
-        class LessButNotCloseEnough
-                : public std::binary_function<Real, Real, bool> {
+        class LessButNotCloseEnough {
           public:
             bool operator()(Real a, Real b) const {
                 return !(close_enough(a, b, 100) || b < a);

--- a/ql/experimental/finitedifferences/hestonrndcalculator.cpp
+++ b/ql/experimental/finitedifferences/hestonrndcalculator.cpp
@@ -64,8 +64,7 @@ namespace {
                   + p.sigma*p.sigma*std::complex<Real>(p_x*p_x, -p_x));
         }
 
-        class CpxPv_Helper
-            : public std::unary_function<Real, Real > {
+        class CpxPv_Helper {
           public:
             CpxPv_Helper(const HestonParams& p, Real x, Time t)
               : p_(p), t_(t), x_(x),

--- a/ql/experimental/math/convolvedstudentt.hpp
+++ b/ql/experimental/math/convolvedstudentt.hpp
@@ -58,8 +58,7 @@ namespace QuantLib {
         independent Student t-random vectors' C.Berg, C.Vignat; June 2009;
         eprint arXiv:0906.3037
     */
-    class CumulativeBehrensFisher // ODD orders only by now, rename?
-        : public std::unary_function<Real, Probability> {
+    class CumulativeBehrensFisher { // ODD orders only by now, rename?
     public:
         typedef Probability result_type;
         typedef Real argument_type;
@@ -161,8 +160,7 @@ namespace QuantLib {
     is used.
     Also the fact that the combination is symmetric is used.
      */
-    class InverseCumulativeBehrensFisher
-        : public std::unary_function<Probability, Real> {
+    class InverseCumulativeBehrensFisher {
     public:
         typedef Real result_type;
         typedef Probability argument_type;

--- a/ql/experimental/mcbasket/pathpayoff.hpp
+++ b/ql/experimental/mcbasket/pathpayoff.hpp
@@ -33,7 +33,7 @@
 namespace QuantLib {
 
     //! Abstract base class for path-dependent option payoffs
-    class PathPayoff : std::unary_function<Matrix, Disposable<Array> > {
+    class PathPayoff {
       public:
         virtual ~PathPayoff() {}
         //! \name Payoff interface

--- a/ql/experimental/models/normalclvmodel.hpp
+++ b/ql/experimental/models/normalclvmodel.hpp
@@ -75,7 +75,7 @@ namespace QuantLib {
         void performCalculations() const;
 
       private:
-        class MappingFunction : public std::binary_function<Time, Real, Real> {
+        class MappingFunction {
           public:
             explicit MappingFunction(const NormalCLVModel& model);
 

--- a/ql/experimental/models/squarerootclvmodel.hpp
+++ b/ql/experimental/models/squarerootclvmodel.hpp
@@ -68,7 +68,7 @@ namespace QuantLib {
         void performCalculations() const;
 
       private:
-        class MappingFunction : public std::binary_function<Time, Real, Real> {
+        class MappingFunction {
           public:
             explicit MappingFunction(const SquareRootCLVModel& model);
 

--- a/ql/experimental/variancegamma/analyticvariancegammaengine.cpp
+++ b/ql/experimental/variancegamma/analyticvariancegammaengine.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
 
     namespace {
 
-        class Integrand : std::unary_function<Real,Real> {
+        class Integrand {
         public:
             Integrand(const ext::shared_ptr<StrikedTypePayoff>& payoff,
                 Real s0, Real t, Real riskFreeDiscount, Real dividendDiscount,

--- a/ql/math/abcdmathfunction.hpp
+++ b/ql/math/abcdmathfunction.hpp
@@ -32,9 +32,12 @@ namespace QuantLib {
     //! %Abcd functional form
     /*! \f[ f(t) = [ a + b*t ] e^{-c*t} + d \f]
         following Rebonato's notation. */
-    class AbcdMathFunction : public std::unary_function<Time, Real> {
+    class AbcdMathFunction {
 
       public:
+        typedef Time argument_type;
+        typedef Real result_type;
+
         AbcdMathFunction(Real a = 0.002,
                          Real b = 0.001, 
                          Real c = 0.16,

--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -104,10 +104,11 @@ namespace QuantLib {
     /* partial specialization for shared pointers, forwarding to their
        pointees. */
     template <class T>
-    struct earlier_than<ext::shared_ptr<T> >
-        : std::binary_function<ext::shared_ptr<T>,
-                               ext::shared_ptr<T>,
-                               bool> {
+    struct earlier_than<ext::shared_ptr<T> > {
+        typedef ext::shared_ptr<T> first_argument_type;
+        typedef ext::shared_ptr<T> second_argument_type;
+        typedef bool result_type;
+
         bool operator()(const ext::shared_ptr<T>& x,
                         const ext::shared_ptr<T>& y) const {
             return earlier_than<T>()(*x,*y);

--- a/ql/math/copulas/alimikhailhaqcopula.hpp
+++ b/ql/math/copulas/alimikhailhaqcopula.hpp
@@ -31,8 +31,12 @@
 namespace QuantLib {
 
     //! Ali-Mikhail-Haq copula
-    class AliMikhailHaqCopula : public std::binary_function<Real,Real,Real> {
+    class AliMikhailHaqCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         AliMikhailHaqCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/claytoncopula.hpp
+++ b/ql/math/copulas/claytoncopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! Clayton copula
-    class ClaytonCopula : public std::binary_function<Real,Real,Real> {
+    class ClaytonCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         ClaytonCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/farliegumbelmorgensterncopula.hpp
+++ b/ql/math/copulas/farliegumbelmorgensterncopula.hpp
@@ -30,9 +30,12 @@
 namespace QuantLib {
 
     //! Farlie-Gumbel-Morgenstern copula
-    class FarlieGumbelMorgensternCopula
-                                : public std::binary_function<Real,Real,Real> {
+    class FarlieGumbelMorgensternCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         FarlieGumbelMorgensternCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/frankcopula.hpp
+++ b/ql/math/copulas/frankcopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! Frank copula
-    class FrankCopula : public std::binary_function<Real,Real,Real> {
+    class FrankCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         FrankCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/galamboscopula.hpp
+++ b/ql/math/copulas/galamboscopula.hpp
@@ -31,8 +31,12 @@
 namespace QuantLib {
 
     //! Galambos copula
-    class GalambosCopula : public std::binary_function<Real,Real,Real> {
+    class GalambosCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         GalambosCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/gaussiancopula.hpp
+++ b/ql/math/copulas/gaussiancopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! Gaussian copula
-    class GaussianCopula : public std::binary_function<Real,Real,Real> {
+    class GaussianCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         GaussianCopula(Real rho);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/gumbelcopula.hpp
+++ b/ql/math/copulas/gumbelcopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! Gumbel copula
-    class GumbelCopula : public std::binary_function<Real,Real,Real> {
+    class GumbelCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         GumbelCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/huslerreisscopula.hpp
+++ b/ql/math/copulas/huslerreisscopula.hpp
@@ -31,8 +31,12 @@
 namespace QuantLib {
 
     //! Husler-Reiss copula
-    class HuslerReissCopula : public std::binary_function<Real,Real,Real> {
+    class HuslerReissCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         HuslerReissCopula(Real theta_);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/independentcopula.hpp
+++ b/ql/math/copulas/independentcopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! independent copula
-    class IndependentCopula : public std::binary_function<Real,Real,Real> {
+    class IndependentCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         Real operator()(Real x, Real y) const;
     };
     

--- a/ql/math/copulas/marshallolkincopula.hpp
+++ b/ql/math/copulas/marshallolkincopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! Marshall-Olkin copula
-    class MarshallOlkinCopula : public std::binary_function<Real,Real,Real> {
+    class MarshallOlkinCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         MarshallOlkinCopula(Real a1, Real a2);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/copulas/maxcopula.hpp
+++ b/ql/math/copulas/maxcopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! max copula
-    class MaxCopula : public std::binary_function<Real,Real,Real> {
+    class MaxCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         Real operator()(Real x, Real y) const;
     };
     

--- a/ql/math/copulas/mincopula.hpp
+++ b/ql/math/copulas/mincopula.hpp
@@ -30,8 +30,12 @@
 namespace QuantLib {
 
     //! min copula
-    class MinCopula : public std::binary_function<Real,Real,Real> {
+    class MinCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         Real operator()(Real x, Real y) const;
     };
     

--- a/ql/math/copulas/plackettcopula.hpp
+++ b/ql/math/copulas/plackettcopula.hpp
@@ -31,8 +31,12 @@
 namespace QuantLib {
 
     //! Plackett copula
-    class PlackettCopula : public std::binary_function<Real,Real,Real> {
+    class PlackettCopula {
       public:
+        typedef Real first_argument_type;
+        typedef Real second_argument_type;
+        typedef Real result_type;
+
         PlackettCopula(Real theta);
         Real operator()(Real x, Real y) const;
       private:

--- a/ql/math/curve.hpp
+++ b/ql/math/curve.hpp
@@ -30,13 +30,16 @@
 namespace QuantLib {
 
     //! abstract curve class
-    class Curve : public std::unary_function<Real, Real> {
+    class Curve {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
         virtual ~Curve() {}
         virtual Real operator()(Real x) const = 0;
     };
 
-    class TestCurve : public Curve {
+    /*! \deprecated Deprecated in version 1.14 */
+    class QL_DEPRECATED TestCurve : public Curve {
     public:
         Real operator()(Real x) const { return std::sin(x); }
     };

--- a/ql/math/distributions/binomialdistribution.hpp
+++ b/ql/math/distributions/binomialdistribution.hpp
@@ -48,8 +48,11 @@ namespace QuantLib {
         Given an integer k it returns its probability in a Binomial
         distribution with parameters p and n.
     */
-    class BinomialDistribution : public std::unary_function<Real,Real> {
+    class BinomialDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         BinomialDistribution(Real p, BigNatural n);
         // function
         Real operator()(BigNatural k) const;
@@ -64,9 +67,11 @@ namespace QuantLib {
         formula here ...
 
     */
-    class CumulativeBinomialDistribution
-    : public std::unary_function<Real,Real> {
+    class CumulativeBinomialDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativeBinomialDistribution(Real p, BigNatural n);
         // function
         Real operator()(BigNatural k) const {

--- a/ql/math/distributions/chisquaredistribution.hpp
+++ b/ql/math/distributions/chisquaredistribution.hpp
@@ -30,9 +30,11 @@
 
 namespace QuantLib {
 
-    class CumulativeChiSquareDistribution
-        : public std::unary_function<Real,Real> {
+    class CumulativeChiSquareDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativeChiSquareDistribution(Real df) : df_(df) {}
         Real operator()(Real x) const;
       private:
@@ -45,9 +47,11 @@ namespace QuantLib {
     QL_DEPRECATED
     typedef CumulativeChiSquareDistribution ChiSquareDistribution;
 
-    class NonCentralCumulativeChiSquareDistribution
-        : public std::unary_function<Real,Real> {
+    class NonCentralCumulativeChiSquareDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         NonCentralCumulativeChiSquareDistribution(Real df, Real ncp)
         : df_(df), ncp_(ncp) {}
         Real operator()(Real x) const;
@@ -61,9 +65,11 @@ namespace QuantLib {
     QL_DEPRECATED
     typedef NonCentralCumulativeChiSquareDistribution NonCentralChiSquareDistribution;
 
-    class InverseNonCentralCumulativeChiSquareDistribution
-        : public std::unary_function<Real,Real> {
+    class InverseNonCentralCumulativeChiSquareDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         InverseNonCentralCumulativeChiSquareDistribution(Real df, Real ncp,
                                                Size maxEvaluations=10,
                                                Real accuracy = 1e-8);

--- a/ql/math/distributions/gammadistribution.hpp
+++ b/ql/math/distributions/gammadistribution.hpp
@@ -30,9 +30,11 @@
 
 namespace QuantLib {
 
-    class CumulativeGammaDistribution
-        : public std::unary_function<Real,Real> {
+    class CumulativeGammaDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativeGammaDistribution(Real a) : a_(a) {
             QL_REQUIRE(a>0.0, "invalid parameter for gamma distribution");
         }
@@ -60,8 +62,11 @@ namespace QuantLib {
         \test the correctness of the returned value is tested by
               checking it against known good results.
     */
-    class GammaFunction : public std::unary_function<Real,Real> {
+    class GammaFunction {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         Real value(Real x) const;
         Real logValue(Real x) const;
       private:

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -41,8 +41,11 @@ namespace QuantLib {
               CumulativeNormalDistribution and InverseCumulativeNormal
               classes.
     */
-    class NormalDistribution : public std::unary_function<Real,Real> {
+    class NormalDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         NormalDistribution(Real average = 0.0,
                            Real sigma = 1.0);
         // function
@@ -65,9 +68,11 @@ namespace QuantLib {
         Handbook of Mathematical Functions,
         Dover Publications, New York (1972)
     */
-    class CumulativeNormalDistribution
-    : public std::unary_function<Real,Real> {
+    class CumulativeNormalDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativeNormalDistribution(Real average = 0.0,
                                      Real sigma   = 1.0);
         // function
@@ -98,9 +103,11 @@ namespace QuantLib {
       variants would not preserve the sequence's low-discrepancy.
 
     */
-    class InverseCumulativeNormal
-        : public std::unary_function<Real,Real> {
+    class InverseCumulativeNormal {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         InverseCumulativeNormal(Real average = 0.0,
                                 Real sigma   = 1.0);
         // function
@@ -197,9 +204,11 @@ namespace QuantLib {
         Peter J. Acklam's approximation is better and is available
         as QuantLib::InverseCumulativeNormal
     */
-    class MoroInverseCumulativeNormal
-    : public std::unary_function<Real,Real> {
+    class MoroInverseCumulativeNormal {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         MoroInverseCumulativeNormal(Real average = 0.0,
                                     Real sigma   = 1.0);
         // function
@@ -238,9 +247,11 @@ namespace QuantLib {
          insufficient accuracy compared to the epsilon for type double,
          do we clean up the result using Halley iteration.
     */
-    class MaddockInverseCumulativeNormal
-    : public std::unary_function<Real,Real> {
+    class MaddockInverseCumulativeNormal {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         MaddockInverseCumulativeNormal(Real average = 0.0,
                                        Real sigma   = 1.0);
         Real operator()(Real x) const;
@@ -250,8 +261,11 @@ namespace QuantLib {
     };
 
     //! Maddock's cumulative normal distribution class
-    class MaddockCumulativeNormal : public std::unary_function<Real,Real> {
+    class MaddockCumulativeNormal {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         MaddockCumulativeNormal(Real average = 0.0,
                                        Real sigma   = 1.0);
         Real operator()(Real x) const;

--- a/ql/math/distributions/poissondistribution.hpp
+++ b/ql/math/distributions/poissondistribution.hpp
@@ -37,8 +37,11 @@ namespace QuantLib {
         \test the correctness of the returned value is tested by
               checking it against known good results.
     */
-    class PoissonDistribution : public std::unary_function<Real,Real> {
+    class PoissonDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         PoissonDistribution(Real mu);
         // function
         Real operator()(BigNatural k) const;
@@ -58,9 +61,11 @@ namespace QuantLib {
         \test the correctness of the returned value is tested by
               checking it against known good results.
     */
-    class CumulativePoissonDistribution
-        : public std::unary_function<Real,Real> {
+    class CumulativePoissonDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativePoissonDistribution(Real mu) : mu_(mu) {}
         Real operator()(BigNatural k) const {
             return 1.0 - incompleteGammaFunction(k+1, mu_);
@@ -74,8 +79,11 @@ namespace QuantLib {
     /*! \test the correctness of the returned value is tested by
               checking it against known good results.
     */
-    class InverseCumulativePoisson : public std::unary_function<Real,Real> {
+    class InverseCumulativePoisson {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         InverseCumulativePoisson(Real lambda = 1.0);
         Real operator()(Real x) const;
       private:

--- a/ql/math/distributions/studenttdistribution.hpp
+++ b/ql/math/distributions/studenttdistribution.hpp
@@ -39,8 +39,11 @@ namespace QuantLib {
         \frac {1} {\left(1+\frac{x^2}{n}\right)^{(n+1)/2}}
         \f]
     */
-    class StudentDistribution : public std::unary_function<Real,Real> {
+    class StudentDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         StudentDistribution(Integer n) : n_(n) {
             QL_REQUIRE(n > 0, "invalid parameter for t-distribution");
         }
@@ -61,9 +64,11 @@ namespace QuantLib {
         \f]
         where \f$ I(z; a, b) \f$ is the regularized incomplete beta function.
     */
-    class CumulativeStudentDistribution
-        : public std::unary_function<Real,Real> {
+    class CumulativeStudentDistribution {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         CumulativeStudentDistribution(Integer n) : n_(n) {
             QL_REQUIRE(n > 0, "invalid parameter for t-distribution");
         }
@@ -77,9 +82,11 @@ namespace QuantLib {
               cumulative Student t-distribution, replacing the Newton
               iteration
     */
-    class InverseCumulativeStudent
-        : public std::unary_function<Real,Real> {
+    class InverseCumulativeStudent {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         InverseCumulativeStudent(Integer n,
                                  Real accuracy = 1e-6,
                                  Size maxIterations = 50)

--- a/ql/math/errorfunction.hpp
+++ b/ql/math/errorfunction.hpp
@@ -33,8 +33,11 @@ namespace QuantLib {
     /*! formula here ...
         Used to calculate the cumulative normal distribution function
     */
-    class ErrorFunction : public std::unary_function<Real,Real> {
+    class ErrorFunction {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         ErrorFunction() {}
         // function
         Real operator()(Real x) const;

--- a/ql/math/functional.hpp
+++ b/ql/math/functional.hpp
@@ -34,8 +34,10 @@ namespace QuantLib {
     // functions
 
     template <class T, class U>
-    class constant : public std::unary_function<T,U> {
+    class constant {
       public:
+        typedef T argument_type;
+        typedef U result_type;
         constant(const U& u) : u_(u) {}
         U operator()(const T&) const { return u_; }
       private:
@@ -43,113 +45,153 @@ namespace QuantLib {
     };
 
     template <class T>
-    class identity : public std::unary_function<T,T> {
+    class identity {
       public:
+        typedef T argument_type;
+        typedef T result_type;
         T operator()(const T& t) const { return t; }
     };
 
     template <class T>
-    class square : public std::unary_function<T,T> {
+    class square {
       public:
+        typedef T argument_type;
+        typedef T result_type;
         T operator()(const T& t) const { return t*t; }
     };
 
     template <class T>
-    class cube : public std::unary_function<T,T> {
+    class cube {
       public:
+        typedef T argument_type;
+        typedef T result_type;
         T operator()(const T& t) const { return t*t*t; }
     };
 
     template <class T>
-    class fourth_power : public std::unary_function<T,T> {
+    class fourth_power {
       public:
+        typedef T argument_type;
+        typedef T result_type;
         T operator()(const T& t) const { T t2 = t*t; return t2*t2; }
     };
 
     // a few shortcuts for common binders
 
     template <class T>
-    class add : public std::unary_function<T,T> {
+    class add {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit add(Real y) : y(y) {}
         Real operator()(T x) const { return x + y; }
     };
 
     template <class T>
-    class subtract : public std::unary_function<T,T> {
+    class subtract {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit subtract(Real y) : y(y) {}
         Real operator()(T x) const { return x - y; }
     };
 
     template <class T>
-    class subtract_from : public std::unary_function<T,T> {
+    class subtract_from {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit subtract_from(Real y) : y(y) {}
         Real operator()(T x) const { return y - x; }
     };
 
     template <class T>
-    class multiply_by : public std::unary_function<T,T> {
+    class multiply_by {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit multiply_by(Real y) : y(y) {}
         Real operator()(T x) const { return x * y; }
     };
 
     template <class T>
-    class divide : public std::unary_function<T,T> {
+    class divide {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit divide(Real y) : y(y) {}
         Real operator()(T x) const { return y / x; }
     };
 
     template <class T>
-    class divide_by : public std::unary_function<T,T> {
+    class divide_by {
         T y;
       public:
+        typedef T argument_type;
+        typedef Real result_type;
+
         explicit divide_by(Real y) : y(y) {}
         Real operator()(T x) const { return x / y; }
     };
 
     template <class T>
-    class less_than : public std::unary_function<T,bool> {
+    class less_than {
         T y;
       public:
+        typedef T argument_type;
+        typedef bool result_type;
+
         explicit less_than(Real y) : y(y) {}
         bool operator()(T x) const { return x < y; }
     };
 
     template <class T>
-    class greater_than : public std::unary_function<T,bool> {
+    class greater_than {
         T y;
       public:
+        typedef T argument_type;
+        typedef bool result_type;
+
         explicit greater_than(Real y) : y(y) {}
         bool operator()(T x) const { return x > y; }
     };
 
     template <class T>
-    class greater_or_equal_to : public std::unary_function<T,bool> {
+    class greater_or_equal_to {
         T y;
       public:
+        typedef T argument_type;
+        typedef bool result_type;
+
         explicit greater_or_equal_to(Real y) : y(y) {}
         bool operator()(T x) const { return x >= y; }
     };
 
     template <class T>
-    class not_zero : public std::unary_function<T,bool> {
+    class not_zero {
       public:
+        typedef T argument_type;
+        typedef bool result_type;
         bool operator()(T x) const { return x != T(); }
     };
 
     template <class T>
-    class not_null : public std::unary_function<T,bool> {
+    class not_null {
         T null;
       public:
+        typedef T argument_type;
+        typedef bool result_type;
+
         not_null() : null(Null<T>()) {}
         bool operator()(T x) const { return x != null; }
     };
@@ -167,10 +209,14 @@ namespace QuantLib {
     };
 
     template <class T>
-    class equal_within : public std::binary_function<T, T, bool> {
+    class equal_within {
       public:
+        typedef T first_argument_type;
+        typedef T second_argument_type;
+        typedef bool result_type;
+
         equal_within(const T& eps) : eps_(eps) {}
-        bool operator()(const T a, const T b) const {
+        bool operator()(const T& a, const T& b) const {
             return std::fabs(a-b) <= eps_;
         }
       private:
@@ -218,10 +264,7 @@ namespace QuantLib {
     }
 
     template <class F, class G, class H>
-    class binary_compose3_function :
-        public std::binary_function<typename G::argument_type,
-                                    typename H::argument_type,
-                                    typename F::result_type>{
+    class binary_compose3_function {
       public:
         typedef typename G::argument_type first_argument_type;
         typedef typename H::argument_type second_argument_type;

--- a/ql/math/interpolations/multicubicspline.hpp
+++ b/ql/math/interpolations/multicubicspline.hpp
@@ -230,8 +230,10 @@ namespace QuantLib {
 
         // no heap memory is allocated
         // in any of the recursive calls
-        class base_cubic_spline : public std::unary_function<Real,Real> {
+        class base_cubic_spline {
           public:
+            typedef Real argument_type;
+            typedef Real result_type;
             typedef base_data data;
             typedef base_data_table data_table;
             typedef base_output_data output_data;
@@ -277,8 +279,10 @@ namespace QuantLib {
             output_data &v_;
         };
 
-        class base_cubic_splint : public std::unary_function<base_arg_type,Real> {
+        class base_cubic_splint {
           public:
+            typedef base_arg_type argument_type;
+            typedef Real result_type;
             typedef base_data data;
             typedef base_data_table data_table;
             typedef base_dimensions dimensions;
@@ -297,23 +301,22 @@ namespace QuantLib {
         };
 
         template<class X>
-        class n_cubic_splint : public
-        std::unary_function<Point<Real, typename X::argument_type>, Real> {
+        class n_cubic_splint {
           public:
-            typedef std::unary_function<Point<Real, typename X::argument_type>,
-                                        Real> super;
+            typedef Point<Real, typename X::argument_type> argument_type;
+            typedef Real result_type;
             typedef Data<base_data, typename X::data> data;
             typedef DataTable<typename X::data_table> data_table;
             typedef Point<Size, typename X::dimensions> dimensions;
             typedef Point<base_output_data, typename X::output_data> output_data;
-            typedef Point<typename super::result_type,
+            typedef Point<result_type,
                           typename X::return_type> return_type;
             n_cubic_splint(const return_type &a, const return_type &b,
                            const return_type &a2, const return_type &b2,
                            const dimensions &i, const data &d, const data &d2,
                            const data_table &y, data_table &y2, output_data &v,
                            output_data &v1, output_data &v2,
-                           typename super::result_type& r)
+                           result_type& r)
             :  a_(a), b_(b), a2_(a2), b2_(b2), i_(i), d_(d), d2_(d2),
                y_(y), y2_(y2), v_(v), v1_(v1), v2_(v2) {
                 for(Size j = 0, dim = y_.size(); j < dim; ++j)

--- a/ql/math/linearleastsquaresregression.hpp
+++ b/ql/math/linearleastsquaresregression.hpp
@@ -34,8 +34,10 @@ namespace QuantLib {
     namespace details {
 
         template <class Container>
-        class LinearFct : public std::unary_function<Real, Container > {
+        class LinearFct {
           public:
+            typedef Container argument_type;
+            typedef Real result_type;
             explicit LinearFct(Size i) : i_(i) {}
 
             inline Real operator()(const Container& x) const {

--- a/ql/math/polynomialmathfunction.hpp
+++ b/ql/math/polynomialmathfunction.hpp
@@ -29,9 +29,12 @@ namespace QuantLib {
     
     //! %Cubic functional form
     /*! \f[ f(t) = \sum_{i=0}^n{c_i t^i} \f] */
-    class PolynomialFunction : public std::unary_function<Time, Real> {
+    class PolynomialFunction {
 
       public:
+        typedef Time argument_type;
+        typedef Real result_type;
+
         PolynomialFunction(const std::vector<Real>& coeff);
 
         //! function value at time t: \f[ f(t) = \sum_{i=0}^n{c_i t^i} \f]

--- a/ql/math/randomnumbers/stochasticcollocationinvcdf.hpp
+++ b/ql/math/randomnumbers/stochasticcollocationinvcdf.hpp
@@ -41,8 +41,11 @@ namespace QuantLib {
         http://papers.ssrn.com/sol3/papers.cfm?abstract_id=2529691
      */
 
-    class StochasticCollocationInvCDF : public std::unary_function<Real,Real> {
+    class StochasticCollocationInvCDF {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         StochasticCollocationInvCDF(
             const boost::function<Real(Real)>& invCDF,
             Size lagrangeOrder,

--- a/ql/methods/finitedifferences/operators/numericaldifferentiation.hpp
+++ b/ql/methods/finitedifferences/operators/numericaldifferentiation.hpp
@@ -39,8 +39,11 @@ namespace QuantLib {
         on Arbitrarily Spaced Grids,
         http://amath.colorado.edu/faculty/fornberg/Docs/MathComp_88_FD_formulas.pdf
     */
-    class NumericalDifferentiation : public std::unary_function<Real, Real> {
+    class NumericalDifferentiation {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         enum Scheme { Central, Backward, Forward };
 
         NumericalDifferentiation(

--- a/ql/methods/montecarlo/lsmbasissystem.cpp
+++ b/ql/methods/montecarlo/lsmbasissystem.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
             &GaussianOrthogonalPolynomial::weightedValue;
 
         // pow(x, order)
-        class MonomialFct : public std::unary_function<Real, Real> {
+        class MonomialFct {
           public:
             explicit MonomialFct(Size order): order_(order) {}
             inline Real operator()(const Real x) const {
@@ -66,7 +66,7 @@ namespace QuantLib {
 
         /* multiplies [Real -> Real] functors
            to create [Array -> Real] functor */
-        class MultiDimFct : public std::unary_function<Real, Array> {
+        class MultiDimFct {
           public:
             explicit MultiDimFct(const VF_R& b): b_(b) {
                 QL_REQUIRE(b_.size()>0, "zero size basis");

--- a/ql/methods/montecarlo/pathpricer.hpp
+++ b/ql/methods/montecarlo/pathpricer.hpp
@@ -37,8 +37,11 @@ namespace QuantLib {
         \ingroup mcarlo
     */
     template<class PathType, class ValueType=Real>
-    class PathPricer : public std::unary_function<PathType, ValueType> {
+    class PathPricer {
       public:
+        typedef PathType argument_type;
+        typedef ValueType result_type;
+
         virtual ~PathPricer() {}
         virtual ValueType operator()(const PathType& path) const=0;
     };

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -164,8 +164,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
         }
     };
 
-    struct CachedSwapKeyHasher
-        : std::unary_function<CachedSwapKey, std::size_t> {
+    struct CachedSwapKeyHasher {
         std::size_t operator()(CachedSwapKey const &x) const {
             std::size_t seed = 0;
             boost::hash_combine(seed, x.index->name());

--- a/ql/payoff.hpp
+++ b/ql/payoff.hpp
@@ -33,8 +33,11 @@
 namespace QuantLib {
 
     //! Abstract base class for option payoffs
-    class Payoff : std::unary_function<Real,Real> {
+    class Payoff {
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         virtual ~Payoff() {}
         //! \name Payoff interface
         //@{

--- a/ql/pricingengines/forward/mcvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/mcvarianceswapengine.hpp
@@ -316,7 +316,7 @@ namespace QuantLib {
 
     namespace detail {
 
-        class Integrand : std::unary_function<Real,Real> {
+        class Integrand {
           public:
             Integrand(const Path& path,
                       const ext::shared_ptr<GeneralizedBlackScholesProcess>&

--- a/ql/pricingengines/vanilla/analytich1hwengine.cpp
+++ b/ql/pricingengines/vanilla/analytich1hwengine.cpp
@@ -26,8 +26,7 @@
 
 namespace QuantLib {
     // integration helper class
-    class AnalyticH1HWEngine::Fj_Helper
-        : public std::unary_function<std::complex<Real>, Real> {
+    class AnalyticH1HWEngine::Fj_Helper {
 
       public:
         Fj_Helper(const Handle<HestonModel>& hestonModel,

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -84,7 +84,7 @@ namespace QuantLib {
             Real operator()(Real x) const { return int_(1.0-x); }
         };
 
-        class u_Max : public std::unary_function<Real, Real> {
+        class u_Max {
           public:
             u_Max(Real c_inf, Real epsilon)
             : c_inf_(c_inf), logEpsilon_(std::log(epsilon)),
@@ -103,7 +103,7 @@ namespace QuantLib {
         };
 
 
-        class uHat_Max : public std::unary_function<Real, Real> {
+        class uHat_Max {
           public:
             uHat_Max(Real v0T2, Real epsilon)
             : v0T2_(v0T2), logEpsilon_(std::log(epsilon)),
@@ -123,9 +123,7 @@ namespace QuantLib {
     }
 
     // helper class for integration
-    class AnalyticHestonEngine::Fj_Helper
-        : public std::unary_function<Real, Real>
-    {
+    class AnalyticHestonEngine::Fj_Helper {
     public:
         Fj_Helper(const VanillaOption::arguments& arguments,
             const ext::shared_ptr<HestonModel>& model,
@@ -368,8 +366,7 @@ namespace QuantLib {
     }
 
 
-    class AnalyticHestonEngine::AP_Helper
-        : public std::unary_function<Real, Real> {
+    class AnalyticHestonEngine::AP_Helper {
       public:
         AP_Helper(Time term, Real s0, Real strike, Real ratio,
                   Volatility sigmaBS,

--- a/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
@@ -29,9 +29,7 @@
 namespace QuantLib {
 
     // helper class for integration
-    class AnalyticPTDHestonEngine::Fj_Helper
-        : public std::unary_function<Real, Real> {
-            
+    class AnalyticPTDHestonEngine::Fj_Helper {
       public:
         Fj_Helper(
             const Handle<PiecewiseTimeDependentHestonModel>& model,
@@ -121,8 +119,7 @@ namespace QuantLib {
                 /phi; 
     }
 
-    class AnalyticPTDHestonEngine::AP_Helper
-        : public std::unary_function<Real, Real> {
+    class AnalyticPTDHestonEngine::AP_Helper {
       public:
         AP_Helper(Time term, Real s0, Real strike, Real ratio,
                   Volatility sigmaBS,

--- a/ql/pricingengines/vanilla/fddividendengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendengine.hpp
@@ -195,7 +195,7 @@ namespace QuantLib {
 
     namespace detail {
 
-        class DividendAdder : std::unary_function<Real,Real> {
+        class DividendAdder {
           private:
             const Dividend *dividend;
           public:

--- a/ql/pricingengines/vanilla/integralengine.cpp
+++ b/ql/pricingengines/vanilla/integralengine.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
 
     namespace {
 
-        class Integrand : std::unary_function<Real,Real> {
+        class Integrand {
           public:
             Integrand(const ext::shared_ptr<Payoff>& payoff,
                       Real s0,

--- a/ql/termstructures/volatility/abcd.hpp
+++ b/ql/termstructures/volatility/abcd.hpp
@@ -90,9 +90,12 @@ namespace QuantLib {
 
     
     // Helper class used by unit tests
-    class AbcdSquared : public std::unary_function<Real,Real> {
+    class AbcdSquared {
       
       public:
+        typedef Real argument_type;
+        typedef Real result_type;
+
         AbcdSquared(Real a, Real b, Real c, Real d, Time T, Time S);
         Real operator()(Time t) const;
       

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -25,7 +25,7 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
-class FSquared : std::unary_function<Real,Real> {
+class FSquared {
   public:
     Real operator()(Real x) const { return x*x; }
 };

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -638,7 +638,7 @@ void DistributionTest::testBivariateCumulativeStudentVsBivariate() {
     
 
 namespace {
-    class InverseNonCentralChiSquared : public std::unary_function<Real,Real> {
+    class InverseNonCentralChiSquared {
       public:
         InverseNonCentralChiSquared(Real df, Real ncp)
         : dist_(df, ncp) {}

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -141,7 +141,7 @@ namespace {
     };
 
     template <class T, class U, class V>
-    struct multiplies : public std::binary_function<T, U, V> {
+    struct multiplies {
         V operator()(T t, U u) { return t*u;}
     };
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -1846,8 +1846,7 @@ void HestonModelTest::testAllIntegrationMethods() {
 }
 
 namespace {
-    class LogCharacteristicFunction
-            : public std::unary_function<Real, Real> {
+    class LogCharacteristicFunction {
       public:
         LogCharacteristicFunction(
             Size n, Time t,

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -424,7 +424,7 @@ void HestonSLVModelTest::testTransformedZeroFlowBC() {
 }
 
 namespace {
-    class q_fct : public std::unary_function<Real, Real> {
+    class q_fct {
       public:
         q_fct(const Array& v, const Array& p, const Real alpha)
         : v_(v), q_(Pow(v, alpha)*p), alpha_(alpha),

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -171,7 +171,7 @@ namespace {
     }
 
     template <class F>
-    class errorFunction : public std::unary_function<Real,Real> {
+    class errorFunction {
       public:
         errorFunction(const F& f) : f_(f) {}
         Real operator()(Real x) const {

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -608,8 +608,7 @@ void MatricesTest::testMoorePenroseInverse() {
 }
 
 namespace {
-    class MatrixMult :
-        public std::unary_function<const Array&, Disposable<Array> > {
+    class MatrixMult {
       public:
         explicit MatrixMult(const Matrix& m) : m_(m) {}
         Disposable<Array> operator()(const Array& x) const {

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -470,7 +470,7 @@ namespace {
     };
 
 
-    class AvgPayoffFct : public std::unary_function<Real,Real> {
+    class AvgPayoffFct {
       public:
         AvgPayoffFct(const ext::shared_ptr<PlainVanillaPayoff>& payoff,
                      Volatility vol, Time T, Real growthFactor)

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -262,7 +262,7 @@ namespace {
         const ext::shared_ptr<YieldTermStructure> qTS_;
     };
 
-    class ProbWeightedPayoff : public std::unary_function<Real, Real> {
+    class ProbWeightedPayoff {
       public:
         ProbWeightedPayoff(
             Time t,

--- a/test-suite/sampledcurve.cpp
+++ b/test-suite/sampledcurve.cpp
@@ -26,7 +26,7 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
-class FSquared : std::unary_function<Real,Real> {
+class FSquared {
 public:
     Real operator()(Real x) const { return x*x;};
 };

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -199,6 +199,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -257,6 +258,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -316,6 +318,7 @@
       <CompileAs>Default</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -375,6 +378,7 @@
       <CompileAs>Default</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -430,6 +434,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -486,6 +491,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -543,6 +549,7 @@
       <CompileAs>Default</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -581,7 +588,7 @@
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;WIN32;_CONSOLE;_SCL_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;_CONSOLE;_SCL_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -602,6 +609,7 @@
       <CompileAs>Default</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -98,7 +98,7 @@ void TimeSeriesTest::testIntervalPrice() {
 namespace boost {
 
     template<>
-    struct hash<Date> : std::unary_function<Date, std::size_t> {
+    struct hash<Date> {
         size_t operator()(const Date& _Keyval) const {
             return boost::hash<Date::serial_type>()(_Keyval.serialNumber());
         }

--- a/test-suite/transformedgrid.cpp
+++ b/test-suite/transformedgrid.cpp
@@ -26,7 +26,7 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
-class PlusOne : std::unary_function<Real,Real> {
+class PlusOne {
 public:
     Real operator()(Real x) const { return x+1;};
 };


### PR DESCRIPTION
They were removed from C++17 and would cause compilation to fail in C++17 mode in VC++.  The typedefs added by the deprecated classes were added back for compatibility with C++03 (which can't use the intended replacement).

Fixes #539.
