### PR TITLE
Fix BMA Coupon Fixing Schedule

### DIFF
--- a/ql/cashflows/averagebmacoupon.cpp
+++ b/ql/cashflows/averagebmacoupon.cpp
@@ -100,6 +100,12 @@ namespace QuantLib {
 
     }
 
+    namespace {
+    void adjustToNextValidFixingDate(Date& d, const ext::shared_ptr<BMAIndex>& index) {
+        while (!index->isValidFixingDate(d) && d > Date::minDate())
+            d--;
+    }
+    } // namespace
 
     AverageBMACoupon::AverageBMACoupon(const Date& paymentDate,
                                        Real nominal,
@@ -118,6 +124,13 @@ namespace QuantLib {
         Integer fixingDays = Integer(index->fixingDays());
         fixingDays += bmaCutoffDays;
         Date fixingStart = cal.advance(startDate, -fixingDays*Days, Preceding);
+
+        // make sure that the value date associated to fixingStart is <= startDate
+        adjustToNextValidFixingDate(fixingStart, index);
+        while (index->valueDate(fixingStart) > startDate && fixingStart > Date::minDate()) {
+            adjustToNextValidFixingDate(--fixingStart, index);
+        }
+
         fixingSchedule_ = index->fixingSchedule(fixingStart, endDate);
 
         setPricer(ext::shared_ptr<FloatingRateCouponPricer>(

--- a/ql/cashflows/averagebmacoupon.cpp
+++ b/ql/cashflows/averagebmacoupon.cpp
@@ -101,7 +101,7 @@ namespace QuantLib {
     }
 
     namespace {
-    void adjustToNextValidFixingDate(Date& d, const ext::shared_ptr<BMAIndex>& index) {
+    void adjustToPreviousValidFixingDate(Date& d, const ext::shared_ptr<BMAIndex>& index) {
         while (!index->isValidFixingDate(d) && d > Date::minDate())
             d--;
     }
@@ -126,9 +126,9 @@ namespace QuantLib {
         Date fixingStart = cal.advance(startDate, -fixingDays*Days, Preceding);
 
         // make sure that the value date associated to fixingStart is <= startDate
-        adjustToNextValidFixingDate(fixingStart, index);
+        adjustToPreviousValidFixingDate(fixingStart, index);
         while (index->valueDate(fixingStart) > startDate && fixingStart > Date::minDate()) {
-            adjustToNextValidFixingDate(--fixingStart, index);
+            adjustToPreviousValidFixingDate(--fixingStart, index);
         }
 
         fixingSchedule_ = index->fixingSchedule(fixingStart, endDate);


### PR DESCRIPTION
Trying to set up a `BMACoupon` with startDate = 01-01-2026, endDate = 01-02-2026 results in an exception "2nd leg: first fixing date valid after period start" since the fixing schedule does not cover the required period.

This PR makes sure that the fixing schedule constructed in the coupon satisfies the requirements in the `AverageBMACouponPricer`.