### PR TITLE
Boost Include and Lib Pathes via BoostPath.props

### DIFF
--- a/BoostPath.props
+++ b/BoostPath.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QL_BOOST_INCLUDE_PATH);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link Condition="'$(Platform)'=='Win32'" Label="Link">
+      <AdditionalLibraryDirectories>$(QL_BOOST_LIB32_PATH);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <Link Condition="'$(Platform)'=='x64'" Label="Link">
+      <AdditionalLibraryDirectories>$(QL_BOOST_LIB64_PATH);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/QuantLib.props
+++ b/QuantLib.props
@@ -9,4 +9,5 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
   </PropertyGroup>
+  <Import Project="BoostPath.props" Condition="'$(VisualStudioVersion)' == '16.0'" />
 </Project>


### PR DESCRIPTION
As discussed in [Building Quantlib in VisualStudio 2019 ](https://github.com/lballabio/QuantLib/issues/616) VS 2019 does not provide `microsoft.cpp.win32.user` anymore to easily set the Boost include and library pathes.

I suggest a `BoostPath.props` file where the pathes are read in from the environment variables
- `QL_BOOST_INCLUDE_PATH`
- `QL_BOOST_LIB32_PATH` and
- `QL_BOOST_LIB64_PATH`.

Currently `BoostPath.props` is loaded within `QuantLib.props`, so it will used in all examples and the test suite automatically as well. 