### PR TITLE
Prune unused (or even undefined) methods.

### DIFF
--- a/ql/experimental/barrieroption/analyticdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/analyticdoublebarrierengine.hpp
@@ -64,7 +64,6 @@ namespace QuantLib {
         Real volatilitySquared() const;
         Real barrierLo() const;
         Real barrierHi() const;
-        Real rebate() const;
         Real stdDeviation() const;
         Rate riskFreeRate() const;
         DiscountFactor riskFreeDiscount() const;

--- a/ql/experimental/barrieroption/wulinyongdoublebarrierengine.cpp
+++ b/ql/experimental/barrieroption/wulinyongdoublebarrierengine.cpp
@@ -129,10 +129,6 @@ namespace QuantLib {
     }
 
 
-    Real WulinYongDoubleBarrierEngine::underlying() const {
-        return process_->x0();
-    }
-
     Real WulinYongDoubleBarrierEngine::strike() const {
         ext::shared_ptr<PlainVanillaPayoff> payoff =
             ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
@@ -146,10 +142,6 @@ namespace QuantLib {
 
     Volatility WulinYongDoubleBarrierEngine::volatility() const {
         return process_->blackVolatility()->blackVol(residualTime(), strike());
-    }
-
-    Real WulinYongDoubleBarrierEngine::stdDeviation() const {
-        return volatility() * std::sqrt(residualTime());
     }
 
     Rate WulinYongDoubleBarrierEngine::riskFreeRate() const {

--- a/ql/experimental/barrieroption/wulinyongdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/wulinyongdoublebarrierengine.hpp
@@ -50,13 +50,9 @@ namespace QuantLib {
         const int series_;
         CumulativeNormalDistribution f_;
         // helper methods
-        Real underlying() const;
         Real strike() const;
         Time residualTime() const;
         Volatility volatility() const;
-        Real barrier() const;
-        Real rebate() const;
-        Real stdDeviation() const;
         Rate riskFreeRate() const;
         DiscountFactor riskFreeDiscount() const;
         Rate dividendYield() const;


### PR DESCRIPTION
Fixes #639 