### PR TITLE
Basic unit tests for TimeGrid class

### DIFF
--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -134,6 +134,7 @@ QL_TESTS = \
 	swaptionvolstructuresutilities.hpp \
 	swingoption.hpp swingoption.cpp \
 	termstructures.hpp termstructures.cpp \
+	timegrid.hpp timegrid.cpp \
 	timeseries.hpp timeseries.cpp \
 	transformedgrid.hpp transformedgrid.cpp \
 	tqreigendecomposition.hpp tqreigendecomposition.cpp \

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -454,7 +454,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(SwaptionVolatilityCubeTest::suite());
     test->add(SwaptionVolatilityMatrixTest::suite());
     test->add(TermStructureTest::suite());
-	test->add(TimeGridTest::suite());
+    test->add(TimeGridTest::suite());
     test->add(TimeSeriesTest::suite());
     test->add(TqrEigenDecompositionTest::suite());
     test->add(TracingTest::suite());

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -184,6 +184,7 @@
 #include "swaptionvolatilitycube.hpp"
 #include "swaptionvolatilitymatrix.hpp"
 #include "termstructures.hpp"
+#include "timegrid.hpp"
 #include "timeseries.hpp"
 #include "tqreigendecomposition.hpp"
 #include "tracing.hpp"
@@ -453,6 +454,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(SwaptionVolatilityCubeTest::suite());
     test->add(SwaptionVolatilityMatrixTest::suite());
     test->add(TermStructureTest::suite());
+	test->add(TimeGridTest::suite());
     test->add(TimeSeriesTest::suite());
     test->add(TqrEigenDecompositionTest::suite());
     test->add(TracingTest::suite());

--- a/test-suite/timegrid.cpp
+++ b/test-suite/timegrid.cpp
@@ -28,11 +28,23 @@ using namespace boost::unit_test_framework;
 void TimeGridTest::testConstructorAdditionalSteps()
 {
     BOOST_TEST_MESSAGE("TimeGrid constructor with additional steps.");
-    const std::vector<Time> test_times = { 1, 2, 4 };
+    std::vector<Time> test_times;
+    test_times.push_back(1.0);
+    test_times.push_back(2.0);
+    test_times.push_back(4.0);
     const TimeGrid tg(test_times.begin(), test_times.end(), 8);
     
     // Expect 8 evenly sized steps over the interval [0, 4].
-    const std::vector<Time> expected_times = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4 };
+    std::vector<Time> expected_times;
+    expected_times.push_back(0.0);
+    expected_times.push_back(0.5);
+    expected_times.push_back(1.0);
+    expected_times.push_back(1.5);
+    expected_times.push_back(2.0);
+    expected_times.push_back(2.5);
+    expected_times.push_back(3.0);
+    expected_times.push_back(3.5);
+    expected_times.push_back(4.0);
     BOOST_CHECK_EQUAL_COLLECTIONS(
     	tg.begin(), tg.end(), expected_times.begin(), expected_times.end());
 }
@@ -40,7 +52,11 @@ void TimeGridTest::testConstructorAdditionalSteps()
 void TimeGridTest::testConstructorMandatorySteps()
 {
     BOOST_TEST_MESSAGE("TimeGrid constructor with only mandatory points.");
-    const std::vector<Time> test_times = { 0, 1, 2, 4 };
+    std::vector<Time> test_times;
+    test_times.push_back(0.0);
+    test_times.push_back(1.0);
+    test_times.push_back(2.0);
+    test_times.push_back(4.0);
     const TimeGrid tg(test_times.begin(), test_times.end());
     
     // Time grid must include all times from passed iterator.
@@ -57,7 +73,13 @@ void TimeGridTest::testConstructorEvenSteps()
     Time end_time = 10;
     Size steps = 5;
     const TimeGrid tg(end_time, steps);
-    const std::vector<Time> expected_times = { 0, 2, 4, 6, 8, 10 };
+    std::vector<Time> expected_times;
+    expected_times.push_back(0.0);
+    expected_times.push_back(2.0);
+    expected_times.push_back(4.0);
+    expected_times.push_back(6.0);
+    expected_times.push_back(8.0);
+    expected_times.push_back(10.0);
     
     BOOST_CHECK_EQUAL_COLLECTIONS(
     	tg.begin(), tg.end(), expected_times.begin(), expected_times.end()
@@ -70,7 +92,7 @@ void TimeGridTest::testConstructorEmptyIterator()
     	"Test if the constructor raises an error for empty iterators."
     );
     
-    const std::vector<Time> times = {};
+    const std::vector<Time> times;
     BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
 }
 
@@ -80,7 +102,11 @@ void TimeGridTest::testConstructorNegativeValuesInIterator()
     	"Test if the constructor raises an error for negative time values."
     );
     
-    const std::vector<Time> times = { -3, 1, 4, 5 };
+    std::vector<Time> times;
+    times.push_back(-3.0);
+    times.push_back(1.0);
+    times.push_back(4.0);
+    times.push_back(5.0);
     BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
 }
 
@@ -88,7 +114,10 @@ void TimeGridTest::testClosestIndex()
 {
     BOOST_TEST_MESSAGE("Test returned index is closest to the requested time."
     );
-    const std::vector<Time> test_times = { 1, 2, 5 };
+    std::vector<Time> test_times;
+    test_times.push_back(1.0);
+    test_times.push_back(2.0);
+    test_times.push_back(5.0);
     const TimeGrid tg(test_times.begin(), test_times.end());
     const Size expected_index = 3;
     
@@ -100,7 +129,10 @@ void TimeGridTest::testClosestIndex()
 void TimeGridTest::testClosestTime()
 {
     BOOST_TEST_MESSAGE("Test returned time matches to the requested index.");
-    const std::vector<Time> test_times = { 1, 2, 5 };
+    std::vector<Time> test_times;
+    test_times.push_back(1.0);
+    test_times.push_back(2.0);
+    test_times.push_back(5.0);
     const TimeGrid tg(test_times.begin(), test_times.end());
     const Size expected_time = 5;
     
@@ -112,7 +144,10 @@ void TimeGridTest::testClosestTime()
 void TimeGridTest::testMandatoryTimes()
 {
     BOOST_TEST_MESSAGE("Test mandatory times are recalled correctly.");
-    const std::vector<Time> test_times = { 1, 2, 4 };
+    std::vector<Time> test_times;
+    test_times.push_back(1.0);
+    test_times.push_back(2.0);
+    test_times.push_back(4.0);
     const TimeGrid tg(test_times.begin(), test_times.end(), 8);
     
     // Mandatory times are those provided by the original iterator.

--- a/test-suite/timegrid.cpp
+++ b/test-suite/timegrid.cpp
@@ -27,114 +27,114 @@ using namespace boost::unit_test_framework;
 
 void TimeGridTest::testConstructorAdditionalSteps()
 {
-	BOOST_TEST_MESSAGE("TimeGrid constructor with additional steps.");
-	const std::vector<Time> test_times = { 1, 2, 4 };
-	const TimeGrid tg(test_times.begin(), test_times.end(), 8);
-
-	// Expect 8 evenly sized steps over the interval [0, 4].
-	const std::vector<Time> expected_times = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4 };
-	BOOST_CHECK_EQUAL_COLLECTIONS(
-		tg.begin(), tg.end(), expected_times.begin(), expected_times.end());
+    BOOST_TEST_MESSAGE("TimeGrid constructor with additional steps.");
+    const std::vector<Time> test_times = { 1, 2, 4 };
+    const TimeGrid tg(test_times.begin(), test_times.end(), 8);
+    
+    // Expect 8 evenly sized steps over the interval [0, 4].
+    const std::vector<Time> expected_times = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4 };
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+    	tg.begin(), tg.end(), expected_times.begin(), expected_times.end());
 }
 
 void TimeGridTest::testConstructorMandatorySteps()
 {
-	BOOST_TEST_MESSAGE("TimeGrid constructor with only mandatory points.");
-	const std::vector<Time> test_times = { 0, 1, 2, 4 };
-	const TimeGrid tg(test_times.begin(), test_times.end());
-
-	// Time grid must include all times from passed iterator.
-	// Further no additional times can be added.
-	BOOST_CHECK_EQUAL_COLLECTIONS(
-		tg.begin(), tg.end(), test_times.begin(), test_times.end());
+    BOOST_TEST_MESSAGE("TimeGrid constructor with only mandatory points.");
+    const std::vector<Time> test_times = { 0, 1, 2, 4 };
+    const TimeGrid tg(test_times.begin(), test_times.end());
+    
+    // Time grid must include all times from passed iterator.
+    // Further no additional times can be added.
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+    	tg.begin(), tg.end(), test_times.begin(), test_times.end());
 }
 
 void TimeGridTest::testConstructorEvenSteps()
 {
-	BOOST_TEST_MESSAGE(
-		"Test TimeGrid construction with n evenly spaced points");
-
-	Time end_time = 10;
-	Size steps = 5;
-	const TimeGrid tg(end_time, steps);
-	const std::vector<Time> expected_times = { 0, 2, 4, 6, 8, 10 };
-
-	BOOST_CHECK_EQUAL_COLLECTIONS(
-		tg.begin(), tg.end(), expected_times.begin(), expected_times.end()
-	);
+    BOOST_TEST_MESSAGE(
+    	"Test TimeGrid construction with n evenly spaced points");
+    
+    Time end_time = 10;
+    Size steps = 5;
+    const TimeGrid tg(end_time, steps);
+    const std::vector<Time> expected_times = { 0, 2, 4, 6, 8, 10 };
+    
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+    	tg.begin(), tg.end(), expected_times.begin(), expected_times.end()
+    );
 }
 
 void TimeGridTest::testConstructorEmptyIterator()
 {
-	BOOST_TEST_MESSAGE(
-		"Test if the constructor raises an error for empty iterators."
-	);
-
-	const std::vector<Time> times = {};
-	BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
+    BOOST_TEST_MESSAGE(
+    	"Test if the constructor raises an error for empty iterators."
+    );
+    
+    const std::vector<Time> times = {};
+    BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
 }
 
 void TimeGridTest::testConstructorNegativeValuesInIterator()
 {
-	BOOST_TEST_MESSAGE(
-		"Test if the constructor raises an error for negative time values."
-	);
-
-	const std::vector<Time> times = { -3, 1, 4, 5 };
-	BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
+    BOOST_TEST_MESSAGE(
+    	"Test if the constructor raises an error for negative time values."
+    );
+    
+    const std::vector<Time> times = { -3, 1, 4, 5 };
+    BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
 }
 
 void TimeGridTest::testClosestIndex()
 {
-	BOOST_TEST_MESSAGE("Test returned index is closest to the requested time."
-	);
-	const std::vector<Time> test_times = { 1, 2, 5 };
-	const TimeGrid tg(test_times.begin(), test_times.end());
-	const Size expected_index = 3;
-
-	QL_ASSERT(tg.closestIndex(4) == expected_index,
-		"Expected index: " << expected_index << ", which does not match " <<
-		"the returned index: " << tg.closestIndex(4));
+    BOOST_TEST_MESSAGE("Test returned index is closest to the requested time."
+    );
+    const std::vector<Time> test_times = { 1, 2, 5 };
+    const TimeGrid tg(test_times.begin(), test_times.end());
+    const Size expected_index = 3;
+    
+    QL_ASSERT(tg.closestIndex(4) == expected_index,
+    	"Expected index: " << expected_index << ", which does not match " <<
+    	"the returned index: " << tg.closestIndex(4));
 }
 
 void TimeGridTest::testClosestTime()
 {
-	BOOST_TEST_MESSAGE("Test returned time matches to the requested index.");
-	const std::vector<Time> test_times = { 1, 2, 5 };
-	const TimeGrid tg(test_times.begin(), test_times.end());
-	const Size expected_time = 5;
-
-	QL_ASSERT(tg.closestTime(4) == expected_time,
-		"Expected time of: " << expected_time << ", which does not match " <<
-		"the returned time: " << tg.closestTime(4));
+    BOOST_TEST_MESSAGE("Test returned time matches to the requested index.");
+    const std::vector<Time> test_times = { 1, 2, 5 };
+    const TimeGrid tg(test_times.begin(), test_times.end());
+    const Size expected_time = 5;
+    
+    QL_ASSERT(tg.closestTime(4) == expected_time,
+    	"Expected time of: " << expected_time << ", which does not match " <<
+    	"the returned time: " << tg.closestTime(4));
 }
 
 void TimeGridTest::testMandatoryTimes()
 {
-	BOOST_TEST_MESSAGE("Test mandatory times are recalled correctly.");
-	const std::vector<Time> test_times = { 1, 2, 4 };
-	const TimeGrid tg(test_times.begin(), test_times.end(), 8);
-
-	// Mandatory times are those provided by the original iterator.
-	const std::vector<Time> tg_mandatory_times = tg.mandatoryTimes();
-	BOOST_CHECK_EQUAL_COLLECTIONS(
-		tg_mandatory_times.begin(), tg_mandatory_times.end(),
-		test_times.begin(), test_times.end());
+    BOOST_TEST_MESSAGE("Test mandatory times are recalled correctly.");
+    const std::vector<Time> test_times = { 1, 2, 4 };
+    const TimeGrid tg(test_times.begin(), test_times.end(), 8);
+    
+    // Mandatory times are those provided by the original iterator.
+    const std::vector<Time> tg_mandatory_times = tg.mandatoryTimes();
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+    	tg_mandatory_times.begin(), tg_mandatory_times.end(),
+    	test_times.begin(), test_times.end());
 }
 
 test_suite* TimeGridTest::suite()
 {
-	test_suite* suite = BOOST_TEST_SUITE("Timegrid tests");
-
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorAdditionalSteps));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorMandatorySteps));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEvenSteps));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEmptyIterator));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorNegativeValuesInIterator));
-
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestIndex));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestTime));
-	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testMandatoryTimes));
-
-	return suite;
+    test_suite* suite = BOOST_TEST_SUITE("Timegrid tests");
+    
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorAdditionalSteps));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorMandatorySteps));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEvenSteps));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEmptyIterator));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorNegativeValuesInIterator));
+    
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestIndex));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestTime));
+    suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testMandatoryTimes));
+    
+    return suite;
 }

--- a/test-suite/timegrid.cpp
+++ b/test-suite/timegrid.cpp
@@ -1,0 +1,140 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+This file is part of QuantLib, a free - software / open - source library
+for financial quantitative analysts and developers - http://quantlib.org/
+
+QuantLib is free software : you can redistribute it and/or modify it
+under the terms of the QuantLib license.You should have received a
+copy of the license along with this program; if not, please email
+<quantlib - dev@lists.sf.net>.The license is also available online at
+<http://quantlib.org/license.shtml>.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.See the license for more details.
+*/
+
+#include "ql/timegrid.hpp"
+#include "timegrid.hpp"
+#include "utilities.hpp"
+
+#include <iostream>
+#include <vector>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+void TimeGridTest::testConstructorAdditionalSteps()
+{
+	BOOST_TEST_MESSAGE("TimeGrid constructor with additional steps.");
+	const std::vector<Time> test_times = { 1, 2, 4 };
+	const TimeGrid tg(test_times.begin(), test_times.end(), 8);
+
+	// Expect 8 evenly sized steps over the interval [0, 4].
+	const std::vector<Time> expected_times = { 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4 };
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		tg.begin(), tg.end(), expected_times.begin(), expected_times.end());
+}
+
+void TimeGridTest::testConstructorMandatorySteps()
+{
+	BOOST_TEST_MESSAGE("TimeGrid constructor with only mandatory points.");
+	const std::vector<Time> test_times = { 0, 1, 2, 4 };
+	const TimeGrid tg(test_times.begin(), test_times.end());
+
+	// Time grid must include all times from passed iterator.
+	// Further no additional times can be added.
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		tg.begin(), tg.end(), test_times.begin(), test_times.end());
+}
+
+void TimeGridTest::testConstructorEvenSteps()
+{
+	BOOST_TEST_MESSAGE(
+		"Test TimeGrid construction with n evenly spaced points");
+
+	Time end_time = 10;
+	Size steps = 5;
+	const TimeGrid tg(end_time, steps);
+	const std::vector<Time> expected_times = { 0, 2, 4, 6, 8, 10 };
+
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		tg.begin(), tg.end(), expected_times.begin(), expected_times.end()
+	);
+}
+
+void TimeGridTest::testConstructorEmptyIterator()
+{
+	BOOST_TEST_MESSAGE(
+		"Test if the constructor raises an error for empty iterators."
+	);
+
+	const std::vector<Time> times = {};
+	BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
+}
+
+void TimeGridTest::testConstructorNegativeValuesInIterator()
+{
+	BOOST_TEST_MESSAGE(
+		"Test if the constructor raises an error for negative time values."
+	);
+
+	const std::vector<Time> times = { -3, 1, 4, 5 };
+	BOOST_CHECK_THROW(const TimeGrid tg(times.begin(), times.end()), Error);
+}
+
+void TimeGridTest::testClosestIndex()
+{
+	BOOST_TEST_MESSAGE("Test returned index is closest to the requested time."
+	);
+	const std::vector<Time> test_times = { 1, 2, 5 };
+	const TimeGrid tg(test_times.begin(), test_times.end());
+	const Size expected_index = 3;
+
+	QL_ASSERT(tg.closestIndex(4) == expected_index,
+		"Expected index: " << expected_index << ", which does not match " <<
+		"the returned index: " << tg.closestIndex(4));
+}
+
+void TimeGridTest::testClosestTime()
+{
+	BOOST_TEST_MESSAGE("Test returned time matches to the requested index.");
+	const std::vector<Time> test_times = { 1, 2, 5 };
+	const TimeGrid tg(test_times.begin(), test_times.end());
+	const Size expected_time = 5;
+
+	QL_ASSERT(tg.closestTime(4) == expected_time,
+		"Expected time of: " << expected_time << ", which does not match " <<
+		"the returned time: " << tg.closestTime(4));
+}
+
+void TimeGridTest::testMandatoryTimes()
+{
+	BOOST_TEST_MESSAGE("Test mandatory times are recalled correctly.");
+	const std::vector<Time> test_times = { 1, 2, 4 };
+	const TimeGrid tg(test_times.begin(), test_times.end(), 8);
+
+	// Mandatory times are those provided by the original iterator.
+	const std::vector<Time> tg_mandatory_times = tg.mandatoryTimes();
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		tg_mandatory_times.begin(), tg_mandatory_times.end(),
+		test_times.begin(), test_times.end());
+}
+
+test_suite* TimeGridTest::suite()
+{
+	test_suite* suite = BOOST_TEST_SUITE("Timegrid tests");
+
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorAdditionalSteps));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorMandatorySteps));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEvenSteps));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEmptyIterator));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorNegativeValuesInIterator));
+
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestIndex));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testClosestTime));
+	suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testMandatoryTimes));
+
+	return suite;
+}

--- a/test-suite/timegrid.hpp
+++ b/test-suite/timegrid.hpp
@@ -22,17 +22,17 @@ FOR A PARTICULAR PURPOSE.See the license for more details.
 
 class TimeGridTest {
 public:
-	static void testConstructorAdditionalSteps();
-	static void testConstructorMandatorySteps();
-	static void testConstructorEvenSteps();
-	static void testConstructorEmptyIterator();
-	static void testConstructorNegativeValuesInIterator();
-
-	static void testClosestIndex();
-	static void testClosestTime();
-	static void testMandatoryTimes();
-
-	static boost::unit_test_framework::test_suite* suite();
+    static void testConstructorAdditionalSteps();
+    static void testConstructorMandatorySteps();
+    static void testConstructorEvenSteps();
+    static void testConstructorEmptyIterator();
+    static void testConstructorNegativeValuesInIterator();
+    
+    static void testClosestIndex();
+    static void testClosestTime();
+    static void testMandatoryTimes();
+    
+    static boost::unit_test_framework::test_suite* suite();
 };
 
 #endif

--- a/test-suite/timegrid.hpp
+++ b/test-suite/timegrid.hpp
@@ -1,0 +1,38 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+This file is part of QuantLib, a free - software / open - source library
+for financial quantitative analysts and developers - http://quantlib.org/
+
+QuantLib is free software : you can redistribute it and/or modify it
+under the terms of the QuantLib license.You should have received a
+copy of the license along with this program; if not, please email
+<quantlib - dev@lists.sf.net>.The license is also available online at
+<http://quantlib.org/license.shtml>.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.See the license for more details.
+*/
+
+#ifndef quantlib_test_time_grid_hpp
+#define quantlib_test_time_grid_hpp
+
+#include <boost/test/unit_test.hpp>
+
+class TimeGridTest {
+public:
+	static void testConstructorAdditionalSteps();
+	static void testConstructorMandatorySteps();
+	static void testConstructorEvenSteps();
+	static void testConstructorEmptyIterator();
+	static void testConstructorNegativeValuesInIterator();
+
+	static void testClosestIndex();
+	static void testClosestTime();
+	static void testMandatoryTimes();
+
+	static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif


### PR DESCRIPTION
Basic unit tests for the TimeGrid class. I've run them on Windows 32bit using Visual Studio. If these look good I can run them on my Ubuntu machine to make sure they run on Linux.

Tests cover:
* Basic constructors with mandatory periods only, additional periods via an iterator and evenly spaced periods.
* Edge cases (empty iterator + negative times) in constructor method.
* Public methods; closestIndex, closestTime and mandatoryTimes.

I'm not sure if there are any more tests you would like to have added.

closes #315 