### PR TITLE
Fix segfault in short eom schedule generation

### DIFF
--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -360,8 +360,8 @@ void ScheduleTest::testFourWeeksTenor() {
     }
 }
 
-void ScheduleTest::testEomSchedule() {
-    BOOST_TEST_MESSAGE("Testing eom schedule...");
+void ScheduleTest::testShortEomSchedule() {
+    BOOST_TEST_MESSAGE("Testing short eom schedule...");
 
     try {
         // seg-faults in 1.15
@@ -374,12 +374,12 @@ void ScheduleTest::testEomSchedule() {
                          .withTerminationDateConvention(ModifiedFollowing)
                          .backwards()
                          .endOfMonth(true);
-        for(Size i=0;i<s.size();++i) {
-            BOOST_TEST_MESSAGE("date #" << i << ": " << s[i]);
-        }
+        BOOST_CHECK(s.size() == 2);
+        BOOST_CHECK(s[0] == Date(21, Feb, 2019));
+        BOOST_CHECK(s[1] == Date(28, Feb, 2019));
     } catch (std::exception& e) {
         BOOST_ERROR(
-            "eom schedule construction caused an exception: " << e.what());
+            "Short eom schedule construction caused an exception: " << e.what());
     }
 }
 
@@ -439,6 +439,6 @@ test_suite* ScheduleTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFourWeeksTenor));
     suite->add(QUANTLIB_TEST_CASE(
                            &ScheduleTest::testScheduleAlwaysHasAStartDate));
-    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testEomSchedule));
+    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testShortEomSchedule));
     return suite;
 }

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -360,6 +360,28 @@ void ScheduleTest::testFourWeeksTenor() {
     }
 }
 
+void ScheduleTest::testEomSchedule() {
+    BOOST_TEST_MESSAGE("Testing eom schedule...");
+
+    try {
+        // seg-faults in 1.15
+        Schedule s = MakeSchedule()
+                         .from(Date(21, Feb, 2019))
+                         .to(Date(28, Feb, 2019))
+                         .withCalendar(TARGET())
+                         .withTenor(1 * Years)
+                         .withConvention(ModifiedFollowing)
+                         .withTerminationDateConvention(ModifiedFollowing)
+                         .backwards()
+                         .endOfMonth(true);
+        for(Size i=0;i<s.size();++i) {
+            BOOST_TEST_MESSAGE("date #" << i << ": " << s[i]);
+        }
+    } catch (std::exception& e) {
+        BOOST_ERROR(
+            "eom schedule construction caused an exception: " << e.what());
+    }
+}
 
 void ScheduleTest::testScheduleAlwaysHasAStartDate() {
     BOOST_TEST_MESSAGE("Testing that variations of MakeSchedule "
@@ -417,5 +439,6 @@ test_suite* ScheduleTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFourWeeksTenor));
     suite->add(QUANTLIB_TEST_CASE(
                            &ScheduleTest::testScheduleAlwaysHasAStartDate));
+    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testEomSchedule));
     return suite;
 }

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -362,63 +362,21 @@ void ScheduleTest::testFourWeeksTenor() {
 
 void ScheduleTest::testShortEomSchedule() {
     BOOST_TEST_MESSAGE("Testing short eom schedule...");
-
-    try {
-        // seg-faults in 1.15
-        Schedule s = MakeSchedule()
-                         .from(Date(21, Feb, 2019))
-                         .to(Date(28, Feb, 2019))
-                         .withCalendar(TARGET())
-                         .withTenor(1 * Years)
-                         .withConvention(ModifiedFollowing)
-                         .withTerminationDateConvention(ModifiedFollowing)
-                         .backwards()
-                         .endOfMonth(true);
-        BOOST_CHECK(s.size() == 2);
-        BOOST_CHECK(s[0] == Date(21, Feb, 2019));
-        BOOST_CHECK(s[1] == Date(28, Feb, 2019));
-    } catch (std::exception& e) {
-        BOOST_ERROR(
-            "Short eom schedule construction caused an exception: " << e.what());
-    }
+    Schedule s;
+    // seg-faults in 1.15
+    BOOST_REQUIRE_NO_THROW(s = MakeSchedule()
+                                   .from(Date(21, Feb, 2019))
+                                   .to(Date(28, Feb, 2019))
+                                   .withCalendar(TARGET())
+                                   .withTenor(1 * Years)
+                                   .withConvention(ModifiedFollowing)
+                                   .withTerminationDateConvention(ModifiedFollowing)
+                                   .backwards()
+                                   .endOfMonth(true));
+    BOOST_REQUIRE(s.size() == 2);
+    BOOST_CHECK(s[0] == Date(21, Feb, 2019));
+    BOOST_CHECK(s[1] == Date(28, Feb, 2019));
 }
-
-void ScheduleTest::testScheduleAlwaysHasAStartDate() {
-    BOOST_TEST_MESSAGE("Testing that variations of MakeSchedule "
-                       "always produce a schedule with a start date...");
-    // Attempt to establish whether the first coupoun payment date is
-    // always the second element of the constructor.
-    Calendar calendar = UnitedStates();
-    Schedule schedule = MakeSchedule()
-        .from(Date(10, January, 2017))
-        .withFirstDate(Date(31, August, 2017))
-        .to(Date(28, February, 2026))
-        .withFrequency(Semiannual)
-        .withCalendar(calendar)
-        .withConvention(Unadjusted)
-        .backwards().endOfMonth(false);
-    QL_ASSERT(schedule.date(0) == Date(10, January, 2017),
-              "The first element should always be the start date");
-    schedule = MakeSchedule()
-        .from(Date(10, January, 2017))
-        .to(Date(28, February, 2026))
-        .withFrequency(Semiannual)
-        .withCalendar(calendar)
-        .withConvention(Unadjusted)
-        .backwards().endOfMonth(false);
-    QL_ASSERT(schedule.date(0) == Date(10, January, 2017),
-              "The first element should always be the start date");
-    schedule = MakeSchedule()
-        .from(Date(31, August, 2017))
-        .to(Date(28, February, 2026))
-        .withFrequency(Semiannual)
-        .withCalendar(calendar)
-        .withConvention(Unadjusted)
-        .backwards().endOfMonth(false);
-    QL_ASSERT(schedule.date(0) == Date(31, August, 2017),
-              "The first element should always be the start date");
-}
-
 
 test_suite* ScheduleTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Schedule tests");
@@ -437,8 +395,6 @@ test_suite* ScheduleTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testCDS2015Convention));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testDateConstructor));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFourWeeksTenor));
-    suite->add(QUANTLIB_TEST_CASE(
-                           &ScheduleTest::testScheduleAlwaysHasAStartDate));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testShortEomSchedule));
     return suite;
 }

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -360,6 +360,42 @@ void ScheduleTest::testFourWeeksTenor() {
     }
 }
 
+void ScheduleTest::testScheduleAlwaysHasAStartDate() {
+    BOOST_TEST_MESSAGE("Testing that variations of MakeSchedule "
+                       "always produce a schedule with a start date...");
+    // Attempt to establish whether the first coupoun payment date is
+    // always the second element of the constructor.
+    Calendar calendar = UnitedStates();
+    Schedule schedule = MakeSchedule()
+        .from(Date(10, January, 2017))
+        .withFirstDate(Date(31, August, 2017))
+        .to(Date(28, February, 2026))
+        .withFrequency(Semiannual)
+        .withCalendar(calendar)
+        .withConvention(Unadjusted)
+        .backwards().endOfMonth(false);
+    QL_ASSERT(schedule.date(0) == Date(10, January, 2017),
+              "The first element should always be the start date");
+    schedule = MakeSchedule()
+        .from(Date(10, January, 2017))
+        .to(Date(28, February, 2026))
+        .withFrequency(Semiannual)
+        .withCalendar(calendar)
+        .withConvention(Unadjusted)
+        .backwards().endOfMonth(false);
+    QL_ASSERT(schedule.date(0) == Date(10, January, 2017),
+              "The first element should always be the start date");
+    schedule = MakeSchedule()
+        .from(Date(31, August, 2017))
+        .to(Date(28, February, 2026))
+        .withFrequency(Semiannual)
+        .withCalendar(calendar)
+        .withConvention(Unadjusted)
+        .backwards().endOfMonth(false);
+    QL_ASSERT(schedule.date(0) == Date(31, August, 2017),
+              "The first element should always be the start date");
+}
+
 void ScheduleTest::testShortEomSchedule() {
     BOOST_TEST_MESSAGE("Testing short eom schedule...");
     Schedule s;

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -431,6 +431,7 @@ test_suite* ScheduleTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testCDS2015Convention));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testDateConstructor));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFourWeeksTenor));
+    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testScheduleAlwaysHasAStartDate));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testShortEomSchedule));
     return suite;
 }

--- a/test-suite/schedule.hpp
+++ b/test-suite/schedule.hpp
@@ -38,6 +38,7 @@ class ScheduleTest {
     static void testDateConstructor();
     static void testFourWeeksTenor();
     static void testScheduleAlwaysHasAStartDate();
+    static void testEomSchedule();
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/schedule.hpp
+++ b/test-suite/schedule.hpp
@@ -38,7 +38,7 @@ class ScheduleTest {
     static void testDateConstructor();
     static void testFourWeeksTenor();
     static void testScheduleAlwaysHasAStartDate();
-    static void testEomSchedule();
+    static void testShortEomSchedule();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
I think we should add the check starting in line 436 in every case (prevents a possible invalid read).

Not 100% sure about the change in line 394, what do you think? The use case on our side is the construction of a schedule for an instrument following certain conventions (1Y tenor, end of month) but in this particular case the overall maturity of the instrument itself is shorter (1W), so the expected result is only the one stub period given by the effective date and the termination date.  The current logic in the schedule building collapses this further to a single date though. In my opinion, this case should be handled similarly as if the tenor was 1W, in which case an end of month adjustment would be skipped in the existing builder as well? 