### PR TITLE
Removed Depreciated Boost::Timer from all examples.

### DIFF
--- a/Examples/BasketLosses/BasketLosses.cpp
+++ b/Examples/BasketLosses/BasketLosses.cpp
@@ -33,7 +33,6 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/currencies/europe.hpp>
 
-#include <boost/timer.hpp>
 #include <boost/assign/std/vector.hpp>
 
 #include <iostream>
@@ -54,7 +53,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Calendar calendar = TARGET();
@@ -299,18 +297,6 @@ int main(int, char* []) {
         std::cout << theBskt->expectedTrancheLoss(calcDate) << std::endl;
         #endif
 
-        Real seconds  = timer.elapsed();
-        Integer hours = Integer(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = Integer(seconds/60);
-        seconds -= minutes * 60;
-        cout << "Run completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s" << endl;
 
         return 0;
     } catch (exception& e) {

--- a/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -41,7 +41,6 @@
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/utilities/dataformatters.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -101,7 +100,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Date todaysDate(15, February, 2002);
@@ -390,19 +388,6 @@ int main(int, char* []) {
             new TreeSwaptionEngine(modelBK, 50)));
         std::cout << "BK:              " << itmBermudanSwaption.NPV()
                   << std::endl;
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
     } catch (std::exception& e) {

--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -41,7 +41,6 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -60,7 +59,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         /*********************
@@ -568,19 +566,6 @@ int main(int, char* []) {
 
          /* "Yield to Price"
             "Price to Yield" */
-
-         double seconds = timer.elapsed();
-         Integer hours = int(seconds/3600);
-         seconds -= hours * 3600;
-         Integer minutes = int(seconds/60);
-         seconds -= minutes * 60;
-         std::cout << " \nRun completed in ";
-         if (hours > 0)
-             std::cout << hours << " h ";
-         if (hours > 0 || minutes > 0)
-             std::cout << minutes << " m ";
-         std::cout << std::fixed << std::setprecision(0)
-         << seconds << " s\n" << std::endl;
 
          return 0;
 

--- a/Examples/CDS/CDS.cpp
+++ b/Examples/CDS/CDS.cpp
@@ -41,7 +41,7 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/currencies/europe.hpp>
 #include <ql/quotes/simplequote.hpp>
-#include <boost/timer.hpp>
+
 #include <iostream>
 #include <iomanip>
 
@@ -57,7 +57,6 @@ namespace QuantLib {
 
 void example01() {
 
-    boost::timer timer;
     std::cout << std::endl;
 
     /*********************
@@ -209,17 +208,6 @@ void example01() {
 
     cout << endl << endl;
 
-    Real seconds = timer.elapsed();
-    Integer hours = Integer(seconds / 3600);
-    seconds -= hours * 3600;
-    Integer minutes = Integer(seconds / 60);
-    seconds -= minutes * 60;
-    cout << "Run completed in ";
-    if (hours > 0)
-        cout << hours << " h ";
-    if (hours > 0 || minutes > 0)
-        cout << minutes << " m ";
-    cout << fixed << setprecision(0) << seconds << " s" << endl;
 }
 
 void example02() {

--- a/Examples/CVAIRS/CVAIRS.cpp
+++ b/Examples/CVAIRS/CVAIRS.cpp
@@ -33,7 +33,6 @@
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -60,7 +59,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Calendar calendar = TARGET();
@@ -241,19 +239,6 @@ int main(int, char* []) {
         }
 
         cout << endl;
-
-        Real seconds  = timer.elapsed();
-        Integer hours = Integer(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = Integer(seconds/60);
-        seconds -= minutes * 60;
-        cout << "Run completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s" << endl;
 
         return 0;
     } catch (exception& e) {

--- a/Examples/CallableBonds/CallableBonds.cpp
+++ b/Examples/CallableBonds/CallableBonds.cpp
@@ -36,7 +36,6 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
-#include <boost/timer.hpp>
 
 using namespace std;
 using namespace QuantLib;
@@ -81,7 +80,6 @@ int main(int, char* [])
 {
     try {
 
-        boost::timer timer;
 
         Date today = Date(16,October,2007);
         Settings::instance().evaluationDate() = today;
@@ -320,19 +318,6 @@ int main(int, char* [])
         cout << "77.31 / 10.65"
              << endl
              << endl;
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        cout << " \nRun completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s\n" << endl;
 
         return 0;
 

--- a/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -28,7 +28,6 @@
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/utilities/dataformatters.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -49,7 +48,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Option::Type type(Option::Put);
@@ -307,19 +305,6 @@ int main(int, char* []) {
                   << std::endl;
 
         std::cout << dblrule << std::endl;
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
     } catch (std::exception& e) {

--- a/Examples/DiscreteHedging/DiscreteHedging.cpp
+++ b/Examples/DiscreteHedging/DiscreteHedging.cpp
@@ -58,7 +58,6 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -172,7 +171,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Time maturity = 1.0/12.0;   // 1 month
@@ -191,19 +189,6 @@ int main(int, char* []) {
 
         hedgesNum = 84;
         rp.compute(hedgesNum, scenarios);
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
     } catch (std::exception& e) {

--- a/Examples/EquityOption/EquityOption.cpp
+++ b/Examples/EquityOption/EquityOption.cpp
@@ -37,7 +37,7 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/utilities/dataformatters.hpp>
 
-#include <boost/timer.hpp>
+
 #include <iostream>
 #include <iomanip>
 
@@ -56,7 +56,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         // set up dates
@@ -396,18 +395,6 @@ int main(int, char* []) {
                   << std::endl;
 
         // End test
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
         return 0;
 
     } catch (std::exception& e) {

--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -31,7 +31,6 @@
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 
 #define LENGTH(a) (sizeof(a)/sizeof(a[0]))
@@ -51,7 +50,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         /*********************
@@ -335,19 +333,6 @@ int main(int, char* []) {
                  << endl
                  << endl;
         }
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        cout << " \nRun completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s\n" << endl;
 
         return 0;
 

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -39,7 +39,6 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/simpledaycounter.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -86,8 +85,6 @@ void printOutput(const std::string& tag,
 int main(int, char* []) {
 
     try {
-
-        boost::timer timer;
 
         const Size numberOfBonds = 15;
         Real cleanPrice[numberOfBonds];
@@ -650,20 +647,6 @@ int main(int, char* []) {
                  << setw(6) << fixed << setprecision(3)
                  << 100.*parRate(*ts66,keyDates,dc) << endl;
         }
-
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
 

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -43,8 +43,6 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 
-#include <boost/timer.hpp>
-
 #include <iostream>
 #include <iomanip>
 
@@ -126,23 +124,6 @@ void printModelCalibration(
         std::cout << std::setw(20) << " " << volatility.back() << std::endl;
 }
 
-// helper function that prints timing information to std::cout
-
-class Timer {
-    boost::timer timer_;
-    double elapsed_;
-
-  public:
-    void start() { timer_ = boost::timer(); }
-    void stop() { elapsed_ = timer_.elapsed(); }
-    double elapsed() const { return elapsed_; }
-};
-
-void printTiming(const Timer &timer) {
-    double seconds = timer.elapsed();
-    std::cout << std::fixed << std::setprecision(1) << "\n(this step took "
-              << seconds << "s)" << std::endl;
-}
 
 // here the main part of the code starts
 
@@ -155,8 +136,6 @@ int main(int argc, char *argv[]) {
         std::cout << "\nThis is some example code showing how to use the GSR "
                      "\n(Gaussian short rate) and Markov Functional model."
                   << std::endl;
-
-        Timer timer;
 
         Date refDate(30, April, 2014);
         Settings::instance().evaluationDate() = refDate;
@@ -271,14 +250,12 @@ int main(int argc, char *argv[]) {
         ext::shared_ptr<SwapIndex> swapBase =
             ext::make_shared<EuriborSwapIsdaFixA>(10 * Years, yts6m, ytsOis);
 
-        timer.start();
+        
         std::vector<ext::shared_ptr<BlackCalibrationHelper> > basket =
             swaption->calibrationBasket(swapBase, *swaptionVol,
                                         BasketGeneratingEngine::Naive);
-        timer.stop();
-
         printBasket(basket);
-        printTiming(timer);
+        
 
         std::cout
             << "\nLet's calibrate our model to this basket. We use a "
@@ -295,23 +272,23 @@ int main(int argc, char *argv[]) {
         EndCriteria ec(1000, 10, 1E-8, 1E-8,
                        1E-8); // only max iterations use actually used by LM
 
-        timer.start();
+        
         gsr->calibrateVolatilitiesIterative(basket, method, ec);
-        timer.stop();
+        
 
         printModelCalibration(basket, gsr->volatility());
-        printTiming(timer);
+        
 
         std::cout << "\nFinally we price our bermudan swaption in the "
                      "calibrated model:" << std::endl;
 
-        timer.start();
+        
         Real npv = swaption->NPV();
-        timer.stop();
+        
 
         std::cout << "\nBermudan swaption NPV (ATM calibrated GSR) = "
                   << std::fixed << std::setprecision(6) << npv << std::endl;
-        printTiming(timer);
+        
 
         std::cout << "\nThere is another mode to generate a calibration basket called"
                      "\nMaturityStrikeByDeltaGamma. This means that the maturity,"
@@ -322,14 +299,14 @@ int main(int argc, char *argv[]) {
                      "\nLet's try this in our case."
                   << std::endl;
 
-        timer.start();
+        
         basket = swaption->calibrationBasket(
             swapBase, *swaptionVol,
             BasketGeneratingEngine::MaturityStrikeByDeltaGamma);
-        timer.stop();
+        
 
         printBasket(basket);
-        printTiming(timer);
+        
 
         std::cout
             << "\nThe calibrated nominal is close to the exotics nominal."
@@ -343,23 +320,23 @@ int main(int argc, char *argv[]) {
         for (Size i = 0; i < basket.size(); ++i)
             basket[i]->setPricingEngine(swaptionEngine);
 
-        timer.start();
+        
         gsr->calibrateVolatilitiesIterative(basket, method, ec);
-        timer.stop();
+        
 
         printModelCalibration(basket, gsr->volatility());
-        printTiming(timer);
+        
 
         std::cout << "\nAnd the bermudan's price becomes:" << std::endl;
 
-        timer.start();
+        
         npv = swaption->NPV();
-        timer.stop();
+        
 
         std::cout << "\nBermudan swaption NPV (deal strike calibrated GSR) = "
                   << std::setprecision(6) << npv << std::endl;
 
-        printTiming(timer);
+        
 
         std::cout
             << "\nWe can do more complicated things, let's e.g. modify the"
@@ -386,14 +363,14 @@ int main(int argc, char *argv[]) {
 
         swaption2->setPricingEngine(nonstandardSwaptionEngine);
 
-        timer.start();
+        
         basket = swaption2->calibrationBasket(
             swapBase, *swaptionVol,
             BasketGeneratingEngine::MaturityStrikeByDeltaGamma);
-        timer.stop();
+        
 
         printBasket(basket);
-        printTiming(timer);
+        
 
         std::cout << "\nThe notional is weighted over the underlying exercised "
                      "\ninto and the maturity is adjusted downwards. The rate"
@@ -437,15 +414,15 @@ int main(int argc, char *argv[]) {
 
         swaption3->setPricingEngine(nonstandardSwaptionEngine2);
 
-        timer.start();
+        
 
         basket = swaption3->calibrationBasket(
             swapBase, *swaptionVol,
             BasketGeneratingEngine::MaturityStrikeByDeltaGamma);
-        timer.stop();
+        
 
         printBasket(basket);
-        printTiming(timer);
+        
 
         std::cout
             << "\nNote that nominals are not exactly 1.0 here. This is"
@@ -459,14 +436,14 @@ int main(int argc, char *argv[]) {
         for (Size i = 0; i < basket.size(); i++)
             basket[i]->setPricingEngine(swaptionEngine);
 
-        timer.start();
+        
         gsr->calibrateVolatilitiesIterative(basket, method, ec);
         Real npv3 = swaption3->NPV();
-        timer.stop();
+        
 
         std::cout << "\nBond's bermudan call right npv = "
                   << std::setprecision(6) << npv3 << std::endl;
-        printTiming(timer);
+        
 
         std::cout
             << "\nUp to now, no credit spread is included in the pricing."
@@ -476,13 +453,13 @@ int main(int argc, char *argv[]) {
 
         oas.linkTo(oas100);
 
-        timer.start();
+        
         basket = swaption3->calibrationBasket(
             swapBase, *swaptionVol,
             BasketGeneratingEngine::MaturityStrikeByDeltaGamma);
-        timer.stop();
+        
         printBasket(basket);
-        printTiming(timer);
+        
 
         std::cout
             << "\nThe adjusted basket takes the credit spread into account."
@@ -494,14 +471,14 @@ int main(int argc, char *argv[]) {
         for (Size i = 0; i < basket.size(); i++)
             basket[i]->setPricingEngine(swaptionEngine);
 
-        timer.start();
+        
         gsr->calibrateVolatilitiesIterative(basket, method, ec);
         Real npv4 = swaption3->NPV();
-        timer.stop();
+        
 
         std::cout << "\nBond's bermudan call right npv (oas = 100bp) = "
                   << std::setprecision(6) << npv4 << std::endl;
-        printTiming(timer);
+        
 
         std::cout
             << "\nThe next instrument we look at is a CMS 10Y vs Euribor "
@@ -544,9 +521,9 @@ int main(int argc, char *argv[]) {
 
         underlying4->setPricingEngine(swapPricer);
 
-        timer.start();
+        
         Real npv5 = underlying4->NPV();
-        timer.stop();
+        
 
         std::cout << "Underlying CMS Swap NPV = " << std::setprecision(6)
                   << npv5 << std::endl;
@@ -555,32 +532,32 @@ int main(int argc, char *argv[]) {
         std::cout << "       Euribor Leg  NPV = " << underlying4->legNPV(1)
                   << std::endl;
 
-        printTiming(timer);
+        
 
         std::cout << "\nWe generate a naive calibration basket and calibrate "
                      "\nthe GSR model to it:" << std::endl;
 
-        timer.start();
+        
         basket = swaption4->calibrationBasket(swapBase, *swaptionVol,
                                               BasketGeneratingEngine::Naive);
         for (Size i = 0; i < basket.size(); ++i)
             basket[i]->setPricingEngine(swaptionEngine);
         gsr->calibrateVolatilitiesIterative(basket, method, ec);
-        timer.stop();
+        
 
         printBasket(basket);
         printModelCalibration(basket, gsr->volatility());
-        printTiming(timer);
+        
 
         std::cout << "\nThe npv of the bermudan swaption is" << std::endl;
 
-        timer.start();
+        
         Real npv6 = swaption4->NPV();
-        timer.stop();
+        
 
         std::cout << "\nFloat swaption NPV (GSR) = " << std::setprecision(6)
                   << npv6 << std::endl;
-        printTiming(timer);
+        
 
         std::cout << "\nIn this case it is also interesting to look at the "
                      "\nunderlying swap npv in the GSR model." << std::endl;
@@ -622,15 +599,15 @@ int main(int argc, char *argv[]) {
 
         swaption4->setPricingEngine(floatEngineMarkov);
 
-        timer.start();
+        
         Real npv7 = swaption4->NPV();
-        timer.stop();
+        
 
         std::cout << "\nThe option npv is the markov model is:" << std::endl;
 
         std::cout << "\nFloat swaption NPV (Markov) = " << std::setprecision(6)
                   << npv7 << std::endl;
-        printTiming(timer);
+        
 
         std::cout << "\nThis is not too far from the GSR price." << std::endl;
 
@@ -662,23 +639,23 @@ int main(int argc, char *argv[]) {
         for (Size i = 0; i < basket.size(); ++i)
             basket[i]->setPricingEngine(swaptionEngineMarkov);
 
-        timer.start();
+        
         markov->calibrate(basket, method, ec);
-        timer.stop();
+        
 
         printModelCalibration(basket, markov->volatility());
-        printTiming(timer);
+        
 
         std::cout << "\nNow let's have a look again at the underlying pricing."
                      "\nIt shouldn't have changed much, because the underlying"
                      "\nsmile is still matched." << std::endl;
 
-        timer.start();
+        
         Real npv8 = swaption4->result<Real>("underlyingValue");
-        timer.stop();
+        
         std::cout << "\nFloat swap NPV (Markov) = " << std::setprecision(6)
                   << npv8 << std::endl;
-        printTiming(timer);
+        
 
         std::cout << "\nThis is close to the previous value as expected."
                   << std::endl;

--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -28,7 +28,7 @@
 #include <ql/experimental/math/particleswarmoptimization.hpp>
 #include <ql/functional.hpp>
 
-#include <boost/timer.hpp>
+
 #include <boost/tuple/tuple.hpp>
 #include <iostream>
 #include <iomanip>
@@ -349,32 +349,17 @@ void testDifferentialEvolution(Size n, Size agents){
     std::cout << "================================================================" << std::endl;
 }
 
-void printTime(double seconds){
-    Integer hours = int(seconds/3600);
-    seconds -= hours * 3600;
-    Integer minutes = int(seconds/60);
-    seconds -= minutes * 60;
-    std::cout << " \nRun completed in ";
-    if (hours > 0)
-        std::cout << hours << " h ";
-    if (hours > 0 || minutes > 0)
-        std::cout << minutes << " m ";
-    std::cout << std::fixed << std::setprecision(0)
-              << seconds << " s\n" << std::endl;
-}
 
 int main(int, char* []) {
 
     try {
         std::cout << std::endl;
-        boost::timer timer;
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Firefly Algorithm Test" << std::endl;
         std::cout << "----------------------------------------------------------------" << std::endl;
         testFirefly();
 
-        printTime(timer.elapsed());
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Hybrid Simulated Annealing Test" << std::endl;
@@ -383,7 +368,6 @@ int main(int, char* []) {
         testGaussianSA(10, 500, 200, 100.0, 0.1, GaussianSimulatedAnnealing::ResetToBestPoint, 150, GaussianSimulatedAnnealing::EveryNewPoint);
         testGaussianSA(30, 500, 200, 100.0, 0.1, GaussianSimulatedAnnealing::ResetToBestPoint, 150, GaussianSimulatedAnnealing::EveryNewPoint);
 
-        printTime(timer.elapsed());
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Particle Swarm Optimization Test" << std::endl;
@@ -392,7 +376,6 @@ int main(int, char* []) {
         testPSO(10);
         testPSO(30);
 
-        printTime(timer.elapsed());
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Simulated Annealing Test" << std::endl;
@@ -401,7 +384,6 @@ int main(int, char* []) {
         testSimulatedAnnealing(10, 10000, 4000);
         testSimulatedAnnealing(30, 10000, 4000);
 
-        printTime(timer.elapsed());
 
         std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
         std::cout << "Differential Evolution Test" << std::endl;
@@ -409,8 +391,6 @@ int main(int, char* []) {
         testDifferentialEvolution(3, 50);
         testDifferentialEvolution(10, 150);
         testDifferentialEvolution(30, 450);
-
-        printTime(timer.elapsed());
 
         return 0;
     } catch (std::exception& e) {

--- a/Examples/LatentModel/LatentModel.cpp
+++ b/Examples/LatentModel/LatentModel.cpp
@@ -27,8 +27,6 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 
-#include <boost/timer.hpp>
-
 #include <iostream>
 #include <iomanip>
 
@@ -53,7 +51,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Calendar calendar = TARGET();
@@ -294,21 +291,6 @@ int main(int, char* []) {
             ;
                 cout << endl;
         }
-
-
-
-        Real seconds  = timer.elapsed();
-        Integer hours = Integer(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = Integer(seconds/60);
-        seconds -= minutes * 60;
-        cout << "Run completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s" << endl;
 
         return 0;
     } catch (exception& e) {

--- a/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
+++ b/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
@@ -49,7 +49,6 @@
 #include <ql/math/interpolations/cubicinterpolation.hpp>
 #include <ql/math/interpolations/loginterpolation.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -68,7 +67,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         /*********************
@@ -919,20 +917,6 @@ int main(int, char* []) {
         std::cout << std::setw(headers[3].size())
                   << io::rate(fairRate) << separator;
         std::cout << std::endl;
-
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
 

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -26,7 +26,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/math/integrals/trapezoidintegral.hpp>
 #include <ql/functional.hpp>
 
-#include <boost/timer.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -73,9 +72,7 @@ int main() {
     #ifndef QL_PATCH_SOLARIS
     GaussianQuadMultidimIntegrator intg(dimension, 15);
 
-    timer.restart();
     Real valueQuad = intg(f);
-    Real secondsQuad = timer.elapsed();
     #endif
 
     std::vector<ext::shared_ptr<Integrator> > integrals;
@@ -86,9 +83,7 @@ int main() {
     std::vector<Real> b_limits(integrals.size(), 4.);
     MultidimIntegral testIntg(integrals);
 
-    timer.restart();
     Real valueGrid = testIntg(f, a_limits, b_limits);
-    Real secondsGrid = timer.elapsed();
 
     cout << fixed << setprecision(4);
     cout << endl << "-------------- " << endl
@@ -99,10 +94,5 @@ int main() {
          << "Grid: " << valueGrid << endl
          << endl;
 
-    cout
-        #ifndef QL_PATCH_SOLARIS
-        << "Seconds for Quad: " << secondsQuad << endl
-        #endif
-        << "Seconds for Grid: " << secondsGrid << endl;
     return 0;
 }

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -52,7 +52,6 @@ struct integrand {
 };
 
 int main() {
-    boost::timer timer;
     std::cout << std::endl;
 
     /* 

--- a/Examples/Replication/Replication.cpp
+++ b/Examples/Replication/Replication.cpp
@@ -39,7 +39,6 @@
 #include <ql/quotes/simplequote.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -57,7 +56,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Date today(29, May, 2006);
@@ -367,19 +365,6 @@ int main(int, char* []) {
             << "risk-free rate are changed. Feel free to experiment with \n"
             << "the example and contribute a patch if you spot any errors."
             << std::endl;
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        std::cout << " \nRun completed in ";
-        if (hours > 0)
-            std::cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            std::cout << minutes << " m ";
-        std::cout << std::fixed << std::setprecision(0)
-                  << seconds << " s\n" << std::endl;
 
         return 0;
     } catch (std::exception& e) {

--- a/Examples/Repo/Repo.cpp
+++ b/Examples/Repo/Repo.cpp
@@ -40,7 +40,6 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 
-#include <boost/timer.hpp>
 #include <iostream>
 #include <iomanip>
 
@@ -59,7 +58,6 @@ int main(int, char* []) {
 
     try {
 
-        boost::timer timer;
         std::cout << std::endl;
 
         Date repoSettlementDate(14,February,2000);;
@@ -224,19 +222,6 @@ int main(int, char* []) {
              << "and 0 settlement days."
              << endl;
 
-
-        double seconds = timer.elapsed();
-        Integer hours = int(seconds/3600);
-        seconds -= hours * 3600;
-        Integer minutes = int(seconds/60);
-        seconds -= minutes * 60;
-        cout << " \nRun completed in ";
-        if (hours > 0)
-            cout << hours << " h ";
-        if (hours > 0 || minutes > 0)
-            cout << minutes << " m ";
-        cout << fixed << setprecision(0)
-             << seconds << " s\n" << endl;
 
         return 0;
 


### PR DESCRIPTION
Straightforward change as described in #666 , in lieu of complicating the library with the most recent versions of Boost::Timer (which is no longer header-only), I have simply removed this functionality from all of the examples. 