### PR TITLE
make yts dates, nodes, times, data members virtual

### DIFF
--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -67,11 +67,11 @@ namespace QuantLib {
         //@}
         //! \name other inspectors
         //@{
-        const std::vector<Time>& times() const;
-        const std::vector<Date>& dates() const;
-        const std::vector<Real>& data() const;
+        virtual const std::vector<Time>& times() const;
+        virtual const std::vector<Date>& dates() const;
+        virtual const std::vector<Real>& data() const;
         const std::vector<DiscountFactor>& discounts() const;
-        std::vector<std::pair<Date, Real> > nodes() const;
+        virtual std::vector<std::pair<Date, Real> > nodes() const;
         //@}
       protected:
         InterpolatedDiscountCurve(

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -67,11 +67,11 @@ namespace QuantLib {
         //@}
         //! \name other inspectors
         //@{
-        const std::vector<Time>& times() const;
-        const std::vector<Date>& dates() const;
-        const std::vector<Real>& data() const;
+        virtual const std::vector<Time>& times() const;
+        virtual const std::vector<Date>& dates() const;
+        virtual const std::vector<Real>& data() const;
         const std::vector<Rate>& forwards() const;
-        std::vector<std::pair<Date, Real> > nodes() const;
+        virtual std::vector<std::pair<Date, Real> > nodes() const;
         //@}
       protected:
         InterpolatedForwardCurve(

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -75,11 +75,11 @@ namespace QuantLib {
         //@}
         //! \name other inspectors
         //@{
-        const std::vector<Time>& times() const;
-        const std::vector<Date>& dates() const;
-        const std::vector<Real>& data() const;
+        virtual const std::vector<Time>& times() const;
+        virtual const std::vector<Date>& dates() const;
+        virtual const std::vector<Real>& data() const;
         const std::vector<Rate>& zeroRates() const;
-        std::vector<std::pair<Date, Real> > nodes() const;
+        virtual std::vector<std::pair<Date, Real> > nodes() const;
         //@}
       protected:
         InterpolatedZeroCurve(


### PR DESCRIPTION
For PiecewiseYieldCurve objects, dates_, data_, times_ are not initialized on construction. Thus, when the corresponding member functions are called, calculate() is invoked first. However, this calculate() is not performed if dates(), times(), nodes() or data() is invoked directly from the base_curve classes of PiecewiseYieldCurve. 

This causes issues in IsdaCdsEngine. Note the dynamic casting to e.g. InterpolatedDiscountCurve and then the call to dates(). This doesn't work unless the curve has already been bootstrapped.

My suggested fix is to make these member functions virtual. Hence the PiecewiseYieldCurve implementation will override these base class implementations, ensuring calculate() is called first before continuing.

Happy to discuss...