### PR TITLE
Deprecate the storage of nominal term structure inside inflation curves.

### DIFF
--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -321,8 +321,9 @@ namespace QuantLib {
 
                         // in this case you can set a pricer
                         // straight away because it only provides computation - not data
-                        ext::shared_ptr<CPICouponPricer> pricer
-                            (new CPICouponPricer);
+                        ext::shared_ptr<CPICouponPricer> pricer =
+                            ext::make_shared<CPICouponPricer>(Handle<CPIVolatilitySurface>(),
+                                                              Handle<YieldTermStructure>());
                         coup->setPricer(pricer);
                         leg.push_back(ext::dynamic_pointer_cast<CashFlow>(coup));
 

--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -24,6 +24,12 @@ namespace QuantLib {
     CPICouponPricer::CPICouponPricer() {}
 
     CPICouponPricer::CPICouponPricer(
+                       const Handle<YieldTermStructure>& nominalTermStructure)
+    : nominalTermStructure_(nominalTermStructure) {
+        registerWith(nominalTermStructure_);
+    }
+
+    CPICouponPricer::CPICouponPricer(
                        const Handle<CPIVolatilitySurface>& capletVol,
                        const Handle<YieldTermStructure>& nominalTermStructure)
     : capletVol_(capletVol), nominalTermStructure_(nominalTermStructure) {
@@ -154,14 +160,5 @@ namespace QuantLib {
         // with a different yield curve
         return gearing_ * adjustedFixing() + spread_;
     }
-
-
-    //=========================================================================
-    // vol-dependent pricers, note that these do not discount
-    //=========================================================================
-
-/*
-    NOT IMPLEMENTED
-*/
 
 }

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -38,11 +38,13 @@ namespace QuantLib {
     */
     class CPICouponPricer : public InflationCouponPricer {
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use one of the other constructors.
                         Deprecated in version 1.19.
         */
         QL_DEPRECATED
         CPICouponPricer();
+
+        explicit CPICouponPricer(const Handle<YieldTermStructure>& nominalTermStructure);
 
         CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol,
                         const Handle<YieldTermStructure>& nominalTermStructure);
@@ -96,7 +98,7 @@ namespace QuantLib {
         Spread spread_;
         Real discount_;
     };
-
+    
 }
 
 #endif

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -38,7 +38,12 @@ namespace QuantLib {
     */
     class CPICouponPricer : public InflationCouponPricer {
       public:
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         CPICouponPricer();
+
         CPICouponPricer(const Handle<CPIVolatilitySurface>& capletVol,
                         const Handle<YieldTermStructure>& nominalTermStructure);
 

--- a/ql/cashflows/inflationcouponpricer.cpp
+++ b/ql/cashflows/inflationcouponpricer.cpp
@@ -23,7 +23,24 @@
 
 namespace QuantLib {
 
+    void setCouponPricer(const Leg& leg,
+                         const ext::shared_ptr<InflationCouponPricer>& p) {
+        for (Size i=0; i<leg.size(); ++i) {
+            ext::shared_ptr<InflationCoupon> c =
+                ext::dynamic_pointer_cast<InflationCoupon>(leg[i]);
+            if (c)
+                c->setPricer(p);
+        }
+    }
+
+
     YoYInflationCouponPricer::YoYInflationCouponPricer() {}
+
+    YoYInflationCouponPricer::YoYInflationCouponPricer(
+                       const Handle<YieldTermStructure>& nominalTermStructure)
+    : nominalTermStructure_(nominalTermStructure) {
+        registerWith(nominalTermStructure_);
+    }
 
     YoYInflationCouponPricer::YoYInflationCouponPricer(
                        const Handle<YoYOptionletVolatilitySurface>& capletVol,

--- a/ql/cashflows/inflationcouponpricer.hpp
+++ b/ql/cashflows/inflationcouponpricer.hpp
@@ -75,17 +75,24 @@ namespace QuantLib {
     };
 
 
+    void setCouponPricer(const Leg& leg,
+                         const ext::shared_ptr<InflationCouponPricer>&);
+
+
     //! base pricer for capped/floored YoY inflation coupons
     /*! \note this pricer can already do swaplets but to get
               volatility-dependent coupons you need the descendents.
     */
     class YoYInflationCouponPricer : public InflationCouponPricer {
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use one of the other constructors.
                         Deprecated in version 1.19.
         */
         QL_DEPRECATED
         YoYInflationCouponPricer();
+
+        explicit YoYInflationCouponPricer(
+            const Handle<YieldTermStructure>& nominalTermStructure);
 
         YoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
@@ -142,13 +149,17 @@ namespace QuantLib {
     //! Black-formula pricer for capped/floored yoy inflation coupons
     class BlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use one of the other constructors.
                         Deprecated in version 1.19.
         */
         QL_DEPRECATED
         BlackYoYInflationCouponPricer()
         : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
                                    Handle<YieldTermStructure>()) {}
+
+        explicit BlackYoYInflationCouponPricer(
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(nominalTermStructure) {}
 
         BlackYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
@@ -163,13 +174,17 @@ namespace QuantLib {
     //! Unit-Displaced-Black-formula pricer for capped/floored yoy inflation coupons
     class UnitDisplacedBlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use one of the other constructors.
                         Deprecated in version 1.19.
         */
         QL_DEPRECATED
         UnitDisplacedBlackYoYInflationCouponPricer()
         : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
                                    Handle<YieldTermStructure>()) {}
+
+        explicit UnitDisplacedBlackYoYInflationCouponPricer(
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(nominalTermStructure) {}
 
         UnitDisplacedBlackYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
@@ -184,13 +199,17 @@ namespace QuantLib {
     //! Bachelier-formula pricer for capped/floored yoy inflation coupons
     class BachelierYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use one of the other constructors.
                         Deprecated in version 1.19.
         */
         QL_DEPRECATED
         BachelierYoYInflationCouponPricer()
         : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
                                    Handle<YieldTermStructure>()) {}
+
+        explicit BachelierYoYInflationCouponPricer(
+            const Handle<YieldTermStructure>& nominalTermStructure)
+        : YoYInflationCouponPricer(nominalTermStructure) {}
 
         BachelierYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,

--- a/ql/cashflows/inflationcouponpricer.hpp
+++ b/ql/cashflows/inflationcouponpricer.hpp
@@ -81,7 +81,12 @@ namespace QuantLib {
     */
     class YoYInflationCouponPricer : public InflationCouponPricer {
       public:
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         YoYInflationCouponPricer();
+
         YoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
             const Handle<YieldTermStructure>& nominalTermStructure);
@@ -137,7 +142,14 @@ namespace QuantLib {
     //! Black-formula pricer for capped/floored yoy inflation coupons
     class BlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        BlackYoYInflationCouponPricer() {}
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        BlackYoYInflationCouponPricer()
+        : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
+                                   Handle<YieldTermStructure>()) {}
+
         BlackYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
             const Handle<YieldTermStructure>& nominalTermStructure)
@@ -151,7 +163,14 @@ namespace QuantLib {
     //! Unit-Displaced-Black-formula pricer for capped/floored yoy inflation coupons
     class UnitDisplacedBlackYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        UnitDisplacedBlackYoYInflationCouponPricer() {}
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        UnitDisplacedBlackYoYInflationCouponPricer()
+        : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
+                                   Handle<YieldTermStructure>()) {}
+
         UnitDisplacedBlackYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
             const Handle<YieldTermStructure>& nominalTermStructure)
@@ -165,7 +184,14 @@ namespace QuantLib {
     //! Bachelier-formula pricer for capped/floored yoy inflation coupons
     class BachelierYoYInflationCouponPricer : public YoYInflationCouponPricer {
       public:
-        BachelierYoYInflationCouponPricer() {}
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        BachelierYoYInflationCouponPricer()
+        : YoYInflationCouponPricer(Handle<YoYOptionletVolatilitySurface>(),
+                                   Handle<YieldTermStructure>()) {}
+
         BachelierYoYInflationCouponPricer(
             const Handle<YoYOptionletVolatilitySurface>& capletVol,
             const Handle<YieldTermStructure>& nominalTermStructure)

--- a/ql/cashflows/yoyinflationcoupon.cpp
+++ b/ql/cashflows/yoyinflationcoupon.cpp
@@ -206,8 +206,9 @@ namespace QuantLib {
 
                     // in this case you can set a pricer
                     // straight away because it only provides computation - not data
-                    ext::shared_ptr<YoYInflationCouponPricer> pricer(
-                                            new YoYInflationCouponPricer);
+                    ext::shared_ptr<YoYInflationCouponPricer> pricer =
+                        ext::make_shared<YoYInflationCouponPricer>(Handle<YoYOptionletVolatilitySurface>(),
+                                                                   Handle<YieldTermStructure>());
                     coup->setPricer(pricer);
                     leg.push_back(ext::dynamic_pointer_cast<CashFlow>(coup));
 

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
@@ -38,14 +38,14 @@ namespace QuantLib {
                                 const Matrix &cPrice,
                                 const Matrix &fPrice)
     : InflationTermStructure(0, cal, baseRate, observationLag, zii->frequency(), 
-                             zii->interpolated(), yts, dc),
-      zii_(zii), cStrikes_(cStrikes), fStrikes_(fStrikes),
+                             zii->interpolated(), dc),
+      zii_(zii), nominalTS_(yts), cStrikes_(cStrikes), fStrikes_(fStrikes),
       cfMaturities_(cfMaturities), cPrice_(cPrice), fPrice_(fPrice),
       nominal_(nominal), bdc_(bdc) {
 
           // does the index have a TS?
           QL_REQUIRE(!zii_->zeroInflationTermStructure().empty(),"ZITS missing from index");
-          QL_REQUIRE(!this->nominalTermStructure().empty(),"nominal TS missing");
+          QL_REQUIRE(!nominalTS_.empty(),"nominal TS missing");
               
         // data consistency checking, enough data?
         QL_REQUIRE(fStrikes_.size() > 1, "not enough floor strikes");

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -140,6 +140,7 @@ namespace QuantLib {
 
 
         Handle<ZeroInflationIndex> zii_;
+        Handle<YieldTermStructure> nominalTS_;
         // data
         std::vector<Rate> cStrikes_;
         std::vector<Rate> fStrikes_;
@@ -255,7 +256,7 @@ namespace QuantLib {
             Matrix(cfStrikes_.size(), cfMaturities_.size(), Null<Real>());
 
         Handle<ZeroInflationTermStructure> zts = zii_->zeroInflationTermStructure();
-        Handle<YieldTermStructure> yts = this->nominalTermStructure();
+        Handle<YieldTermStructure> yts = nominalTS_;
         QL_REQUIRE(!zts.empty(), "Zts is empty!!!");
         QL_REQUIRE(!yts.empty(), "Yts is empty!!!");
 

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
@@ -35,8 +35,8 @@ namespace QuantLib {
                                 const std::vector<Period> &cfMaturities,
                                 const Matrix &cPrice,
                                 const Matrix &fPrice)
-    : InflationTermStructure(0, cal, baseRate, lag, yii->frequency(), yii->interpolated(), nominal, dc),
-      fixingDays_(fixingDays), bdc_(bdc), yoyIndex_(yii),
+    : InflationTermStructure(0, cal, baseRate, lag, yii->frequency(), yii->interpolated(), dc),
+      fixingDays_(fixingDays), bdc_(bdc), yoyIndex_(yii), nominalTS_(nominal),
       cStrikes_(cStrikes), fStrikes_(fStrikes),
       cfMaturities_(cfMaturities), cPrice_(cPrice), fPrice_(fPrice) {
 

--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <ql/termstructures/inflation/inflationhelpers.hpp>
+#include <ql/cashflows/inflationcouponpricer.hpp>
 #include <ql/indexes/inflationindex.hpp>
 #include <ql/pricingengines/swap/discountingswapengine.hpp>
 #include <ql/utilities/null_deleter.hpp>
@@ -216,12 +217,16 @@ namespace QuantLib {
                                                     paymentConvention_));
 
 
-        // Because very simple instrument only takes
-        // standard discounting swap engine.
+        // The instrument takes a standard discounting swap engine.
+        // The inflation-related work is done by the coupons via the pricer.
+        Handle<YieldTermStructure> nominalTS =
+            !nominalTermStructure_.empty() ?
+            nominalTermStructure_ :
+            y->nominalTermStructure(); 
         yyiis_->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new DiscountingSwapEngine(!nominalTermStructure_.empty() ?
-                                              nominalTermStructure_ :
-                                              y->nominalTermStructure())));
+                    new DiscountingSwapEngine(nominalTS)));
+        setCouponPricer(yyiis_->yoyLeg(),
+                        ext::make_shared<YoYInflationCouponPricer>(nominalTS));
     }
 
 }

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -46,6 +46,22 @@ namespace QuantLib {
                                        const Period& lag,
                                        Frequency frequency,
                                        bool indexIsInterpolated,
+                                       const std::vector<Date>& dates,
+                                       const std::vector<Rate>& rates,
+                                       const Interpolator &interpolator
+                                                            = Interpolator());
+
+        /*! \deprecated Use the constructor not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       const Calendar& calendar,
+                                       const DayCounter& dayCounter,
+                                       const Period& lag,
+                                       Frequency frequency,
+                                       bool indexIsInterpolated,
                                        const Handle<YieldTermStructure>& yTS,
                                        const std::vector<Date>& dates,
                                        const std::vector<Rate>& rates,
@@ -85,6 +101,21 @@ namespace QuantLib {
                                        Frequency frequency,
                                        bool indexIsInterpolated,
                                        Rate baseZeroRate,
+                                       const Interpolator &interpolator
+                                                            = Interpolator());
+
+        /*! \deprecated Use the constructor not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       const Calendar& calendar,
+                                       const DayCounter& dayCounter,
+                                       const Period& lag,
+                                       Frequency frequency,
+                                       bool indexIsInterpolated,
+                                       Rate baseZeroRate,
                                        const Handle<YieldTermStructure>& yTS,
                                        const Interpolator &interpolator
                                                             = Interpolator());
@@ -104,12 +135,11 @@ namespace QuantLib {
                                    const Period& lag,
                                    Frequency frequency,
                                    bool indexIsInterpolated,
-                                   const Handle<YieldTermStructure>& yTS,
                                    const std::vector<Date>& dates,
                                    const std::vector<Rate>& rates,
                                    const Interpolator& interpolator)
     : ZeroInflationTermStructure(referenceDate, calendar, dayCounter, rates[0],
-                                 lag, frequency, indexIsInterpolated, yTS),
+                                 lag, frequency, indexIsInterpolated),
       InterpolatedCurve<Interpolator>(std::vector<Time>(), rates, interpolator),
       dates_(dates) {
 
@@ -119,7 +149,7 @@ namespace QuantLib {
           // i.e. referenceDate - lag, at least must be in the relevant
           // period
           std::pair<Date,Date> lim =
-                inflationPeriod(yTS->referenceDate() - this->observationLag(), frequency);
+                inflationPeriod(referenceDate - this->observationLag(), frequency);
           QL_REQUIRE(lim.first <= dates_[0] && dates_[0] <= lim.second,
                    "first data date is not in base period, date: " << dates_[0]
                    << " not within [" << lim.first << "," << lim.second << "]");
@@ -132,8 +162,6 @@ namespace QuantLib {
                   dates_[i] = inflationPeriod(dates_[i], frequency).first;
               }
           }
-
-
 
           QL_REQUIRE(this->data_.size() == dates_.size(),
                    "indices/dates count mismatch: "
@@ -162,6 +190,85 @@ namespace QuantLib {
           this->interpolation_.update();
     }
 
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::
+    InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   bool indexIsInterpolated,
+                                   const Handle<YieldTermStructure>& yTS,
+                                   const std::vector<Date>& dates,
+                                   const std::vector<Rate>& rates,
+                                   const Interpolator& interpolator)
+    : ZeroInflationTermStructure(referenceDate, calendar, dayCounter, rates[0],
+                                 lag, frequency, indexIsInterpolated, yTS),
+      InterpolatedCurve<Interpolator>(std::vector<Time>(), rates, interpolator),
+      dates_(dates) {
+
+          QL_REQUIRE(dates_.size() > 1, "too few dates: " << dates_.size());
+
+          // check that the data starts from the beginning,
+          // i.e. referenceDate - lag, at least must be in the relevant
+          // period
+          std::pair<Date,Date> lim =
+                inflationPeriod(referenceDate - this->observationLag(), frequency);
+          QL_REQUIRE(lim.first <= dates_[0] && dates_[0] <= lim.second,
+                   "first data date is not in base period, date: " << dates_[0]
+                   << " not within [" << lim.first << "," << lim.second << "]");
+
+          // by convention, if the index is not interpolated we pull all the dates
+          // back to the start of their inflationPeriods
+          // otherwise the time calculations will be inconsistent
+          if (!indexIsInterpolated_) {
+              for (Size i = 0; i < dates_.size(); i++) {
+                  dates_[i] = inflationPeriod(dates_[i], frequency).first;
+              }
+          }
+
+          QL_REQUIRE(this->data_.size() == dates_.size(),
+                   "indices/dates count mismatch: "
+                   << this->data_.size() << " vs " << dates_.size());
+
+          this->times_.resize(dates_.size());
+          this->times_[0] = timeFromReference(dates_[0]);
+          for (Size i = 1; i < dates_.size(); i++) {
+              QL_REQUIRE(dates_[i] > dates_[i-1],
+                       "dates not sorted");
+
+              // but must be greater than -1
+              QL_REQUIRE(this->data_[i] > -1.0, "zero inflation data < -100 %");
+
+              // this can be negative
+              this->times_[i] = timeFromReference(dates_[i]);
+              QL_REQUIRE(!close(this->times_[i],this->times_[i-1]),
+                       "two dates correspond to the same time "
+                       "under this curve's day count convention");
+          }
+
+          this->interpolation_ =
+                this->interpolator_.interpolate(this->times_.begin(),
+                                                this->times_.end(),
+                                                this->data_.begin());
+          this->interpolation_.update();
+    }
+
+
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::
+    InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   bool indexIsInterpolated,
+                                   Rate baseZeroRate,
+                                   const Interpolator& interpolator)
+    :  ZeroInflationTermStructure(referenceDate, calendar, dayCounter, baseZeroRate,
+                                  lag, frequency, indexIsInterpolated),
+       InterpolatedCurve<Interpolator>(interpolator) {
+    }
 
     template <class Interpolator>
     InterpolatedZeroInflationCurve<Interpolator>::

--- a/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
@@ -56,6 +56,29 @@ namespace QuantLib {
                Frequency frequency,
                bool indexIsInterpolated,
                Rate baseYoYRate,
+               const std::vector<ext::shared_ptr<typename Traits::helper> >&
+                                                                  instruments,
+               Real accuracy = 1.0e-12,
+               const Interpolator& i = Interpolator())
+        : base_curve(referenceDate, calendar, dayCounter, baseYoYRate,
+                     lag, frequency, indexIsInterpolated, i),
+          instruments_(instruments), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+        /*! \deprecated Use the constructor not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        PiecewiseYoYInflationCurve(
+               const Date& referenceDate,
+               const Calendar& calendar,
+               const DayCounter& dayCounter,
+               const Period& lag,
+               Frequency frequency,
+               bool indexIsInterpolated,
+               Rate baseYoYRate,
                const Handle<YieldTermStructure>& nominalTS,
                const std::vector<ext::shared_ptr<typename Traits::helper> >&
                                                                   instruments,
@@ -65,11 +88,10 @@ namespace QuantLib {
                      lag, frequency, indexIsInterpolated,
                      nominalTS, i),
           instruments_(instruments), accuracy_(accuracy) {
-
-
             bootstrap_.setup(this);
         }
         //@}
+
         //! \name Inflation interface
         //@{
         Date baseDate() const;

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -46,8 +46,32 @@ namespace QuantLib {
       public:
         typedef Traits traits_type;
         typedef Interpolator interpolator_type;
+
         //! \name Constructors
         //@{
+        PiecewiseZeroInflationCurve(
+               const Date& referenceDate,
+               const Calendar& calendar,
+               const DayCounter& dayCounter,
+               const Period& lag,
+               Frequency frequency,
+               bool indexIsInterpolated,
+               Rate baseZeroRate,
+               const std::vector<ext::shared_ptr<typename Traits::helper> >&
+                                                                  instruments,
+               Real accuracy = 1.0e-12,
+               const Interpolator& i = Interpolator())
+        : base_curve(referenceDate, calendar, dayCounter,
+                     lag, frequency, indexIsInterpolated, baseZeroRate, i),
+          instruments_(instruments), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+        /*! \deprecated Use the constructor not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         PiecewiseZeroInflationCurve(
                const Date& referenceDate,
                const Calendar& calendar,
@@ -68,6 +92,7 @@ namespace QuantLib {
             bootstrap_.setup(this);
         }
         //@}
+
         //! \name Inflation interface
         //@{
         Date baseDate() const;

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -27,6 +27,51 @@ namespace QuantLib {
                                         const Period& observationLag,
                                         Frequency frequency,
                                         bool indexIsInterpolated,
+                                        const DayCounter& dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(dayCounter),
+      observationLag_(observationLag), frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
+      baseRate_(baseRate) {
+        setSeasonality(seasonality);
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        const Date& referenceDate,
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
+                                        const bool indexIsInterpolated,
+                                        const Calendar& calendar,
+                                        const DayCounter& dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(referenceDate, calendar, dayCounter),
+      observationLag_(observationLag),
+      frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
+      baseRate_(baseRate) {
+        setSeasonality(seasonality);
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        Natural settlementDays,
+                                        const Calendar& calendar,
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
+                                        bool indexIsInterpolated,
+                                        const DayCounter &dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(settlementDays, calendar, dayCounter),
+      observationLag_(observationLag),
+      frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
+      baseRate_(baseRate) {
+        setSeasonality(seasonality);
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
+                                        bool indexIsInterpolated,
                                         const Handle<YieldTermStructure>& yTS,
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
@@ -112,6 +157,56 @@ namespace QuantLib {
                                     const Period& observationLag,
                                     Frequency frequency,
                                     bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(baseZeroRate, observationLag, frequency, indexIsInterpolated,
+                             dayCounter, seasonality) {
+    }
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    const Date& referenceDate,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(referenceDate, baseZeroRate, observationLag, frequency, indexIsInterpolated,
+                             calendar, dayCounter, seasonality) {
+    }
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    Natural settlementDays,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseZeroRate, observationLag, frequency, indexIsInterpolated,
+                             dayCounter, seasonality) {
+    }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++11-extensions"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
                                     const Handle<YieldTermStructure>& yTS,
                                     const ext::shared_ptr<Seasonality> &seasonality)
     : InflationTermStructure(baseZeroRate, observationLag, frequency, indexIsInterpolated,
@@ -145,6 +240,16 @@ namespace QuantLib {
     : InflationTermStructure(settlementDays, calendar, baseZeroRate, observationLag, frequency, indexIsInterpolated,
                              yTS, dayCounter, seasonality) {
     }
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     Rate ZeroInflationTermStructure::zeroRate(const Date &d, const Period& instObsLag,
                                               bool forceLinearInterpolation,
@@ -194,6 +299,54 @@ namespace QuantLib {
         return zeroRateImpl(t);
     }
 
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    const DayCounter& dayCounter,
+                                    Rate baseYoYRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(baseYoYRate, observationLag, frequency, indexIsInterpolated,
+                             dayCounter, seasonality) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    const Date& referenceDate,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseYoYRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(referenceDate, baseYoYRate, observationLag, frequency, indexIsInterpolated,
+                             calendar, dayCounter, seasonality) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    Natural settlementDays,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseYoYRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseYoYRate, observationLag,
+                             frequency, indexIsInterpolated, dayCounter, seasonality) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++11-extensions"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     const DayCounter& dayCounter,
                                     Rate baseYoYRate,
@@ -231,6 +384,16 @@ namespace QuantLib {
     : InflationTermStructure(settlementDays, calendar, baseYoYRate, observationLag,
                              frequency, indexIsInterpolated,
                              yTS, dayCounter, seasonality) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 
     Rate YoYInflationTermStructure::yoyRate(const Date &d, const Period& instObsLag,

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -40,9 +40,41 @@ namespace QuantLib {
                                const Period& observationLag,
                                Frequency frequency,
                                bool indexIsInterpolated,
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        InflationTermStructure(const Date& referenceDate,
+                               Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
+                               bool indexIsInterpolated,
+                               const Calendar& calendar = Calendar(),
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        InflationTermStructure(Natural settlementDays,
+                               const Calendar& calendar,
+                               Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
+                               bool indexIsInterpolated,
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InflationTermStructure(Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
+                               bool indexIsInterpolated,
                                const Handle<YieldTermStructure>& yTS,
                                const DayCounter& dayCounter = DayCounter(),
                                const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         InflationTermStructure(const Date& referenceDate,
                                Rate baseRate,
                                const Period& observationLag,
@@ -52,6 +84,11 @@ namespace QuantLib {
                                const Calendar& calendar = Calendar(),
                                const DayCounter& dayCounter = DayCounter(),
                                const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Rate baseRate,
@@ -103,7 +140,7 @@ namespace QuantLib {
         // instruments to build the term structure, since the rate at
         // time 0-lag is non-zero, since we deal (effectively) with
         // "forwards".
-        virtual void setBaseRate(const Rate &r){baseRate_=r;}
+        virtual void setBaseRate(const Rate &r) { baseRate_ = r; }
 
 
         // range-checking
@@ -133,9 +170,44 @@ namespace QuantLib {
                                    const Period& lag,
                                    Frequency frequency,
                                    bool indexIsInterpolated,
+                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        ZeroInflationTermStructure(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   const bool indexIsInterpolated,
+                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        ZeroInflationTermStructure(Natural settlementDays,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   bool indexIsInterpolated,
+                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        ZeroInflationTermStructure(const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   bool indexIsInterpolated,
                                    const Handle<YieldTermStructure>& yTS,
                                    const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
 
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(const Date& referenceDate,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,
@@ -146,6 +218,11 @@ namespace QuantLib {
                                    const Handle<YieldTermStructure>& yTS,
                                    const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
 
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,
@@ -198,9 +275,44 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
+                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        YoYInflationTermStructure(const Date& referenceDate,
+                                  const Calendar& calendar,
+                                  const DayCounter& dayCounter,
+                                  Rate baseYoYRate,
+                                  const Period& lag,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        YoYInflationTermStructure(Natural settlementDays,
+                                  const Calendar& calendar,
+                                  const DayCounter& dayCounter,
+                                  Rate baseYoYRate,
+                                  const Period& lag,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        YoYInflationTermStructure(const DayCounter& dayCounter,
+                                  Rate baseYoYRate,
+                                  const Period& lag,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
                                   const Handle<YieldTermStructure>& yieldTS,
                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
 
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         YoYInflationTermStructure(const Date& referenceDate,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,
@@ -211,6 +323,11 @@ namespace QuantLib {
                                   const Handle<YieldTermStructure>& yieldTS,
                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
 
+        /*! \deprecated Use one of the constructors not taking a yield
+                        term structure.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
         YoYInflationTermStructure(Natural settlementDays,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -377,7 +377,7 @@ void InflationTest::testZeroTermStructure() {
                         new PiecewiseZeroInflationCurve<Linear>(
                         evaluationDate, calendar, dc, observationLag,
                         frequency, ii->interpolated(), baseZeroRate,
-                        Handle<YieldTermStructure>(nominalTS), helpers));
+                        helpers));
     pZITS->recalculate();
 
     // first check that the zero rates on the curve match the data
@@ -512,7 +512,7 @@ void InflationTest::testZeroTermStructure() {
             new PiecewiseZeroInflationCurve<Linear>(
             evaluationDate, calendar, dc, observationLagyes,
             frequency, iiyes->interpolated(), baseZeroRate,
-            Handle<YieldTermStructure>(nominalTS), helpersyes));
+            helpersyes));
     pZITSyes->recalculate();
 
     // first check that the zero rates on the curve match the data
@@ -871,7 +871,7 @@ void InflationTest::testYYTermStructure() {
         new PiecewiseYoYInflationCurve<Linear>(
                 evaluationDate, calendar, dc, observationLag,
                 iir->frequency(),iir->interpolated(), baseYYRate,
-                Handle<YieldTermStructure>(nominalTS), helpers));
+                helpers));
     pYYTS->recalculate();
 
     // validation
@@ -881,6 +881,8 @@ void InflationTest::testYYTermStructure() {
     // usual swap engine
     Handle<YieldTermStructure> hTS(nominalTS);
     ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+    ext::shared_ptr<InflationCouponPricer> pricer =
+        ext::make_shared<YoYInflationCouponPricer>(hTS);
 
     // make sure that the index has the latest yoy term structure
     hy.linkTo(pYYTS);
@@ -909,7 +911,7 @@ void InflationTest::testYYTermStructure() {
                                         UnitedKingdom());
 
         yyS2.setPricingEngine(sppe);
-
+        setCouponPricer(yyS2.yoyLeg(), pricer);
 
 
         BOOST_CHECK_MESSAGE(fabs(yyS2.NPV())<eps,"fresh yoy swap NPV!=0 from TS "
@@ -947,6 +949,7 @@ void InflationTest::testYYTermStructure() {
                                     UnitedKingdom());
 
         yyS3.setPricingEngine(sppe);
+        setCouponPricer(yyS3.yoyLeg(), pricer);
 
         BOOST_CHECK_MESSAGE(fabs(yyS3.NPV())< 20000.0,
                             "unexpected size of aged YoY swap, aged "

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -41,6 +41,7 @@
 #include <ql/indexes/inflation/euhicp.hpp>
 #include <ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp>
 #include <ql/cashflows/yoyinflationcoupon.hpp>
+#include <ql/cashflows/inflationcouponpricer.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/time/calendars/unitedkingdom.hpp>
@@ -183,7 +184,7 @@ namespace inflation_capfloor_test {
                 new PiecewiseYoYInflationCurve<Linear>(
                         evaluationDate, calendar, dc, observationLag,
                         iir->frequency(),iir->interpolated(), baseYYRate,
-                        Handle<YieldTermStructure>(nominalTS), helpers));
+                        helpers));
             pYYTS->recalculate();
             yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
 
@@ -460,6 +461,8 @@ void InflationCapFloorTest::testParity() {
                     Handle<YieldTermStructure> hTS(vars.nominalTS);
                     ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
                     swap.setPricingEngine(sppe);
+                    setCouponPricer(swap.yoyLeg(),
+                                    ext::make_shared<YoYInflationCouponPricer>(vars.nominalTS));
 
                     // N.B. nominals are 10e6
                     if (std::fabs((cap->NPV()-floor->NPV()) - swap.NPV()) > 1.0e-6) {

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -160,7 +160,7 @@ namespace inflation_cpi_bond_test {
                   new PiecewiseZeroInflationCurve<Linear>(
                          evaluationDate, calendar, dayCounter, observationLag,
                          ii->frequency(),ii->interpolated(), baseZeroRate,
-                         Handle<YieldTermStructure>(yTS), helpers)));
+                         helpers)));
         }
 
         // teardown
@@ -209,7 +209,11 @@ void InflationCPIBondTest::testCleanPrice() {
 
     ext::shared_ptr<DiscountingBondEngine> engine(
                                  new DiscountingBondEngine(common.yTS));
+    ext::shared_ptr<InflationCouponPricer> pricer =
+        ext::make_shared<CPICouponPricer>(common.yTS);
+
     bond.setPricingEngine(engine);
+    setCouponPricer(bond.cashflows(), pricer);
 
     Real storedPrice = 383.01816406;
     Real calculated = bond.cleanPrice();

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -269,7 +269,7 @@ namespace inflation_cpi_capfloor_test {
                                 new PiecewiseZeroInflationCurve<Linear>(
                                     evaluationDate, calendar, dcZCIIS, observationLag,
                                     ii->frequency(),ii->interpolated(), baseZeroRate,
-                                    Handle<YieldTermStructure>(nominalTS), helpers));
+                                    helpers));
             pCPIts->recalculate();
             cpiUK.linkTo(pCPIts);
             hii.linkTo(ii);

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -195,7 +195,7 @@ namespace inflation_volatility_test {
         ext::shared_ptr<InterpolatedYoYInflationCurve<Linear> >
             pYTSEU( new InterpolatedYoYInflationCurve<Linear>(
                     eval, TARGET(), Actual365Fixed(), Period(2,Months), Monthly,
-                    indexIsInterpolated, nominalGBP, d, r) );
+                    indexIsInterpolated, d, r) );
         yoyEU.linkTo(pYTSEU);
 
         // price data


### PR DESCRIPTION
In some cases, this requires passing the term structure to an instrument through a pricer; for instance,

    CPIBond bond(...);
    bond.setPricingEngine(ext::make_shared<DiscountingBondEngine>(discountCurve));

now also requires 

    setCouponPricer(bond.cashflows(), ext::make_shared<CPICouponPricer>(nominalTS));

since the nominal curve is no longer stored inside the inflation index passed to the bond.