### PR TITLE
allow fixing calendar selection in BMA index

### DIFF
--- a/ql/indexes/bmaindex.cpp
+++ b/ql/indexes/bmaindex.cpp
@@ -19,7 +19,6 @@
 
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/currencies/america.hpp>
-#include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 
 namespace QuantLib {
@@ -40,12 +39,13 @@ namespace QuantLib {
 
     }
 
-    BMAIndex::BMAIndex(const Handle<YieldTermStructure>& h)
+    BMAIndex::BMAIndex(const Handle<YieldTermStructure>& h,
+                       const Calendar& fixingCalendar)
     : InterestRateIndex("BMA",
                         1 * Weeks,
                         1,
                         USDCurrency(),
-                        UnitedStates(UnitedStates::NYSE),
+                        fixingCalendar,
                         ActualActual(ActualActual::ISDA)),
       termStructure_(h) {
         registerWith (h);

--- a/ql/indexes/bmaindex.hpp
+++ b/ql/indexes/bmaindex.hpp
@@ -27,6 +27,7 @@
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/indexes/interestrateindex.hpp>
 #include <ql/time/schedule.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
 
 namespace QuantLib {
 
@@ -40,7 +41,9 @@ namespace QuantLib {
     class BMAIndex : public InterestRateIndex {
       public:
         explicit BMAIndex(const Handle<YieldTermStructure>& h =
-                                                Handle<YieldTermStructure>());
+                                            Handle<YieldTermStructure>(),
+                          const Calendar& fixingCalendar =
+                                            UnitedStates(UnitedStates::NYSE));
         //! \name Index interface
         //@{
         /*! BMA is fixed weekly on Wednesdays.


### PR DESCRIPTION
Current `BMAIndex` implementation hard-codes `UnitedStates::NYSE` fixing calendar, which does not match the SIFMA holiday recommendations, see [https://www.sifma.org/resources/general/holiday-schedule/](https://www.sifma.org/resources/general/holiday-schedule/). The proposed change allows user to specify a holiday calendar, defaulting to the current value of `UnitedStates::NYSE` (note that QuantLib currently has no SIFMA holiday calendar implementation). Existing code will be unaffected by the change.