### PR TITLE
Use lcov and Coveralls action to produce and upload a coverage file.

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -33,8 +33,3 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./coverage/lcov.info
-    - name: Upload coverage to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run:
-        bash <(curl -s https://codecov.io/bash) -y .codecov.yml -X gcov -f '!*usr*.gcov'

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,8 +1,5 @@
 name: Coverage report
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -11,26 +8,31 @@ jobs:
     - name: Setup
       run: |
         sudo apt install -y lcov libboost-all-dev
-        pip install --user wheel
-        pip install --user cpp-coveralls
     - name: Compile
       run: |
         ./autogen.sh
         ./configure --disable-shared CXXFLAGS='-O1 -fprofile-arcs -ftest-coverage' LDFLAGS='-lgcov'
         make -j 2
+    - name: Capture baseline
+      run: |
+        mkdir -p coverage tmp
+        lcov --no-external --capture --initial --directory . --output-file ./tmp/lcov_base.info
     - name: Run tests
       run: |
         ./test-suite/quantlib-test-suite --log_level=message
     - name: Run examples
       run: |
         make -C Examples check-examples
-    - name: Upload coverage to Coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALL_TOKEN }}
-        TRAVIS_JOB_ID: "#${{ github.run_id }}"
+    - name: Capture coverage
       run: |
-        echo "service_name: github-actions" > .coveralls.yml
-        ~/.local/bin/coveralls --exclude Examples --exclude test-suite --exclude CMakeFiles --gcov-options '\-lp'
+        lcov --no-external --capture --directory . --output-file ./tmp/lcov_run.info
+        lcov --add-tracefile ./tmp/lcov_base.info --add-tracefile ./tmp/lcov_run.info --output-file ./tmp/lcov_total.info
+        lcov --remove ./tmp/lcov_total.info "$PWD/Examples/*" "$PWD/test-suite/*" --output-file ./coverage/lcov.info
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./coverage/lcov.info
     - name: Upload coverage to Codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Another test PR to check integration with Coveralls.