### PR TITLE
fix clang format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,7 +22,7 @@ FixNamespaceComments: false
 
 BinPackParameters: false
 AllowShortFunctionsOnASingleLine: Inline
-AlwaysBreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: true
 
 # T& x, not T &x:
 


### PR DESCRIPTION
the variant using 'Yes' does not work with clang-format 6.0.0, is that an old convention (or a brand new one?)