### PR TITLE
Publicly expose Calendar::addedHolidays and Calendar::removeHolidays

### DIFF
--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -89,10 +89,10 @@ namespace QuantLib {
         */
 
         /*! Returns the set of added holidays for the given calendar */
-        std::set<Date> addedHolidays() const;
+        const std::set<Date>& addedHolidays() const;
         
         /*! Returns the set of removed holidays for the given calendar */
-        std::set<Date> removedHolidays() const;
+        const std::set<Date>& removedHolidays() const;
 
         bool isBusinessDay(const Date& d) const;
         /*! Returns <tt>true</tt> iff the date is a holiday for the given
@@ -201,12 +201,12 @@ namespace QuantLib {
         return impl_->name();
     }
 
-    inline std::set<Date> Calendar::addedHolidays() const {
+    inline const std::set<Date>& Calendar::addedHolidays() const {
         QL_REQUIRE(impl_, "no implementation provided");
         return impl_->addedHolidays;
     }
 
-    inline std::set<Date> Calendar::removedHolidays() const {
+    inline const std::set<Date>& Calendar::removedHolidays() const {
         QL_REQUIRE(impl_, "no implementation provided");
         return impl_->removedHolidays;
     }

--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -87,6 +87,13 @@ namespace QuantLib {
         /*! Returns <tt>true</tt> iff the date is a business day for the
             given market.
         */
+
+        /*! Returns the set of added holidays for the given calendar */
+        std::set<Date> addedHolidays() const;
+        
+        /*! Returns the set of removed holidays for the given calendar */
+        std::set<Date> removedHolidays() const;
+
         bool isBusinessDay(const Date& d) const;
         /*! Returns <tt>true</tt> iff the date is a holiday for the given
             market.
@@ -192,6 +199,16 @@ namespace QuantLib {
     inline std::string Calendar::name() const {
         QL_REQUIRE(impl_, "no implementation provided");
         return impl_->name();
+    }
+
+    inline std::set<Date> Calendar::addedHolidays() const {
+        QL_REQUIRE(impl_, "no implementation provided");
+        return impl_->addedHolidays;
+    }
+
+    inline std::set<Date> Calendar::removedHolidays() const {
+        QL_REQUIRE(impl_, "no implementation provided");
+        return impl_->removedHolidays;
     }
 
     inline bool Calendar::isBusinessDay(const Date& d) const {

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -62,6 +62,14 @@ void CalendarTest::testModifiedCalendars() {
     c1.addHoliday(d2);
 
     // test
+    std::set<Date> addedHolidays(c1.addedHolidays());
+    std::set<Date> removedHolidays(c1.removedHolidays());
+
+    QL_REQUIRE(addedHolidays.find(d1) == addedHolidays.end(), "did not expect to find date in addedHolidays");
+    QL_REQUIRE(addedHolidays.find(d2) != addedHolidays.end(), "expected to find date in addedHolidays");
+    QL_REQUIRE(removedHolidays.find(d1) != removedHolidays.end(), "expected to find date in removedHolidays");
+    QL_REQUIRE(removedHolidays.find(d2) == removedHolidays.end(), "did not expect to find date in removedHolidays");
+
     if (c1.isHoliday(d1))
         BOOST_FAIL(d1 << " still a holiday for original TARGET instance");
     if (c1.isBusinessDay(d2))


### PR DESCRIPTION
For calendars, I've found it useful to have the list of added and remove public holidays exposed.

This PR adds the necessary methods to expose them. Not sure if this is the correct implementation and whether the `std::set<Date>` should by returned by value or by reference. This PR currently returns it by value, which probably means the user cannot alter the underlying items in the set (not sure). Please guide me as you think this should be implemented, if at all.