### PR TITLE
Deprecate term-structure constructors taking jumps and no reference date.

### DIFF
--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -73,11 +73,10 @@ namespace QuantLib {
         const std::vector<DiscountFactor>& discounts() const;
         std::vector<std::pair<Date, Real> > nodes() const;
         //@}
+
       protected:
-        InterpolatedDiscountCurve(
+        explicit InterpolatedDiscountCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
         InterpolatedDiscountCurve(
             const Date& referenceDate,
@@ -92,6 +91,18 @@ namespace QuantLib {
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
             const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InterpolatedDiscountCurve(
+            const DayCounter&,
+            const std::vector<Handle<Quote> >& jumps,
+            const std::vector<Date>& jumpDates = std::vector<Date>(),
+            const Interpolator& interpolator = Interpolator());
+
         //! \name YieldTermStructure implementation
         //@{
         DiscountFactor discountImpl(Time) const;
@@ -171,10 +182,8 @@ namespace QuantLib {
     template <class T>
     InterpolatedDiscountCurve<T>::InterpolatedDiscountCurve(
                                     const DayCounter& dayCounter,
-                                    const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates,
                                     const T& interpolator)
-    : YieldTermStructure(dayCounter, jumps, jumpDates),
+    : YieldTermStructure(dayCounter),
       InterpolatedCurve<T>(interpolator) {}
 
     template <class T>
@@ -197,6 +206,38 @@ namespace QuantLib {
                                     const T& interpolator)
     : YieldTermStructure(settlementDays, calendar, dayCounter, jumps, jumpDates),
       InterpolatedCurve<T>(interpolator) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    template <class T>
+    InterpolatedDiscountCurve<T>::InterpolatedDiscountCurve(
+                                    const DayCounter& dayCounter,
+                                    const std::vector<Handle<Quote> >& jumps,
+                                    const std::vector<Date>& jumpDates,
+                                    const T& interpolator)
+    : YieldTermStructure(dayCounter, jumps, jumpDates),
+      InterpolatedCurve<T>(interpolator) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     template <class T>
     InterpolatedDiscountCurve<T>::InterpolatedDiscountCurve(

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -73,11 +73,10 @@ namespace QuantLib {
         const std::vector<Rate>& forwards() const;
         std::vector<std::pair<Date, Real> > nodes() const;
         //@}
+
       protected:
-        InterpolatedForwardCurve(
+        explicit InterpolatedForwardCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
         InterpolatedForwardCurve(
             const Date& referenceDate,
@@ -92,6 +91,18 @@ namespace QuantLib {
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
             const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InterpolatedForwardCurve(
+            const DayCounter&,
+            const std::vector<Handle<Quote> >& jumps,
+            const std::vector<Date>& jumpDates = std::vector<Date>(),
+            const Interpolator& interpolator = Interpolator());
+
         //! \name ForwardRateStructure implementation
         //@{
         Rate forwardImpl(Time t) const;
@@ -182,11 +193,8 @@ namespace QuantLib {
     template <class T>
     InterpolatedForwardCurve<T>::InterpolatedForwardCurve(
                                     const DayCounter& dayCounter,
-                                    const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates,
                                     const T& interpolator)
-    : ForwardRateStructure(dayCounter, jumps, jumpDates),
-      InterpolatedCurve<T>(interpolator) {}
+    : ForwardRateStructure(dayCounter), InterpolatedCurve<T>(interpolator) {}
 
     template <class T>
     InterpolatedForwardCurve<T>::InterpolatedForwardCurve(
@@ -208,6 +216,38 @@ namespace QuantLib {
                                     const T& interpolator)
     : ForwardRateStructure(settlementDays, calendar, dayCounter, jumps, jumpDates),
       InterpolatedCurve<T>(interpolator) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    template <class T>
+    InterpolatedForwardCurve<T>::InterpolatedForwardCurve(
+                                    const DayCounter& dayCounter,
+                                    const std::vector<Handle<Quote> >& jumps,
+                                    const std::vector<Date>& jumpDates,
+                                    const T& interpolator)
+    : ForwardRateStructure(dayCounter, jumps, jumpDates),
+      InterpolatedCurve<T>(interpolator) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     template <class T>
     InterpolatedForwardCurve<T>::InterpolatedForwardCurve(

--- a/ql/termstructures/yield/forwardstructure.cpp
+++ b/ql/termstructures/yield/forwardstructure.cpp
@@ -23,11 +23,8 @@
 
 namespace QuantLib {
 
-    ForwardRateStructure::ForwardRateStructure(
-                                    const DayCounter& dc,
-                                    const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates)
-    : YieldTermStructure(dc, jumps, jumpDates) {}
+    ForwardRateStructure::ForwardRateStructure(const DayCounter& dc)
+    : YieldTermStructure(dc) {}
 
     ForwardRateStructure::ForwardRateStructure(
                                     const Date& refDate,
@@ -44,6 +41,36 @@ namespace QuantLib {
                                     const std::vector<Handle<Quote> >& jumps,
                                     const std::vector<Date>& jumpDates)
     : YieldTermStructure(settlDays, cal, dc, jumps, jumpDates) {}
+
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    ForwardRateStructure::ForwardRateStructure(
+                                    const DayCounter& dc,
+                                    const std::vector<Handle<Quote> >& jumps,
+                                    const std::vector<Date>& jumpDates)
+    : YieldTermStructure(dc, jumps, jumpDates) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     Rate ForwardRateStructure::zeroYieldImpl(Time t) const {
         if (t == 0.0)

--- a/ql/termstructures/yield/forwardstructure.hpp
+++ b/ql/termstructures/yield/forwardstructure.hpp
@@ -48,11 +48,9 @@ namespace QuantLib {
             constructors.
         */
         //@{
-        ForwardRateStructure(
-            const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
-        ForwardRateStructure(
+        explicit ForwardRateStructure(
+            const DayCounter& dayCounter = DayCounter());
+        explicit ForwardRateStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dayCounter = DayCounter(),
@@ -63,6 +61,16 @@ namespace QuantLib {
             const Calendar& cal,
             const DayCounter& dayCounter = DayCounter(),
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
+            const std::vector<Date>& jumpDates = std::vector<Date>());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        ForwardRateStructure(
+            const DayCounter& dayCounter,
+            const std::vector<Handle<Quote> >& jumps,
             const std::vector<Date>& jumpDates = std::vector<Date>());
         //@}
       protected:

--- a/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
+++ b/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
@@ -65,9 +65,7 @@ class InterpolatedSimpleZeroCurve : public YieldTermStructure, protected Interpo
     //@}
   protected:
     explicit InterpolatedSimpleZeroCurve(const DayCounter &,
-                                const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
-                                const std::vector<Date> &jumpDates = std::vector<Date>(),
-                                const Interpolator &interpolator = Interpolator());
+                                         const Interpolator &interpolator = Interpolator());
     InterpolatedSimpleZeroCurve(const Date &referenceDate, const DayCounter &,
                                 const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
                                 const std::vector<Date> &jumpDates = std::vector<Date>(),
@@ -76,6 +74,16 @@ class InterpolatedSimpleZeroCurve : public YieldTermStructure, protected Interpo
                                 const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
                                 const std::vector<Date> &jumpDates = std::vector<Date>(),
                                 const Interpolator &interpolator = Interpolator());
+
+    /*! \deprecated Passing jumps without a reference date never worked correctly.
+                    Use one of the other constructors instead.
+                    Deprecated in version 1.19.
+    */
+    QL_DEPRECATED
+    explicit InterpolatedSimpleZeroCurve(const DayCounter &,
+                                         const std::vector<Handle<Quote> > &jumps,
+                                         const std::vector<Date> &jumpDates = std::vector<Date>(),
+                                         const Interpolator &interpolator = Interpolator());
     //! \name YieldTermStructure implementation
     //@{
     DiscountFactor discountImpl(Time t) const;
@@ -131,10 +139,8 @@ template <class T> DiscountFactor InterpolatedSimpleZeroCurve<T>::discountImpl(T
 }
 
 template <class T>
-InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(const DayCounter &dayCounter,
-                                                            const std::vector<Handle<Quote> > &jumps,
-                                                            const std::vector<Date> &jumpDates, const T &interpolator)
-    : YieldTermStructure(dayCounter, jumps, jumpDates), InterpolatedCurve<T>(interpolator) {}
+InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(const DayCounter &dayCounter, const T &interpolator)
+    : YieldTermStructure(dayCounter), InterpolatedCurve<T>(interpolator) {}
 
 template <class T>
 InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(const Date &referenceDate, const DayCounter &dayCounter,
@@ -148,6 +154,36 @@ InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(Natural settlementDa
                                                             const std::vector<Handle<Quote> > &jumps,
                                                             const std::vector<Date> &jumpDates, const T &interpolator)
     : YieldTermStructure(settlementDays, calendar, dayCounter, jumps, jumpDates), InterpolatedCurve<T>(interpolator) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+template <class T>
+InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(const DayCounter &dayCounter,
+                                                            const std::vector<Handle<Quote> > &jumps,
+                                                            const std::vector<Date> &jumpDates,
+                                                            const T &interpolator)
+    : YieldTermStructure(dayCounter, jumps, jumpDates), InterpolatedCurve<T>(interpolator) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 template <class T>
 InterpolatedSimpleZeroCurve<T>::InterpolatedSimpleZeroCurve(const std::vector<Date> &dates,

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -81,11 +81,10 @@ namespace QuantLib {
         const std::vector<Rate>& zeroRates() const;
         std::vector<std::pair<Date, Real> > nodes() const;
         //@}
+
       protected:
-        InterpolatedZeroCurve(
+        explicit InterpolatedZeroCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
         InterpolatedZeroCurve(
             const Date& referenceDate,
@@ -100,6 +99,18 @@ namespace QuantLib {
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
             const std::vector<Date>& jumpDates = std::vector<Date>(),
             const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroCurve(
+            const DayCounter&,
+            const std::vector<Handle<Quote> >& jumps,
+            const std::vector<Date>& jumpDates = std::vector<Date>(),
+            const Interpolator& interpolator = Interpolator());
+
         //! \name ZeroYieldStructure implementation
         //@{
         Rate zeroYieldImpl(Time t) const;
@@ -173,11 +184,8 @@ namespace QuantLib {
     template <class T>
     InterpolatedZeroCurve<T>::InterpolatedZeroCurve(
                                     const DayCounter& dayCounter,
-                                    const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates,
                                     const T& interpolator)
-    : ZeroYieldStructure(dayCounter, jumps, jumpDates),
-      InterpolatedCurve<T>(interpolator) {}
+    : ZeroYieldStructure(dayCounter), InterpolatedCurve<T>(interpolator) {}
 
     template <class T>
     InterpolatedZeroCurve<T>::InterpolatedZeroCurve(
@@ -199,6 +207,38 @@ namespace QuantLib {
                                     const T& interpolator)
     : ZeroYieldStructure(settlementDays, calendar, dayCounter, jumps, jumpDates),
       InterpolatedCurve<T>(interpolator) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    template <class T>
+    InterpolatedZeroCurve<T>::InterpolatedZeroCurve(
+                                    const DayCounter& dayCounter,
+                                    const std::vector<Handle<Quote> >& jumps,
+                                    const std::vector<Date>& jumpDates,
+                                    const T& interpolator)
+    : ZeroYieldStructure(dayCounter, jumps, jumpDates),
+      InterpolatedCurve<T>(interpolator) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     template <class T>
     InterpolatedZeroCurve<T>::InterpolatedZeroCurve(

--- a/ql/termstructures/yield/zeroyieldstructure.cpp
+++ b/ql/termstructures/yield/zeroyieldstructure.cpp
@@ -23,11 +23,8 @@
 
 namespace QuantLib {
 
-    ZeroYieldStructure::ZeroYieldStructure(
-                                    const DayCounter& dc,
-                                    const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates)
-    : YieldTermStructure(dc, jumps, jumpDates) {}
+    ZeroYieldStructure::ZeroYieldStructure(const DayCounter& dc)
+    : YieldTermStructure(dc) {}
 
     ZeroYieldStructure::ZeroYieldStructure(
                                     const Date& refDate,
@@ -44,5 +41,34 @@ namespace QuantLib {
                                     const std::vector<Handle<Quote> >& jumps,
                                     const std::vector<Date>& jumpDates)
     : YieldTermStructure(settlementDays, cal, dc, jumps, jumpDates) {}
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(QL_PATCH_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
+    ZeroYieldStructure::ZeroYieldStructure(
+                                    const DayCounter& dc,
+                                    const std::vector<Handle<Quote> >& jumps,
+                                    const std::vector<Date>& jumpDates)
+    : YieldTermStructure(dc, jumps, jumpDates) {}
+
+#if defined(QL_PATCH_MSVC)
+#pragma warning(pop)
+#endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 }

--- a/ql/termstructures/yield/zeroyieldstructure.hpp
+++ b/ql/termstructures/yield/zeroyieldstructure.hpp
@@ -48,11 +48,9 @@ namespace QuantLib {
             constructors.
         */
         //@{
-        ZeroYieldStructure(
-            const DayCounter& dc = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
-        ZeroYieldStructure(
+        explicit ZeroYieldStructure(
+            const DayCounter& dc = DayCounter());
+        explicit ZeroYieldStructure(
             const Date& referenceDate,
             const Calendar& calendar = Calendar(),
             const DayCounter& dc = DayCounter(),
@@ -63,6 +61,16 @@ namespace QuantLib {
             const Calendar& calendar,
             const DayCounter& dc = DayCounter(),
             const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
+            const std::vector<Date>& jumpDates = std::vector<Date>());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        ZeroYieldStructure(
+            const DayCounter& dc,
+            const std::vector<Handle<Quote> >& jumps,
             const std::vector<Date>& jumpDates = std::vector<Date>());
         //@}
       protected:

--- a/ql/termstructures/yieldtermstructure.hpp
+++ b/ql/termstructures/yieldtermstructure.hpp
@@ -48,9 +48,7 @@ namespace QuantLib {
             constructors.
         */
         //@{
-        YieldTermStructure(const DayCounter& dc = DayCounter(),
-                           const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-                           const std::vector<Date>& jumpDates = std::vector<Date>());
+        explicit YieldTermStructure(const DayCounter& dc = DayCounter());
         YieldTermStructure(const Date& referenceDate,
                            const Calendar& cal = Calendar(),
                            const DayCounter& dc = DayCounter(),
@@ -60,6 +58,15 @@ namespace QuantLib {
                            const Calendar& cal,
                            const DayCounter& dc = DayCounter(),
                            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
+                           const std::vector<Date>& jumpDates = std::vector<Date>());
+
+        /*! \deprecated Passing jumps without a reference date never worked correctly.
+                        Use one of the other constructors instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        YieldTermStructure(const DayCounter& dc,
+                           const std::vector<Handle<Quote> >& jumps,
                            const std::vector<Date>& jumpDates = std::vector<Date>());
         //@}
 
@@ -170,7 +177,7 @@ namespace QuantLib {
         //@}
       private:
         // methods
-        void setJumps();
+        void setJumps(const Date& referenceDate);
         // data members
         std::vector<Handle<Quote> > jumps_;
         std::vector<Date> jumpDates_;


### PR DESCRIPTION
When no dates were passed, the jumps were initialized incorrectly.