### PR TITLE
mandatory times are not guaranteed to be sorted, the grid is

### DIFF
--- a/ql/pricingengines/swap/treeswapengine.cpp
+++ b/ql/pricingengines/swap/treeswapengine.cpp
@@ -18,27 +18,23 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/pricingengines/swap/treeswapengine.hpp>
 #include <ql/pricingengines/swap/discretizedswap.hpp>
+#include <ql/pricingengines/swap/treeswapengine.hpp>
 
 namespace QuantLib {
 
-    TreeVanillaSwapEngine::TreeVanillaSwapEngine(
-                               const ext::shared_ptr<ShortRateModel>& model,
-                              Size timeSteps,
-                              const Handle<YieldTermStructure>& termStructure)
-    : LatticeShortRateModelEngine<VanillaSwap::arguments,
-                                  VanillaSwap::results>(model, timeSteps),
+    TreeVanillaSwapEngine::TreeVanillaSwapEngine(const ext::shared_ptr<ShortRateModel>& model,
+                                                 Size timeSteps,
+                                                 const Handle<YieldTermStructure>& termStructure)
+    : LatticeShortRateModelEngine<VanillaSwap::arguments, VanillaSwap::results>(model, timeSteps),
       termStructure_(termStructure) {
         registerWith(termStructure_);
     }
 
-    TreeVanillaSwapEngine::TreeVanillaSwapEngine(
-                               const ext::shared_ptr<ShortRateModel>& model,
-                              const TimeGrid& timeGrid,
-                              const Handle<YieldTermStructure>& termStructure)
-    : LatticeShortRateModelEngine<VanillaSwap::arguments,
-                                  VanillaSwap::results>(model, timeGrid),
+    TreeVanillaSwapEngine::TreeVanillaSwapEngine(const ext::shared_ptr<ShortRateModel>& model,
+                                                 const TimeGrid& timeGrid,
+                                                 const Handle<YieldTermStructure>& termStructure)
+    : LatticeShortRateModelEngine<VanillaSwap::arguments, VanillaSwap::results>(model, timeGrid),
       termStructure_(termStructure) {
         registerWith(termStructure_);
     }
@@ -71,11 +67,11 @@ namespace QuantLib {
             lattice = model_->tree(timeGrid);
         }
 
-        swap.initialize(lattice, lattice->timeGrid().back());
+        Time maxTime = *std::max_element(times.begin(), times.end());
+        swap.initialize(lattice, maxTime);
         swap.rollback(0.0);
 
         results_.value = swap.presentValue();
     }
 
 }
-

--- a/ql/pricingengines/swap/treeswapengine.cpp
+++ b/ql/pricingengines/swap/treeswapengine.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
             lattice = model_->tree(timeGrid);
         }
 
-        swap.initialize(lattice, times.back());
+        swap.initialize(lattice, lattice->timeGrid().back());
         swap.rollback(0.0);
 
         results_.value = swap.presentValue();


### PR DESCRIPTION
We used the TreeVanillaSwapEngine as a prototype for our implementation and got puzzled, as our mandatoryTimes() were not sorted as the DiscretizedSwap.mandatoryTimes() are (by chance?).

If you want to rely on the fact that the rollback starts at the last time it would be better to use the grid.

So there is no error in the current implementation, but if one uses the TreeVanillaSwapEngine as a scaffold for another implementation it will avoid confusion. 

Best regards,
Ralf