### PR TITLE
Deprecate unused BMA index constructor; fix observability.

### DIFF
--- a/ql/indexes/bmaindex.cpp
+++ b/ql/indexes/bmaindex.cpp
@@ -19,6 +19,7 @@
 
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/currencies/america.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 
 namespace QuantLib {
@@ -37,6 +38,17 @@ namespace QuantLib {
             return previousWednesday(date+7);
         }
 
+    }
+
+    BMAIndex::BMAIndex(const Handle<YieldTermStructure>& h)
+    : InterestRateIndex("BMA",
+                        1 * Weeks,
+                        1,
+                        USDCurrency(),
+                        UnitedStates(UnitedStates::GovernmentBond),
+                        ActualActual(ActualActual::ISDA)),
+      termStructure_(h) {
+        registerWith (h);
     }
 
     BMAIndex::BMAIndex(const Handle<YieldTermStructure>& h,

--- a/ql/indexes/bmaindex.hpp
+++ b/ql/indexes/bmaindex.hpp
@@ -27,7 +27,6 @@
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/indexes/interestrateindex.hpp>
 #include <ql/time/schedule.hpp>
-#include <ql/time/calendars/unitedstates.hpp>
 
 namespace QuantLib {
 
@@ -41,14 +40,17 @@ namespace QuantLib {
     class BMAIndex : public InterestRateIndex {
       public:
         explicit BMAIndex(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>(),
-                          const Calendar& fixingCalendar =
-                                    UnitedStates(UnitedStates::GovernmentBond));
+                                    Handle<YieldTermStructure>());
+        /*! \deprecated Use the other constructor instead.
+                        Deprecated in version 1.19.
+        */
+        QL_DEPRECATED
+        BMAIndex(const Handle<YieldTermStructure>& h,
+                 const Calendar& fixingCalendar);
         //! \name Index interface
         //@{
         /*! BMA is fixed weekly on Wednesdays.
         */
-        std::string name() const { return "BMA"; }
         bool isValidFixingDate(const Date& fixingDate) const;
         //@}
         //! \name Inspectors

--- a/ql/indexes/interestrateindex.cpp
+++ b/ql/indexes/interestrateindex.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
         name_ = out.str();
 
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(name()));
+        registerWith(IndexManager::instance().notifier(InterestRateIndex::name()));
     }
 
     Rate InterestRateIndex::fixing(const Date& fixingDate,

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -70,6 +70,7 @@ set(QuantLib-Test_SRC
     hestonslvmodel.cpp
     himalayaoption.cpp
     hybridhestonhullwhiteprocess.cpp
+    indexes.cpp
     inflation.cpp
     inflationcapfloor.cpp
     inflationcapflooredcoupon.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -71,6 +71,7 @@ QL_TESTS = \
 	hestonslvmodel.hpp hestonslvmodel.cpp \
 	himalayaoption.hpp himalayaoption.cpp \
 	hybridhestonhullwhiteprocess.hpp hybridhestonhullwhiteprocess.cpp \
+	indexes.hpp indexes.cpp \
 	inflation.hpp inflation.cpp \
 	inflationcapfloor.hpp inflationcapfloor.cpp \
 	inflationcapflooredcoupon.hpp inflationcapflooredcoupon.cpp \

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -1,0 +1,64 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "indexes.hpp"
+#include "utilities.hpp"
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/bmaindex.hpp>
+#include <ql/utilities/dataformatters.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+void IndexTest::testFixingObservability() {
+    BOOST_TEST_MESSAGE("Testing observability of index fixings...");
+
+    ext::shared_ptr<InterestRateIndex> i1 = ext::make_shared<Euribor6M>();
+    ext::shared_ptr<InterestRateIndex> i2 = ext::make_shared<BMAIndex>();
+
+    Flag f1;
+    f1.registerWith(i1);
+    f1.lower();
+    
+    Flag f2;
+    f2.registerWith(i2);
+    f2.lower();
+    
+    Date today = Date::todaysDate();
+
+    ext::make_shared<Euribor6M>()->addFixing(today, -0.003);
+    if (!f1.isUp())
+        BOOST_FAIL("Observer was not notified of added Euribor fixing");
+
+    Date d = today;
+    while (d.weekday() != Wednesday)
+        d++;
+
+    ext::make_shared<BMAIndex>()->addFixing(d, 0.01);
+    if (!f2.isUp())
+        BOOST_FAIL("Observer was not notified of added BMA fixing");
+}
+
+
+test_suite* IndexTest::suite() {
+    test_suite* suite = BOOST_TEST_SUITE("index tests");
+    suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingObservability));
+    return suite;
+}
+

--- a/test-suite/indexes.hpp
+++ b/test-suite/indexes.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_indexes_hpp
+#define quantlib_test_indexes_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class IndexTest {
+  public:
+    static void testFixingObservability();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -131,6 +131,7 @@
 #include "hestonslvmodel.hpp"
 #include "himalayaoption.hpp"
 #include "hybridhestonhullwhiteprocess.hpp"
+#include "indexes.hpp"
 #include "inflation.hpp"
 #include "inflationcapfloor.hpp"
 #include "inflationcapflooredcoupon.hpp"
@@ -416,6 +417,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(GsrTest::suite());
     test->add(HestonModelTest::suite(speed));
     test->add(HybridHestonHullWhiteProcessTest::suite(speed));
+    test->add(IndexTest::suite());
     test->add(InflationTest::suite());
     test->add(InflationCapFloorTest::suite());
     test->add(InflationCapFlooredCouponTest::suite());

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -705,6 +705,7 @@
     <ClCompile Include="hestonslvmodel.cpp" />
     <ClCompile Include="himalayaoption.cpp" />
     <ClCompile Include="hybridhestonhullwhiteprocess.cpp" />
+    <ClCompile Include="indexes.cpp" />
     <ClCompile Include="inflation.cpp" />
     <ClCompile Include="inflationcapfloor.cpp" />
     <ClCompile Include="inflationcapflooredcoupon.cpp" />
@@ -860,6 +861,7 @@
     <ClInclude Include="hestonslvmodel.hpp" />
     <ClInclude Include="himalayaoption.hpp" />
     <ClInclude Include="hybridhestonhullwhiteprocess.hpp" />
+    <ClInclude Include="indexes.hpp" />
     <ClInclude Include="inflation.hpp" />
     <ClInclude Include="inflationcapfloor.hpp" />
     <ClInclude Include="inflationcapflooredcoupon.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -197,6 +197,9 @@
     <ClCompile Include="hybridhestonhullwhiteprocess.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="indexes.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="inflation.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -654,6 +657,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="hybridhestonhullwhiteprocess.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="indexes.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="inflation.hpp">


### PR DESCRIPTION
Previously, adding a fixing to a BMA index would not notify observers.