### PR TITLE
Fix typos

### DIFF
--- a/Docs/pages/fixedincome.docs
+++ b/Docs/pages/fixedincome.docs
@@ -112,7 +112,7 @@
     return a trinomial tree. For yield-curve consistent models, the fitting
     parameter can be determined either analytically (when possible) or 
     numerically. When a tree is built, it is then pretty straightforward to 
-    implement a pricer for any path-independant derivative. Just implement
+    implement a pricer for any path-independent derivative. Just implement
     a class derived from NumericalDerivative (see 
     QuantLib::NumericalSwaption for example) and roll it back until 
     the present time...

--- a/Examples/CVAIRS/CVAIRS.cpp
+++ b/Examples/CVAIRS/CVAIRS.cpp
@@ -203,7 +203,7 @@ int main(int, char* []) {
             .withType(swapType));
 
         cout << "-- Correction in the contract fix rate in bp --" << endl;
-        /* The paper plots correction to be substracted, here is printed
+        /* The paper plots correction to be subtracted, here is printed
            with its sign 
         */
         for(Size i=0; i<riskySwaps.size(); i++) {

--- a/ql/experimental/credit/basecorrelationlossmodel.hpp
+++ b/ql/experimental/credit/basecorrelationlossmodel.hpp
@@ -65,7 +65,7 @@ namespace QuantLib {
     Users should select their models according to this; choosing the copula or
     a random loss given default base model (or more exotic ones). \par
     Notice this is different to a bespoke base correlation loss (bespoke here 
-    refering to basket composition, not just attachment levels) ; where 
+    referring to basket composition, not just attachment levels) ; where 
     loss interpolation is on the expected loss value to match the two baskets. 
     Therefore the correlation surface should refer to the same basket intended
     to be priced. But this is left to the user and is not implemented in the 

--- a/ql/experimental/credit/basket.cpp
+++ b/ql/experimental/credit/basket.cpp
@@ -66,7 +66,7 @@ namespace QuantLib {
         // At this point Issuers in the pool might or might not have
         //   probability term structures for the defultKeys(eventType+
         //   currency+seniority) entering in this basket. This is not
-        //   neccessarily a problem.
+        //   necessarily a problem.
         for (Size i = 0; i < notionals_.size(); i++) {
             basketNotional_ += notionals_[i];
             attachmentAmount_ += notionals_[i] * attachmentRatio_;

--- a/ql/experimental/credit/basket.hpp
+++ b/ql/experimental/credit/basket.hpp
@@ -297,7 +297,7 @@ namespace QuantLib {
         mutable Real trancheNotional_;
         /* Caches. Most of the times one wants statistics on the distribution of
         futures losses at arbitrary dates but some problems (e.g. derivatives 
-        pricing) work with todays (evalDate) magnitudes which do not require a 
+        pricing) work with today's (evalDate) magnitudes which do not require a 
         loss model and would be too expensive to recompute on every call.
         */
         mutable Real evalDateSettledLoss_,

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -379,7 +379,7 @@ namespace QuantLib {
         if(// included in test below-> (dist.begin()->second >=1.) ||
             (dist.begin()->second >= perc))return dist.begin()->first;
 
-        // deterministic case (e.g. date requested is todays date)
+        // deterministic case (e.g. date requested is today's date)
         if(dist.size() == 1) return dist.begin()->first;
 
         if(perc == 1.) return dist.rbegin()->first;

--- a/ql/experimental/credit/defaultevent.hpp
+++ b/ql/experimental/credit/defaultevent.hpp
@@ -143,7 +143,7 @@ namespace QuantLib {
 
         /*! matches the event if this event would trigger a contract
             related to the requested event type.  Notice the
-            contractual event types are not neccesarily atomic.
+            contractual event types are not necessarily atomic.
             Notice it does not check seniority or currency only event
             type.  typically used from Issuer
         */

--- a/ql/experimental/credit/gaussianlhplossmodel.hpp
+++ b/ql/experimental/credit/gaussianlhplossmodel.hpp
@@ -203,7 +203,7 @@ namespace QuantLib {
         averarage recovery with a time dependence: 
         $\hat{R}(t) = \frac{\sum_i R_i N_i P_i(t)}{\sum_i N_i P_i(t)}$
         But the date dependence increases significantly the calculations cost.
-        Notice that this problem dissapears if the recoveries are all equal.
+        Notice that this problem disappears if the recoveries are all equal.
         */
         
         Real beta_;

--- a/ql/experimental/credit/randomlosslatentmodel.hpp
+++ b/ql/experimental/credit/randomlosslatentmodel.hpp
@@ -197,7 +197,7 @@ namespace QuantLib {
                 // Determine the realized recovery rate:
                 /* For this; 'conditionalRecovery' needs to compute the pdef on 
                 the realized def event date from the simulation. Yet, this might
-                have fallen between todays date and the default TS reference 
+                have fallen between today's date and the default TS reference 
                 date(usually a two day gap) To avoid requesting a negative time
                 probability the date is moved to the TS date 
                 Unless the gap is ridiculous this has no practical effect for 

--- a/ql/experimental/credit/recursivelossmodel.hpp
+++ b/ql/experimental/credit/recursivelossmodel.hpp
@@ -261,7 +261,7 @@ namespace QuantLib {
 
         if(dist.begin()->second >=1.) return dist.begin()->first;
 
-        // deterministic case (e.g. date requested is todays date)
+        // deterministic case (e.g. date requested is today's date)
         if(dist.size() == 1) return dist.begin()->first;
 
         if(percentile == 1.) return dist.rbegin()->second;

--- a/ql/experimental/math/convolvedstudentt.hpp
+++ b/ql/experimental/math/convolvedstudentt.hpp
@@ -123,7 +123,7 @@ namespace QuantLib {
             \f[
             \int_0^{\infty} \frac{e^{-ax}sin(bx)}{x} dx = arctg2(b/a)
             \f]
-            The GP complex integration is simplified thanks to the symetry of
+            The GP complex integration is simplified thanks to the symmetry of
             the distribution.
         */
         Probability operator()(const Real x) const;

--- a/ql/experimental/math/multidimintegrator.hpp
+++ b/ql/experimental/math/multidimintegrator.hpp
@@ -91,7 +91,7 @@ namespace QuantLib {
         /* vector of, functions returning reals And taking as argument: 
         1.- a const ref to a function taking vectors 
         2.- a vector, 3. another vector. typedefs eventually...
-         at first sight this might look like mimicking a virtual table, it isnt 
+         at first sight this might look like mimicking a virtual table, it isn't 
          that. The reason is to be able to select the correct integration 
          dimension at run time, this can not be done before because of the 
          template argument restriction to be constant known at compilation.

--- a/ql/experimental/volatility/noarbsabr.hpp
+++ b/ql/experimental/volatility/noarbsabr.hpp
@@ -38,7 +38,7 @@
     For tau < 0.25 phi is extrapolated flat.
     For rho outside [-0.75, 0.75] phi is extrapolated linearly.
 
-    There are some parameter sets that are admissable, yet do
+    There are some parameter sets that are admissible, yet do
     not allow for the adjustment procedure as suggested in the
     paper to force the model implied forward to the correct
     value. In this case, no adjustment is done, leading to a

--- a/ql/experimental/volatility/noarbsabrinterpolation.hpp
+++ b/ql/experimental/volatility/noarbsabrinterpolation.hpp
@@ -43,7 +43,7 @@ struct NoArbSabrSpecs {
                        std::vector<bool> &paramIsFixed, const Real &forward,
                        const Real expiryTime, const std::vector<Real> &addParams) {
         SABRSpecs().defaultValues(params, paramIsFixed, forward, expiryTime, addParams);
-        // check if alpha / beta is admissable, otherwise adjust
+        // check if alpha / beta is admissible, otherwise adjust
         // if possible (i.e. not fixed, otherwise an exception will
         // be thrown from the model constructor anyway)
         Real sigmaI = params[0] * std::pow(forward, params[1] - 1.0);
@@ -138,7 +138,7 @@ struct NoArbSabrSpecs {
                     detail::NoArbSabrModel::beta_min) *
                        (std::atan(x[1]) + M_PI / 2.0) / M_PI;
         // we compute alpha from sigmaI using beta
-        // if alpha is fixed we have to check if beta is admissable
+        // if alpha is fixed we have to check if beta is admissible
         // and adjust if need be
         if (paramIsFixed[0]) {
             y[0] = params[0];

--- a/ql/experimental/volatility/zabr.hpp
+++ b/ql/experimental/volatility/zabr.hpp
@@ -71,7 +71,7 @@ class ZabrModel {
   private:
     const Real expiryTime_, forward_;
     const Real alpha_, beta_, nu_, rho_,
-        gamma_; // nu_ here is a tranformed version of the input nu !
+        gamma_; // nu_ here is a transformed version of the input nu !
 
     Real x(const Real strike) const;
     Disposable<std::vector<Real> > x(const std::vector<Real> &strikes) const;

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
          values with act/act convention within a period.
          Note that stored "fixings" are always flat (constant)
          within a period and interpolated as needed.  This
-         is because interpolation adds an addional availability
+         is because interpolation adds an additional availability
          lag (because you always need the next period to
          give the previous period's value)
          and enables storage of the most recent uninterpolated value.

--- a/ql/instruments/cpiswap.hpp
+++ b/ql/instruments/cpiswap.hpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         different.
 
         This swap can mimic a ZCIIS where [(1+q)^n - 1] is exchanged
-        against (cpi ratio - 1), by using differnt nominals on each
+        against (cpi ratio - 1), by using different nominals on each
         leg and setting subtractInflationNominal to true.  ALSO -
         there must be just one date in each schedule.
 

--- a/ql/math/integrals/kronrodintegral.hpp
+++ b/ql/math/integrals/kronrodintegral.hpp
@@ -69,7 +69,7 @@ namespace QuantLib {
         points Gauss-Kronrod integration rule.  This is more robust in
         that it allows to integrate less smooth functions (though
         singular functions should be integrated using dedicated
-        algorithms) but less efficient beacuse it does not reuse
+        algorithms) but less efficient because it does not reuse
         precedently computed points during computation steps.
 
         References:

--- a/ql/math/optimization/problem.hpp
+++ b/ql/math/optimization/problem.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             QL_REQUIRE(!constraint.empty(), "empty constraint given");
         }
 
-        /*! \warning it does not reset the current minumum to any initial value
+        /*! \warning it does not reset the current minimum to any initial value
         */
         void reset();
 

--- a/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
+++ b/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
@@ -63,7 +63,7 @@ namespace QuantLib
         {
             bool done = innerProduct_->nextTimeStep(currentState, numberCashFlowsThisStep,cashFlowsGenerated_);
 
-            // tranform the data
+            // transform the data
             for (Size i=0; i < numberOfProducts_; ++i)
                 for (Size j=0; j< numberCashFlowsThisStep[i]; ++j)
                 {

--- a/ql/models/shortrate/onefactormodels/markovfunctional.hpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.hpp
@@ -81,7 +81,7 @@ namespace QuantLib {
 
       A bad fit to the initial yield term structure may be due to a non suitable
       input smile or accumulating numerical errors in very long term calibrations.
-      The former point is adressed by smile pretreatment options. The latter point
+      The former point is addressed by smile pretreatment options. The latter point
       may be tackled by higher values for the numerical parameters possibly
       together with NTL high precision computing.
 

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.hpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
        exercise into right.
 
        All float coupons with start date greater or equal to the
-       respective option expiry are consideres to be part of the
+       respective option expiry are considered to be part of the
        exercise into right.
 
        For redemption flows an associated start date is considered

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
         <li>Friday</li>
         <li>Saturday</li>
         </ul>
-        Other holidays for wich no rule is given
+        Other holidays for which no rule is given
         (data available for 2013-2044 only:)
         <ul>
         <li>Purim, Adar 14th (between Feb 24th & Mar 26th)</li>

--- a/ql/time/calendars/thailand.hpp
+++ b/ql/time/calendars/thailand.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
     //! %Thailand calendars
     /*! Holidays for the Thailand exchange
         Holidays observed by financial institutions (not to be confused with bank holidays in the United Kingdom) are regulated by the Bank of Thailand.
-        If a holiday fall on a weekend the government will annouce a replacement day (usally the following monday).
+        If a holiday fall on a weekend the government will annouce a replacement day (usually the following monday).
 
         Sometimes the government add one or two extra holidays in a year.
 

--- a/ql/time/calendars/turkey.cpp
+++ b/ql/time/calendars/turkey.cpp
@@ -158,7 +158,7 @@ namespace QuantLib {
 				|| (m == August && d >= 21 && d <= 24))
 				return false;
 		}
-		// Note: Holidays >= 2019 are not yet officially anounced by borsaistanbul.com
+		// Note: Holidays >= 2019 are not yet officially announced by borsaistanbul.com
 		// and need further validation
 		else if (y == 2019) {
 			// Ramadan

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -724,13 +724,13 @@ void BondTest::testCached() {
         BondFunctions::cleanPrice(bond3, marketYield3, bondDayCount3, Compounded, freq),
         cachedPrice3,
         tolerance,
-        "Failed to reproduce the cached price for bond 3 with schedule and the earlierst possible settlment date"
+        "Failed to reproduce the cached price for bond 3 with schedule and the earlierst possible settlement date"
     );
     checkValue(
         BondFunctions::cleanPrice(bond3NoSchedule, marketYield3, bondDayCount3NoSchedule, Compounded, freq),
         cachedPrice3,
         tolerance,
-        "Failed to reproduce the cached price for bond 3 with no schedule and the earlierst possible settlment date"
+        "Failed to reproduce the cached price for bond 3 with no schedule and the earlierst possible settlement date"
     );
 }
 

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -592,7 +592,7 @@ void InflationTest::testZeroTermStructure() {
     // Perform checks on the seasonality for this interpolated index
     checkSeasonality(hz, iiyes);
 
-    // remove circular refernce
+    // remove circular reference
     hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 
@@ -949,7 +949,7 @@ void InflationTest::testYYTermStructure() {
                             <<", legs "<< yyS3.legNPV(0) << " and " << yyS3.legNPV(1)
                             );
     }
-    // remove circular refernce
+    // remove circular reference
     hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -392,7 +392,7 @@ void InflationCapFloorTest::testConsistency() {
         }
     }
     } // pricer loop
-    // remove circular refernce
+    // remove circular reference
     vars.hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 
@@ -472,7 +472,7 @@ void InflationCapFloorTest::testParity() {
             }
         }
     }
-    // remove circular refernce
+    // remove circular reference
     vars.hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 
@@ -547,7 +547,7 @@ void InflationCapFloorTest::testCachedValue() {
                         <<floor->NPV()<<" should be "<<cachedFloorNPVbac<<" bac Black pricer"
                         <<" diff was "<<(fabs(floor->NPV()-cachedFloorNPVbac)));
 
-    // remove circular refernce
+    // remove circular reference
     vars.hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -687,7 +687,7 @@ void InflationCapFlooredCouponTest::testDecomposition() {
                     << "\n" <<
                     "  Diff: " << error );
     }
-    // remove circular refernce
+    // remove circular reference
     vars.hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 
@@ -795,7 +795,7 @@ void InflationCapFlooredCouponTest::testInstrumentEquality() {
             }
         }
     }
-    // remove circular refernce
+    // remove circular reference
     vars.hy.linkTo(ext::shared_ptr<YoYInflationTermStructure>());
 }
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -388,7 +388,7 @@ void InflationCPICapFloorTest::cpicapfloorpricesurface() {
             << ", does not equal the expected premium, " << expPremium << ".");
     }
 
-    // remove circular refernce
+    // remove circular reference
     common.hcpi.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 
@@ -449,7 +449,7 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
     QL_REQUIRE(fabs(cached - aCap.NPV())<1e-10,"InterpolatingCPICapFloorEngine does not reproduce cached price: "
                << cached << " vs " << aCap.NPV());
 
-    // remove circular refernce
+    // remove circular reference
     common.hcpi.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -374,7 +374,7 @@ void CPISwapTest::consistency() {
     QL_REQUIRE(diff<max_diff,
                "failed stored consistency value test, ratio = " << diff);
 
-    // remove circular refernce
+    // remove circular reference
     common.hcpi.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 
@@ -429,7 +429,7 @@ void CPISwapTest::zciisconsistency() {
     for (Size i=0; i<2; i++) {
         QL_REQUIRE(fabs(cS.legNPV(i)-zciis.legNPV(i))<1e-3,"zciis leg does not equal CPISwap leg");
     }
-    // remove circular refernce
+    // remove circular reference
     common.hcpi.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 
@@ -521,7 +521,7 @@ void CPISwapTest::cpibondconsistency() {
     cpiB.setPricingEngine(dbe);
 
     QL_REQUIRE(fabs(cpiB.NPV() - zisV.legNPV(0))<1e-5,"cpi bond does not equal equivalent cpi swap leg");
-    // remove circular refernce
+    // remove circular reference
     common.hcpi.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 

--- a/test-suite/mclongstaffschwartzengine.cpp
+++ b/test-suite/mclongstaffschwartzengine.cpp
@@ -106,7 +106,7 @@ namespace {
             ext::shared_ptr<GeneralizedBlackScholesProcess> process =
                 ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
                                                     processArray->process(0));
-            QL_REQUIRE(process, "generalized Black-Scholes proces required");
+            QL_REQUIRE(process, "generalized Black-Scholes process required");
 
             ext::shared_ptr<AmericanMaxPathPricer> earlyExercisePathPricer(
                           new AmericanMaxPathPricer(this->arguments_.payoff));


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.