### PR TITLE
Add new, capped payoff

### DIFF
--- a/ql/instruments/payoffs.cpp
+++ b/ql/instruments/payoffs.cpp
@@ -99,6 +99,19 @@ namespace QuantLib {
             Payoff::accept(v);
     }
 
+    Real CappedPayoff::operator()(Real price) const {
+        return std::min<Real>(PlainVanillaPayoff::operator()(price), cap_);
+    }
+
+    void CappedPayoff::accept(AcyclicVisitor& v) {
+        Visitor<CappedPayoff>* v1 =
+            dynamic_cast<Visitor<CappedPayoff>*>(&v);
+        if (v1 != 0)
+            v1->visit(*this);
+        else
+            Payoff::accept(v);
+    }
+
     Real PercentageStrikePayoff::operator()(Real price) const {
         switch (type_) {
           case Option::Call:

--- a/ql/instruments/payoffs.hpp
+++ b/ql/instruments/payoffs.hpp
@@ -114,6 +114,20 @@ namespace QuantLib {
         //@}
     };
 
+    //! Capped payoff
+    class CappedPayoff : public PlainVanillaPayoff {
+      public:
+        CappedPayoff(Option::Type type,
+                     Real strike,
+                     Real cap)
+        : PlainVanillaPayoff(type, strike), cap_(cap) {}
+        std::string name() const { return "Capped";}
+        Real operator()(Real price) const;
+        virtual void accept(AcyclicVisitor&);
+      protected:
+        Real cap_;
+    };
+
     //! %Payoff with strike expressed as percentage
     class PercentageStrikePayoff : public StrikedTypePayoff {
       public:


### PR DESCRIPTION
No coverage via automated tests (yet?), but verified visually:

<details>
  <summary>Python code to produce following payoff diagrams. (Changes to QuantLib-SWIG to be submitted in a subsequent PR.)</summary>

```python
def make_test_option(payoff, spot_price):
    import QuantLib as ql
    
    calculation_date = ql.Date(15, 3, 2020)
    ql.Settings.instance().evaluationDate = calculation_date

    test_option = ql.VanillaOption(
        payoff,
        ql.AmericanExercise(
            calculation_date,
            ql.Date(15, 3, 2020)
        )
    )

    test_option.setPricingEngine(
        ql.BinomialVanillaEngine(
            process=ql.BlackScholesMertonProcess(
                s0=ql.QuoteHandle(ql.SimpleQuote(spot_price)),
                dividendTS=ql.YieldTermStructureHandle(
                    ql.FlatForward(
                        calculation_date,
                        0, # dividend rate
                        ql.Actual365Fixed(),
                    )
                ),
                riskFreeTS=ql.YieldTermStructureHandle(
                    ql.FlatForward(
                        calculation_date,
                        0.185, # risk-free rate
                        ql.Actual365Fixed(),
                    )
                ),
                volTS=ql.BlackVolTermStructureHandle(
                    ql.BlackConstantVol(
                        calculation_date,
                        ql.UnitedStates(),
                        0.35, # annualized historical volatility
                        ql.Actual365Fixed(),
                    )
                ),
            ),
            type="coxrossrubinstein",
            steps=250
        )
    )
    
    return test_option

from QuantLib import CappedPayoff, Date, Option, PlainVanillaPayoff
vanilla_option = make_test_option(PlainVanillaPayoff(Option.Put, 140), 150)

vanilla_payoffs = []
capped_payoffs = []

eval_price = 0
while eval_price < 300:
    vanilla_put = make_test_option(
        PlainVanillaPayoff(Option.Put, 140), eval_price,
    )
    vanilla_payoffs.append(vanilla_option.payoff()(eval_price))
    
    capped_put = make_test_option(
        CappedPayoff(Option.Put, 140, 50), eval_price,
    )
    capped_payoffs.append(capped_put.payoff()(eval_price))
    eval_price = eval_price + 1
    
from matplotlib import pyplot
pyplot.plot(vanilla_payoffs, label="Vanilla Put", linewidth=5)
pyplot.plot(capped_payoffs, label="Capped Put", linewidth=3)
pyplot.legend()
pyplot.show()
```
</details>

![image](https://user-images.githubusercontent.com/7883777/71565579-e6391280-2a7d-11ea-99da-2fec8463be4c.png)
