### PR TITLE
par approximation for FRAs

### DIFF
--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -30,12 +30,14 @@ namespace QuantLib {
                            Rate strikeForwardRate,
                            Real notionalAmount,
                            const ext::shared_ptr<IborIndex>& index,
-                           const Handle<YieldTermStructure>& discountCurve)
+                           const Handle<YieldTermStructure>& discountCurve,
+                           const bool useIndexedCoupon)
     : Forward(index->dayCounter(), index->fixingCalendar(),
               index->businessDayConvention(),
               index->fixingDays(), ext::shared_ptr<Payoff>(),
               valueDate, maturityDate, discountCurve),
-      fraType_(type), notionalAmount_(notionalAmount), index_(index) {
+      fraType_(type), notionalAmount_(notionalAmount), index_(index),
+      useIndexedCoupon_(useIndexedCoupon) {
 
         QL_REQUIRE(notionalAmount > 0.0, "notionalAmount must be positive");
 
@@ -104,18 +106,16 @@ namespace QuantLib {
     }
 
     void ForwardRateAgreement::calculateForwardRate() const {
-#ifdef QL_USE_INDEXED_COUPON
-        forwardRate_ = InterestRate(index_->fixing(fixingDate()),
-                                    index_->dayCounter(),
-                                    Simple, Once);
-#else
-        // par coupon approximation
-        forwardRate_ = InterestRate((index_->forwardingTermStructure()->discount(valueDate_) /
-                                         index_->forwardingTermStructure()->discount(maturityDate_) -
-                                     1.0) /
-                                        index_->dayCounter().yearFraction(valueDate_, maturityDate_),
-                                    index_->dayCounter(), Simple, Once);
-#endif
+        if (useIndexedCoupon_)
+            forwardRate_ =
+                InterestRate(index_->fixing(fixingDate()), index_->dayCounter(), Simple, Once);
+        else
+            // par coupon approximation
+            forwardRate_ =
+                InterestRate((index_->forwardingTermStructure()->discount(valueDate_) /
+                                  index_->forwardingTermStructure()->discount(maturityDate_) -
+                              1.0) /
+                                 index_->dayCounter().yearFraction(valueDate_, maturityDate_),
+                             index_->dayCounter(), Simple, Once);
     }
-
 }

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -113,6 +113,9 @@ namespace QuantLib {
         InterestRate strikeForwardRate_;
         Real notionalAmount_;
         ext::shared_ptr<IborIndex> index_;
+
+      private:
+        void calculateForwardRate() const;
     };
 
 }

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -83,7 +83,8 @@ namespace QuantLib {
                              Real notionalAmount,
                              const ext::shared_ptr<IborIndex>& index,
                              const Handle<YieldTermStructure>& discountCurve =
-                                                 Handle<YieldTermStructure>());
+                                                 Handle<YieldTermStructure>(),
+                             const bool useIndexedCoupon = true);
         //! \name Calculations
         //@{
         /*! A FRA expires/settles on the valueDate */
@@ -113,6 +114,7 @@ namespace QuantLib {
         InterestRate strikeForwardRate_;
         Real notionalAmount_;
         ext::shared_ptr<IborIndex> index_;
+        const bool useIndexedCoupon_;
 
       private:
         void calculateForwardRate() const;

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -575,7 +575,7 @@ namespace QuantLib {
                                periodToStart_ + iborIndex_->tenor(),
                                iborIndex_->businessDayConvention(),
                                iborIndex_->endOfMonth());
-#ifdef QL_INDEXED_COUPON
+#ifdef QL_USE_INDEXED_COUPON
         // latest relevant date is calculated from earliestDate_ instead
         latestRelevantDate_ = iborIndex_->maturityDate(earliestDate_);
 #else

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -379,9 +379,10 @@ namespace QuantLib {
                                  bool endOfMonth,
                                  const DayCounter& dayCounter,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(monthsToStart*Months),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         QL_REQUIRE(monthsToEnd>monthsToStart,
                    "monthsToEnd (" << monthsToEnd <<
                    ") must be grater than monthsToStart (" << monthsToStart <<
@@ -406,9 +407,10 @@ namespace QuantLib {
                                  bool endOfMonth,
                                  const DayCounter& dayCounter,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(monthsToStart*Months),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         QL_REQUIRE(monthsToEnd>monthsToStart,
                    "monthsToEnd (" << monthsToEnd <<
                    ") must be grater than monthsToStart (" << monthsToStart <<
@@ -428,9 +430,10 @@ namespace QuantLib {
                                  Natural monthsToStart,
                                  const ext::shared_ptr<IborIndex>& i,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(monthsToStart*Months),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // take fixing into account
         iborIndex_ = i->clone(termStructureHandle_);
         // We want to be notified of changes of fixings, but we don't
@@ -446,9 +449,10 @@ namespace QuantLib {
                                  Natural monthsToStart,
                                  const ext::shared_ptr<IborIndex>& i,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(monthsToStart*Months),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // take fixing into account
         iborIndex_ = i->clone(termStructureHandle_);
         // see above
@@ -467,9 +471,10 @@ namespace QuantLib {
                                  bool endOfMonth,
                                  const DayCounter& dayCounter,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(periodToStart),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // no way to take fixing into account,
         // even if we would like to for FRA over today
         iborIndex_ = ext::make_shared<IborIndex>("no-fix", // correct family name would be needed
@@ -490,9 +495,10 @@ namespace QuantLib {
                                  bool endOfMonth,
                                  const DayCounter& dayCounter,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(periodToStart),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // no way to take fixing into account,
         // even if we would like to for FRA over today
         iborIndex_ = ext::make_shared<IborIndex>("no-fix", // correct family name would be needed
@@ -508,9 +514,10 @@ namespace QuantLib {
                                  Period periodToStart,
                                  const ext::shared_ptr<IborIndex>& i,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(periodToStart),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // take fixing into account
         iborIndex_ = i->clone(termStructureHandle_);
         // see above
@@ -524,9 +531,10 @@ namespace QuantLib {
                                  Period periodToStart,
                                  const ext::shared_ptr<IborIndex>& i,
                                  Pillar::Choice pillarChoice,
-                                 Date customPillarDate)
+                                 Date customPillarDate,
+                                 const bool useIndexedCoupon)
     : RelativeDateRateHelper(rate), periodToStart_(periodToStart),
-      pillarChoice_(pillarChoice) {
+      pillarChoice_(pillarChoice), useIndexedCoupon_(useIndexedCoupon) {
         // take fixing into account
         iborIndex_ = i->clone(termStructureHandle_);
         // see above
@@ -538,12 +546,13 @@ namespace QuantLib {
 
     Real FraRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
-#ifdef QL_USE_INDEXED_COUPON
-        return iborIndex_->fixing(fixingDate_, true);
-#else
-        return (termStructure_->discount(earliestDate_) / termStructure_->discount(maturityDate_) - 1.0) /
-               spanningTime_;
-#endif
+        if (useIndexedCoupon_)
+            return iborIndex_->fixing(fixingDate_, true);
+        else
+            return (termStructure_->discount(earliestDate_) /
+                        termStructure_->discount(maturityDate_) -
+                    1.0) /
+                   spanningTime_;
     }
 
     void FraRateHelper::setTermStructure(YieldTermStructure* t) {
@@ -575,13 +584,13 @@ namespace QuantLib {
                                periodToStart_ + iborIndex_->tenor(),
                                iborIndex_->businessDayConvention(),
                                iborIndex_->endOfMonth());
-#ifdef QL_USE_INDEXED_COUPON
-        // latest relevant date is calculated from earliestDate_ instead
-        latestRelevantDate_ = iborIndex_->maturityDate(earliestDate_);
-#else
-        latestRelevantDate_ = maturityDate_;
-        spanningTime_ = iborIndex_->dayCounter().yearFraction(earliestDate_, maturityDate_);
-#endif
+        if(useIndexedCoupon_)
+            // latest relevant date is calculated from earliestDate_ instead
+            latestRelevantDate_ = iborIndex_->maturityDate(earliestDate_);
+        else {
+            latestRelevantDate_ = maturityDate_;
+            spanningTime_ = iborIndex_->dayCounter().yearFraction(earliestDate_, maturityDate_);
+        }
 
         switch (pillarChoice_) {
           case Pillar::MaturityDate:

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -225,6 +225,9 @@ namespace QuantLib {
         Pillar::Choice pillarChoice_;
         ext::shared_ptr<IborIndex> iborIndex_;
         RelinkableHandle<YieldTermStructure> termStructureHandle_;
+#ifndef QL_USE_INDEXED_COUPON
+		Real spanningTime_;
+#endif
     };
 
 

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -158,7 +158,8 @@ namespace QuantLib {
                       bool endOfMonth,
                       const DayCounter& dayCounter,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(Rate rate,
                       Natural monthsToStart,
                       Natural monthsToEnd,
@@ -168,17 +169,20 @@ namespace QuantLib {
                       bool endOfMonth,
                       const DayCounter& dayCounter,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(const Handle<Quote>& rate,
                       Natural monthsToStart,
                       const ext::shared_ptr<IborIndex>& iborIndex,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(Rate rate,
                       Natural monthsToStart,
                       const ext::shared_ptr<IborIndex>& iborIndex,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(const Handle<Quote>& rate,
                       Period periodToStart,
                       Natural lengthInMonths,
@@ -188,7 +192,8 @@ namespace QuantLib {
                       bool endOfMonth,
                       const DayCounter& dayCounter,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(Rate rate,
                       Period periodToStart,
                       Natural lengthInMonths,
@@ -198,17 +203,20 @@ namespace QuantLib {
                       bool endOfMonth,
                       const DayCounter& dayCounter,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(const Handle<Quote>& rate,
                       Period periodToStart,
                       const ext::shared_ptr<IborIndex>& iborIndex,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         FraRateHelper(Rate rate,
                       Period periodToStart,
                       const ext::shared_ptr<IborIndex>& iborIndex,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date());
+                      Date customPillarDate = Date(),
+                      const bool useIndexedCoupon = true);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const;
@@ -225,9 +233,8 @@ namespace QuantLib {
         Pillar::Choice pillarChoice_;
         ext::shared_ptr<IborIndex> iborIndex_;
         RelinkableHandle<YieldTermStructure> termStructureHandle_;
-#ifndef QL_USE_INDEXED_COUPON
+        const bool useIndexedCoupon_;
         Real spanningTime_;
-#endif
     };
 
 

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -226,7 +226,7 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> iborIndex_;
         RelinkableHandle<YieldTermStructure> termStructureHandle_;
 #ifndef QL_USE_INDEXED_COUPON
-		Real spanningTime_;
+        Real spanningTime_;
 #endif
     };
 

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -33,11 +33,14 @@ using namespace boost::unit_test_framework;
 void ForwardRateAgreementTest::testConstructionWithoutACurve() {
         BOOST_TEST_MESSAGE("Testing forward rate agreement construction...");
 
-        Date spotDate = QuantLib::Settings::instance().evaluationDate();
+        Date today = QuantLib::Settings::instance().evaluationDate();
 
         // set up the index
         RelinkableHandle<YieldTermStructure> curveHandle;
         ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(Period(3, Months), curveHandle);
+
+        // determine the settlement date for a FRA
+        Date settlementDate = index->fixingCalendar().advance(today, index->fixingDays() * Days);
 
         // set up quotes with no values
         std::vector<ext::shared_ptr<SimpleQuote> > quotes;
@@ -51,15 +54,15 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
         helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]), Period(2, Years), index));
         helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]), Period(3, Years), index));
 
-        ext::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve = ext::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(spotDate,
+        ext::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve = ext::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(today,
                                                                                                                                                              helpers,
                                                                                                                                                              index->dayCounter());
 
         curveHandle.linkTo(curve);
 
         // set up the instrument to price
-        ForwardRateAgreement fra(spotDate + Period(6, Months),
-                                 spotDate + Period(18, Months),
+        ForwardRateAgreement fra(settlementDate + Period(12, Months),
+                                 settlementDate + Period(15, Months),
                                  Position::Long,
                                  0,
                                  1,

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -50,13 +50,36 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
 
         // set up the curve (this bit is a very rough sketch - i'm actually using swaps !)
         std::vector<ext::shared_ptr<RateHelper> > helpers;
-        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[0]), Period(1, Years), index));
-        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]), Period(2, Years), index));
-        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]), Period(3, Years), index));
-
-        ext::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve = ext::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(today,
-                                                                                                                                                             helpers,
-                                                                                                                                                             index->dayCounter());
+        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[0]),
+                                                          Period(1, Years), index,
+                                                          Pillar::LastRelevantDate, Date(),
+#ifdef QL_USE_INDEXED_COUPON
+                                                          false
+#else
+                                                          true
+#endif
+));
+        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[1]),
+                                                          Period(2, Years), index,
+                                                          Pillar::LastRelevantDate, Date(),
+#ifdef QL_USE_INDEXED_COUPON
+                                                          false
+#else
+                                                          true
+#endif
+));
+        helpers.push_back(ext::make_shared<FraRateHelper>(Handle<Quote>(quotes[2]),
+                                                          Period(3, Years), index,
+                                                          Pillar::LastRelevantDate, Date(),
+#ifdef QL_USE_INDEXED_COUPON
+                                                          false
+#else
+                                                          true
+#endif
+));
+        ext::shared_ptr<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> > curve =
+            ext::make_shared<PiecewiseYieldCurve<ForwardRate, QuantLib::Cubic> >(
+                today, helpers, index->dayCounter());
 
         curveHandle.linkTo(curve);
 
@@ -67,7 +90,13 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
                                  0,
                                  1,
                                  index,
-                                 curveHandle);
+                                 curveHandle,
+#ifdef QL_USE_INDEXED_COUPON
+                                 false
+#else
+                                 true
+#endif
+);
 
         // finally put values in the quotes
         quotes[0]->setValue(0.01);

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -72,8 +72,8 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
         quotes[2]->setValue(0.03);
 
         double rate = fra.forwardRate();
-        if (std::fabs(rate - 0.0100006) > 1e-6) {
-                BOOST_ERROR("grid creation failed");
+        if (std::fabs(rate - 0.01) > 1e-6) {
+            BOOST_ERROR("grid creation failed, got rate " << rate << " expected " << 0.01);
         }
 }
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -429,7 +429,8 @@ namespace {
                                       fraData[i].units,
                                       euribor3m->businessDayConvention(),
                                       euribor3m->endOfMonth());
-            Date end = vars.calendar.advance(start, 3, Months,
+            BOOST_REQUIRE(fraData[i].units == Months);
+            Date end = vars.calendar.advance(vars.settlement, 3 + fraData[i].n, Months,
                                              euribor3m->businessDayConvention(),
                                              euribor3m->endOfMonth());
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -268,7 +268,15 @@ namespace {
                                   euribor3m->fixingCalendar(),
                                   euribor3m->businessDayConvention(),
                                   euribor3m->endOfMonth(),
-                                  euribor3m->dayCounter()));
+                                  euribor3m->dayCounter(),
+                                  Pillar::LastRelevantDate,
+                                  Date(),
+#ifdef QL_USE_INDEXED_COUPON
+                                  false
+#else
+                                  true
+#endif
+));
             }
             Date immDate = Date();
             for (Size i = 0; i<immFuts; i++) {


### PR DESCRIPTION
This change implements a "par coupon approximation" for FRAs in analogy to swaps or more precisely to the forward rate estimation in `IborCoupon`.

I appreciate that this is a breaking change. Still, there might be reasons to consider doing the change:

- when trying to match zero rates from rate curve stripped in Blooomberg it turns out that this requires the usage of the par coupon approximation for both swaps and FRAs
- a more academic argument is that the current implementation is inconsistent to a certain degree since the forward rate for FRAs is estimated differently from what is done for the floating periods of swaps

As a side note, the FRAs defined in the piecewise yield curve test seem not to match what is usually traded, this is also fixed in the PR (which is actually necessary to make the test suite pass after the change described above).