### PR TITLE
fix wulinyongdoublebarrierengine not saving rebateIn

### DIFF
--- a/ql/experimental/barrieroption/wulinyongdoublebarrierengine.cpp
+++ b/ql/experimental/barrieroption/wulinyongdoublebarrierengine.cpp
@@ -127,6 +127,7 @@ namespace QuantLib {
         results_.additionalResults["vanilla"] = european;
         results_.additionalResults["barrierOut"] = barrierOut;
         results_.additionalResults["barrierIn"] = european - barrierOut;
+        results_.additionalResults["rebateIn"] = rebateIn;
     }
 
 


### PR DESCRIPTION
save `rebateIn` to `results_.additionalResults`