### PR TITLE
Clarify ./configure message for Boost Test search

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -130,7 +130,7 @@ AC_DEFUN([QL_CHECK_BOOST_UBLAS],
 # ------------------------
 # Check whether the Boost unit-test framework is available
 AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
-[AC_MSG_CHECKING([for Boost unit-test framework and Boost timer])
+[AC_MSG_CHECKING([for Boost Test, Boost Timer and Boost System])
  AC_REQUIRE([AC_PROG_CC])
  ql_original_LIBS=$LIBS
  ql_original_CXXFLAGS=$CXXFLAGS


### PR DESCRIPTION
I installed `libboost-test-dev` and `libboost-timer-dev`, but this check still failed for me.  I dug in to `config.log` and found that it was actually the lack of Boost System that was hampering me.  Then I looked at the PR that introduced these dependencies, #692, and noticed that the message was updated with the addition of Timer, but not with the addition of System, so it seemed a simple oversight that I could easily correct to save others from the same trouble.

I also took the liberty of formalizing the library names in the message, since when I was installing these dependencies it wasn't immediately clear to me that "unit-test framework" was a part of Boost Test.  (I initially thought perhaps it was yet another Boost library entirely.)