### PR TITLE
Return delta from Black cap/floor engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,9 @@ test-suite/bin/*.lib
 test-suite/bin/*.pdb
 test-suite/.unit_test_profile.txt
 
-
+# Netbeans
+nbproject/private/*
+nbproject/project.xml
+nbproject/project.properties
+nbproject/configurations.xml
+.cproject

--- a/.gitignore
+++ b/.gitignore
@@ -112,8 +112,5 @@ test-suite/bin/*.pdb
 test-suite/.unit_test_profile.txt
 
 # Netbeans
-nbproject/private/*
-nbproject/project.xml
-nbproject/project.properties
-nbproject/configurations.xml
+nbproject
 .cproject

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -793,5 +793,26 @@ namespace QuantLib {
                                      stdDev, discount);
     }
 
+    Real bachelierBlackFormulaItmAssetProbability(
+                        Option::Type optionType,
+                        Real strike,
+                        Real forward,
+                        Real stdDev) {
+        QL_REQUIRE(stdDev>=0.0,
+                   "stdDev (" << stdDev << ") must be non-negative");
+        Real d = (forward-strike)*optionType, h = d/stdDev;
+        if (stdDev==0.0)
+            return std::max(d, 0.0);
+        CumulativeNormalDistribution phi;
+        Real result = phi(h);
+        return result;
+    }
 
+    Real bachelierBlackFormulaItmAssetProbability(
+                        const ext::shared_ptr<PlainVanillaPayoff>& payoff,
+                        Real forward,
+                        Real stdDev) {
+        return bachelierBlackFormulaItmAssetProbability(payoff->optionType(),
+            payoff->strike(), forward, stdDev);
+    }
 }

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -549,7 +549,7 @@ namespace QuantLib {
             payoff->strike(), forward, stdDev , displacement);
     }
 
-    Real blackFormulaItmAssetProbability(
+    Real blackFormulaAssetItmProbability(
                         Option::Type optionType,
                         Real strike,
                         Real forward,
@@ -568,12 +568,12 @@ namespace QuantLib {
         return phi(optionType*d1);
     }
 
-    Real blackFormulaItmAssetProbability(
+    Real blackFormulaAssetItmProbability(
                         const ext::shared_ptr<PlainVanillaPayoff>& payoff,
                         Real forward,
                         Real stdDev,
                         Real displacement) {
-        return blackFormulaItmAssetProbability(payoff->optionType(),
+        return blackFormulaAssetItmProbability(payoff->optionType(),
             payoff->strike(), forward, stdDev , displacement);
     }
 
@@ -793,7 +793,7 @@ namespace QuantLib {
                                      stdDev, discount);
     }
 
-    Real bachelierBlackFormulaItmAssetProbability(
+    Real bachelierBlackFormulaAssetItmProbability(
                         Option::Type optionType,
                         Real strike,
                         Real forward,
@@ -808,11 +808,11 @@ namespace QuantLib {
         return result;
     }
 
-    Real bachelierBlackFormulaItmAssetProbability(
+    Real bachelierBlackFormulaAssetItmProbability(
                         const ext::shared_ptr<PlainVanillaPayoff>& payoff,
                         Real forward,
                         Real stdDev) {
-        return bachelierBlackFormulaItmAssetProbability(payoff->optionType(),
+        return bachelierBlackFormulaAssetItmProbability(payoff->optionType(),
             payoff->strike(), forward, stdDev);
     }
 }

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -10,6 +10,7 @@
  Copyright (C) 2013 Gary Kennedy
  Copyright (C) 2015 Peter Caspers
  Copyright (C) 2017 Klaus Spanderen
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -548,6 +548,34 @@ namespace QuantLib {
             payoff->strike(), forward, stdDev , displacement);
     }
 
+    Real blackFormulaItmAssetProbability(
+                        Option::Type optionType,
+                        Real strike,
+                        Real forward,
+                        Real stdDev,
+                        Real displacement) {
+        checkParameters(strike, forward, displacement);
+        if (stdDev==0.0)
+            return (forward*optionType < strike*optionType ? 1.0 : 0.0);
+
+        forward = forward + displacement;
+        strike = strike + displacement;
+        if (strike==0.0)
+            return (optionType==Option::Call ? 1.0 : 0.0);
+        Real d1 = std::log(forward/strike)/stdDev + 0.5*stdDev;
+        CumulativeNormalDistribution phi;
+        return phi(optionType*d1);
+    }
+
+    Real blackFormulaItmAssetProbability(
+                        const ext::shared_ptr<PlainVanillaPayoff>& payoff,
+                        Real forward,
+                        Real stdDev,
+                        Real displacement) {
+        return blackFormulaItmAssetProbability(payoff->optionType(),
+            payoff->strike(), forward, stdDev , displacement);
+    }
+
     Real blackFormulaVolDerivative(Rate strike,
                                       Rate forward,
                                       Real stdDev,

--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -235,6 +235,27 @@ namespace QuantLib {
                         Real stdDev,
                         Real displacement = 0.0);
 
+/*! Black 1976 probability of being in the money in the asset martingale
+        measure, i.e. N(d1).
+        It is a risk-neutral probability, not the real world one.
+    */
+    Real blackFormulaItmAssetProbability(
+                        Option::Type optionType,
+                        Real strike,
+                        Real forward,
+                        Real stdDev,
+                        Real displacement = 0.0);
+
+    /*! Black 1976 probability of being in the money in the asset martingale
+        measure, i.e. N(d1).
+        It is a risk-neutral probability, not the real world one.
+    */
+    Real blackFormulaItmAssetProbability(
+                        const ext::shared_ptr<PlainVanillaPayoff>& payoff,
+                        Real forward,
+                        Real stdDev,
+                        Real displacement = 0.0);
+    
     /*! Black 1976 formula for standard deviation derivative
         \warning instead of volatility it uses standard deviation, i.e.
                  volatility*sqrt(timeToMaturity), and it returns the

--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -236,7 +236,7 @@ namespace QuantLib {
                         Real stdDev,
                         Real displacement = 0.0);
 
-/*! Black 1976 probability of being in the money in the asset martingale
+    /*! Black 1976 probability of being in the money in the asset martingale
         measure, i.e. N(d1).
         It is a risk-neutral probability, not the real world one.
     */
@@ -374,6 +374,25 @@ namespace QuantLib {
                                                 Real forward,
                                                 Real stdDev,
                                                 Real discount = 1.0);
+
+    /*! Bachelier formula for probability of being in the money in the asset martingale
+        measure, i.e. N(d).
+        It is a risk-neutral probability, not the real world one.
+    */
+    Real bachelierBlackFormulaItmAssetProbability(
+                        Option::Type optionType,
+                        Real strike,
+                        Real forward,
+                        Real stdDev);
+
+    /*! Bachelier formula for of being in the money in the asset martingale
+        measure, i.e. N(d).
+        It is a risk-neutral probability, not the real world one.
+    */
+    Real bachelierBlackFormulaItmAssetProbability(
+                        const ext::shared_ptr<PlainVanillaPayoff>& payoff,
+                        Real forward,
+                        Real stdDev);                                                
 
 }
 

--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -240,7 +240,7 @@ namespace QuantLib {
         measure, i.e. N(d1).
         It is a risk-neutral probability, not the real world one.
     */
-    Real blackFormulaItmAssetProbability(
+    Real blackFormulaAssetItmProbability(
                         Option::Type optionType,
                         Real strike,
                         Real forward,
@@ -251,7 +251,7 @@ namespace QuantLib {
         measure, i.e. N(d1).
         It is a risk-neutral probability, not the real world one.
     */
-    Real blackFormulaItmAssetProbability(
+    Real blackFormulaAssetItmProbability(
                         const ext::shared_ptr<PlainVanillaPayoff>& payoff,
                         Real forward,
                         Real stdDev,
@@ -379,7 +379,7 @@ namespace QuantLib {
         measure, i.e. N(d).
         It is a risk-neutral probability, not the real world one.
     */
-    Real bachelierBlackFormulaItmAssetProbability(
+    Real bachelierBlackFormulaAssetItmProbability(
                         Option::Type optionType,
                         Real strike,
                         Real forward,
@@ -389,7 +389,7 @@ namespace QuantLib {
         measure, i.e. N(d).
         It is a risk-neutral probability, not the real world one.
     */
-    Real bachelierBlackFormulaItmAssetProbability(
+    Real bachelierBlackFormulaAssetItmProbability(
                         const ext::shared_ptr<PlainVanillaPayoff>& payoff,
                         Real forward,
                         Real stdDev);                                                

--- a/ql/pricingengines/blackformula.hpp
+++ b/ql/pricingengines/blackformula.hpp
@@ -10,6 +10,7 @@
  Copyright (C) 2013 Gary Kennedy
  Copyright (C) 2015 Peter Caspers
  Copyright (C) 2017 Klaus Spanderen
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2014, 2015 Michael von den Driesch
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -65,8 +66,11 @@ namespace QuantLib {
         Real vega = 0.0;
         Size optionlets = arguments_.startDates.size();
         std::vector<Real> values(optionlets, 0.0);
+        std::vector<Real> deltas(optionlets, 0.0);
         std::vector<Real> vegas(optionlets, 0.0);
         std::vector<Real> stdDevs(optionlets, 0.0);
+        std::vector<Real> deflators(optionlets, 0.0);
+        std::vector<Real> accrualFactors(optionlets, 0.0);
         CapFloor::Type type = arguments_.type;
         Date today = vol_->referenceDate();
         Date settlement = discountCurve_->referenceDate();
@@ -77,10 +81,14 @@ namespace QuantLib {
             // should be implemented.
             // For the time being just discard expired caplets
             if (paymentDate > settlement) {
-                DiscountFactor d = arguments_.nominals[i] *
+                Real accrualFactor = arguments_.nominals[i] *
                                    arguments_.gearings[i] *
-                                   discountCurve_->discount(paymentDate) *
                                    arguments_.accrualTimes[i];
+                Real d = accrualFactor *
+                         discountCurve_->discount(paymentDate);
+
+                deflators[i] = d;
+                accrualFactors[i] = accrualFactor;
 
                 Rate forward = arguments_.forwards[i];
 
@@ -96,6 +104,8 @@ namespace QuantLib {
                                                                    strike));
                         vegas[i] = bachelierBlackFormulaStdDevDerivative(strike,
                             forward, stdDevs[i], d) * sqrtTime;
+                        deltas[i] = bachelierBlackFormulaItmAssetProbability(Option::Call,
+                            strike, forward, stdDevs[i]);
                     }
                     // include caplets with past fixing date
                     values[i] = bachelierBlackFormula(Option::Call,
@@ -104,21 +114,27 @@ namespace QuantLib {
                 if (type == CapFloor::Floor || type == CapFloor::Collar) {
                     Rate strike = arguments_.floorRates[i];
                     Real floorletVega = 0.0;
+                    Real floorletDelta = 0.0;
                     if (sqrtTime>0.0) {
                         stdDevs[i] = std::sqrt(vol_->blackVariance(fixingDate,
                                                                    strike));
                         floorletVega = bachelierBlackFormulaStdDevDerivative(strike,
                             forward, stdDevs[i], d) * sqrtTime;
+                        floorletDelta = Option::Put * bachelierBlackFormulaItmAssetProbability(
+                                                        Option::Put, strike, forward, 
+                                                        stdDevs[i]);
                     }
                     Real floorlet = bachelierBlackFormula(Option::Put,
                         strike, forward, stdDevs[i], d);
                     if (type == CapFloor::Floor) {
                         values[i] = floorlet;
                         vegas[i] = floorletVega;
+                        deltas[i] = floorletDelta;
                     } else {
                         // a collar is long a cap and short a floor
                         values[i] -= floorlet;
                         vegas[i] -= floorletVega;
+                        deltas[i] -= floorletDelta;
                     }
                 }
                 value += values[i];
@@ -130,7 +146,11 @@ namespace QuantLib {
 
         results_.additionalResults["optionletsPrice"] = values;
         results_.additionalResults["optionletsVega"] = vegas;
+        results_.additionalResults["optionletsDelta"] = deltas;
+        results_.additionalResults["optionletsDeflators"] = deflators;
         results_.additionalResults["optionletsAtmForward"] = arguments_.forwards;
+        results_.additionalResults["optionletsAccrualFactors"] = accrualFactors;
+        results_.additionalResults["optionletsEndDates"] = arguments_.endDates;
         if (type != CapFloor::Collar)
             results_.additionalResults["optionletsStdDev"] = stdDevs;
     }

--- a/ql/pricingengines/capfloor/blackcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/blackcapfloorengine.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2001, 2002, 2003 Sadruddin Rejeb
  Copyright (C) 2006, 2007 StatPro Italia srl
  Copyright (C) 2015 Michael von den Driesch
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/pricingengines/capfloor/blackcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/blackcapfloorengine.cpp
@@ -98,8 +98,7 @@ namespace QuantLib {
                 Real accrualFactor = arguments_.nominals[i] *
                                    arguments_.gearings[i] *
                                    arguments_.accrualTimes[i];
-                DiscountFactor d = accrualFactor *
-                                   discountCurve_->discount(paymentDate);
+                Real d = accrualFactor * discountCurve_->discount(paymentDate);
                 deflators[i] = d;
                 accrualFactors[i] = accrualFactor;
                 Rate forward = arguments_.forwards[i];

--- a/ql/pricingengines/capfloor/blackcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/blackcapfloorengine.cpp
@@ -84,6 +84,7 @@ namespace QuantLib {
         std::vector<Real> vegas(optionlets, 0.0);
         std::vector<Real> stdDevs(optionlets, 0.0);
         std::vector<Real> deflators(optionlets, 0.0);
+        std::vector<Real> accrualFactors(optionlets, 0.0);
         CapFloor::Type type = arguments_.type;
         Date today = vol_->referenceDate();
         Date settlement = discountCurve_->referenceDate();
@@ -100,7 +101,7 @@ namespace QuantLib {
                 DiscountFactor d = accrualFactor *
                                    discountCurve_->discount(paymentDate);
                 deflators[i] = d;
-
+                accrualFactors[i] = accrualFactor;
                 Rate forward = arguments_.forwards[i];
 
                 Date fixingDate = arguments_.fixingDates[i];
@@ -160,6 +161,8 @@ namespace QuantLib {
         results_.additionalResults["optionletsDelta"] = deltas;
         results_.additionalResults["optionletsDeflators"] = deflators;
         results_.additionalResults["optionletsAtmForward"] = arguments_.forwards;
+        results_.additionalResults["optionletsAccrualFactors"] = accrualFactors;
+        results_.additionalResults["optionletsEndDates"] = arguments_.endDates;
         if (type != CapFloor::Collar)
             results_.additionalResults["optionletsStdDev"] = stdDevs;
     }

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 RiskMap srl
  Copyright (C) 2004, 2005, 2006, 2007, 2008 StatPro Italia srl
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -668,21 +668,21 @@ void CapFloorTest::testCachedValueFromOptionLets() {
     floorletPrices = floor->result<std::vector<Real> >("optionletsPrice");
     
 
-    std::cout << "How many caplets: " << LENGTH(capletPrices) << std::endl;
+    std::cout << "How many caplets: " << capletPrices.size() << std::endl;
     std::cout << "today: \t" << vars.termStructure->referenceDate() << std::endl;
 
-    if (LENGTH(capletPrices) != 40)
+    if (capletPrices.size() != 40)
         BOOST_ERROR(
             "failed to produce prices for all caplets:\n"
-            << "    calculated: " << LENGTH(capletPrices) << " caplet prices\n"
+            << "    calculated: " << capletPrices.size() << " caplet prices\n"
             << "    expected:   " << 40);
 
-    for (Size n=0; n<LENGTH(capletPrices); n++){
+    for (Size n=0; n<capletPrices.size(); n++){
         calculatedCapletsNPV += capletPrices[n];
         std::cout << "  Caplet: \t" << n << " = " << capletPrices[n] << std::endl;     
     }
 
-    for (Size n=0; n<LENGTH(floorletPrices); n++){
+    for (Size n=0; n<floorletPrices.size(); n++){
         calculatedFloorletsNPV += floorletPrices[n];
         std::cout << "  Floorlet: \t" << n << " = " << floorletPrices[n] << "\n"; 
     }

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -729,8 +729,8 @@ void CapFloorTest::testOptionLetsDelta() {
     std::vector<Real> capletUpPrices, 
                       capletDownPrices,
                       capletAnalyticDelta,
-                      capletDeflatorsUp,
-                      capletDeflatorsDown,
+                      capletDiscountFactorsUp,
+                      capletDiscountFactorsDown,
                       capletForwardsUp,
                       capletForwardsDown,
                       capletFDDelta(capletsNum, 0.0); 
@@ -738,8 +738,8 @@ void CapFloorTest::testOptionLetsDelta() {
     std::vector<Real> floorletUpPrices, 
                       floorletDownPrices,
                       floorletAnalyticDelta,
-                      floorletDeflatorsUp,
-                      floorletDeflatorsDown,
+                      floorletDiscountFactorsUp,
+                      floorletDiscountFactorsDown,
                       floorletForwardsUp,
                       floorletForwardsDown,
                       floorletFDDelta(floorletNum, 0.0);
@@ -750,33 +750,43 @@ void CapFloorTest::testOptionLetsDelta() {
     spread->setValue(eps);
     capletUpPrices = cap->result<std::vector<Real> >("optionletsPrice");
     floorletUpPrices = floor->result<std::vector<Real> >("optionletsPrice");
-    capletDeflatorsUp = cap->result<std::vector<Real> >("optionletsDeflators");
-    floorletDeflatorsUp = floor->result<std::vector<Real> >("optionletsDeflators");
+    capletDiscountFactorsUp = cap->result<std::vector<Real> >("optionletsDiscountFactor");
+    floorletDiscountFactorsUp = floor->result<std::vector<Real> >("optionletsDiscountFactor");
     capletForwardsUp = cap->result<std::vector<Real> >("optionletsAtmForward");
     floorletForwardsUp = floor->result<std::vector<Real> >("optionletsAtmForward");
     
     spread->setValue(-eps);
     capletDownPrices = cap->result<std::vector<Real> >("optionletsPrice");
     floorletDownPrices = floor->result<std::vector<Real> >("optionletsPrice");
-    capletDeflatorsDown = cap->result<std::vector<Real> >("optionletsDeflators");
-    floorletDeflatorsDown = floor->result<std::vector<Real> >("optionletsDeflators");
+    capletDiscountFactorsDown = cap->result<std::vector<Real> >("optionletsDiscountFactor");
+    floorletDiscountFactorsDown = floor->result<std::vector<Real> >("optionletsDiscountFactor");
     capletForwardsDown = cap->result<std::vector<Real> >("optionletsAtmForward");
     floorletForwardsDown = floor->result<std::vector<Real> >("optionletsAtmForward");
 
+    Real accrualFactor;
+    Leg capLeg = cap->floatingLeg();
+    Leg floorLeg = floor->floatingLeg();
+    
     for (Size n=1; n < capletUpPrices.size(); n++){
         // calculating only caplet's FD sensitivity w.r.t. forward rate
         // without the effect of sensitivity related to changed discount factor
-        capletFDDelta[n] = (capletUpPrices[n] / capletDeflatorsUp[n]
-                           - capletDownPrices[n] / capletDeflatorsDown[n]) 
-                           / (capletForwardsUp[n] - capletForwardsDown[n]);
+        ext::shared_ptr<FloatingRateCoupon> c = ext::dynamic_pointer_cast<FloatingRateCoupon>(capLeg[n]);
+        accrualFactor = c->nominal() * c->accrualPeriod() * c->gearing();
+        capletFDDelta[n] = (capletUpPrices[n] / capletDiscountFactorsUp[n]
+                           - capletDownPrices[n] / capletDiscountFactorsDown[n]) 
+                           / (capletForwardsUp[n] - capletForwardsDown[n])
+                           / accrualFactor;
     }
 
     for (Size n=0; n<floorletUpPrices.size(); n++){
         // calculating only caplet's FD sensitivity w.r.t. forward rate
         // without the effect of sensitivity related to changed discount factor
-        floorletFDDelta[n] = (floorletUpPrices[n] / floorletDeflatorsUp[n] 
-                             - floorletDownPrices[n] / floorletDeflatorsDown[n]) 
-                             / (floorletForwardsUp[n] - floorletForwardsDown[n]);        
+        ext::shared_ptr<FloatingRateCoupon> c = ext::dynamic_pointer_cast<FloatingRateCoupon>(floorLeg[n]);
+        accrualFactor = c->nominal() * c->accrualPeriod() * c->gearing();
+        floorletFDDelta[n] = (floorletUpPrices[n] / floorletDiscountFactorsUp[n] 
+                             - floorletDownPrices[n] / floorletDiscountFactorsDown[n]) 
+                             / (floorletForwardsUp[n] - floorletForwardsDown[n])
+                             / accrualFactor;        
     }
 
     for (Size n=0; n<capletAnalyticDelta.size(); n++){
@@ -843,8 +853,8 @@ void CapFloorTest::testBachelierOptionLetsDelta() {
     std::vector<Real> capletUpPrices, 
                       capletDownPrices,
                       capletAnalyticDelta,
-                      capletDeflatorsUp,
-                      capletDeflatorsDown,
+                      capletDiscountFactorsUp,
+                      capletDiscountFactorsDown,
                       capletForwardsUp,
                       capletForwardsDown,
                       capletFDDelta(capletsNum, 0.0); 
@@ -852,8 +862,8 @@ void CapFloorTest::testBachelierOptionLetsDelta() {
     std::vector<Real> floorletUpPrices, 
                       floorletDownPrices,
                       floorletAnalyticDelta,
-                      floorletDeflatorsUp,
-                      floorletDeflatorsDown,
+                      floorletDiscountFactorsUp,
+                      floorletDiscountFactorsDown,
                       floorletForwardsUp,
                       floorletForwardsDown,
                       floorletFDDelta(floorletNum, 0.0);
@@ -864,33 +874,43 @@ void CapFloorTest::testBachelierOptionLetsDelta() {
     spread->setValue(eps);
     capletUpPrices = cap->result<std::vector<Real> >("optionletsPrice");
     floorletUpPrices = floor->result<std::vector<Real> >("optionletsPrice");
-    capletDeflatorsUp = cap->result<std::vector<Real> >("optionletsDeflators");
-    floorletDeflatorsUp = floor->result<std::vector<Real> >("optionletsDeflators");
+    capletDiscountFactorsUp = cap->result<std::vector<Real> >("optionletsDiscountFactor");
+    floorletDiscountFactorsUp = floor->result<std::vector<Real> >("optionletsDiscountFactor");
     capletForwardsUp = cap->result<std::vector<Real> >("optionletsAtmForward");
     floorletForwardsUp = floor->result<std::vector<Real> >("optionletsAtmForward");
     
     spread->setValue(-eps);
     capletDownPrices = cap->result<std::vector<Real> >("optionletsPrice");
     floorletDownPrices = floor->result<std::vector<Real> >("optionletsPrice");
-    capletDeflatorsDown = cap->result<std::vector<Real> >("optionletsDeflators");
-    floorletDeflatorsDown = floor->result<std::vector<Real> >("optionletsDeflators");
+    capletDiscountFactorsDown = cap->result<std::vector<Real> >("optionletsDiscountFactor");
+    floorletDiscountFactorsDown = floor->result<std::vector<Real> >("optionletsDiscountFactor");
     capletForwardsDown = cap->result<std::vector<Real> >("optionletsAtmForward");
     floorletForwardsDown = floor->result<std::vector<Real> >("optionletsAtmForward");
 
+    Real accrualFactor;
+    Leg capLeg = cap->floatingLeg();
+    Leg floorLeg = floor->floatingLeg();
+    
     for (Size n=1; n < capletUpPrices.size(); n++){
         // calculating only caplet's FD sensitivity w.r.t. forward rate
         // without the effect of sensitivity related to changed discount factor
-        capletFDDelta[n] = (capletUpPrices[n] / capletDeflatorsUp[n]
-                           - capletDownPrices[n] / capletDeflatorsDown[n]) 
-                           / (capletForwardsUp[n] - capletForwardsDown[n]);
+        ext::shared_ptr<FloatingRateCoupon> c = ext::dynamic_pointer_cast<FloatingRateCoupon>(capLeg[n]);
+        accrualFactor = c->nominal() * c->accrualPeriod() * c->gearing();
+        capletFDDelta[n] = (capletUpPrices[n] / capletDiscountFactorsUp[n]
+                           - capletDownPrices[n] / capletDiscountFactorsDown[n]) 
+                           / (capletForwardsUp[n] - capletForwardsDown[n])
+                           / accrualFactor;
     }
 
     for (Size n=0; n<floorletUpPrices.size(); n++){
         // calculating only caplet's FD sensitivity w.r.t. forward rate
         // without the effect of sensitivity related to changed discount factor
-        floorletFDDelta[n] = (floorletUpPrices[n] / floorletDeflatorsUp[n] 
-                             - floorletDownPrices[n] / floorletDeflatorsDown[n]) 
-                             / (floorletForwardsUp[n] - floorletForwardsDown[n]);        
+        ext::shared_ptr<FloatingRateCoupon> c = ext::dynamic_pointer_cast<FloatingRateCoupon>(floorLeg[n]);
+        accrualFactor = c->nominal() * c->accrualPeriod() * c->gearing();
+        floorletFDDelta[n] = (floorletUpPrices[n] / floorletDiscountFactorsUp[n] 
+                             - floorletDownPrices[n] / floorletDiscountFactorsDown[n]) 
+                             / (floorletForwardsUp[n] - floorletForwardsDown[n])
+                             / accrualFactor;        
     }
 
     for (Size n=0; n<capletAnalyticDelta.size(); n++){

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -635,18 +635,13 @@ void CapFloorTest::testCachedValueFromOptionLets() {
     // par coupon price
     Real cachedCapNPV   = 6.87570026732,
          cachedFloorNPV = 2.65812927959;
-    Real calculatedCapNPV   = 0.0,
-         calculatedFloorNPV = 0.0,   
-         calculatedCapletsNPV = 0.0,
+    Real calculatedCapletsNPV = 0.0,
          calculatedFloorletsNPV = 0.0;
-
 #else
     // index fixing price
     Real cachedCapNPV   = 6.87630307745,
          cachedFloorNPV = 2.65796764715;
-    Real calculatedCapNPV   = 0.0,
-         calculatedFloorNPV = 0.0,   
-         calculatedCapletsNPV = 0.0,
+    Real calculatedCapletsNPV = 0.0,
          calculatedFloorletsNPV = 0.0;
 #endif
     // test Black floor price against cached value

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -631,18 +631,17 @@ void CapFloorTest::testCachedValueFromOptionLets() {
                                                           0.07,0.20);
     ext::shared_ptr<Instrument> floor = vars.makeCapFloor(CapFloor::Floor,leg,
                                                             0.03,0.20);
+    Real calculatedCapletsNPV = 0.0,
+         calculatedFloorletsNPV = 0.0;
+
 #ifndef QL_USE_INDEXED_COUPON
     // par coupon price
     Real cachedCapNPV   = 6.87570026732,
          cachedFloorNPV = 2.65812927959;
-    Real calculatedCapletsNPV = 0.0,
-         calculatedFloorletsNPV = 0.0;
 #else
     // index fixing price
     Real cachedCapNPV   = 6.87630307745,
          cachedFloorNPV = 2.65796764715;
-    Real calculatedCapletsNPV = 0.0,
-         calculatedFloorletsNPV = 0.0;
 #endif
     // test Black floor price against cached value
     std::vector<Real> capletPrices;

--- a/test-suite/capfloor.hpp
+++ b/test-suite/capfloor.hpp
@@ -38,6 +38,7 @@ class CapFloorTest {
     static void testCachedValue();
     static void testCachedValueFromOptionLets();
     static void testOptionLetsDelta();
+    static void testBachelierOptionLetsDelta();
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/capfloor.hpp
+++ b/test-suite/capfloor.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2003 RiskMap srl
  Copyright (C) 2007 StatPro Italia srl
+ Copyright (C) 2019 Wojciech Ślusarski
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/capfloor.hpp
+++ b/test-suite/capfloor.hpp
@@ -36,6 +36,7 @@ class CapFloorTest {
     static void testImpliedVolatility();
     static void testCachedValue();
     static void testCachedValueFromOptionLets();
+    static void testOptionLetsDelta();
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/capfloor.hpp
+++ b/test-suite/capfloor.hpp
@@ -35,6 +35,7 @@ class CapFloorTest {
     static void testATMRate();
     static void testImpliedVolatility();
     static void testCachedValue();
+    static void testCachedValueFromOptionLets();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
I am working on adding delta coefficients to `additionalResults` of 'CapFloor' instruments.
For the moment I am working with `BlackCapFloorEngine`, but I intend to do similar task at least for  `BachelierCapFloorEngine`.
Since the work involves changes in widely used classes, I started with a small unittest, which was a copy of `CapFloorTest::testCachedValue`.
Initially the test was supposed to be written for `optionletsForwardDelta`, but having experienced strange behavior, I reworked it to something similar to original test.

The added test is `CapFloorTest::testCachedValueFromOptionLets`.

I am calling the test by:
```bash
/home/wojtek/coding/github/QuantLib/build/test-suite/quantlib-test-suite --log_level=test_suite --run_test=*/Cap*
```
The relevant outcome is:

```bash
Testing Black cap/floor price as a sum of optionlets prices against cached values...
Current instance date:  March 14th, 2002
How many caplets: 3
today:  March 18th, 2002
/home/wojtek/coding/github/QuantLib/test-suite/capfloor.cpp(678): error: in "QuantLib test suite/Cap and floor tests/QuantLib__detail__quantlib_test_case(&CapFloorTest__testCachedValueFromOptionLets)": failed to produce prices for all caplets:
    calculated: 3 caplet prices
    expected:   40
  Caplet:       0 = 0
  Caplet:       1 = 0.00162713
  Caplet:       2 = 0.0125048
  Floorlet:     0 = 0
  Floorlet:     1 = 7.91291e-06
  Floorlet:     2 = 0.000507892
/home/wojtek/coding/github/QuantLib/test-suite/capfloor.cpp(695): error: in "QuantLib test suite/Cap and floor tests/QuantLib__detail__quantlib_test_case(&CapFloorTest__testCachedValueFromOptionLets)": failed to reproduce cached cap value from its caplets' values:
    calculated: 0.0141319590521
    expected:   6.87570026732
/home/wojtek/coding/github/QuantLib/test-suite/capfloor.cpp(702): error: in "QuantLib test suite/Cap and floor tests/QuantLib__detail__quantlib_test_case(&CapFloorTest__testCachedValueFromOptionLets)": failed to reproduce cached floor value from its floorlets' values:
    calculated: 0.000515805278017
    expected:   2.65812927959
```
As you can see, the first test based on the call to `cap->NPV()` passes the test.
Unfortunately, the later tests fail. We are testing here a 20Y long cap, so there should be 39 or 40 caplets. I will appreciate any hint explaining why the call to `cap->result<std::vector<Real> >("optionletsPrice");` truncates the result only to three items.
The similar call in Python, thanks to recently introduced change would provide all the caplet prices.

I am sorry for using standard output in the test, but that was the quickest way to add some debugging info (I am not yet familiar with boost unit testing framwork to add some debug only level test output).

As there is still plenty of work to be done here, I mark this as a draft pr.

Regards,
Wojtek
