### PR TITLE
Deprecate remaining old-style FD dividend options

### DIFF
--- a/ql/methods/finitedifferences/finitedifferencemodel.hpp
+++ b/ql/methods/finitedifferences/finitedifferencemodel.hpp
@@ -103,7 +103,11 @@ namespace QuantLib {
                     condition->applyTo(a,from);
             }
             for (Size i=0; i<steps; ++i, t -= dt) {
-                Time now = t, next = t-dt;
+                Time now = t;
+                // make sure last step ends exactly on "to" in order to not
+                // miss a stopping time at "to" due to numerical issues
+                Time next = (i < steps -1)? t-dt : to;
+
                 if (std::fabs(to-next) < std::sqrt(QL_EPSILON)) next = to;
                 bool hit = false;
                 for (Integer j = static_cast<Integer>(stoppingTimes_.size())-1; j >= 0 ; --j) {

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
             : process->dividendYield();
 
         Time lastDivTime = 0.0;
-        Real fwd = S - spotAdjustment;
+        Real fwd = S + spotAdjustment;
         Real mi = fwd, ma = fwd;
 
         for (Size i=0; i < intermediateSteps.size(); ++i) {

--- a/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
@@ -79,8 +79,8 @@ namespace QuantLib {
     }
 
     Real Fdm1DimSolver::thetaAt(Real x) const {
-        QL_REQUIRE(conditions_->stoppingTimes().front() > 0.0,
-                   "stopping time at zero-> can't calculate theta");
+        if (conditions_->stoppingTimes().front() == 0.0)
+            return Null<Real>();
 
         calculate();
         Array thetaValues(resultValues_.size());

--- a/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
@@ -89,8 +89,8 @@ namespace QuantLib {
     }
 
     Real Fdm2DimSolver::thetaAt(Real x, Real y) const {
-        QL_REQUIRE(conditions_->stoppingTimes().front() > 0.0,
-                   "stopping time at zero-> can't calculate theta");
+        if (conditions_->stoppingTimes().front() == 0.0)
+            return Null<Real>();
 
         calculate();
         Matrix thetaValues(resultValues_.rows(), resultValues_.columns());

--- a/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
@@ -107,8 +107,9 @@ namespace QuantLib {
     }
 
     Real Fdm3DimSolver::thetaAt(Real x, Real y, Rate z) const {
-        QL_REQUIRE(conditions_->stoppingTimes().front() > 0.0,
-                   "stopping time at zero-> can't calculate theta");
+        if (conditions_->stoppingTimes().front() == 0.0)
+            return Null<Real>();
+
         calculate();
 
         const Array& rhs = thetaCondition_->getValues();

--- a/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
+++ b/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
@@ -145,8 +145,9 @@ namespace QuantLib {
 
     template <Size N> inline
     Real FdmNdimSolver<N>::thetaAt(const std::vector<Real>& x) const {
-        QL_REQUIRE(conditions_->stoppingTimes().front() > 0.0,
-                   "stopping time at zero-> can't calculate theta");
+        if (conditions_->stoppingTimes().front() == 0.0)
+            return Null<Real>();
+
         calculate();
         const Array& rhs = thetaCondition_->getValues();
         const ext::shared_ptr<FdmLinearOpLayout> layout

--- a/ql/pricingengines/vanilla/fdblackscholesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdblackscholesvanillaengine.cpp
@@ -82,8 +82,8 @@ namespace QuantLib {
             dividendSchedule = arguments_.cashFlow;
             break;
           case Escrowed:
-            for (DividendSchedule::const_iterator divIter
-                     = arguments_.cashFlow.begin();
+            for (DividendSchedule::const_iterator
+                    divIter = arguments_.cashFlow.begin();
                  divIter != arguments_.cashFlow.end(); ++divIter) {
 
                 const Date divDate = (*divIter)->date();

--- a/ql/pricingengines/vanilla/fddividendamericanengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendamericanengine.hpp
@@ -32,18 +32,8 @@
 namespace QuantLib {
 
     //! Finite-differences pricing engine for dividend American options
-    /*! \deprecated Use FDDividendAmericanEngineMerton73 instead if you
-                    want to use the Merton 73 escowed dividend model;
-                    use FdBlackScholesVanillaEngine otherwise.
+    /*! \deprecated Use FdBlackScholesVanillaEngine instead.
                     Deprecated in version 1.17.
-
-        \ingroup vanillaengines
-
-        \test
-        - the correctness of the returned greeks is tested by
-          reproducing numerical derivatives.
-        - the invariance of the results upon addition of null
-          dividends is tested.
     */
     template <template <class> class Scheme = CrankNicolson>
     class QL_DEPRECATED FDDividendAmericanEngine
@@ -61,9 +51,11 @@ namespace QuantLib {
 
 
     //! Finite-differences pricing engine for dividend American options
-    /*! This engine uses the Merton 73 escowed dividend model. */
+    /*! \deprecated Use FdBlackScholesVanillaEngine instead.
+                    Deprecated in version 1.17.
+    */
     template <template <class> class Scheme = CrankNicolson>
-    class FDDividendAmericanEngineMerton73
+    class QL_DEPRECATED FDDividendAmericanEngineMerton73
         : public FDEngineAdapter<FDAmericanCondition<
                                      FDDividendEngineMerton73<Scheme> >,
                                  DividendVanillaOption::engine> {

--- a/ql/pricingengines/vanilla/fddividendeuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendeuropeanengine.hpp
@@ -30,18 +30,8 @@
 namespace QuantLib {
 
     //! Finite-differences pricing engine for dividend European options
-    /*! \deprecated Use FDDividendEuropeanEngineMerton73 instead if you
-                    want to use the Merton 73 escowed dividend model;
-                    use FdBlackScholesVanillaEngine otherwise.
+    /*! \deprecated Use FdBlackScholesVanillaEngine instead.
                     Deprecated in version 1.17.
-
-        \ingroup vanillaengines
-
-        \test
-        - the correctness of the returned greeks is tested by
-          reproducing numerical derivatives.
-        - the invariance of the results upon addition of null
-          dividends is tested.
     */
     template <template <class> class Scheme = CrankNicolson>
     class QL_DEPRECATED FDDividendEuropeanEngine
@@ -59,9 +49,11 @@ namespace QuantLib {
 
 
     //! Finite-differences pricing engine for dividend European options
-    /*! This engine uses the Merton 73 escowed dividend model. */
+    /*! \deprecated Use FdBlackScholesVanillaEngine instead.
+                    Deprecated in version 1.17.
+    */
     template <template <class> class Scheme = CrankNicolson>
-    class FDDividendEuropeanEngineMerton73
+    class QL_DEPRECATED FDDividendEuropeanEngineMerton73
         : public FDEngineAdapter<FDDividendEngineMerton73<Scheme>,
                                  DividendVanillaOption::engine> {
         typedef FDEngineAdapter<FDDividendEngineMerton73<Scheme>,

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -743,7 +743,6 @@ namespace {
                         Real value = option.NPV();
                         calculated["delta"]  = option.delta();
                         calculated["gamma"]  = option.gamma();
-                        // calculated["theta"]  = option.theta();
 
                         if (value > spot->value()*1.0e-5) {
                           // perturb spot and get delta and gamma
@@ -965,10 +964,10 @@ namespace {
         option.setPricingEngine(engine);
         Real calculated = option.NPV();
 
+        ext::shared_ptr<Exercise> europeanExercise =
+            ext::make_shared<EuropeanExercise>(exercise->lastDate());
         DividendVanillaOption europeanOption(
-            payoff, 
-            ext::make_shared<EuropeanExercise>(exercise->lastDate()), 
-            dividendDates, dividends);
+            payoff, europeanExercise, dividendDates, dividends);
 
         europeanOption.setPricingEngine(
             ext::make_shared<AnalyticDividendEuropeanEngine>(process));

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -964,6 +964,17 @@ namespace {
         option.setPricingEngine(engine);
         Real calculated = option.NPV();
 
+        switch(model) {
+          case FdBlackScholesVanillaEngine::Spot:
+            BOOST_CHECK_THROW(option.theta(), QuantLib::Error);
+            break;
+          case FdBlackScholesVanillaEngine::Escrowed:
+            BOOST_CHECK_NO_THROW(option.theta());
+            break;
+          default:
+            QL_FAIL("unknown dividend model type");
+        }
+
         ext::shared_ptr<Exercise> europeanExercise =
             ext::make_shared<EuropeanExercise>(exercise->lastDate());
         DividendVanillaOption europeanOption(

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -622,10 +622,11 @@ void DividendOptionTest::testFdEuropeanValues() {
                             new BlackScholesMertonProcess(Handle<Quote>(spot),
                                                           qTS, rTS, volTS));
 
-          ext::shared_ptr<PricingEngine> engine(
-              new FDDividendEuropeanEngineMerton73<CrankNicolson>(stochProcess,
-                                                                  timeSteps,
-                                                                  gridPoints));
+          ext::shared_ptr<PricingEngine> engine =
+              MakeFdBlackScholesVanillaEngine(stochProcess)
+              .withTGrid(timeSteps)
+              .withXGrid(gridPoints)
+              .withCashDividendModel(FdBlackScholesVanillaEngine::Escrowed);
 
           ext::shared_ptr<PricingEngine> ref_engine(
                             new AnalyticDividendEuropeanEngine(stochProcess));
@@ -674,9 +675,9 @@ void DividendOptionTest::testFdEuropeanValues() {
 
 namespace {
 
-    template <class Engine>
     void testFdGreeks(const Date& today,
-                      const ext::shared_ptr<Exercise>& exercise) {
+                      const ext::shared_ptr<Exercise>& exercise,
+                      FdBlackScholesVanillaEngine::CashDividendModel model) {
 
         std::map<std::string,Real> calculated, expected, tolerance;
         tolerance["delta"] = 5.0e-3;
@@ -719,8 +720,10 @@ namespace {
                             new BlackScholesMertonProcess(Handle<Quote>(spot),
                                                           qTS, rTS, volTS));
 
-                ext::shared_ptr<PricingEngine> engine(
-                                                    new Engine(stochProcess));
+                ext::shared_ptr<PricingEngine> engine =
+                    MakeFdBlackScholesVanillaEngine(stochProcess)
+                    .withCashDividendModel(model);
+                
                 DividendVanillaOption option(payoff, exercise,
                                              dividendDates, dividends);
                 option.setPricingEngine(engine);
@@ -809,8 +812,8 @@ void DividendOptionTest::testFdEuropeanGreeks() {
     for (Size i=0; i<LENGTH(lengths); i++) {
         Date exDate = today + lengths[i]*Years;
         ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-        testFdGreeks<FDDividendEuropeanEngineMerton73<CrankNicolson> >(today,exercise);
-        testFdGreeks<FdBlackScholesVanillaEngine>(today,exercise);
+        testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Spot);
+        testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
     }
 }
 
@@ -826,19 +829,18 @@ void DividendOptionTest::testFdAmericanGreeks() {
 
     for (Size i=0; i<LENGTH(lengths); i++) {
         Date exDate = today + lengths[i]*Years;
-        ext::shared_ptr<Exercise> exercise(
-                                          new AmericanExercise(today,exDate));
-        testFdGreeks<FDDividendAmericanEngineMerton73<CrankNicolson> >(today,exercise);
-        testFdGreeks<FdBlackScholesVanillaEngine>(today,exercise);
+        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
+        testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Spot);
+        testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
     }
 }
 
 
 namespace {
 
-    template <class Engine>
     void testFdDegenerate(const Date& today,
-                          const ext::shared_ptr<Exercise>& exercise) {
+                          const ext::shared_ptr<Exercise>& exercise,
+                          FdBlackScholesVanillaEngine::CashDividendModel model) {
 
         DayCounter dc = Actual360();
         ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(54.625));
@@ -853,8 +855,11 @@ namespace {
         Size timeSteps = 300;
         Size gridPoints = 300;
 
-        ext::shared_ptr<PricingEngine> engine(
-                                    new Engine(process,timeSteps,gridPoints));
+        ext::shared_ptr<PricingEngine> engine =
+              MakeFdBlackScholesVanillaEngine(process)
+              .withTGrid(timeSteps)
+              .withXGrid(gridPoints)
+              .withCashDividendModel(model);
 
         ext::shared_ptr<StrikedTypePayoff> payoff(
                                   new PlainVanillaPayoff(Option::Call, 55.0));
@@ -868,10 +873,9 @@ namespace {
                                       dividendDates, dividends);
         option1.setPricingEngine(engine);
 
-        // FLOATING_POINT_EXCEPTION
         Real refValue = option1.NPV();
 
-        for (Size i=0; i<=6; i++) {
+        for (Size i=1; i<=6; i++) {
 
             dividends.push_back(0.0);
             dividendDates.push_back(today+i);
@@ -905,7 +909,8 @@ void DividendOptionTest::testFdEuropeanDegenerate() {
 
     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
 
-    testFdDegenerate<FDDividendEuropeanEngineMerton73<CrankNicolson> >(today,exercise);
+    testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Spot);
+    testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
 }
 
 void DividendOptionTest::testFdAmericanDegenerate() {
@@ -921,7 +926,83 @@ void DividendOptionTest::testFdAmericanDegenerate() {
 
     ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
 
-    testFdDegenerate<FDDividendAmericanEngineMerton73<CrankNicolson> >(today,exercise);
+    testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Spot);
+    testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
+}
+
+
+namespace {
+
+    void testFdDividendAtTZero(const Date& today,
+                               const ext::shared_ptr<Exercise>& exercise,
+                               FdBlackScholesVanillaEngine::CashDividendModel model) {
+
+        DayCounter dc = Actual360();
+        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(54.625));
+        Handle<YieldTermStructure> rTS(flatRate(0.052706, dc));
+        Handle<YieldTermStructure> qTS(flatRate(0.0, dc));
+        Handle<BlackVolTermStructure> volTS(flatVol(0.282922, dc));
+
+        ext::shared_ptr<BlackScholesMertonProcess> process(
+                            new BlackScholesMertonProcess(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS));
+
+        Size timeSteps = 300;
+        Size gridPoints = 300;
+
+        ext::shared_ptr<PricingEngine> engine =
+              MakeFdBlackScholesVanillaEngine(process)
+              .withTGrid(timeSteps)
+              .withXGrid(gridPoints)
+              .withCashDividendModel(model);
+
+        ext::shared_ptr<StrikedTypePayoff> payoff(
+                                  new PlainVanillaPayoff(Option::Call, 55.0));
+
+        std::vector<Rate> dividends(1, 0.5);
+        std::vector<Date> dividendDates(1, today);
+
+        DividendVanillaOption option(payoff, exercise,
+                                     dividendDates, dividends);
+        option.setPricingEngine(engine);
+        option.NPV();
+    }
+
+}
+
+
+void DividendOptionTest::testFdEuropeanWithDividendToday() {
+
+    BOOST_TEST_MESSAGE(
+         "Testing finite-differences dividend European option with dividend on today's date...");
+
+    SavedSettings backup;
+
+    Date today = Date(27,February,2005);
+    Settings::instance().evaluationDate() = today;
+    Date exDate(13,April,2005);
+
+    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+
+    testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Spot);
+    testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
+}
+
+void DividendOptionTest::testFdAmericanWithDividendToday() {
+
+    BOOST_TEST_MESSAGE(
+         "Testing finite-differences dividend American option with dividend on today's date...");
+
+    SavedSettings backup;
+
+    Date today = Date(27,February,2005);
+    Settings::instance().evaluationDate() = today;
+    Date exDate(13,April,2005);
+
+    ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
+
+    testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Spot);
+    testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
 }
 
 
@@ -1001,23 +1082,6 @@ void DividendOptionTest::testEscrowedDividendModel() {
                    << "\n    difference: " << std::fabs(pdeNPV - analyticNPV)
                    << "\n    tolerance:  " << tol);
     }
-
-    option.setPricingEngine(
-        ext::make_shared<FDDividendEuropeanEngineMerton73<> >(
-            process, 50, 200));
-
-    const Real deprecatedPDENPV = option.NPV();
-
-    if (std::fabs(deprecatedPDENPV - analyticNPV) > tol) {
-        BOOST_FAIL("Failed to reproduce European option values "
-                "with the escrowed dividend model and the "
-                "FDDividendEuropeanEngineMerton73 engine"
-                   << "\n    calculated: " << pdeNPV
-                   << "\n    expected:   " << analyticNPV
-                   << "\n    difference: "
-                   << std::fabs(deprecatedPDENPV - analyticNPV)
-                   << "\n    tolerance:  " << tol);
-    }
 }
 
 test_suite* DividendOptionTest::suite() {
@@ -1029,18 +1093,17 @@ test_suite* DividendOptionTest::suite() {
     // Doesn't quite work.  Need to use discounted values
     //suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testEuropeanEndLimit));
     suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testEuropeanGreeks));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testFdEuropeanValues));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testFdEuropeanGreeks));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testFdAmericanGreeks));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(
                               &DividendOptionTest::testFdEuropeanDegenerate));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(
                               &DividendOptionTest::testFdAmericanDegenerate));
+    suite->add(QUANTLIB_TEST_CASE(
+                              &DividendOptionTest::testFdEuropeanWithDividendToday));
+    suite->add(QUANTLIB_TEST_CASE(
+                              &DividendOptionTest::testFdAmericanWithDividendToday));
     suite->add(QUANTLIB_TEST_CASE(
                  &DividendOptionTest::testEscrowedDividendModel));
 

--- a/test-suite/dividendoption.hpp
+++ b/test-suite/dividendoption.hpp
@@ -37,6 +37,8 @@ class DividendOptionTest {
     static void testFdAmericanGreeks();
     static void testFdEuropeanDegenerate();
     static void testFdAmericanDegenerate();
+    static void testFdEuropeanWithDividendToday();
+    static void testFdAmericanWithDividendToday();
     static void testEscrowedDividendModel();
 
     static boost::unit_test_framework::test_suite* suite();


### PR DESCRIPTION
contains Luigi's PR #714. 
behaviour for dividend payments a t=0 is in sync with AnalyticDividendEuropeanEngine.
theta calculation for spot dividend model with a dividend payment at t=0 is disabled.