### PR TITLE
Require Boost 1.48 or later

### DIFF
--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -184,7 +184,6 @@ int test(OptimizationMethod& method, CostFunction& f, const EndCriteria& endCrit
     return 1;
 }
 
-#if BOOST_VERSION >= 104700
 void testFirefly() {
     /*
     The Eggholder function is only in 2 dimensions, it has a multitude
@@ -211,7 +210,6 @@ void testFirefly() {
     test(fa, f, ec, x, constraint, optimum);
     std::cout << "================================================================" << std::endl;
 }
-#endif
 
 void testSimulatedAnnealing(Size dimension, Size maxSteps, Size staticSteps){
 
@@ -297,7 +295,6 @@ void testGaussianSA(Size dimension, Size maxSteps, Size staticSteps, Real initia
     std::cout << "================================================================" << std::endl;
 }
 
-#if BOOST_VERSION >= 104700
 void testPSO(Size n){
     /*The Rosenbrock function has a global minima at (1.0, ...) and a local minima at (-1.0, 1.0, ...)
     The difficulty lies in the weird shape of the function*/
@@ -320,7 +317,6 @@ void testPSO(Size n){
     test(pso, f, ec, x, constraint, optimum);
     std::cout << "================================================================" << std::endl;
 }
-#endif
 
 void testDifferentialEvolution(Size n, Size agents){
     /*The Rosenbrock function has a global minima at (1.0, ...) and a local minima at (-1.0, 1.0, ...)
@@ -373,14 +369,12 @@ int main(int, char* []) {
         std::cout << std::endl;
         boost::timer timer;
 
-#if BOOST_VERSION >= 104700
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Firefly Algorithm Test" << std::endl;
         std::cout << "----------------------------------------------------------------" << std::endl;
         testFirefly();
 
         printTime(timer.elapsed());
-#endif
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Hybrid Simulated Annealing Test" << std::endl;
@@ -391,7 +385,6 @@ int main(int, char* []) {
 
         printTime(timer.elapsed());
 
-#if BOOST_VERSION >= 104700
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Particle Swarm Optimization Test" << std::endl;
         std::cout << "----------------------------------------------------------------" << std::endl;
@@ -400,7 +393,6 @@ int main(int, char* []) {
         testPSO(30);
 
         printTime(timer.elapsed());
-#endif
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Simulated Annealing Test" << std::endl;

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -55,11 +55,11 @@ AC_DEFUN([QL_CHECK_BOOST_DEVEL],
 # ----------------------
 # Check whether the Boost installation is up to date
 AC_DEFUN([QL_CHECK_BOOST_VERSION],
-[AC_MSG_CHECKING([for Boost version >= 1.43])
+[AC_MSG_CHECKING([for Boost version >= 1.48])
  AC_REQUIRE([QL_CHECK_BOOST_DEVEL])
  AC_TRY_COMPILE(
     [@%:@include <boost/version.hpp>],
-    [@%:@if BOOST_VERSION < 104300
+    [@%:@if BOOST_VERSION < 104800
      @%:@error too old
      @%:@endif],
     [AC_MSG_RESULT([yes])],
@@ -146,7 +146,7 @@ AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
                   boost_unit_test_framework-$CC_BASENAME-mt \
                   boost_unit_test_framework-mt ; do
      LIBS="$ql_original_LIBS -l$boost_lib"
-     # 1.33.1 or 1.34 static
+     # static version
      CXXFLAGS="$ql_original_CXXFLAGS"
      boost_unit_found=no
      AC_LINK_IFELSE([AC_LANG_SOURCE(
@@ -162,7 +162,7 @@ AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
           boost_defines=""
           break],
          [])
-     # 1.34 shared
+     # shared version
      CXXFLAGS="$ql_original_CXXFLAGS -DBOOST_TEST_MAIN -DBOOST_TEST_DYN_LINK"
      boost_unit_found=no
      AC_LINK_IFELSE([AC_LANG_SOURCE(

--- a/ql/experimental/math/fireflyalgorithm.cpp
+++ b/ql/experimental/math/fireflyalgorithm.cpp
@@ -17,10 +17,6 @@ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/qldefines.hpp>
-
-#if BOOST_VERSION >= 104700
-
 #include <ql/experimental/math/fireflyalgorithm.hpp>
 #include <ql/math/randomnumbers/sobolrsg.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -246,6 +242,4 @@ namespace QuantLib {
         }
     }
 }
-
-#endif
 

--- a/ql/experimental/math/fireflyalgorithm.hpp
+++ b/ql/experimental/math/fireflyalgorithm.hpp
@@ -27,10 +27,6 @@ http://arxiv.org/pdf/1003.1464.pdf
 #ifndef quantlib_optimization_fireflyalgorithm_hpp
 #define quantlib_optimization_fireflyalgorithm_hpp
 
-#include <ql/qldefines.hpp>
-
-#if BOOST_VERSION >= 104700
-
 #include <ql/math/optimization/problem.hpp>
 #include <ql/math/optimization/constraint.hpp>
 #include <ql/experimental/math/isotropicrandomwalk.hpp>
@@ -281,7 +277,5 @@ namespace QuantLib {
         Size iteration_;
     };
 }
-
-#endif
 
 #endif

--- a/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
+++ b/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
@@ -34,19 +34,11 @@ typedef boost::mt19937 base_generator_type;
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/lognormal_distribution.hpp>
 #include <boost/random/cauchy_distribution.hpp>
-#if BOOST_VERSION >= 104700
 #include <boost/random/uniform_real_distribution.hpp>
 typedef boost::random::uniform_real_distribution<double> uniform;
 typedef boost::random::normal_distribution<> normal_random;
 typedef boost::random::lognormal_distribution<> lognormal_random;
 typedef boost::random::cauchy_distribution<> cauchy_random;
-#else
-#include <boost/random/uniform_real.hpp>
-typedef boost::uniform_real<> uniform;
-typedef boost::normal_distribution<> normal_random;
-typedef boost::lognormal_distribution<> lognormal_random;
-typedef boost::cauchy_distribution<> cauchy_random;
-#endif
 
 #include <boost/random/variate_generator.hpp>
 typedef boost::variate_generator<base_generator_type&, uniform > uniform_variate;

--- a/ql/experimental/math/levyflightdistribution.hpp
+++ b/ql/experimental/math/levyflightdistribution.hpp
@@ -24,11 +24,6 @@
 #ifndef quantlib_levy_flight_distribution_hpp
 #define quantlib_levy_flight_distribution_hpp
 
-#include <ql/qldefines.hpp>
-
-// The included Boost.Random headers were added in Boost 1.47
-#if BOOST_VERSION >= 104700
-
 #include <ql/types.hpp>
 #include <ql/errors.hpp>
 #include <boost/config/no_tr1/cmath.hpp>
@@ -200,7 +195,5 @@ namespace QuantLib {
     };
 
 }
-
-#endif
 
 #endif

--- a/ql/experimental/math/particleswarmoptimization.cpp
+++ b/ql/experimental/math/particleswarmoptimization.cpp
@@ -17,10 +17,6 @@ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/qldefines.hpp>
-
-#if BOOST_VERSION >= 104700
-
 #include <ql/experimental/math/particleswarmoptimization.hpp>
 #include <ql/math/randomnumbers/sobolrsg.hpp>
 #include <cmath>
@@ -402,4 +398,4 @@ namespace QuantLib {
         }
     }
 }
-#endif
+

--- a/ql/experimental/math/particleswarmoptimization.hpp
+++ b/ql/experimental/math/particleswarmoptimization.hpp
@@ -27,10 +27,6 @@ Computation, 6(2): 58–73.
 #ifndef quantlib_optimization_particleswarmoptimization_hpp
 #define quantlib_optimization_particleswarmoptimization_hpp
 
-#include <ql/qldefines.hpp>
-
-#if BOOST_VERSION >= 104700
-
 #include <ql/math/optimization/problem.hpp>
 #include <ql/math/optimization/constraint.hpp>
 #include <ql/math/randomnumbers/mt19937uniformrng.hpp>
@@ -415,5 +411,4 @@ namespace QuantLib {
 
 }
 
-#endif
 #endif

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -39,13 +39,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 #ifndef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
 
-// Boost libraries prior to 1.47 have a bug in the hash function,
-// which makes boost::unordered_set very inefficient if the key is of type
-// ext::shared_ptr. In this case fall back to std::set.
-#if BOOST_VERSION < 104700
-#include <set>
-#endif
-
 namespace QuantLib {
 
     class Observer;
@@ -106,11 +99,7 @@ namespace QuantLib {
     /*! \ingroup patterns */
     class Observer {
       public:
-#if BOOST_VERSION < 104700
-        typedef std::set<ext::shared_ptr<Observable> > set_type;
-#else
         typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
-#endif
         typedef set_type::iterator iterator;
 
         // constructors, assignment, destructor

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -37,7 +37,7 @@
 
 #include <boost/config.hpp>
 #include <boost/version.hpp>
-#if BOOST_VERSION < 103900
+#if BOOST_VERSION < 104800
     #error using an old version of Boost, please update.
 #endif
 #if !defined(BOOST_ENABLE_ASSERT_HANDLER)


### PR DESCRIPTION
The minimum requirement used to be version 1.43, but parts of the library had to be conditionally disabled when using a version this old.

Boost 1.48 came out in 2011, so it doesn't seem unreasonable to require.