### PR TITLE
Small fix to Canada Calendar

### DIFF
--- a/ql/time/calendars/canada.cpp
+++ b/ql/time/calendars/canada.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         Day em = easterMonday(y);
         if (isWeekend(w)
             // New Year's Day (possibly moved to Monday)
-            || ((d == 1 || (d == 2 && w == Monday)) && m == January)
+            || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == January)
             // Family Day (third Monday in February, since 2008)
             || ((d >= 15 && d <= 21) && w == Monday && m == February
                 && y >= 2008)
@@ -86,7 +86,7 @@ namespace QuantLib {
         Day em = easterMonday(y);
         if (isWeekend(w)
             // New Year's Day (possibly moved to Monday)
-            || ((d == 1 || (d == 2 && w == Monday)) && m == January)
+            || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == January)
             // Family Day (third Monday in February, since 2008)
             || ((d >= 15 && d <= 21) && w == Monday && m == February
                 && y >= 2008)
@@ -114,4 +114,3 @@ namespace QuantLib {
     }
 
 }
-


### PR DESCRIPTION
The following Monday is a business holiday if New Years day falls on either a Saturday or Sunday in Canada. In USA, the following Monday is only a business holiday if New Years day occurs on the Sunday.

For example, in 2022 Jan 3 is a holiday in Canada but not in USA.

See https://www.timeanddate.com/calendar/?year=2022&country=27