### PR TITLE
Add boost::hash specialization for Date

### DIFF
--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -833,11 +833,11 @@ namespace QuantLib {
 #ifdef QL_HIGH_RESOLUTION_DATE
         std::size_t seed = 0;
         boost::hash_combine(seed, d.serialNumber());
-        boost::hash_combine(seed, d.dateTime().total_nanoseconds());
+        boost::hash_combine(seed, d.dateTime().time_of_day().total_nanoseconds());
         return seed;
 #else
 
-        return boost::hash<Date::serial_type>{}(d.serialNumber());
+        return boost::hash<Date::serial_type>()(d.serialNumber());
 #endif
     }
 

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -7,6 +7,8 @@
  Copyright (C) 2006 Katiuscia Manzoni
  Copyright (C) 2006 Toyin Akin
  Copyright (C) 2015 Klaus Spanderen
+ Copyright (C) 2020 Leonardo Arcari
+ Copyright (C) 2020 Kline s.r.l.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,6 +33,7 @@
 #endif
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/functional/hash.hpp>
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
 #endif
@@ -826,6 +829,17 @@ namespace QuantLib {
         }
     }
 
+    std::size_t hash_value(const Date& d) {
+#ifdef QL_HIGH_RESOLUTION_DATE
+        std::size_t seed = 0;
+        boost::hash_combine(seed, d.serialNumber());
+        boost::hash_combine(seed, d.dateTime().total_nanoseconds());
+        return seed;
+#else
+
+        return boost::hash<Date::serial_type>{}(d.serialNumber());
+#endif
+    }
 
     // date formatting
 

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -7,6 +7,8 @@
  Copyright (C) 2006 Katiuscia Manzoni
  Copyright (C) 2006 Toyin Akin
  Copyright (C) 2015 Klaus Spanderen
+ Copyright (C) 2020 Leonardo Arcari
+ Copyright (C) 2020 Kline s.r.l.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -277,6 +279,29 @@ namespace QuantLib {
     bool operator>(const Date&, const Date&);
     /*! \relates Date */
     bool operator>=(const Date&, const Date&);
+
+    /*!
+      Compute a hash value of @p d.
+
+      This method makes Date hashable via <tt>boost::hash</tt>.
+
+      Example:
+
+      \code{.cpp}
+      #include <boost/unordered_set.hpp>
+
+      boost::unordered_set<Date> set;
+      Date d = Date(1, Jan, 2020); 
+
+      set.insert(d);
+      assert(set.count(d)); // 'd' was added to 'set'
+      \endcode
+
+      \param [in] d Date to hash
+      \return A hash value of @p d
+      \relates Date
+    */
+    std::size_t hash_value(const Date& d);
 
     /*! \relates Date */
     std::ostream& operator<<(std::ostream&, const Date&);

--- a/test-suite/dates.cpp
+++ b/test-suite/dates.cpp
@@ -473,7 +473,7 @@ void DateTest::canHash() {
     boost::unordered_set<Date> set;
     set.insert(start_date);
 
-    if (!set.count(start_date)) {
+    if (set.count(start_date) == 0) {
         BOOST_FAIL("Expected to find date " << start_date << " in unordered_set\n");
     }
 }
@@ -497,4 +497,3 @@ test_suite* DateTest::suite(SpeedLevel speed) {
 
     return suite;
 }
-

--- a/test-suite/dates.cpp
+++ b/test-suite/dates.cpp
@@ -6,6 +6,8 @@
  Copyright (C) 2003 RiskMap srl
  Copyright (C) 2015 Maddalena Zanzi
  Copyright (c) 2015 Klaus Spanderen
+ Copyright (C) 2020 Leonardo Arcari
+ Copyright (C) 2020 Kline s.r.l.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -24,11 +26,14 @@
 #include "dates.hpp"
 #include "utilities.hpp"
 #include <ql/time/date.hpp>
+#include <ql/time/timeunit.hpp>
 #include <ql/time/imm.hpp>
 #include <ql/time/ecb.hpp>
 #include <ql/time/asx.hpp>
 #include <ql/utilities/dataparsers.hpp>
 
+#include <boost/unordered_set.hpp>
+#include <boost/functional/hash.hpp>
 #include <sstream>
 
 using namespace QuantLib;
@@ -432,6 +437,46 @@ void DateTest::intraday() {
 #endif
 }
 
+void DateTest::canHash() {
+    BOOST_TEST_MESSAGE("Testing parsing of dates...");
+
+    Date start_date = Date(1, Jan, 2020);
+    int nb_tests = 500;
+
+    boost::hash<Date> hasher;
+
+    // Check hash values
+    for (int i = 0; i < nb_tests; ++i) {
+        for (int j = 0; j < nb_tests; ++j) {
+            Date lhs = start_date + i;
+            Date rhs = start_date + j;
+
+            if (lhs == rhs && hasher(lhs) != hasher(rhs)) {
+                BOOST_FAIL("Equal dates are expected to have same hash value\n"
+                           << "rhs = " << lhs << '\n'
+                           << "lhs = " << rhs << '\n'
+                           << "hash(lhs) = " << hasher(lhs) << '\n'
+                           << "hash(rhs) = " << hasher(rhs) << '\n');
+            }
+
+            if (lhs != rhs && hasher(lhs) == hasher(rhs)) {
+                BOOST_FAIL("Different dates are expected to have different hash value\n"
+                           << "rhs = " << lhs << '\n'
+                           << "lhs = " << rhs << '\n'
+                           << "hash(lhs) = " << hasher(lhs) << '\n'
+                           << "hash(rhs) = " << hasher(rhs) << '\n');
+            }
+        }
+    }
+
+    // Check if Date can be used as unordered_set key
+    boost::unordered_set<Date> set;
+    set.insert(start_date);
+
+    if (!set.count(start_date)) {
+        BOOST_FAIL("Expected to find date " << start_date << " in unordered_set\n");
+    }
+}
 
 test_suite* DateTest::suite(SpeedLevel speed) {
     test_suite* suite = BOOST_TEST_SUITE("Date tests");
@@ -444,6 +489,7 @@ test_suite* DateTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&DateTest::parseDates));
     #endif
     suite->add(QUANTLIB_TEST_CASE(&DateTest::intraday));
+    suite->add(QUANTLIB_TEST_CASE(&DateTest::canHash));
 
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&DateTest::asxDates));

--- a/test-suite/dates.hpp
+++ b/test-suite/dates.hpp
@@ -2,6 +2,8 @@
 
 /*
  Copyright (C) 2003 RiskMap srl
+ Copyright (C) 2020 Leonardo Arcari
+ Copyright (C) 2020 Kline s.r.l.
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -35,6 +37,7 @@ class DateTest {
     static void isoDates();
     static void parseDates();
     static void intraday();
+    static void canHash();
     static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -95,17 +95,6 @@ void TimeSeriesTest::testIntervalPrice() {
                                                                low);
 }
 
-namespace boost {
-
-    template<>
-    struct hash<Date> {
-        size_t operator()(const Date& _Keyval) const {
-            return boost::hash<Date::serial_type>()(_Keyval.serialNumber());
-        }
-    };
-
-}
-
 void TimeSeriesTest::testIterators() {
     BOOST_TEST_MESSAGE("Testing time series iterators...");
     std::vector<Date> dates;


### PR DESCRIPTION
This PR adds `hash_value` method to `Date`, enabling `boost::hash<Date>`