### PR TITLE
Add basic doc comments to include all classes inheriting from OptimizationMethod in doxygen

### DIFF
--- a/ql/math/optimization/linesearchbasedmethod.hpp
+++ b/ql/math/optimization/linesearchbasedmethod.hpp
@@ -33,6 +33,7 @@ namespace QuantLib {
 
     class LineSearch;
 
+    //! Line search based method
     class LineSearchBasedMethod : public OptimizationMethod {
       public:
         explicit LineSearchBasedMethod(

--- a/ql/math/optimization/simulatedannealing.hpp
+++ b/ql/math/optimization/simulatedannealing.hpp
@@ -42,6 +42,7 @@ namespace QuantLib {
     */
 
     template <class RNG = MersenneTwisterUniformRng>
+    //! Simulated Annealing
     class SimulatedAnnealing : public OptimizationMethod {
 
       public:

--- a/ql/math/optimization/simulatedannealing.hpp
+++ b/ql/math/optimization/simulatedannealing.hpp
@@ -41,8 +41,8 @@ namespace QuantLib {
         \ingroup optimizers
     */
 
-    template <class RNG = MersenneTwisterUniformRng>
     //! Simulated Annealing
+    template <class RNG = MersenneTwisterUniformRng>
     class SimulatedAnnealing : public OptimizationMethod {
 
       public:


### PR DESCRIPTION
Add basic doc comments just to enable doxygen to generate a complete inheritance diagram for OptimizationMethod.

Resolves issue #675, but only for class OptimizationMethod.