### PR TITLE
Finite Difference Engine for Option under CoxIngersollRoss Short Rate Process

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1175,6 +1175,7 @@
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmg2op.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmhestonhullwhiteop.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmhestonop.hpp" />
+    <ClInclude Include="ql\methods\finitedifferences\operators\fdmcirop.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmhullwhiteop.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmlinearop.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmlinearopcomposite.hpp" />
@@ -1218,6 +1219,7 @@
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmg2solver.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmhestonhullwhitesolver.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmhestonsolver.hpp" />
+    <ClInclude Include="ql\methods\finitedifferences\solvers\fdmcirsolver.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmhullwhitesolver.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmndimsolver.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmsimple2dbssolver.hpp" />
@@ -1569,6 +1571,7 @@
     <ClInclude Include="ql\pricingengines\vanilla\fdsimplebsswingengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\fdstepconditionengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\fdvanillaengine.hpp" />
+    <ClInclude Include="ql\pricingengines\vanilla\fdcirvanillaengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\hestonexpansionengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\integralengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\jumpdiffusionengine.hpp" />
@@ -1583,6 +1586,7 @@
     <ClInclude Include="ql\processes\all.hpp" />
     <ClInclude Include="ql\processes\batesprocess.hpp" />
     <ClInclude Include="ql\processes\blackscholesprocess.hpp" />
+    <ClInclude Include="ql\processes\coxingersollrossprocess.hpp" />
     <ClInclude Include="ql\processes\endeulerdiscretization.hpp" />
     <ClInclude Include="ql\processes\eulerdiscretization.hpp" />
     <ClInclude Include="ql\processes\forwardmeasureprocess.hpp" />
@@ -2293,6 +2297,7 @@
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmg2op.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmhestonhullwhiteop.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmhestonop.cpp" />
+    <ClCompile Include="ql\methods\finitedifferences\operators\fdmcirop.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmhullwhiteop.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmlinearoplayout.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmlocalvolfwdop.cpp" />
@@ -2323,6 +2328,7 @@
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmg2solver.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmhestonhullwhitesolver.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmhestonsolver.cpp" />
+    <ClCompile Include="ql\methods\finitedifferences\solvers\fdmcirsolver.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmhullwhitesolver.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmsimple2dbssolver.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\stepconditions\fdmamericanstepcondition.cpp" />
@@ -2565,6 +2571,7 @@
     <ClCompile Include="ql\pricingengines\vanilla\fdsabrvanillaengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\fdsimplebsswingengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\fdvanillaengine.cpp" />
+    <ClCompile Include="ql\pricingengines\vanilla\fdcirvanillaengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\hestonexpansionengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\integralengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\jumpdiffusionengine.cpp" />
@@ -2574,6 +2581,7 @@
     <ClCompile Include="ql\pricingengines\vanilla\mchestonhullwhiteengine.cpp" />
     <ClCompile Include="ql\processes\batesprocess.cpp" />
     <ClCompile Include="ql\processes\blackscholesprocess.cpp" />
+    <ClCompile Include="ql\processes\coxingersollrossprocess.cpp" />
     <ClCompile Include="ql\processes\endeulerdiscretization.cpp" />
     <ClCompile Include="ql\processes\eulerdiscretization.cpp" />
     <ClCompile Include="ql\processes\forwardmeasureprocess.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2241,6 +2241,9 @@
     <ClInclude Include="ql\processes\blackscholesprocess.hpp">
       <Filter>processes</Filter>
     </ClInclude>
+    <ClInclude Include="ql\processes\coxingersollrossprocess.hpp">
+      <Filter>processes</Filter>
+    </ClInclude>
     <ClInclude Include="ql\processes\endeulerdiscretization.hpp">
       <Filter>processes</Filter>
     </ClInclude>
@@ -2260,6 +2263,9 @@
       <Filter>processes</Filter>
     </ClInclude>
     <ClInclude Include="ql\processes\hestonprocess.hpp">
+      <Filter>processes</Filter>
+    </ClInclude>
+    <ClInclude Include="ql\processes\coxingersollross.hpp">
       <Filter>processes</Filter>
     </ClInclude>
     <ClInclude Include="ql\processes\hullwhiteprocess.hpp">
@@ -3892,6 +3898,9 @@
     <ClInclude Include="ql\pricingengines\vanilla\fdhestonvanillaengine.hpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\vanilla\fdcirvanillaengine.hpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClInclude>
     <ClInclude Include="ql\methods\finitedifferences\meshers\fdm1dmesher.hpp">
       <Filter>methods\finitedifferences\meshers</Filter>
     </ClInclude>
@@ -3949,6 +3958,9 @@
     <ClInclude Include="ql\methods\finitedifferences\operators\fdmhestonop.hpp">
       <Filter>methods\finitedifferences\operators</Filter>
     </ClInclude>
+    <ClInclude Include="ql\methods\finitedifferences\operators\fdmcirop.hpp">
+      <Filter>methods\finitedifferences\operators</Filter>
+    </ClInclude>
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmbatessolver.hpp">
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClInclude>
@@ -3959,6 +3971,9 @@
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClInclude>
     <ClInclude Include="ql\methods\finitedifferences\solvers\fdmhestonsolver.hpp">
+      <Filter>methods\finitedifferences\solvers</Filter>
+    </ClInclude>
+    <ClInclude Include="ql\methods\finitedifferences\solvers\fdmcirsolver.hpp">
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClInclude>
     <ClInclude Include="ql\methods\finitedifferences\meshers\fdmblackscholesmesher.hpp">
@@ -5445,6 +5460,9 @@
     <ClCompile Include="ql\processes\blackscholesprocess.cpp">
       <Filter>processes</Filter>
     </ClCompile>
+    <ClCompile Include="ql\processes\coxingersollrossprocess.cpp">
+      <Filter>processes</Filter>
+    </ClCompile>
     <ClCompile Include="ql\processes\endeulerdiscretization.cpp">
       <Filter>processes</Filter>
     </ClCompile>
@@ -5464,6 +5482,9 @@
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\hestonprocess.cpp">
+      <Filter>processes</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\processes\coxingersollross.cpp">
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\hullwhiteprocess.cpp">
@@ -6621,6 +6642,9 @@
     <ClCompile Include="ql\pricingengines\vanilla\fdhestonvanillaengine.cpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClCompile>
+    <ClCompile Include="ql\pricingengines\vanilla\fdcirvanillaengine.cpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\operators\fdm2dblackscholesop.cpp">
       <Filter>methods\finitedifferences\operators</Filter>
     </ClCompile>
@@ -6666,6 +6690,9 @@
     <ClCompile Include="ql\methods\finitedifferences\operators\fdmhestonop.cpp">
       <Filter>methods\finitedifferences\operators</Filter>
     </ClCompile>
+    <ClCompile Include="ql\methods\finitedifferences\operators\fdmcirop.cpp">
+      <Filter>methods\finitedifferences\operators</Filter>
+    </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmbatessolver.cpp">
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClCompile>
@@ -6676,6 +6703,9 @@
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\solvers\fdmhestonsolver.cpp">
+      <Filter>methods\finitedifferences\solvers</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\methods\finitedifferences\solvers\fdmcirsolver.cpp">
       <Filter>methods\finitedifferences\solvers</Filter>
     </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\meshers\fdmblackscholesmesher.cpp">

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2265,9 +2265,6 @@
     <ClInclude Include="ql\processes\hestonprocess.hpp">
       <Filter>processes</Filter>
     </ClInclude>
-    <ClInclude Include="ql\processes\coxingersollross.hpp">
-      <Filter>processes</Filter>
-    </ClInclude>
     <ClInclude Include="ql\processes\hullwhiteprocess.hpp">
       <Filter>processes</Filter>
     </ClInclude>
@@ -5482,9 +5479,6 @@
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\hestonprocess.cpp">
-      <Filter>processes</Filter>
-    </ClCompile>
-    <ClCompile Include="ql\processes\coxingersollross.cpp">
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\hullwhiteprocess.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -453,6 +453,7 @@ set(QuantLib_SRC
     methods/finitedifferences/operators/fdmg2op.cpp
     methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
     methods/finitedifferences/operators/fdmhestonop.cpp
+    methods/finitedifferences/operators/fdmcirop.cpp
     methods/finitedifferences/operators/fdmhullwhiteop.cpp
     methods/finitedifferences/operators/fdmlinearoplayout.cpp
     methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
@@ -483,6 +484,7 @@ set(QuantLib_SRC
     methods/finitedifferences/solvers/fdmg2solver.cpp
     methods/finitedifferences/solvers/fdmhestonhullwhitesolver.cpp
     methods/finitedifferences/solvers/fdmhestonsolver.cpp
+    methods/finitedifferences/solvers/fdmcirsolver.cpp
     methods/finitedifferences/solvers/fdmhullwhitesolver.cpp
     methods/finitedifferences/solvers/fdmsimple2dbssolver.cpp
     methods/finitedifferences/stepconditions/fdmamericanstepcondition.cpp
@@ -722,6 +724,7 @@ set(QuantLib_SRC
     pricingengines/vanilla/exponentialfittinghestonengine.cpp
     pricingengines/vanilla/fdbatesvanillaengine.cpp
     pricingengines/vanilla/fdblackscholesvanillaengine.cpp
+    pricingengines/vanilla/fdcirvanillaengine.cpp
     pricingengines/vanilla/fdcevvanillaengine.cpp
     pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
     pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -752,6 +755,7 @@ set(QuantLib_SRC
     processes/merton76process.cpp
     processes/mfstateprocess.cpp
     processes/ornsteinuhlenbeckprocess.cpp
+    processes/coxingersollrossprocess.cpp
     processes/squarerootprocess.cpp
     processes/stochasticprocessarray.cpp
     quotes/eurodollarfuturesquote.cpp
@@ -1602,6 +1606,7 @@ set(QuantLib_HDR
     methods/finitedifferences/operators/fdmg2op.hpp
     methods/finitedifferences/operators/fdmhestonhullwhiteop.hpp
     methods/finitedifferences/operators/fdmhestonop.hpp
+    methods/finitedifferences/operators/fdmcirop.hpp
     methods/finitedifferences/operators/fdmhullwhiteop.hpp
     methods/finitedifferences/operators/fdmlinearop.hpp
     methods/finitedifferences/operators/fdmlinearopcomposite.hpp
@@ -1645,6 +1650,7 @@ set(QuantLib_HDR
     methods/finitedifferences/solvers/fdmg2solver.hpp
     methods/finitedifferences/solvers/fdmhestonhullwhitesolver.hpp
     methods/finitedifferences/solvers/fdmhestonsolver.hpp
+    methods/finitedifferences/solvers/fdmcirsolver.hpp
     methods/finitedifferences/solvers/fdmhullwhitesolver.hpp
     methods/finitedifferences/solvers/fdmndimsolver.hpp
     methods/finitedifferences/solvers/fdmsimple2dbssolver.hpp
@@ -1988,6 +1994,7 @@ set(QuantLib_HDR
     pricingengines/vanilla/fdbatesvanillaengine.hpp
     pricingengines/vanilla/fdbermudanengine.hpp
     pricingengines/vanilla/fdblackscholesvanillaengine.hpp
+    pricingengines/vanilla/fdcirvanillaengine.hpp
     pricingengines/vanilla/fdcevvanillaengine.hpp
     pricingengines/vanilla/fdconditions.hpp
     pricingengines/vanilla/fddividendamericanengine.hpp
@@ -2032,6 +2039,7 @@ set(QuantLib_HDR
     processes/merton76process.hpp
     processes/mfstateprocess.hpp
     processes/ornsteinuhlenbeckprocess.hpp
+    processes/coxingersollrossprocess.hpp
     processes/squarerootprocess.hpp
     processes/stochasticprocessarray.hpp
     qldefines.hpp

--- a/ql/methods/finitedifferences/operators/Makefile.am
+++ b/ql/methods/finitedifferences/operators/Makefile.am
@@ -11,6 +11,7 @@ this_include_HEADERS = \
 	fdmg2op.hpp \
 	fdmhestonhullwhiteop.hpp \
 	fdmhestonop.hpp \
+	fdmcirop.hpp \
 	fdmhullwhiteop.hpp \
 	fdmlinearopcomposite.hpp \
 	fdmlocalvolfwdop.hpp \
@@ -35,6 +36,7 @@ cpp_files = \
 	fdmg2op.cpp \
 	fdmhestonhullwhiteop.cpp \
 	fdmhestonop.cpp \
+	fdmcirop.cpp \
 	fdmhullwhiteop.cpp \
 	fdmlinearoplayout.cpp \
 	fdmlocalvolfwdop.cpp \

--- a/ql/methods/finitedifferences/operators/all.hpp
+++ b/ql/methods/finitedifferences/operators/all.hpp
@@ -8,6 +8,7 @@
 #include <ql/methods/finitedifferences/operators/fdmg2op.hpp>
 #include <ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.hpp>
 #include <ql/methods/finitedifferences/operators/fdmhestonop.hpp>
+#include <ql/methods/finitedifferences/operators/fdmcirop.hpp>
 #include <ql/methods/finitedifferences/operators/fdmhullwhiteop.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearopcomposite.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlocalvolfwdop.hpp>

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -1,0 +1,183 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
+#include <ql/methods/finitedifferences/operators/fdmcirop.hpp>
+#include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
+#include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
+#include <ql/methods/finitedifferences/operators/secondordermixedderivativeop.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+
+namespace QuantLib {
+
+    FdmCIREquityPart::FdmCIREquityPart(
+        const ext::shared_ptr<FdmMesher>& mesher,
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess,
+        Real strike)
+    : dxMap_ (FirstDerivativeOp(0, mesher)),
+      dxxMap_(SecondDerivativeOp(0, mesher)),
+      mapT_ (0, mesher),
+      mesher_(mesher),
+      qTS_(bsProcess->dividendYield().currentLink()),
+      strike_(strike),
+      sigma1_(bsProcess->blackVolatility().currentLink()){
+    }
+
+    void FdmCIREquityPart::setTime(Time t1, Time t2) {
+        const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
+
+        const Real v = sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1);
+
+        mapT_.axpyb(mesher_->locations(1) - q - 0.5*v, dxMap_,
+                        dxxMap_.mult(Array(mesher_->layout()->size(), v/2)), -0.5*mesher_->locations(1));
+    }
+
+    const TripleBandLinearOp& FdmCIREquityPart::getMap() const {
+        return mapT_;
+    }
+
+    FdmCIRRatesPart::FdmCIRRatesPart(
+        const ext::shared_ptr<FdmMesher>& mesher,
+        Real sigma, Real kappa, Real theta)
+    : dyMap_(SecondDerivativeOp(1, mesher)
+                   .mult(sigma*sigma*mesher->locations(1))
+                   .add(FirstDerivativeOp(1, mesher)
+                   .mult(kappa*(theta - mesher->locations(1))))),
+      mapT_(1, mesher),
+      mesher_(mesher){
+    }
+
+    void FdmCIRRatesPart::setTime(Time t1, Time t2) {
+        mapT_.axpyb(Array(), dyMap_, dyMap_, -0.5*mesher_->locations(1));
+    }
+
+    const TripleBandLinearOp& FdmCIRRatesPart::getMap() const {
+        return mapT_;
+    }
+
+    FdmCIRMixedPart::FdmCIRMixedPart(
+        const ext::shared_ptr<FdmMesher>& mesher,
+        const ext::shared_ptr<CoxIngersollRossProcess> & cirProcess,
+        const ext::shared_ptr<GeneralizedBlackScholesProcess> & bsProcess,
+        const Real rho,
+        const Real strike)
+        : dyMap_(SecondOrderMixedDerivativeOp(0, 1, mesher)
+                     .mult(Array(mesher->layout()->size(), 2*rho*cirProcess->volatility()))),
+          mapT_(0, 1, mesher),
+          mesher_(mesher),
+          sigma1_(bsProcess->blackVolatility().currentLink()),
+          strike_(strike){
+    }
+
+    void FdmCIRMixedPart::setTime(Time t1, Time t2) {
+        const Real v = std::sqrt(sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1));
+        NinePointLinearOp op(dyMap_.mult(Array(mesher_->layout()->size(), v)));
+        mapT_.swap(op);
+    }
+
+    const NinePointLinearOp& FdmCIRMixedPart::getMap() const {
+        return mapT_;
+    }
+
+    FdmCIROp::FdmCIROp(
+        const ext::shared_ptr<FdmMesher>& mesher,
+        const ext::shared_ptr<CoxIngersollRossProcess> & cirProcess,
+        const ext::shared_ptr<GeneralizedBlackScholesProcess> & bsProcess,
+        const Real rho,
+        const Real strike)
+    : dxMap_(mesher,
+             bsProcess,
+             strike),
+      dyMap_(mesher,
+             cirProcess->volatility(),
+             cirProcess->speed(),
+             cirProcess->level()),
+      dzMap_(mesher,
+             cirProcess,
+             bsProcess,
+             rho,
+             strike){
+    }
+
+
+    void FdmCIROp::setTime(Time t1, Time t2) {
+        dxMap_.setTime(t1, t2);
+        dyMap_.setTime(t1, t2);
+        dzMap_.setTime(t1, t2);
+    }
+
+    Size FdmCIROp::size() const {
+        return 2;
+    }
+
+    Disposable<Array> FdmCIROp::apply(const Array& u) const {
+        Array dx = dxMap_.getMap().apply(u);
+        Array dy = dyMap_.getMap().apply(u);
+        Array dz = dzMap_.getMap().apply(u);
+
+        return (dy + dx + dz);
+    }
+
+    Disposable<Array> FdmCIROp::apply_direction(Size direction,
+                                                   const Array& r) const {
+        if (direction == 0)
+            return dxMap_.getMap().apply(r);
+        else if (direction == 1)
+            return dyMap_.getMap().apply(r);
+        else
+            QL_FAIL("direction too large");
+    }
+
+    Disposable<Array> FdmCIROp::apply_mixed(const Array& r) const {
+        return dzMap_.getMap().apply(r);
+    }
+
+    Disposable<Array>
+        FdmCIROp::solve_splitting(Size direction,
+                                     const Array& r, Real a) const {
+
+        if (direction == 0) {
+            return dxMap_.getMap().solve_splitting(r, a, 1.0);
+        }
+        else if (direction == 1) {
+            return dyMap_.getMap().solve_splitting(r, a, 1.0);
+        }
+        else
+            QL_FAIL("direction too large");
+    }
+
+    Disposable<Array>
+        FdmCIROp::preconditioner(const Array& r, Real dt) const {
+
+        return solve_splitting(1, solve_splitting(0, r, dt), dt) ;
+    }
+
+#if !defined(QL_NO_UBLAS_SUPPORT)
+    Disposable<std::vector<SparseMatrix> >
+    FdmCIROp::toMatrixDecomp() const {
+        std::vector<SparseMatrix> retVal(3);
+
+        retVal[0] = dxMap_.getMap().toMatrix();
+        retVal[1] = dyMap_.getMap().toMatrix();
+        retVal[2] = dzMap_.getMap().toMatrix();
+
+        return retVal;
+    }
+#endif
+}

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -23,7 +23,6 @@
 #include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
 #include <ql/methods/finitedifferences/operators/secondordermixedderivativeop.hpp>
 #include <ql/processes/blackscholesprocess.hpp>
-#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -38,11 +37,9 @@ namespace QuantLib {
       qTS_(bsProcess->dividendYield().currentLink()),
       strike_(strike),
       sigma1_(bsProcess->blackVolatility().currentLink()){
-        BOOST_TEST_CHECKPOINT("initialised equity");
     }
 
     void FdmCIREquityPart::setTime(Time t1, Time t2) {
-        BOOST_TEST_CHECKPOINT("set time equity");
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
         const Real v = sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1);
@@ -52,7 +49,6 @@ namespace QuantLib {
     }
 
     const TripleBandLinearOp& FdmCIREquityPart::getMap() const {
-        BOOST_TEST_CHECKPOINT("get map equity");
         return mapT_;
     }
 
@@ -65,16 +61,13 @@ namespace QuantLib {
                    .mult(kappa*(theta - mesher->locations(1))))),
       mapT_(1, mesher),
       mesher_(mesher){
-        BOOST_TEST_CHECKPOINT("initialised rates");
     }
 
     void FdmCIRRatesPart::setTime(Time t1, Time t2) {
-        BOOST_TEST_CHECKPOINT("set time rates");
         mapT_.axpyb(Array(), dyMap_, dyMap_, -0.5*mesher_->locations(1));
     }
 
     const TripleBandLinearOp& FdmCIRRatesPart::getMap() const {
-        BOOST_TEST_CHECKPOINT("get map rates");
         return mapT_;
     }
 
@@ -93,14 +86,12 @@ namespace QuantLib {
     }
 
     void FdmCIRMixedPart::setTime(Time t1, Time t2) {
-        BOOST_TEST_CHECKPOINT("set time mixed");
         const Real v = std::sqrt(sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1));
         NinePointLinearOp op(dyMap_.mult(Array(mesher_->layout()->size(), v)));
         mapT_.reset(op);
     }
 
     const NinePointLinearOp& FdmCIRMixedPart::getMap() const {
-        BOOST_TEST_CHECKPOINT("get map mixed");
         return mapT_;
     }
 
@@ -122,7 +113,6 @@ namespace QuantLib {
              bsProcess,
              rho,
              strike){
-        BOOST_TEST_CHECKPOINT("initialised fdmcirop");
     }
 
 
@@ -137,7 +127,6 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmCIROp::apply(const Array& u) const {
-        BOOST_TEST_CHECKPOINT("Applying");
         Array dx = dxMap_.getMap().apply(u);
         Array dy = dyMap_.getMap().apply(u);
         Array dz = dzMap_.getMap().apply(u);
@@ -147,7 +136,6 @@ namespace QuantLib {
 
     Disposable<Array> FdmCIROp::apply_direction(Size direction,
                                                    const Array& r) const {
-        BOOST_TEST_CHECKPOINT("Apply direction");
         if (direction == 0)
             return dxMap_.getMap().apply(r);
         else if (direction == 1)
@@ -157,14 +145,13 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmCIROp::apply_mixed(const Array& r) const {
-        BOOST_TEST_CHECKPOINT("apply mixed");
         return dzMap_.getMap().apply(r);
     }
 
     Disposable<Array>
         FdmCIROp::solve_splitting(Size direction,
                                      const Array& r, Real a) const {
-        BOOST_TEST_CHECKPOINT("solve splitting");
+
         if (direction == 0) {
             return dxMap_.getMap().solve_splitting(r, a, 1.0);
         }

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -88,7 +88,7 @@ namespace QuantLib {
     void FdmCIRMixedPart::setTime(Time t1, Time t2) {
         const Real v = std::sqrt(sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1));
         NinePointLinearOp op(dyMap_.mult(Array(mesher_->layout()->size(), v)));
-        mapT_.reset(op);
+        mapT_.swap(op);
     }
 
     const NinePointLinearOp& FdmCIRMixedPart::getMap() const {

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -23,6 +23,7 @@
 #include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
 #include <ql/methods/finitedifferences/operators/secondordermixedderivativeop.hpp>
 #include <ql/processes/blackscholesprocess.hpp>
+#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -37,9 +38,11 @@ namespace QuantLib {
       qTS_(bsProcess->dividendYield().currentLink()),
       strike_(strike),
       sigma1_(bsProcess->blackVolatility().currentLink()){
+        BOOST_TEST_CHECKPOINT("initialised equity");
     }
 
     void FdmCIREquityPart::setTime(Time t1, Time t2) {
+        BOOST_TEST_CHECKPOINT("set time equity");
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
         const Real v = sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1);
@@ -49,6 +52,7 @@ namespace QuantLib {
     }
 
     const TripleBandLinearOp& FdmCIREquityPart::getMap() const {
+        BOOST_TEST_CHECKPOINT("get map equity");
         return mapT_;
     }
 
@@ -61,13 +65,16 @@ namespace QuantLib {
                    .mult(kappa*(theta - mesher->locations(1))))),
       mapT_(1, mesher),
       mesher_(mesher){
+        BOOST_TEST_CHECKPOINT("initialised rates");
     }
 
     void FdmCIRRatesPart::setTime(Time t1, Time t2) {
+        BOOST_TEST_CHECKPOINT("set time rates");
         mapT_.axpyb(Array(), dyMap_, dyMap_, -0.5*mesher_->locations(1));
     }
 
     const TripleBandLinearOp& FdmCIRRatesPart::getMap() const {
+        BOOST_TEST_CHECKPOINT("get map rates");
         return mapT_;
     }
 
@@ -86,12 +93,14 @@ namespace QuantLib {
     }
 
     void FdmCIRMixedPart::setTime(Time t1, Time t2) {
+        BOOST_TEST_CHECKPOINT("set time mixed");
         const Real v = std::sqrt(sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1));
         NinePointLinearOp op(dyMap_.mult(Array(mesher_->layout()->size(), v)));
         mapT_.reset(op);
     }
 
     const NinePointLinearOp& FdmCIRMixedPart::getMap() const {
+        BOOST_TEST_CHECKPOINT("get map mixed");
         return mapT_;
     }
 
@@ -113,6 +122,7 @@ namespace QuantLib {
              bsProcess,
              rho,
              strike){
+        BOOST_TEST_CHECKPOINT("initialised fdmcirop");
     }
 
 
@@ -127,6 +137,7 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmCIROp::apply(const Array& u) const {
+        BOOST_TEST_CHECKPOINT("Applying");
         Array dx = dxMap_.getMap().apply(u);
         Array dy = dyMap_.getMap().apply(u);
         Array dz = dzMap_.getMap().apply(u);
@@ -136,6 +147,7 @@ namespace QuantLib {
 
     Disposable<Array> FdmCIROp::apply_direction(Size direction,
                                                    const Array& r) const {
+        BOOST_TEST_CHECKPOINT("Apply direction");
         if (direction == 0)
             return dxMap_.getMap().apply(r);
         else if (direction == 1)
@@ -145,13 +157,14 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmCIROp::apply_mixed(const Array& r) const {
+        BOOST_TEST_CHECKPOINT("apply mixed");
         return dzMap_.getMap().apply(r);
     }
 
     Disposable<Array>
         FdmCIROp::solve_splitting(Size direction,
                                      const Array& r, Real a) const {
-
+        BOOST_TEST_CHECKPOINT("solve splitting");
         if (direction == 0) {
             return dxMap_.getMap().solve_splitting(r, a, 1.0);
         }

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -88,7 +88,7 @@ namespace QuantLib {
     void FdmCIRMixedPart::setTime(Time t1, Time t2) {
         const Real v = std::sqrt(sigma1_->blackForwardVariance(t1, t2, strike_)/(t2-t1));
         NinePointLinearOp op(dyMap_.mult(Array(mesher_->layout()->size(), v)));
-        mapT_.swap(op);
+        mapT_.reset(op);
     }
 
     const NinePointLinearOp& FdmCIRMixedPart::getMap() const {

--- a/ql/methods/finitedifferences/operators/fdmcirop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.hpp
@@ -1,0 +1,128 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file fdmcirop.hpp
+    \brief CIR linear operator
+*/
+
+#ifndef quantlib_fdm_cir_op_hpp
+#define quantlib_fdm_cir_op_hpp
+
+#include <ql/methods/finitedifferences/operators/fdmlinearopcomposite.hpp>
+#include <ql/methods/finitedifferences/operators/firstderivativeop.hpp>
+#include <ql/methods/finitedifferences/operators/ninepointlinearop.hpp>
+#include <ql/methods/finitedifferences/operators/triplebandlinearop.hpp>
+#include <ql/methods/finitedifferences/utilities/fdmquantohelper.hpp>
+#include <ql/models/shortrate/onefactormodels/coxingersollross.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/termstructures/volatility/equityfx/localvoltermstructure.hpp>
+
+namespace QuantLib {
+
+    class FdmCIREquityPart {
+      public:
+        FdmCIREquityPart(
+            const ext::shared_ptr<FdmMesher>& mesher,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess> & bsProcess,
+            Real strike);
+
+        void setTime(Time t1, Time t2);
+        const TripleBandLinearOp& getMap() const;
+
+      protected:
+        const FirstDerivativeOp  dxMap_;
+        const TripleBandLinearOp dxxMap_;
+        TripleBandLinearOp mapT_;
+
+        const ext::shared_ptr<FdmMesher> mesher_;
+        const ext::shared_ptr<YieldTermStructure> qTS_;
+        const Real strike_;
+        const ext::shared_ptr<BlackVolTermStructure> sigma1_;
+    };
+
+    class FdmCIRRatesPart {
+      public:
+        FdmCIRRatesPart(
+            const ext::shared_ptr<FdmMesher>& mesher,
+            Real sigma, Real kappa, Real theta);
+
+        void setTime(Time t1, Time t2);
+        const TripleBandLinearOp& getMap() const;
+
+      protected:
+        const TripleBandLinearOp dyMap_;
+        TripleBandLinearOp mapT_;
+        const ext::shared_ptr<FdmMesher> mesher_;
+    };
+
+    class FdmCIRMixedPart {
+      public:
+        FdmCIRMixedPart(
+            const ext::shared_ptr<FdmMesher>& mesher,
+            const ext::shared_ptr<CoxIngersollRossProcess> & cirProcess,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess> & bsProcess,
+            const Real rho,
+            const Real strike);
+
+        void setTime(Time t1, Time t2);
+        const NinePointLinearOp& getMap() const;
+
+      protected:
+        const NinePointLinearOp dyMap_;
+        NinePointLinearOp mapT_;
+        const ext::shared_ptr<FdmMesher> mesher_;
+        const ext::shared_ptr<BlackVolTermStructure> sigma1_;
+        const Real strike_;
+    };
+
+
+    class FdmCIROp : public FdmLinearOpComposite {
+      public:
+        FdmCIROp(
+            const ext::shared_ptr<FdmMesher>& mesher,
+            const ext::shared_ptr<CoxIngersollRossProcess> & cirProcess,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess> & bsProcess,
+            const Real rho,
+            const Real strike);
+
+        Size size() const;
+        void setTime(Time t1, Time t2);
+
+        Disposable<Array> apply(const Array& r) const;
+        Disposable<Array> apply_mixed(const Array& r) const;
+
+        Disposable<Array> apply_direction(Size direction,
+                                          const Array& r) const;
+        Disposable<Array> solve_splitting(Size direction,
+                                          const Array& r, Real s) const;
+        Disposable<Array> preconditioner(const Array& r, Real s) const;
+
+#if !defined(QL_NO_UBLAS_SUPPORT)
+        Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const;
+#endif
+      private:
+        FdmCIREquityPart dxMap_;
+        FdmCIRRatesPart dyMap_;
+        FdmCIRMixedPart dzMap_;
+    };
+}
+
+#endif

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -201,6 +201,29 @@ namespace QuantLib {
         return retVal;
     }
 
+    void NinePointLinearOp::reset(NinePointLinearOp m)
+    {
+        const Size size = mesher_->layout()->size();
+
+        std::copy(m.i00_.get(), m.i00_.get()+size, i00_.get());
+        std::copy(m.i10_.get(), m.i10_.get()+size, i10_.get());
+        std::copy(m.i20_.get(), m.i20_.get()+size, i20_.get());
+        std::copy(m.i01_.get(), m.i01_.get()+size, i01_.get());
+        std::copy(m.i21_.get(), m.i21_.get()+size, i21_.get());
+        std::copy(m.i02_.get(), m.i02_.get()+size, i02_.get());
+        std::copy(m.i12_.get(), m.i12_.get()+size, i12_.get());
+        std::copy(m.i22_.get(), m.i22_.get()+size, i22_.get());
+        std::copy(m.a00_.get(), m.a00_.get()+size, a00_.get());
+        std::copy(m.a10_.get(), m.a10_.get()+size, a10_.get());
+        std::copy(m.a20_.get(), m.a20_.get()+size, a20_.get());
+        std::copy(m.a01_.get(), m.a01_.get()+size, a01_.get());
+        std::copy(m.a11_.get(), m.a11_.get()+size, a11_.get());
+        std::copy(m.a21_.get(), m.a21_.get()+size, a21_.get());
+        std::copy(m.a02_.get(), m.a02_.get()+size, a02_.get());
+        std::copy(m.a12_.get(), m.a12_.get()+size, a12_.get());
+        std::copy(m.a22_.get(), m.a22_.get()+size, a22_.get());
+    }
+
     void NinePointLinearOp::swap(NinePointLinearOp& m) {
         std::swap(d0_, m.d0_);
         std::swap(d1_, m.d1_);

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -201,29 +201,6 @@ namespace QuantLib {
         return retVal;
     }
 
-    void NinePointLinearOp::reset(NinePointLinearOp m)
-    {
-        const Size size = mesher_->layout()->size();
-
-        std::copy(m.i00_.get(), m.i00_.get()+size, i00_.get());
-        std::copy(m.i10_.get(), m.i10_.get()+size, i10_.get());
-        std::copy(m.i20_.get(), m.i20_.get()+size, i20_.get());
-        std::copy(m.i01_.get(), m.i01_.get()+size, i01_.get());
-        std::copy(m.i21_.get(), m.i21_.get()+size, i21_.get());
-        std::copy(m.i02_.get(), m.i02_.get()+size, i02_.get());
-        std::copy(m.i12_.get(), m.i12_.get()+size, i12_.get());
-        std::copy(m.i22_.get(), m.i22_.get()+size, i22_.get());
-        std::copy(m.a00_.get(), m.a00_.get()+size, a00_.get());
-        std::copy(m.a10_.get(), m.a10_.get()+size, a10_.get());
-        std::copy(m.a20_.get(), m.a20_.get()+size, a20_.get());
-        std::copy(m.a01_.get(), m.a01_.get()+size, a01_.get());
-        std::copy(m.a11_.get(), m.a11_.get()+size, a11_.get());
-        std::copy(m.a21_.get(), m.a21_.get()+size, a21_.get());
-        std::copy(m.a02_.get(), m.a02_.get()+size, a02_.get());
-        std::copy(m.a12_.get(), m.a12_.get()+size, a12_.get());
-        std::copy(m.a22_.get(), m.a22_.get()+size, a22_.get());
-    }
-
     void NinePointLinearOp::swap(NinePointLinearOp& m) {
         std::swap(d0_, m.d0_);
         std::swap(d1_, m.d1_);

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -47,6 +47,7 @@ namespace QuantLib {
         Disposable<NinePointLinearOp> mult(const Array& u) const;
 
         void swap(NinePointLinearOp& m);
+        void reset(NinePointLinearOp m);
 
 #if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<SparseMatrix> toMatrix() const;

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -47,7 +47,6 @@ namespace QuantLib {
         Disposable<NinePointLinearOp> mult(const Array& u) const;
 
         void swap(NinePointLinearOp& m);
-        void reset(NinePointLinearOp m);
 
 #if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<SparseMatrix> toMatrix() const;

--- a/ql/methods/finitedifferences/solvers/Makefile.am
+++ b/ql/methods/finitedifferences/solvers/Makefile.am
@@ -14,6 +14,7 @@ this_include_HEADERS = \
 	fdmg2solver.hpp \
 	fdmhestonhullwhitesolver.hpp \
 	fdmhestonsolver.hpp \
+	fdmcirsolver.hpp \
 	fdmhullwhitesolver.hpp \
 	fdmndimsolver.hpp \
 	fdmsimple2dbssolver.hpp \
@@ -30,6 +31,7 @@ cpp_files = \
 	fdmg2solver.cpp \
 	fdmhestonhullwhitesolver.cpp \
 	fdmhestonsolver.cpp \
+	fdmcirsolver.cpp \
 	fdmhullwhitesolver.cpp \
 	fdmsimple2dbssolver.cpp
 

--- a/ql/methods/finitedifferences/solvers/all.hpp
+++ b/ql/methods/finitedifferences/solvers/all.hpp
@@ -11,6 +11,7 @@
 #include <ql/methods/finitedifferences/solvers/fdmg2solver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmhestonhullwhitesolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmhestonsolver.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmcirsolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmhullwhitesolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmndimsolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmsimple2dbssolver.hpp>

--- a/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
@@ -1,0 +1,76 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/methods/finitedifferences/operators/fdmcirop.hpp>
+#include <ql/methods/finitedifferences/solvers/fdm2dimsolver.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmcirsolver.hpp>
+
+namespace QuantLib {
+
+    FdmCIRSolver::FdmCIRSolver(
+        const Handle<CoxIngersollRossProcess>& cirProcess,
+        const Handle<GeneralizedBlackScholesProcess>& bsProcess,
+        const FdmSolverDesc& solverDesc,
+        const FdmSchemeDesc& schemeDesc,
+        const Real rho,
+        const Real strike)
+    : bsProcess_(bsProcess),
+      cirProcess_(cirProcess),
+      solverDesc_(solverDesc),
+      schemeDesc_(schemeDesc),
+      rho_(rho),
+      strike_(strike){
+        registerWith(bsProcess_);
+        registerWith(cirProcess_);
+    }
+
+    void FdmCIRSolver::performCalculations() const {
+        ext::shared_ptr<FdmLinearOpComposite> op(
+			ext::make_shared<FdmCIROp>(
+                solverDesc_.mesher,
+                cirProcess_.currentLink(),
+                bsProcess_.currentLink(),
+                rho_,
+                strike_));
+
+        solver_ = ext::make_shared<Fdm2DimSolver>(solverDesc_, schemeDesc_, op);
+    }
+
+    Real FdmCIRSolver::valueAt(Real s, Real r) const {
+        calculate();
+        return solver_->interpolateAt(std::log(s), r);
+    }
+
+    Real FdmCIRSolver::deltaAt(Real s, Real r) const {
+        calculate();
+        return solver_->derivativeX(std::log(s), r)/s;
+    }
+
+    Real FdmCIRSolver::gammaAt(Real s, Real r) const {
+        calculate();
+        const Real x = std::log(s);
+        return (solver_->derivativeXX(x, r)-solver_->derivativeX(x, r))/(s*s);
+    }
+
+    Real FdmCIRSolver::thetaAt(Real s, Real r) const {
+        calculate();
+        return solver_->thetaAt(std::log(s), r);
+    }
+}

--- a/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
@@ -17,10 +17,11 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/processes/hestonprocess.hpp>
 #include <ql/methods/finitedifferences/operators/fdmcirop.hpp>
 #include <ql/methods/finitedifferences/solvers/fdm2dimsolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmcirsolver.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -42,6 +43,7 @@ namespace QuantLib {
     }
 
     void FdmCIRSolver::performCalculations() const {
+        BOOST_TEST_CHECKPOINT("performCalculations");
         ext::shared_ptr<FdmLinearOpComposite> op(
 			ext::make_shared<FdmCIROp>(
                 solverDesc_.mesher,

--- a/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmcirsolver.cpp
@@ -17,11 +17,10 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+#include <ql/processes/hestonprocess.hpp>
 #include <ql/methods/finitedifferences/operators/fdmcirop.hpp>
 #include <ql/methods/finitedifferences/solvers/fdm2dimsolver.hpp>
 #include <ql/methods/finitedifferences/solvers/fdmcirsolver.hpp>
-#include <ql/processes/hestonprocess.hpp>
-#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -43,7 +42,6 @@ namespace QuantLib {
     }
 
     void FdmCIRSolver::performCalculations() const {
-        BOOST_TEST_CHECKPOINT("performCalculations");
         ext::shared_ptr<FdmLinearOpComposite> op(
 			ext::make_shared<FdmCIROp>(
                 solverDesc_.mesher,

--- a/ql/methods/finitedifferences/solvers/fdmcirsolver.hpp
+++ b/ql/methods/finitedifferences/solvers/fdmcirsolver.hpp
@@ -1,0 +1,71 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file fdmcirsolver.hpp
+*/
+
+#ifndef quantlib_fdm_cir_solver_hpp
+#define quantlib_fdm_cir_solver_hpp
+
+#include <ql/handle.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmsolverdesc.hpp>
+#include <ql/methods/finitedifferences/utilities/fdmdirichletboundary.hpp>
+#include <ql/methods/finitedifferences/utilities/fdmquantohelper.hpp>
+#include <ql/models/shortrate/onefactormodels/coxingersollross.hpp>
+#include <ql/patterns/lazyobject.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
+#include <ql/termstructures/volatility/equityfx/localvoltermstructure.hpp>
+
+namespace QuantLib {
+
+    class HestonProcess;
+    class Fdm2DimSolver;
+
+    class FdmCIRSolver : public LazyObject {
+      public:
+        FdmCIRSolver(
+            const Handle<CoxIngersollRossProcess>& process,
+            const Handle<GeneralizedBlackScholesProcess>& bsProcess,
+            const FdmSolverDesc& solverDesc,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+            const Real rho = 1.0,
+            const Real strike = 1.0);
+
+        Real valueAt(Real s, Real v) const;
+        Real deltaAt(Real s, Real v) const;
+        Real gammaAt(Real s, Real v) const;
+        Real thetaAt(Real s, Real v) const;
+
+      protected:
+        void performCalculations() const;
+        
+      private:
+        const Handle<GeneralizedBlackScholesProcess> bsProcess_;
+        const Handle<CoxIngersollRossProcess> cirProcess_;
+        const FdmSolverDesc solverDesc_;
+        const FdmSchemeDesc schemeDesc_;
+        const Real rho_;
+        const Real strike_;
+
+        mutable ext::shared_ptr<Fdm2DimSolver> solver_;
+    };
+}
+
+#endif

--- a/ql/pricingengines/vanilla/Makefile.am
+++ b/ql/pricingengines/vanilla/Makefile.am
@@ -38,6 +38,7 @@ this_include_HEADERS = \
     fdeuropeanengine.hpp \
 	fdhestonhullwhitevanillaengine.hpp \
 	fdhestonvanillaengine.hpp \
+	fdcirvanillaengine.hpp \
     fdmultiperiodengine.hpp \
     fdsabrvanillaengine.hpp \
     fdshoutengine.hpp \
@@ -80,6 +81,7 @@ cpp_files = \
 	fdcevvanillaengine.cpp \
 	fdhestonhullwhitevanillaengine.cpp \
 	fdhestonvanillaengine.cpp \
+	fdcirvanillaengine.cpp \
 	fdsabrvanillaengine.cpp \
 	fdsimplebsswingengine.cpp \
     fdvanillaengine.cpp \

--- a/ql/pricingengines/vanilla/all.hpp
+++ b/ql/pricingengines/vanilla/all.hpp
@@ -35,6 +35,7 @@
 #include <ql/pricingengines/vanilla/fdeuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
+#include <ql/pricingengines/vanilla/fdcirvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/fdmultiperiodengine.hpp>
 #include <ql/pricingengines/vanilla/fdsabrvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/fdshoutengine.hpp>

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -28,7 +28,6 @@
 #include <ql/pricingengines/vanilla/fdcirvanillaengine.hpp>
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/processes/coxingersollrossprocess.hpp>
-#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -48,7 +47,6 @@ namespace QuantLib {
     }
 
     FdmSolverDesc FdCIRVanillaEngine::getSolverDesc(Real) const {
-        BOOST_TEST_CHECKPOINT("Initialising stuff");
         DividendSchedule dividendSchedule = DividendSchedule();
 
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -59,8 +57,6 @@ namespace QuantLib {
         const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
             new FdmSimpleProcess1dMesher(rGrid_, cirProcess_, maturity, tGrid_));
 
-        BOOST_TEST_CHECKPOINT("Initialising stuff 2");
-
         // The equity mesher
         const ext::shared_ptr<Fdm1dMesher> equityMesher(
             new FdmBlackScholesMesher(
@@ -69,8 +65,6 @@ namespace QuantLib {
                 std::pair<Real, Real>(payoff->strike(), 0.1),
                 dividendSchedule, quantoHelper_,
                 0.0));
-
-        BOOST_TEST_CHECKPOINT("Initialising stuff 3");
         
         const ext::shared_ptr<FdmMesher> mesher(
             new FdmMesherComposite(equityMesher, shortRateMesher));
@@ -78,8 +72,6 @@ namespace QuantLib {
         // Calculator
         const ext::shared_ptr<FdmInnerValueCalculator> calculator(
                           new FdmLogInnerValue(arguments_.payoff, mesher, 0));
-
-        BOOST_TEST_CHECKPOINT("Initialising stuff 4");
 
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -89,8 +81,6 @@ namespace QuantLib {
                                  bsProcess_->riskFreeRate()->referenceDate(),
                                  bsProcess_->riskFreeRate()->dayCounter());
 
-        BOOST_TEST_CHECKPOINT("Initialising stuff 5");
-
         // Boundary conditions
         const FdmBoundaryConditionSet boundaries;
 
@@ -99,8 +89,6 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        BOOST_TEST_CHECKPOINT("Initialising stuff 6");
-
        return solverDesc;
     }
 
@@ -108,15 +96,11 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
 
-        BOOST_TEST_CHECKPOINT("calculate 1");
-
         ext::shared_ptr<FdmCIRSolver> solver(new FdmCIRSolver(
                     Handle<CoxIngersollRossProcess>(cirProcess_),
                     Handle<GeneralizedBlackScholesProcess>(bsProcess_),
                     getSolverDesc(1.5), schemeDesc_,
                     rho_, payoff->strike()));
-
-        BOOST_TEST_CHECKPOINT("calculate 2");
 
         const Real r0   = cirProcess_->x0();
         const Real spot = bsProcess_->x0();

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -28,6 +28,7 @@
 #include <ql/pricingengines/vanilla/fdcirvanillaengine.hpp>
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/processes/coxingersollrossprocess.hpp>
+#include <boost/test/test_tools.hpp>
 
 namespace QuantLib {
 
@@ -47,6 +48,7 @@ namespace QuantLib {
     }
 
     FdmSolverDesc FdCIRVanillaEngine::getSolverDesc(Real) const {
+        BOOST_TEST_CHECKPOINT("Initialising stuff");
         DividendSchedule dividendSchedule = DividendSchedule();
 
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -57,6 +59,8 @@ namespace QuantLib {
         const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
             new FdmSimpleProcess1dMesher(rGrid_, cirProcess_, maturity, tGrid_));
 
+        BOOST_TEST_CHECKPOINT("Initialising stuff 2");
+
         // The equity mesher
         const ext::shared_ptr<Fdm1dMesher> equityMesher(
             new FdmBlackScholesMesher(
@@ -65,6 +69,8 @@ namespace QuantLib {
                 std::pair<Real, Real>(payoff->strike(), 0.1),
                 dividendSchedule, quantoHelper_,
                 0.0));
+
+        BOOST_TEST_CHECKPOINT("Initialising stuff 3");
         
         const ext::shared_ptr<FdmMesher> mesher(
             new FdmMesherComposite(equityMesher, shortRateMesher));
@@ -72,6 +78,8 @@ namespace QuantLib {
         // Calculator
         const ext::shared_ptr<FdmInnerValueCalculator> calculator(
                           new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+
+        BOOST_TEST_CHECKPOINT("Initialising stuff 4");
 
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -81,6 +89,8 @@ namespace QuantLib {
                                  bsProcess_->riskFreeRate()->referenceDate(),
                                  bsProcess_->riskFreeRate()->dayCounter());
 
+        BOOST_TEST_CHECKPOINT("Initialising stuff 5");
+
         // Boundary conditions
         const FdmBoundaryConditionSet boundaries;
 
@@ -89,6 +99,8 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
+        BOOST_TEST_CHECKPOINT("Initialising stuff 6");
+
        return solverDesc;
     }
 
@@ -96,11 +108,15 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
 
+        BOOST_TEST_CHECKPOINT("calculate 1");
+
         ext::shared_ptr<FdmCIRSolver> solver(new FdmCIRSolver(
                     Handle<CoxIngersollRossProcess>(cirProcess_),
                     Handle<GeneralizedBlackScholesProcess>(bsProcess_),
                     getSolverDesc(1.5), schemeDesc_,
                     rho_, payoff->strike()));
+
+        BOOST_TEST_CHECKPOINT("calculate 2");
 
         const Real r0   = cirProcess_->x0();
         const Real spot = bsProcess_->x0();

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -89,7 +89,7 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-       return solverDesc;
+        return solverDesc;
     }
 
     void FdCIRVanillaEngine::calculate() const {

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -106,9 +106,9 @@ namespace QuantLib {
         const Real spot = bsProcess_->x0();
 
         results_.value = solver->valueAt(spot, r0);
-        //results_.delta = solver->deltaAt(spot, r0);
-        //results_.gamma = solver->gammaAt(spot, r0);
-        //results_.theta = solver->thetaAt(spot, r0);
+        results_.delta = solver->deltaAt(spot, r0);
+        results_.gamma = solver->gammaAt(spot, r0);
+        results_.theta = solver->thetaAt(spot, r0);
     }
 
     MakeFdCIRVanillaEngine::MakeFdCIRVanillaEngine(

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -1,0 +1,176 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+
+#include <ql/methods/finitedifferences/meshers/fdmblackscholesmesher.hpp>
+#include <ql/methods/finitedifferences/meshers/fdmmeshercomposite.hpp>
+#include <ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.hpp>
+#include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmcirsolver.hpp>
+#include <ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.hpp>
+#include <ql/methods/finitedifferences/utilities/fdminnervaluecalculator.hpp>
+#include <ql/pricingengines/vanilla/fdcirvanillaengine.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
+
+namespace QuantLib {
+
+    FdCIRVanillaEngine::FdCIRVanillaEngine(
+            const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess,
+            Size tGrid, Size xGrid, Size rGrid, Size dampingSteps,
+            const Real rho,
+            const FdmSchemeDesc& schemeDesc,
+            const ext::shared_ptr<FdmQuantoHelper>& quantoHelper)
+    : tGrid_(tGrid), xGrid_(xGrid), rGrid_(rGrid), dampingSteps_(dampingSteps),
+      rho_(rho),
+      schemeDesc_(schemeDesc),
+      bsProcess_(bsProcess),
+      cirProcess_(cirProcess),
+      quantoHelper_(quantoHelper){
+    }
+
+    FdmSolverDesc FdCIRVanillaEngine::getSolverDesc(Real) const {
+        DividendSchedule dividendSchedule = DividendSchedule();
+
+        const ext::shared_ptr<StrikedTypePayoff> payoff =
+            ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
+        const Time maturity = bsProcess_->time(arguments_.exercise->lastDate());
+
+        // The short rate mesher
+        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
+            new FdmSimpleProcess1dMesher(rGrid_, cirProcess_, maturity, tGrid_));
+
+        // The equity mesher
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(
+            new FdmBlackScholesMesher(
+                xGrid_, bsProcess_, maturity, payoff->strike(),
+                Null<Real>(), Null<Real>(), 0.0001, 1.5,
+                std::pair<Real, Real>(payoff->strike(), 0.1),
+                dividendSchedule, quantoHelper_,
+                0.0));
+        
+        const ext::shared_ptr<FdmMesher> mesher(
+            new FdmMesherComposite(equityMesher, shortRateMesher));
+
+        // Calculator
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
+                          new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+
+        // Step conditions
+        const ext::shared_ptr<FdmStepConditionComposite> conditions = 
+             FdmStepConditionComposite::vanillaComposite(
+                                 arguments_.cashFlow, arguments_.exercise, 
+                                 mesher, calculator,
+                                 bsProcess_->riskFreeRate()->referenceDate(),
+                                 bsProcess_->riskFreeRate()->dayCounter());
+
+        // Boundary conditions
+        const FdmBoundaryConditionSet boundaries;
+
+        // Solver
+        FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
+                                     calculator, maturity,
+                                     tGrid_, dampingSteps_ };
+
+       return solverDesc;
+    }
+
+    void FdCIRVanillaEngine::calculate() const {
+        const ext::shared_ptr<StrikedTypePayoff> payoff =
+            ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
+
+        ext::shared_ptr<FdmCIRSolver> solver(new FdmCIRSolver(
+                    Handle<CoxIngersollRossProcess>(cirProcess_),
+                    Handle<GeneralizedBlackScholesProcess>(bsProcess_),
+                    getSolverDesc(1.5), schemeDesc_,
+                    rho_, payoff->strike()));
+
+        const Real r0   = cirProcess_->x0();
+        const Real spot = bsProcess_->x0();
+
+        results_.value = solver->valueAt(spot, r0);
+        //results_.delta = solver->deltaAt(spot, r0);
+        //results_.gamma = solver->gammaAt(spot, r0);
+        //results_.theta = solver->thetaAt(spot, r0);
+    }
+
+    MakeFdCIRVanillaEngine::MakeFdCIRVanillaEngine(
+       const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess,
+       const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess,
+       const Real rho)
+      : cirProcess_(cirProcess),
+        bsProcess_(bsProcess),
+        rho_(rho),
+        tGrid_(10),
+        xGrid_(100),
+        rGrid_(100),
+        dampingSteps_(0),
+        schemeDesc_(
+            ext::make_shared<FdmSchemeDesc>(FdmSchemeDesc::ModifiedHundsdorfer())),
+        quantoHelper_(ext::shared_ptr<FdmQuantoHelper>()) {}
+
+    MakeFdCIRVanillaEngine& MakeFdCIRVanillaEngine::withQuantoHelper(
+        const ext::shared_ptr<FdmQuantoHelper>& quantoHelper) {
+        quantoHelper_ = quantoHelper;
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withTGrid(Size tGrid) {
+        tGrid_ = tGrid;
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withXGrid(Size xGrid) {
+        xGrid_ = xGrid;
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withRGrid(Size rGrid) {
+        rGrid_ = rGrid;
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withDampingSteps(Size dampingSteps) {
+        dampingSteps_ = dampingSteps;
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withFdmSchemeDesc(
+        const FdmSchemeDesc& schemeDesc) {
+        schemeDesc_ = ext::make_shared<FdmSchemeDesc>(schemeDesc);
+        return *this;
+    }
+
+    MakeFdCIRVanillaEngine::operator
+    ext::shared_ptr<PricingEngine>() const {
+        return ext::make_shared<FdCIRVanillaEngine>(
+            cirProcess_,
+            bsProcess_,
+            tGrid_, xGrid_, rGrid_, dampingSteps_,
+            rho_,
+            *schemeDesc_,
+            quantoHelper_);
+    }
+}

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
@@ -1,0 +1,100 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file fdcirvanillaengine.hpp
+    \brief Finite-Differences CIR vanilla option engine
+*/
+
+#ifndef quantlib_fd_cir_vanilla_engine_hpp
+#define quantlib_fd_cir_vanilla_engine_hpp
+
+#include <ql/instruments/dividendvanillaoption.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
+#include <ql/methods/finitedifferences/solvers/fdmsolverdesc.hpp>
+#include <ql/models/equity/hestonmodel.hpp>
+#include <ql/pricingengines/genericmodelengine.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
+#include <ql/termstructures/volatility/equityfx/localvoltermstructure.hpp>
+
+namespace QuantLib {
+
+    //! Finite-Differences CIR Vanilla Option engine
+
+    /*! \ingroup vanillaengines
+
+        \test the engine has been tested to converge among different schemes.
+    */
+    class FdmQuantoHelper;
+
+    class FdCIRVanillaEngine : public DividendVanillaOption::engine {
+      public:
+        explicit FdCIRVanillaEngine(
+            const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess,
+            Size tGrid, Size xGrid, Size vGrid, Size dampingSteps,
+            const Real rho_,
+            const FdmSchemeDesc& schemeDesc,
+            const ext::shared_ptr<FdmQuantoHelper>& quantoHelper);
+
+        void calculate() const;
+
+        FdmSolverDesc getSolverDesc(Real equityScaleFactor) const;
+
+      private:
+        const Size tGrid_, xGrid_, rGrid_, dampingSteps_;
+        const Real rho_;
+        const FdmSchemeDesc schemeDesc_;
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess_;
+        const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess_;
+        
+        ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
+    };
+
+    class MakeFdCIRVanillaEngine {
+      public:
+        explicit MakeFdCIRVanillaEngine(
+            const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess,
+            const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess,
+            const Real rho);
+
+        MakeFdCIRVanillaEngine& withQuantoHelper(
+            const ext::shared_ptr<FdmQuantoHelper>& quantoHelper);
+
+        MakeFdCIRVanillaEngine& withTGrid(Size tGrid);
+        MakeFdCIRVanillaEngine& withXGrid(Size xGrid);
+        MakeFdCIRVanillaEngine& withRGrid(Size rGrid);
+        MakeFdCIRVanillaEngine& withDampingSteps(
+            Size dampingSteps);
+
+        MakeFdCIRVanillaEngine& withFdmSchemeDesc(
+            const FdmSchemeDesc& schemeDesc);
+
+        operator ext::shared_ptr<PricingEngine>() const;
+
+      private:
+        const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess_;
+        const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess_;
+        const Real rho_;
+        Size tGrid_, xGrid_, rGrid_, dampingSteps_;
+        ext::shared_ptr<FdmSchemeDesc> schemeDesc_;
+        ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
+    };
+}
+
+#endif

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
@@ -60,8 +60,8 @@ namespace QuantLib {
         const Size tGrid_, xGrid_, rGrid_, dampingSteps_;
         const Real rho_;
         const FdmSchemeDesc schemeDesc_;
-        const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess_;
-        const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess_;
+        ext::shared_ptr<CoxIngersollRossProcess> cirProcess_;
         
         ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
     };
@@ -88,8 +88,8 @@ namespace QuantLib {
         operator ext::shared_ptr<PricingEngine>() const;
 
       private:
-        const ext::shared_ptr<CoxIngersollRossProcess>& cirProcess_;
-        const ext::shared_ptr<GeneralizedBlackScholesProcess>& bsProcess_;
+        ext::shared_ptr<CoxIngersollRossProcess> cirProcess_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess_;
         const Real rho_;
         Size tGrid_, xGrid_, rGrid_, dampingSteps_;
         ext::shared_ptr<FdmSchemeDesc> schemeDesc_;

--- a/ql/processes/Makefile.am
+++ b/ql/processes/Makefile.am
@@ -21,6 +21,7 @@ this_include_HEADERS = \
 	merton76process.hpp \
 	mfstateprocess.hpp \
 	ornsteinuhlenbeckprocess.hpp \
+	coxingersollrossprocess.hpp \
 	squarerootprocess.hpp \
 	stochasticprocessarray.hpp
 
@@ -42,6 +43,7 @@ cpp_files = \
 	merton76process.cpp \
 	mfstateprocess.cpp \
 	ornsteinuhlenbeckprocess.cpp \
+	coxingersollrossprocess.cpp \
 	squarerootprocess.cpp \
 	stochasticprocessarray.cpp
 

--- a/ql/processes/all.hpp
+++ b/ql/processes/all.hpp
@@ -18,6 +18,7 @@
 #include <ql/processes/merton76process.hpp>
 #include <ql/processes/mfstateprocess.hpp>
 #include <ql/processes/ornsteinuhlenbeckprocess.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
 #include <ql/processes/squarerootprocess.hpp>
 #include <ql/processes/stochasticprocessarray.hpp>
 

--- a/ql/processes/coxingersollrossprocess.cpp
+++ b/ql/processes/coxingersollrossprocess.cpp
@@ -1,0 +1,41 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/processes/coxingersollrossprocess.hpp>
+
+namespace QuantLib {
+
+    CoxIngersollRossProcess::CoxIngersollRossProcess(Real speed,
+                                                       Volatility vol,
+                                                       Real x0,
+                                                       Real level)
+    : x0_(x0), speed_(speed), level_(level), volatility_(vol) {
+        QL_REQUIRE(volatility_ >= 0.0, "negative volatility given");
+    }
+
+    Real CoxIngersollRossProcess::variance(Time, Real, Time dt) const {
+        Real exponent1 = std::exp(-speed_ * dt);
+        Real exponent2 = std::exp(-2 * speed_ * dt);
+        Real fraction = (volatility_ * volatility_) / speed_;
+
+        return x0_ * fraction * (exponent1 - exponent2) + level_ * fraction * (1 - exponent1) * (1 - exponent1);
+    }
+
+}
+

--- a/ql/processes/coxingersollrossprocess.hpp
+++ b/ql/processes/coxingersollrossprocess.hpp
@@ -1,0 +1,107 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file coxingersollross.hpp
+    \brief CoxIngersollRoss process
+*/
+
+#ifndef quantlib_coxingersollross_process_hpp
+#define quantlib_coxingersollross_process_hpp
+
+#include <ql/stochasticprocess.hpp>
+
+namespace QuantLib {
+
+    //! CoxIngersollRoss process class
+    /*! This class describes the CoxIngersollRoss process governed by
+        \f[
+            dx = a (r - x_t) dt + \sqrt{x_t}\sigma dW_t.
+        \f]
+
+        \ingroup processes
+    */
+    class CoxIngersollRossProcess : public StochasticProcess1D {
+      public:
+        CoxIngersollRossProcess(Real speed,
+                                 Volatility vol,
+                                 Real x0 = 0.0,
+                                 Real level = 0.0);
+        //@{
+        Real drift(Time t,
+                   Real x) const;
+        Real diffusion(Time t,
+                       Real x) const;
+        Real expectation(Time t0,
+                         Real x0,
+                         Time dt) const;
+        Real stdDeviation(Time t0,
+                          Real x0,
+                          Time dt) const;
+        //@}
+        Real x0() const;
+        Real speed() const;
+        Real volatility() const;
+        Real level() const;
+        Real variance(Time t0,
+                      Real x0,
+                      Time dt) const;
+      private:
+        Real x0_, speed_, level_;
+        Volatility volatility_;
+    };
+
+    // inline
+
+    inline Real CoxIngersollRossProcess::x0() const {
+        return x0_;
+    }
+
+    inline Real CoxIngersollRossProcess::speed() const {
+        return speed_;
+    }
+
+    inline Real CoxIngersollRossProcess::volatility() const {
+        return volatility_;
+    }
+
+    inline Real CoxIngersollRossProcess::level() const {
+        return level_;
+    }
+
+    inline Real CoxIngersollRossProcess::drift(Time, Real x) const {
+        return speed_ * (level_ - x);
+    }
+
+    inline Real CoxIngersollRossProcess::diffusion(Time, Real) const {
+        return volatility_;
+    }
+
+    inline Real CoxIngersollRossProcess::expectation(Time, Real x0,
+                                               Time dt) const {
+        return level_ + (x0 - level_) * std::exp(-speed_*dt);
+    }
+
+    inline Real CoxIngersollRossProcess::stdDeviation(Time t, Real x0,
+                                                Time dt) const {
+        return std::sqrt(variance(t,x0,dt));
+    }
+
+}
+
+#endif

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -55,6 +55,7 @@ set(QuantLib-Test_SRC
     fastfouriertransform.cpp
     fdcev.cpp
     fdheston.cpp
+    fdcir.cpp
     fdmlinearop.cpp
     fdsabr.cpp
     fittedbonddiscountcurve.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -55,6 +55,7 @@ QL_TESTS = \
 	extensibleoptions.hpp extensibleoptions.cpp \
 	fastfouriertransform.hpp fastfouriertransform.cpp \
 	fdheston.hpp fdheston.cpp \
+	fdcir.hpp fdcir.cpp \
 	fdmlinearop.hpp fdmlinearop.cpp \
 	fdcev.hpp fdcev.cpp \
 	fdsabr.hpp fdsabr.cpp \

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -44,11 +44,11 @@ void FdCIRTest::testFdmCIRConvergence() {
 
     FdmSchemeDesc schemes[] = {
         FdmSchemeDesc::Hundsdorfer(),
-        /**FdmSchemeDesc::ModifiedCraigSneyd(),
+        FdmSchemeDesc::ModifiedCraigSneyd(),
         FdmSchemeDesc::ModifiedHundsdorfer(),
         FdmSchemeDesc::CraigSneyd(),
         FdmSchemeDesc::TrBDF2(),
-        FdmSchemeDesc::CrankNicolson(),**/
+        FdmSchemeDesc::CrankNicolson(),
     };
 
     // set up dates

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -1,0 +1,123 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+  Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "fdcir.hpp"
+#include "fdheston.hpp"
+#include "utilities.hpp"
+#include <ql/instruments/barrieroption.hpp>
+#include <ql/math/functional.hpp>
+#include <ql/models/equity/hestonmodel.hpp>
+#include <ql/pricingengines/barrier/fdhestonbarrierengine.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
+#include <ql/pricingengines/vanilla/fdcirvanillaengine.hpp>
+#include <ql/processes/coxingersollrossprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/localconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <boost/assign/std/vector.hpp>
+#include <boost/tuple/tuple.hpp>
+
+using namespace QuantLib;
+using namespace boost::assign;
+using boost::unit_test_framework::test_suite;
+
+void FdCIRTest::testFdmCIRConvergence() {
+    BOOST_TEST_MESSAGE("Testing FDM CIR convergence...");
+
+    FdmSchemeDesc schemes[] = {
+        FdmSchemeDesc::Hundsdorfer(),
+        /**FdmSchemeDesc::ModifiedCraigSneyd(),
+        FdmSchemeDesc::ModifiedHundsdorfer(),
+        FdmSchemeDesc::CraigSneyd(),
+        FdmSchemeDesc::TrBDF2(),
+        FdmSchemeDesc::CrankNicolson(),**/
+    };
+
+    // set up dates
+    Date today = Date::todaysDate();
+
+    // our options
+    Option::Type type(Option::Put);
+    Real underlying = 36;
+    Real strike = 40;
+    Spread dividendYield = 0.00;
+    Rate riskFreeRate = 0.06;
+    Volatility volatility = 0.20;
+    Date maturity = today + 365;
+    DayCounter dayCounter = Actual365Fixed();
+
+    ext::shared_ptr<Exercise> europeanExercise(
+        new EuropeanExercise(maturity));
+
+    Handle<Quote> underlyingH(
+        ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+
+    Handle<YieldTermStructure> flatTermStructure(
+        ext::shared_ptr<YieldTermStructure>(flatRate(today, riskFreeRate, dayCounter)));
+    Handle<YieldTermStructure> flatDividendTS(
+        ext::shared_ptr<YieldTermStructure>(flatRate(today, dividendYield, dayCounter)));
+    Handle<BlackVolTermStructure> flatVolTS(
+        ext::shared_ptr<BlackVolTermStructure>(flatVol(today, volatility, dayCounter)));
+    ext::shared_ptr<StrikedTypePayoff> payoff(
+        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
+        new BlackScholesMertonProcess(underlyingH, flatDividendTS,
+                                      flatTermStructure, flatVolTS));
+
+    VanillaOption europeanOption(payoff, europeanExercise);
+
+    Real speed = 1.2188;
+    Real cirSigma = 0.02438;
+    Real level = 0.0183;
+    Real initialRate = 0.06;
+    Real rho = 0.00789;
+    Real lambda = -0.5726;
+    Real newSpeed = speed + (cirSigma*lambda); //1.0792
+    Real newLevel = (level * speed)/(speed + (cirSigma*lambda));//// 0.0240
+
+    ext::shared_ptr<CoxIngersollRossProcess> cirProcess(new CoxIngersollRossProcess(newSpeed, cirSigma, initialRate, newLevel));
+
+    Real expected = 4.275;
+    Real tolerance = 0.0003;
+
+    for (Size l=0; l < LENGTH(schemes); ++l) {
+        ext::shared_ptr<PricingEngine> fdcirengine = MakeFdCIRVanillaEngine(cirProcess, bsmProcess, rho)
+            .withFdmSchemeDesc(schemes[l]);
+        europeanOption.setPricingEngine(fdcirengine);
+        Real calculated = europeanOption.NPV();
+        if (std::fabs(expected - calculated) > tolerance) {
+            BOOST_ERROR("Failed to reproduce expected npv"
+                            << "\n    calculated: " << calculated
+                            << "\n    expected:   " << expected
+                            << "\n    tolerance:  " << tolerance);
+        }
+    }
+
+}
+
+test_suite* FdCIRTest::suite(SpeedLevel speed) {
+    test_suite* suite = BOOST_TEST_SUITE("Finite Difference CIR tests");
+
+    suite->add(QUANTLIB_TEST_CASE(&FdCIRTest::testFdmCIRConvergence));
+
+    return suite;
+}
+

--- a/test-suite/fdcir.hpp
+++ b/test-suite/fdcir.hpp
@@ -1,0 +1,36 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Lew Wei Hao
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_fd_cir_hpp
+#define quantlib_test_fd_cir_hpp
+
+#include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class FdCIRTest {
+public:
+    static void testFdmCIRConvergence();
+
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
+};
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -366,7 +366,6 @@ test_suite* init_unit_test_suite(int, char* []) {
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
 
-    test->add(FdCIRTest::suite(speed));
     test->add(AmericanOptionTest::suite());
     test->add(AndreasenHugeVolatilityInterplTest::suite(speed));
     test->add(ArrayTest::suite());
@@ -405,6 +404,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(FdHestonTest::suite(speed));
     test->add(FdmLinearOpTest::suite());
     test->add(FdCevTest::suite(speed));
+    test->add(FdCIRTest::suite(speed));
     test->add(FdSabrTest::suite(speed));
     test->add(FittedBondDiscountCurveTest::suite());
     test->add(ForwardOptionTest::suite());

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -115,6 +115,7 @@
 #include "extensibleoptions.hpp"
 #include "fastfouriertransform.hpp"
 #include "fdheston.hpp"
+#include "fdcir.hpp"
 #include "fdmlinearop.hpp"
 #include "fdcev.hpp"
 #include "fdsabr.hpp"
@@ -400,6 +401,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(EuropeanOptionTest::suite());
     test->add(ExchangeRateTest::suite());
     test->add(FastFourierTransformTest::suite());
+    test->add(FdCIRTest::suite(speed));
     test->add(FdHestonTest::suite(speed));
     test->add(FdmLinearOpTest::suite());
     test->add(FdCevTest::suite(speed));

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -366,6 +366,7 @@ test_suite* init_unit_test_suite(int, char* []) {
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
 
+    test->add(FdCIRTest::suite(speed));
     test->add(AmericanOptionTest::suite());
     test->add(AndreasenHugeVolatilityInterplTest::suite(speed));
     test->add(ArrayTest::suite());
@@ -401,7 +402,6 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(EuropeanOptionTest::suite());
     test->add(ExchangeRateTest::suite());
     test->add(FastFourierTransformTest::suite());
-    test->add(FdCIRTest::suite(speed));
     test->add(FdHestonTest::suite(speed));
     test->add(FdmLinearOpTest::suite());
     test->add(FdCevTest::suite(speed));

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -693,6 +693,7 @@
     <ClCompile Include="functions.cpp" />
     <ClCompile Include="fastfouriertransform.cpp" />
     <ClCompile Include="fdheston.cpp" />
+    <ClCompile Include="fdcir.cpp" />
     <ClCompile Include="fdmlinearop.cpp" />
     <ClCompile Include="forwardoption.cpp" />
     <ClCompile Include="forwardrateagreement.cpp" />
@@ -847,6 +848,7 @@
     <ClInclude Include="functions.hpp" />
     <ClInclude Include="fastfouriertransform.hpp" />
     <ClInclude Include="fdheston.hpp" />
+    <ClInclude Include="fdcir.hpp" />
     <ClInclude Include="fdmlinearop.hpp" />
     <ClInclude Include="forwardoption.hpp" />
     <ClInclude Include="forwardrateagreement.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -164,6 +164,9 @@
     <ClCompile Include="fdheston.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="fdcir.cpp">
+          <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="fdmlinearop.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -620,6 +623,9 @@
     <ClInclude Include="fdheston.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="fdcir.hpp">
+          <Filter>Header Files</Filter>
+        </ClInclude>
     <ClInclude Include="fdmlinearop.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
The short rate for a CoxIngersollRoss process can be described by the following SDE

![cir](https://user-images.githubusercontent.com/13846110/82995519-42589080-a036-11ea-981f-366ffc39c27d.PNG)

By following the methodology described here http://scriptiesonline.uba.uva.nl/document/656101, using Ito's Lemma and riskless portfolio, the PDE for an option under CIR short rate can be derived as

![pde1](https://user-images.githubusercontent.com/13846110/82995315-03c2d600-a036-11ea-844a-16eb4710499a.PNG)

By doing a change of variables for X=lnS, the PDE becomes

![pde2](https://user-images.githubusercontent.com/13846110/82995423-27861c00-a036-11ea-931d-bb1742cebdb3.PNG)

A test has been added to show that the value converges between multiple evolver schemes.

Also, as the sigma for the underlying black scholes process can only be determined during setTime(t1, t2), I needed a way to update the coefficients in the ninepointlinearop(equivalent to the apxb in triplebandlinearop) so i created a reset method for that but I'm open to better ways of doing that instead.
