### PR TITLE
Add BondHelper constructors to use new Bond::Price::Type parameter

### DIFF
--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -29,8 +29,8 @@ namespace QuantLib {
 
     BondHelper::BondHelper(const Handle<Quote>& price,
                            const ext::shared_ptr<Bond>& bond,
-                           const bool useCleanPrice)
-    : RateHelper(price), bond_(ext::make_shared<Bond>(*bond)) {
+                           const Bond::Price::Type priceType)
+    : RateHelper(price), bond_(ext::make_shared<Bond>(*bond)), priceType_(priceType) {
 
         // the bond's last cashflow date, which can be later than
         // bond's maturity date because of adjustment
@@ -39,8 +39,22 @@ namespace QuantLib {
 
         bond_->setPricingEngine(
              ext::make_shared<DiscountingBondEngine>(termStructureHandle_));
+    }
 
-        useCleanPrice_ = useCleanPrice;
+    BondHelper::BondHelper(const Handle<Quote>& price,
+                           const ext::shared_ptr<Bond>& bond,
+                           const bool useCleanPrice)
+        : RateHelper(price), bond_(ext::make_shared<Bond>(*bond)) {
+
+        // the bond's last cashflow date, which can be later than
+        // bond's maturity date because of adjustment
+        latestDate_ = bond_->cashflows().back()->date();
+        earliestDate_ = bond_->nextCashFlowDate();
+
+        bond_->setPricingEngine(
+            ext::make_shared<DiscountingBondEngine>(termStructureHandle_));
+
+        priceType_ = useCleanPrice ? Bond::Price::Clean : Bond::Price::Dirty;
     }
 
     void BondHelper::setTermStructure(YieldTermStructure* t) {
@@ -56,7 +70,19 @@ namespace QuantLib {
         QL_REQUIRE(termStructure_ != 0, "term structure not set");
         // we didn't register as observers - force calculation
         bond_->recalculate();
-        return useCleanPrice_ ? bond_->cleanPrice() : bond_->dirtyPrice();
+
+        switch (priceType_) {
+            case Bond::Price::Clean:
+                return bond_->cleanPrice();
+                break;
+
+            case Bond::Price::Dirty:
+                return bond_->dirtyPrice();
+                break;
+
+            default:
+                QL_FAIL("This price type isn't implemented.");
+        }
     }
 
     void BondHelper::accept(AcyclicVisitor& v) {
@@ -83,6 +109,33 @@ namespace QuantLib {
                                     const Calendar& exCouponCalendar,
                                     const BusinessDayConvention exCouponConvention,
                                     bool exCouponEndOfMonth,
+                                    const Bond::Price::Type priceType)
+    : BondHelper(price,
+                 ext::shared_ptr<Bond>(
+                     new FixedRateBond(settlementDays, faceAmount, schedule,
+                                       coupons, dayCounter, paymentConvention,
+                                       redemption, issueDate, paymentCalendar,
+                                       exCouponPeriod, exCouponCalendar,
+                                       exCouponConvention, exCouponEndOfMonth)),
+                 priceType) {
+        fixedRateBond_ = ext::dynamic_pointer_cast<FixedRateBond>(bond_);
+    }
+
+    FixedRateBondHelper::FixedRateBondHelper(
+                                    const Handle<Quote>& price,
+                                    Natural settlementDays,
+                                    Real faceAmount,
+                                    const Schedule& schedule,
+                                    const std::vector<Rate>& coupons,
+                                    const DayCounter& dayCounter,
+                                    BusinessDayConvention paymentConvention,
+                                    Real redemption,
+                                    const Date& issueDate,
+                                    const Calendar& paymentCalendar,
+                                    const Period& exCouponPeriod,
+                                    const Calendar& exCouponCalendar,
+                                    const BusinessDayConvention exCouponConvention,
+                                    bool exCouponEndOfMonth,
                                     const bool useCleanPrice)
     : BondHelper(price,
                  ext::shared_ptr<Bond>(
@@ -91,7 +144,7 @@ namespace QuantLib {
                                        redemption, issueDate, paymentCalendar,
                                        exCouponPeriod, exCouponCalendar,
                                        exCouponConvention, exCouponEndOfMonth)),
-                 useCleanPrice) {
+                 useCleanPrice ? Bond::Price::Clean : Bond::Price::Dirty) {
         fixedRateBond_ = ext::dynamic_pointer_cast<FixedRateBond>(bond_);
     }
 
@@ -123,15 +176,46 @@ namespace QuantLib {
                             const Calendar& exCouponCalendar,
                             const BusinessDayConvention exCouponConvention,
                             bool exCouponEndOfMonth,
-                            const bool useCleanPrice)
+                            const Bond::Price::Type priceType)
     : BondHelper(price,
                  ext::shared_ptr<Bond>(
-                     new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI, 
+                     new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI,
                                        observationLag, cpiIndex, observationInterpolation,
                                        schedule, fixedRate, accrualDayCounter, paymentConvention,
                                        issueDate, paymentCalendar, exCouponPeriod, exCouponCalendar,
                                        exCouponConvention, exCouponEndOfMonth)),
-                 useCleanPrice) {
+                 priceType) {
+        cpiBond_ = ext::dynamic_pointer_cast<CPIBond>(bond_);
+    }
+
+    CPIBondHelper::CPIBondHelper(
+                            const Handle<Quote>& price,
+                            Natural settlementDays,
+                            Real faceAmount,
+                            const bool growthOnly,
+                            Real baseCPI,
+                            const Period& observationLag,
+                            const ext::shared_ptr<ZeroInflationIndex>& cpiIndex,
+                            CPI::InterpolationType observationInterpolation,
+                            const Schedule& schedule,
+                            const std::vector<Rate>& fixedRate,
+                            const DayCounter& accrualDayCounter,
+                            BusinessDayConvention paymentConvention,
+                            const Date& issueDate,
+                            const Calendar& paymentCalendar,
+                            const Period& exCouponPeriod,
+                            const Calendar& exCouponCalendar,
+                            const BusinessDayConvention exCouponConvention,
+                            bool exCouponEndOfMonth,
+                            const bool useCleanPrice)
+    : BondHelper(price,
+                 ext::shared_ptr<Bond>(
+                     new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI,
+                                       observationLag, cpiIndex, observationInterpolation,
+                                       schedule, fixedRate, accrualDayCounter, paymentConvention,
+                                       issueDate, paymentCalendar, exCouponPeriod, exCouponCalendar,
+                                       exCouponConvention, exCouponEndOfMonth)),
+                 useCleanPrice ? Bond::Price::Clean : Bond::Price::Dirty) {
         cpiBond_ = ext::dynamic_pointer_cast<CPIBond>(bond_);
     }
 
@@ -143,4 +227,5 @@ namespace QuantLib {
         else
             BootstrapHelper<YieldTermStructure>::accept(v);
     }
+
 }

--- a/ql/termstructures/yield/bondhelpers.hpp
+++ b/ql/termstructures/yield/bondhelpers.hpp
@@ -47,7 +47,15 @@ namespace QuantLib {
         */
         BondHelper(const Handle<Quote>& price,
                    const ext::shared_ptr<Bond>& bond,
-                   bool useCleanPrice = true);
+                   const Bond::Price::Type priceType = Bond::Price::Clean);
+
+        /*! \deprecated Use the other overload instead.
+                        Deprecated in version 1.18.
+        */
+        QL_DEPRECATED
+        BondHelper(const Handle<Quote>& price,
+                   const ext::shared_ptr<Bond>& bond,
+                   bool useCleanPrice);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const;
@@ -56,7 +64,14 @@ namespace QuantLib {
         //! \name Additional inspectors
         //@{
         ext::shared_ptr<Bond> bond() const;
+
+        /*! \deprecated Use the priceType() method instead.
+                        Deprecated in version 1.18.
+        */
+        QL_DEPRECATED
         bool useCleanPrice() const;
+
+        Bond::Price::Type priceType() const;
         //@}
         //! \name Visitability
         //@{
@@ -65,7 +80,7 @@ namespace QuantLib {
       protected:
         ext::shared_ptr<Bond> bond_;
         RelinkableHandle<YieldTermStructure> termStructureHandle_;
-        bool useCleanPrice_;        
+        Bond::Price::Type priceType_;
     };
 
     //! Fixed-coupon bond helper for curve bootstrap
@@ -85,7 +100,28 @@ namespace QuantLib {
                             const Calendar& exCouponCalendar = Calendar(),
                             const BusinessDayConvention exCouponConvention = Unadjusted,
                             bool exCouponEndOfMonth = false,
-                            const bool useCleanPrice = true);
+                            const Bond::Price::Type priceType = Bond::Price::Clean);
+
+        /*! \deprecated Use the other overload instead.
+                        Deprecated in version 1.18.
+        */
+        QL_DEPRECATED
+        FixedRateBondHelper(const Handle<Quote>& price,
+                            Natural settlementDays,
+                            Real faceAmount,
+                            const Schedule& schedule,
+                            const std::vector<Rate>& coupons,
+                            const DayCounter& dayCounter,
+                            BusinessDayConvention paymentConv,
+                            Real redemption,
+                            const Date& issueDate,
+                            const Calendar& paymentCalendar,
+                            const Period& exCouponPeriod,
+                            const Calendar& exCouponCalendar,
+                            const BusinessDayConvention exCouponConvention,
+                            bool exCouponEndOfMonth,
+                            const bool useCleanPrice);
+
         //! \name Additional inspectors
         //@{
         ext::shared_ptr<FixedRateBond> fixedRateBond() const;
@@ -106,7 +142,11 @@ namespace QuantLib {
     }
 
     inline bool BondHelper::useCleanPrice() const {
-        return useCleanPrice_;
+        return priceType_ == Bond::Price::Clean;
+    }
+
+    inline Bond::Price::Type BondHelper::priceType() const {
+        return priceType_;
     }
 
     inline ext::shared_ptr<FixedRateBond>
@@ -118,6 +158,30 @@ namespace QuantLib {
     class CPIBondHelper : public BondHelper {
       public:
         CPIBondHelper(const Handle<Quote>& price,
+                      Natural settlementDays,
+                      Real faceAmount,
+                      const bool growthOnly,
+                      Real baseCPI,
+                      const Period& observationLag,
+                      const ext::shared_ptr<ZeroInflationIndex>& cpiIndex,
+                      CPI::InterpolationType observationInterpolation,
+                      const Schedule& schedule,
+                      const std::vector<Rate>& fixedRate,
+                      const DayCounter& accrualDayCounter,
+                      BusinessDayConvention paymentConvention = Following,
+                      const Date& issueDate = Date(),
+                      const Calendar& paymentCalendar = Calendar(),
+                      const Period& exCouponPeriod = Period(),
+                      const Calendar& exCouponCalendar = Calendar(),
+                      const BusinessDayConvention exCouponConvention = Unadjusted,
+                      bool exCouponEndOfMonth = false,
+                      const Bond::Price::Type priceType = Bond::Price::Clean);
+
+        /*! \deprecated Use the other overload instead.
+                        Deprecated in version 1.18.
+        */
+        QL_DEPRECATED
+        CPIBondHelper(const Handle<Quote>& price,
                             Natural settlementDays,
                             Real faceAmount,
                             const bool growthOnly,
@@ -128,14 +192,14 @@ namespace QuantLib {
                             const Schedule& schedule,
                             const std::vector<Rate>& fixedRate,
                             const DayCounter& accrualDayCounter,
-                            BusinessDayConvention paymentConvention = Following,
-                            const Date& issueDate = Date(),
-                            const Calendar& paymentCalendar = Calendar(),
-                            const Period& exCouponPeriod = Period(),
-                            const Calendar& exCouponCalendar = Calendar(),
-                            const BusinessDayConvention exCouponConvention = Unadjusted,
-                            bool exCouponEndOfMonth = false,
-                            const bool useCleanPrice = true);
+                            BusinessDayConvention paymentConvention,
+                            const Date& issueDate,
+                            const Calendar& paymentCalendar,
+                            const Period& exCouponPeriod,
+                            const Calendar& exCouponCalendar,
+                            const BusinessDayConvention exCouponConvention,
+                            bool exCouponEndOfMonth,
+                            const bool useCleanPrice);
         //! \name Additional inspectors
         //@{
         ext::shared_ptr<CPIBond> cpiBond() const;
@@ -148,11 +212,11 @@ namespace QuantLib {
         ext::shared_ptr<CPIBond> cpiBond_;
     };
 
-
     inline ext::shared_ptr<CPIBond>
     CPIBondHelper::cpiBond() const {
         return cpiBond_;
     }
+
 }
 
 #endif

--- a/ql/termstructures/yield/bondhelpers.hpp
+++ b/ql/termstructures/yield/bondhelpers.hpp
@@ -83,6 +83,7 @@ namespace QuantLib {
         Bond::Price::Type priceType_;
     };
 
+
     //! Fixed-coupon bond helper for curve bootstrap
     class FixedRateBondHelper : public BondHelper {
       public:
@@ -134,25 +135,6 @@ namespace QuantLib {
         ext::shared_ptr<FixedRateBond> fixedRateBond_;
     };
 
-
-    // inline
-
-    inline ext::shared_ptr<Bond> BondHelper::bond() const {
-        return bond_;
-    }
-
-    inline bool BondHelper::useCleanPrice() const {
-        return priceType_ == Bond::Price::Clean;
-    }
-
-    inline Bond::Price::Type BondHelper::priceType() const {
-        return priceType_;
-    }
-
-    inline ext::shared_ptr<FixedRateBond>
-    FixedRateBondHelper::fixedRateBond() const {
-        return fixedRateBond_;
-    }
 
     //! CPI bond helper for curve bootstrap
     class CPIBondHelper : public BondHelper {
@@ -211,6 +193,26 @@ namespace QuantLib {
       protected:
         ext::shared_ptr<CPIBond> cpiBond_;
     };
+
+
+    // inline
+
+    inline ext::shared_ptr<Bond> BondHelper::bond() const {
+        return bond_;
+    }
+
+    inline bool BondHelper::useCleanPrice() const {
+        return priceType_ == Bond::Price::Clean;
+    }
+
+    inline Bond::Price::Type BondHelper::priceType() const {
+        return priceType_;
+    }
+
+    inline ext::shared_ptr<FixedRateBond>
+    FixedRateBondHelper::fixedRateBond() const {
+        return fixedRateBond_;
+    }
 
     inline ext::shared_ptr<CPIBond>
     CPIBondHelper::cpiBond() const {

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -285,7 +285,7 @@ namespace QuantLib {
                 modelPrice += cf[k]->amount() *
                                     fittingMethod_->discountFunction(x, tenor);
             }
-            if (helper->useCleanPrice())
+            if (helper->priceType() == Bond::Price::Clean)
                 modelPrice -= bond->accruedAmount(bondSettlement);
 
             // adjust price (NPV) for forward settlement


### PR DESCRIPTION
This PR builds on the work in #648 . It adds constructors on the `BondHelper` classes to use the new `Bond::Price::Type` values and deprecates the old constructors that rely on `useCleanPrice`.

I didn't add explicit tests, but the existing tests that use `BondHelper`s test this implicitly.