### PR TITLE
Get bind placeholders from boost::placeholders namespace.

### DIFF
--- a/ql/functional.hpp
+++ b/ql/functional.hpp
@@ -34,7 +34,7 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 #include <boost/function.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/ref.hpp>
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
@@ -59,6 +59,9 @@ namespace QuantLib {
         using boost::ref;
         using boost::cref;
         namespace placeholders {
+            #if BOOST_VERSION >= 106000
+            using namespace boost::placeholders;
+            #else
             using ::_1;
             using ::_2;
             using ::_3;
@@ -68,6 +71,7 @@ namespace QuantLib {
             using ::_7;
             using ::_8;
             using ::_9;
+            #endif
         }
         #endif
 

--- a/ql/patterns/observable.cpp
+++ b/ql/patterns/observable.cpp
@@ -96,7 +96,13 @@ namespace QuantLib {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
-#include <boost/bind.hpp>
+
+#if !defined(BOOST_BIND_NO_PLACEHOLDERS)
+#define BOOST_BIND_NO_PLACEHOLDERS
+#include <boost/bind/bind.hpp>
+#undef BOOST_BIND_NO_PLACEHOLDERS
+#endif
+
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Since version 1.60, bind placeholders (`_1`, `_2` etc.) are defined in the `boost::placeholders` namespace.  This avoid a deprecation note when including the `<boost/bind.hpp>`, which imports them in the global namespace.