### PR TITLE
introduce flag rather than casting

### DIFF
--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -197,12 +197,12 @@ namespace QuantLib {
             }
 
             // ok, so it's not constant. Maybe it's strike-independent?
-            ext::shared_ptr<BlackVarianceCurve> volCurve = blackVolatility()->isCurve();
+            bool volCurve = blackVolatility()->isCurve();
 
             if (volCurve) {
                 // ok, we can use the optimized algorithm
-                localVolatility_.linkTo(ext::make_shared<LocalVolCurve>(
-                    Handle<BlackVarianceCurve>(blackVolatility())));
+                localVolatility_.linkTo(
+                    ext::make_shared<LocalVolCurve>(blackVolatility()));
                 updated_ = true;
                 return localVolatility_;
             }

--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -184,9 +184,8 @@ namespace QuantLib {
             isStrikeIndependent_=true;
 
             // constant Black vol?
-            ext::shared_ptr<BlackConstantVol> constVol =
-                ext::dynamic_pointer_cast<BlackConstantVol>(
-                                                          *blackVolatility());
+            bool constVol = blackVolatility.isConstant();
+
             if (constVol) {
                 // ok, the local vol is constant too.
                 localVolatility_.linkTo(ext::make_shared<LocalConstantVol>(
@@ -198,9 +197,8 @@ namespace QuantLib {
             }
 
             // ok, so it's not constant. Maybe it's strike-independent?
-            ext::shared_ptr<BlackVarianceCurve> volCurve =
-                ext::dynamic_pointer_cast<BlackVarianceCurve>(
-                                                          *blackVolatility());
+            ext::shared_ptr<BlackVarianceCurve> volCurve = blackVolatility().isCurve();
+
             if (volCurve) {
                 // ok, we can use the optimized algorithm
                 localVolatility_.linkTo(ext::make_shared<LocalVolCurve>(

--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -184,25 +184,25 @@ namespace QuantLib {
             isStrikeIndependent_=true;
 
             // constant Black vol?
-            bool constVol = blackVolatility.isConstant();
+            bool constVol = blackVolatility()->isConstant();
 
             if (constVol) {
                 // ok, the local vol is constant too.
                 localVolatility_.linkTo(ext::make_shared<LocalConstantVol>(
-                    constVol->referenceDate(),
-                    constVol->blackVol(0.0, x0_->value()),
-                    constVol->dayCounter()));
+                    blackVolatility()->referenceDate(),
+                    blackVolatility()->blackVol(0.0, x0_->value()),
+                    blackVolatility()->dayCounter()));
                 updated_ = true;
                 return localVolatility_;
             }
 
             // ok, so it's not constant. Maybe it's strike-independent?
-            ext::shared_ptr<BlackVarianceCurve> volCurve = blackVolatility().isCurve();
+            ext::shared_ptr<BlackVarianceCurve> volCurve = blackVolatility()->isCurve();
 
             if (volCurve) {
                 // ok, we can use the optimized algorithm
                 localVolatility_.linkTo(ext::make_shared<LocalVolCurve>(
-                    Handle<BlackVarianceCurve>(volCurve)));
+                    Handle<BlackVarianceCurve>(blackVolatility())));
                 updated_ = true;
                 return localVolatility_;
             }

--- a/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
@@ -54,6 +54,11 @@ namespace QuantLib {
                          const Calendar&,
                          const Handle<Quote>& volatility,
                          const DayCounter& dayCounter);
+        //! \name BlackVolTermStructure interface
+        //@{
+        bool isConstant() const { return true; }
+        bool isCurve() const { return true; }
+        //@}
         //! \name TermStructure interface
         //@{
         Date maxDate() const;

--- a/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
@@ -61,6 +61,11 @@ namespace QuantLib {
         Real minStrike() const;
         Real maxStrike() const;
         //@}
+        //! \name BlackVolTermStructure interface
+        //@{
+        bool isConstant() const { return false; }
+        bool isCurve() const { return true; }
+        //@}
         //! \name Modifiers
         //@{
         template <class Interpolator>

--- a/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
@@ -101,6 +101,10 @@ namespace QuantLib {
                                   Time time2,
                                   Real strike,
                                   bool extrapolate = false) const;
+        //! is the volatility constant across strikes and maturities?
+        virtual bool isConstant() const { return false; }
+        //! is the volatility independent of the strike?
+        virtual bool isCurve() const { return false; }
         //@}
         //! \name Visitability
         //@{

--- a/ql/termstructures/volatility/equityfx/localvolcurve.hpp
+++ b/ql/termstructures/volatility/equityfx/localvolcurve.hpp
@@ -32,10 +32,11 @@ namespace QuantLib {
     //! Local volatility curve derived from a Black curve
     class LocalVolCurve : public LocalVolTermStructure {
       public:
-        LocalVolCurve(const Handle<BlackVarianceCurve>& curve)
+        LocalVolCurve(const Handle<BlackVolTermStructure>& curve)
         : LocalVolTermStructure(curve->businessDayConvention(),
                                 curve->dayCounter()),
           blackVarianceCurve_(curve) {
+            QL_REQUIRE(curve->isCurve(), "expected vol curve");
             registerWith(blackVarianceCurve_);
         }
         //! \name TermStructure interface
@@ -69,7 +70,7 @@ namespace QuantLib {
       protected:
         Volatility localVolImpl(Time, Real) const;
       private:
-        Handle<BlackVarianceCurve> blackVarianceCurve_;
+        Handle<BlackVolTermStructure> blackVarianceCurve_;
     };
 
 

--- a/ql/termstructures/volatility/equityfx/localvolcurve.hpp
+++ b/ql/termstructures/volatility/equityfx/localvolcurve.hpp
@@ -32,13 +32,13 @@ namespace QuantLib {
     //! Local volatility curve derived from a Black curve
     class LocalVolCurve : public LocalVolTermStructure {
       public:
-        LocalVolCurve(const Handle<BlackVolTermStructure>& curve)
-        : LocalVolTermStructure(curve->businessDayConvention(),
-                                curve->dayCounter()),
-          blackVarianceCurve_(curve) {
-            QL_REQUIRE(curve->isCurve(), "expected vol curve");
-            registerWith(blackVarianceCurve_);
-        }
+          explicit LocalVolCurve(const Handle<BlackVolTermStructure>& curve)
+              : LocalVolTermStructure(curve->businessDayConvention(),
+                                      curve->dayCounter()),
+                blackVarianceCurve_(curve) {
+              QL_REQUIRE(curve->isCurve(), "expected vol curve");
+              registerWith(blackVarianceCurve_);
+          }
         //! \name TermStructure interface
         //@{
         const Date& referenceDate() const {


### PR DESCRIPTION
this allows client implementations of the BlackVolTermStructure interface to identify themselves as being constant or curves within the GeneralizedBlackScholesProcess; this information is currently derived from casting to hardcoded classes there