### PR TITLE
Fix out of bound access in CalendarTest::testDayLists

### DIFF
--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -24,20 +24,20 @@
 
 #include "calendars.hpp"
 #include "utilities.hpp"
+#include <ql/errors.hpp>
 #include <ql/time/calendar.hpp>
+#include <ql/time/calendars/bespokecalendar.hpp>
 #include <ql/time/calendars/brazil.hpp>
 #include <ql/time/calendars/china.hpp>
 #include <ql/time/calendars/germany.hpp>
 #include <ql/time/calendars/italy.hpp>
+#include <ql/time/calendars/japan.hpp>
+#include <ql/time/calendars/jointcalendar.hpp>
 #include <ql/time/calendars/russia.hpp>
+#include <ql/time/calendars/southkorea.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/unitedkingdom.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
-#include <ql/time/calendars/japan.hpp>
-#include <ql/time/calendars/southkorea.hpp>
-#include <ql/time/calendars/jointcalendar.hpp>
-#include <ql/time/calendars/bespokecalendar.hpp>
-#include <ql/errors.hpp>
 #include <fstream>
 
 using namespace QuantLib;
@@ -49,8 +49,8 @@ void CalendarTest::testModifiedCalendars() {
 
     Calendar c1 = TARGET();
     Calendar c2 = UnitedStates(UnitedStates::NYSE);
-    Date d1(1,May,2004);      // holiday for both calendars
-    Date d2(26,April,2004);   // business day
+    Date d1(1, May, 2004);    // holiday for both calendars
+    Date d2(26, April, 2004); // business day
 
     QL_REQUIRE(c1.isHoliday(d1), "wrong assumption---correct the test");
     QL_REQUIRE(c1.isBusinessDay(d2), "wrong assumption---correct the test");
@@ -66,10 +66,14 @@ void CalendarTest::testModifiedCalendars() {
     std::set<Date> addedHolidays(c1.addedHolidays());
     std::set<Date> removedHolidays(c1.removedHolidays());
 
-    QL_REQUIRE(addedHolidays.find(d1) == addedHolidays.end(), "did not expect to find date in addedHolidays");
-    QL_REQUIRE(addedHolidays.find(d2) != addedHolidays.end(), "expected to find date in addedHolidays");
-    QL_REQUIRE(removedHolidays.find(d1) != removedHolidays.end(), "expected to find date in removedHolidays");
-    QL_REQUIRE(removedHolidays.find(d2) == removedHolidays.end(), "did not expect to find date in removedHolidays");
+    QL_REQUIRE(addedHolidays.find(d1) == addedHolidays.end(),
+               "did not expect to find date in addedHolidays");
+    QL_REQUIRE(addedHolidays.find(d2) != addedHolidays.end(),
+               "expected to find date in addedHolidays");
+    QL_REQUIRE(removedHolidays.find(d1) != removedHolidays.end(),
+               "expected to find date in removedHolidays");
+    QL_REQUIRE(removedHolidays.find(d2) == removedHolidays.end(),
+               "did not expect to find date in removedHolidays");
 
     if (c1.isHoliday(d1))
         BOOST_FAIL(d1 << " still a holiday for original TARGET instance");
@@ -104,82 +108,74 @@ void CalendarTest::testJointCalendars() {
 
     BOOST_TEST_MESSAGE("Testing joint calendars...");
 
-    Calendar c1 = TARGET(),
-             c2 = UnitedKingdom(),
-             c3 = UnitedStates(UnitedStates::NYSE),
-             c4 = Japan(),
-             c5 = Germany();
+    Calendar c1 = TARGET(), c2 = UnitedKingdom(), c3 = UnitedStates(UnitedStates::NYSE),
+             c4 = Japan(), c5 = Germany();
 
     std::vector<Calendar> calendar_vect;
-    calendar_vect.reserve( 5 );
+    calendar_vect.reserve(5);
     calendar_vect.push_back(c1);
     calendar_vect.push_back(c2);
     calendar_vect.push_back(c3);
     calendar_vect.push_back(c4);
     calendar_vect.push_back(c5);
 
-    Calendar c12h = JointCalendar(c1,c2,JoinHolidays),
-             c12b = JointCalendar(c1,c2,JoinBusinessDays),
-             c123h = JointCalendar(c1,c2,c3,JoinHolidays),
-             c123b = JointCalendar(c1,c2,c3,JoinBusinessDays),
-             c1234h = JointCalendar(c1,c2,c3,c4,JoinHolidays),
-             c1234b = JointCalendar(c1,c2,c3,c4,JoinBusinessDays),
-             cvh = JointCalendar(calendar_vect,JoinHolidays);
+    Calendar c12h = JointCalendar(c1, c2, JoinHolidays),
+             c12b = JointCalendar(c1, c2, JoinBusinessDays),
+             c123h = JointCalendar(c1, c2, c3, JoinHolidays),
+             c123b = JointCalendar(c1, c2, c3, JoinBusinessDays),
+             c1234h = JointCalendar(c1, c2, c3, c4, JoinHolidays),
+             c1234b = JointCalendar(c1, c2, c3, c4, JoinBusinessDays),
+             cvh = JointCalendar(calendar_vect, JoinHolidays);
 
     // test one year, starting today
-    Date firstDate = Date::todaysDate(),
-         endDate = firstDate + 1*Years;
+    Date firstDate = Date::todaysDate(), endDate = firstDate + 1 * Years;
 
     for (Date d = firstDate; d < endDate; d++) {
 
-        bool b1 = c1.isBusinessDay(d),
-             b2 = c2.isBusinessDay(d),
-             b3 = c3.isBusinessDay(d),
-             b4 = c4.isBusinessDay(d),
-             b5 = c5.isBusinessDay(d);
+        bool b1 = c1.isBusinessDay(d), b2 = c2.isBusinessDay(d), b3 = c3.isBusinessDay(d),
+             b4 = c4.isBusinessDay(d), b5 = c5.isBusinessDay(d);
 
         if ((b1 && b2) != c12h.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c12h.name() << " (joining holidays)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c12h.name()
+                                  << " (joining holidays)\n"
+                                  << "    and its components");
 
         if ((b1 || b2) != c12b.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c12b.name() << " (joining business days)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c12b.name()
+                                  << " (joining business days)\n"
+                                  << "    and its components");
 
         if ((b1 && b2 && b3) != c123h.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c123h.name() << " (joining holidays)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c123h.name()
+                                  << " (joining holidays)\n"
+                                  << "    and its components");
 
         if ((b1 || b2 || b3) != c123b.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c123b.name() << " (joining business days)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c123b.name()
+                                  << " (joining business days)\n"
+                                  << "    and its components");
 
         if ((b1 && b2 && b3 && b4) != c1234h.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c1234h.name() << " (joining holidays)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c1234h.name()
+                                  << " (joining holidays)\n"
+                                  << "    and its components");
 
         if ((b1 || b2 || b3 || b4) != c1234b.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << c1234b.name() << " (joining business days)\n"
-                       << "    and its components");
+                                  << "    inconsistency between joint calendar " << c1234b.name()
+                                  << " (joining business days)\n"
+                                  << "    and its components");
 
         if ((b1 && b2 && b3 && b4 && b5) != cvh.isBusinessDay(d))
             BOOST_FAIL("At date " << d << ":\n"
-                       << "    inconsistency between joint calendar "
-                       << cvh.name() << " (joining holidays)\n"
-                       << "    and its components");
-
+                                  << "    inconsistency between joint calendar " << cvh.name()
+                                  << " (joining holidays)\n"
+                                  << "    and its components");
     }
 }
 
@@ -187,62 +183,58 @@ void CalendarTest::testUSSettlement() {
     BOOST_TEST_MESSAGE("Testing US settlement holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(19,January,2004));
-    expectedHol.push_back(Date(16,February,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(5,July,2004));
-    expectedHol.push_back(Date(6,September,2004));
-    expectedHol.push_back(Date(11,October,2004));
-    expectedHol.push_back(Date(11,November,2004));
-    expectedHol.push_back(Date(25,November,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(19, January, 2004));
+    expectedHol.push_back(Date(16, February, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(5, July, 2004));
+    expectedHol.push_back(Date(6, September, 2004));
+    expectedHol.push_back(Date(11, October, 2004));
+    expectedHol.push_back(Date(11, November, 2004));
+    expectedHol.push_back(Date(25, November, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
-    expectedHol.push_back(Date(31,December,2004));
-    expectedHol.push_back(Date(17,January,2005));
-    expectedHol.push_back(Date(21,February,2005));
-    expectedHol.push_back(Date(30,May,2005));
-    expectedHol.push_back(Date(4,July,2005));
-    expectedHol.push_back(Date(5,September,2005));
-    expectedHol.push_back(Date(10,October,2005));
-    expectedHol.push_back(Date(11,November,2005));
-    expectedHol.push_back(Date(24,November,2005));
-    expectedHol.push_back(Date(26,December,2005));
+    expectedHol.push_back(Date(31, December, 2004));
+    expectedHol.push_back(Date(17, January, 2005));
+    expectedHol.push_back(Date(21, February, 2005));
+    expectedHol.push_back(Date(30, May, 2005));
+    expectedHol.push_back(Date(4, July, 2005));
+    expectedHol.push_back(Date(5, September, 2005));
+    expectedHol.push_back(Date(10, October, 2005));
+    expectedHol.push_back(Date(11, November, 2005));
+    expectedHol.push_back(Date(24, November, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
 
     Calendar c = UnitedStates(UnitedStates::Settlement);
-    std::vector<Date> hol = c.holidayList(Date( 1, January, 2004),
-                                          Date(31,December, 2005));
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
-    for (Size i=0; i<hol.size(); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2005));
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
+    for (Size i = 0; i < hol.size(); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
 
     // before Uniform Monday Holiday Act
     expectedHol = std::vector<Date>();
-    expectedHol.push_back(Date(2,January,1961));
-    expectedHol.push_back(Date(22,February,1961));
-    expectedHol.push_back(Date(30,May,1961));
-    expectedHol.push_back(Date(4,July,1961));
-    expectedHol.push_back(Date(4,September,1961));
-    expectedHol.push_back(Date(10,November,1961));
-    expectedHol.push_back(Date(23,November,1961));
-    expectedHol.push_back(Date(25,December,1961));
+    expectedHol.push_back(Date(2, January, 1961));
+    expectedHol.push_back(Date(22, February, 1961));
+    expectedHol.push_back(Date(30, May, 1961));
+    expectedHol.push_back(Date(4, July, 1961));
+    expectedHol.push_back(Date(4, September, 1961));
+    expectedHol.push_back(Date(10, November, 1961));
+    expectedHol.push_back(Date(23, November, 1961));
+    expectedHol.push_back(Date(25, December, 1961));
 
-    hol = c.holidayList(Date( 1, January, 1961),
-                        Date(31,December, 1961));
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
-    for (Size i=0; i<hol.size(); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    hol = c.holidayList(Date(1, January, 1961), Date(31, December, 1961));
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
+    for (Size i = 0; i < hol.size(); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
 }
 
@@ -250,130 +242,125 @@ void CalendarTest::testUSGovernmentBondMarket() {
     BOOST_TEST_MESSAGE("Testing US government bond market holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(19,January,2004));
-    expectedHol.push_back(Date(16,February,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(11,June,2004)); // Reagan's funeral
-    expectedHol.push_back(Date(5,July,2004));
-    expectedHol.push_back(Date(6,September,2004));
-    expectedHol.push_back(Date(11,October,2004));
-    expectedHol.push_back(Date(11,November,2004));
-    expectedHol.push_back(Date(25,November,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(19, January, 2004));
+    expectedHol.push_back(Date(16, February, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(11, June, 2004)); // Reagan's funeral
+    expectedHol.push_back(Date(5, July, 2004));
+    expectedHol.push_back(Date(6, September, 2004));
+    expectedHol.push_back(Date(11, October, 2004));
+    expectedHol.push_back(Date(11, November, 2004));
+    expectedHol.push_back(Date(25, November, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
     Calendar c = UnitedStates(UnitedStates::GovernmentBond);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2004));
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2004));
 
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testUSNewYorkStockExchange() {
     BOOST_TEST_MESSAGE("Testing New York Stock Exchange holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(19,January,2004));
-    expectedHol.push_back(Date(16,February,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(11,June,2004));
-    expectedHol.push_back(Date(5,July,2004));
-    expectedHol.push_back(Date(6,September,2004));
-    expectedHol.push_back(Date(25,November,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(19, January, 2004));
+    expectedHol.push_back(Date(16, February, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(11, June, 2004));
+    expectedHol.push_back(Date(5, July, 2004));
+    expectedHol.push_back(Date(6, September, 2004));
+    expectedHol.push_back(Date(25, November, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
-    expectedHol.push_back(Date(17,January,2005));
-    expectedHol.push_back(Date(21,February,2005));
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(30,May,2005));
-    expectedHol.push_back(Date(4,July,2005));
-    expectedHol.push_back(Date(5,September,2005));
-    expectedHol.push_back(Date(24,November,2005));
-    expectedHol.push_back(Date(26,December,2005));
+    expectedHol.push_back(Date(17, January, 2005));
+    expectedHol.push_back(Date(21, February, 2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(30, May, 2005));
+    expectedHol.push_back(Date(4, July, 2005));
+    expectedHol.push_back(Date(5, September, 2005));
+    expectedHol.push_back(Date(24, November, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
 
-    expectedHol.push_back(Date(2,January,2006));
-    expectedHol.push_back(Date(16,January,2006));
-    expectedHol.push_back(Date(20,February,2006));
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(29,May,2006));
-    expectedHol.push_back(Date(4,July,2006));
-    expectedHol.push_back(Date(4,September,2006));
-    expectedHol.push_back(Date(23,November,2006));
-    expectedHol.push_back(Date(25,December,2006));
+    expectedHol.push_back(Date(2, January, 2006));
+    expectedHol.push_back(Date(16, January, 2006));
+    expectedHol.push_back(Date(20, February, 2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(29, May, 2006));
+    expectedHol.push_back(Date(4, July, 2006));
+    expectedHol.push_back(Date(4, September, 2006));
+    expectedHol.push_back(Date(23, November, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
 
     Calendar c = UnitedStates(UnitedStates::NYSE);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2006));
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2006));
 
     Size i;
-    for (i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    for (i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 
     std::vector<Date> histClose;
-    histClose.push_back(Date(30,October,2012));  // Hurricane Sandy
-    histClose.push_back(Date(29,October,2012));  // Hurricane Sandy
-    histClose.push_back(Date(11,June,2004));     // Reagan's funeral
-    histClose.push_back(Date(14,September,2001));// September 11, 2001
-    histClose.push_back(Date(13,September,2001));// September 11, 2001
-    histClose.push_back(Date(12,September,2001));// September 11, 2001
-    histClose.push_back(Date(11,September,2001));// September 11, 2001
-    histClose.push_back(Date(27,April,1994));    // Nixon's funeral.
-    histClose.push_back(Date(27,September,1985));// Hurricane Gloria
-    histClose.push_back(Date(14,July,1977));     // 1977 Blackout
-    histClose.push_back(Date(25,January,1973));  // Johnson's funeral.
-    histClose.push_back(Date(28,December,1972)); // Truman's funeral
-    histClose.push_back(Date(21,July,1969));     // Lunar exploration nat. day
-    histClose.push_back(Date(31,March,1969));    // Eisenhower's funeral
-    histClose.push_back(Date(10,February,1969)); // heavy snow
-    histClose.push_back(Date(5,July,1968));      // Day after Independence Day
-    histClose.push_back(Date(9,April,1968));     // Mourning for MLK
-    histClose.push_back(Date(24,December,1965)); // Christmas Eve
-    histClose.push_back(Date(25,November,1963)); // Kennedy's funeral
-    histClose.push_back(Date(29,May,1961));      // Day before Decoration Day
-    histClose.push_back(Date(26,December,1958)); // Day after Christmas
-    histClose.push_back(Date(24,December,1956)); // Christmas Eve
-    histClose.push_back(Date(24,December,1954)); // Christmas Eve
+    histClose.push_back(Date(30, October, 2012));   // Hurricane Sandy
+    histClose.push_back(Date(29, October, 2012));   // Hurricane Sandy
+    histClose.push_back(Date(11, June, 2004));      // Reagan's funeral
+    histClose.push_back(Date(14, September, 2001)); // September 11, 2001
+    histClose.push_back(Date(13, September, 2001)); // September 11, 2001
+    histClose.push_back(Date(12, September, 2001)); // September 11, 2001
+    histClose.push_back(Date(11, September, 2001)); // September 11, 2001
+    histClose.push_back(Date(27, April, 1994));     // Nixon's funeral.
+    histClose.push_back(Date(27, September, 1985)); // Hurricane Gloria
+    histClose.push_back(Date(14, July, 1977));      // 1977 Blackout
+    histClose.push_back(Date(25, January, 1973));   // Johnson's funeral.
+    histClose.push_back(Date(28, December, 1972));  // Truman's funeral
+    histClose.push_back(Date(21, July, 1969));      // Lunar exploration nat. day
+    histClose.push_back(Date(31, March, 1969));     // Eisenhower's funeral
+    histClose.push_back(Date(10, February, 1969));  // heavy snow
+    histClose.push_back(Date(5, July, 1968));       // Day after Independence Day
+    histClose.push_back(Date(9, April, 1968));      // Mourning for MLK
+    histClose.push_back(Date(24, December, 1965));  // Christmas Eve
+    histClose.push_back(Date(25, November, 1963));  // Kennedy's funeral
+    histClose.push_back(Date(29, May, 1961));       // Day before Decoration Day
+    histClose.push_back(Date(26, December, 1958));  // Day after Christmas
+    histClose.push_back(Date(24, December, 1956));  // Christmas Eve
+    histClose.push_back(Date(24, December, 1954));  // Christmas Eve
     // June 12-Dec. 31, 1968
     // Four day week (closed on Wednesdays) - Paperwork Crisis
-    histClose.push_back(Date(12,Jun,1968));
-    histClose.push_back(Date(19,Jun,1968));
-    histClose.push_back(Date(26,Jun,1968));
-    histClose.push_back(Date(3,Jul,1968 ));
-    histClose.push_back(Date(10,Jul,1968));
-    histClose.push_back(Date(17,Jul,1968));
-    histClose.push_back(Date(20,Nov,1968));
-    histClose.push_back(Date(27,Nov,1968));
-    histClose.push_back(Date(4,Dec,1968 ));
-    histClose.push_back(Date(11,Dec,1968));
-    histClose.push_back(Date(18,Dec,1968));
+    histClose.push_back(Date(12, Jun, 1968));
+    histClose.push_back(Date(19, Jun, 1968));
+    histClose.push_back(Date(26, Jun, 1968));
+    histClose.push_back(Date(3, Jul, 1968));
+    histClose.push_back(Date(10, Jul, 1968));
+    histClose.push_back(Date(17, Jul, 1968));
+    histClose.push_back(Date(20, Nov, 1968));
+    histClose.push_back(Date(27, Nov, 1968));
+    histClose.push_back(Date(4, Dec, 1968));
+    histClose.push_back(Date(11, Dec, 1968));
+    histClose.push_back(Date(18, Dec, 1968));
     // Presidential election days
-    histClose.push_back(Date(4,Nov,1980));
-    histClose.push_back(Date(2,Nov,1976));
-    histClose.push_back(Date(7,Nov,1972));
-    histClose.push_back(Date(5,Nov,1968));
-    histClose.push_back(Date(3,Nov,1964));
-    for (i=0; i<histClose.size(); i++) {
+    histClose.push_back(Date(4, Nov, 1980));
+    histClose.push_back(Date(2, Nov, 1976));
+    histClose.push_back(Date(7, Nov, 1972));
+    histClose.push_back(Date(5, Nov, 1968));
+    histClose.push_back(Date(3, Nov, 1964));
+    for (i = 0; i < histClose.size(); i++) {
         if (!c.isHoliday(histClose[i]))
-            BOOST_FAIL(histClose[i]
-                       << " should be holiday (historical close)");
+            BOOST_FAIL(histClose[i] << " should be holiday (historical close)");
     }
 }
 
@@ -381,65 +368,62 @@ void CalendarTest::testTARGET() {
     BOOST_TEST_MESSAGE("Testing TARGET holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,1999));
-    expectedHol.push_back(Date(31,December,1999));
+    expectedHol.push_back(Date(1, January, 1999));
+    expectedHol.push_back(Date(31, December, 1999));
 
-    expectedHol.push_back(Date(21,April,2000));
-    expectedHol.push_back(Date(24,April,2000));
-    expectedHol.push_back(Date(1,May,2000));
-    expectedHol.push_back(Date(25,December,2000));
-    expectedHol.push_back(Date(26,December,2000));
+    expectedHol.push_back(Date(21, April, 2000));
+    expectedHol.push_back(Date(24, April, 2000));
+    expectedHol.push_back(Date(1, May, 2000));
+    expectedHol.push_back(Date(25, December, 2000));
+    expectedHol.push_back(Date(26, December, 2000));
 
-    expectedHol.push_back(Date(1,January,2001));
-    expectedHol.push_back(Date(13,April,2001));
-    expectedHol.push_back(Date(16,April,2001));
-    expectedHol.push_back(Date(1,May,2001));
-    expectedHol.push_back(Date(25,December,2001));
-    expectedHol.push_back(Date(26,December,2001));
-    expectedHol.push_back(Date(31,December,2001));
+    expectedHol.push_back(Date(1, January, 2001));
+    expectedHol.push_back(Date(13, April, 2001));
+    expectedHol.push_back(Date(16, April, 2001));
+    expectedHol.push_back(Date(1, May, 2001));
+    expectedHol.push_back(Date(25, December, 2001));
+    expectedHol.push_back(Date(26, December, 2001));
+    expectedHol.push_back(Date(31, December, 2001));
 
-    expectedHol.push_back(Date(1,January,2002));
-    expectedHol.push_back(Date(29,March,2002));
-    expectedHol.push_back(Date(1,April,2002));
-    expectedHol.push_back(Date(1,May,2002));
-    expectedHol.push_back(Date(25,December,2002));
-    expectedHol.push_back(Date(26,December,2002));
+    expectedHol.push_back(Date(1, January, 2002));
+    expectedHol.push_back(Date(29, March, 2002));
+    expectedHol.push_back(Date(1, April, 2002));
+    expectedHol.push_back(Date(1, May, 2002));
+    expectedHol.push_back(Date(25, December, 2002));
+    expectedHol.push_back(Date(26, December, 2002));
 
-    expectedHol.push_back(Date(1,January,2003));
-    expectedHol.push_back(Date(18,April,2003));
-    expectedHol.push_back(Date(21,April,2003));
-    expectedHol.push_back(Date(1,May,2003));
-    expectedHol.push_back(Date(25,December,2003));
-    expectedHol.push_back(Date(26,December,2003));
+    expectedHol.push_back(Date(1, January, 2003));
+    expectedHol.push_back(Date(18, April, 2003));
+    expectedHol.push_back(Date(21, April, 2003));
+    expectedHol.push_back(Date(1, May, 2003));
+    expectedHol.push_back(Date(25, December, 2003));
+    expectedHol.push_back(Date(26, December, 2003));
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
 
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(28,March,2005));
-    expectedHol.push_back(Date(26,December,2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(28, March, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
 
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(17,April,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(25,December,2006));
-    expectedHol.push_back(Date(26,December,2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(17, April, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
+    expectedHol.push_back(Date(26, December, 2006));
 
     Calendar c = TARGET();
-    std::vector<Date> hol = c.holidayList(Date(1,January,1999),
-                                          Date(31,December,2006));
+    std::vector<Date> hol = c.holidayList(Date(1, January, 1999), Date(31, December, 2006));
 
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
-
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testGermanyFrankfurt() {
@@ -447,31 +431,29 @@ void CalendarTest::testGermanyFrankfurt() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2003));
-    expectedHol.push_back(Date(18,April,2003));
-    expectedHol.push_back(Date(21,April,2003));
-    expectedHol.push_back(Date(1,May,2003));
-    expectedHol.push_back(Date(24,December,2003));
-    expectedHol.push_back(Date(25,December,2003));
-    expectedHol.push_back(Date(26,December,2003));
+    expectedHol.push_back(Date(1, January, 2003));
+    expectedHol.push_back(Date(18, April, 2003));
+    expectedHol.push_back(Date(21, April, 2003));
+    expectedHol.push_back(Date(1, May, 2003));
+    expectedHol.push_back(Date(24, December, 2003));
+    expectedHol.push_back(Date(25, December, 2003));
+    expectedHol.push_back(Date(26, December, 2003));
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
     Calendar c = Germany(Germany::FrankfurtStockExchange);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2003),
-                                          Date(31,December,2004));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2003), Date(31, December, 2004));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testGermanyEurex() {
@@ -479,31 +461,29 @@ void CalendarTest::testGermanyEurex() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2003));
-    expectedHol.push_back(Date(18,April,2003));
-    expectedHol.push_back(Date(21,April,2003));
-    expectedHol.push_back(Date(1,May,2003));
-    expectedHol.push_back(Date(24,December,2003));
-    expectedHol.push_back(Date(25,December,2003));
-    expectedHol.push_back(Date(26,December,2003));
+    expectedHol.push_back(Date(1, January, 2003));
+    expectedHol.push_back(Date(18, April, 2003));
+    expectedHol.push_back(Date(21, April, 2003));
+    expectedHol.push_back(Date(1, May, 2003));
+    expectedHol.push_back(Date(24, December, 2003));
+    expectedHol.push_back(Date(25, December, 2003));
+    expectedHol.push_back(Date(26, December, 2003));
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
     Calendar c = Germany(Germany::Eurex);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2003),
-                                          Date(31,December,2004));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2003), Date(31, December, 2004));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testGermanyXetra() {
@@ -511,31 +491,29 @@ void CalendarTest::testGermanyXetra() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2003));
-    expectedHol.push_back(Date(18,April,2003));
-    expectedHol.push_back(Date(21,April,2003));
-    expectedHol.push_back(Date(1,May,2003));
-    expectedHol.push_back(Date(24,December,2003));
-    expectedHol.push_back(Date(25,December,2003));
-    expectedHol.push_back(Date(26,December,2003));
+    expectedHol.push_back(Date(1, January, 2003));
+    expectedHol.push_back(Date(18, April, 2003));
+    expectedHol.push_back(Date(21, April, 2003));
+    expectedHol.push_back(Date(1, May, 2003));
+    expectedHol.push_back(Date(24, December, 2003));
+    expectedHol.push_back(Date(25, December, 2003));
+    expectedHol.push_back(Date(26, December, 2003));
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(24,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
 
     Calendar c = Germany(Germany::Xetra);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2003),
-                                          Date(31,December,2004));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2003), Date(31, December, 2004));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testUKSettlement() {
@@ -543,54 +521,52 @@ void CalendarTest::testUKSettlement() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(3,May,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(30,August,2004));
-    expectedHol.push_back(Date(27,December,2004));
-    expectedHol.push_back(Date(28,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(3, May, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(30, August, 2004));
+    expectedHol.push_back(Date(27, December, 2004));
+    expectedHol.push_back(Date(28, December, 2004));
 
-    expectedHol.push_back(Date(3,January,2005));
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(28,March,2005));
-    expectedHol.push_back(Date(2,May,2005));
-    expectedHol.push_back(Date(30,May,2005));
-    expectedHol.push_back(Date(29,August,2005));
-    expectedHol.push_back(Date(26,December,2005));
-    expectedHol.push_back(Date(27,December,2005));
+    expectedHol.push_back(Date(3, January, 2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(28, March, 2005));
+    expectedHol.push_back(Date(2, May, 2005));
+    expectedHol.push_back(Date(30, May, 2005));
+    expectedHol.push_back(Date(29, August, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
+    expectedHol.push_back(Date(27, December, 2005));
 
-    expectedHol.push_back(Date(2,January,2006));
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(17,April,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(29,May,2006));
-    expectedHol.push_back(Date(28,August,2006));
-    expectedHol.push_back(Date(25,December,2006));
-    expectedHol.push_back(Date(26,December,2006));
+    expectedHol.push_back(Date(2, January, 2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(17, April, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(29, May, 2006));
+    expectedHol.push_back(Date(28, August, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
+    expectedHol.push_back(Date(26, December, 2006));
 
-    expectedHol.push_back(Date(1,January,2007));
-    expectedHol.push_back(Date(6,April,2007));
-    expectedHol.push_back(Date(9,April,2007));
-    expectedHol.push_back(Date(7,May,2007));
-    expectedHol.push_back(Date(28,May,2007));
-    expectedHol.push_back(Date(27,August,2007));
-    expectedHol.push_back(Date(25,December,2007));
-    expectedHol.push_back(Date(26,December,2007));
+    expectedHol.push_back(Date(1, January, 2007));
+    expectedHol.push_back(Date(6, April, 2007));
+    expectedHol.push_back(Date(9, April, 2007));
+    expectedHol.push_back(Date(7, May, 2007));
+    expectedHol.push_back(Date(28, May, 2007));
+    expectedHol.push_back(Date(27, August, 2007));
+    expectedHol.push_back(Date(25, December, 2007));
+    expectedHol.push_back(Date(26, December, 2007));
 
     Calendar c = UnitedKingdom(UnitedKingdom::Settlement);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2007));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2007));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testUKExchange() {
@@ -598,54 +574,52 @@ void CalendarTest::testUKExchange() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(3,May,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(30,August,2004));
-    expectedHol.push_back(Date(27,December,2004));
-    expectedHol.push_back(Date(28,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(3, May, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(30, August, 2004));
+    expectedHol.push_back(Date(27, December, 2004));
+    expectedHol.push_back(Date(28, December, 2004));
 
-    expectedHol.push_back(Date(3,January,2005));
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(28,March,2005));
-    expectedHol.push_back(Date(2,May,2005));
-    expectedHol.push_back(Date(30,May,2005));
-    expectedHol.push_back(Date(29,August,2005));
-    expectedHol.push_back(Date(26,December,2005));
-    expectedHol.push_back(Date(27,December,2005));
+    expectedHol.push_back(Date(3, January, 2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(28, March, 2005));
+    expectedHol.push_back(Date(2, May, 2005));
+    expectedHol.push_back(Date(30, May, 2005));
+    expectedHol.push_back(Date(29, August, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
+    expectedHol.push_back(Date(27, December, 2005));
 
-    expectedHol.push_back(Date(2,January,2006));
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(17,April,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(29,May,2006));
-    expectedHol.push_back(Date(28,August,2006));
-    expectedHol.push_back(Date(25,December,2006));
-    expectedHol.push_back(Date(26,December,2006));
+    expectedHol.push_back(Date(2, January, 2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(17, April, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(29, May, 2006));
+    expectedHol.push_back(Date(28, August, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
+    expectedHol.push_back(Date(26, December, 2006));
 
-    expectedHol.push_back(Date(1,January,2007));
-    expectedHol.push_back(Date(6,April,2007));
-    expectedHol.push_back(Date(9,April,2007));
-    expectedHol.push_back(Date(7,May,2007));
-    expectedHol.push_back(Date(28,May,2007));
-    expectedHol.push_back(Date(27,August,2007));
-    expectedHol.push_back(Date(25,December,2007));
-    expectedHol.push_back(Date(26,December,2007));
+    expectedHol.push_back(Date(1, January, 2007));
+    expectedHol.push_back(Date(6, April, 2007));
+    expectedHol.push_back(Date(9, April, 2007));
+    expectedHol.push_back(Date(7, May, 2007));
+    expectedHol.push_back(Date(28, May, 2007));
+    expectedHol.push_back(Date(27, August, 2007));
+    expectedHol.push_back(Date(25, December, 2007));
+    expectedHol.push_back(Date(26, December, 2007));
 
     Calendar c = UnitedKingdom(UnitedKingdom::Exchange);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2007));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2007));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testUKMetals() {
@@ -653,54 +627,52 @@ void CalendarTest::testUKMetals() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(3,May,2004));
-    expectedHol.push_back(Date(31,May,2004));
-    expectedHol.push_back(Date(30,August,2004));
-    expectedHol.push_back(Date(27,December,2004));
-    expectedHol.push_back(Date(28,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(3, May, 2004));
+    expectedHol.push_back(Date(31, May, 2004));
+    expectedHol.push_back(Date(30, August, 2004));
+    expectedHol.push_back(Date(27, December, 2004));
+    expectedHol.push_back(Date(28, December, 2004));
 
-    expectedHol.push_back(Date(3,January,2005));
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(28,March,2005));
-    expectedHol.push_back(Date(2,May,2005));
-    expectedHol.push_back(Date(30,May,2005));
-    expectedHol.push_back(Date(29,August,2005));
-    expectedHol.push_back(Date(26,December,2005));
-    expectedHol.push_back(Date(27,December,2005));
+    expectedHol.push_back(Date(3, January, 2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(28, March, 2005));
+    expectedHol.push_back(Date(2, May, 2005));
+    expectedHol.push_back(Date(30, May, 2005));
+    expectedHol.push_back(Date(29, August, 2005));
+    expectedHol.push_back(Date(26, December, 2005));
+    expectedHol.push_back(Date(27, December, 2005));
 
-    expectedHol.push_back(Date(2,January,2006));
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(17,April,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(29,May,2006));
-    expectedHol.push_back(Date(28,August,2006));
-    expectedHol.push_back(Date(25,December,2006));
-    expectedHol.push_back(Date(26,December,2006));
+    expectedHol.push_back(Date(2, January, 2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(17, April, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(29, May, 2006));
+    expectedHol.push_back(Date(28, August, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
+    expectedHol.push_back(Date(26, December, 2006));
 
-    expectedHol.push_back(Date(1,January,2007));
-    expectedHol.push_back(Date(6,April,2007));
-    expectedHol.push_back(Date(9,April,2007));
-    expectedHol.push_back(Date(7,May,2007));
-    expectedHol.push_back(Date(28,May,2007));
-    expectedHol.push_back(Date(27,August,2007));
-    expectedHol.push_back(Date(25,December,2007));
-    expectedHol.push_back(Date(26,December,2007));
+    expectedHol.push_back(Date(1, January, 2007));
+    expectedHol.push_back(Date(6, April, 2007));
+    expectedHol.push_back(Date(9, April, 2007));
+    expectedHol.push_back(Date(7, May, 2007));
+    expectedHol.push_back(Date(28, May, 2007));
+    expectedHol.push_back(Date(27, August, 2007));
+    expectedHol.push_back(Date(25, December, 2007));
+    expectedHol.push_back(Date(26, December, 2007));
 
     Calendar c = UnitedKingdom(UnitedKingdom::Metals);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2007));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2007));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testItalyExchange() {
@@ -708,647 +680,643 @@ void CalendarTest::testItalyExchange() {
 
     std::vector<Date> expectedHol;
 
-    expectedHol.push_back(Date(1,January,2002));
-    expectedHol.push_back(Date(29,March,2002));
-    expectedHol.push_back(Date(1,April,2002));
-    expectedHol.push_back(Date(1,May,2002));
-    expectedHol.push_back(Date(15,August,2002));
-    expectedHol.push_back(Date(24,December,2002));
-    expectedHol.push_back(Date(25,December,2002));
-    expectedHol.push_back(Date(26,December,2002));
-    expectedHol.push_back(Date(31,December,2002));
+    expectedHol.push_back(Date(1, January, 2002));
+    expectedHol.push_back(Date(29, March, 2002));
+    expectedHol.push_back(Date(1, April, 2002));
+    expectedHol.push_back(Date(1, May, 2002));
+    expectedHol.push_back(Date(15, August, 2002));
+    expectedHol.push_back(Date(24, December, 2002));
+    expectedHol.push_back(Date(25, December, 2002));
+    expectedHol.push_back(Date(26, December, 2002));
+    expectedHol.push_back(Date(31, December, 2002));
 
-    expectedHol.push_back(Date(1,January,2003));
-    expectedHol.push_back(Date(18,April,2003));
-    expectedHol.push_back(Date(21,April,2003));
-    expectedHol.push_back(Date(1,May,2003));
-    expectedHol.push_back(Date(15,August,2003));
-    expectedHol.push_back(Date(24,December,2003));
-    expectedHol.push_back(Date(25,December,2003));
-    expectedHol.push_back(Date(26,December,2003));
-    expectedHol.push_back(Date(31,December,2003));
+    expectedHol.push_back(Date(1, January, 2003));
+    expectedHol.push_back(Date(18, April, 2003));
+    expectedHol.push_back(Date(21, April, 2003));
+    expectedHol.push_back(Date(1, May, 2003));
+    expectedHol.push_back(Date(15, August, 2003));
+    expectedHol.push_back(Date(24, December, 2003));
+    expectedHol.push_back(Date(25, December, 2003));
+    expectedHol.push_back(Date(26, December, 2003));
+    expectedHol.push_back(Date(31, December, 2003));
 
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(9,April,2004));
-    expectedHol.push_back(Date(12,April,2004));
-    expectedHol.push_back(Date(24,December,2004));
-    expectedHol.push_back(Date(31,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(9, April, 2004));
+    expectedHol.push_back(Date(12, April, 2004));
+    expectedHol.push_back(Date(24, December, 2004));
+    expectedHol.push_back(Date(31, December, 2004));
 
     Calendar c = Italy(Italy::Exchange);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2002),
-                                          Date(31,December,2004));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2002), Date(31, December, 2004));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
-void CalendarTest::testRussia()
-{
-  BOOST_TEST_MESSAGE("Testing Russia holiday list...");
+void CalendarTest::testRussia() {
+    BOOST_TEST_MESSAGE("Testing Russia holiday list...");
 
-  std::vector<Date> expectedHol;
-  
-  // exhaustive holiday list for the year 2012
-  expectedHol.push_back(Date(1, January, 2012));
-  expectedHol.push_back(Date(2, January, 2012));
-  expectedHol.push_back(Date(7, January, 2012));
-  expectedHol.push_back(Date(8, January, 2012));
-  expectedHol.push_back(Date(14, January, 2012));
-  expectedHol.push_back(Date(15, January, 2012));
-  expectedHol.push_back(Date(21, January, 2012));
-  expectedHol.push_back(Date(22, January, 2012));
-  expectedHol.push_back(Date(28, January, 2012));
-  expectedHol.push_back(Date(29, January, 2012));
-  expectedHol.push_back(Date(4, February, 2012));
-  expectedHol.push_back(Date(5, February, 2012));
-  expectedHol.push_back(Date(11, February, 2012));
-  expectedHol.push_back(Date(12, February, 2012));
-  expectedHol.push_back(Date(18, February, 2012));
-  expectedHol.push_back(Date(19, February, 2012));
-  expectedHol.push_back(Date(23, February, 2012));
-  expectedHol.push_back(Date(25, February, 2012));
-  expectedHol.push_back(Date(26, February, 2012));
-  expectedHol.push_back(Date(3, March, 2012));
-  expectedHol.push_back(Date(4, March, 2012));
-  expectedHol.push_back(Date(8, March, 2012));
-  expectedHol.push_back(Date(9, March, 2012));
-  expectedHol.push_back(Date(10, March, 2012));
-  expectedHol.push_back(Date(17, March, 2012));
-  expectedHol.push_back(Date(18, March, 2012));
-  expectedHol.push_back(Date(24, March, 2012));
-  expectedHol.push_back(Date(25, March, 2012));
-  expectedHol.push_back(Date(31, March, 2012));
-  expectedHol.push_back(Date(1, April, 2012));
-  expectedHol.push_back(Date(7, April, 2012));
-  expectedHol.push_back(Date(8, April, 2012));
-  expectedHol.push_back(Date(14, April, 2012));
-  expectedHol.push_back(Date(15, April, 2012));
-  expectedHol.push_back(Date(21, April, 2012));
-  expectedHol.push_back(Date(22, April, 2012));
-  expectedHol.push_back(Date(29, April, 2012));
-  expectedHol.push_back(Date(30, April, 2012));
-  expectedHol.push_back(Date(1, May, 2012));
-  expectedHol.push_back(Date(6, May, 2012));
-  expectedHol.push_back(Date(9, May, 2012));
-  expectedHol.push_back(Date(13, May, 2012));
-  expectedHol.push_back(Date(19, May, 2012));
-  expectedHol.push_back(Date(20, May, 2012));
-  expectedHol.push_back(Date(26, May, 2012));
-  expectedHol.push_back(Date(27, May, 2012));
-  expectedHol.push_back(Date(2, June, 2012));
-  expectedHol.push_back(Date(3, June, 2012));
-  expectedHol.push_back(Date(10, June, 2012));
-  expectedHol.push_back(Date(11, June, 2012));
-  expectedHol.push_back(Date(12, June, 2012));
-  expectedHol.push_back(Date(16, June, 2012));
-  expectedHol.push_back(Date(17, June, 2012));
-  expectedHol.push_back(Date(23, June, 2012));
-  expectedHol.push_back(Date(24, June, 2012));
-  expectedHol.push_back(Date(30, June, 2012));
-  expectedHol.push_back(Date(1, July, 2012));
-  expectedHol.push_back(Date(7, July, 2012));
-  expectedHol.push_back(Date(8, July, 2012));
-  expectedHol.push_back(Date(14, July, 2012));
-  expectedHol.push_back(Date(15, July, 2012));
-  expectedHol.push_back(Date(21, July, 2012));
-  expectedHol.push_back(Date(22, July, 2012));
-  expectedHol.push_back(Date(28, July, 2012));
-  expectedHol.push_back(Date(29, July, 2012));
-  expectedHol.push_back(Date(4, August, 2012));
-  expectedHol.push_back(Date(5, August, 2012));
-  expectedHol.push_back(Date(11, August, 2012));
-  expectedHol.push_back(Date(12, August, 2012));
-  expectedHol.push_back(Date(18, August, 2012));
-  expectedHol.push_back(Date(19, August, 2012));
-  expectedHol.push_back(Date(25, August, 2012));
-  expectedHol.push_back(Date(26, August, 2012));
-  expectedHol.push_back(Date(1, September, 2012));
-  expectedHol.push_back(Date(2, September, 2012));
-  expectedHol.push_back(Date(8, September, 2012));
-  expectedHol.push_back(Date(9, September, 2012));
-  expectedHol.push_back(Date(15, September, 2012));
-  expectedHol.push_back(Date(16, September, 2012));
-  expectedHol.push_back(Date(22, September, 2012));
-  expectedHol.push_back(Date(23, September, 2012));
-  expectedHol.push_back(Date(29, September, 2012));
-  expectedHol.push_back(Date(30, September, 2012));
-  expectedHol.push_back(Date(6, October, 2012));
-  expectedHol.push_back(Date(7, October, 2012));
-  expectedHol.push_back(Date(13, October, 2012));
-  expectedHol.push_back(Date(14, October, 2012));
-  expectedHol.push_back(Date(20, October, 2012));
-  expectedHol.push_back(Date(21, October, 2012));
-  expectedHol.push_back(Date(27, October, 2012));
-  expectedHol.push_back(Date(28, October, 2012));
-  expectedHol.push_back(Date(3, November, 2012));
-  expectedHol.push_back(Date(4, November, 2012));
-  expectedHol.push_back(Date(5, November, 2012));
-  expectedHol.push_back(Date(10, November, 2012));
-  expectedHol.push_back(Date(11, November, 2012));
-  expectedHol.push_back(Date(17, November, 2012));
-  expectedHol.push_back(Date(18, November, 2012));
-  expectedHol.push_back(Date(24, November, 2012));
-  expectedHol.push_back(Date(25, November, 2012));
-  expectedHol.push_back(Date(1, December, 2012));
-  expectedHol.push_back(Date(2, December, 2012));
-  expectedHol.push_back(Date(8, December, 2012));
-  expectedHol.push_back(Date(9, December, 2012));
-  expectedHol.push_back(Date(15, December, 2012));
-  expectedHol.push_back(Date(16, December, 2012));
-  expectedHol.push_back(Date(22, December, 2012));
-  expectedHol.push_back(Date(23, December, 2012));
-  expectedHol.push_back(Date(29, December, 2012));
-  expectedHol.push_back(Date(30, December, 2012));
-  expectedHol.push_back(Date(31, December, 2012));
+    std::vector<Date> expectedHol;
 
-  // exhaustive holiday list for the year 2013
-  expectedHol.push_back(Date(1, January, 2013));
-  expectedHol.push_back(Date(2, January, 2013));
-  expectedHol.push_back(Date(3, January, 2013));
-  expectedHol.push_back(Date(4, January, 2013));
-  expectedHol.push_back(Date(5, January, 2013));
-  expectedHol.push_back(Date(6, January, 2013));
-  expectedHol.push_back(Date(7, January, 2013));
-  expectedHol.push_back(Date(12, January, 2013));
-  expectedHol.push_back(Date(13, January, 2013));
-  expectedHol.push_back(Date(19, January, 2013));
-  expectedHol.push_back(Date(20, January, 2013));
-  expectedHol.push_back(Date(26, January, 2013));
-  expectedHol.push_back(Date(27, January, 2013));
-  expectedHol.push_back(Date(2, February, 2013));
-  expectedHol.push_back(Date(3, February, 2013));
-  expectedHol.push_back(Date(9, February, 2013));
-  expectedHol.push_back(Date(10, February, 2013));
-  expectedHol.push_back(Date(16, February, 2013));
-  expectedHol.push_back(Date(17, February, 2013));
-  expectedHol.push_back(Date(23, February, 2013));
-  expectedHol.push_back(Date(24, February, 2013));
-  expectedHol.push_back(Date(2, March, 2013));
-  expectedHol.push_back(Date(3, March, 2013));
-  expectedHol.push_back(Date(8, March, 2013));
-  expectedHol.push_back(Date(9, March, 2013));
-  expectedHol.push_back(Date(10, March, 2013));
-  expectedHol.push_back(Date(16, March, 2013));
-  expectedHol.push_back(Date(17, March, 2013));
-  expectedHol.push_back(Date(23, March, 2013));
-  expectedHol.push_back(Date(24, March, 2013));
-  expectedHol.push_back(Date(30, March, 2013));
-  expectedHol.push_back(Date(31, March, 2013));
-  expectedHol.push_back(Date(6, April, 2013));
-  expectedHol.push_back(Date(7, April, 2013));
-  expectedHol.push_back(Date(13, April, 2013));
-  expectedHol.push_back(Date(14, April, 2013));
-  expectedHol.push_back(Date(20, April, 2013));
-  expectedHol.push_back(Date(21, April, 2013));
-  expectedHol.push_back(Date(27, April, 2013));
-  expectedHol.push_back(Date(28, April, 2013));
-  expectedHol.push_back(Date(1, May, 2013));
-  expectedHol.push_back(Date(4, May, 2013));
-  expectedHol.push_back(Date(5, May, 2013));
-  expectedHol.push_back(Date(9, May, 2013));
-  expectedHol.push_back(Date(11, May, 2013));
-  expectedHol.push_back(Date(12, May, 2013));
-  expectedHol.push_back(Date(18, May, 2013));
-  expectedHol.push_back(Date(19, May, 2013));
-  expectedHol.push_back(Date(25, May, 2013));
-  expectedHol.push_back(Date(26, May, 2013));
-  expectedHol.push_back(Date(1, June, 2013));
-  expectedHol.push_back(Date(2, June, 2013));
-  expectedHol.push_back(Date(8, June, 2013));
-  expectedHol.push_back(Date(9, June, 2013));
-  expectedHol.push_back(Date(12, June, 2013));
-  expectedHol.push_back(Date(15, June, 2013));
-  expectedHol.push_back(Date(16, June, 2013));
-  expectedHol.push_back(Date(22, June, 2013));
-  expectedHol.push_back(Date(23, June, 2013));
-  expectedHol.push_back(Date(29, June, 2013));
-  expectedHol.push_back(Date(30, June, 2013));
-  expectedHol.push_back(Date(6, July, 2013));
-  expectedHol.push_back(Date(7, July, 2013));
-  expectedHol.push_back(Date(13, July, 2013));
-  expectedHol.push_back(Date(14, July, 2013));
-  expectedHol.push_back(Date(20, July, 2013));
-  expectedHol.push_back(Date(21, July, 2013));
-  expectedHol.push_back(Date(27, July, 2013));
-  expectedHol.push_back(Date(28, July, 2013));
-  expectedHol.push_back(Date(3, August, 2013));
-  expectedHol.push_back(Date(4, August, 2013));
-  expectedHol.push_back(Date(10, August, 2013));
-  expectedHol.push_back(Date(11, August, 2013));
-  expectedHol.push_back(Date(17, August, 2013));
-  expectedHol.push_back(Date(18, August, 2013));
-  expectedHol.push_back(Date(24, August, 2013));
-  expectedHol.push_back(Date(25, August, 2013));
-  expectedHol.push_back(Date(31, August, 2013));
-  expectedHol.push_back(Date(1, September, 2013));
-  expectedHol.push_back(Date(7, September, 2013));
-  expectedHol.push_back(Date(8, September, 2013));
-  expectedHol.push_back(Date(14, September, 2013));
-  expectedHol.push_back(Date(15, September, 2013));
-  expectedHol.push_back(Date(21, September, 2013));
-  expectedHol.push_back(Date(22, September, 2013));
-  expectedHol.push_back(Date(28, September, 2013));
-  expectedHol.push_back(Date(29, September, 2013));
-  expectedHol.push_back(Date(5, October, 2013));
-  expectedHol.push_back(Date(6, October, 2013));
-  expectedHol.push_back(Date(12, October, 2013));
-  expectedHol.push_back(Date(13, October, 2013));
-  expectedHol.push_back(Date(19, October, 2013));
-  expectedHol.push_back(Date(20, October, 2013));
-  expectedHol.push_back(Date(26, October, 2013));
-  expectedHol.push_back(Date(27, October, 2013));
-  expectedHol.push_back(Date(2, November, 2013));
-  expectedHol.push_back(Date(3, November, 2013));
-  expectedHol.push_back(Date(4, November, 2013));
-  expectedHol.push_back(Date(9, November, 2013));
-  expectedHol.push_back(Date(10, November, 2013));
-  expectedHol.push_back(Date(16, November, 2013));
-  expectedHol.push_back(Date(17, November, 2013));
-  expectedHol.push_back(Date(23, November, 2013));
-  expectedHol.push_back(Date(24, November, 2013));
-  expectedHol.push_back(Date(30, November, 2013));
-  expectedHol.push_back(Date(1, December, 2013));
-  expectedHol.push_back(Date(7, December, 2013));
-  expectedHol.push_back(Date(8, December, 2013));
-  expectedHol.push_back(Date(14, December, 2013));
-  expectedHol.push_back(Date(15, December, 2013));
-  expectedHol.push_back(Date(21, December, 2013));
-  expectedHol.push_back(Date(22, December, 2013));
-  expectedHol.push_back(Date(28, December, 2013));
-  expectedHol.push_back(Date(29, December, 2013));
-  expectedHol.push_back(Date(31, December, 2013));
+    // exhaustive holiday list for the year 2012
+    expectedHol.push_back(Date(1, January, 2012));
+    expectedHol.push_back(Date(2, January, 2012));
+    expectedHol.push_back(Date(7, January, 2012));
+    expectedHol.push_back(Date(8, January, 2012));
+    expectedHol.push_back(Date(14, January, 2012));
+    expectedHol.push_back(Date(15, January, 2012));
+    expectedHol.push_back(Date(21, January, 2012));
+    expectedHol.push_back(Date(22, January, 2012));
+    expectedHol.push_back(Date(28, January, 2012));
+    expectedHol.push_back(Date(29, January, 2012));
+    expectedHol.push_back(Date(4, February, 2012));
+    expectedHol.push_back(Date(5, February, 2012));
+    expectedHol.push_back(Date(11, February, 2012));
+    expectedHol.push_back(Date(12, February, 2012));
+    expectedHol.push_back(Date(18, February, 2012));
+    expectedHol.push_back(Date(19, February, 2012));
+    expectedHol.push_back(Date(23, February, 2012));
+    expectedHol.push_back(Date(25, February, 2012));
+    expectedHol.push_back(Date(26, February, 2012));
+    expectedHol.push_back(Date(3, March, 2012));
+    expectedHol.push_back(Date(4, March, 2012));
+    expectedHol.push_back(Date(8, March, 2012));
+    expectedHol.push_back(Date(9, March, 2012));
+    expectedHol.push_back(Date(10, March, 2012));
+    expectedHol.push_back(Date(17, March, 2012));
+    expectedHol.push_back(Date(18, March, 2012));
+    expectedHol.push_back(Date(24, March, 2012));
+    expectedHol.push_back(Date(25, March, 2012));
+    expectedHol.push_back(Date(31, March, 2012));
+    expectedHol.push_back(Date(1, April, 2012));
+    expectedHol.push_back(Date(7, April, 2012));
+    expectedHol.push_back(Date(8, April, 2012));
+    expectedHol.push_back(Date(14, April, 2012));
+    expectedHol.push_back(Date(15, April, 2012));
+    expectedHol.push_back(Date(21, April, 2012));
+    expectedHol.push_back(Date(22, April, 2012));
+    expectedHol.push_back(Date(29, April, 2012));
+    expectedHol.push_back(Date(30, April, 2012));
+    expectedHol.push_back(Date(1, May, 2012));
+    expectedHol.push_back(Date(6, May, 2012));
+    expectedHol.push_back(Date(9, May, 2012));
+    expectedHol.push_back(Date(13, May, 2012));
+    expectedHol.push_back(Date(19, May, 2012));
+    expectedHol.push_back(Date(20, May, 2012));
+    expectedHol.push_back(Date(26, May, 2012));
+    expectedHol.push_back(Date(27, May, 2012));
+    expectedHol.push_back(Date(2, June, 2012));
+    expectedHol.push_back(Date(3, June, 2012));
+    expectedHol.push_back(Date(10, June, 2012));
+    expectedHol.push_back(Date(11, June, 2012));
+    expectedHol.push_back(Date(12, June, 2012));
+    expectedHol.push_back(Date(16, June, 2012));
+    expectedHol.push_back(Date(17, June, 2012));
+    expectedHol.push_back(Date(23, June, 2012));
+    expectedHol.push_back(Date(24, June, 2012));
+    expectedHol.push_back(Date(30, June, 2012));
+    expectedHol.push_back(Date(1, July, 2012));
+    expectedHol.push_back(Date(7, July, 2012));
+    expectedHol.push_back(Date(8, July, 2012));
+    expectedHol.push_back(Date(14, July, 2012));
+    expectedHol.push_back(Date(15, July, 2012));
+    expectedHol.push_back(Date(21, July, 2012));
+    expectedHol.push_back(Date(22, July, 2012));
+    expectedHol.push_back(Date(28, July, 2012));
+    expectedHol.push_back(Date(29, July, 2012));
+    expectedHol.push_back(Date(4, August, 2012));
+    expectedHol.push_back(Date(5, August, 2012));
+    expectedHol.push_back(Date(11, August, 2012));
+    expectedHol.push_back(Date(12, August, 2012));
+    expectedHol.push_back(Date(18, August, 2012));
+    expectedHol.push_back(Date(19, August, 2012));
+    expectedHol.push_back(Date(25, August, 2012));
+    expectedHol.push_back(Date(26, August, 2012));
+    expectedHol.push_back(Date(1, September, 2012));
+    expectedHol.push_back(Date(2, September, 2012));
+    expectedHol.push_back(Date(8, September, 2012));
+    expectedHol.push_back(Date(9, September, 2012));
+    expectedHol.push_back(Date(15, September, 2012));
+    expectedHol.push_back(Date(16, September, 2012));
+    expectedHol.push_back(Date(22, September, 2012));
+    expectedHol.push_back(Date(23, September, 2012));
+    expectedHol.push_back(Date(29, September, 2012));
+    expectedHol.push_back(Date(30, September, 2012));
+    expectedHol.push_back(Date(6, October, 2012));
+    expectedHol.push_back(Date(7, October, 2012));
+    expectedHol.push_back(Date(13, October, 2012));
+    expectedHol.push_back(Date(14, October, 2012));
+    expectedHol.push_back(Date(20, October, 2012));
+    expectedHol.push_back(Date(21, October, 2012));
+    expectedHol.push_back(Date(27, October, 2012));
+    expectedHol.push_back(Date(28, October, 2012));
+    expectedHol.push_back(Date(3, November, 2012));
+    expectedHol.push_back(Date(4, November, 2012));
+    expectedHol.push_back(Date(5, November, 2012));
+    expectedHol.push_back(Date(10, November, 2012));
+    expectedHol.push_back(Date(11, November, 2012));
+    expectedHol.push_back(Date(17, November, 2012));
+    expectedHol.push_back(Date(18, November, 2012));
+    expectedHol.push_back(Date(24, November, 2012));
+    expectedHol.push_back(Date(25, November, 2012));
+    expectedHol.push_back(Date(1, December, 2012));
+    expectedHol.push_back(Date(2, December, 2012));
+    expectedHol.push_back(Date(8, December, 2012));
+    expectedHol.push_back(Date(9, December, 2012));
+    expectedHol.push_back(Date(15, December, 2012));
+    expectedHol.push_back(Date(16, December, 2012));
+    expectedHol.push_back(Date(22, December, 2012));
+    expectedHol.push_back(Date(23, December, 2012));
+    expectedHol.push_back(Date(29, December, 2012));
+    expectedHol.push_back(Date(30, December, 2012));
+    expectedHol.push_back(Date(31, December, 2012));
 
-  // exhaustive holiday list for the year 2014
-  expectedHol.push_back(Date(1, January, 2014));
-  expectedHol.push_back(Date(2, January, 2014));
-  expectedHol.push_back(Date(3, January, 2014));
-  expectedHol.push_back(Date(4, January, 2014));
-  expectedHol.push_back(Date(5, January, 2014));
-  expectedHol.push_back(Date(7, January, 2014));
-  expectedHol.push_back(Date(11, January, 2014));
-  expectedHol.push_back(Date(12, January, 2014));
-  expectedHol.push_back(Date(18, January, 2014));
-  expectedHol.push_back(Date(19, January, 2014));
-  expectedHol.push_back(Date(25, January, 2014));
-  expectedHol.push_back(Date(26, January, 2014));
-  expectedHol.push_back(Date(1, February, 2014));
-  expectedHol.push_back(Date(2, February, 2014));
-  expectedHol.push_back(Date(8, February, 2014));
-  expectedHol.push_back(Date(9, February, 2014));
-  expectedHol.push_back(Date(15, February, 2014));
-  expectedHol.push_back(Date(16, February, 2014));
-  expectedHol.push_back(Date(22, February, 2014));
-  expectedHol.push_back(Date(23, February, 2014));
-  expectedHol.push_back(Date(1, March, 2014));
-  expectedHol.push_back(Date(2, March, 2014));
-  expectedHol.push_back(Date(8, March, 2014));
-  expectedHol.push_back(Date(9, March, 2014));
-  expectedHol.push_back(Date(10, March, 2014));
-  expectedHol.push_back(Date(15, March, 2014));
-  expectedHol.push_back(Date(16, March, 2014));
-  expectedHol.push_back(Date(22, March, 2014));
-  expectedHol.push_back(Date(23, March, 2014));
-  expectedHol.push_back(Date(29, March, 2014));
-  expectedHol.push_back(Date(30, March, 2014));
-  expectedHol.push_back(Date(5, April, 2014));
-  expectedHol.push_back(Date(6, April, 2014));
-  expectedHol.push_back(Date(12, April, 2014));
-  expectedHol.push_back(Date(13, April, 2014));
-  expectedHol.push_back(Date(19, April, 2014));
-  expectedHol.push_back(Date(20, April, 2014));
-  expectedHol.push_back(Date(26, April, 2014));
-  expectedHol.push_back(Date(27, April, 2014));
-  expectedHol.push_back(Date(1, May, 2014));
-  expectedHol.push_back(Date(3, May, 2014));
-  expectedHol.push_back(Date(4, May, 2014));
-  expectedHol.push_back(Date(9, May, 2014));
-  expectedHol.push_back(Date(10, May, 2014));
-  expectedHol.push_back(Date(11, May, 2014));
-  expectedHol.push_back(Date(17, May, 2014));
-  expectedHol.push_back(Date(18, May, 2014));
-  expectedHol.push_back(Date(24, May, 2014));
-  expectedHol.push_back(Date(25, May, 2014));
-  expectedHol.push_back(Date(31, May, 2014));
-  expectedHol.push_back(Date(1, June, 2014));
-  expectedHol.push_back(Date(7, June, 2014));
-  expectedHol.push_back(Date(8, June, 2014));
-  expectedHol.push_back(Date(12, June, 2014));
-  expectedHol.push_back(Date(14, June, 2014));
-  expectedHol.push_back(Date(15, June, 2014));
-  expectedHol.push_back(Date(21, June, 2014));
-  expectedHol.push_back(Date(22, June, 2014));
-  expectedHol.push_back(Date(28, June, 2014));
-  expectedHol.push_back(Date(29, June, 2014));
-  expectedHol.push_back(Date(5, July, 2014));
-  expectedHol.push_back(Date(6, July, 2014));
-  expectedHol.push_back(Date(12, July, 2014));
-  expectedHol.push_back(Date(13, July, 2014));
-  expectedHol.push_back(Date(19, July, 2014));
-  expectedHol.push_back(Date(20, July, 2014));
-  expectedHol.push_back(Date(26, July, 2014));
-  expectedHol.push_back(Date(27, July, 2014));
-  expectedHol.push_back(Date(2, August, 2014));
-  expectedHol.push_back(Date(3, August, 2014));
-  expectedHol.push_back(Date(9, August, 2014));
-  expectedHol.push_back(Date(10, August, 2014));
-  expectedHol.push_back(Date(16, August, 2014));
-  expectedHol.push_back(Date(17, August, 2014));
-  expectedHol.push_back(Date(23, August, 2014));
-  expectedHol.push_back(Date(24, August, 2014));
-  expectedHol.push_back(Date(30, August, 2014));
-  expectedHol.push_back(Date(31, August, 2014));
-  expectedHol.push_back(Date(6, September, 2014));
-  expectedHol.push_back(Date(7, September, 2014));
-  expectedHol.push_back(Date(13, September, 2014));
-  expectedHol.push_back(Date(14, September, 2014));
-  expectedHol.push_back(Date(20, September, 2014));
-  expectedHol.push_back(Date(21, September, 2014));
-  expectedHol.push_back(Date(27, September, 2014));
-  expectedHol.push_back(Date(28, September, 2014));
-  expectedHol.push_back(Date(4, October, 2014));
-  expectedHol.push_back(Date(5, October, 2014));
-  expectedHol.push_back(Date(11, October, 2014));
-  expectedHol.push_back(Date(12, October, 2014));
-  expectedHol.push_back(Date(18, October, 2014));
-  expectedHol.push_back(Date(19, October, 2014));
-  expectedHol.push_back(Date(25, October, 2014));
-  expectedHol.push_back(Date(26, October, 2014));
-  expectedHol.push_back(Date(1, November, 2014));
-  expectedHol.push_back(Date(2, November, 2014));
-  expectedHol.push_back(Date(4, November, 2014));
-  expectedHol.push_back(Date(8, November, 2014));
-  expectedHol.push_back(Date(9, November, 2014));
-  expectedHol.push_back(Date(15, November, 2014));
-  expectedHol.push_back(Date(16, November, 2014));
-  expectedHol.push_back(Date(22, November, 2014));
-  expectedHol.push_back(Date(23, November, 2014));
-  expectedHol.push_back(Date(29, November, 2014));
-  expectedHol.push_back(Date(30, November, 2014));
-  expectedHol.push_back(Date(6, December, 2014));
-  expectedHol.push_back(Date(7, December, 2014));
-  expectedHol.push_back(Date(13, December, 2014));
-  expectedHol.push_back(Date(14, December, 2014));
-  expectedHol.push_back(Date(20, December, 2014));
-  expectedHol.push_back(Date(21, December, 2014));
-  expectedHol.push_back(Date(27, December, 2014));
-  expectedHol.push_back(Date(28, December, 2014));
-  expectedHol.push_back(Date(31, December, 2014));
+    // exhaustive holiday list for the year 2013
+    expectedHol.push_back(Date(1, January, 2013));
+    expectedHol.push_back(Date(2, January, 2013));
+    expectedHol.push_back(Date(3, January, 2013));
+    expectedHol.push_back(Date(4, January, 2013));
+    expectedHol.push_back(Date(5, January, 2013));
+    expectedHol.push_back(Date(6, January, 2013));
+    expectedHol.push_back(Date(7, January, 2013));
+    expectedHol.push_back(Date(12, January, 2013));
+    expectedHol.push_back(Date(13, January, 2013));
+    expectedHol.push_back(Date(19, January, 2013));
+    expectedHol.push_back(Date(20, January, 2013));
+    expectedHol.push_back(Date(26, January, 2013));
+    expectedHol.push_back(Date(27, January, 2013));
+    expectedHol.push_back(Date(2, February, 2013));
+    expectedHol.push_back(Date(3, February, 2013));
+    expectedHol.push_back(Date(9, February, 2013));
+    expectedHol.push_back(Date(10, February, 2013));
+    expectedHol.push_back(Date(16, February, 2013));
+    expectedHol.push_back(Date(17, February, 2013));
+    expectedHol.push_back(Date(23, February, 2013));
+    expectedHol.push_back(Date(24, February, 2013));
+    expectedHol.push_back(Date(2, March, 2013));
+    expectedHol.push_back(Date(3, March, 2013));
+    expectedHol.push_back(Date(8, March, 2013));
+    expectedHol.push_back(Date(9, March, 2013));
+    expectedHol.push_back(Date(10, March, 2013));
+    expectedHol.push_back(Date(16, March, 2013));
+    expectedHol.push_back(Date(17, March, 2013));
+    expectedHol.push_back(Date(23, March, 2013));
+    expectedHol.push_back(Date(24, March, 2013));
+    expectedHol.push_back(Date(30, March, 2013));
+    expectedHol.push_back(Date(31, March, 2013));
+    expectedHol.push_back(Date(6, April, 2013));
+    expectedHol.push_back(Date(7, April, 2013));
+    expectedHol.push_back(Date(13, April, 2013));
+    expectedHol.push_back(Date(14, April, 2013));
+    expectedHol.push_back(Date(20, April, 2013));
+    expectedHol.push_back(Date(21, April, 2013));
+    expectedHol.push_back(Date(27, April, 2013));
+    expectedHol.push_back(Date(28, April, 2013));
+    expectedHol.push_back(Date(1, May, 2013));
+    expectedHol.push_back(Date(4, May, 2013));
+    expectedHol.push_back(Date(5, May, 2013));
+    expectedHol.push_back(Date(9, May, 2013));
+    expectedHol.push_back(Date(11, May, 2013));
+    expectedHol.push_back(Date(12, May, 2013));
+    expectedHol.push_back(Date(18, May, 2013));
+    expectedHol.push_back(Date(19, May, 2013));
+    expectedHol.push_back(Date(25, May, 2013));
+    expectedHol.push_back(Date(26, May, 2013));
+    expectedHol.push_back(Date(1, June, 2013));
+    expectedHol.push_back(Date(2, June, 2013));
+    expectedHol.push_back(Date(8, June, 2013));
+    expectedHol.push_back(Date(9, June, 2013));
+    expectedHol.push_back(Date(12, June, 2013));
+    expectedHol.push_back(Date(15, June, 2013));
+    expectedHol.push_back(Date(16, June, 2013));
+    expectedHol.push_back(Date(22, June, 2013));
+    expectedHol.push_back(Date(23, June, 2013));
+    expectedHol.push_back(Date(29, June, 2013));
+    expectedHol.push_back(Date(30, June, 2013));
+    expectedHol.push_back(Date(6, July, 2013));
+    expectedHol.push_back(Date(7, July, 2013));
+    expectedHol.push_back(Date(13, July, 2013));
+    expectedHol.push_back(Date(14, July, 2013));
+    expectedHol.push_back(Date(20, July, 2013));
+    expectedHol.push_back(Date(21, July, 2013));
+    expectedHol.push_back(Date(27, July, 2013));
+    expectedHol.push_back(Date(28, July, 2013));
+    expectedHol.push_back(Date(3, August, 2013));
+    expectedHol.push_back(Date(4, August, 2013));
+    expectedHol.push_back(Date(10, August, 2013));
+    expectedHol.push_back(Date(11, August, 2013));
+    expectedHol.push_back(Date(17, August, 2013));
+    expectedHol.push_back(Date(18, August, 2013));
+    expectedHol.push_back(Date(24, August, 2013));
+    expectedHol.push_back(Date(25, August, 2013));
+    expectedHol.push_back(Date(31, August, 2013));
+    expectedHol.push_back(Date(1, September, 2013));
+    expectedHol.push_back(Date(7, September, 2013));
+    expectedHol.push_back(Date(8, September, 2013));
+    expectedHol.push_back(Date(14, September, 2013));
+    expectedHol.push_back(Date(15, September, 2013));
+    expectedHol.push_back(Date(21, September, 2013));
+    expectedHol.push_back(Date(22, September, 2013));
+    expectedHol.push_back(Date(28, September, 2013));
+    expectedHol.push_back(Date(29, September, 2013));
+    expectedHol.push_back(Date(5, October, 2013));
+    expectedHol.push_back(Date(6, October, 2013));
+    expectedHol.push_back(Date(12, October, 2013));
+    expectedHol.push_back(Date(13, October, 2013));
+    expectedHol.push_back(Date(19, October, 2013));
+    expectedHol.push_back(Date(20, October, 2013));
+    expectedHol.push_back(Date(26, October, 2013));
+    expectedHol.push_back(Date(27, October, 2013));
+    expectedHol.push_back(Date(2, November, 2013));
+    expectedHol.push_back(Date(3, November, 2013));
+    expectedHol.push_back(Date(4, November, 2013));
+    expectedHol.push_back(Date(9, November, 2013));
+    expectedHol.push_back(Date(10, November, 2013));
+    expectedHol.push_back(Date(16, November, 2013));
+    expectedHol.push_back(Date(17, November, 2013));
+    expectedHol.push_back(Date(23, November, 2013));
+    expectedHol.push_back(Date(24, November, 2013));
+    expectedHol.push_back(Date(30, November, 2013));
+    expectedHol.push_back(Date(1, December, 2013));
+    expectedHol.push_back(Date(7, December, 2013));
+    expectedHol.push_back(Date(8, December, 2013));
+    expectedHol.push_back(Date(14, December, 2013));
+    expectedHol.push_back(Date(15, December, 2013));
+    expectedHol.push_back(Date(21, December, 2013));
+    expectedHol.push_back(Date(22, December, 2013));
+    expectedHol.push_back(Date(28, December, 2013));
+    expectedHol.push_back(Date(29, December, 2013));
+    expectedHol.push_back(Date(31, December, 2013));
 
-  // exhaustive holiday list for the year 2015
-  expectedHol.push_back(Date(1, January, 2015));
-  expectedHol.push_back(Date(2, January, 2015));
-  expectedHol.push_back(Date(3, January, 2015));
-  expectedHol.push_back(Date(4, January, 2015));
-  expectedHol.push_back(Date(7, January, 2015));
-  expectedHol.push_back(Date(10, January, 2015));
-  expectedHol.push_back(Date(11, January, 2015));
-  expectedHol.push_back(Date(17, January, 2015));
-  expectedHol.push_back(Date(18, January, 2015));
-  expectedHol.push_back(Date(24, January, 2015));
-  expectedHol.push_back(Date(25, January, 2015));
-  expectedHol.push_back(Date(31, January, 2015));
-  expectedHol.push_back(Date(1, February, 2015));
-  expectedHol.push_back(Date(7, February, 2015));
-  expectedHol.push_back(Date(8, February, 2015));
-  expectedHol.push_back(Date(14, February, 2015));
-  expectedHol.push_back(Date(15, February, 2015));
-  expectedHol.push_back(Date(21, February, 2015));
-  expectedHol.push_back(Date(22, February, 2015));
-  expectedHol.push_back(Date(23, February, 2015));
-  expectedHol.push_back(Date(28, February, 2015));
-  expectedHol.push_back(Date(1, March, 2015));
-  expectedHol.push_back(Date(7, March, 2015));
-  expectedHol.push_back(Date(8, March, 2015));
-  expectedHol.push_back(Date(9, March, 2015));
-  expectedHol.push_back(Date(14, March, 2015));
-  expectedHol.push_back(Date(15, March, 2015));
-  expectedHol.push_back(Date(21, March, 2015));
-  expectedHol.push_back(Date(22, March, 2015));
-  expectedHol.push_back(Date(28, March, 2015));
-  expectedHol.push_back(Date(29, March, 2015));
-  expectedHol.push_back(Date(4, April, 2015));
-  expectedHol.push_back(Date(5, April, 2015));
-  expectedHol.push_back(Date(11, April, 2015));
-  expectedHol.push_back(Date(12, April, 2015));
-  expectedHol.push_back(Date(18, April, 2015));
-  expectedHol.push_back(Date(19, April, 2015));
-  expectedHol.push_back(Date(25, April, 2015));
-  expectedHol.push_back(Date(26, April, 2015));
-  expectedHol.push_back(Date(1, May, 2015));
-  expectedHol.push_back(Date(2, May, 2015));
-  expectedHol.push_back(Date(3, May, 2015));
-  expectedHol.push_back(Date(9, May, 2015));
-  expectedHol.push_back(Date(10, May, 2015));
-  expectedHol.push_back(Date(11, May, 2015));
-  expectedHol.push_back(Date(16, May, 2015));
-  expectedHol.push_back(Date(17, May, 2015));
-  expectedHol.push_back(Date(23, May, 2015));
-  expectedHol.push_back(Date(24, May, 2015));
-  expectedHol.push_back(Date(30, May, 2015));
-  expectedHol.push_back(Date(31, May, 2015));
-  expectedHol.push_back(Date(6, June, 2015));
-  expectedHol.push_back(Date(7, June, 2015));
-  expectedHol.push_back(Date(12, June, 2015));
-  expectedHol.push_back(Date(13, June, 2015));
-  expectedHol.push_back(Date(14, June, 2015));
-  expectedHol.push_back(Date(20, June, 2015));
-  expectedHol.push_back(Date(21, June, 2015));
-  expectedHol.push_back(Date(27, June, 2015));
-  expectedHol.push_back(Date(28, June, 2015));
-  expectedHol.push_back(Date(4, July, 2015));
-  expectedHol.push_back(Date(5, July, 2015));
-  expectedHol.push_back(Date(11, July, 2015));
-  expectedHol.push_back(Date(12, July, 2015));
-  expectedHol.push_back(Date(18, July, 2015));
-  expectedHol.push_back(Date(19, July, 2015));
-  expectedHol.push_back(Date(25, July, 2015));
-  expectedHol.push_back(Date(26, July, 2015));
-  expectedHol.push_back(Date(1, August, 2015));
-  expectedHol.push_back(Date(2, August, 2015));
-  expectedHol.push_back(Date(8, August, 2015));
-  expectedHol.push_back(Date(9, August, 2015));
-  expectedHol.push_back(Date(15, August, 2015));
-  expectedHol.push_back(Date(16, August, 2015));
-  expectedHol.push_back(Date(22, August, 2015));
-  expectedHol.push_back(Date(23, August, 2015));
-  expectedHol.push_back(Date(29, August, 2015));
-  expectedHol.push_back(Date(30, August, 2015));
-  expectedHol.push_back(Date(5, September, 2015));
-  expectedHol.push_back(Date(6, September, 2015));
-  expectedHol.push_back(Date(12, September, 2015));
-  expectedHol.push_back(Date(13, September, 2015));
-  expectedHol.push_back(Date(19, September, 2015));
-  expectedHol.push_back(Date(20, September, 2015));
-  expectedHol.push_back(Date(26, September, 2015));
-  expectedHol.push_back(Date(27, September, 2015));
-  expectedHol.push_back(Date(3, October, 2015));
-  expectedHol.push_back(Date(4, October, 2015));
-  expectedHol.push_back(Date(10, October, 2015));
-  expectedHol.push_back(Date(11, October, 2015));
-  expectedHol.push_back(Date(17, October, 2015));
-  expectedHol.push_back(Date(18, October, 2015));
-  expectedHol.push_back(Date(24, October, 2015));
-  expectedHol.push_back(Date(25, October, 2015));
-  expectedHol.push_back(Date(31, October, 2015));
-  expectedHol.push_back(Date(1, November, 2015));
-  expectedHol.push_back(Date(4, November, 2015));
-  expectedHol.push_back(Date(7, November, 2015));
-  expectedHol.push_back(Date(8, November, 2015));
-  expectedHol.push_back(Date(14, November, 2015));
-  expectedHol.push_back(Date(15, November, 2015));
-  expectedHol.push_back(Date(21, November, 2015));
-  expectedHol.push_back(Date(22, November, 2015));
-  expectedHol.push_back(Date(28, November, 2015));
-  expectedHol.push_back(Date(29, November, 2015));
-  expectedHol.push_back(Date(5, December, 2015));
-  expectedHol.push_back(Date(6, December, 2015));
-  expectedHol.push_back(Date(12, December, 2015));
-  expectedHol.push_back(Date(13, December, 2015));
-  expectedHol.push_back(Date(19, December, 2015));
-  expectedHol.push_back(Date(20, December, 2015));
-  expectedHol.push_back(Date(26, December, 2015));
-  expectedHol.push_back(Date(27, December, 2015));
-  expectedHol.push_back(Date(31, December, 2015));
+    // exhaustive holiday list for the year 2014
+    expectedHol.push_back(Date(1, January, 2014));
+    expectedHol.push_back(Date(2, January, 2014));
+    expectedHol.push_back(Date(3, January, 2014));
+    expectedHol.push_back(Date(4, January, 2014));
+    expectedHol.push_back(Date(5, January, 2014));
+    expectedHol.push_back(Date(7, January, 2014));
+    expectedHol.push_back(Date(11, January, 2014));
+    expectedHol.push_back(Date(12, January, 2014));
+    expectedHol.push_back(Date(18, January, 2014));
+    expectedHol.push_back(Date(19, January, 2014));
+    expectedHol.push_back(Date(25, January, 2014));
+    expectedHol.push_back(Date(26, January, 2014));
+    expectedHol.push_back(Date(1, February, 2014));
+    expectedHol.push_back(Date(2, February, 2014));
+    expectedHol.push_back(Date(8, February, 2014));
+    expectedHol.push_back(Date(9, February, 2014));
+    expectedHol.push_back(Date(15, February, 2014));
+    expectedHol.push_back(Date(16, February, 2014));
+    expectedHol.push_back(Date(22, February, 2014));
+    expectedHol.push_back(Date(23, February, 2014));
+    expectedHol.push_back(Date(1, March, 2014));
+    expectedHol.push_back(Date(2, March, 2014));
+    expectedHol.push_back(Date(8, March, 2014));
+    expectedHol.push_back(Date(9, March, 2014));
+    expectedHol.push_back(Date(10, March, 2014));
+    expectedHol.push_back(Date(15, March, 2014));
+    expectedHol.push_back(Date(16, March, 2014));
+    expectedHol.push_back(Date(22, March, 2014));
+    expectedHol.push_back(Date(23, March, 2014));
+    expectedHol.push_back(Date(29, March, 2014));
+    expectedHol.push_back(Date(30, March, 2014));
+    expectedHol.push_back(Date(5, April, 2014));
+    expectedHol.push_back(Date(6, April, 2014));
+    expectedHol.push_back(Date(12, April, 2014));
+    expectedHol.push_back(Date(13, April, 2014));
+    expectedHol.push_back(Date(19, April, 2014));
+    expectedHol.push_back(Date(20, April, 2014));
+    expectedHol.push_back(Date(26, April, 2014));
+    expectedHol.push_back(Date(27, April, 2014));
+    expectedHol.push_back(Date(1, May, 2014));
+    expectedHol.push_back(Date(3, May, 2014));
+    expectedHol.push_back(Date(4, May, 2014));
+    expectedHol.push_back(Date(9, May, 2014));
+    expectedHol.push_back(Date(10, May, 2014));
+    expectedHol.push_back(Date(11, May, 2014));
+    expectedHol.push_back(Date(17, May, 2014));
+    expectedHol.push_back(Date(18, May, 2014));
+    expectedHol.push_back(Date(24, May, 2014));
+    expectedHol.push_back(Date(25, May, 2014));
+    expectedHol.push_back(Date(31, May, 2014));
+    expectedHol.push_back(Date(1, June, 2014));
+    expectedHol.push_back(Date(7, June, 2014));
+    expectedHol.push_back(Date(8, June, 2014));
+    expectedHol.push_back(Date(12, June, 2014));
+    expectedHol.push_back(Date(14, June, 2014));
+    expectedHol.push_back(Date(15, June, 2014));
+    expectedHol.push_back(Date(21, June, 2014));
+    expectedHol.push_back(Date(22, June, 2014));
+    expectedHol.push_back(Date(28, June, 2014));
+    expectedHol.push_back(Date(29, June, 2014));
+    expectedHol.push_back(Date(5, July, 2014));
+    expectedHol.push_back(Date(6, July, 2014));
+    expectedHol.push_back(Date(12, July, 2014));
+    expectedHol.push_back(Date(13, July, 2014));
+    expectedHol.push_back(Date(19, July, 2014));
+    expectedHol.push_back(Date(20, July, 2014));
+    expectedHol.push_back(Date(26, July, 2014));
+    expectedHol.push_back(Date(27, July, 2014));
+    expectedHol.push_back(Date(2, August, 2014));
+    expectedHol.push_back(Date(3, August, 2014));
+    expectedHol.push_back(Date(9, August, 2014));
+    expectedHol.push_back(Date(10, August, 2014));
+    expectedHol.push_back(Date(16, August, 2014));
+    expectedHol.push_back(Date(17, August, 2014));
+    expectedHol.push_back(Date(23, August, 2014));
+    expectedHol.push_back(Date(24, August, 2014));
+    expectedHol.push_back(Date(30, August, 2014));
+    expectedHol.push_back(Date(31, August, 2014));
+    expectedHol.push_back(Date(6, September, 2014));
+    expectedHol.push_back(Date(7, September, 2014));
+    expectedHol.push_back(Date(13, September, 2014));
+    expectedHol.push_back(Date(14, September, 2014));
+    expectedHol.push_back(Date(20, September, 2014));
+    expectedHol.push_back(Date(21, September, 2014));
+    expectedHol.push_back(Date(27, September, 2014));
+    expectedHol.push_back(Date(28, September, 2014));
+    expectedHol.push_back(Date(4, October, 2014));
+    expectedHol.push_back(Date(5, October, 2014));
+    expectedHol.push_back(Date(11, October, 2014));
+    expectedHol.push_back(Date(12, October, 2014));
+    expectedHol.push_back(Date(18, October, 2014));
+    expectedHol.push_back(Date(19, October, 2014));
+    expectedHol.push_back(Date(25, October, 2014));
+    expectedHol.push_back(Date(26, October, 2014));
+    expectedHol.push_back(Date(1, November, 2014));
+    expectedHol.push_back(Date(2, November, 2014));
+    expectedHol.push_back(Date(4, November, 2014));
+    expectedHol.push_back(Date(8, November, 2014));
+    expectedHol.push_back(Date(9, November, 2014));
+    expectedHol.push_back(Date(15, November, 2014));
+    expectedHol.push_back(Date(16, November, 2014));
+    expectedHol.push_back(Date(22, November, 2014));
+    expectedHol.push_back(Date(23, November, 2014));
+    expectedHol.push_back(Date(29, November, 2014));
+    expectedHol.push_back(Date(30, November, 2014));
+    expectedHol.push_back(Date(6, December, 2014));
+    expectedHol.push_back(Date(7, December, 2014));
+    expectedHol.push_back(Date(13, December, 2014));
+    expectedHol.push_back(Date(14, December, 2014));
+    expectedHol.push_back(Date(20, December, 2014));
+    expectedHol.push_back(Date(21, December, 2014));
+    expectedHol.push_back(Date(27, December, 2014));
+    expectedHol.push_back(Date(28, December, 2014));
+    expectedHol.push_back(Date(31, December, 2014));
 
-  // exhaustive holiday list for the year 2016
-  expectedHol.push_back(Date(1, January, 2016));
-  expectedHol.push_back(Date(2, January, 2016));
-  expectedHol.push_back(Date(3, January, 2016));
-  expectedHol.push_back(Date(7, January, 2016));
-  expectedHol.push_back(Date(8, January, 2016));
-  expectedHol.push_back(Date(9, January, 2016));
-  expectedHol.push_back(Date(10, January, 2016));
-  expectedHol.push_back(Date(16, January, 2016));
-  expectedHol.push_back(Date(17, January, 2016));
-  expectedHol.push_back(Date(23, January, 2016));
-  expectedHol.push_back(Date(24, January, 2016));
-  expectedHol.push_back(Date(30, January, 2016));
-  expectedHol.push_back(Date(31, January, 2016));
-  expectedHol.push_back(Date(6, February, 2016));
-  expectedHol.push_back(Date(7, February, 2016));
-  expectedHol.push_back(Date(13, February, 2016));
-  expectedHol.push_back(Date(14, February, 2016));
-  expectedHol.push_back(Date(21, February, 2016));
-  expectedHol.push_back(Date(23, February, 2016));
-  expectedHol.push_back(Date(27, February, 2016));
-  expectedHol.push_back(Date(28, February, 2016));
-  expectedHol.push_back(Date(5, March, 2016));
-  expectedHol.push_back(Date(6, March, 2016));
-  expectedHol.push_back(Date(8, March, 2016));
-  expectedHol.push_back(Date(12, March, 2016));
-  expectedHol.push_back(Date(13, March, 2016));
-  expectedHol.push_back(Date(19, March, 2016));
-  expectedHol.push_back(Date(20, March, 2016));
-  expectedHol.push_back(Date(26, March, 2016));
-  expectedHol.push_back(Date(27, March, 2016));
-  expectedHol.push_back(Date(2, April, 2016));
-  expectedHol.push_back(Date(3, April, 2016));
-  expectedHol.push_back(Date(9, April, 2016));
-  expectedHol.push_back(Date(10, April, 2016));
-  expectedHol.push_back(Date(16, April, 2016));
-  expectedHol.push_back(Date(17, April, 2016));
-  expectedHol.push_back(Date(23, April, 2016));
-  expectedHol.push_back(Date(24, April, 2016));
-  expectedHol.push_back(Date(30, April, 2016));
-  expectedHol.push_back(Date(1, May, 2016));
-  expectedHol.push_back(Date(2, May, 2016));
-  expectedHol.push_back(Date(3, May, 2016));
-  expectedHol.push_back(Date(7, May, 2016));
-  expectedHol.push_back(Date(8, May, 2016));
-  expectedHol.push_back(Date(9, May, 2016));
-  expectedHol.push_back(Date(14, May, 2016));
-  expectedHol.push_back(Date(15, May, 2016));
-  expectedHol.push_back(Date(21, May, 2016));
-  expectedHol.push_back(Date(22, May, 2016));
-  expectedHol.push_back(Date(28, May, 2016));
-  expectedHol.push_back(Date(29, May, 2016));
-  expectedHol.push_back(Date(4, June, 2016));
-  expectedHol.push_back(Date(5, June, 2016));
-  expectedHol.push_back(Date(11, June, 2016));
-  expectedHol.push_back(Date(12, June, 2016));
-  expectedHol.push_back(Date(13, June, 2016));
-  expectedHol.push_back(Date(18, June, 2016));
-  expectedHol.push_back(Date(19, June, 2016));
-  expectedHol.push_back(Date(25, June, 2016));
-  expectedHol.push_back(Date(26, June, 2016));
-  expectedHol.push_back(Date(2, July, 2016));
-  expectedHol.push_back(Date(3, July, 2016));
-  expectedHol.push_back(Date(9, July, 2016));
-  expectedHol.push_back(Date(10, July, 2016));
-  expectedHol.push_back(Date(16, July, 2016));
-  expectedHol.push_back(Date(17, July, 2016));
-  expectedHol.push_back(Date(23, July, 2016));
-  expectedHol.push_back(Date(24, July, 2016));
-  expectedHol.push_back(Date(30, July, 2016));
-  expectedHol.push_back(Date(31, July, 2016));
-  expectedHol.push_back(Date(6, August, 2016));
-  expectedHol.push_back(Date(7, August, 2016));
-  expectedHol.push_back(Date(13, August, 2016));
-  expectedHol.push_back(Date(14, August, 2016));
-  expectedHol.push_back(Date(20, August, 2016));
-  expectedHol.push_back(Date(21, August, 2016));
-  expectedHol.push_back(Date(27, August, 2016));
-  expectedHol.push_back(Date(28, August, 2016));
-  expectedHol.push_back(Date(3, September, 2016));
-  expectedHol.push_back(Date(4, September, 2016));
-  expectedHol.push_back(Date(10, September, 2016));
-  expectedHol.push_back(Date(11, September, 2016));
-  expectedHol.push_back(Date(17, September, 2016));
-  expectedHol.push_back(Date(18, September, 2016));
-  expectedHol.push_back(Date(24, September, 2016));
-  expectedHol.push_back(Date(25, September, 2016));
-  expectedHol.push_back(Date(1, October, 2016));
-  expectedHol.push_back(Date(2, October, 2016));
-  expectedHol.push_back(Date(8, October, 2016));
-  expectedHol.push_back(Date(9, October, 2016));
-  expectedHol.push_back(Date(15, October, 2016));
-  expectedHol.push_back(Date(16, October, 2016));
-  expectedHol.push_back(Date(22, October, 2016));
-  expectedHol.push_back(Date(23, October, 2016));
-  expectedHol.push_back(Date(29, October, 2016));
-  expectedHol.push_back(Date(30, October, 2016));
-  expectedHol.push_back(Date(4, November, 2016));
-  expectedHol.push_back(Date(5, November, 2016));
-  expectedHol.push_back(Date(6, November, 2016));
-  expectedHol.push_back(Date(12, November, 2016));
-  expectedHol.push_back(Date(13, November, 2016));
-  expectedHol.push_back(Date(19, November, 2016));
-  expectedHol.push_back(Date(20, November, 2016));
-  expectedHol.push_back(Date(26, November, 2016));
-  expectedHol.push_back(Date(27, November, 2016));
-  expectedHol.push_back(Date(3, December, 2016));
-  expectedHol.push_back(Date(4, December, 2016));
-  expectedHol.push_back(Date(10, December, 2016));
-  expectedHol.push_back(Date(11, December, 2016));
-  expectedHol.push_back(Date(17, December, 2016));
-  expectedHol.push_back(Date(18, December, 2016));
-  expectedHol.push_back(Date(24, December, 2016));
-  expectedHol.push_back(Date(25, December, 2016));
-  expectedHol.push_back(Date(30, December, 2016));
-  expectedHol.push_back(Date(31, December, 2016));
-  
-  Calendar c = Russia(Russia::MOEX);
-  
-  
-  std::vector<Date> hol = c.holidayList(
-    Date(1, January, 2012),
-    Date(31, December, 2016), // only dates for which calendars are available
-    true); // include week-ends since lists are exhaustive
-  for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
-    if (hol[i] != expectedHol[i])
-      BOOST_FAIL("expected holiday was " << expectedHol[i]
-        << " while calculated holiday is " << hol[i]);
-  }
-  if (hol.size() != expectedHol.size())
-    BOOST_FAIL("there were " << expectedHol.size()
-      << " expected holidays, while there are " << hol.size()
-      << " calculated holidays");
+    // exhaustive holiday list for the year 2015
+    expectedHol.push_back(Date(1, January, 2015));
+    expectedHol.push_back(Date(2, January, 2015));
+    expectedHol.push_back(Date(3, January, 2015));
+    expectedHol.push_back(Date(4, January, 2015));
+    expectedHol.push_back(Date(7, January, 2015));
+    expectedHol.push_back(Date(10, January, 2015));
+    expectedHol.push_back(Date(11, January, 2015));
+    expectedHol.push_back(Date(17, January, 2015));
+    expectedHol.push_back(Date(18, January, 2015));
+    expectedHol.push_back(Date(24, January, 2015));
+    expectedHol.push_back(Date(25, January, 2015));
+    expectedHol.push_back(Date(31, January, 2015));
+    expectedHol.push_back(Date(1, February, 2015));
+    expectedHol.push_back(Date(7, February, 2015));
+    expectedHol.push_back(Date(8, February, 2015));
+    expectedHol.push_back(Date(14, February, 2015));
+    expectedHol.push_back(Date(15, February, 2015));
+    expectedHol.push_back(Date(21, February, 2015));
+    expectedHol.push_back(Date(22, February, 2015));
+    expectedHol.push_back(Date(23, February, 2015));
+    expectedHol.push_back(Date(28, February, 2015));
+    expectedHol.push_back(Date(1, March, 2015));
+    expectedHol.push_back(Date(7, March, 2015));
+    expectedHol.push_back(Date(8, March, 2015));
+    expectedHol.push_back(Date(9, March, 2015));
+    expectedHol.push_back(Date(14, March, 2015));
+    expectedHol.push_back(Date(15, March, 2015));
+    expectedHol.push_back(Date(21, March, 2015));
+    expectedHol.push_back(Date(22, March, 2015));
+    expectedHol.push_back(Date(28, March, 2015));
+    expectedHol.push_back(Date(29, March, 2015));
+    expectedHol.push_back(Date(4, April, 2015));
+    expectedHol.push_back(Date(5, April, 2015));
+    expectedHol.push_back(Date(11, April, 2015));
+    expectedHol.push_back(Date(12, April, 2015));
+    expectedHol.push_back(Date(18, April, 2015));
+    expectedHol.push_back(Date(19, April, 2015));
+    expectedHol.push_back(Date(25, April, 2015));
+    expectedHol.push_back(Date(26, April, 2015));
+    expectedHol.push_back(Date(1, May, 2015));
+    expectedHol.push_back(Date(2, May, 2015));
+    expectedHol.push_back(Date(3, May, 2015));
+    expectedHol.push_back(Date(9, May, 2015));
+    expectedHol.push_back(Date(10, May, 2015));
+    expectedHol.push_back(Date(11, May, 2015));
+    expectedHol.push_back(Date(16, May, 2015));
+    expectedHol.push_back(Date(17, May, 2015));
+    expectedHol.push_back(Date(23, May, 2015));
+    expectedHol.push_back(Date(24, May, 2015));
+    expectedHol.push_back(Date(30, May, 2015));
+    expectedHol.push_back(Date(31, May, 2015));
+    expectedHol.push_back(Date(6, June, 2015));
+    expectedHol.push_back(Date(7, June, 2015));
+    expectedHol.push_back(Date(12, June, 2015));
+    expectedHol.push_back(Date(13, June, 2015));
+    expectedHol.push_back(Date(14, June, 2015));
+    expectedHol.push_back(Date(20, June, 2015));
+    expectedHol.push_back(Date(21, June, 2015));
+    expectedHol.push_back(Date(27, June, 2015));
+    expectedHol.push_back(Date(28, June, 2015));
+    expectedHol.push_back(Date(4, July, 2015));
+    expectedHol.push_back(Date(5, July, 2015));
+    expectedHol.push_back(Date(11, July, 2015));
+    expectedHol.push_back(Date(12, July, 2015));
+    expectedHol.push_back(Date(18, July, 2015));
+    expectedHol.push_back(Date(19, July, 2015));
+    expectedHol.push_back(Date(25, July, 2015));
+    expectedHol.push_back(Date(26, July, 2015));
+    expectedHol.push_back(Date(1, August, 2015));
+    expectedHol.push_back(Date(2, August, 2015));
+    expectedHol.push_back(Date(8, August, 2015));
+    expectedHol.push_back(Date(9, August, 2015));
+    expectedHol.push_back(Date(15, August, 2015));
+    expectedHol.push_back(Date(16, August, 2015));
+    expectedHol.push_back(Date(22, August, 2015));
+    expectedHol.push_back(Date(23, August, 2015));
+    expectedHol.push_back(Date(29, August, 2015));
+    expectedHol.push_back(Date(30, August, 2015));
+    expectedHol.push_back(Date(5, September, 2015));
+    expectedHol.push_back(Date(6, September, 2015));
+    expectedHol.push_back(Date(12, September, 2015));
+    expectedHol.push_back(Date(13, September, 2015));
+    expectedHol.push_back(Date(19, September, 2015));
+    expectedHol.push_back(Date(20, September, 2015));
+    expectedHol.push_back(Date(26, September, 2015));
+    expectedHol.push_back(Date(27, September, 2015));
+    expectedHol.push_back(Date(3, October, 2015));
+    expectedHol.push_back(Date(4, October, 2015));
+    expectedHol.push_back(Date(10, October, 2015));
+    expectedHol.push_back(Date(11, October, 2015));
+    expectedHol.push_back(Date(17, October, 2015));
+    expectedHol.push_back(Date(18, October, 2015));
+    expectedHol.push_back(Date(24, October, 2015));
+    expectedHol.push_back(Date(25, October, 2015));
+    expectedHol.push_back(Date(31, October, 2015));
+    expectedHol.push_back(Date(1, November, 2015));
+    expectedHol.push_back(Date(4, November, 2015));
+    expectedHol.push_back(Date(7, November, 2015));
+    expectedHol.push_back(Date(8, November, 2015));
+    expectedHol.push_back(Date(14, November, 2015));
+    expectedHol.push_back(Date(15, November, 2015));
+    expectedHol.push_back(Date(21, November, 2015));
+    expectedHol.push_back(Date(22, November, 2015));
+    expectedHol.push_back(Date(28, November, 2015));
+    expectedHol.push_back(Date(29, November, 2015));
+    expectedHol.push_back(Date(5, December, 2015));
+    expectedHol.push_back(Date(6, December, 2015));
+    expectedHol.push_back(Date(12, December, 2015));
+    expectedHol.push_back(Date(13, December, 2015));
+    expectedHol.push_back(Date(19, December, 2015));
+    expectedHol.push_back(Date(20, December, 2015));
+    expectedHol.push_back(Date(26, December, 2015));
+    expectedHol.push_back(Date(27, December, 2015));
+    expectedHol.push_back(Date(31, December, 2015));
+
+    // exhaustive holiday list for the year 2016
+    expectedHol.push_back(Date(1, January, 2016));
+    expectedHol.push_back(Date(2, January, 2016));
+    expectedHol.push_back(Date(3, January, 2016));
+    expectedHol.push_back(Date(7, January, 2016));
+    expectedHol.push_back(Date(8, January, 2016));
+    expectedHol.push_back(Date(9, January, 2016));
+    expectedHol.push_back(Date(10, January, 2016));
+    expectedHol.push_back(Date(16, January, 2016));
+    expectedHol.push_back(Date(17, January, 2016));
+    expectedHol.push_back(Date(23, January, 2016));
+    expectedHol.push_back(Date(24, January, 2016));
+    expectedHol.push_back(Date(30, January, 2016));
+    expectedHol.push_back(Date(31, January, 2016));
+    expectedHol.push_back(Date(6, February, 2016));
+    expectedHol.push_back(Date(7, February, 2016));
+    expectedHol.push_back(Date(13, February, 2016));
+    expectedHol.push_back(Date(14, February, 2016));
+    expectedHol.push_back(Date(21, February, 2016));
+    expectedHol.push_back(Date(23, February, 2016));
+    expectedHol.push_back(Date(27, February, 2016));
+    expectedHol.push_back(Date(28, February, 2016));
+    expectedHol.push_back(Date(5, March, 2016));
+    expectedHol.push_back(Date(6, March, 2016));
+    expectedHol.push_back(Date(8, March, 2016));
+    expectedHol.push_back(Date(12, March, 2016));
+    expectedHol.push_back(Date(13, March, 2016));
+    expectedHol.push_back(Date(19, March, 2016));
+    expectedHol.push_back(Date(20, March, 2016));
+    expectedHol.push_back(Date(26, March, 2016));
+    expectedHol.push_back(Date(27, March, 2016));
+    expectedHol.push_back(Date(2, April, 2016));
+    expectedHol.push_back(Date(3, April, 2016));
+    expectedHol.push_back(Date(9, April, 2016));
+    expectedHol.push_back(Date(10, April, 2016));
+    expectedHol.push_back(Date(16, April, 2016));
+    expectedHol.push_back(Date(17, April, 2016));
+    expectedHol.push_back(Date(23, April, 2016));
+    expectedHol.push_back(Date(24, April, 2016));
+    expectedHol.push_back(Date(30, April, 2016));
+    expectedHol.push_back(Date(1, May, 2016));
+    expectedHol.push_back(Date(2, May, 2016));
+    expectedHol.push_back(Date(3, May, 2016));
+    expectedHol.push_back(Date(7, May, 2016));
+    expectedHol.push_back(Date(8, May, 2016));
+    expectedHol.push_back(Date(9, May, 2016));
+    expectedHol.push_back(Date(14, May, 2016));
+    expectedHol.push_back(Date(15, May, 2016));
+    expectedHol.push_back(Date(21, May, 2016));
+    expectedHol.push_back(Date(22, May, 2016));
+    expectedHol.push_back(Date(28, May, 2016));
+    expectedHol.push_back(Date(29, May, 2016));
+    expectedHol.push_back(Date(4, June, 2016));
+    expectedHol.push_back(Date(5, June, 2016));
+    expectedHol.push_back(Date(11, June, 2016));
+    expectedHol.push_back(Date(12, June, 2016));
+    expectedHol.push_back(Date(13, June, 2016));
+    expectedHol.push_back(Date(18, June, 2016));
+    expectedHol.push_back(Date(19, June, 2016));
+    expectedHol.push_back(Date(25, June, 2016));
+    expectedHol.push_back(Date(26, June, 2016));
+    expectedHol.push_back(Date(2, July, 2016));
+    expectedHol.push_back(Date(3, July, 2016));
+    expectedHol.push_back(Date(9, July, 2016));
+    expectedHol.push_back(Date(10, July, 2016));
+    expectedHol.push_back(Date(16, July, 2016));
+    expectedHol.push_back(Date(17, July, 2016));
+    expectedHol.push_back(Date(23, July, 2016));
+    expectedHol.push_back(Date(24, July, 2016));
+    expectedHol.push_back(Date(30, July, 2016));
+    expectedHol.push_back(Date(31, July, 2016));
+    expectedHol.push_back(Date(6, August, 2016));
+    expectedHol.push_back(Date(7, August, 2016));
+    expectedHol.push_back(Date(13, August, 2016));
+    expectedHol.push_back(Date(14, August, 2016));
+    expectedHol.push_back(Date(20, August, 2016));
+    expectedHol.push_back(Date(21, August, 2016));
+    expectedHol.push_back(Date(27, August, 2016));
+    expectedHol.push_back(Date(28, August, 2016));
+    expectedHol.push_back(Date(3, September, 2016));
+    expectedHol.push_back(Date(4, September, 2016));
+    expectedHol.push_back(Date(10, September, 2016));
+    expectedHol.push_back(Date(11, September, 2016));
+    expectedHol.push_back(Date(17, September, 2016));
+    expectedHol.push_back(Date(18, September, 2016));
+    expectedHol.push_back(Date(24, September, 2016));
+    expectedHol.push_back(Date(25, September, 2016));
+    expectedHol.push_back(Date(1, October, 2016));
+    expectedHol.push_back(Date(2, October, 2016));
+    expectedHol.push_back(Date(8, October, 2016));
+    expectedHol.push_back(Date(9, October, 2016));
+    expectedHol.push_back(Date(15, October, 2016));
+    expectedHol.push_back(Date(16, October, 2016));
+    expectedHol.push_back(Date(22, October, 2016));
+    expectedHol.push_back(Date(23, October, 2016));
+    expectedHol.push_back(Date(29, October, 2016));
+    expectedHol.push_back(Date(30, October, 2016));
+    expectedHol.push_back(Date(4, November, 2016));
+    expectedHol.push_back(Date(5, November, 2016));
+    expectedHol.push_back(Date(6, November, 2016));
+    expectedHol.push_back(Date(12, November, 2016));
+    expectedHol.push_back(Date(13, November, 2016));
+    expectedHol.push_back(Date(19, November, 2016));
+    expectedHol.push_back(Date(20, November, 2016));
+    expectedHol.push_back(Date(26, November, 2016));
+    expectedHol.push_back(Date(27, November, 2016));
+    expectedHol.push_back(Date(3, December, 2016));
+    expectedHol.push_back(Date(4, December, 2016));
+    expectedHol.push_back(Date(10, December, 2016));
+    expectedHol.push_back(Date(11, December, 2016));
+    expectedHol.push_back(Date(17, December, 2016));
+    expectedHol.push_back(Date(18, December, 2016));
+    expectedHol.push_back(Date(24, December, 2016));
+    expectedHol.push_back(Date(25, December, 2016));
+    expectedHol.push_back(Date(30, December, 2016));
+    expectedHol.push_back(Date(31, December, 2016));
+
+    Calendar c = Russia(Russia::MOEX);
+
+
+    std::vector<Date> hol =
+        c.holidayList(Date(1, January, 2012),
+                      Date(31, December, 2016), // only dates for which calendars are available
+                      true);                    // include week-ends since lists are exhaustive
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
+    }
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testBrazil() {
@@ -1356,44 +1324,42 @@ void CalendarTest::testBrazil() {
 
     std::vector<Date> expectedHol;
 
-    //expectedHol.push_back(Date(1,January,2005)); // Saturday
-    expectedHol.push_back(Date(7,February,2005));
-    expectedHol.push_back(Date(8,February,2005));
-    expectedHol.push_back(Date(25,March,2005));
-    expectedHol.push_back(Date(21,April,2005));
-    //expectedHol.push_back(Date(1,May,2005)); // Sunday
-    expectedHol.push_back(Date(26,May,2005));
-    expectedHol.push_back(Date(7,September,2005));
-    expectedHol.push_back(Date(12,October,2005));
-    expectedHol.push_back(Date(2,November,2005));
-    expectedHol.push_back(Date(15,November,2005));
-    //expectedHol.push_back(Date(25,December,2005)); // Sunday
+    // expectedHol.push_back(Date(1,January,2005)); // Saturday
+    expectedHol.push_back(Date(7, February, 2005));
+    expectedHol.push_back(Date(8, February, 2005));
+    expectedHol.push_back(Date(25, March, 2005));
+    expectedHol.push_back(Date(21, April, 2005));
+    // expectedHol.push_back(Date(1,May,2005)); // Sunday
+    expectedHol.push_back(Date(26, May, 2005));
+    expectedHol.push_back(Date(7, September, 2005));
+    expectedHol.push_back(Date(12, October, 2005));
+    expectedHol.push_back(Date(2, November, 2005));
+    expectedHol.push_back(Date(15, November, 2005));
+    // expectedHol.push_back(Date(25,December,2005)); // Sunday
 
-    //expectedHol.push_back(Date(1,January,2006)); // Sunday
-    expectedHol.push_back(Date(27,February,2006));
-    expectedHol.push_back(Date(28,February,2006));
-    expectedHol.push_back(Date(14,April,2006));
-    expectedHol.push_back(Date(21,April,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(15,June,2006));
-    expectedHol.push_back(Date(7,September,2006));
-    expectedHol.push_back(Date(12,October,2006));
-    expectedHol.push_back(Date(2,November,2006));
-    expectedHol.push_back(Date(15,November,2006));
-    expectedHol.push_back(Date(25,December,2006));
+    // expectedHol.push_back(Date(1,January,2006)); // Sunday
+    expectedHol.push_back(Date(27, February, 2006));
+    expectedHol.push_back(Date(28, February, 2006));
+    expectedHol.push_back(Date(14, April, 2006));
+    expectedHol.push_back(Date(21, April, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(15, June, 2006));
+    expectedHol.push_back(Date(7, September, 2006));
+    expectedHol.push_back(Date(12, October, 2006));
+    expectedHol.push_back(Date(2, November, 2006));
+    expectedHol.push_back(Date(15, November, 2006));
+    expectedHol.push_back(Date(25, December, 2006));
 
     Calendar c = Brazil();
-    std::vector<Date> hol = c.holidayList(Date(1,January,2005),
-                                          Date(31,December,2006));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2005), Date(31, December, 2006));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 
@@ -1401,183 +1367,179 @@ void CalendarTest::testSouthKoreanSettlement() {
     BOOST_TEST_MESSAGE("Testing South-Korean settlement holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(21,January,2004));
-    expectedHol.push_back(Date(22,January,2004));
-    expectedHol.push_back(Date(23,January,2004));
-    expectedHol.push_back(Date(1,March,2004));
-    expectedHol.push_back(Date(5,April,2004));
-    expectedHol.push_back(Date(15,April,2004)); // election day
-//    expectedHol.push_back(Date(1,May,2004)); // Saturday
-    expectedHol.push_back(Date(5,May,2004));
-    expectedHol.push_back(Date(26,May,2004));
-//    expectedHol.push_back(Date(6,June,2004)); // Sunday
-//    expectedHol.push_back(Date(17,July,2004)); // Saturday
-//    expectedHol.push_back(Date(15,August,2004)); // Sunday
-    expectedHol.push_back(Date(27,September,2004));
-    expectedHol.push_back(Date(28,September,2004));
-    expectedHol.push_back(Date(29,September,2004));
-//    expectedHol.push_back(Date(3,October,2004)); // Sunday
-//    expectedHol.push_back(Date(25,December,2004)); // Saturday
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(21, January, 2004));
+    expectedHol.push_back(Date(22, January, 2004));
+    expectedHol.push_back(Date(23, January, 2004));
+    expectedHol.push_back(Date(1, March, 2004));
+    expectedHol.push_back(Date(5, April, 2004));
+    expectedHol.push_back(Date(15, April, 2004)); // election day
+    //    expectedHol.push_back(Date(1,May,2004)); // Saturday
+    expectedHol.push_back(Date(5, May, 2004));
+    expectedHol.push_back(Date(26, May, 2004));
+    //    expectedHol.push_back(Date(6,June,2004)); // Sunday
+    //    expectedHol.push_back(Date(17,July,2004)); // Saturday
+    //    expectedHol.push_back(Date(15,August,2004)); // Sunday
+    expectedHol.push_back(Date(27, September, 2004));
+    expectedHol.push_back(Date(28, September, 2004));
+    expectedHol.push_back(Date(29, September, 2004));
+    //    expectedHol.push_back(Date(3,October,2004)); // Sunday
+    //    expectedHol.push_back(Date(25,December,2004)); // Saturday
 
-//    expectedHol.push_back(Date(1,January,2005)); // Saturday
-    expectedHol.push_back(Date(8,February,2005));
-    expectedHol.push_back(Date(9,February,2005));
-    expectedHol.push_back(Date(10,February,2005));
-    expectedHol.push_back(Date(1,March,2005));
-    expectedHol.push_back(Date(5,April,2005));
-    expectedHol.push_back(Date(5,May,2005));
-//    expectedHol.push_back(Date(15,May,2005)); // Sunday
-    expectedHol.push_back(Date(6,June,2005));
-//    expectedHol.push_back(Date(17,July,2005)); // Sunday
-    expectedHol.push_back(Date(15,August,2005));
-//    expectedHol.push_back(Date(17,September,2005)); // Saturday
-//    expectedHol.push_back(Date(18,September,2005)); // Sunday
-    expectedHol.push_back(Date(19,September,2005));
-    expectedHol.push_back(Date(3,October,2005));
-//    expectedHol.push_back(Date(25,December,2005)); // Sunday
+    //    expectedHol.push_back(Date(1,January,2005)); // Saturday
+    expectedHol.push_back(Date(8, February, 2005));
+    expectedHol.push_back(Date(9, February, 2005));
+    expectedHol.push_back(Date(10, February, 2005));
+    expectedHol.push_back(Date(1, March, 2005));
+    expectedHol.push_back(Date(5, April, 2005));
+    expectedHol.push_back(Date(5, May, 2005));
+    //    expectedHol.push_back(Date(15,May,2005)); // Sunday
+    expectedHol.push_back(Date(6, June, 2005));
+    //    expectedHol.push_back(Date(17,July,2005)); // Sunday
+    expectedHol.push_back(Date(15, August, 2005));
+    //    expectedHol.push_back(Date(17,September,2005)); // Saturday
+    //    expectedHol.push_back(Date(18,September,2005)); // Sunday
+    expectedHol.push_back(Date(19, September, 2005));
+    expectedHol.push_back(Date(3, October, 2005));
+    //    expectedHol.push_back(Date(25,December,2005)); // Sunday
 
-//    expectedHol.push_back(Date(1,January,2006)); // Sunday
-//    expectedHol.push_back(Date(28,January,2006)); // Saturday
-//    expectedHol.push_back(Date(29,January,2006)); // Sunday
-    expectedHol.push_back(Date(30,January,2006));
-    expectedHol.push_back(Date(1,March,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(5,May,2006));
-    expectedHol.push_back(Date(31,May,2006)); // election
-    expectedHol.push_back(Date(6,June,2006));
-    expectedHol.push_back(Date(17,July,2006));
-    expectedHol.push_back(Date(15,August,2006));
-    expectedHol.push_back(Date(3,October,2006));
-    expectedHol.push_back(Date(5,October,2006));
-    expectedHol.push_back(Date(6,October,2006));
-//    expectedHol.push_back(Date(7,October,2006)); // Saturday
-    expectedHol.push_back(Date(25,December,2006));
+    //    expectedHol.push_back(Date(1,January,2006)); // Sunday
+    //    expectedHol.push_back(Date(28,January,2006)); // Saturday
+    //    expectedHol.push_back(Date(29,January,2006)); // Sunday
+    expectedHol.push_back(Date(30, January, 2006));
+    expectedHol.push_back(Date(1, March, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(5, May, 2006));
+    expectedHol.push_back(Date(31, May, 2006)); // election
+    expectedHol.push_back(Date(6, June, 2006));
+    expectedHol.push_back(Date(17, July, 2006));
+    expectedHol.push_back(Date(15, August, 2006));
+    expectedHol.push_back(Date(3, October, 2006));
+    expectedHol.push_back(Date(5, October, 2006));
+    expectedHol.push_back(Date(6, October, 2006));
+    //    expectedHol.push_back(Date(7,October,2006)); // Saturday
+    expectedHol.push_back(Date(25, December, 2006));
 
-    expectedHol.push_back(Date(1,January,2007));
-//    expectedHol.push_back(Date(17,February,2007)); // Saturday
-//    expectedHol.push_back(Date(18,February,2007)); // Sunday
-    expectedHol.push_back(Date(19,February,2007));
-    expectedHol.push_back(Date(1,March,2007));
-    expectedHol.push_back(Date(1,May,2007));
-//    expectedHol.push_back(Date(5,May,2007)); // Saturday
-    expectedHol.push_back(Date(24,May,2007));
-    expectedHol.push_back(Date(6,June,2007));
-    expectedHol.push_back(Date(17,July,2007));
-    expectedHol.push_back(Date(15,August,2007));
-    expectedHol.push_back(Date(24,September,2007));
-    expectedHol.push_back(Date(25,September,2007));
-    expectedHol.push_back(Date(26,September,2007));
-    expectedHol.push_back(Date(3,October,2007));
-    expectedHol.push_back(Date(19,December,2007)); // election
-    expectedHol.push_back(Date(25,December,2007));
+    expectedHol.push_back(Date(1, January, 2007));
+    //    expectedHol.push_back(Date(17,February,2007)); // Saturday
+    //    expectedHol.push_back(Date(18,February,2007)); // Sunday
+    expectedHol.push_back(Date(19, February, 2007));
+    expectedHol.push_back(Date(1, March, 2007));
+    expectedHol.push_back(Date(1, May, 2007));
+    //    expectedHol.push_back(Date(5,May,2007)); // Saturday
+    expectedHol.push_back(Date(24, May, 2007));
+    expectedHol.push_back(Date(6, June, 2007));
+    expectedHol.push_back(Date(17, July, 2007));
+    expectedHol.push_back(Date(15, August, 2007));
+    expectedHol.push_back(Date(24, September, 2007));
+    expectedHol.push_back(Date(25, September, 2007));
+    expectedHol.push_back(Date(26, September, 2007));
+    expectedHol.push_back(Date(3, October, 2007));
+    expectedHol.push_back(Date(19, December, 2007)); // election
+    expectedHol.push_back(Date(25, December, 2007));
 
     Calendar c = SouthKorea(SouthKorea::Settlement);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2007));
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2007));
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testKoreaStockExchange() {
     BOOST_TEST_MESSAGE("Testing Korea Stock Exchange holiday list...");
 
     std::vector<Date> expectedHol;
-    expectedHol.push_back(Date(1,January,2004));
-    expectedHol.push_back(Date(21,January,2004));
-    expectedHol.push_back(Date(22,January,2004));
-    expectedHol.push_back(Date(23,January,2004));
-    expectedHol.push_back(Date(1,March,2004));
-    expectedHol.push_back(Date(5,April,2004));
-    expectedHol.push_back(Date(15,April,2004)); //election day
-//    expectedHol.push_back(Date(1,May,2004)); // Saturday
-    expectedHol.push_back(Date(5,May,2004));
-    expectedHol.push_back(Date(26,May,2004));
-//    expectedHol.push_back(Date(6,June,2004)); // Sunday
-//    expectedHol.push_back(Date(17,July,2004)); // Saturday
-//    expectedHol.push_back(Date(15,August,2004)); // Sunday
-    expectedHol.push_back(Date(27,September,2004));
-    expectedHol.push_back(Date(28,September,2004));
-    expectedHol.push_back(Date(29,September,2004));
-//    expectedHol.push_back(Date(3,October,2004)); // Sunday
-//    expectedHol.push_back(Date(25,December,2004)); // Saturday
-    expectedHol.push_back(Date(31,December,2004));
+    expectedHol.push_back(Date(1, January, 2004));
+    expectedHol.push_back(Date(21, January, 2004));
+    expectedHol.push_back(Date(22, January, 2004));
+    expectedHol.push_back(Date(23, January, 2004));
+    expectedHol.push_back(Date(1, March, 2004));
+    expectedHol.push_back(Date(5, April, 2004));
+    expectedHol.push_back(Date(15, April, 2004)); // election day
+    //    expectedHol.push_back(Date(1,May,2004)); // Saturday
+    expectedHol.push_back(Date(5, May, 2004));
+    expectedHol.push_back(Date(26, May, 2004));
+    //    expectedHol.push_back(Date(6,June,2004)); // Sunday
+    //    expectedHol.push_back(Date(17,July,2004)); // Saturday
+    //    expectedHol.push_back(Date(15,August,2004)); // Sunday
+    expectedHol.push_back(Date(27, September, 2004));
+    expectedHol.push_back(Date(28, September, 2004));
+    expectedHol.push_back(Date(29, September, 2004));
+    //    expectedHol.push_back(Date(3,October,2004)); // Sunday
+    //    expectedHol.push_back(Date(25,December,2004)); // Saturday
+    expectedHol.push_back(Date(31, December, 2004));
 
-//    expectedHol.push_back(Date(1,January,2005)); // Saturday
-    expectedHol.push_back(Date(8,February,2005));
-    expectedHol.push_back(Date(9,February,2005));
-    expectedHol.push_back(Date(10,February,2005));
-    expectedHol.push_back(Date(1,March,2005));
-    expectedHol.push_back(Date(5,April,2005));
-    expectedHol.push_back(Date(5,May,2005));
-//    expectedHol.push_back(Date(15,May,2005)); // Sunday
-    expectedHol.push_back(Date(6,June,2005));
-//    expectedHol.push_back(Date(17,July,2005)); // Sunday
-    expectedHol.push_back(Date(15,August,2005));
-//    expectedHol.push_back(Date(17,September,2005)); // Saturday
-//    expectedHol.push_back(Date(18,September,2005)); // Sunday
-    expectedHol.push_back(Date(19,September,2005));
-    expectedHol.push_back(Date(3,October,2005));
-//    expectedHol.push_back(Date(25,December,2005)); // Sunday
-    expectedHol.push_back(Date(30,December,2005));
+    //    expectedHol.push_back(Date(1,January,2005)); // Saturday
+    expectedHol.push_back(Date(8, February, 2005));
+    expectedHol.push_back(Date(9, February, 2005));
+    expectedHol.push_back(Date(10, February, 2005));
+    expectedHol.push_back(Date(1, March, 2005));
+    expectedHol.push_back(Date(5, April, 2005));
+    expectedHol.push_back(Date(5, May, 2005));
+    //    expectedHol.push_back(Date(15,May,2005)); // Sunday
+    expectedHol.push_back(Date(6, June, 2005));
+    //    expectedHol.push_back(Date(17,July,2005)); // Sunday
+    expectedHol.push_back(Date(15, August, 2005));
+    //    expectedHol.push_back(Date(17,September,2005)); // Saturday
+    //    expectedHol.push_back(Date(18,September,2005)); // Sunday
+    expectedHol.push_back(Date(19, September, 2005));
+    expectedHol.push_back(Date(3, October, 2005));
+    //    expectedHol.push_back(Date(25,December,2005)); // Sunday
+    expectedHol.push_back(Date(30, December, 2005));
 
-//    expectedHol.push_back(Date(1,January,2006)); // Sunday
-//    expectedHol.push_back(Date(28,January,2006)); // Saturday
-//    expectedHol.push_back(Date(29,January,2006)); // Sunday
-    expectedHol.push_back(Date(30,January,2006));
-    expectedHol.push_back(Date(1,March,2006));
-    expectedHol.push_back(Date(1,May,2006));
-    expectedHol.push_back(Date(5,May,2006));
-    expectedHol.push_back(Date(31,May,2006)); // election
-    expectedHol.push_back(Date(6,June,2006));
-    expectedHol.push_back(Date(17,July,2006));
-    expectedHol.push_back(Date(15,August,2006));
-    expectedHol.push_back(Date(3,October,2006));
-    expectedHol.push_back(Date(5,October,2006));
-    expectedHol.push_back(Date(6,October,2006));
-//    expectedHol.push_back(Date(7,October,2006)); // Saturday
-    expectedHol.push_back(Date(25,December,2006));
-    expectedHol.push_back(Date(29,December,2006));
+    //    expectedHol.push_back(Date(1,January,2006)); // Sunday
+    //    expectedHol.push_back(Date(28,January,2006)); // Saturday
+    //    expectedHol.push_back(Date(29,January,2006)); // Sunday
+    expectedHol.push_back(Date(30, January, 2006));
+    expectedHol.push_back(Date(1, March, 2006));
+    expectedHol.push_back(Date(1, May, 2006));
+    expectedHol.push_back(Date(5, May, 2006));
+    expectedHol.push_back(Date(31, May, 2006)); // election
+    expectedHol.push_back(Date(6, June, 2006));
+    expectedHol.push_back(Date(17, July, 2006));
+    expectedHol.push_back(Date(15, August, 2006));
+    expectedHol.push_back(Date(3, October, 2006));
+    expectedHol.push_back(Date(5, October, 2006));
+    expectedHol.push_back(Date(6, October, 2006));
+    //    expectedHol.push_back(Date(7,October,2006)); // Saturday
+    expectedHol.push_back(Date(25, December, 2006));
+    expectedHol.push_back(Date(29, December, 2006));
 
-    expectedHol.push_back(Date(1,January,2007));
-//    expectedHol.push_back(Date(17,February,2007)); // Saturday
-//    expectedHol.push_back(Date(18,February,2007)); // Sunday
-    expectedHol.push_back(Date(19,February,2007));
-    expectedHol.push_back(Date(1,March,2007));
-    expectedHol.push_back(Date(1,May,2007));
-//    expectedHol.push_back(Date(5,May,2007)); // Saturday
-    expectedHol.push_back(Date(24,May,2007));
-    expectedHol.push_back(Date(6,June,2007));
-    expectedHol.push_back(Date(17,July,2007));
-    expectedHol.push_back(Date(15,August,2007));
-    expectedHol.push_back(Date(24,September,2007));
-    expectedHol.push_back(Date(25,September,2007));
-    expectedHol.push_back(Date(26,September,2007));
-    expectedHol.push_back(Date(3,October,2007));
-    expectedHol.push_back(Date(19,December,2007)); // election
-    expectedHol.push_back(Date(25,December,2007));
-    expectedHol.push_back(Date(31,December,2007));
+    expectedHol.push_back(Date(1, January, 2007));
+    //    expectedHol.push_back(Date(17,February,2007)); // Saturday
+    //    expectedHol.push_back(Date(18,February,2007)); // Sunday
+    expectedHol.push_back(Date(19, February, 2007));
+    expectedHol.push_back(Date(1, March, 2007));
+    expectedHol.push_back(Date(1, May, 2007));
+    //    expectedHol.push_back(Date(5,May,2007)); // Saturday
+    expectedHol.push_back(Date(24, May, 2007));
+    expectedHol.push_back(Date(6, June, 2007));
+    expectedHol.push_back(Date(17, July, 2007));
+    expectedHol.push_back(Date(15, August, 2007));
+    expectedHol.push_back(Date(24, September, 2007));
+    expectedHol.push_back(Date(25, September, 2007));
+    expectedHol.push_back(Date(26, September, 2007));
+    expectedHol.push_back(Date(3, October, 2007));
+    expectedHol.push_back(Date(19, December, 2007)); // election
+    expectedHol.push_back(Date(25, December, 2007));
+    expectedHol.push_back(Date(31, December, 2007));
 
     Calendar c = SouthKorea(SouthKorea::KRX);
-    std::vector<Date> hol = c.holidayList(Date(1,January,2004),
-                                          Date(31,December,2007));
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2004), Date(31, December, 2007));
 
-    for (Size i=0; i<std::min<Size>(hol.size(), expectedHol.size()); i++) {
-        if (hol[i]!=expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                       << " while calculated holiday is " << hol[i]);
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
-    if (hol.size()!=expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-                   << " expected holidays, while there are " << hol.size()
-                   << " calculated holidays");
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testChinaSSE() {
@@ -1720,23 +1682,21 @@ void CalendarTest::testChinaSSE() {
     expectedHol.push_back(Date(8, October, 2020));
 
     Calendar c = China(China::SSE);
-    std::vector<Date> hol = c.holidayList(Date(1, January, 2014),
-                                          Date(31, December, 2020));
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2014), Date(31, December, 2020));
 
     for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
         if (hol[i] != expectedHol[i])
-            BOOST_FAIL("expected holiday was " << expectedHol[i]
-                << " while calculated holiday is " << hol[i]);
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
     }
     if (hol.size() != expectedHol.size())
-        BOOST_FAIL("there were " << expectedHol.size()
-            << " expected holidays, while there are " << hol.size()
-            << " calculated holidays");
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
 }
 
 void CalendarTest::testChinaIB() {
     BOOST_TEST_MESSAGE("Testing China Inter Bank working weekends list...");
-    
+
     std::vector<Date> expectedWorkingWeekEnds;
 
     // China Inter Bank working weekends list in the year 2014
@@ -1802,17 +1762,18 @@ void CalendarTest::testChinaIB() {
     while (start <= end) {
         if (c.isBusinessDay(start) && c.isWeekend(start.weekday())) {
             if (expectedWorkingWeekEnds[k] != start)
-                BOOST_FAIL("expected working weekend was " << expectedWorkingWeekEnds[k]
-                    << " while calculated working weekend is " << start);
+                BOOST_FAIL("expected working weekend was "
+                           << expectedWorkingWeekEnds[k] << " while calculated working weekend is "
+                           << start);
             ++k;
         }
         ++start;
     }
-    
+
     if (k != (expectedWorkingWeekEnds.size()))
         BOOST_FAIL("there were " << expectedWorkingWeekEnds.size()
-            << " expected working weekends, while there are " << k
-            << " calculated working weekends");
+                                 << " expected working weekends, while there are " << k
+                                 << " calculated working weekends");
 }
 
 void CalendarTest::testEndOfMonth() {
@@ -1821,162 +1782,92 @@ void CalendarTest::testEndOfMonth() {
     Calendar c = TARGET(); // any calendar would be OK
 
     Date eom, counter = Date::minDate();
-    Date last = Date::maxDate() - 2*Months;
+    Date last = Date::maxDate() - 2 * Months;
 
-    while (counter<=last) {
+    while (counter <= last) {
         eom = c.endOfMonth(counter);
         // check that eom is eom
         if (!c.isEndOfMonth(eom))
-            BOOST_FAIL("\n  "
-                       << eom.weekday() << " " << eom
-                       << " is not the last business day in "
-                       << eom.month() << " " << eom.year()
-                       << " according to " << c.name());
+            BOOST_FAIL("\n  " << eom.weekday() << " " << eom << " is not the last business day in "
+                              << eom.month() << " " << eom.year() << " according to " << c.name());
         // check that eom is in the same month as counter
-        if (eom.month()!=counter.month())
-            BOOST_FAIL("\n  "
-                       << eom
-                       << " is not in the same month as "
-                       << counter);
+        if (eom.month() != counter.month())
+            BOOST_FAIL("\n  " << eom << " is not in the same month as " << counter);
         counter = counter + 1;
     }
 }
 
 void CalendarTest::testBusinessDaysBetween() {
 
-    BOOST_TEST_MESSAGE("Testing calculation of business days between dates..."); 
+    BOOST_TEST_MESSAGE("Testing calculation of business days between dates...");
 
     std::vector<Date> testDates;
-    testDates.push_back(Date(1,February,2002)); //isBusinessDay = true
-    testDates.push_back(Date(4,February,2002)); //isBusinessDay = true
-    testDates.push_back(Date(16,May,2003)); //isBusinessDay = true
-    testDates.push_back(Date(17,December,2003)); //isBusinessDay = true
-    testDates.push_back(Date(17,December,2004)); //isBusinessDay = true
-    testDates.push_back(Date(19,December,2005)); //isBusinessDay = true
-    testDates.push_back(Date(2,January,2006)); //isBusinessDay = true
-    testDates.push_back(Date(13,March,2006)); //isBusinessDay = true
-    testDates.push_back(Date(15,May,2006)); //isBusinessDay = true
-    testDates.push_back(Date(17,March,2006)); //isBusinessDay = true
-    testDates.push_back(Date(15,May,2006)); //isBusinessDay = true
-    testDates.push_back(Date(26,July,2006)); //isBusinessDay = true
-    testDates.push_back(Date(26,July,2006)); //isBusinessDay = true
-    testDates.push_back(Date(27,July,2006)); //isBusinessDay = true
-	testDates.push_back(Date(29,July,2006)); //isBusinessDay = false
-    testDates.push_back(Date(29,July,2006)); //isBusinessDay = false
+    testDates.push_back(Date(1, February, 2002));  // isBusinessDay = true
+    testDates.push_back(Date(4, February, 2002));  // isBusinessDay = true
+    testDates.push_back(Date(16, May, 2003));      // isBusinessDay = true
+    testDates.push_back(Date(17, December, 2003)); // isBusinessDay = true
+    testDates.push_back(Date(17, December, 2004)); // isBusinessDay = true
+    testDates.push_back(Date(19, December, 2005)); // isBusinessDay = true
+    testDates.push_back(Date(2, January, 2006));   // isBusinessDay = true
+    testDates.push_back(Date(13, March, 2006));    // isBusinessDay = true
+    testDates.push_back(Date(15, May, 2006));      // isBusinessDay = true
+    testDates.push_back(Date(17, March, 2006));    // isBusinessDay = true
+    testDates.push_back(Date(15, May, 2006));      // isBusinessDay = true
+    testDates.push_back(Date(26, July, 2006));     // isBusinessDay = true
+    testDates.push_back(Date(26, July, 2006));     // isBusinessDay = true
+    testDates.push_back(Date(27, July, 2006));     // isBusinessDay = true
+    testDates.push_back(Date(29, July, 2006));     // isBusinessDay = false
+    testDates.push_back(Date(29, July, 2006));     // isBusinessDay = false
 
-	//default params: from date included, to excluded
-    Date::serial_type expected[] = {
-        1,
-        321,
-        152,
-        251,
-        252,
-        10,
-        48,
-        42,
-        -38,
-        38,
-        51,
-		0,
-		1,
-		2,
-		0
-    };
+    // default params: from date included, to excluded
+    Date::serial_type expected[] = {1, 321, 152, 251, 252, 10, 48, 42, -38, 38, 51, 0, 1, 2, 0};
 
-	//exclude from, include to
-	Date::serial_type expected_include_to[] = {
-		1,
-		321,
-		152,
-		251,
-		252,
-		10,
-		48,
-		42,
-		-38,
-		38,
-		51,
-		0,
-		1,
-		1,
-		0
-	};
+    // exclude from, include to
+    Date::serial_type expected_include_to[] = {1,   321, 152, 251, 252, 10, 48, 42,
+                                               -38, 38,  51,  0,   1,   1,  0};
 
-	//include both from and to
-	Date::serial_type expected_include_all[] = {
-		2,
-		322,
-		153,
-		252,
-        253,
-		11,
-		49,
-		43,
-		-39,
-		39,
-		52,
-		1,
-		2,
-		2,
-		0
-	};
+    // include both from and to
+    Date::serial_type expected_include_all[] = {2,   322, 153, 252, 253, 11, 49, 43,
+                                                -39, 39,  52,  1,   2,   2,  0};
 
-	//exclude both from and to
-	Date::serial_type expected_exclude_all[] = {
-		0,
-		320,
-		151,
-		250,
-		251,
-		9,
-		47,
-		41,
-		-37,
-		37,
-		50,
-		0,
-		0,
-		1,
-		0
-	};
+    // exclude both from and to
+    Date::serial_type expected_exclude_all[] = {0,   320, 151, 250, 251, 9, 47, 41,
+                                                -37, 37,  50,  0,   0,   1, 0};
 
     Calendar calendar = Brazil();
 
-    for (Size i=1; i<testDates.size(); i++) {
-        Integer calculated = calendar.businessDaysBetween(testDates[i-1],
-                                                          testDates[i], true, false);
-        if (calculated != expected[i-1]) {
-            BOOST_ERROR("from " << testDates[i-1] << " included"
-                        << " to " << testDates[i] << " excluded:\n"
-                        << "    calculated: " << calculated << "\n"
-                        << "    expected:   " << expected[i-1]);
+    for (Size i = 1; i < testDates.size(); i++) {
+        Integer calculated =
+            calendar.businessDaysBetween(testDates[i - 1], testDates[i], true, false);
+        if (calculated != expected[i - 1]) {
+            BOOST_ERROR("from " << testDates[i - 1] << " included"
+                                << " to " << testDates[i] << " excluded:\n"
+                                << "    calculated: " << calculated << "\n"
+                                << "    expected:   " << expected[i - 1]);
         }
 
-		calculated = calendar.businessDaysBetween(testDates[i-1],
-														  testDates[i], false, true);
-		if (calculated != expected_include_to[i-1]) {
-            BOOST_ERROR("from " << testDates[i-1] << " excluded"
-                        << " to " << testDates[i] << " included:\n"
-                        << "    calculated: " << calculated << "\n"
-                        << "    expected:   " << expected_include_to[i-1]);
+        calculated = calendar.businessDaysBetween(testDates[i - 1], testDates[i], false, true);
+        if (calculated != expected_include_to[i - 1]) {
+            BOOST_ERROR("from " << testDates[i - 1] << " excluded"
+                                << " to " << testDates[i] << " included:\n"
+                                << "    calculated: " << calculated << "\n"
+                                << "    expected:   " << expected_include_to[i - 1]);
         }
 
-		calculated = calendar.businessDaysBetween(testDates[i-1],
-                                                          testDates[i], true, true);
-		if (calculated != expected_include_all[i-1]) {
-        	BOOST_ERROR("from " << testDates[i-1] << " included"
-                        << " to " << testDates[i] << " included:\n"
-                        << "    calculated: " << calculated << "\n"
-                        << "    expected:   " << expected_include_all[i-1]);
-		}
+        calculated = calendar.businessDaysBetween(testDates[i - 1], testDates[i], true, true);
+        if (calculated != expected_include_all[i - 1]) {
+            BOOST_ERROR("from " << testDates[i - 1] << " included"
+                                << " to " << testDates[i] << " included:\n"
+                                << "    calculated: " << calculated << "\n"
+                                << "    expected:   " << expected_include_all[i - 1]);
+        }
 
-		calculated = calendar.businessDaysBetween(testDates[i-1],
-                                                                  testDates[i], false, false);
-        if (calculated != expected_exclude_all[i-1]) {
-            BOOST_ERROR("from " << testDates[i-1] << " excluded"
-                        << " to " << testDates[i] << " excluded:\n"
-                        << "    calculated: " << calculated << "\n"
-                        << "    expected:   " << expected_exclude_all[i-1]);
+        calculated = calendar.businessDaysBetween(testDates[i - 1], testDates[i], false, false);
+        if (calculated != expected_exclude_all[i - 1]) {
+            BOOST_ERROR("from " << testDates[i - 1] << " excluded"
+                                << " to " << testDates[i] << " excluded:\n"
+                                << "    calculated: " << calculated << "\n"
+                                << "    expected:   " << expected_exclude_all[i - 1]);
         }
     }
 }
@@ -2052,7 +1943,7 @@ void CalendarTest::testBespokeCalendars() {
     if (!b1.isBusinessDay(testDate4))
         BOOST_ERROR(testDate4 << " erroneously detected as holiday");
 
-    BespokeCalendar a2 = a1;  // linked to a1
+    BespokeCalendar a2 = a1; // linked to a1
 
     a2.addWeekend(Saturday);
 
@@ -2093,7 +1984,6 @@ void CalendarTest::testBespokeCalendars() {
         BOOST_ERROR(testDate3 << " (marked as holiday) not detected");
     if (a2.isBusinessDay(testDate4))
         BOOST_ERROR(testDate4 << " (marked as holiday) not detected");
-
 }
 
 void CalendarTest::testIntradayAddHolidays() {
@@ -2104,11 +1994,11 @@ void CalendarTest::testIntradayAddHolidays() {
 
     Calendar c1 = TARGET();
     Calendar c2 = UnitedStates(UnitedStates::NYSE);
-    Date d1(1,May,2004);      // holiday for both calendars
-    Date d2(26,April,2004, 0, 0, 1, 1);   // business day
+    Date d1(1, May, 2004);                // holiday for both calendars
+    Date d2(26, April, 2004, 0, 0, 1, 1); // business day
 
-    Date d1Mock(1,May,2004, 1, 1, 0, 0);      // holiday for both calendars
-    Date d2Mock(26,April,2004);   // business day
+    Date d1Mock(1, May, 2004, 1, 1, 0, 0); // holiday for both calendars
+    Date d2Mock(26, April, 2004);          // business day
 
     // this works anyhow because implementation uses day() month() etc
     QL_REQUIRE(c1.isHoliday(d1), "wrong assumption---correct the test");
@@ -2136,11 +2026,11 @@ void CalendarTest::testIntradayAddHolidays() {
         BOOST_FAIL(d2 << " still a business day for original TARGET instance");
 
     if (c1.isHoliday(d1Mock))
-        BOOST_FAIL(d1Mock << " still a holiday for original TARGET instance" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d1Mock << " still a holiday for original TARGET instance"
+                          << " and different hours/min/secs");
     if (c1.isBusinessDay(d2Mock))
-        BOOST_FAIL(d2Mock << " still a business day for generic TARGET instance" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d2Mock << " still a business day for generic TARGET instance"
+                          << " and different hours/min/secs");
 
     // any instance of TARGET should be modified...
     Calendar c3 = TARGET();
@@ -2150,11 +2040,11 @@ void CalendarTest::testIntradayAddHolidays() {
         BOOST_FAIL(d2 << " still a business day for generic TARGET instance");
 
     if (c3.isHoliday(d1Mock))
-        BOOST_FAIL(d1Mock << " still a holiday for original TARGET instance" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d1Mock << " still a holiday for original TARGET instance"
+                          << " and different hours/min/secs");
     if (c3.isBusinessDay(d2Mock))
-        BOOST_FAIL(d2Mock << " still a business day for generic TARGET instance" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d2Mock << " still a business day for generic TARGET instance"
+                          << " and different hours/min/secs");
 
     // ...but not other calendars
     if (c2.isBusinessDay(d1))
@@ -2163,11 +2053,11 @@ void CalendarTest::testIntradayAddHolidays() {
         BOOST_FAIL(d2 << " holiday for New York");
 
     if (c2.isBusinessDay(d1Mock))
-        BOOST_FAIL(d1Mock << " business day for New York" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d1Mock << " business day for New York"
+                          << " and different hours/min/secs");
     if (c2.isHoliday(d2Mock))
-        BOOST_FAIL(d2Mock << " holiday for New York" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d2Mock << " holiday for New York"
+                          << " and different hours/min/secs");
 
     // restore original holiday set---test the other way around
     c3.addHoliday(d1Mock);
@@ -2179,8 +2069,8 @@ void CalendarTest::testIntradayAddHolidays() {
         BOOST_FAIL(d2 << " still a holiday");
 
     if (c1.isBusinessDay(d1Mock))
-        BOOST_FAIL(d1Mock << " still a business day" <<
-                    " and different hours/min/secs");
+        BOOST_FAIL(d1Mock << " still a business day"
+                          << " and different hours/min/secs");
     if (c1.isHoliday(d2Mock))
         BOOST_FAIL(d2Mock << " still a holiday and different hours/min/secs");
 
@@ -2191,8 +2081,7 @@ void CalendarTest::testDayLists() {
 
     BOOST_TEST_MESSAGE("Testing holidayList and businessDaysList...");
     Calendar germany = Germany();
-    Date firstDate = Settings::instance().evaluationDate(),
-         endDate = firstDate + 1*Years;
+    Date firstDate = Settings::instance().evaluationDate(), endDate = firstDate + 1 * Years;
 
     std::vector<Date> holidays = germany.holidayList(firstDate, endDate, true);
     std::vector<Date> businessDays = germany.businessDayList(firstDate, endDate);
@@ -2200,19 +2089,19 @@ void CalendarTest::testDayLists() {
     std::vector<Date>::iterator it_holidays = holidays.begin(),
                                 it_businessDays = businessDays.begin();
     for (Date d = firstDate; d < endDate; d++) {
-        if(it_holidays != holidays.end() &&  it_businessDays != businessDays.end() && d == *it_holidays && d == *it_businessDays) {
+        if (it_holidays != holidays.end() && it_businessDays != businessDays.end() &&
+            d == *it_holidays && d == *it_businessDays) {
             BOOST_FAIL("Date " << d << "is both holiday and business day.");
             ++it_holidays;
             ++it_businessDays;
-        } else if (it_holidays != holidays.end() && d == *it_holidays){
+        } else if (it_holidays != holidays.end() && d == *it_holidays) {
             ++it_holidays;
         } else if (it_businessDays != businessDays.end() && d == *it_businessDays) {
             ++it_businessDays;
         } else {
-            BOOST_FAIL( "Date " << d << "is neither holiday nor business day.");
+            BOOST_FAIL("Date " << d << "is neither holiday nor business day.");
         }
     }
-
 }
 
 test_suite* CalendarTest::suite() {
@@ -2221,14 +2110,14 @@ test_suite* CalendarTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testBrazil));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testRussia));
 
-//    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testItalySettlement));
+    //    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testItalySettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testItalyExchange));
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKSettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKExchange));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKMetals));
 
-//    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanySettlement));
+    //    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanySettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyFrankfurt));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyXetra));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyEurex));
@@ -2257,4 +2146,3 @@ test_suite* CalendarTest::suite() {
 
     return suite;
 }
-

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -2200,13 +2200,13 @@ void CalendarTest::testDayLists() {
     std::vector<Date>::iterator it_holidays = holidays.begin(),
                                 it_businessDays = businessDays.begin();
     for (Date d = firstDate; d < endDate; d++) {
-        if(d == *it_holidays && d == *it_businessDays) {
+        if(it_holidays != holidays.end() &&  it_businessDays != businessDays.end() && d == *it_holidays && d == *it_businessDays) {
             BOOST_FAIL("Date " << d << "is both holiday and business day.");
             ++it_holidays;
             ++it_businessDays;
-        } else if (d == *it_holidays){
+        } else if (it_holidays != holidays.end() && d == *it_holidays){
             ++it_holidays;
-        } else if (d == *it_businessDays) {
+        } else if (it_businessDays != businessDays.end() && d == *it_businessDays) {
             ++it_businessDays;
         } else {
             BOOST_FAIL( "Date " << d << "is neither holiday nor business day.");

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -7,6 +7,8 @@
  Copyright (C) 2008 Charles Chongseok Hyun
  Copyright (C) 2015 Dmitri Nesteruk
  Copyright (C) 2020 Piotr Siejda
+ Copyright (C) 2020 Leonardo Arcari
+ Copyright (C) 2020 Kline s.r.l.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/


### PR DESCRIPTION
This PR fixes an out of bound bug in `CalendarTest::testDayLists`.

Basically, no *iterator-end-check* was performed in https://github.com/lballabio/QuantLib/blob/e6e81b23cf3dbf81be5ae86bfe8b3b94ceb0a8ca/test-suite/calendars.cpp#L2203

 Therefore, when either `it_holidays` or `it_businessDays` reach `end` iterator, they're still dereferenced to be checked against `d`, hence yielding to undefined behavior.

This was detected by `MSVC` when compiling `test-suite` in debug mode.

