### PR TITLE
Remove switch for negative rates.

### DIFF
--- a/Docs/pages/config.docs
+++ b/Docs/pages/config.docs
@@ -57,12 +57,6 @@
     performance. Undefined by default.
 
     \code
-    #define QL_NEGATIVE_RATES
-    \endcode
-    If defined (the default), negative yield rates are allowed in a
-    few places where they used to be forbidden.
-
-    \code
     #define QL_EXTRA_SAFETY_CHECKS
     \endcode
     If defined, extra run-time checks are added to a few

--- a/configure.ac
+++ b/configure.ac
@@ -206,21 +206,6 @@ if test "$ql_indexed_coupon" = "yes" ; then
 fi
 AC_MSG_RESULT([$ql_indexed_coupon])
 
-AC_MSG_CHECKING([whether to enable negative rates])
-AC_ARG_ENABLE([negative-rates],
-              AC_HELP_STRING([--enable-negative-rates],
-                             [If enabled (the default), negative yield
-                              rates are allowed.  If disabled, some
-                              features (notably, curve bootstrapping)
-                              will throw when negative rates are found.]),
-              [ql_negative_rates=$enableval],
-              [ql_negative_rates=yes])
-if test "$ql_negative_rates" = "yes" ; then
-   AC_DEFINE([QL_NEGATIVE_RATES],[1],
-             [Define this if negative yield rates should be allowed.])
-fi
-AC_MSG_RESULT([$ql_negative_rates])
-
 AC_MSG_CHECKING([whether to enable extra safety checks])
 AC_ARG_ENABLE([extra-safety-checks],
               AC_HELP_STRING([--enable-extra-safety-checks],

--- a/ql/termstructures/yield/bootstraptraits.hpp
+++ b/ql/termstructures/yield/bootstraptraits.hpp
@@ -83,12 +83,8 @@ namespace QuantLib {
                                   Size) // firstAliveHelper
         {
             if (validData) {
-                #if defined(QL_NEGATIVE_RATES)
                 return *(std::min_element(c->data().begin(),
                                           c->data().end()))/2.0;
-                #else
-                return c->data().back()/2.0;
-                #endif
             }
             Time dt = c->times()[i] - c->times()[i-1];
             return c->data()[i-1] * std::exp(- detail::maxRate * dt);
@@ -99,13 +95,8 @@ namespace QuantLib {
                                   bool validData,
                                   Size) // firstAliveHelper
         {
-            #if defined(QL_NEGATIVE_RATES)
             Time dt = c->times()[i] - c->times()[i-1];
             return c->data()[i-1] * std::exp(detail::maxRate * dt);
-            #else
-            // discounts cannot increase
-            return c->data()[i-1];
-            #endif
         }
 
         // root-finding update
@@ -166,19 +157,11 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::min_element(c->data().begin(), c->data().end()));
-                #if defined(QL_NEGATIVE_RATES)
                 return r<0.0 ? r*2.0 : r/2.0;
-                #else
-                return r/2.0;
-                #endif
             }
-            #if defined(QL_NEGATIVE_RATES)
             // no constraints.
             // We choose as min a value very unlikely to be exceeded.
             return -detail::maxRate;
-            #else
-            return QL_EPSILON;
-            #endif
         }
         template <class C>
         static Real maxValueAfter(Size,
@@ -188,11 +171,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::max_element(c->data().begin(), c->data().end()));
-                #if defined(QL_NEGATIVE_RATES)
                 return r<0.0 ? r/2.0 : r*2.0;
-                #else
-                return r*2.0;
-                #endif
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
@@ -259,19 +238,11 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::min_element(c->data().begin(), c->data().end()));
-                #if defined(QL_NEGATIVE_RATES)
                 return r<0.0 ? r*2.0 : r/2.0;
-                #else
-                return r/2.0;
-                #endif
             }
-            #if defined(QL_NEGATIVE_RATES)
             // no constraints.
             // We choose as min a value very unlikely to be exceeded.
             return -detail::maxRate;
-            #else
-            return QL_EPSILON;
-            #endif
         }
         template <class C>
         static Real maxValueAfter(Size,
@@ -281,11 +252,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::max_element(c->data().begin(), c->data().end()));
-                #if defined(QL_NEGATIVE_RATES)
                 return r<0.0 ? r/2.0 : r*2.0;
-                #else
-                return r*2.0;
-                #endif
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.

--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -265,14 +265,6 @@ namespace QuantLib {
                        "two dates correspond to the same time "
                        "under this curve's day count convention");
             QL_REQUIRE(this->data_[i] > 0.0, "negative discount");
-            #if !defined(QL_NEGATIVE_RATES)
-            QL_REQUIRE(this->data_[i] <= this->data_[i-1],
-                       "negative forward rate implied by the discount " <<
-                       this->data_[i] << " at " << dates_[i] <<
-                       " (t=" << this->times_[i] << ") after the discount " <<
-                       this->data_[i-1] << " at " << dates_[i-1] <<
-                       " (t=" << this->times_[i-1] << ")");
-            #endif
         }
 
         this->interpolation_ =

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -272,9 +272,6 @@ namespace QuantLib {
             QL_REQUIRE(!close(this->times_[i], this->times_[i-1]),
                        "two dates correspond to the same time "
                        "under this curve's day count convention");
-            #if !defined(QL_NEGATIVE_RATES)
-            QL_REQUIRE(this->data_[i] >= 0.0, "negative forward");
-            #endif
         }
 
         this->interpolation_ =

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -269,9 +269,6 @@ namespace QuantLib {
             Time dt = 1.0/365;
             InterestRate r(this->data_[0], dayCounter(), compounding, frequency);
             this->data_[0] = r.equivalentRate(Continuous, NoFrequency, dt);
-            #if !defined(QL_NEGATIVE_RATES)
-            QL_REQUIRE(this->data_[0] > 0.0, "non-positive yield");
-            #endif
         }
 
         for (Size i=1; i<dates_.size(); ++i) {
@@ -289,19 +286,6 @@ namespace QuantLib {
                 InterestRate r(this->data_[i], dayCounter(), compounding, frequency);
                 this->data_[i] = r.equivalentRate(Continuous, NoFrequency, this->times_[i]);
             }
-
-            #if !defined(QL_NEGATIVE_RATES)
-            QL_REQUIRE(this->data_[i] > 0.0, "non-positive yield");
-            // positive yields are not enough to ensure non-negative fwd rates
-            // so here's a stronger requirement
-            QL_REQUIRE(this->data_[i] * this->times_[i] -
-                this->data_[i - 1] * this->times_[i - 1] >= 0.0,
-                "negative forward rate implied by the zero yield " <<
-                io::rate(this->data_[i]) << " at " << dates_[i] <<
-                " (t=" << this->times_[i] << ") after the zero yield " <<
-                io::rate(this->data_[i - 1]) << " at " << dates_[i - 1] <<
-                " (t=" << this->times_[i - 1] << ")");
-            #endif
         }
 
         this->interpolation_ =

--- a/ql/termstructures/yieldtermstructure.cpp
+++ b/ql/termstructures/yieldtermstructure.cpp
@@ -102,11 +102,6 @@ namespace QuantLib {
                 QL_REQUIRE(thisJump > 0.0,
                            "invalid " << io::ordinal(i+1) << " jump value: " <<
                            thisJump);
-                #if !defined(QL_NEGATIVE_RATES)
-                QL_REQUIRE(thisJump <= 1.0,
-                           "invalid " << io::ordinal(i+1) << " jump value: " <<
-                           thisJump);
-                #endif
                 jumpEffect *= thisJump;
             }
         }

--- a/ql/userconfig.hpp
+++ b/ql/userconfig.hpp
@@ -47,11 +47,6 @@
 //#   define QL_ENABLE_TRACING
 #endif
 
-/* Define this if negative rates should be allowed. */
-#ifndef QL_NEGATIVE_RATES
-#   define QL_NEGATIVE_RATES
-#endif
-
 /* Define this if extra safety checks should be performed. This can degrade
    performance. */
 #ifndef QL_EXTRA_SAFETY_CHECKS

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -420,12 +420,9 @@ void BasismodelsTest::testTenorswaptionvts() {
 
 test_suite* BasismodelsTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Basismodels tests");
-    // The test data use current market conditions, i.e., negative rates.
-    #if defined(QL_NEGATIVE_RATES)
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testSwaptioncfsContCompSpread));
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testSwaptioncfsSimpleCompSpread));
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testTenoroptionletvts));
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testTenorswaptionvts));
-    #endif
     return suite;
 }

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -253,11 +253,8 @@ namespace {
 
         for (int i = 0; i < 18; i++) {
             if (i + 1 != 6 && i + 1 != 12 && i + 1 != 18) {
-#ifndef QL_NEGATIVE_RATES
-                if (i + 10 != 16 && i + 10 != 17)
-#endif
-                    r6m.push_back(ext::make_shared<FraRateHelper>(
-                        Handle<Quote>(q6m[10 + i]), i + 1,
+                r6m.push_back(ext::make_shared<FraRateHelper>(
+                            Handle<Quote>(q6m[10 + i]), i + 1,
                                           i + 7, 2, TARGET(), ModifiedFollowing,
                                           false, Actual360()));
             }

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -828,13 +828,10 @@ test_suite* OptionletStripperTest::suite() {
                        &OptionletStripperTest::testTermVolatilityStripping2));
     suite->add(QUANTLIB_TEST_CASE(
                        &OptionletStripperTest::testSwitchStrike));
-
-    #if defined(QL_NEGATIVE_RATES)
     suite->add(QUANTLIB_TEST_CASE(
         &OptionletStripperTest::testTermVolatilityStrippingNormalVol));
     suite->add(QUANTLIB_TEST_CASE(
         &OptionletStripperTest::testTermVolatilityStrippingShiftedLogNormalVol));
-    #endif
 
     return suite;
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -654,17 +654,6 @@ void PiecewiseYieldCurveTest::testLinearDiscountConsistency() {
     testBMACurveConsistency<Discount,Linear,IterativeBootstrap>(vars);
 }
 
-void PiecewiseYieldCurveTest::testLogLinearZeroConsistency() {
-
-    BOOST_TEST_MESSAGE(
-        "Testing consistency of piecewise-log-linear zero-yield curve...");
-
-    CommonVars vars;
-
-    testCurveConsistency<ZeroYield,LogLinear,IterativeBootstrap>(vars);
-    testBMACurveConsistency<ZeroYield,LogLinear,IterativeBootstrap>(vars);
-}
-
 void PiecewiseYieldCurveTest::testLinearZeroConsistency() {
 
     BOOST_TEST_MESSAGE(
@@ -1128,11 +1117,6 @@ test_suite* PiecewiseYieldCurveTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(
                  &PiecewiseYieldCurveTest::testLinearDiscountConsistency));
 
-    #if !defined(QL_NEGATIVE_RATES)
-    // if rates can be negative, we can't interpolate loglinearly
-    suite->add(QUANTLIB_TEST_CASE(
-                     &PiecewiseYieldCurveTest::testLogLinearZeroConsistency));
-    #endif
     suite->add(QUANTLIB_TEST_CASE(
                  &PiecewiseYieldCurveTest::testLinearZeroConsistency));
     suite->add(QUANTLIB_TEST_CASE(
@@ -1163,9 +1147,8 @@ test_suite* PiecewiseYieldCurveTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(
                &PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate));
 
-    #if defined(QL_NEGATIVE_RATES) && !defined(QL_USE_INDEXED_COUPON)
-    // This regression test didn't work with indexed coupons or
-    // without negative rates anyway.
+    #if !defined(QL_USE_INDEXED_COUPON)
+    // This regression test didn't work with indexed coupons anyway.
     suite->add(QUANTLIB_TEST_CASE(
                              &PiecewiseYieldCurveTest::testBadPreviousCurve));
     #endif

--- a/test-suite/piecewiseyieldcurve.hpp
+++ b/test-suite/piecewiseyieldcurve.hpp
@@ -31,7 +31,6 @@ class PiecewiseYieldCurveTest {
     static void testLogLinearDiscountConsistency();
     static void testLinearDiscountConsistency();
 
-    static void testLogLinearZeroConsistency();
     static void testLinearZeroConsistency();
     static void testSplineZeroConsistency();
 

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -313,12 +313,6 @@ test_suite* init_unit_test_suite(int, char* []) {
         #else
         "QuantLib " QL_VERSION
         #endif
-        "\n  QL_NEGATIVE_RATES "
-        #ifdef QL_NEGATIVE_RATES
-        "       defined"
-        #else
-        "     undefined"
-        #endif
         "\n  QL_EXTRA_SAFETY_CHECKS "
         #ifdef QL_EXTRA_SAFETY_CHECKS
         "  defined"


### PR DESCRIPTION
It's been the default for a long time, and nowadays I don't see a use case for forcing positive rates that is worth maintaining the switch.