### PR TITLE
fix testSpecializedBondVsGenericBondUsingAsw

### DIFF
--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -2008,7 +2008,7 @@ void AssetSwapTest::testGenericBondImplied() {
                                 parAssetSwap);
     zeroCpnAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice2 = zeroCpnAssetSwap2.fairCleanPrice();
-    Real error9 = std::fabs(cmsBondAssetSwapPrice2-cmsBondPrice2);
+    Real error9 = std::fabs(zeroCpnBondAssetSwapPrice2-zeroCpnBondPrice2);
 
     if (error9>tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:"

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -4203,7 +4203,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
                                zeroCpnSpecializedBondAssetSwap2.fairCleanPrice();
     Real error15 = std::fabs(zeroCpnBondAssetSwapPrice2
                              -zeroCpnSpecializedBondAssetSwapPrice2);
-    if (error8>tolerance) {
+    if (error15>tolerance) {
         BOOST_FAIL("wrong clean price for zerocpn bond:"
                     << std::fixed << std::setprecision(4)
                     << "\n  generic zero cpn bond's clean price: "


### PR DESCRIPTION
Closes #605.

this pull request fix assetswap_test, testSpecializedBondVsGenericBondUsingAsw
line 4206, it should be comparing `error15` to `tolerance` instead of `error8`

```cpp
    Real error15 = std::fabs(zeroCpnBondAssetSwapPrice2
                             -zeroCpnSpecializedBondAssetSwapPrice2);
    if (error15>tolerance) {
        BOOST_FAIL("wrong clean price for zerocpn bond:"
                    << std::fixed << std::setprecision(4)
                    << "\n  generic zero cpn bond's clean price: "
                    << zeroCpnBondAssetSwapPrice2
                    << "\n  equivalent specialized bond's price: "
                    << zeroCpnSpecializedBondAssetSwapPrice2
                    << "\n  error:                 " << error15
                    << "\n  tolerance:             " << tolerance);
    }
```