### PR TITLE
init isStrikeIndependent_

### DIFF
--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -41,7 +41,8 @@ namespace QuantLib {
       x0_(x0), riskFreeRate_(riskFreeTS),
       dividendYield_(dividendTS), blackVolatility_(blackVolTS),
       externalLocalVolTS_(localVolTS),
-      forceDiscretization_(false), hasExternalLocalVol_(true), updated_(false) {
+      forceDiscretization_(false), hasExternalLocalVol_(true), updated_(false),
+      isStrikeIndependent_(false) {
         registerWith(x0_);
         registerWith(riskFreeRate_);
         registerWith(dividendYield_);
@@ -59,7 +60,8 @@ namespace QuantLib {
     : StochasticProcess1D(disc), x0_(x0), riskFreeRate_(riskFreeTS),
       dividendYield_(dividendTS), blackVolatility_(blackVolTS),
       forceDiscretization_(forceDiscretization),
-      hasExternalLocalVol_(false), updated_(false) {
+      hasExternalLocalVol_(false), updated_(false),
+      isStrikeIndependent_(false) {
         registerWith(x0_);
         registerWith(riskFreeRate_);
         registerWith(dividendYield_);


### PR DESCRIPTION
I noticed this when using `GeneralizedBlackScholesProcess` with an externally given local vol ts: Since `isStrikeIndependent_` was `true` in my case, mc simulation results based on `evolve()` looked wrong.