### PR TITLE
visual studio 19 build

### DIFF
--- a/cmake/quantlib.cmake
+++ b/cmake/quantlib.cmake
@@ -8,7 +8,9 @@ macro(get_quantlib_library_name QL_OUTPUT_NAME)
         
         # - toolset
         # ...taken from FindBoost.cmake
-        if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
+        if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.20)
+            set(QL_LIB_TOOLSET "-vc142")
+        elseif (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.10)
             set(QL_LIB_TOOLSET "-vc141")
         elseif(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
             set(QL_LIB_TOOLSET "-vc140")


### PR DESCRIPTION
update for visual studio 19.

with the commit below, library now is QuantLib-vc142-x64-mt-gd.lib, but get_quantlib_library_name returns 141

https://github.com/lballabio/QuantLib/commit/a6c542411d1aa9b85dc80e24d4c87ae74ea23b26#diff-3d6479e6b3bc8e03b8a29c9694e7fa84