### PR TITLE
comparisons in Handle should be const

### DIFF
--- a/ql/handle.hpp
+++ b/ql/handle.hpp
@@ -86,13 +86,13 @@ namespace QuantLib {
         operator ext::shared_ptr<Observable>() const;
         //! equality test
         template <class U>
-        bool operator==(const Handle<U>& other) { return link_==other.link_; }
+        bool operator==(const Handle<U>& other) const { return link_==other.link_; }
         //! disequality test
         template <class U>
-        bool operator!=(const Handle<U>& other) { return link_!=other.link_; }
+        bool operator!=(const Handle<U>& other) const { return link_!=other.link_; }
         //! strict weak ordering
         template <class U>
-        bool operator<(const Handle<U>& other) { return link_ < other.link_; }
+        bool operator<(const Handle<U>& other) const { return link_ < other.link_; }
     };
 
     //! Relinkable handle to an observable


### PR DESCRIPTION
e.g. the following code does not compile without this fix

```
#include <ql/handle.hpp>
std::map<int, QuantLib::Handle<int>> m,n;
bool test = m == n;
```