### PR TITLE
Add .clang-format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,54 @@
+---
+Language:        Cpp
+Standard:        Cpp03
+
+
+# The following is close to the style we've been using all these years
+# without formalizing it.  Formatting won't be enforced, but this file
+# can help if you want to use the general feel of the library.
+
+
+# General appearance:
+
+BasedOnStyle: LLVM
+
+IndentWidth: 4
+ColumnLimit: 100
+NamespaceIndentation: All
+MaxEmptyLinesToKeep: 2
+FixNamespaceComments: false
+
+# Function declarations:
+
+BinPackParameters: false
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakTemplateDeclarations: Yes
+
+# T& x, not T &x:
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# QuantLib headers first, then Boost, then std
+
+SortIncludes: true
+IncludeBlocks: Merge
+IncludeCategories: 
+  - Regex:           '^"'
+    Priority:        1
+  - Regex:           '^<ql/'
+    Priority:        2
+  - Regex:           '^<boost/'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        4
+
+# Other:
+
+AlignEscapedNewlines: Left
+BreakBeforeTernaryOperators: false
+ConstructorInitializerIndentWidth: 0
+SortUsingDeclarations: false
+IndentCaseLabels: true
+
+...


### PR DESCRIPTION
It's here as a convenience; the style is not enforced.

I've no plans of formatting the whole library, as I see no upside in that.