### PR TITLE
Adding New Years Eve Holiday back for Eurex calendar

### DIFF
--- a/ql/time/calendars/germany.cpp
+++ b/ql/time/calendars/germany.cpp
@@ -162,7 +162,9 @@ namespace QuantLib {
             // Christmas
             || (d == 25 && m == December)
             // Christmas Day
-            || (d == 26 && m == December))
+            || (d == 26 && m == December)
+            // New Year's Eve
+            || (d == 31 && m == December))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }

--- a/ql/time/calendars/germany.hpp
+++ b/ql/time/calendars/germany.hpp
@@ -86,6 +86,7 @@ namespace QuantLib {
         <li>Christmas' Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Christmas Holiday, December 26th</li>
+        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Holidays for the Euwax exchange

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -470,11 +470,13 @@ void CalendarTest::testGermanyEurex() {
     expectedHol.push_back(Date(24, December, 2003));
     expectedHol.push_back(Date(25, December, 2003));
     expectedHol.push_back(Date(26, December, 2003));
+    expectedHol.push_back(Date(31, December,2003));
 
     expectedHol.push_back(Date(1, January, 2004));
     expectedHol.push_back(Date(9, April, 2004));
     expectedHol.push_back(Date(12, April, 2004));
     expectedHol.push_back(Date(24, December, 2004));
+    expectedHol.push_back(Date(31,December,2004));
 
     Calendar c = Germany(Germany::Eurex);
     std::vector<Date> hol = c.holidayList(Date(1, January, 2003), Date(31, December, 2004));


### PR DESCRIPTION
Fix for #840 after New Years was removed from all German calendars.