### PR TITLE
Implement Bond::Price::Type parameter in Bond::yield() method

### DIFF
--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -205,14 +205,19 @@ namespace QuantLib {
                      Compounding comp,
                      Frequency freq,
                      Real accuracy,
-                     Size maxEvaluations) const {
+                     Size maxEvaluations,
+                     Real guess,
+                     Bond::Price::Type priceType) const {
         Real currentNotional = notional(settlementDate());
         if (currentNotional == 0.0)
             return 0.0;
 
-        return BondFunctions::yield(*this, cleanPrice(), dc, comp, freq,
+        Real price = priceType == Bond::Price::Clean ? cleanPrice() : dirtyPrice();
+
+        return BondFunctions::yield(*this, price, dc, comp, freq,
                                     settlementDate(),
-                                    accuracy, maxEvaluations);
+                                    accuracy, maxEvaluations,
+                                    guess, priceType);
     }
 
     Real Bond::cleanPrice(Rate y,
@@ -236,19 +241,22 @@ namespace QuantLib {
             + accruedAmount(settlement);
     }
 
-    Rate Bond::yield(Real cleanPrice,
+    Rate Bond::yield(Real price,
                      const DayCounter& dc,
                      Compounding comp,
                      Frequency freq,
                      Date settlement,
                      Real accuracy,
-                     Size maxEvaluations) const {
+                     Size maxEvaluations,
+                     Real guess,
+                     Bond::Price::Type priceType) const {
         Real currentNotional = notional(settlement);
         if (currentNotional == 0.0)
             return 0.0;
 
-        return BondFunctions::yield(*this, cleanPrice, dc, comp, freq,
-                                    settlement, accuracy, maxEvaluations);
+        return BondFunctions::yield(*this, price, dc, comp, freq,
+                                    settlement, accuracy, maxEvaluations,
+                                    guess, priceType);
     }
 
     Real Bond::accruedAmount(Date settlement) const {

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -170,7 +170,9 @@ namespace QuantLib {
                    Compounding comp,
                    Frequency freq,
                    Real accuracy = 1.0e-8,
-                   Size maxEvaluations = 100) const;
+                   Size maxEvaluations = 100,
+                   Real guess = 0.05,
+                   Bond::Price::Type priceType = Bond::Price::Clean) const;
 
         //! clean price given a yield and settlement date
         /*! The default bond settlement is used if no date is given. */
@@ -200,7 +202,9 @@ namespace QuantLib {
                    Frequency freq,
                    Date settlementDate = Date(),
                    Real accuracy = 1.0e-8,
-                   Size maxEvaluations = 100) const;
+                   Size maxEvaluations = 100,
+                   Real guess = 0.05,
+                   Bond::Price::Type priceType = Bond::Price::Clean) const;
 
         //! accrued amount at a given date
         /*! The default bond settlement is used if no date is given. */


### PR DESCRIPTION
This PR extends the previous work on `Bond::Price::Type` and adds the parameter to `Bond::yield()` methods