### PR TITLE
Added first coupon dayCounter to FixedRateBond

### DIFF
--- a/ql/instruments/bonds/fixedratebond.cpp
+++ b/ql/instruments/bonds/fixedratebond.cpp
@@ -41,20 +41,20 @@ namespace QuantLib {
                                  const Calendar& exCouponCalendar,
                                  const BusinessDayConvention exCouponConvention,
                                  bool exCouponEndOfMonth,
-                                 const DayCounter& stubAccrualDayCounter)
+                                 const DayCounter& firstPeriodDayCounter)
      : Bond(settlementDays,
             paymentCalendar==Calendar() ? schedule.calendar() : paymentCalendar,
             issueDate),
        frequency_(schedule.hasTenor() ? schedule.tenor().frequency() : NoFrequency),
        dayCounter_(accrualDayCounter),
-       stubDayCounter_(stubAccrualDayCounter) {
+       firstPeriodDayCounter_(firstPeriodDayCounter) {
 
         maturityDate_ = schedule.endDate();
 
         cashflows_ = FixedRateLeg(schedule)
             .withNotionals(faceAmount)
             .withCouponRates(coupons, accrualDayCounter)
-            .withFirstPeriodDayCounter(stubAccrualDayCounter==DayCounter() ? accrualDayCounter : stubAccrualDayCounter)
+            .withFirstPeriodDayCounter(firstPeriodDayCounter)
             .withPaymentCalendar(calendar_)
             .withPaymentAdjustment(paymentConvention)
             .withExCouponPeriod(exCouponPeriod,
@@ -88,12 +88,12 @@ namespace QuantLib {
                                  const Calendar& exCouponCalendar,
                                  const BusinessDayConvention exCouponConvention,
                                  bool exCouponEndOfMonth,
-                                 const DayCounter& stubAccrualDayCounter)
+                                 const DayCounter& firstPeriodDayCounter)
      : Bond(settlementDays,
             paymentCalendar==Calendar() ? calendar : paymentCalendar,
             issueDate),
       frequency_(tenor.frequency()), dayCounter_(accrualDayCounter),
-      stubDayCounter_(stubAccrualDayCounter) {
+      firstPeriodDayCounter_(firstPeriodDayCounter) {
 
         maturityDate_ = maturityDate;
 
@@ -125,7 +125,7 @@ namespace QuantLib {
         cashflows_ = FixedRateLeg(schedule)
             .withNotionals(faceAmount)
             .withCouponRates(coupons, accrualDayCounter)
-            .withFirstPeriodDayCounter(stubAccrualDayCounter==DayCounter() ? accrualDayCounter : stubAccrualDayCounter)
+            .withFirstPeriodDayCounter(firstPeriodDayCounter)
             .withPaymentCalendar(calendar_)
             .withPaymentAdjustment(paymentConvention)
             .withExCouponPeriod(exCouponPeriod,
@@ -173,16 +173,6 @@ namespace QuantLib {
 
         QL_ENSURE(!cashflows().empty(), "bond with no cashflows!");
         QL_ENSURE(redemptions_.size() == 1, "multiple redemptions created");
-    }
-    const DayCounter& FixedRateBond::dayCounter(const Date& d){
-        if (stubDayCounter_==DayCounter())
-            return dayCounter_;
-        else
-            QL_ENSURE(d!=Date(),"No Date given for bond with short stub dayCounter");
-            if(d<(cashflows()[1])->date())
-                return stubDayCounter_;
-            else
-                return dayCounter_;
     }
 
 }

--- a/ql/instruments/bonds/fixedratebond.hpp
+++ b/ql/instruments/bonds/fixedratebond.hpp
@@ -58,7 +58,8 @@ namespace QuantLib {
                       const Period& exCouponPeriod = Period(),
                       const Calendar& exCouponCalendar = Calendar(),
                       BusinessDayConvention exCouponConvention = Unadjusted,
-                      bool exCouponEndOfMonth = false);
+                      bool exCouponEndOfMonth = false,
+                      const DayCounter& stubDayCounter = DayCounter());
         /*! simple annual compounding coupon rates
             with internal schedule calculation */
         FixedRateBond(Natural settlementDays,
@@ -80,7 +81,8 @@ namespace QuantLib {
                       const Period& exCouponPeriod = Period(),
                       const Calendar& exCouponCalendar = Calendar(),
                       BusinessDayConvention exCouponConvention = Unadjusted,
-                      bool exCouponEndOfMonth = false);
+                      bool exCouponEndOfMonth = false,
+                      const DayCounter& stubDayCounter = DayCounter());
         //! generic compounding and frequency InterestRate coupons
         FixedRateBond(Natural settlementDays,
                       Real faceAmount,
@@ -95,10 +97,11 @@ namespace QuantLib {
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false);
         Frequency frequency() const { return frequency_; }
-        const DayCounter& dayCounter() const { return dayCounter_; }
+        const DayCounter& dayCounter(const Date& d=Date());
       protected:
         Frequency frequency_;
         DayCounter dayCounter_;
+        DayCounter stubDayCounter_;
     };
 
 }

--- a/ql/instruments/bonds/fixedratebond.hpp
+++ b/ql/instruments/bonds/fixedratebond.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
                       const Calendar& exCouponCalendar = Calendar(),
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false,
-                      const DayCounter& stubDayCounter = DayCounter());
+                      const DayCounter& firstPeriodDayCounter = DayCounter());
         /*! simple annual compounding coupon rates
             with internal schedule calculation */
         FixedRateBond(Natural settlementDays,
@@ -82,7 +82,7 @@ namespace QuantLib {
                       const Calendar& exCouponCalendar = Calendar(),
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false,
-                      const DayCounter& stubDayCounter = DayCounter());
+                      const DayCounter& firstPeriodDayCounter = DayCounter());
         //! generic compounding and frequency InterestRate coupons
         FixedRateBond(Natural settlementDays,
                       Real faceAmount,
@@ -97,11 +97,12 @@ namespace QuantLib {
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false);
         Frequency frequency() const { return frequency_; }
-        const DayCounter& dayCounter(const Date& d=Date());
+        const DayCounter& dayCounter() const {return dayCounter_;}
+        const DayCounter& firstPeriodDayCounter() const {return firstPeriodDayCounter_;}
       protected:
         Frequency frequency_;
         DayCounter dayCounter_;
-        DayCounter stubDayCounter_;
+        DayCounter firstPeriodDayCounter_;
     };
 
 }


### PR DESCRIPTION
Canadian bonds have a different day count convention on a short first stub for both cashflow generation and accrual. This modification adds support for an additional first coupon day counter in the FixedRateBond class. The only api change is a new optional argument in two of the FixedRateBond constructors.