### PR TITLE
Don't rely on the inflation curve providing a nominal curve

### DIFF
--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -21,11 +21,20 @@
 
 namespace QuantLib {
 
-    CPICouponPricer::
-    CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol)
-    : capletVol_(capletVol) {
+    CPICouponPricer::CPICouponPricer() {}
 
-        if( !capletVol_.empty() ) registerWith(capletVol_);
+    CPICouponPricer::CPICouponPricer(
+                       const Handle<CPIVolatilitySurface>& capletVol)
+    : capletVol_(capletVol) {
+        registerWith(capletVol_);
+    }
+
+    CPICouponPricer::CPICouponPricer(
+                       const Handle<CPIVolatilitySurface>& capletVol,
+                       const Handle<YieldTermStructure>& nominalTermStructure)
+    : capletVol_(capletVol), nominalTermStructure_(nominalTermStructure) {
+        registerWith(capletVol_);
+        registerWith(nominalTermStructure_);
     }
 
 
@@ -48,13 +57,12 @@ namespace QuantLib {
     }
 
 
-    Rate CPICouponPricer::floorletRate(Rate effectiveFloor) const{
-        return floorletPrice(effectiveFloor)/
-        (coupon_->accrualPeriod()*discount_);
+    Rate CPICouponPricer::floorletRate(Rate effectiveFloor) const {
+        return gearing_ * optionletRate(Option::Put, effectiveFloor);
     }
 
     Rate CPICouponPricer::capletRate(Rate effectiveCap) const{
-        return capletPrice(effectiveCap)/(coupon_->accrualPeriod()*discount_);
+        return gearing_ * optionletRate(Option::Call, effectiveCap);
     }
 
 
@@ -67,7 +75,14 @@ namespace QuantLib {
 
 
     Real CPICouponPricer::optionletPrice(Option::Type optionType,
-                                                  Real effStrike) const {
+                                         Real effStrike) const {
+        QL_REQUIRE(discount_ != Null<Real>(), "no nominal term structure provided");
+        return optionletRate(optionType, effStrike) * coupon_->accrualPeriod() * discount_;
+    }
+
+
+    Real CPICouponPricer::optionletRate(Option::Type optionType,
+                                        Real effStrike) const {
         Date fixingDate = coupon_->fixingDate();
         if (fixingDate <= Settings::instance().evaluationDate()) {
             // the amount is determined
@@ -79,7 +94,7 @@ namespace QuantLib {
                 a = effStrike;
                 b = coupon_->indexFixing();
             }
-            return std::max(a - b, 0.0)* coupon_->accrualPeriod()*discount_;
+            return std::max(a - b, 0.0);
         } else {
             // not yet determined, use Black/DD1/Bachelier/whatever from Impl
             QL_REQUIRE(!capletVolatility().empty(),
@@ -87,11 +102,10 @@ namespace QuantLib {
             Real stdDev =
             std::sqrt(capletVolatility()->totalVariance(fixingDate,
                                                         effStrike));
-            Rate fixing = optionletPriceImp(optionType,
-                                            effStrike,
-                                            adjustedFixing(),
-                                            stdDev);
-            return fixing * coupon_->accrualPeriod() * discount_;
+            return optionletPriceImp(optionType,
+                                     effStrike,
+                                     adjustedFixing(),
+                                     stdDev);
         }
     }
 
@@ -111,7 +125,10 @@ namespace QuantLib {
         gearing_ = coupon_->fixedRate();
         spread_ = coupon_->spread();
         paymentDate_ = coupon_->date();
-        rateCurve_ = ext::dynamic_pointer_cast<ZeroInflationIndex>(coupon.index())
+        rateCurve_ =
+            !nominalTermStructure_.empty() ?
+            nominalTermStructure_ :
+            ext::dynamic_pointer_cast<ZeroInflationIndex>(coupon.index())
             ->zeroInflationTermStructure()
             ->nominalTermStructure();
 
@@ -119,19 +136,20 @@ namespace QuantLib {
         // use yield curve from index (which sets discount)
 
         discount_ = 1.0;
-        if (paymentDate_ > rateCurve_->referenceDate())
-            discount_ = rateCurve_->discount(paymentDate_);
-
-        spreadLegValue_ = spread_ * coupon_->accrualPeriod()* discount_;
-
+        if (paymentDate_ > rateCurve_->referenceDate()) {
+            if (rateCurve_.empty()) {
+                // allow to extract rates, but mark the discount as invalid for prices
+                discount_ = Null<Real>();
+            } else {
+                discount_ = rateCurve_->discount(paymentDate_);
+            }
+        }
     }
 
 
     Real CPICouponPricer::swapletPrice() const {
-
-        Real swapletPrice = adjustedFixing() * coupon_->accrualPeriod() * discount_;
-        //std::cout << swapletPrice << " SWAPLET price" << std::endl;
-        return gearing_ * swapletPrice + spreadLegValue_;
+        QL_REQUIRE(discount_ != Null<Real>(), "no nominal term structure provided");
+        return swapletRate() * coupon_->accrualPeriod() * discount_;
     }
 
 
@@ -140,9 +158,9 @@ namespace QuantLib {
         // a yield curve, i.e. we do not get the problem
         // that a discounting-instrument-pricer is used
         // with a different yield curve
-        //std::cout << (gearing_ * adjustedFixing() + spread_) << " SWAPLET rate" << gearing_ << " " << spread_ << std::endl;
         return gearing_ * adjustedFixing() + spread_;
     }
+
 
     //=========================================================================
     // vol-dependent pricers, note that these do not discount

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -37,12 +37,23 @@ namespace QuantLib {
               volatility-dependent coupons you need to implement the descendents.
     */
     class CPICouponPricer : public InflationCouponPricer {
-    public:
-        CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol
-                                 = Handle<CPIVolatilitySurface>());
+      public:
+        CPICouponPricer();
+        /*! \deprecated Use the constructor also taking an explicit
+                        nominal term structure.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        explicit CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol);
+        CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol,
+                        const Handle<YieldTermStructure>& nominalTermStructure);
 
         virtual Handle<CPIVolatilitySurface> capletVolatility() const{
             return capletVol_;
+        }
+
+        virtual Handle<YieldTermStructure> nominalTermStructure() const{
+            return nominalTermStructure_;
         }
 
         virtual void setCapletVolatility(
@@ -62,25 +73,31 @@ namespace QuantLib {
 
 
     protected:
-        //! can replace this if really required
         virtual Real optionletPrice(Option::Type optionType,
                                     Real effStrike) const;
 
-        //! usually only need implement this (of course they may need
-        //! to re-implement initialize too ...)
+        virtual Real optionletRate(Option::Type optionType,
+                                   Real effStrike) const;
+
+        /*! Derived classes usually only need to implement this.
+
+            The name of the method is misleading.  This actually
+            returns the rate of the optionlet (so not discounted and
+            not accrued).
+        */
         virtual Real optionletPriceImp(Option::Type, Real strike,
                                        Real forward, Real stdDev) const;
         virtual Rate adjustedFixing(Rate fixing = Null<Rate>()) const;
 
         //! data
         Handle<CPIVolatilitySurface> capletVol_;
+        Handle<YieldTermStructure> nominalTermStructure_;
         const CPICoupon* coupon_;
         Real gearing_;
         Spread spread_;
         Real discount_;
-        Real spreadLegValue_;
     };
 
-}   // namespace QuantLib
+}
 
 #endif

--- a/ql/cashflows/inflationcouponpricer.hpp
+++ b/ql/cashflows/inflationcouponpricer.hpp
@@ -80,17 +80,29 @@ namespace QuantLib {
               volatility-dependent coupons you need the descendents.
     */
     class YoYInflationCouponPricer : public InflationCouponPricer {
-    public:
-        YoYInflationCouponPricer(const Handle<YoYOptionletVolatilitySurface>& capletVol
-                                 = Handle<YoYOptionletVolatilitySurface>());
+      public:
+        YoYInflationCouponPricer();
+        /*! \deprecated Use the constructor also taking an explicit
+                        nominal term structure.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        explicit YoYInflationCouponPricer(
+            const Handle<YoYOptionletVolatilitySurface>& capletVol);
+        YoYInflationCouponPricer(
+            const Handle<YoYOptionletVolatilitySurface>& capletVol,
+            const Handle<YieldTermStructure>& nominalTermStructure);
 
         virtual Handle<YoYOptionletVolatilitySurface> capletVolatility() const{
             return capletVol_;
         }
 
+        virtual Handle<YieldTermStructure> nominalTermStructure() const{
+            return nominalTermStructure_;
+        }
+
         virtual void setCapletVolatility(
             const Handle<YoYOptionletVolatilitySurface>& capletVol);
-
 
         //! \name InflationCouponPricer interface
         //@{
@@ -103,72 +115,96 @@ namespace QuantLib {
         virtual void initialize(const InflationCoupon&);
         //@}
 
-
-    protected:
-        //! car replace this if really required
+      protected:
         virtual Real optionletPrice(Option::Type optionType,
                                     Real effStrike) const;
+        virtual Real optionletRate(Option::Type optionType,
+                                   Real effStrike) const;
 
-        //! usually only need implement this (of course they may need
-        //! to re-implement initialize too ...)
+        /*! Derived classes usually only need to implement this.
+
+            The name of the method is misleading.  This actually
+            returns the rate of the optionlet (so not discounted and
+            not accrued).
+        */
         virtual Real optionletPriceImp(Option::Type, Real strike,
                                        Real forward, Real stdDev) const;
         virtual Rate adjustedFixing(Rate fixing = Null<Rate>()) const;
 
         //! data
         Handle<YoYOptionletVolatilitySurface> capletVol_;
+        Handle<YieldTermStructure> nominalTermStructure_;
         const YoYInflationCoupon* coupon_;
         Real gearing_;
         Spread spread_;
         Real discount_;
-        Real spreadLegValue_;
     };
 
 
     //! Black-formula pricer for capped/floored yoy inflation coupons
     class BlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
-    public:
+      public:
+        BlackYoYInflationCouponPricer() {}
+        /*! \deprecated Use the constructor also taking an explicit
+                        nominal term structure.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        explicit BlackYoYInflationCouponPricer(
+            const Handle<YoYOptionletVolatilitySurface>& capletVol)
+        : YoYInflationCouponPricer(capletVol, Handle<YieldTermStructure>()) {}
         BlackYoYInflationCouponPricer(
-            const Handle<YoYOptionletVolatilitySurface>& capletVol
-                        = Handle<YoYOptionletVolatilitySurface>())
-        : YoYInflationCouponPricer(capletVol) {}
-        virtual ~BlackYoYInflationCouponPricer() {}
-
-    protected:
+            const Handle<YoYOptionletVolatilitySurface>& capletVol,
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(capletVol, nominalTermStructure) {}
+      protected:
         Real optionletPriceImp(Option::Type, Real strike,
                                Real forward, Real stdDev) const;
     };
 
 
     //! Unit-Displaced-Black-formula pricer for capped/floored yoy inflation coupons
-    class UnitDisplacedBlackYoYInflationCouponPricer
-    : public YoYInflationCouponPricer {
-    public:
+    class UnitDisplacedBlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
+      public:
+        UnitDisplacedBlackYoYInflationCouponPricer() {}
+        /*! \deprecated Use the constructor also taking an explicit
+                        nominal term structure.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        explicit UnitDisplacedBlackYoYInflationCouponPricer(
+            const Handle<YoYOptionletVolatilitySurface>& capletVol)
+        : YoYInflationCouponPricer(capletVol, Handle<YieldTermStructure>()) {}
         UnitDisplacedBlackYoYInflationCouponPricer(
-            const Handle<YoYOptionletVolatilitySurface>& capletVol
-                        = Handle<YoYOptionletVolatilitySurface>())
-            : YoYInflationCouponPricer(capletVol) {}
-        virtual ~UnitDisplacedBlackYoYInflationCouponPricer() {}
-    protected:
+            const Handle<YoYOptionletVolatilitySurface>& capletVol,
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(capletVol, nominalTermStructure) {}
+      protected:
         Real optionletPriceImp(Option::Type, Real strike,
                                Real forward, Real stdDev) const;
     };
 
 
     //! Bachelier-formula pricer for capped/floored yoy inflation coupons
-    class BachelierYoYInflationCouponPricer
-    : public YoYInflationCouponPricer {
-    public:
+    class BachelierYoYInflationCouponPricer : public YoYInflationCouponPricer {
+      public:
+        BachelierYoYInflationCouponPricer() {}
+        /*! \deprecated Use the constructor also taking an explicit
+                        nominal term structure.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        explicit BachelierYoYInflationCouponPricer(
+            const Handle<YoYOptionletVolatilitySurface>& capletVol)
+        : YoYInflationCouponPricer(capletVol, Handle<YieldTermStructure>()) {}
         BachelierYoYInflationCouponPricer(
-            const Handle<YoYOptionletVolatilitySurface>& capletVol
-                        = Handle<YoYOptionletVolatilitySurface>())
-            : YoYInflationCouponPricer(capletVol) {}
-        virtual ~BachelierYoYInflationCouponPricer() {}
-    protected:
+            const Handle<YoYOptionletVolatilitySurface>& capletVol,
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(capletVol, nominalTermStructure) {}
+      protected:
         Real optionletPriceImp(Option::Type, Real strike,
                                Real forward, Real stdDev) const;
     };
-
 
 }
 

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -508,6 +508,8 @@ namespace QuantLib {
     void InterpolatedYoYCapFloorTermPriceSurface<I2D,I1D>::
     calculateYoYTermStructure() const {
 
+        Handle<YieldTermStructure> nominalH( nominalTermStructure() );
+
         // which yoy-swap points to use in building the yoy-fwd curve?
         // for now pick every year
         Size nYears = (Size)(0.5+timeFromReference(referenceDate()+cfMaturities_.back()));
@@ -522,7 +524,7 @@ namespace QuantLib {
                 new YearOnYearInflationSwapHelper(
                                 quote, observationLag(), maturity,
                                 calendar(), bdc_, dayCounter(),
-                                yoyIndex()));
+                                yoyIndex(), nominalH));
             YYhelpers.push_back (anInstrument);
         }
 
@@ -531,7 +533,6 @@ namespace QuantLib {
         // we pick this as the end of the curve
         Rate baseYoYRate = atmYoYSwapRate( referenceDate() );//!
 
-        Handle<YieldTermStructure> nominalH( nominalTermStructure() );
         // Linear is OK because we have every year
         ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> >   pYITS(
               new PiecewiseYoYInflationCurve<Linear>(

--- a/ql/experimental/inflation/yoyoptionlethelpers.cpp
+++ b/ql/experimental/inflation/yoyoptionlethelpers.cpp
@@ -42,14 +42,14 @@ namespace QuantLib {
       pricer_(pricer) {
 
         // build the instrument to reprice (only need do this once)
-        yoyCapFloor_ = ext::make_shared<YoYInflationCapFloor>(
-                 
-                     MakeYoYInflationCapFloor(capFloorType_, n_, calendar_,
-                                              index_, lag_, strike_)
-                    .withNominal(notional)
-                    .withFixingDays(fixingDays_)
-                    .withPaymentDayCounter(yoyDayCounter_)
-                                          );
+        yoyCapFloor_ =
+            MakeYoYInflationCapFloor(capFloorType_, index_,
+                                     n_, calendar_, lag_)
+            .withNominal(notional)
+            .withFixingDays(fixingDays_)
+            .withPaymentDayCounter(yoyDayCounter_)
+            .withStrike(strike_);
+
         // dates already build in lag of index/instrument
         // these are the dates of the values of the index
         // that fix the capfloor

--- a/ql/instruments/makeyoyinflationcapfloor.cpp
+++ b/ql/instruments/makeyoyinflationcapfloor.cpp
@@ -25,7 +25,21 @@
 
 namespace QuantLib {
 
-    MakeYoYInflationCapFloor::MakeYoYInflationCapFloor(YoYInflationCapFloor::Type capFloorType,
+    MakeYoYInflationCapFloor::MakeYoYInflationCapFloor(
+                                YoYInflationCapFloor::Type capFloorType,
+                                const ext::shared_ptr<YoYInflationIndex>& index,
+                                const Size& length, const Calendar& cal,
+                                const Period& observationLag)
+    : capFloorType_(capFloorType), length_(length),
+      calendar_(cal), index_(index), observationLag_(observationLag),
+      strike_(Null<Rate>()), firstCapletExcluded_(false),
+      asOptionlet_(false), effectiveDate_(Date()),
+      dayCounter_(Thirty360()), roll_(ModifiedFollowing), fixingDays_(0),
+      nominal_(1000000.0)
+     {}
+
+    MakeYoYInflationCapFloor::MakeYoYInflationCapFloor(
+                                YoYInflationCapFloor::Type capFloorType,
                                 const Size& length, const Calendar& cal,
                                 const ext::shared_ptr<YoYInflationIndex>& index,
                                 const Period& observationLag, Rate strike,
@@ -78,11 +92,15 @@ namespace QuantLib {
         std::vector<Rate> strikeVector(1, strike_);
         if (strike_ == Null<Rate>()) {
             // ATM on the forecasting curve
-            QL_REQUIRE(!index_->yoyInflationTermStructure().empty(),
-                       "no forecasting yoy term structure set for " <<
-                       index_->name());
-            Handle<YieldTermStructure> fc
-            = index_->yoyInflationTermStructure()->nominalTermStructure();
+            Handle<YieldTermStructure> fc;
+            if (!nominalTermStructure_.empty()) {
+                fc = nominalTermStructure_;
+            } else {
+                QL_REQUIRE(!index_->yoyInflationTermStructure().empty(),
+                           "no forecasting yoy term structure set for " <<
+                           index_->name());
+                fc = index_->yoyInflationTermStructure()->nominalTermStructure();
+            }
             strikeVector[0] = CashFlows::atmRate(leg,**fc,
                                                  false, fc->referenceDate());
         }
@@ -130,6 +148,27 @@ namespace QuantLib {
     MakeYoYInflationCapFloor& MakeYoYInflationCapFloor::withPricingEngine(
         const ext::shared_ptr<PricingEngine>& engine) {
         engine_ = engine;
+        return *this;
+    }
+
+    MakeYoYInflationCapFloor&
+    MakeYoYInflationCapFloor::withStrike(Rate strike) {
+        QL_REQUIRE(nominalTermStructure_.empty(), "ATM strike already given");
+        strike_ = strike;
+        return *this;
+    }
+
+    MakeYoYInflationCapFloor&
+    MakeYoYInflationCapFloor::withAtmStrike(
+                      const Handle<YieldTermStructure>& nominalTermStructure) {
+        QL_REQUIRE(strike_ == Null<Rate>(), "explicit strike already given");
+        nominalTermStructure_ = nominalTermStructure;
+        return *this;
+    }
+
+    MakeYoYInflationCapFloor&
+    MakeYoYInflationCapFloor::withForwardStart(Period forwardStart) {
+        forwardStart_ = forwardStart;
         return *this;
     }
 

--- a/ql/instruments/makeyoyinflationcapfloor.hpp
+++ b/ql/instruments/makeyoyinflationcapfloor.hpp
@@ -36,8 +36,23 @@ namespace QuantLib {
         standard yoy inflation cap and floor.
      */
     class MakeYoYInflationCapFloor {
-    public:
-        MakeYoYInflationCapFloor(YoYInflationCapFloor::Type capFloorType,
+      public:
+        MakeYoYInflationCapFloor(
+                        YoYInflationCapFloor::Type capFloorType,
+                        const ext::shared_ptr<YoYInflationIndex>& index,
+                        const Size& length, const Calendar& cal,
+                        const Period& observationLag);
+        /*! \deprecated Use the other constructor.  In order to
+                        specify the strike, you'll have to call either
+                        withStrike (with an explicit strike) or
+                        withAtmStrike (to get a strike at the money on
+                        the passed nominal term structure).  In order
+                        to specify a forward start, you'll have to call
+                        withForwardStart.
+        */
+        QL_DEPRECATED
+        MakeYoYInflationCapFloor(
+                        YoYInflationCapFloor::Type capFloorType,
                         const Size& length, const Calendar& cal,
                         const ext::shared_ptr<YoYInflationIndex>& index,
                         const Period& observationLag, Rate strike = Null<Rate>(),
@@ -48,17 +63,19 @@ namespace QuantLib {
         MakeYoYInflationCapFloor& withPaymentDayCounter(const DayCounter&);
         MakeYoYInflationCapFloor& withPaymentAdjustment(BusinessDayConvention);
         MakeYoYInflationCapFloor& withFixingDays(Natural fixingDays);
-
+        MakeYoYInflationCapFloor& withPricingEngine(
+                const ext::shared_ptr<PricingEngine>& engine);
+        //! only get last coupon
+        MakeYoYInflationCapFloor& asOptionlet(bool b = true);
+        MakeYoYInflationCapFloor& withStrike(Rate strike);
+        MakeYoYInflationCapFloor& withAtmStrike(
+                      const Handle<YieldTermStructure>& nominalTermStructure);
+        MakeYoYInflationCapFloor& withForwardStart(Period forwardStart);
 
         operator YoYInflationCapFloor() const;
         operator ext::shared_ptr<YoYInflationCapFloor>() const ;
 
-        //! only get last coupon
-        MakeYoYInflationCapFloor& asOptionlet(bool b = true);
-
-        MakeYoYInflationCapFloor& withPricingEngine(
-                const ext::shared_ptr<PricingEngine>& engine);
-    private:
+      private:
         YoYInflationCapFloor::Type capFloorType_;
         Size length_;
         Calendar calendar_;
@@ -72,7 +89,7 @@ namespace QuantLib {
         BusinessDayConvention roll_;
         Natural fixingDays_;
         Real nominal_;
-
+        Handle<YieldTermStructure> nominalTermStructure_;
 
         ext::shared_ptr<PricingEngine> engine_;
     };

--- a/ql/instruments/makeyoyinflationcapfloor.hpp
+++ b/ql/instruments/makeyoyinflationcapfloor.hpp
@@ -49,6 +49,7 @@ namespace QuantLib {
                         the passed nominal term structure).  In order
                         to specify a forward start, you'll have to call
                         withForwardStart.
+                        Deprecated in version 1.5.
         */
         QL_DEPRECATED
         MakeYoYInflationCapFloor(

--- a/ql/pricingengines/inflation/inflationcapfloorengines.cpp
+++ b/ql/pricingengines/inflation/inflationcapfloorengines.cpp
@@ -27,6 +27,18 @@ namespace QuantLib {
 
     YoYInflationCapFloorEngine::YoYInflationCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>& index,
+                    const Handle<YoYOptionletVolatilitySurface>& volatility,
+                    const Handle<YieldTermStructure>& nominalTermStructure)
+    : index_(index), volatility_(volatility),
+      nominalTermStructure_(nominalTermStructure) {
+        registerWith(index_);
+        registerWith(volatility_);
+        registerWith(nominalTermStructure_);
+    }
+
+
+    YoYInflationCapFloorEngine::YoYInflationCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>& index,
                     const Handle<YoYOptionletVolatilitySurface>& volatility)
     : index_(index), volatility_(volatility) {
         registerWith(index_);
@@ -57,10 +69,11 @@ namespace QuantLib {
 
         Handle<YoYInflationTermStructure> yoyTS
         = index()->yoyInflationTermStructure();
-        Handle<YieldTermStructure> nominalTS
-        = yoyTS->nominalTermStructure();
+        Handle<YieldTermStructure> nominalTS =
+            !nominalTermStructure_.empty() ?
+            nominalTermStructure_ :
+            yoyTS->nominalTermStructure();
         Date settlement = nominalTS->referenceDate();
-
 
         for (Size i=0; i<optionlets; ++i) {
             Date paymentDate = arguments_.payDates[i];
@@ -130,10 +143,18 @@ namespace QuantLib {
     //======================================================================
     // pricer implementations
     //======================================================================
+
+    YoYInflationBlackCapFloorEngine::YoYInflationBlackCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>& index,
+                    const Handle<YoYOptionletVolatilitySurface>& volatility,
+                    const Handle<YieldTermStructure>& nominalTermStructure)
+    : YoYInflationCapFloorEngine(index, volatility, nominalTermStructure) {}
+
     YoYInflationBlackCapFloorEngine::YoYInflationBlackCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>& index,
                     const Handle<YoYOptionletVolatilitySurface>& volatility)
-    : YoYInflationCapFloorEngine(index, volatility) {}
+    : YoYInflationCapFloorEngine(index, volatility,
+                                 Handle<YieldTermStructure>()) {}
 
 
     Real YoYInflationBlackCapFloorEngine::optionletImpl(Option::Type type, Rate strike,
@@ -149,8 +170,16 @@ namespace QuantLib {
     YoYInflationUnitDisplacedBlackCapFloorEngine
     ::YoYInflationUnitDisplacedBlackCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>& index,
+                    const Handle<YoYOptionletVolatilitySurface>& volatility,
+                    const Handle<YieldTermStructure>& nominalTermStructure)
+    : YoYInflationCapFloorEngine(index, volatility, nominalTermStructure) {}
+
+    YoYInflationUnitDisplacedBlackCapFloorEngine
+    ::YoYInflationUnitDisplacedBlackCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>& index,
                     const Handle<YoYOptionletVolatilitySurface>& volatility)
-    : YoYInflationCapFloorEngine(index, volatility) {}
+    : YoYInflationCapFloorEngine(index, volatility,
+                                 Handle<YieldTermStructure>()) {}
 
 
     Real YoYInflationUnitDisplacedBlackCapFloorEngine::optionletImpl(
@@ -166,8 +195,15 @@ namespace QuantLib {
 
     YoYInflationBachelierCapFloorEngine::YoYInflationBachelierCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>& index,
+                    const Handle<YoYOptionletVolatilitySurface>& volatility,
+                    const Handle<YieldTermStructure>& nominalTermStructure)
+    : YoYInflationCapFloorEngine(index, volatility, nominalTermStructure) {}
+
+    YoYInflationBachelierCapFloorEngine::YoYInflationBachelierCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>& index,
                     const Handle<YoYOptionletVolatilitySurface>& volatility)
-    : YoYInflationCapFloorEngine(index, volatility) {}
+    : YoYInflationCapFloorEngine(index, volatility,
+                                 Handle<YieldTermStructure>()) {}
 
 
     Real YoYInflationBachelierCapFloorEngine::optionletImpl(Option::Type type, Rate strike,

--- a/ql/pricingengines/inflation/inflationcapfloorengines.hpp
+++ b/ql/pricingengines/inflation/inflationcapfloorengines.hpp
@@ -37,13 +37,19 @@ namespace QuantLib {
     //! Base YoY inflation cap/floor engine
     /*! This class doesn't know yet what sort of vol it is.  The
         inflation index must be linked to a yoy inflation term
-        structure.  This provides the curves, hence the call uses a
-        shared_ptr<> not a handle<> to the index.
+        structure.
 
         \ingroup inflationcapfloorengines
     */
     class YoYInflationCapFloorEngine : public YoYInflationCapFloor::engine {
-    public:
+      public:
+        YoYInflationCapFloorEngine(const ext::shared_ptr<YoYInflationIndex>&,
+                                   const Handle<YoYOptionletVolatilitySurface>& vol,
+                                   const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the constructor with an explicit nominal curve.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
         YoYInflationCapFloorEngine(const ext::shared_ptr<YoYInflationIndex>&,
                                    const Handle<YoYOptionletVolatilitySurface>& vol);
 
@@ -53,7 +59,7 @@ namespace QuantLib {
         void setVolatility(const Handle<YoYOptionletVolatilitySurface>& vol);
 
         void calculate() const;
-    protected:
+      protected:
         //! descendents only need to implement this
         virtual Real optionletImpl(Option::Type type, Rate strike,
                                    Rate forward, Real stdDev,
@@ -61,6 +67,7 @@ namespace QuantLib {
 
         ext::shared_ptr<YoYInflationIndex> index_;
         Handle<YoYOptionletVolatilitySurface> volatility_;
+        Handle<YieldTermStructure> nominalTermStructure_;
     };
 
 
@@ -68,49 +75,65 @@ namespace QuantLib {
     //! Black-formula inflation cap/floor engine (standalone, i.e. no coupon pricer)
     class YoYInflationBlackCapFloorEngine
     : public YoYInflationCapFloorEngine {
-    public:
+      public:
+        YoYInflationBlackCapFloorEngine(const ext::shared_ptr<YoYInflationIndex>&,
+                                        const Handle<YoYOptionletVolatilitySurface>& vol,
+                                        const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the constructor with an explicit nominal curve.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
         YoYInflationBlackCapFloorEngine(const ext::shared_ptr<YoYInflationIndex>&,
                                         const Handle<YoYOptionletVolatilitySurface>&);
 
-    protected:
-
+      protected:
         virtual Real optionletImpl(Option::Type, Real strike,
                                    Real forward, Real stdDev,
                                    Real d) const;
-
     };
 
 
     //! Unit Displaced Black-formula inflation cap/floor engine (standalone, i.e. no coupon pricer)
     class YoYInflationUnitDisplacedBlackCapFloorEngine
     : public YoYInflationCapFloorEngine {
-    public:
+      public:
+        YoYInflationUnitDisplacedBlackCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>&,
+                    const Handle<YoYOptionletVolatilitySurface>& vol,
+                    const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the constructor with an explicit nominal curve.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
         YoYInflationUnitDisplacedBlackCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>&,
                     const Handle<YoYOptionletVolatilitySurface>&);
-    protected:
-
+      protected:
         virtual Real optionletImpl(Option::Type, Real strike,
                                    Real forward, Real stdDev,
                                    Real d) const;
-
     };
 
 
     //! Unit Displaced Black-formula inflation cap/floor engine (standalone, i.e. no coupon pricer)
     class YoYInflationBachelierCapFloorEngine
     : public YoYInflationCapFloorEngine {
-    public:
+      public:
+        YoYInflationBachelierCapFloorEngine(
+                    const ext::shared_ptr<YoYInflationIndex>&,
+                    const Handle<YoYOptionletVolatilitySurface>& vol,
+                    const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the constructor with an explicit nominal curve.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
         YoYInflationBachelierCapFloorEngine(
                     const ext::shared_ptr<YoYInflationIndex>&,
                     const Handle<YoYOptionletVolatilitySurface>&);
-
-    protected:
-
+      protected:
         virtual Real optionletImpl(Option::Type, Real strike,
                                    Real forward, Real stdDev,
                                    Real d) const;
-
     };
 
 }

--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -21,10 +21,58 @@
 #include <ql/termstructures/inflation/inflationhelpers.hpp>
 #include <ql/indexes/inflationindex.hpp>
 #include <ql/pricingengines/swap/discountingswapengine.hpp>
-
 #include <ql/utilities/null_deleter.hpp>
 
 namespace QuantLib {
+
+    ZeroCouponInflationSwapHelper::ZeroCouponInflationSwapHelper(
+        const Handle<Quote>& quote,
+        const Period& swapObsLag,
+        const Date& maturity,
+        const Calendar& calendar,
+        BusinessDayConvention paymentConvention,
+        const DayCounter& dayCounter,
+        const ext::shared_ptr<ZeroInflationIndex>& zii,
+        const Handle<YieldTermStructure>& nominalTermStructure)
+    : BootstrapHelper<ZeroInflationTermStructure>(quote),
+      swapObsLag_(swapObsLag), maturity_(maturity), calendar_(calendar),
+      paymentConvention_(paymentConvention), dayCounter_(dayCounter),
+      zii_(zii), nominalTermStructure_(nominalTermStructure) {
+
+        if (zii_->interpolated()) {
+            // if interpolated then simple
+            earliestDate_ = maturity_ - swapObsLag_;
+            latestDate_ = maturity_ - swapObsLag_;
+        } else {
+            // but if NOT interpolated then the value is valid
+            // for every day in an inflation period so you actually
+            // get an extended validity, however for curve building
+            // just put the first date because using that convention
+            // for the base date throughout
+            std::pair<Date,Date> limStart = inflationPeriod(maturity_ - swapObsLag_,
+                                                            zii_->frequency());
+            earliestDate_ = limStart.first;
+            latestDate_ = limStart.first;
+        }
+
+        // check that the observation lag of the swap
+        // is compatible with the availability lag of the index AND
+        // it's interpolation (assuming the start day is spot)
+        if (zii_->interpolated()) {
+            Period pShift(zii_->frequency());
+            QL_REQUIRE(swapObsLag_ - pShift > zii_->availabilityLag(),
+                       "inconsistency between swap observation of index "
+                       << swapObsLag_ <<
+                       " index availability " << zii_->availabilityLag() <<
+                       " index period " << pShift <<
+                       " and index availability " << zii_->availabilityLag() <<
+                       " need (obsLag-index period) > availLag");
+        }
+
+        registerWith(Settings::instance().evaluationDate());
+        registerWith(nominalTermStructure_);
+    }
+
 
     ZeroCouponInflationSwapHelper::ZeroCouponInflationSwapHelper(
         const Handle<Quote>& quote,
@@ -35,9 +83,9 @@ namespace QuantLib {
         const DayCounter& dayCounter,
         const ext::shared_ptr<ZeroInflationIndex>& zii)
     : BootstrapHelper<ZeroInflationTermStructure>(quote),
-    swapObsLag_(swapObsLag), maturity_(maturity), calendar_(calendar),
-    paymentConvention_(paymentConvention), dayCounter_(dayCounter),
-    zii_(zii) {
+      swapObsLag_(swapObsLag), maturity_(maturity), calendar_(calendar),
+      paymentConvention_(paymentConvention), dayCounter_(dayCounter),
+      zii_(zii) {
 
         if (zii_->interpolated()) {
             // if interpolated then simple
@@ -72,6 +120,7 @@ namespace QuantLib {
         registerWith(Settings::instance().evaluationDate());
     }
 
+
     Real ZeroCouponInflationSwapHelper::impliedQuote() const {
         // what does the term structure imply?
         // in this case just the same value ... trivial case
@@ -79,6 +128,7 @@ namespace QuantLib {
         zciis_->recalculate();
         return zciis_->fairRate();
     }
+
 
     void ZeroCouponInflationSwapHelper::setTermStructure(
             ZeroInflationTermStructure* z) {
@@ -97,8 +147,11 @@ namespace QuantLib {
 
         ext::shared_ptr<ZeroInflationIndex> new_zii = zii_->clone(zits);
 
+        Handle<YieldTermStructure> nominalTS =
+            !nominalTermStructure_.empty() ? nominalTermStructure_ : z->nominalTermStructure();
+
         Real nominal = 1000000.0;   // has to be something but doesn't matter what
-        Date start = z->nominalTermStructure()->referenceDate();
+        Date start = nominalTS->referenceDate();
         zciis_.reset(new ZeroCouponInflationSwap(
                                 ZeroCouponInflationSwap::Payer,
                                 nominal, start, maturity_,
@@ -107,7 +160,56 @@ namespace QuantLib {
         // Because very simple instrument only takes
         // standard discounting swap engine.
         zciis_->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new DiscountingSwapEngine(z->nominalTermStructure())));
+                new DiscountingSwapEngine(nominalTS)));
+    }
+
+
+    YearOnYearInflationSwapHelper::YearOnYearInflationSwapHelper(
+        const Handle<Quote>& quote,
+        const Period& swapObsLag,
+        const Date& maturity,
+        const Calendar& calendar,
+        BusinessDayConvention paymentConvention,
+        const DayCounter& dayCounter,
+        const ext::shared_ptr<YoYInflationIndex>& yii,
+        const Handle<YieldTermStructure>& nominalTermStructure)
+    : BootstrapHelper<YoYInflationTermStructure>(quote),
+      swapObsLag_(swapObsLag), maturity_(maturity),
+      calendar_(calendar), paymentConvention_(paymentConvention),
+      dayCounter_(dayCounter), yii_(yii), nominalTermStructure_(nominalTermStructure) {
+
+        if (yii_->interpolated()) {
+            // if interpolated then simple
+            earliestDate_ = maturity_ - swapObsLag_;
+            latestDate_ = maturity_ - swapObsLag_;
+        } else {
+            // but if NOT interpolated then the value is valid
+            // for every day in an inflation period so you actually
+            // get an extended validity, however for curve building
+            // just put the first date because using that convention
+            // for the base date throughout
+            std::pair<Date,Date> limStart = inflationPeriod(maturity_ - swapObsLag_,
+                                                            yii_->frequency());
+            earliestDate_ = limStart.first;
+            latestDate_ = limStart.first;
+        }
+
+        // check that the observation lag of the swap
+        // is compatible with the availability lag of the index AND
+        // it's interpolation (assuming the start day is spot)
+        if (yii_->interpolated()) {
+            Period pShift(yii_->frequency());
+            QL_REQUIRE(swapObsLag_ - pShift > yii_->availabilityLag(),
+                       "inconsistency between swap observation of index "
+                       << swapObsLag_ <<
+                       " index availability " << yii_->availabilityLag() <<
+                       " index period " << pShift <<
+                       " and index availability " << yii_->availabilityLag() <<
+                       " need (obsLag-index period) > availLag");
+        }
+
+        registerWith(Settings::instance().evaluationDate());
+        registerWith(nominalTermStructure_);
     }
 
 
@@ -120,9 +222,9 @@ namespace QuantLib {
         const DayCounter& dayCounter,
         const ext::shared_ptr<YoYInflationIndex>& yii)
     : BootstrapHelper<YoYInflationTermStructure>(quote),
-    swapObsLag_(swapObsLag), maturity_(maturity),
-    calendar_(calendar), paymentConvention_(paymentConvention),
-    dayCounter_(dayCounter), yii_(yii) {
+      swapObsLag_(swapObsLag), maturity_(maturity),
+      calendar_(calendar), paymentConvention_(paymentConvention),
+      dayCounter_(dayCounter), yii_(yii) {
 
         if (yii_->interpolated()) {
             // if interpolated then simple
@@ -165,6 +267,7 @@ namespace QuantLib {
         yyiis_->recalculate();
         return yyiis_->fairRate();
     }
+
 
     void YearOnYearInflationSwapHelper::setTermStructure(
                 YoYInflationTermStructure* y) {
@@ -213,7 +316,9 @@ namespace QuantLib {
         // Because very simple instrument only takes
         // standard discounting swap engine.
         yyiis_->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new DiscountingSwapEngine(y->nominalTermStructure())));
+                    new DiscountingSwapEngine(!nominalTermStructure_.empty() ?
+                                              nominalTermStructure_ :
+                                              y->nominalTermStructure())));
     }
 
 }

--- a/ql/termstructures/inflation/inflationhelpers.hpp
+++ b/ql/termstructures/inflation/inflationhelpers.hpp
@@ -43,11 +43,24 @@ namespace QuantLib {
             const Calendar& calendar,   // index may have null calendar as valid on every day
             BusinessDayConvention paymentConvention,
             const DayCounter& dayCounter,
+            const ext::shared_ptr<ZeroInflationIndex>& zii,
+            const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
+        ZeroCouponInflationSwapHelper(
+            const Handle<Quote>& quote,
+            const Period& swapObsLag,   // lag on swap observation of index
+            const Date& maturity,
+            const Calendar& calendar,   // index may have null calendar as valid on every day
+            BusinessDayConvention paymentConvention,
+            const DayCounter& dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& zii);
 
         void setTermStructure(ZeroInflationTermStructure*);
         Real impliedQuote() const;
-    protected:
+      protected:
         Period swapObsLag_;
         Date maturity_;
         Calendar calendar_;
@@ -55,13 +68,26 @@ namespace QuantLib {
         DayCounter dayCounter_;
         ext::shared_ptr<ZeroInflationIndex> zii_;
         ext::shared_ptr<ZeroCouponInflationSwap> zciis_;
+        Handle<YieldTermStructure> nominalTermStructure_;
     };
 
 
     //! Year-on-year inflation-swap bootstrap helper
     class YearOnYearInflationSwapHelper
-    : public BootstrapHelper<YoYInflationTermStructure> {
-    public:
+        : public BootstrapHelper<YoYInflationTermStructure> {
+      public:
+        YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
+                                      const Period& swapObsLag_,
+                                      const Date& maturity,
+                                      const Calendar& calendar,
+                                      BusinessDayConvention paymentConvention,
+                                      const DayCounter& dayCounter,
+                                      const ext::shared_ptr<YoYInflationIndex>& yii,
+                                      const Handle<YieldTermStructure>& nominalTermStructure);
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.15.
+        */
+        QL_DEPRECATED
         YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
                                       const Period& swapObsLag_,
                                       const Date& maturity,
@@ -72,7 +98,7 @@ namespace QuantLib {
 
         void setTermStructure(YoYInflationTermStructure*);
         Real impliedQuote() const;
-    protected:
+      protected:
         Period swapObsLag_;
         Date maturity_;
         Calendar calendar_;
@@ -80,6 +106,7 @@ namespace QuantLib {
         DayCounter dayCounter_;
         ext::shared_ptr<YoYInflationIndex> yii_;
         ext::shared_ptr<YearOnYearInflationSwap> yyiis_;
+        Handle<YieldTermStructure> nominalTermStructure_;
     };
 
 }

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -77,7 +77,8 @@ namespace {
             const ext::shared_ptr<I> &ii, const Period &observationLag,
             const Calendar &calendar,
             const BusinessDayConvention &bdc,
-            const DayCounter &dc) {
+            const DayCounter &dc,
+            const Handle<YieldTermStructure>& yTS) {
 
         std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
         for (Size i=0; i<N; i++) {
@@ -86,7 +87,7 @@ namespace {
                 new SimpleQuote(iiData[i].rate/100.0)));
             ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(
                 quote, observationLag, maturity,
-                calendar, bdc, dc, ii));
+                calendar, bdc, dc, ii, yTS));
             instruments.push_back(anInstrument);
         }
 
@@ -365,7 +366,8 @@ void InflationTest::testZeroTermStructure() {
     makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
                 ZeroInflationIndex>(zcData, LENGTH(zcData), ii,
                                     observationLag,
-                                    calendar, bdc, dc);
+                                    calendar, bdc, dc,
+                                    Handle<YieldTermStructure>(nominalTS));
 
     Rate baseZeroRate = zcData[0].rate/100.0;
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
@@ -500,7 +502,8 @@ void InflationTest::testZeroTermStructure() {
     makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
     ZeroInflationIndex>(zcData, LENGTH(zcData), iiyes,
                         observationLagyes,
-                        calendar, bdc, dc);
+                        calendar, bdc, dc,
+                        Handle<YieldTermStructure>(nominalTS));
 
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITSyes(
             new PiecewiseZeroInflationCurve<Linear>(
@@ -854,8 +857,9 @@ void InflationTest::testYYTermStructure() {
     std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > helpers =
     makeHelpers<YoYInflationTermStructure,YearOnYearInflationSwapHelper,
     YoYInflationIndex>(yyData, LENGTH(yyData), iir,
-                        observationLag,
-                        calendar, bdc, dc);
+                       observationLag,
+                       calendar, bdc, dc,
+                       Handle<YieldTermStructure>(nominalTS));
 
     Rate baseYYRate = yyData[0].rate/100.0;
     ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> > pYYTS(

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -208,14 +208,14 @@ namespace {
 
 
         ext::shared_ptr<PricingEngine> makeEngine(Volatility volatility,
-                                                    Size which) {
+                                                  Size which) {
 
             ext::shared_ptr<YoYInflationIndex>
             yyii = ext::dynamic_pointer_cast<YoYInflationIndex>(iir);
 
             Handle<YoYOptionletVolatilitySurface>
                 vol(ext::make_shared<ConstantYoYOptionletVolatility>(
-                    volatility,
+                                                       volatility,
                                                        settlementDays,
                                                        calendar,
                                                        convention,
@@ -228,15 +228,15 @@ namespace {
             switch (which) {
                 case 0:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBlackCapFloorEngine(iir, vol));
+                            new YoYInflationBlackCapFloorEngine(iir, vol, nominalTS));
                     break;
                 case 1:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol));
+                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol, nominalTS));
                     break;
                 case 2:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBachelierCapFloorEngine(iir, vol));
+                            new YoYInflationBachelierCapFloorEngine(iir, vol, nominalTS));
                     break;
                 default:
                     BOOST_FAIL("unknown engine request: which = "<<which
@@ -249,10 +249,10 @@ namespace {
 
 
         ext::shared_ptr<YoYInflationCapFloor> makeYoYCapFloor(YoYInflationCapFloor::Type type,
-                                                 const Leg& leg,
-                                                 Rate strike,
-                                                 Volatility volatility,
-                                                 Size which) {
+                                                              const Leg& leg,
+                                                              Rate strike,
+                                                              Volatility volatility,
+                                                              Size which) {
             ext::shared_ptr<YoYInflationCapFloor> result;
             switch (type) {
                 case YoYInflationCapFloor::Cap:

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -67,7 +67,8 @@ namespace {
                  const ext::shared_ptr<I> &ii, const Period &observationLag,
                  const Calendar &calendar,
                  const BusinessDayConvention &bdc,
-                 const DayCounter &dc) {
+                 const DayCounter &dc,
+                 const Handle<YieldTermStructure>& discountCurve) {
 
         std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
         for (Size i=0; i<N; i++) {
@@ -76,7 +77,7 @@ namespace {
                     new SimpleQuote(iiData[i].rate/100.0)));
             ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(
                     quote, observationLag, maturity,
-                    calendar, bdc, dc, ii));
+                    calendar, bdc, dc, ii, discountCurve));
             instruments.push_back(anInstrument);
         }
 
@@ -174,7 +175,8 @@ namespace {
             makeHelpers<YoYInflationTermStructure,YearOnYearInflationSwapHelper,
             YoYInflationIndex>(yyData, LENGTH(yyData), iir,
                                observationLag,
-                               calendar, convention, dc);
+                               calendar, convention, dc,
+                               Handle<YieldTermStructure>(nominalTS));
 
             Rate baseYYRate = yyData[0].rate/100.0;
             ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> > pYYTS(

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -328,15 +328,15 @@ namespace {
             switch (which) {
                 case 0:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBlackCapFloorEngine(iir, vol));
+                            new YoYInflationBlackCapFloorEngine(iir, vol, nominalTS));
                     break;
                 case 1:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol));
+                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol, nominalTS));
                     break;
                 case 2:
                     return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBachelierCapFloorEngine(iir, vol));
+                            new YoYInflationBachelierCapFloorEngine(iir, vol, nominalTS));
                     break;
                 default:
                     BOOST_FAIL("unknown engine request: which = "<<which

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -70,7 +70,8 @@ namespace {
                         const ext::shared_ptr<I> &ii, const Period &observationLag,
                         const Calendar &calendar,
                         const BusinessDayConvention &bdc,
-                        const DayCounter &dc) {
+                        const DayCounter &dc,
+                        const Handle<YieldTermStructure>& discountCurve) {
 
         std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
         for (Size i=0; i<N; i++) {
@@ -79,7 +80,7 @@ namespace {
                             new SimpleQuote(iiData[i].rate/100.0)));
             ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(
                             quote, observationLag, maturity,
-                            calendar, bdc, dc, ii));
+                            calendar, bdc, dc, ii, discountCurve));
             instruments.push_back(anInstrument);
         }
 
@@ -184,7 +185,8 @@ namespace {
             makeHelpers<YoYInflationTermStructure,YearOnYearInflationSwapHelper,
             YoYInflationIndex>(yyData, LENGTH(yyData), iir,
                                observationLag,
-                               calendar, convention, dc);
+                               calendar, convention, dc,
+                               Handle<YieldTermStructure>(nominalTS));
 
             Rate baseYYRate = yyData[0].rate/100.0;
             ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> > pYYTS(

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -262,15 +262,15 @@ namespace {
             switch (which) {
                 case 0:
                     pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new BlackYoYInflationCouponPricer(vol));
+                            new BlackYoYInflationCouponPricer(vol, nominalTS));
                     break;
                 case 1:
                     pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new UnitDisplacedBlackYoYInflationCouponPricer(vol));
+                            new UnitDisplacedBlackYoYInflationCouponPricer(vol, nominalTS));
                     break;
                 case 2:
                     pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new BachelierYoYInflationCouponPricer(vol));
+                            new BachelierYoYInflationCouponPricer(vol, nominalTS));
                     break;
                 default:
                     BOOST_FAIL("unknown coupon pricer request: which = "<<which

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -57,7 +57,8 @@ namespace {
         const Period& observationLag,
         const Calendar& calendar,
         const BusinessDayConvention& bdc,
-        const DayCounter& dc) {
+        const DayCounter& dc,
+        const Handle<YieldTermStructure>& yTS) {
 
         std::vector<ext::shared_ptr<Helper> > instruments;
         for (Size i=0; i<N; i++) {
@@ -67,7 +68,7 @@ namespace {
             ext::shared_ptr<Helper> h(
                       new ZeroCouponInflationSwapHelper(quote, observationLag,
                                                         maturity, calendar,
-                                                        bdc, dc, ii));
+                                                        bdc, dc, ii, yTS));
             instruments.push_back(h);
         }
         return instruments;
@@ -152,7 +153,7 @@ namespace {
 
             std::vector<ext::shared_ptr<Helper> > helpers =
                 makeHelpers(zciisData, LENGTH(zciisData), ii,
-                            observationLag, calendar, convention, dayCounter);
+                            observationLag, calendar, convention, dayCounter, yTS);
 
             Rate baseZeroRate = zciisData[0].rate/100.0;
             cpiTS.linkTo(ext::shared_ptr<ZeroInflationTermStructure>(

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -67,7 +67,8 @@ namespace {
         const ext::shared_ptr<I> &ii, const Period &observationLag,
         const Calendar &calendar,
         const BusinessDayConvention &bdc,
-        const DayCounter &dc) {
+        const DayCounter &dc,
+        const Handle<YieldTermStructure>& discountCurve) {
 
         std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
         for (Size i=0; i<N; i++) {
@@ -76,7 +77,7 @@ namespace {
                                 new SimpleQuote(iiData[i].rate/100.0)));
             ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(
                                 quote, observationLag, maturity,
-                                calendar, bdc, dc, ii));
+                                calendar, bdc, dc, ii, discountCurve));
             instruments.push_back(anInstrument);
         }
 
@@ -258,7 +259,8 @@ namespace {
             makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
             ZeroInflationIndex>(zciisData, zciisDataLength, ii,
                                 observationLag,
-                                calendar, convention, dcZCIIS);
+                                calendar, convention, dcZCIIS,
+                                Handle<YieldTermStructure>(nominalTS));
 
             // we can use historical or first ZCIIS for this
             // we know historical is WAY off market-implied, so use market implied flat.

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -59,7 +59,8 @@ namespace {
         const ext::shared_ptr<I> &ii, const Period &observationLag,
         const Calendar &calendar,
         const BusinessDayConvention &bdc,
-        const DayCounter &dc) {
+        const DayCounter &dc,
+        const Handle<YieldTermStructure>& discountCurve) {
 
         std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
         for (Size i=0; i<N; i++) {
@@ -68,7 +69,7 @@ namespace {
                                 new SimpleQuote(iiData[i].rate/100.0)));
             ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(
                                 quote, observationLag, maturity,
-                                calendar, bdc, dc, ii));
+                                calendar, bdc, dc, ii, discountCurve));
             instruments.push_back(anInstrument);
         }
 
@@ -237,7 +238,8 @@ namespace {
             makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
             ZeroInflationIndex>(zciisData, zciisDataLength, ii,
                                 observationLag,
-                                calendar, convention, dcZCIIS);
+                                calendar, convention, dcZCIIS,
+                                Handle<YieldTermStructure>(nominalTS));
 
             // we can use historical or first ZCIIS for this
             // we know historical is WAY off market-implied, so use market implied flat.

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -298,7 +298,7 @@ void InflationVolTest::testYoYPriceSurfaceToVol() {
     ext::shared_ptr<YoYOptionletVolatilitySurface> pVS;
     Handle<YoYOptionletVolatilitySurface> hVS(pVS, false); // pVS does NOT own whatever it points to later, hence the handle does not either
     ext::shared_ptr<YoYInflationUnitDisplacedBlackCapFloorEngine>
-        yoyPricerUD(new YoYInflationUnitDisplacedBlackCapFloorEngine(yoyIndexEU,hVS)); //hVS
+        yoyPricerUD(new YoYInflationUnitDisplacedBlackCapFloorEngine(yoyIndexEU,hVS,nominalEUR)); //hVS
     // N.B. the vol gets set in the stripper ... else no point!
 
     // cap stripper


### PR DESCRIPTION
This is a precondition for removing the nominal curve from inflation curves (the fact that their base class stores it is inconsistent with all other curves in the library).

