### PR TITLE
ensure a volatility and shift can be read for given swapLength

### DIFF
--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -271,11 +271,12 @@ namespace QuantLib {
 
         Time swapLength =  vol_->swapLength(swap.floatingSchedule().dates().front(),
                                             swap.floatingSchedule().dates().back());
-        results_.additionalResults["swapLength"] = swapLength;
 
         // swapLength is rounded to whole months. To ensure we can read a variance
         // and a shift from vol_ we floor swapLength at 1/12 here therefore.
         swapLength = std::max(swapLength, 1.0 / 12.0);
+        results_.additionalResults["swapLength"] = swapLength;
+
         Real variance = vol_->blackVariance(exerciseDate,
                                                    swapLength,
                                                    strike);

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -273,6 +273,9 @@ namespace QuantLib {
                                             swap.floatingSchedule().dates().back());
         results_.additionalResults["swapLength"] = swapLength;
 
+        // swapLength is rounded to whole months. To ensure we can read a variance
+        // and a shift from vol_ we floor swapLength at 1/12 here therefore.
+        swapLength = std::max(swapLength, 1.0 / 12.0);
         Real variance = vol_->blackVariance(exerciseDate,
                                                    swapLength,
                                                    strike);


### PR DESCRIPTION
This PR prevents the black swaption engine from throwing an exception "non-positive swap length (0) given" when the underlying length is less than half a month and therefore rounded down to zero in `SwaptionVolatilityStructure::swapLength()`. Instead the volatility and shift are read at a swap length of 1/12 in this case.