### PR TITLE
Let a fitted bond curve work correctly as an evaluator.

### DIFF
--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -200,16 +200,24 @@ namespace QuantLib {
             x = curve_->guessSolution_;
         }
 
-        if(curve_->maxEvaluations_ == 0)
+        if (curve_->maxEvaluations_ == 0)
         {
-            //Don't calculate, simply use given parameters to provide a fitted curve.
-            //This turns the fittedbonddiscountcurve into an evaluator of the parametric
-            //curve, for example allowing to use the parameters for a credit spread curve
-            //calculated with bonds in one currency to be coupled to a discount curve in 
-            //another currency. 
+            // Don't calculate, simply use the given parameters to provide a fitted curve.
+            // This turns the fittedbonddiscountcurve into an evaluator of the parametric
+            // curve, for example allowing to use the parameters for a credit spread curve
+            // calculated with bonds in one currency to be coupled to a discount curve in
+            // another currency.
+
+            QL_REQUIRE(!curve_->guessSolution_.empty(), "no guess provided");
+
+            solution_ = curve_->guessSolution_;
+
+            numberOfIterations_ = 0;
+            costValue_ = costFunction.value(solution_);
+
             return;
         }
-        
+
         //workaround for backwards compatibility
         ext::shared_ptr<OptimizationMethod> optimization = optimizationMethod_;
         if(!optimization){

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -58,6 +58,7 @@ QL_TESTS = \
 	fdmlinearop.hpp fdmlinearop.cpp \
 	fdcev.hpp fdcev.cpp \
 	fdsabr.hpp fdsabr.cpp \
+	fittedbonddiscountcurve.hpp fittedbonddiscountcurve.cpp \
 	forwardoption.hpp forwardoption.cpp \
 	forwardrateagreement.hpp forwardrateagreement.cpp \
 	functions.hpp functions.cpp \

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -1,0 +1,67 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2019 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "fittedbonddiscountcurve.hpp"
+#include "utilities.hpp"
+#include <ql/termstructures/yield/fittedbonddiscountcurve.hpp>
+#include <ql/termstructures/yield/nonlinearfittingmethods.hpp>
+#include <ql/instruments/bonds/zerocouponbond.hpp>
+#include <ql/time/calendars/target.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+void FittedBondDiscountCurveTest::testEvaluation() {
+
+    BOOST_TEST_MESSAGE("Testing that fitted bond curves work as evaluators...");
+
+    Date today = Settings::instance().evaluationDate();
+    ext::shared_ptr<Bond> bond = ext::make_shared<ZeroCouponBond>(3, TARGET(), 100.0,
+                                                                  today + Period(10, Years));
+    Handle<Quote> q(ext::make_shared<SimpleQuote>(100.0));
+
+    std::vector<ext::shared_ptr<BondHelper> > helpers(1);
+    helpers[0] = ext::make_shared<BondHelper>(q, bond);
+
+    ExponentialSplinesFitting fittingMethod;
+
+    Size maxIterations = 0;
+    Array guess(9);
+    guess[0] = -51293.44;
+    guess[1] = -212240.36;
+    guess[2] = 168668.51;
+    guess[3] = 88792.74;
+    guess[4] = 120712.13;
+    guess[5] = -34332.83;
+    guess[6] = -66479.66;
+    guess[7] = 13605.17;
+    guess[8] = 0.0;
+
+    FittedBondDiscountCurve curve(0, TARGET(), helpers, Actual365Fixed(),
+                                  fittingMethod, 1e-10, maxIterations, guess);
+
+    BOOST_CHECK_NO_THROW(curve.discount(3.0));
+}
+
+
+test_suite* FittedBondDiscountCurveTest::suite() {
+    test_suite* suite = BOOST_TEST_SUITE("Fitted bond discount curve tests");
+    suite->add(QUANTLIB_TEST_CASE(&FittedBondDiscountCurveTest::testEvaluation));
+    return suite;
+}

--- a/test-suite/fittedbonddiscountcurve.hpp
+++ b/test-suite/fittedbonddiscountcurve.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2019 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_fitted_bond_discount_curve_hpp
+#define quantlib_test_fitted_bond_discount_curve_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class FittedBondDiscountCurveTest {
+  public:
+    static void testEvaluation();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -118,6 +118,7 @@
 #include "fdmlinearop.hpp"
 #include "fdcev.hpp"
 #include "fdsabr.hpp"
+#include "fittedbonddiscountcurve.hpp"
 #include "forwardoption.hpp"
 #include "forwardrateagreement.hpp"
 #include "functions.hpp"
@@ -403,6 +404,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(FdmLinearOpTest::suite());
     test->add(FdCevTest::suite(speed));
     test->add(FdSabrTest::suite(speed));
+    test->add(FittedBondDiscountCurveTest::suite());
     test->add(ForwardOptionTest::suite());
     test->add(ForwardRateAgreementTest::suite());
     test->add(FunctionsTest::suite());

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -681,6 +681,7 @@
     <ClCompile Include="extensibleoptions.cpp" />
     <ClCompile Include="fdcev.cpp" />
     <ClCompile Include="fdsabr.cpp" />
+    <ClCompile Include="fittedbonddiscountcurve.cpp" />
     <ClCompile Include="functions.cpp" />
     <ClCompile Include="fastfouriertransform.cpp" />
     <ClCompile Include="fdheston.cpp" />
@@ -834,6 +835,7 @@
     <ClInclude Include="extensibleoptions.hpp" />
     <ClInclude Include="fdcev.hpp" />
     <ClInclude Include="fdsabr.hpp" />
+    <ClInclude Include="fittedbonddiscountcurve.hpp" />
     <ClInclude Include="functions.hpp" />
     <ClInclude Include="fastfouriertransform.hpp" />
     <ClInclude Include="fdheston.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -462,6 +462,9 @@
     <ClCompile Include="fdsabr.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="fittedbonddiscountcurve.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="americanoption.hpp">
@@ -921,6 +924,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="fdsabr.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fittedbonddiscountcurve.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Fixes #718.