### PR TITLE
Black vasicek pricing engine

### DIFF
--- a/Examples/EquityOption/EquityOption.cpp
+++ b/Examples/EquityOption/EquityOption.cpp
@@ -32,9 +32,10 @@
 #include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/mceuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/mcamericanengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanvasicekengine.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/utilities/dataformatters.hpp>
-
+#include <ql/models/shortrate/onefactormodels/vasicek.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -139,6 +140,24 @@ int main(int, char* []) {
         method = "Black-Scholes";
         europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
                                      new AnalyticEuropeanEngine(bsmProcess)));
+        std::cout << std::setw(widths[0]) << std::left << method
+                  << std::fixed
+                  << std::setw(widths[1]) << std::left << europeanOption.NPV()
+                  << std::setw(widths[2]) << std::left << "N/A"
+                  << std::setw(widths[3]) << std::left << "N/A"
+                  << std::endl;
+
+        //Vasicek rates model for European
+        method = "Black Vasicek Model";
+        Real r0 = riskFreeRate;
+        Real a = 0.3;
+        Real b = 0.3;
+        Real sigma_r = 0.15;
+        Real riskPremium = 0.0;
+        Real correlation = 0.5;
+        ext::shared_ptr<Vasicek> vasicekProcess(new Vasicek(r0, a, b, sigma_r, riskPremium));
+        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new AnalyticBlackVasicekEngine(bsmProcess, vasicekProcess, correlation)));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()

--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1533,6 +1533,7 @@
     <ClInclude Include="ql\pricingengines\vanilla\analyticdigitalamericanengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\analyticdividendeuropeanengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\analyticeuropeanengine.hpp" />
+    <ClInclude Include="ql\pricingengines\vanilla\analyticeuropeanvasicekengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\analyticgjrgarchengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\analytich1hwengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\analytichestonengine.hpp" />
@@ -2537,6 +2538,7 @@
     <ClCompile Include="ql\pricingengines\vanilla\analyticdigitalamericanengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\analyticdividendeuropeanengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\analyticeuropeanengine.cpp" />
+    <ClCompile Include="ql\pricingengines\vanilla\analyticeuropeanvasicekengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\analyticgjrgarchengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\analytich1hwengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\analytichestonengine.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2400,6 +2400,9 @@
     <ClInclude Include="ql\pricingengines\vanilla\analyticeuropeanengine.hpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\vanilla\analyticeuropeanvasicekengine.hpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClInclude>
     <ClInclude Include="ql\pricingengines\vanilla\analyticgjrgarchengine.hpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
@@ -5533,6 +5536,9 @@
       <Filter>pricingengines\vanilla</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\vanilla\analyticeuropeanengine.cpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\pricingengines\vanilla\analyticeuropeanvasicekengine.cpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\vanilla\analyticgjrgarchengine.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -706,6 +706,7 @@ set(QuantLib_SRC
     pricingengines/vanilla/analyticdigitalamericanengine.cpp
     pricingengines/vanilla/analyticdividendeuropeanengine.cpp
     pricingengines/vanilla/analyticeuropeanengine.cpp
+    pricingengines/vanilla/analyticeuropeanvasicekengine.cpp
     pricingengines/vanilla/analyticgjrgarchengine.cpp
     pricingengines/vanilla/analytich1hwengine.cpp
     pricingengines/vanilla/analytichestonengine.cpp
@@ -1963,6 +1964,7 @@ set(QuantLib_HDR
     pricingengines/vanilla/analyticdigitalamericanengine.hpp
     pricingengines/vanilla/analyticdividendeuropeanengine.hpp
     pricingengines/vanilla/analyticeuropeanengine.hpp
+    pricingengines/vanilla/analyticeuropeanvasicekengine.hpp
     pricingengines/vanilla/analyticgjrgarchengine.hpp
     pricingengines/vanilla/analytich1hwengine.hpp
     pricingengines/vanilla/analytichestonengine.hpp

--- a/ql/models/shortrate/onefactormodels/vasicek.hpp
+++ b/ql/models/shortrate/onefactormodels/vasicek.hpp
@@ -55,6 +55,7 @@ namespace QuantLib {
         Real b() const { return b_(0.0); }
         Real lambda() const { return lambda_(0.0); }
         Real sigma() const { return sigma_(0.0); }
+        Real r0() const { return r0_;}
 
       protected:
         virtual Real A(Time t, Time T) const;

--- a/ql/pricingengines/vanilla/Makefile.am
+++ b/ql/pricingengines/vanilla/Makefile.am
@@ -8,6 +8,7 @@ this_include_HEADERS = \
     analyticdigitalamericanengine.hpp \
     analyticdividendeuropeanengine.hpp \
     analyticeuropeanengine.hpp \
+    analyticeuropeanvasicekengine.hpp \
     analyticcevengine.hpp \
     analyticgjrgarchengine.hpp \
     analytich1hwengine.hpp \
@@ -56,6 +57,7 @@ cpp_files = \
     analyticdigitalamericanengine.cpp \
     analyticdividendeuropeanengine.cpp \
     analyticeuropeanengine.cpp \
+    analyticeuropeanvasicekengine.cpp \
     analyticcevengine.cpp \
     analyticgjrgarchengine.cpp \
     analytich1hwengine.cpp \

--- a/ql/pricingengines/vanilla/all.hpp
+++ b/ql/pricingengines/vanilla/all.hpp
@@ -5,6 +5,7 @@
 #include <ql/pricingengines/vanilla/analyticdigitalamericanengine.hpp>
 #include <ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanvasicekengine.hpp>
 #include <ql/pricingengines/vanilla/analyticcevengine.hpp>
 #include <ql/pricingengines/vanilla/analyticgjrgarchengine.hpp>
 #include <ql/pricingengines/vanilla/analytich1hwengine.hpp>

--- a/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.cpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.cpp
@@ -1,0 +1,89 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/exercise.hpp>
+#include <boost/function.hpp>
+#include <ql/math/integrals/simpsonintegral.hpp>
+#include "analyticeuropeanvasicekengine.hpp"
+#include <ql/math/distributions/normaldistribution.hpp>
+
+namespace QuantLib {
+
+    Real g_k(Real t, Real kappa){
+        return (1 - std::exp(- kappa * t )) / kappa;
+    }
+
+    class integrand_vasicek {
+    private:
+        const Real sigma_s_;
+        const Real sigma_r_;
+        const Real correlation_;
+        const Real kappa_;
+        const Real T_;
+    public:
+        integrand_vasicek(Real sigma_s, Real sigma_r, Real correlation, Real kappa, Real T)
+                : sigma_s_(sigma_s), sigma_r_(sigma_r), correlation_(correlation), kappa_(kappa), T_(T){}
+        Real operator()(Real u) const {
+            Real g = g_k(T_ - u, kappa_);
+            return (sigma_s_ * sigma_s_) + (2 * correlation_ * sigma_s_ * sigma_r_ * g) + (sigma_r_ * sigma_r_ * g * g);
+        }
+    };
+
+    AnalyticBlackVasicekEngine::AnalyticBlackVasicekEngine(
+            const ext::shared_ptr<GeneralizedBlackScholesProcess>& blackProcess,
+            const ext::shared_ptr<Vasicek>& vasicekProcess,
+            Real correlation)
+    : blackProcess_(blackProcess), vasicekProcess_(vasicekProcess), simpsonIntegral_(new SimpsonIntegral(1e-5, 1000)), correlation_(correlation) {
+        registerWith(blackProcess_);
+        registerWith(vasicekProcess_);
+    }
+
+    void AnalyticBlackVasicekEngine::calculate() const {
+        QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
+                   "not an European option");
+
+        ext::shared_ptr<StrikedTypePayoff> payoff =
+                ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
+
+        QL_REQUIRE(payoff, "non-striked payoff given");
+
+        CumulativeNormalDistribution f;
+
+        Real t = 0;
+        Real T = blackProcess_->riskFreeRate().currentLink()->dayCounter().yearFraction(blackProcess_->riskFreeRate().currentLink()->referenceDate(),arguments_.exercise->lastDate());
+        Real kappa = vasicekProcess_->a();
+        Real S_t = blackProcess_->x0();
+        Real K = payoff->strike();
+        Real sigma_s = blackProcess_->blackVolatility()->blackVol(t, K);
+        Real sigma_r = vasicekProcess_->sigma();
+        Real r_t = vasicekProcess_->r0();
+
+        Real zcb = vasicekProcess_->discountBond(t, T, r_t);
+        Real epsilon = payoff->optionType() == Option::Call ? 1 : -1;
+        Real upsilon = (*simpsonIntegral_)(integrand_vasicek(sigma_s, sigma_r, correlation_, kappa, T), t, T);
+        Real d_positive = (std::log((S_t / K) / zcb) + upsilon / 2) / std::sqrt(upsilon);
+        Real d_negative = (std::log((S_t / K) / zcb) - upsilon / 2) / std::sqrt(upsilon);
+        Real n_d1 = f(epsilon * d_positive);
+        Real n_d2 = f(epsilon * d_negative);
+
+        results_.value = epsilon * ((S_t * n_d1) - (zcb * K * n_d2));
+    }
+
+}
+

--- a/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.cpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.cpp
@@ -25,25 +25,29 @@
 
 namespace QuantLib {
 
-    Real g_k(Real t, Real kappa){
-        return (1 - std::exp(- kappa * t )) / kappa;
-    }
+    namespace {
 
-    class integrand_vasicek {
-    private:
-        const Real sigma_s_;
-        const Real sigma_r_;
-        const Real correlation_;
-        const Real kappa_;
-        const Real T_;
-    public:
-        integrand_vasicek(Real sigma_s, Real sigma_r, Real correlation, Real kappa, Real T)
-                : sigma_s_(sigma_s), sigma_r_(sigma_r), correlation_(correlation), kappa_(kappa), T_(T){}
-        Real operator()(Real u) const {
-            Real g = g_k(T_ - u, kappa_);
-            return (sigma_s_ * sigma_s_) + (2 * correlation_ * sigma_s_ * sigma_r_ * g) + (sigma_r_ * sigma_r_ * g * g);
+        Real g_k(Real t, Real kappa){
+            return (1 - std::exp(- kappa * t )) / kappa;
         }
-    };
+
+        class integrand_vasicek {
+          private:
+            const Real sigma_s_;
+            const Real sigma_r_;
+            const Real correlation_;
+            const Real kappa_;
+            const Real T_;
+          public:
+            integrand_vasicek(Real sigma_s, Real sigma_r, Real correlation, Real kappa, Real T)
+            : sigma_s_(sigma_s), sigma_r_(sigma_r), correlation_(correlation), kappa_(kappa), T_(T){}
+            Real operator()(Real u) const {
+                Real g = g_k(T_ - u, kappa_);
+                return (sigma_s_ * sigma_s_) + (2 * correlation_ * sigma_s_ * sigma_r_ * g) + (sigma_r_ * sigma_r_ * g * g);
+            }
+        };
+
+    }
 
     AnalyticBlackVasicekEngine::AnalyticBlackVasicekEngine(
             const ext::shared_ptr<GeneralizedBlackScholesProcess>& blackProcess,
@@ -66,7 +70,7 @@ namespace QuantLib {
         CumulativeNormalDistribution f;
 
         Real t = 0;
-        Real T = blackProcess_->riskFreeRate().currentLink()->dayCounter().yearFraction(blackProcess_->riskFreeRate().currentLink()->referenceDate(),arguments_.exercise->lastDate());
+        Real T = blackProcess_->riskFreeRate()->dayCounter().yearFraction(blackProcess_->riskFreeRate().currentLink()->referenceDate(),arguments_.exercise->lastDate());
         Real kappa = vasicekProcess_->a();
         Real S_t = blackProcess_->x0();
         Real K = payoff->strike();

--- a/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.hpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanvasicekengine.hpp
@@ -1,0 +1,54 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_analytic_black_vasicek_engine_hpp
+#define quantlib_analytic_black_vasicek_engine_hpp
+
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/models/shortrate/onefactormodels/vasicek.hpp>
+#include <ql/math/integrals/integral.hpp>
+
+namespace QuantLib {
+
+    /**
+     *
+     * Pricing of Vanilla European options under stochastic Vasicek interest rate model
+     * Analytical solution is based on following research paper:
+     *
+     * http://hsrm-mathematik.de/WS201516/master/option-pricing/Black-Scholes-Vasicek-Model.pdf
+     */
+
+    class AnalyticBlackVasicekEngine : public VanillaOption::engine {
+      public:
+        AnalyticBlackVasicekEngine(
+                    const ext::shared_ptr<GeneralizedBlackScholesProcess>&,
+                    const ext::shared_ptr<Vasicek>&,
+                    Real correlation);
+        void calculate() const;
+      private:
+        ext::shared_ptr<GeneralizedBlackScholesProcess> blackProcess_;
+        ext::shared_ptr<Vasicek> vasicekProcess_;
+        ext::shared_ptr<Integrator> simpsonIntegral_;
+        Real correlation_;
+    };
+
+}
+
+#endif


### PR DESCRIPTION
This pull request is to add an analytical pricing engine for vanilla via the Vasicek interest rate model.

Analytical formula is based on the following research paper
http://hsrm-mathematik.de/WS201516/master/option-pricing/Black-Scholes-Vasicek-Model.pdf

Example usage has been added under EquityOption.cpp

