### PR TITLE
Pass explicit bootstrap to PiecewiseYieldCurve

### DIFF
--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -63,8 +63,8 @@ namespace QuantLib {
           public LazyObject {
       private:
         typedef typename Traits::template curve<Interpolator>::type base_curve;
-        typedef PiecewiseYieldCurve<Traits,Interpolator,Bootstrap> this_curve;
       public:
+        typedef PiecewiseYieldCurve<Traits,Interpolator,Bootstrap> this_curve;
         typedef Traits traits_type;
         typedef Interpolator interpolator_type;
         //! \name Constructors

--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -63,10 +63,11 @@ namespace QuantLib {
           public LazyObject {
       private:
         typedef typename Traits::template curve<Interpolator>::type base_curve;
-      public:
         typedef PiecewiseYieldCurve<Traits,Interpolator,Bootstrap> this_curve;
+      public:
         typedef Traits traits_type;
         typedef Interpolator interpolator_type;
+        typedef Bootstrap<this_curve> bootstrap_type;
         //! \name Constructors
         //@{
         PiecewiseYieldCurve(
@@ -79,7 +80,7 @@ namespace QuantLib {
                const std::vector<Date>& jumpDates = std::vector<Date>(),
                Real accuracy = 1.0e-12,
                const Interpolator& i = Interpolator(),
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(referenceDate, dayCounter, jumps, jumpDates, i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
@@ -92,7 +93,7 @@ namespace QuantLib {
                const DayCounter& dayCounter,
                Real accuracy,
                const Interpolator& i = Interpolator(),
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(referenceDate, dayCounter,
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
@@ -105,7 +106,7 @@ namespace QuantLib {
                                                                   instruments,
                const DayCounter& dayCounter,
                const Interpolator& i,
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(referenceDate, dayCounter,
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
@@ -122,7 +123,7 @@ namespace QuantLib {
                const std::vector<Date>& jumpDates = std::vector<Date>(),
                Real accuracy = 1.0e-12,
                const Interpolator& i = Interpolator(),
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(settlementDays, calendar, dayCounter, jumps, jumpDates, i),
           instruments_(instruments),
           accuracy_(accuracy), bootstrap_(bootstrap) {
@@ -136,7 +137,7 @@ namespace QuantLib {
                const DayCounter& dayCounter,
                Real accuracy,
                const Interpolator& i = Interpolator(),
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(settlementDays, calendar, dayCounter,
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),
@@ -150,7 +151,7 @@ namespace QuantLib {
                                                                   instruments,
                const DayCounter& dayCounter,
                const Interpolator& i,
-               const Bootstrap<this_curve>& bootstrap = Bootstrap<this_curve>())
+               const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(settlementDays, calendar, dayCounter,
                      std::vector<Handle<Quote> >(), std::vector<Date>(), i),
           instruments_(instruments),

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1115,7 +1115,7 @@ void PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap() {
     ext::shared_ptr<YieldTermStructure> yts = 
         ext::make_shared<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >(
             vars.settlement, vars.instruments, Actual360(), Linear(),
-            IterativeBootstrap<PwLinearForward>());
+            IterativeBootstrap<PwLinearForward::this_curve>());
 
     // Check anything to show that the construction succeeded
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
@@ -1124,7 +1124,7 @@ void PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap() {
     typedef PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> PwCmForward;
     yts = ext::make_shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >(
         vars.settlement, vars.instruments, Actual360(), ConvexMonotone(), 
-        LocalBootstrap<PwCmForward>());
+        LocalBootstrap<PwCmForward::this_curve>());
     
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1113,19 +1113,19 @@ void PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap() {
     // With an explicit IterativeBootstrap object
     typedef PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> PwLinearForward;
     ext::shared_ptr<YieldTermStructure> yts = 
-        ext::make_shared<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >(
+        ext::make_shared<PwLinearForward>(
             vars.settlement, vars.instruments, Actual360(), Linear(),
-            IterativeBootstrap<PwLinearForward::this_curve>());
+            PwLinearForward::bootstrap_type());
 
     // Check anything to show that the construction succeeded
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
 
     // With an explicit LocalBootstrap object
     typedef PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> PwCmForward;
-    yts = ext::make_shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >(
+    yts = ext::make_shared<PwCmForward>(
         vars.settlement, vars.instruments, Actual360(), ConvexMonotone(), 
-        LocalBootstrap<PwCmForward::this_curve>());
-    
+        PwCmForward::bootstrap_type());
+
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
 }
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1104,6 +1104,28 @@ void PiecewiseYieldCurveTest::testBadPreviousCurve() {
     }
 }
 
+void PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap() {
+
+    BOOST_TEST_MESSAGE("Testing that construction with an explicit bootstrap succeeds...");
+
+    CommonVars vars;
+
+    // With an explicit IterativeBootstrap object
+    ext::shared_ptr<YieldTermStructure> yts = 
+        ext::make_shared<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >(
+            vars.settlement, vars.instruments, Actual360(), Linear(),
+            IterativeBootstrap<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >());
+
+    // Check anything to show that the construction succeeded
+    BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
+
+    // With an explicit LocalBootstrap object
+    yts = ext::make_shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >(
+        vars.settlement, vars.instruments, Actual360(), ConvexMonotone(),
+        LocalBootstrap<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >());
+    
+    BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
+}
 
 test_suite* PiecewiseYieldCurveTest::suite() {
 
@@ -1152,6 +1174,8 @@ test_suite* PiecewiseYieldCurveTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(
                              &PiecewiseYieldCurveTest::testBadPreviousCurve));
     #endif
+
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap));
 
     return suite;
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1111,18 +1111,20 @@ void PiecewiseYieldCurveTest::testConstructionWithExplicitBootstrap() {
     CommonVars vars;
 
     // With an explicit IterativeBootstrap object
+    typedef PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> PwLinearForward;
     ext::shared_ptr<YieldTermStructure> yts = 
         ext::make_shared<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >(
             vars.settlement, vars.instruments, Actual360(), Linear(),
-            IterativeBootstrap<PiecewiseYieldCurve<ForwardRate, Linear, IterativeBootstrap> >());
+            IterativeBootstrap<PwLinearForward>());
 
     // Check anything to show that the construction succeeded
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
 
     // With an explicit LocalBootstrap object
+    typedef PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> PwCmForward;
     yts = ext::make_shared<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >(
-        vars.settlement, vars.instruments, Actual360(), ConvexMonotone(),
-        LocalBootstrap<PiecewiseYieldCurve<ForwardRate, ConvexMonotone, LocalBootstrap> >());
+        vars.settlement, vars.instruments, Actual360(), ConvexMonotone(), 
+        LocalBootstrap<PwCmForward>());
     
     BOOST_CHECK_NO_THROW(yts->discount(1.0, true));
 }

--- a/test-suite/piecewiseyieldcurve.hpp
+++ b/test-suite/piecewiseyieldcurve.hpp
@@ -54,6 +54,8 @@ class PiecewiseYieldCurveTest {
 
     static void testBadPreviousCurve();
 
+    static void testConstructionWithExplicitBootstrap();
+
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
When trying to construct a `PiecewiseYieldCurve` with an explicit `Bootstrap` instance, there is a compilation error. The additional test triggers this compilation error and the subsequent commit allows the code to compile.