### PR TITLE
Iterative bootstrap - widen min, max in search and fall back

### DIFF
--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -130,7 +130,10 @@ namespace detail {
     : accuracy_(accuracy), minValue_(minValue), maxValue_(maxValue),
       maxAttempts_(maxAttempts), maxFactor_(maxFactor), minFactor_(minFactor), dontThrow_(dontThrow),
       dontThrowSteps_(dontThrowSteps), ts_(0), initialized_(false), validCurve_(false),
-      loopRequired_(Interpolator::global) {}
+      loopRequired_(Interpolator::global) {
+        QL_REQUIRE(maxFactor_ >= 1.0, "Expected that maxFactor would be at least 1.0 but got " << maxFactor_);
+        QL_REQUIRE(minFactor_ >= 1.0, "Expected that minFactor would be at least 1.0 but got " << minFactor_);
+    }
 
     template <class Curve>
     void IterativeBootstrap<Curve>::setup(Curve* ts) {

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -550,15 +550,6 @@ void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
     IterativeBootstrap<SPCurve> ibNoThrow(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0, true, 3);
     dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter, ibNoThrow);
     BOOST_CHECK_NO_THROW(dpts->survivalProbability(testDate));
-
-    for (const auto inst : instruments) {
-        Date latestDate = inst->latestDate();
-        Date pillarDate = inst->pillarDate();
-        Date latestRelevantDate = inst->latestRelevantDate();
-        Real sp = dpts->survivalProbability(pillarDate);
-        BOOST_TEST_MESSAGE(io::iso_date(latestDate) << "," << io::iso_date(pillarDate) << "," <<
-            io::iso_date(latestRelevantDate) << "," << std::fixed << std::setprecision(12) << sp);
-    }
 }
 
 

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -338,9 +338,13 @@ namespace {
 
         bool operator()(const Error& ex) {
             string errMsg(ex.what());
-            BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
-            BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
-            return errMsg.find(expMsg) != string::npos;
+            if (errMsg.find(expMsg) == string::npos) {
+                BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
+                BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
+                return false;
+            } else {
+                return true;
+            }
         }
 
         string expMsg;

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -24,6 +24,7 @@
 #include <ql/termstructures/credit/defaultprobabilityhelpers.hpp>
 #include <ql/termstructures/credit/flathazardrate.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/discountcurve.hpp>
 #include <ql/instruments/creditdefaultswap.hpp>
 #include <ql/pricingengines/credit/midpointcdsengine.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
@@ -31,13 +32,23 @@
 #include <ql/math/interpolations/loginterpolation.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/time/calendars/target.hpp>
+#include <ql/time/calendars/weekendsonly.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/utilities/dataformatters.hpp>
 #include <iomanip>
+#include <map>
+#include <string>
+#include <vector>
+#include <boost/assign/list_of.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
+using boost::assign::list_of;
+using boost::assign::map_list_of;
+using std::map;
+using std::vector;
+using std::string;
 
 void DefaultProbabilityCurveTest::testDefaultProbability() {
 
@@ -320,6 +331,21 @@ namespace {
         }
     }
 
+    // Used to check that the exception message contains the expected message string, expMsg.
+    struct ExpErrorPred {
+
+        ExpErrorPred(const string& msg) : expMsg(msg) {}
+
+        bool operator()(const Error& ex) {
+            string errMsg(ex.what());
+            BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
+            BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
+            return errMsg.find(expMsg) != string::npos;
+        }
+
+        string expMsg;
+    };
+
 }
 
 void DefaultProbabilityCurveTest::testFlatHazardConsistency() {
@@ -397,6 +423,144 @@ void DefaultProbabilityCurveTest::testUpfrontBootstrap() {
         BOOST_ERROR("Cash-flow settings improperly modified");
 }
 
+/* This test attempts to build a default curve from CDS spreads as of 1 Apr 2020. The spreads are real and from a 
+   distressed reference entity with an inverted CDS spread curve. Using the default IterativeBootstrap with no 
+   retries, the default curve building fails. Allowing retries, it expands the min survival probability bounds but 
+   still fails. We set dontThrow to true in IterativeBootstrap to use a fall back curve.
+*/
+void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
+
+    BOOST_TEST_MESSAGE("Testing iterative boostrap with retries...");
+
+    SavedSettings backup;
+
+    Date asof(1, Apr, 2020);
+    Settings::instance().evaluationDate() = asof;
+    Actual365Fixed tsDayCounter;
+
+    // USD discount curve built out of FedFunds OIS swaps.
+    vector<Date> usdCurveDates = list_of
+        (Date(1, Apr, 2020))
+        (Date(2, Apr, 2020))
+        (Date(14, Apr, 2020))
+        (Date(21, Apr, 2020))
+        (Date(28, Apr, 2020))
+        (Date(6, May, 2020))
+        (Date(5, Jun, 2020))
+        (Date(7, Jul, 2020))
+        (Date(5, Aug, 2020))
+        (Date(8, Sep, 2020))
+        (Date(7, Oct, 2020))
+        (Date(5, Nov, 2020))
+        (Date(7, Dec, 2020))
+        (Date(6, Jan, 2021))
+        (Date(5, Feb, 2021))
+        (Date(5, Mar, 2021))
+        (Date(7, Apr, 2021))
+        (Date(4, Apr, 2022))
+        (Date(3, Apr, 2023))
+        (Date(3, Apr, 2024))
+        (Date(3, Apr, 2025))
+        (Date(5, Apr, 2027))
+        (Date(3, Apr, 2030))
+        (Date(3, Apr, 2035))
+        (Date(3, Apr, 2040))
+        (Date(4, Apr, 2050));
+
+    vector<DiscountFactor> usdCurveDfs = list_of
+        (1.000000000)
+        (0.999955835)
+        (0.999931070)
+        (0.999914629)
+        (0.999902799)
+        (0.999887990)
+        (0.999825782)
+        (0.999764392)
+        (0.999709076)
+        (0.999647785)
+        (0.999594638)
+        (0.999536198)
+        (0.999483093)
+        (0.999419291)
+        (0.999379417)
+        (0.999324981)
+        (0.999262356)
+        (0.999575101)
+        (0.996135441)
+        (0.995228348)
+        (0.989366687)
+        (0.979271200)
+        (0.961150726)
+        (0.926265361)
+        (0.891640651)
+        (0.839314063);
+
+    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear>>(
+        usdCurveDates, usdCurveDfs, tsDayCounter));
+
+    // CDS spreads
+    map<Period, Rate> cdsSpreads = map_list_of
+        (6 * Months, 2.957980250)
+        (1 * Years, 3.076933100)
+        (2 * Years, 2.944524520)
+        (3 * Years, 2.844498960)
+        (4 * Years, 2.769234420)
+        (5 * Years, 2.713474100);
+    Real recoveryRate = 0.035;
+
+    // Conventions
+    Integer settlementDays = 1;
+    WeekendsOnly calendar;
+    Frequency frequency = Quarterly;
+    BusinessDayConvention paymentConvention = Following;
+    DateGeneration::Rule rule = DateGeneration::CDS2015;
+    Actual360 dayCounter;
+    Actual360 lastPeriodDayCounter(true);
+
+    // Create the CDS spread helpers.
+    vector<ext::shared_ptr<DefaultProbabilityHelper>> instruments;
+    for (map<Period, Rate>::const_iterator it = cdsSpreads.begin(); it != cdsSpreads.end(); it++) {
+        instruments.push_back(ext::make_shared<SpreadCdsHelper>(it->second, it->first, settlementDays, calendar,
+            frequency, paymentConvention, rule, dayCounter, recoveryRate, usdYts, true, true, Date(),
+            lastPeriodDayCounter));
+    }
+
+    // Create the default curve with the default IterativeBootstrap.
+    typedef PiecewiseDefaultCurve<SurvivalProbability, LogLinear, IterativeBootstrap> SPCurve;
+    ext::shared_ptr<DefaultProbabilityTermStructure> dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter);
+
+    // Check that the default curve throws by requesting a default probability.
+    Date testDate(21, Dec, 2020);
+    BOOST_CHECK_EXCEPTION(dpts->survivalProbability(testDate), Error,
+        ExpErrorPred("1st iteration: failed at 1st alive instrument"));
+
+    // Create the default curve with an IterativeBootstrap allowing for 4 retries.
+    // Use a maxFactor value of 1.0 so that we still use the previous survival probability at each pillar. In other
+    // words, the survival probability cannot increase with time so best max at current pillar is the previous 
+    // pillar's value - there is no point increasing it on a retry.
+    IterativeBootstrap<SPCurve> ib(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0);
+    dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter, ib);
+
+    // Check that the default curve still throws. It throws at the third pillar because the survival probability is 
+    // too low at the second pillar.
+    BOOST_CHECK_EXCEPTION(dpts->survivalProbability(testDate), Error,
+        ExpErrorPred("1st iteration: failed at 3rd alive instrument"));
+
+    // Create the default curve with an IterativeBootstrap that allows for 4 retries and does not throw.
+    IterativeBootstrap<SPCurve> ibNoThrow(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0, true, 3);
+    dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter, ibNoThrow);
+    BOOST_CHECK_NO_THROW(dpts->survivalProbability(testDate));
+
+    for (const auto inst : instruments) {
+        Date latestDate = inst->latestDate();
+        Date pillarDate = inst->pillarDate();
+        Date latestRelevantDate = inst->latestRelevantDate();
+        Real sp = dpts->survivalProbability(pillarDate);
+        BOOST_TEST_MESSAGE(io::iso_date(latestDate) << "," << io::iso_date(pillarDate) << "," <<
+            io::iso_date(latestRelevantDate) << "," << std::fixed << std::setprecision(12) << sp);
+    }
+}
+
 
 test_suite* DefaultProbabilityCurveTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("Default-probability curve tests");
@@ -416,5 +580,7 @@ test_suite* DefaultProbabilityCurveTest::suite() {
                 &DefaultProbabilityCurveTest::testSingleInstrumentBootstrap));
     suite->add(QUANTLIB_TEST_CASE(
                          &DefaultProbabilityCurveTest::testUpfrontBootstrap));
+    suite->add(QUANTLIB_TEST_CASE(
+                &DefaultProbabilityCurveTest::testIterativeBootstrapRetries));
     return suite;
 }

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -547,7 +547,7 @@ void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
         ExpErrorPred("1st iteration: failed at 3rd alive instrument"));
 
     // Create the default curve with an IterativeBootstrap that allows for 4 retries and does not throw.
-    IterativeBootstrap<SPCurve> ibNoThrow(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0, true, 3);
+    IterativeBootstrap<SPCurve> ibNoThrow(Null<Real>(), Null<Real>(), Null<Real>(), 5, 1.0, 10.0, true, 2);
     dpts = ext::make_shared<SPCurve>(asof, instruments, tsDayCounter, ibNoThrow);
     BOOST_CHECK_NO_THROW(dpts->survivalProbability(testDate));
 }

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -334,7 +334,7 @@ namespace {
     // Used to check that the exception message contains the expected message string, expMsg.
     struct ExpErrorPred {
 
-        ExpErrorPred(const string& msg) : expMsg(msg) {}
+        explicit ExpErrorPred(const string& msg) : expMsg(msg) {}
 
         bool operator()(const Error& ex) {
             string errMsg(ex.what());
@@ -495,7 +495,7 @@ void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
         (0.891640651)
         (0.839314063);
 
-    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear>>(
+    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear> >(
         usdCurveDates, usdCurveDfs, tsDayCounter));
 
     // CDS spreads
@@ -518,11 +518,12 @@ void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
     Actual360 lastPeriodDayCounter(true);
 
     // Create the CDS spread helpers.
-    vector<ext::shared_ptr<DefaultProbabilityHelper>> instruments;
-    for (map<Period, Rate>::const_iterator it = cdsSpreads.begin(); it != cdsSpreads.end(); it++) {
-        instruments.push_back(ext::make_shared<SpreadCdsHelper>(it->second, it->first, settlementDays, calendar,
-            frequency, paymentConvention, rule, dayCounter, recoveryRate, usdYts, true, true, Date(),
-            lastPeriodDayCounter));
+    vector<ext::shared_ptr<DefaultProbabilityHelper> > instruments;
+    for (map<Period, Rate>::const_iterator it = cdsSpreads.begin(); it != cdsSpreads.end(); ++it) {
+        instruments.push_back(ext::shared_ptr<SpreadCdsHelper>(
+            new SpreadCdsHelper(it->second, it->first, settlementDays, calendar,
+                                frequency, paymentConvention, rule, dayCounter, recoveryRate, usdYts, true, true, Date(),
+                                lastPeriodDayCounter)));
     }
 
     // Create the default curve with the default IterativeBootstrap.

--- a/test-suite/defaultprobabilitycurves.hpp
+++ b/test-suite/defaultprobabilitycurves.hpp
@@ -36,6 +36,7 @@ class DefaultProbabilityCurveTest {
     static void testLogLinearSurvivalConsistency();
     static void testSingleInstrumentBootstrap();
     static void testUpfrontBootstrap();
+    static void testIterativeBootstrapRetries();
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -52,9 +52,18 @@
 #include <ql/pricingengines/bond/discountingbondengine.hpp>
 #include <ql/pricingengines/swap/discountingswapengine.hpp>
 #include <iomanip>
+#include <map>
+#include <string>
+#include <vector>
+#include <boost/assign/list_of.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
+using boost::assign::list_of;
+using boost::assign::map_list_of;
+using std::map;
+using std::vector;
+using std::string;
 
 namespace piecewise_yield_curve_test {
 
@@ -629,6 +638,21 @@ namespace piecewise_yield_curve_test {
             }
         }
     }
+
+    // Used to check that the exception message contains the expected message string, expMsg.
+    struct ExpErrorPred {
+
+        ExpErrorPred(const string& msg) : expMsg(msg) {}
+
+        bool operator()(const Error& ex) {
+            string errMsg(ex.what());
+            BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
+            BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
+            return errMsg.find(expMsg) != string::npos;
+        }
+
+        string expMsg;
+    };
 
 }
 
@@ -1364,6 +1388,112 @@ void PiecewiseYieldCurveTest::testGlobalBootstrap() {
     }
 }
 
+/* This test attempts to build an ARS collateralised in USD curve as of 25 Sep 2019. Using the default 
+   IterativeBootstrap with no retries, the yield curve building fails. Allowing retries, it expands the min and max 
+   bounds and passes.
+*/
+void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
+
+    BOOST_TEST_MESSAGE("Testing iterative boostrap with retries...");
+
+    SavedSettings backup;
+
+    Date asof(25, Sep, 2019);
+    Settings::instance().evaluationDate() = asof;
+    Actual365Fixed tsDayCounter;
+
+    // USD discount curve built out of FedFunds OIS swaps.
+    vector<Date> usdCurveDates = list_of
+        (Date(25, Sep, 2019))
+        (Date(26, Sep, 2019))
+        (Date(8, Oct, 2019))
+        (Date(16, Oct, 2019))
+        (Date(22, Oct, 2019))
+        (Date(30, Oct, 2019))
+        (Date(2, Dec, 2019))
+        (Date(31, Dec, 2019))
+        (Date(29, Jan, 2020))
+        (Date(2, Mar, 2020))
+        (Date(31, Mar, 2020))
+        (Date(29, Apr, 2020))
+        (Date(29, May, 2020))
+        (Date(1, Jul, 2020))
+        (Date(29, Jul, 2020))
+        (Date(31, Aug, 2020))
+        (Date(30, Sep, 2020));
+
+    vector<DiscountFactor> usdCurveDfs = list_of
+        (1.000000000)
+        (0.999940837)
+        (0.999309357)
+        (0.998894646)
+        (0.998574816)
+        (0.998162528)
+        (0.996552511)
+        (0.995197584)
+        (0.993915264)
+        (0.992530008)
+        (0.991329696)
+        (0.990179606)
+        (0.989005698)
+        (0.987751691)
+        (0.986703371)
+        (0.985495036)
+        (0.984413446);
+
+    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear>>(
+        usdCurveDates, usdCurveDfs, tsDayCounter));
+
+    // USD/ARS forward points
+    Handle<Quote> arsSpot(ext::make_shared<SimpleQuote>(56.881));
+    map<Period, Real> arsFwdPoints = map_list_of
+        (1 * Months, 8.5157)
+        (2 * Months, 12.7180)
+        (3 * Months, 17.8310)
+        (6 * Months, 30.3680)
+        (9 * Months, 45.5520)
+        (1 * Years, 60.7370);
+
+    // Create the FX swap rate helpers for the ARS in USD curve.
+    vector<ext::shared_ptr<RateHelper>> instruments;
+    for (map<Period, Real>::const_iterator it = arsFwdPoints.begin(); it != arsFwdPoints.end(); it++) {
+        Handle<Quote> arsFwd(ext::make_shared<SimpleQuote>(it->second));
+        instruments.push_back(ext::make_shared<FxSwapRateHelper>(arsFwd, arsSpot, it->first, 2,
+            UnitedStates(), Following, false, true, usdYts));
+    }
+
+    // Create the ARS in USD curve with the default IterativeBootstrap.
+    typedef PiecewiseYieldCurve<Discount, LogLinear, IterativeBootstrap> LLDFCurve;
+    ext::shared_ptr<YieldTermStructure> arsYts = ext::make_shared<LLDFCurve>(asof, instruments, tsDayCounter);
+
+    // USD/ARS spot date. The date on which we check the ARS discount curve.
+    Date spotDate(27, Sep, 2019);
+
+    // Check that the ARS in USD curve throws by requesting a discount factor.
+    using piecewise_yield_curve_test::ExpErrorPred;
+    BOOST_CHECK_EXCEPTION(arsYts->discount(spotDate), Error,
+        ExpErrorPred("1st iteration: failed at 1st alive instrument"));
+
+    // Create the ARS in USD curve with an IterativeBootstrap allowing for 4 retries.
+    IterativeBootstrap<LLDFCurve> ib(Null<Real>(), Null<Real>(), Null<Real>(), 5);
+    arsYts = ext::make_shared<LLDFCurve>(asof, instruments, tsDayCounter, ib);
+    
+    // Check that the ARS in USD curve builds and populate the spot ARS discount factor.
+    DiscountFactor spotDfArs;
+    BOOST_REQUIRE_NO_THROW(spotDfArs = arsYts->discount(spotDate));
+
+    // Additional dates and discount factors used in the final check i.e. that calculated 1Y FX forward equals input.
+    Date oneYearFwdDate(28, Sep, 2020);
+    DiscountFactor spotDfUsd = usdYts->discount(spotDate);
+    DiscountFactor oneYearDfUsd = usdYts->discount(oneYearFwdDate);
+
+    // Given that the ARS in USD curve builds, check that the 1Y USD/ARS forward rate is as expected.
+    DiscountFactor oneYearDfArs = arsYts->discount(oneYearFwdDate);
+    Real calcFwd = (spotDfArs * arsSpot->value() / oneYearDfArs) / (spotDfUsd / oneYearDfUsd);
+    Real expFwd = arsSpot->value() + arsFwdPoints.at(1 * Years);
+    BOOST_CHECK_SMALL(calcFwd - expFwd, 1e-10);
+}
+
 test_suite* PiecewiseYieldCurveTest::suite() {
 
     test_suite* suite = BOOST_TEST_SUITE("Piecewise yield curve tests");
@@ -1418,6 +1548,8 @@ test_suite* PiecewiseYieldCurveTest::suite() {
 #ifndef QL_USE_INDEXED_COUPON
     suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testGlobalBootstrap));
 #endif
+
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testIterativeBootstrapRetries));
 
     return suite;
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -642,7 +642,7 @@ namespace piecewise_yield_curve_test {
     // Used to check that the exception message contains the expected message string, expMsg.
     struct ExpErrorPred {
 
-        ExpErrorPred(const string& msg) : expMsg(msg) {}
+        explicit ExpErrorPred(const string& msg) : expMsg(msg) {}
 
         bool operator()(const Error& ex) {
             string errMsg(ex.what());
@@ -1441,7 +1441,7 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
         (0.985495036)
         (0.984413446);
 
-    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear>>(
+    Handle<YieldTermStructure> usdYts(ext::make_shared<InterpolatedDiscountCurve<LogLinear> >(
         usdCurveDates, usdCurveDfs, tsDayCounter));
 
     // USD/ARS forward points
@@ -1455,8 +1455,8 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
         (1 * Years, 60.7370);
 
     // Create the FX swap rate helpers for the ARS in USD curve.
-    vector<ext::shared_ptr<RateHelper>> instruments;
-    for (map<Period, Real>::const_iterator it = arsFwdPoints.begin(); it != arsFwdPoints.end(); it++) {
+    vector<ext::shared_ptr<RateHelper> > instruments;
+    for (map<Period, Real>::const_iterator it = arsFwdPoints.begin(); it != arsFwdPoints.end(); ++it) {
         Handle<Quote> arsFwd(ext::make_shared<SimpleQuote>(it->second));
         instruments.push_back(ext::make_shared<FxSwapRateHelper>(arsFwd, arsSpot, it->first, 2,
             UnitedStates(), Following, false, true, usdYts));

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1479,7 +1479,7 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
     arsYts = ext::make_shared<LLDFCurve>(asof, instruments, tsDayCounter, ib);
     
     // Check that the ARS in USD curve builds and populate the spot ARS discount factor.
-    DiscountFactor spotDfArs;
+    DiscountFactor spotDfArs = 1.0;
     BOOST_REQUIRE_NO_THROW(spotDfArs = arsYts->discount(spotDate));
 
     // Additional dates and discount factors used in the final check i.e. that calculated 1Y FX forward equals input.

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -646,9 +646,13 @@ namespace piecewise_yield_curve_test {
 
         bool operator()(const Error& ex) {
             string errMsg(ex.what());
-            BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
-            BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
-            return errMsg.find(expMsg) != string::npos;
+            if (errMsg.find(expMsg) == string::npos) {
+                BOOST_TEST_MESSAGE("Error expected to contain: '" << expMsg << "'.");
+                BOOST_TEST_MESSAGE("Actual error is: '" << errMsg << "'.");
+                return false;
+            } else {
+                return true;
+            }
         }
 
         string expMsg;

--- a/test-suite/piecewiseyieldcurve.hpp
+++ b/test-suite/piecewiseyieldcurve.hpp
@@ -59,6 +59,8 @@ class PiecewiseYieldCurveTest {
 
     static void testGlobalBootstrap();
 
+    static void testIterativeBootstrapRetries();
+
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
This pull request proposes two separate features for the `IterativeBootstrap` class:
1. ability to retry on failure at each pillar, up to a maximum number of attempts, with a possible widening of the minimum and maximum on each retry.
2. a flag that allows the bootstrap to not throw and fall back on the _best_ result between the minimum and maximum value at each pillar.

For 1 above, the parameters `maxAttempts`, `maxFactor` and `minFactor` are relevant. If `maxAttempts` is set to `1`, which is its default value, the bootstrap behaves exactly as before and there are no retries at each pillar. If `maxAttempts` is greater than `1`, say `n`, the search for a root at each pillar during the bootstrap can be attempted up to `n` times. On each successive attempt, the search area from minimum to maximum is widened using `minFactor` and `maxFactor` respectively. If the previous minimum was negative, it is multiplied by `minFactor` and if it was positive it is divided by `minFactor`. Similarly, if the previous maximum was negative, it is divided by `maxFactor` and if it was positive it is multiplied by `maxFactor`. The unit test `PiecewiseYieldCurveTest::testIterativeBootstrapRetries()` uses this to bootstrap an ARS collateralised in USD curve as of 25 Sep 2019.

For 2 above, the parameters `dontThrow` and `dontThrowSteps` are relevant. If `dontThrow` is `false`, which is its default value, the bootstrap behaves exactly as before and if the bootstrap fails an error is thrown. If `dontThrow` is `true`, and the search for a root at a pillar fails, after possibly retrying, the value that gives the lowest helper error, between the minimum and maximum value inclusive, at that pillar is used and the bootstrap proceeds to the next pillar. The `dontThrowSteps` parameter is the number of steps used in the search for the value that gives the lowest helper error. In some cases, e.g. CDS spread helper and a survival probability curve, the relationship is monotone so the value will the minimum or maximum value itself. The unit test `DefaultProbabilityCurveTest::testIterativeBootstrapRetries()` uses this, and the retries in 1, on a distressed CDS curve that fails to bootstrap from the 3rd pillar (2Y) out. We see quite a number of CDS curves like this and it is desirable for the bootstrap to pass in this approximate manner, log the bootstrap error sizes and process the CDS or basket trade as opposed to having a failure and none of the dependent trades being processed. It also proves useful when there is a kink in a cap/floor volatility surface and an `IterativeBootstrap`-based optionlet stripping is allowed to continue.