### PR TITLE
Avoid instabilities in test case.

### DIFF
--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -610,7 +610,7 @@ void RiskNeutralDensityCalculatorTest::testBlackScholesWithSkew() {
         ext::make_shared<HestonBlackVolSurface>(
             Handle<HestonModel>(ext::make_shared<HestonModel>(hestonProcess)),
             AnalyticHestonEngine::AndersenPiterbarg,
-            AnalyticHestonEngine::Integration::discreteTrapezoid(32)));
+            AnalyticHestonEngine::Integration::discreteTrapezoid(64)));
 
     const ext::shared_ptr<TimeGrid> timeGrid(new TimeGrid(maturity, 51));
 


### PR DESCRIPTION
The previous value could give slightly different results (depending on the version of libc on Ubuntu) that would get amplified by the local-volatility calculation, causing the test to fail.