### PR TITLE
Make QuantLib.spec file pass %check

### DIFF
--- a/QuantLib.spec.in
+++ b/QuantLib.spec.in
@@ -32,7 +32,6 @@ Summary: The header files and the static library.
 Group: Development/Libraries
 Requires: QuantLib = %{version}, boost >= 1.43.0
 BuildRequires: boost-devel >= 1.43.0
-BuildRequires: emacs
 
 %description devel
 QuantLib is an open source C++ library for financial quantitative analysts
@@ -77,7 +76,7 @@ You'll want to install this package if you need a reference to QuantLib.
 CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ; \
 CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ; \
 FFLAGS="${FFLAGS:-%optflags}" ; export FFLAGS ; \
-%configure --prefix=%{_prefix}
+%configure --prefix=%{_prefix} EMACS=no
 make %{?_smp_mflags}
 # make documentations
 cd Docs
@@ -119,7 +118,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/ql/
 %{_libdir}/*
 %{_datadir}/aclocal/*
-%{_datadir}/emacs/*
 %{_bindir}/quantlib-config
 %{_mandir}/man1/quantlib-config.1.gz
 

--- a/QuantLib.spec.in
+++ b/QuantLib.spec.in
@@ -118,6 +118,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/ql/
 %{_libdir}/*
 %{_datadir}/aclocal/*
+%{_datadir}/emacs/*
 %{_bindir}/quantlib-config
 %{_mandir}/man1/quantlib-config.1.gz
 
@@ -146,6 +147,6 @@ rm -rf $RPM_BUILD_ROOT
 - Modified Makefile.am and Makefile.in in Docs/:
     $(DVIPS) refman -> $(DVIPS) -o refman.ps refman
 
-* Tue Aug 22 2003 Liguo Song <liguo.song@vanderbilt.edu>
+* Fri Aug 22 2003 Liguo Song <liguo.song@vanderbilt.edu>
 - Initial package. Refer to Changelog.txt for previous changes.
 - RPM package beta test

--- a/QuantLib.spec.in
+++ b/QuantLib.spec.in
@@ -32,6 +32,7 @@ Summary: The header files and the static library.
 Group: Development/Libraries
 Requires: QuantLib = %{version}, boost >= 1.43.0
 BuildRequires: boost-devel >= 1.43.0
+BuildRequires: emacs
 
 %description devel
 QuantLib is an open source C++ library for financial quantitative analysts


### PR DESCRIPTION
Executing rpmbuild -ba QuantLib.spec executes %build and %install successfully but fails %check