### PR TITLE
Avoid internal usage of all.hpp headers.

### DIFF
--- a/Examples/MarketModels/MarketModels.cpp
+++ b/Examples/MarketModels/MarketModels.cpp
@@ -21,7 +21,33 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #ifdef BOOST_MSVC
 #  include <ql/auto_link.hpp>
 #endif
-#include <ql/models/marketmodels/all.hpp>
+#include <ql/models/marketmodels/marketmodel.hpp>
+#include <ql/models/marketmodels/accountingengine.hpp>
+#include <ql/models/marketmodels/pathwiseaccountingengine.hpp>
+#include <ql/models/marketmodels/products/multiproductcomposite.hpp>
+#include <ql/models/marketmodels/products/multistep/multistepswap.hpp>
+#include <ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.hpp>
+#include <ql/models/marketmodels/products/multistep/exerciseadapter.hpp>
+#include <ql/models/marketmodels/products/multistep/multistepnothing.hpp>
+#include <ql/models/marketmodels/products/multistep/multistepinversefloater.hpp>
+#include <ql/models/marketmodels/products/pathwise/pathwiseproductswap.hpp>
+#include <ql/models/marketmodels/products/pathwise/pathwiseproductinversefloater.hpp>
+#include <ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.hpp>
+#include <ql/models/marketmodels/models/flatvol.hpp>
+#include <ql/models/marketmodels/callability/swapratetrigger.hpp>
+#include <ql/models/marketmodels/callability/swapbasissystem.hpp>
+#include <ql/models/marketmodels/callability/swapforwardbasissystem.hpp>
+#include <ql/models/marketmodels/callability/nothingexercisevalue.hpp>
+#include <ql/models/marketmodels/callability/collectnodedata.hpp>
+#include <ql/models/marketmodels/callability/lsstrategy.hpp>
+#include <ql/models/marketmodels/callability/upperboundengine.hpp>
+#include <ql/models/marketmodels/correlations/expcorrelations.hpp>
+#include <ql/models/marketmodels/browniangenerators/mtbrowniangenerator.hpp>
+#include <ql/models/marketmodels/browniangenerators/sobolbrowniangenerator.hpp>
+#include <ql/models/marketmodels/evolvers/lognormalfwdratepc.hpp>
+#include <ql/models/marketmodels/evolvers/lognormalfwdrateeuler.hpp>
+#include <ql/models/marketmodels/pathwisegreeks/bumpinstrumentjacobian.hpp>
+#include <ql/models/marketmodels/utilities.hpp>
 #include <ql/methods/montecarlo/genericlsregression.hpp>
 #include <ql/legacy/libormarketmodels/lmlinexpcorrmodel.hpp>
 #include <ql/legacy/libormarketmodels/lmextlinexpvolmodel.hpp>

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -25,20 +25,22 @@
 #include <ql/experimental/basismodels/tenorswaptionvts.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/instruments/swaption.hpp>
-#include <ql/math/interpolations/all.hpp>
 #include <ql/pricingengines/swap/discountingswapengine.hpp>
-#include <ql/termstructures/volatility/optionlet/all.hpp>
+#include <ql/termstructures/volatility/optionlet/strippedoptionlet.hpp>
+#include <ql/termstructures/volatility/optionlet/strippedoptionletadapter.hpp>
 #include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
-#include <ql/termstructures/yield/all.hpp>
-#include <ql/time/all.hpp>
-#include <ql/types.hpp>
+#include <ql/termstructures/yield/zerocurve.hpp>
+#include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
 namespace {
 
-    // auxilliary data
+    // auxiliary data
     Period termsData[] = {
         Period(0, Days),   Period(1, Years), Period(2, Years),  Period(3, Years),
         Period(5, Years),  Period(7, Years), Period(10, Years), Period(15, Years),

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -20,7 +20,9 @@
 #include "catbonds.hpp"
 #include "utilities.hpp"
 #include <ql/types.hpp>
-#include <ql/experimental/catbonds/all.hpp>
+#include <ql/experimental/catbonds/catbond.hpp>
+#include <ql/experimental/catbonds/catrisk.hpp>
+#include <ql/experimental/catbonds/montecarlocatbondengine.hpp>
 #include <ql/instruments/bonds/floatingratebond.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/unitedstates.hpp>

--- a/test-suite/piecewisezerospreadedtermstructure.cpp
+++ b/test-suite/piecewisezerospreadedtermstructure.cpp
@@ -25,7 +25,9 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
-#include <ql/math/interpolations/all.hpp>
+#include <ql/math/interpolations/forwardflatinterpolation.hpp>
+#include <ql/math/interpolations/backwardflatinterpolation.hpp>
+#include <ql/math/interpolations/cubicinterpolation.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;


### PR DESCRIPTION
They might be convenient at first, but once one knows what is required, they're not worth the added compilation time.  I'm not sure whether we should discourage their use, or deprecate them in some way.  But at least we can avoid their usage in the library itself.