### PR TITLE
Copy shared_ptr to preserve derived class information

### DIFF
--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
     BondHelper::BondHelper(const Handle<Quote>& price,
                            const ext::shared_ptr<Bond>& bond,
                            const bool useCleanPrice)
-    : RateHelper(price), bond_(ext::make_shared<Bond>(*bond)) {
+    : RateHelper(price), bond_(bond) {
 
         // the bond's last cashflow date, which can be later than
         // bond's maturity date because of adjustment


### PR DESCRIPTION
This is to fix #333 . I looked in to history of file. Can't see reason to use make_shared . And don't see any downside of copying passed shared_ptr . Which will solve this problem.