### PR TITLE
Fixed German calendar , by removing 31st Dec as holiday

### DIFF
--- a/ql/time/calendars/germany.cpp
+++ b/ql/time/calendars/germany.cpp
@@ -86,9 +86,7 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Boxing Day
-            || (d == 26 && m == December)
-            // New Year's Eve
-            || (d == 31 && m == December))
+            || (d == 26 && m == December))
             return false;
         return true;
     }
@@ -114,9 +112,7 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Christmas Day
-            || (d == 26 && m == December)
-            // New Year's Eve
-            || (d == 31 && m == December))
+            || (d == 26 && m == December))
             return false;
         return true;
     }
@@ -141,9 +137,7 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Christmas Day
-            || (d == 26 && m == December)
-            // New Year's Eve
-            || (d == 31 && m == December))
+            || (d == 26 && m == December))
             return false;
         return true;
     }
@@ -168,9 +162,7 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Christmas Day
-            || (d == 26 && m == December)
-            // New Year's Eve
-            || (d == 31 && m == December))
+            || (d == 26 && m == December))
             return false;
         return true;
     }
@@ -197,9 +189,7 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Christmas Day
-            || (d == 26 && m == December)
-            // New Year's Eve
-            || (d == 31 && m == December))
+            || (d == 26 && m == December))
             return false;
         return true;
     }

--- a/ql/time/calendars/germany.hpp
+++ b/ql/time/calendars/germany.hpp
@@ -44,7 +44,6 @@ namespace QuantLib {
         <li>Christmas Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Boxing Day, December 26th</li>
-        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Holidays for the Frankfurt Stock exchange
@@ -59,7 +58,6 @@ namespace QuantLib {
         <li>Christmas' Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Christmas Holiday, December 26th</li>
-        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Holidays for the Xetra exchange
@@ -74,7 +72,6 @@ namespace QuantLib {
         <li>Christmas' Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Christmas Holiday, December 26th</li>
-        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Holidays for the Eurex exchange
@@ -89,7 +86,6 @@ namespace QuantLib {
         <li>Christmas' Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Christmas Holiday, December 26th</li>
-        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Holidays for the Euwax exchange
@@ -105,7 +101,6 @@ namespace QuantLib {
         <li>Christmas' Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Christmas Holiday, December 26th</li>
-        <li>New Year's Eve, December 31st</li>
         </ul>
 
         \ingroup calendars

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -454,13 +454,11 @@ void CalendarTest::testGermanyFrankfurt() {
     expectedHol.push_back(Date(24,December,2003));
     expectedHol.push_back(Date(25,December,2003));
     expectedHol.push_back(Date(26,December,2003));
-    expectedHol.push_back(Date(31,December,2003));
 
     expectedHol.push_back(Date(1,January,2004));
     expectedHol.push_back(Date(9,April,2004));
     expectedHol.push_back(Date(12,April,2004));
     expectedHol.push_back(Date(24,December,2004));
-    expectedHol.push_back(Date(31,December,2004));
 
     Calendar c = Germany(Germany::FrankfurtStockExchange);
     std::vector<Date> hol = Calendar::holidayList(c, Date(1,January,2003),
@@ -488,13 +486,11 @@ void CalendarTest::testGermanyEurex() {
     expectedHol.push_back(Date(24,December,2003));
     expectedHol.push_back(Date(25,December,2003));
     expectedHol.push_back(Date(26,December,2003));
-    expectedHol.push_back(Date(31,December,2003));
 
     expectedHol.push_back(Date(1,January,2004));
     expectedHol.push_back(Date(9,April,2004));
     expectedHol.push_back(Date(12,April,2004));
     expectedHol.push_back(Date(24,December,2004));
-    expectedHol.push_back(Date(31,December,2004));
 
     Calendar c = Germany(Germany::Eurex);
     std::vector<Date> hol = Calendar::holidayList(c, Date(1,January,2003),
@@ -522,13 +518,11 @@ void CalendarTest::testGermanyXetra() {
     expectedHol.push_back(Date(24,December,2003));
     expectedHol.push_back(Date(25,December,2003));
     expectedHol.push_back(Date(26,December,2003));
-    expectedHol.push_back(Date(31,December,2003));
 
     expectedHol.push_back(Date(1,January,2004));
     expectedHol.push_back(Date(9,April,2004));
     expectedHol.push_back(Date(12,April,2004));
     expectedHol.push_back(Date(24,December,2004));
-    expectedHol.push_back(Date(31,December,2004));
 
     Calendar c = Germany(Germany::Xetra);
     std::vector<Date> hol = Calendar::holidayList(c, Date(1,January,2003),


### PR DESCRIPTION
Removed 31 st Dec as holiday from German calendar #768 