### PR TITLE
Import global boost placeholders into ext::placeholders namespace.

### DIFF
--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -207,7 +207,6 @@ namespace QuantLib {
         Trivial method for testing
         */
         Probability probOfDefault(Size iName, const Date& d) const {
-            using namespace ext::placeholders;
             QL_REQUIRE(basket_, "No portfolio basket set.");
             const ext::shared_ptr<Pool>& pool = basket_->pool();
             // avoid repeating this in the integration:
@@ -224,7 +223,7 @@ namespace QuantLib {
                 this,
                 inverseCumulativeY(pUncond, iName),
                 iName, 
-                _1)
+                ext::placeholders::_1)
               ));
         }
         /*! Pearsons' default probability correlation. 
@@ -239,7 +238,6 @@ namespace QuantLib {
         defaults in the basket portfolio at a given time.
         */
         Probability probAtLeastNEvents(Size n, const Date& date) const {
-            using namespace ext::placeholders;
             return integratedExpectedValue(
              ext::function<Real (const std::vector<Real>& v1)>(
               ext::bind(
@@ -247,7 +245,7 @@ namespace QuantLib {
               this,
               n,
               ext::cref(date),
-              _1)
+              ext::placeholders::_1)
              ));
         }
     };
@@ -259,7 +257,6 @@ namespace QuantLib {
     Real DefaultLatentModel<CP>::defaultCorrelation(const Date& d, 
         Size iNamei, Size iNamej) const 
     {
-        using namespace ext::placeholders;
         QL_REQUIRE(basket_, "No portfolio basket set.");
 
         const ext::shared_ptr<Pool>& pool = basket_->pool();
@@ -280,7 +277,8 @@ namespace QuantLib {
               ext::function<Real (const std::vector<Real>& v1)>(
                 ext::bind(
                 &DefaultLatentModel<CP>::condProbProduct,
-                this, invPi, invPj, iNamei, iNamej, _1) ));
+                this, invPi, invPj, iNamei, iNamej,
+                ext::placeholders::_1) ));
         }else{
             E1i1j = pi;
         }

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -591,14 +591,16 @@ namespace QuantLib {
         */
         Real integratedExpectedValue(
             const ext::function<Real(const std::vector<Real>& v1)>& f) const {
-            using namespace ext::placeholders;
+
             // function composition: composes the integrand with the density 
             //   through a product.
             return 
                 integration()->integrate(
                     ext::bind(std::multiplies<Real>(), 
-                    ext::bind(&copulaPolicyImpl::density, copula_, _1),
-                              ext::bind(ext::cref(f), _1)));   
+                    ext::bind(&copulaPolicyImpl::density, copula_,
+                              ext::placeholders::_1),
+                              ext::bind(ext::cref(f),
+                                        ext::placeholders::_1)));   
         }
         /*! Integrates an arbitrary vector function over the density domain(i.e.
          computes its expected value).
@@ -607,13 +609,13 @@ namespace QuantLib {
             // const ext::function<std::vector<Real>(
             const ext::function<Disposable<std::vector<Real> >(
                 const std::vector<Real>& v1)>& f ) const {
-            using namespace ext::placeholders;
             return 
                 integration()->integrateV(//see note in LMIntegrators base class
                     ext::bind<Disposable<std::vector<Real> > >(
                         detail::multiplyV(),
-                        ext::bind(&copulaPolicyImpl::density, copula_, _1),
-                        ext::bind(ext::cref(f), _1)));
+                        ext::bind(&copulaPolicyImpl::density, copula_,
+                                  ext::placeholders::_1),
+                        ext::bind(ext::cref(f), ext::placeholders::_1)));
         }
     protected:
         // Integrable models must provide their integrator.

--- a/ql/experimental/math/multidimintegrator.hpp
+++ b/ql/experimental/math/multidimintegrator.hpp
@@ -125,9 +125,9 @@ namespace QuantLib {
 
     template<>
     void inline MultidimIntegral::spawnFcts<1>() const {
-        using namespace ext::placeholders;
         integrationLevelEntries_[0] = 
-            ext::bind(&MultidimIntegral::integrate<0>, this, _1, _2, _3);
+            ext::bind(&MultidimIntegral::integrate<0>, this,
+                      ext::placeholders::_1, ext::placeholders::_2, ext::placeholders::_3);
     }
 
     template<int nT>
@@ -136,11 +136,10 @@ namespace QuantLib {
         const std::vector<Real>& a,
         const std::vector<Real>& b) const 
     {
-        using namespace ext::placeholders;
         return 
             (*integrators_[nT])(
                 ext::bind(&MultidimIntegral::vectorBinder<nT>, this, f, 
-                    _1, ext::cref(a), ext::cref(b)), a[nT], b[nT]);
+                    ext::placeholders::_1, ext::cref(a), ext::cref(b)), a[nT], b[nT]);
     }
 
     template<int T_N> 
@@ -156,10 +155,9 @@ namespace QuantLib {
 
     template<Size depth>
     void MultidimIntegral::spawnFcts() const {
-        using namespace ext::placeholders;
         integrationLevelEntries_[depth-1] =
           ext::bind(&MultidimIntegral::integrate<depth-1>, this, 
-            _1, _2, _3);
+            ext::placeholders::_1, ext::placeholders::_2, ext::placeholders::_3);
         spawnFcts<depth-1>();
     }
 

--- a/ql/experimental/math/multidimquadrature.hpp
+++ b/ql/experimental/math/multidimquadrature.hpp
@@ -61,7 +61,6 @@ namespace QuantLib {
 
             template <class F> // todo: fix copies.
             detail::DispArray operator()(const F& f) const {
-                using namespace ext::placeholders;
                 //first one, we do not know the size of the vector returned by f
                 Integer i = order()-1;
                 std::vector<Real> term = f(x_[i]);// potential copy! @#$%^!!!
@@ -74,8 +73,9 @@ namespace QuantLib {
                     // sum[j] += term[j] * w_[i];
                     std::transform(term.begin(), term.end(), sum.begin(), 
                         sum.begin(), 
-                        ext::bind(std::plus<Real>(), _2,
-                            ext::bind(std::multiplies<Real>(), w_[i], _1)));
+                        ext::bind(std::plus<Real>(), ext::placeholders::_2,
+                            ext::bind(std::multiplies<Real>(), w_[i],
+                                      ext::placeholders::_1)));
                 }
                 return sum;
             }
@@ -136,15 +136,14 @@ namespace QuantLib {
         //    class construction time) handles to the integration entry points
         template<Size levelSpawn>
         void spawnFcts() const {
-            using namespace ext::placeholders;
             integrationEntries_[levelSpawn-1] = 
                 ext::bind(
                 &GaussianQuadMultidimIntegrator::scalarIntegrator<levelSpawn>, 
-                    this, _1, _2);
+                    this, ext::placeholders::_1, ext::placeholders::_2);
             integrationEntriesVR_[levelSpawn-1] = 
                 ext::bind(
                 &GaussianQuadMultidimIntegrator::vectorIntegratorVR<levelSpawn>, 
-                    this, _1, _2);
+                    this, ext::placeholders::_1, ext::placeholders::_2);
             spawnFcts<levelSpawn-1>();
         }
         //@}
@@ -156,13 +155,12 @@ namespace QuantLib {
             ext::function<Real (const std::vector<Real>& arg1)> f, 
             const Real mFctr) const 
         {
-            using namespace ext::placeholders;
             varBuffer_[intgDepth-1] = mFctr;
             return integral_(ext::bind(
                 &GaussianQuadMultidimIntegrator::scalarIntegrator<intgDepth-1>,
                 this,
                 f,
-                _1)
+                ext::placeholders::_1)
             );
         }
 
@@ -171,14 +169,13 @@ namespace QuantLib {
             const ext::function<detail::DispArray(const std::vector<Real>& arg1)>& f,
             const Real mFctr) const 
         {
-            using namespace ext::placeholders;
             varBuffer_[intgDepth-1] = mFctr;
             return 
               integralV_(ext::bind(
                &GaussianQuadMultidimIntegrator::vectorIntegratorVR<intgDepth-1>,
                this,
                f,
-               _1)
+               ext::placeholders::_1)
             );
         }
     private:
@@ -212,12 +209,11 @@ namespace QuantLib {
     inline Real GaussianQuadMultidimIntegrator::operator()(
         const ext::function<Real (const std::vector<Real>& v1)>& f) const
     {
-        using namespace ext::placeholders;
         return integral_(ext::bind(
                    // integration entry level is selected now
                    integrationEntries_[dimension_-1],
                    ext::cref(f),
-                   _1)
+                   ext::placeholders::_1)
                    );
     }
 
@@ -226,7 +222,6 @@ namespace QuantLib {
     inline Real GaussianQuadMultidimIntegrator::integrate<Real>(
         const ext::function<Real (const std::vector<Real>& v1)>& f) const 
     {
-        using namespace ext::placeholders;
         // integration variables
         // call vector quadrature integration with the function and start 
         // values, kicks in recursion over the dimensions of the integration
@@ -235,7 +230,7 @@ namespace QuantLib {
                    // integration entry level is selected now
                    integrationEntries_[dimension_-1],
                    ext::cref(f),
-                   _1)
+                   ext::placeholders::_1)
                    );
     }
 
@@ -244,11 +239,10 @@ namespace QuantLib {
     inline detail::DispArray GaussianQuadMultidimIntegrator::integrate<detail::DispArray>(
         const ext::function<detail::DispArray (const std::vector<Real>& v1)>& f) const
     {
-        using namespace ext::placeholders;
         return integralV_(ext::bind(
                    ext::cref(integrationEntriesVR_[dimension_-1]),
                    ext::cref(f),
-                   _1)
+                   ext::placeholders::_1)
                    );
     } 
 
@@ -276,13 +270,12 @@ namespace QuantLib {
     //! Terminal level:
     template<>
     inline void GaussianQuadMultidimIntegrator::spawnFcts<1>() const {
-        using namespace ext::placeholders;
         integrationEntries_[0] = 
           ext::bind(&GaussianQuadMultidimIntegrator::scalarIntegrator<1>, 
-          this, _1, _2);
+          this, ext::placeholders::_1, ext::placeholders::_2);
         integrationEntriesVR_[0] = 
          ext::bind(&GaussianQuadMultidimIntegrator::vectorIntegratorVR<1>, 
-         this, _1, _2);
+         this, ext::placeholders::_1, ext::placeholders::_2);
     }
 
 }

--- a/ql/functional.hpp
+++ b/ql/functional.hpp
@@ -58,7 +58,17 @@ namespace QuantLib {
         using boost::bind;
         using boost::ref;
         using boost::cref;
-        namespace placeholders {}
+        namespace placeholders {
+            using ::_1;
+            using ::_2;
+            using ::_3;
+            using ::_4;
+            using ::_5;
+            using ::_6;
+            using ::_7;
+            using ::_8;
+            using ::_9;
+        }
         #endif
 
     }

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -113,7 +113,7 @@ namespace linear_least_square_regression_test {
 
     struct get_item {
         Size i;
-        get_item(Size i) : i(i) {}
+        explicit get_item(Size i) : i(i) {}
         Real operator()(const Array& a) const {
             return a[i];
         }

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -109,10 +109,16 @@ void LinearLeastSquaresRegressionTest::testRegression() {
     }
 }
 
-namespace {
-    Real f(const Array& a, Size i) {
-        return a[i];
-    }
+namespace linear_least_square_regression_test {
+
+    struct get_item {
+        Size i;
+        get_item(Size i) : i(i) {}
+        Real operator()(const Array& a) const {
+            return a[i];
+        }
+    };
+
 }
 
 void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
@@ -121,6 +127,7 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
         "Testing multi-dimensional linear least-squares regression...");
 
     using namespace ext::placeholders;
+    using namespace linear_least_square_regression_test;
 
     SavedSettings backup;
 
@@ -132,7 +139,7 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
     std::vector<ext::function<Real(Array)> > v;
     v.push_back(constant<Array, Real>(1.0));
     for (Size i=0; i < dims; ++i) {
-        v.push_back(ext::bind(f, _1, i));
+        v.push_back(get_item(i));
     }
 
     Array coeff(v.size());

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -482,8 +482,6 @@ void RiskNeutralDensityCalculatorTest::testLocalVolatilityRND() {
 void RiskNeutralDensityCalculatorTest::testSquareRootProcessRND() {
     BOOST_TEST_MESSAGE("Testing probability density for a square root process...");
 
-    using namespace ext::placeholders;
-
     struct SquareRootProcessParams {
         const Real v0, kappa, theta, sigma;
     };
@@ -506,7 +504,7 @@ void RiskNeutralDensityCalculatorTest::testSquareRootProcessRND() {
             const Real cdfCalculated = rndCalculator.cdf(v, t);
             const Real cdfExpected = GaussLobattoIntegral(10000, 0.01*tol)(
                 ext::bind(&SquareRootProcessRNDCalculator::pdf,
-                    &rndCalculator, _1, t), 0, v);
+                          &rndCalculator, ext::placeholders::_1, t), 0, v);
 
             if (std::fabs(cdfCalculated - cdfExpected) > tol) {
                 BOOST_FAIL("failed to calculate cdf"
@@ -735,8 +733,6 @@ void RiskNeutralDensityCalculatorTest::testMassAtZeroCEVProcessRND() {
     BOOST_TEST_MESSAGE("Testing the mass at zero for a "
                        "constant elasticity of variance (CEV) process...");
 
-    using namespace ext::placeholders;
-
     const Real f0 = 100.0;
     const Time t = 2.75;
 
@@ -759,7 +755,7 @@ void RiskNeutralDensityCalculatorTest::testMassAtZeroCEVProcessRND() {
         const Real ax = 15.0*std::sqrt(t)*alpha*std::pow(f0, beta);
 
         const Real calculated = GaussLobattoIntegral(1000, 1e-8)(
-            ext::bind(&CEVRNDCalculator::pdf, calculator, _1, t),
+            ext::bind(&CEVRNDCalculator::pdf, calculator, ext::placeholders::_1, t),
                       std::max(QL_EPSILON, f0-ax), f0+ax) +
             calculator->massAtZero(t);
 

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -191,7 +191,6 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
     BOOST_TEST_MESSAGE(
         "Testing mapping function of the square root kernel process...");
 
-    using namespace ext::placeholders;
     using namespace square_root_clv_model;
 
     SavedSettings backup;
@@ -269,7 +268,8 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
                 rTS->discount(m)).value();
 
             const CLVModelPayoff clvModelPayoff(
-                optionType, strike, ext::bind(g, t, _1));
+                optionType, strike,
+                ext::bind(g, t, ext::placeholders::_1));
 
             const ext::function<Real(Real)> f = integrand(clvModelPayoff, dist);
 


### PR DESCRIPTION
For some combination of configure flags, both the std and the boost version of the `_1`, `_2`... placeholders are imported in some files so the code needs to disambiguate.  This change allows referring to them as `ext::placeholders::_1` regardless of the chosen implementation.