### PR TITLE
fix to have option of using std::tuple

### DIFF
--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -29,7 +29,7 @@
 #include <ql/functional.hpp>
 
 
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 #include <iostream>
 #include <iomanip>
 

--- a/configure.ac
+++ b/configure.ac
@@ -412,11 +412,30 @@ if test "$ql_use_std_function" = "yes" ; then
 fi
 AC_MSG_RESULT([$ql_use_std_function])
 
+
+AC_MSG_CHECKING([whether to enable standard smart tuple])
+AC_ARG_ENABLE([std-tuple],
+              AC_HELP_STRING([--enable-std-tuple],
+                             [If enabled, std::tuple and related
+                              classes and functions will be used instead
+                              of ext::tuple; this requires you to set
+                              your compiler's standard to at least C++11.
+                              If disabled (the default) the Boost facilities
+                              are used.]),
+              [ql_use_std_tuple=$enableval],
+              [ql_use_std_tuple=no])
+if test "$ql_use_std_tuple" = "yes" ; then
+   AC_DEFINE([QL_USE_STD_TUPLE],[1],
+             [Define this if you want to use standard smart tuple.])
+fi
+AC_MSG_RESULT([$ql_use_std_pointers])
+
 AC_MSG_CHECKING([whether to enable available std classes])
 AC_ARG_ENABLE([std-classes],
               AC_HELP_STRING([--enable-std-classes],
                              [This is a shortcut for --enable-std-pointers
-                              --enable-std-unique-ptr --enable-std-function.
+                              --enable-std-unique-ptr --enable-std-function
+			      --enable-std-tuple.
                               If enabled, this supersedes any --disable
                               option passed for the above.]),
               [ql_use_std_classes=$enableval],
@@ -428,6 +447,8 @@ if test "$ql_use_std_classes" = "yes" ; then
              [Define this if you want to replace std::auto_ptr with std::unique_ptr.])
    AC_DEFINE([QL_USE_STD_FUNCTION],[1],
              [Define this if you want to use std::function and std::bind.])
+   AC_DEFINE([QL_USE_STD_TUPLE],[1],
+             [Define this if you want to use std::tuple.])
 fi
 AC_MSG_RESULT([$ql_use_std_classes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -413,12 +413,12 @@ fi
 AC_MSG_RESULT([$ql_use_std_function])
 
 
-AC_MSG_CHECKING([whether to enable standard smart tuple])
+AC_MSG_CHECKING([whether to enable std::tuple])
 AC_ARG_ENABLE([std-tuple],
               AC_HELP_STRING([--enable-std-tuple],
                              [If enabled, std::tuple and related
-                              classes and functions will be used instead
-                              of ext::tuple; this requires you to set
+                              functions will be used instead
+                              of boost::tuple; this requires you to set
                               your compiler's standard to at least C++11.
                               If disabled (the default) the Boost facilities
                               are used.]),
@@ -426,7 +426,7 @@ AC_ARG_ENABLE([std-tuple],
               [ql_use_std_tuple=no])
 if test "$ql_use_std_tuple" = "yes" ; then
    AC_DEFINE([QL_USE_STD_TUPLE],[1],
-             [Define this if you want to use standard smart tuple.])
+             [Define this if you want to use std::tuple.])
 fi
 AC_MSG_RESULT([$ql_use_std_pointers])
 

--- a/ql/Makefile.am
+++ b/ql/Makefile.am
@@ -57,6 +57,7 @@ this_include_HEADERS = \
 	termstructure.hpp \
 	timegrid.hpp \
 	timeseries.hpp \
+	tuple.hpp \
 	types.hpp \
 	version.hpp \
 	volatilitymodel.hpp

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -21,6 +21,7 @@
 #ifndef quantlib_randomdefault_latent_model_hpp
 #define quantlib_randomdefault_latent_model_hpp
 
+#include <ql/tuple.hpp>
 #include <ql/math/beta.hpp>
 #include <ql/math/statistics/histogram.hpp>
 #include <ql/math/statistics/riskstatistics.hpp>
@@ -189,7 +190,7 @@ namespace QuantLib {
         virtual Real percentile(const Date& d, Real percentile) const;
         /*! Returns the VaR value for a given percentile and the 95 confidence
         interval of that value. */
-        virtual boost::tuples::tuple<Real, Real, Real> percentileAndInterval(
+        virtual ext::tuple<Real, Real, Real> percentileAndInterval(
             const Date& d, Real percentile) const;
         /*! Distributes the total VaR amount along the portfolio counterparties.
             The passed loss amount is in loss units.
@@ -534,7 +535,7 @@ namespace QuantLib {
     template<template <class, class> class D, class C, class URNG>
     Real RandomLM<D, C, URNG>::percentile(const Date& d, Real perc) const {
         // need to specify return type in tuples' get is parametric
-        return percentileAndInterval(d, perc).template get<0>();
+        return ext::get<0>(percentileAndInterval(d, perc));
     }
 
 
@@ -545,7 +546,7 @@ namespace QuantLib {
     of the stimator just computed. See the reference for a discussion.
     */
     template<template <class, class> class D, class C, class URNG>
-    boost::tuples::tuple<Real, Real, Real> // disposable?
+    ext::tuple<Real, Real, Real> // disposable?
         RandomLM<D, C, URNG>::percentileAndInterval(const Date& d,
             Real percentile) const {
 
@@ -624,7 +625,7 @@ namespace QuantLib {
         lowerPercentile = rankLosses[r];
         upperPercentile = rankLosses[s];
 
-        return boost::tuples::tuple<Real, Real, Real>(quantileValue,
+        return ext::tuple<Real, Real, Real>(quantileValue,
             lowerPercentile, upperPercentile);
     }
 

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -20,6 +20,7 @@
 #ifndef quantlib_saddle_point_lossmodel_hpp
 #define quantlib_saddle_point_lossmodel_hpp
 
+#include <ql/tuple.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/solvers1d/newton.hpp>
 #include <ql/math/functional.hpp>
@@ -152,11 +153,11 @@ namespace QuantLib {
           Included for optimization, most methods work on expansion of these 
           terms.
           Alternatively use a local private buffer member? */
-        boost::tuples::tuple<Real, Real, Real, Real> CumGen0234DerivCond(
+        ext::tuple<Real, Real, Real, Real> CumGen0234DerivCond(
             const std::vector<Real>& invUncondProbs,
             Real saddle, 
             const std::vector<Real>&  mktFactor) const;
-        boost::tuples::tuple<Real, Real> CumGen02DerivCond(
+        ext::tuple<Real, Real> CumGen02DerivCond(
             const std::vector<Real>& invUncondProbs,
             Real saddle, 
             const std::vector<Real>&  mktFactor) const;
@@ -775,7 +776,7 @@ namespace QuantLib {
     }
 
     template<class CP>
-    boost::tuples::tuple<Real, Real, Real, Real> /// DISPOSABLE????
+    ext::tuple<Real, Real, Real, Real> /// DISPOSABLE????
         SaddlePointLossModel<CP>::CumGen0234DerivCond(
         const std::vector<Real>& invUncondProbs,
         Real saddle, 
@@ -814,12 +815,12 @@ namespace QuantLib {
                 (12.*suma1*suma1*suma2 - 
                     6.*std::pow(suma1,4.)/suma0)/suma0)/suma0)/suma0;
         }
-        return boost::tuples::tuple<Real, Real, Real, Real>(deriv0, deriv2, 
+        return ext::tuple<Real, Real, Real, Real>(deriv0, deriv2, 
             deriv3, deriv4);
     }
 
     template<class CP>
-    boost::tuples::tuple<Real, Real> /// DISPOSABLE???? 
+    ext::tuple<Real, Real> /// DISPOSABLE???? 
         SaddlePointLossModel<CP>::CumGen02DerivCond(
         const std::vector<Real>& invUncondProbs,
         Real saddle, 
@@ -849,7 +850,7 @@ namespace QuantLib {
             //deriv1 += suma1 / suma0;
             deriv2 += suma2 / suma0 - std::pow(suma1 / suma0 , 2.);
         }
-        return boost::tuples::tuple<Real, Real>(deriv0, deriv2);
+        return ext::tuple<Real, Real>(deriv0, deriv2);
     }
 
     // ----- Saddle point search ----------------------------------------------
@@ -1029,13 +1030,13 @@ namespace QuantLib {
         Real saddlePt = findSaddle(invUncondProbs,
             relativeLoss, mktFactor);
 
-        boost::tuples::tuple<Real, Real, Real, Real> cumulants = 
+        ext::tuple<Real, Real, Real, Real> cumulants = 
             CumGen0234DerivCond(invUncondProbs, 
                 saddlePt, mktFactor);
-        Real baseVal = cumulants.get<0>();
-        Real secondVal = cumulants.get<1>();
-        Real K3Saddle = cumulants.get<2>();
-        Real K4Saddle = cumulants.get<3>();
+        Real baseVal = ext::get<0>(cumulants);
+        Real secondVal = ext::get<1>(cumulants);
+        Real K3Saddle = ext::get<2>(cumulants);
+        Real K4Saddle = ext::get<3>(cumulants);
 
         Real saddleTo2 = saddlePt * saddlePt;
         Real saddleTo3 = saddleTo2 * saddlePt;
@@ -1118,11 +1119,11 @@ namespace QuantLib {
         Real saddlePt = findSaddle(invUncondPs,
             relativeLoss, mktFactor);
 
-        boost::tuples::tuple<Real, Real> cumulants = 
+        ext::tuple<Real, Real> cumulants = 
             CumGen02DerivCond(invUncondPs,
                 saddlePt, mktFactor);
-        Real baseVal = cumulants.get<0>();
-        Real secondVal = cumulants.get<1>();
+        Real baseVal = ext::get<0>(cumulants);
+        Real secondVal = ext::get<1>(cumulants);
 
         Real saddleTo2 = saddlePt * saddlePt;
 
@@ -1173,14 +1174,14 @@ namespace QuantLib {
         Real saddlePt = findSaddle(invUncondPs,
             relativeLoss, mktFactor);
 
-        boost::tuples::tuple<Real, Real, Real, Real> cumulants = 
+        ext::tuple<Real, Real, Real, Real> cumulants = 
             CumGen0234DerivCond(invUncondPs,
             saddlePt, mktFactor);
         /// access them directly rather than through this copy
-        Real K0Saddle = cumulants.get<0>();
-        Real K2Saddle = cumulants.get<1>();
-        Real K3Saddle = cumulants.get<2>();
-        Real K4Saddle = cumulants.get<3>();
+        Real K0Saddle = ext::get<0>(cumulants);
+        Real K2Saddle = ext::get<1>(cumulants);
+        Real K3Saddle = ext::get<2>(cumulants);
+        Real K4Saddle = ext::get<3>(cumulants);
         /* see, for instance R.Martin "he saddle point method and portfolio 
         optionalities." in Risk December 2006 p.93 */
         //\todo the exponentials below are dangerous and agressive, tame them.
@@ -1384,11 +1385,11 @@ namespace QuantLib {
         // Broda and Paolella:
         Real elCondRatio = elCond / remainingNotional_;
 
-        boost::tuples::tuple<Real, Real, Real, Real> cumulants = 
+        ext::tuple<Real, Real, Real, Real> cumulants = 
             CumGen0234DerivCond(uncondProbs, 
                 saddlePt, mktFactor);
-        Real K0Saddle = cumulants.get<0>();///USE THEM DIRECTLY
-        Real K2Saddle = cumulants.get<1>();
+        Real K0Saddle = ext::get<0>(cumulants);///USE THEM DIRECTLY
+        Real K2Saddle = ext::get<1>(cumulants);
 
         Real wq = std::sqrt(2. * saddlePt * lossPercRatio - 2. * K0Saddle);
         //std::sqrt(-2. * saddlePt * lossPerc + 2. * K0Saddle);????

--- a/ql/experimental/models/hestonslvfdmmodel.cpp
+++ b/ql/experimental/models/hestonslvfdmmodel.cpp
@@ -59,7 +59,7 @@ namespace QuantLib {
             Time t0, Time t1, Size vGrid,
             Real v0, const HestonSLVFokkerPlanckFdmParams& params) {
 
-            std::vector<boost::tuple<Real, Real, bool> > cPoints;
+            std::vector<ext::tuple<Real, Real, bool> > cPoints;
 
             const Real v0Density = params.v0Density;
             const Real upperBoundDensity = params.vUpperBoundDensity;
@@ -85,9 +85,9 @@ namespace QuantLib {
                     const Real v0Center = std::log(v0);
 
                     cPoints +=
-                        boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                        boost::make_tuple(v0Center, v0Density, true),
-                        boost::make_tuple(upperBound, upperBoundDensity, false);
+                        ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                        ext::make_tuple(v0Center, v0Density, true),
+                        ext::make_tuple(upperBound, upperBoundDensity, false);
 
                     return ext::make_shared<Concentrating1dMesher>(
                         lowerBound, upperBound, vGrid, cPoints, 1e-8);
@@ -98,9 +98,9 @@ namespace QuantLib {
                       const Real v0Center = v0;
 
                       cPoints +=
-                          boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                          boost::make_tuple(v0Center, v0Density, true),
-                          boost::make_tuple(upperBound, upperBoundDensity, false);
+                          ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                          ext::make_tuple(v0Center, v0Density, true),
+                          ext::make_tuple(upperBound, upperBoundDensity, false);
 
                       return ext::make_shared<Concentrating1dMesher>(
                           lowerBound, upperBound, vGrid, cPoints, 1e-8);
@@ -111,9 +111,9 @@ namespace QuantLib {
                     const Real v0Center = v0;
 
                     cPoints +=
-                        boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                        boost::make_tuple(v0Center, v0Density, true),
-                        boost::make_tuple(upperBound, upperBoundDensity, false);
+                        ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                        ext::make_tuple(v0Center, v0Density, true),
+                        ext::make_tuple(upperBound, upperBoundDensity, false);
 
                     return ext::make_shared<Concentrating1dMesher>(
                         lowerBound, upperBound, vGrid, cPoints, 1e-8);

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -150,7 +150,7 @@ namespace QuantLib {
 
     Concentrating1dMesher::Concentrating1dMesher(
         Real start, Real end, Size size,
-        const std::vector<boost::tuple<Real, Real, bool> >& cPoints,
+        const std::vector<ext::tuple<Real, Real, bool> >& cPoints,
         Real tol)
     : Fdm1dMesher(size) {
         using namespace ext::placeholders;
@@ -158,10 +158,10 @@ namespace QuantLib {
         QL_REQUIRE(end > start, "end must be larger than start");
 
         std::vector<Real> points, betas;
-        for (std::vector<boost::tuple<Real, Real, bool> >::const_iterator
+        for (std::vector<ext::tuple<Real, Real, bool> >::const_iterator
                 iter = cPoints.begin(); iter != cPoints.end(); ++iter) {
-            points.push_back(iter->get<0>());
-            betas.push_back(square<Real>()(iter->get<1>()*(end-start)));
+            points.push_back(ext::get<0>(*iter));
+            betas.push_back(square<Real>()(ext::get<1>(*iter)*(end-start)));
         }
 
         // get scaling factor a so that y(1) = end
@@ -200,7 +200,7 @@ namespace QuantLib {
         std::vector<std::pair<Real, Real> > w(1, std::make_pair(0.0, 0.0));
 
         for (Size i=0; i < points.size(); ++i) {
-            if (cPoints[i].get<2>() && points[i] > start && points[i] < end) {
+            if (ext::get<2>(cPoints[i]) && points[i] > start && points[i] < end) {
 
                 const Size j = std::distance(y.begin(),
                         std::lower_bound(y.begin(), y.end(), points[i]));

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp
@@ -29,7 +29,7 @@
 #include <ql/methods/finitedifferences/meshers/fdm1dmesher.hpp>
 #include <ql/utilities/null.hpp>
 
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 
 #include <utility>
 #include <vector>
@@ -47,7 +47,7 @@ namespace QuantLib {
 
         Concentrating1dMesher(
             Real start, Real end, Size size,
-            const std::vector<boost::tuple<Real, Real, bool> >& cPoints,
+            const std::vector<ext::tuple<Real, Real, bool> >& cPoints,
             Real tol = 1e-8);
     };
 }

--- a/ql/quantlib.hpp
+++ b/ql/quantlib.hpp
@@ -38,6 +38,7 @@
 #include <ql/termstructure.hpp>
 #include <ql/timegrid.hpp>
 #include <ql/timeseries.hpp>
+#include <ql/tuple.hpp>
 #include <ql/types.hpp>
 #include <ql/volatilitymodel.hpp>
 

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -496,10 +496,7 @@ namespace QuantLib {
     AndreasenHugeVolatilityInterpl::calibrationError() const {
         calculate();
 
-        return ext::make_tuple<Real, Real, Real>(
-               ext::forward<Real>(minError_),
-               ext::forward<Real>(maxError_),
-               ext::forward<Real>(avgError_));
+        return ext::make_tuple(minError_, maxError_, avgError_);
     }
 
     Size AndreasenHugeVolatilityInterpl::getExerciseTimeIdx(Time t) const {
@@ -574,12 +571,8 @@ namespace QuantLib {
 
         Real fwd = spot_->value()*qTS_->discount(t)/df;
 
-        priceCache_[t] = ext::make_tuple<
-            Real,
-            ext::shared_ptr<Array>,
-            ext::shared_ptr<Interpolation> >(
-                ext::forward<Real>(fwd),
-                ext::forward<ext::shared_ptr<Array> >(prices),
+        priceCache_[t] = ext::make_tuple(
+                fwd, prices,
                 ext::make_shared<CubicNaturalSpline>(
                     gridPoints_.begin()+1, gridPoints_.end()-1,
                     prices->begin()+1));
@@ -654,11 +647,8 @@ namespace QuantLib {
 
         Real fwd = spot_->value()*qTS_->discount(t)/rTS_->discount(t);
 
-        localVolCache_[t] = ext::make_tuple<
-            Real,
-            ext::shared_ptr<Array>,
-            ext::shared_ptr<Interpolation> >(
-                ext::forward<Real>(fwd), ext::forward<ext::shared_ptr<Array> >(localVol),
+        localVolCache_[t] = ext::make_tuple(
+                fwd, localVol,
                 ext::make_shared<LinearInterpolation>(
                     gridPoints_.begin()+1, gridPoints_.end()-1,
                     localVol->begin()+1));

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -492,12 +492,14 @@ namespace QuantLib {
         return rTS_;
     }
 
-    boost::tuple<Real, Real, Real>
+    ext::tuple<Real, Real, Real>
     AndreasenHugeVolatilityInterpl::calibrationError() const {
         calculate();
 
-        return boost::make_tuple<Real, Real, Real>(
-            minError_, maxError_, avgError_);
+        return ext::make_tuple<Real, Real, Real>(
+               ext::forward<Real>(minError_),
+               ext::forward<Real>(maxError_),
+               ext::forward<Real>(avgError_));
     }
 
     Size AndreasenHugeVolatilityInterpl::getExerciseTimeIdx(Time t) const {
@@ -510,13 +512,13 @@ namespace QuantLib {
     Real AndreasenHugeVolatilityInterpl::getCacheValue(
         Real strike, const TimeValueCacheType::const_iterator& f) const {
 
-        const Real fwd = f->second.get<0>();
+        const Real fwd = ext::get<0>(f->second);
         const Real k = std::log(strike / fwd);
 
         const Real s = std::max(gridPoints_[1],
             std::min(*(gridPoints_.end()-2), k));
 
-        return (*(f->second.get<2>()))(s);
+        return (*(ext::get<2>(f->second)))(s);
     }
 
     Disposable<Array> AndreasenHugeVolatilityInterpl::getPriceSlice(
@@ -539,7 +541,7 @@ namespace QuantLib {
         const DiscountFactor df = rTS_->discount(t);
 
         if (f != priceCache_.end()) {
-            const Real fwd = f->second.get<0>();
+            const Real fwd = ext::get<0>(f->second);
 
             Real price = getCacheValue(strike, f);
 
@@ -555,7 +557,7 @@ namespace QuantLib {
         calculate();
 
 
-        const ext::shared_ptr<Array> prices(
+        ext::shared_ptr<Array> prices(
             ext::make_shared<Array>(gridPoints_));
 
         switch (calibrationType_) {
@@ -570,13 +572,14 @@ namespace QuantLib {
             QL_FAIL("unknown calibration type");
         }
 
-        const Real fwd = spot_->value()*qTS_->discount(t)/df;
+        Real fwd = spot_->value()*qTS_->discount(t)/df;
 
-        priceCache_[t] = boost::make_tuple<
+        priceCache_[t] = ext::make_tuple<
             Real,
             ext::shared_ptr<Array>,
             ext::shared_ptr<Interpolation> >(
-                fwd, prices,
+                ext::forward<Real>(fwd),
+                ext::forward<ext::shared_ptr<Array> >(prices),
                 ext::make_shared<CubicNaturalSpline>(
                     gridPoints_.begin()+1, gridPoints_.end()-1,
                     prices->begin()+1));
@@ -626,7 +629,7 @@ namespace QuantLib {
 
         calculate();
 
-        const ext::shared_ptr<Array> localVol(
+        ext::shared_ptr<Array> localVol(
             ext::make_shared<Array>(gridPoints_.size()));
 
         switch (calibrationType_) {
@@ -649,13 +652,13 @@ namespace QuantLib {
             QL_FAIL("unknown calibration type");
         }
 
-        const Real fwd = spot_->value()*qTS_->discount(t)/rTS_->discount(t);
+        Real fwd = spot_->value()*qTS_->discount(t)/rTS_->discount(t);
 
-        localVolCache_[t] = boost::make_tuple<
+        localVolCache_[t] = ext::make_tuple<
             Real,
             ext::shared_ptr<Array>,
             ext::shared_ptr<Interpolation> >(
-                fwd, localVol,
+                ext::forward<Real>(fwd), ext::forward<ext::shared_ptr<Array> >(localVol),
                 ext::make_shared<LinearInterpolation>(
                     gridPoints_.begin()+1, gridPoints_.end()-1,
                     localVol->begin()+1));

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
@@ -33,7 +33,7 @@
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/termstructures/volatility/equityfx/localvoltermstructure.hpp>
 
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 #include <utility>
 
 namespace QuantLib {
@@ -85,7 +85,7 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& riskFreeRate() const;
 
         // returns min, max and average error in volatility units
-        boost::tuple<Real, Real, Real> calibrationError() const;
+        ext::tuple<Real, Real, Real> calibrationError() const;
 
         // returns the option price of the calibration type. In case
         // of CallPut it return the call option price
@@ -98,7 +98,7 @@ namespace QuantLib {
 
       private:
         typedef std::map<Time,
-            boost::tuple<
+            ext::tuple<
                 Real,
                 ext::shared_ptr<Array>,
                 ext::shared_ptr<Interpolation> > > TimeValueCacheType;

--- a/ql/tuple.hpp
+++ b/ql/tuple.hpp
@@ -30,7 +30,6 @@
 #include <tuple>
 #else
 #include <boost/tuple/tuple.hpp>
-#include <boost/move/move.hpp>
 #endif
 
 namespace QuantLib {
@@ -41,12 +40,10 @@ namespace QuantLib {
         using std::tuple;                   // NOLINT(misc-unused-using-decls)
         using std::make_tuple;              // NOLINT(misc-unused-using-decls)
         using std::get;                     // NOLINT(misc-unused-using-decls)
-        using std::forward;                 // NOLINT(misc-unused-using-decls)
         #else
         using boost::tuple;                 // NOLINT(misc-unused-using-decls)
         using boost::make_tuple;            // NOLINT(misc-unused-using-decls)
         using boost::get;                   // NOLINT(misc-unused-using-decls)
-        using boost::forward;                   // NOLINT(misc-unused-using-decls)
         #endif
 
     }

--- a/ql/tuple.hpp
+++ b/ql/tuple.hpp
@@ -1,0 +1,58 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2018 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file tuple.hpp
+    \brief Maps tuple to either the boost or std implementation
+*/
+
+#ifndef quantlib_tuple_hpp
+#define quantlib_tuple_hpp
+
+#include <ql/qldefines.hpp>
+
+#if defined(QL_USE_STD_TUPLE)
+#include <tuple>
+#else
+#include <boost/tuple/tuple.hpp>
+#include <boost/move/move.hpp>
+#endif
+
+namespace QuantLib {
+
+    namespace ext {
+
+        #if defined(QL_USE_STD_TUPLE)
+        using std::tuple;                   // NOLINT(misc-unused-using-decls)
+        using std::make_tuple;              // NOLINT(misc-unused-using-decls)
+        using std::get;                     // NOLINT(misc-unused-using-decls)
+        using std::forward;                 // NOLINT(misc-unused-using-decls)
+        #else
+        using boost::tuple;                 // NOLINT(misc-unused-using-decls)
+        using boost::make_tuple;            // NOLINT(misc-unused-using-decls)
+        using boost::get;                   // NOLINT(misc-unused-using-decls)
+        using boost::forward;                   // NOLINT(misc-unused-using-decls)
+        #endif
+
+    }
+
+}
+
+
+#endif
+

--- a/ql/userconfig.hpp
+++ b/ql/userconfig.hpp
@@ -102,6 +102,13 @@
 //#    define QL_USE_STD_FUNCTION
 #endif
 
+/* Define this to use std::tuple instead of
+   boost::function and boost::bind.  This requires you to set your
+   compiler's standard to at least C++11. */
+#ifndef QL_USE_STD_TUPLE
+//#    define QL_USE_STD_TUPLE
+#endif
+
 /* Define this to enable the parallel unit test runner */
 #ifndef QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER
 //#    define QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -175,11 +175,11 @@ namespace andreasen_huge_volatility_interpl_test {
                     expected.interpolationType,
                     expected.calibrationType));
 
-        const boost::tuple<Real, Real, Real> error =
+        const ext::tuple<Real, Real, Real> error =
             andreasenHugeVolInterplation->calibrationError();
 
-        const Real maxError = error.get<1>();
-        const Real avgError = error.get<2>();
+        const Real maxError = ext::get<1>(error);
+        const Real avgError = ext::get<2>(error);
 
         if (maxError > expected.maxError || avgError > expected.avgError) {
             BOOST_FAIL("Failed to reproduce calibration error"
@@ -915,7 +915,7 @@ void AndreasenHugeVolatilityInterplTest::testDifferentOptimizers() {
         const ext::shared_ptr<OptimizationMethod> optimizationMethod =
             optimizationMethods[i];
 
-        const Real avgError = AndreasenHugeVolatilityInterpl(
+        const Real avgError = ext::get<2>(AndreasenHugeVolatilityInterpl(
             data.calibrationSet,
             data.spot,
             data.rTS, data.qTS,
@@ -923,7 +923,7 @@ void AndreasenHugeVolatilityInterplTest::testDifferentOptimizers() {
             AndreasenHugeVolatilityInterpl::Call,
             400,
             Null<Real>(), Null<Real>(),
-            optimizationMethod).calibrationError().get<2>();
+            optimizationMethod).calibrationError());
 
         if (boost::math::isnan(avgError) || avgError > 0.0001) {
             BOOST_FAIL("failed to calibrate Andreasen-Huge "

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -33,7 +33,6 @@
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <boost/assign/std/vector.hpp>
-#include <ql/tuple.hpp>
 
 using namespace QuantLib;
 using namespace boost::assign;

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -33,7 +33,7 @@
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <boost/assign/std/vector.hpp>
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 
 using namespace QuantLib;
 using namespace boost::assign;

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -43,7 +43,7 @@
 #include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
 
 #include <boost/assign/std/vector.hpp>
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 
 using namespace QuantLib;
 using namespace boost::assign;
@@ -960,15 +960,15 @@ void FdHestonTest::testSpuriousOscillations() {
 
     option.setupArguments(hestonEngine->getArguments());
 
-    const boost::tuple<FdmSchemeDesc, std::string, bool> descs[] = {
-        boost::make_tuple(FdmSchemeDesc::CraigSneyd(), "Craig-Sneyd", true),
-        boost::make_tuple(FdmSchemeDesc::Hundsdorfer(), "Hundsdorfer", true),
-        boost::make_tuple(
+    const ext::tuple<FdmSchemeDesc, std::string, bool> descs[] = {
+        ext::make_tuple(FdmSchemeDesc::CraigSneyd(), "Craig-Sneyd", true),
+        ext::make_tuple(FdmSchemeDesc::Hundsdorfer(), "Hundsdorfer", true),
+        ext::make_tuple(
            FdmSchemeDesc::ModifiedHundsdorfer(), "Mod. Hundsdorfer", true),
-        boost::make_tuple(FdmSchemeDesc::Douglas(), "Douglas", true),
-        boost::make_tuple(FdmSchemeDesc::CrankNicolson(), "Crank-Nicolson", true),
-        boost::make_tuple(FdmSchemeDesc::ImplicitEuler(), "Implicit", false),
-        boost::make_tuple(FdmSchemeDesc::TrBDF2(), "TR-BDF2", false)
+        ext::make_tuple(FdmSchemeDesc::Douglas(), "Douglas", true),
+        ext::make_tuple(FdmSchemeDesc::CrankNicolson(), "Crank-Nicolson", true),
+        ext::make_tuple(FdmSchemeDesc::ImplicitEuler(), "Implicit", false),
+        ext::make_tuple(FdmSchemeDesc::TrBDF2(), "TR-BDF2", false)
     };
 
     for (Size j=0; j < LENGTH(descs); ++j) {
@@ -976,7 +976,7 @@ void FdHestonTest::testSpuriousOscillations() {
             ext::make_shared<FdmHestonSolver>(
                 Handle<HestonProcess>(process),
                 hestonEngine->getSolverDesc(1.0),
-                descs[j].get<0>());
+                ext::get<0>(descs[j]));
 
         std::vector<Real> gammas;
         for (Real x=99; x < 101.001; x+=0.1) {
@@ -993,12 +993,12 @@ void FdHestonTest::testSpuriousOscillations() {
         const Real tol = 0.01;
         const bool hasSpuriousOscillations = maximum > tol;
 
-        if (hasSpuriousOscillations != descs[j].get<2>()) {
+        if (hasSpuriousOscillations != ext::get<2>(descs[j])) {
             BOOST_ERROR("unable to reproduce spurious oscillation behaviour "
-                     << "\n   scheme name          : " << descs[j].get<1>()
+                     << "\n   scheme name          : " << ext::get<1>(descs[j])
                      << "\n   oscillations observed: "
                          << hasSpuriousOscillations
-                     << "\n   oscillations expected: " << descs[j].get<2>()
+                     << "\n   oscillations expected: " << ext::get<2>(descs[j])
             );
         }
     }

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -752,7 +752,7 @@ namespace {
         const FdmSquareRootFwdOp::TransformationType transformationType
             = testCase.trafoType;
         Real lowerBound, upperBound;
-        std::vector<boost::tuple<Real, Real, bool> > cPoints;
+        std::vector<ext::tuple<Real, Real, bool> > cPoints;
 
         const SquareRootProcessRNDCalculator rnd(v0, kappa, theta, sigma);
         switch (transformationType) {
@@ -765,9 +765,9 @@ namespace {
             const Real v0Density = 10.0;
             const Real upperBoundDensity = 100;
             const Real lowerBoundDensity = 1.0;
-            cPoints += boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                       boost::make_tuple(v0Center, v0Density, true),
-                       boost::make_tuple(upperBound, upperBoundDensity, false);
+            cPoints += ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                       ext::make_tuple(v0Center, v0Density, true),
+                       ext::make_tuple(upperBound, upperBoundDensity, false);
           }
         break;
         case FdmSquareRootFwdOp::Plain:
@@ -778,8 +778,8 @@ namespace {
             const Real v0Center = v0;
             const Real v0Density = 0.1;
             const Real lowerBoundDensity = 0.0001;
-            cPoints += boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                       boost::make_tuple(v0Center, v0Density, true);
+            cPoints += ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                       ext::make_tuple(v0Center, v0Density, true);
           }
         break;
         case FdmSquareRootFwdOp::Power:
@@ -790,8 +790,8 @@ namespace {
             const Real v0Center = v0;
             const Real v0Density = 1.0;
             const Real lowerBoundDensity = 0.005;
-            cPoints += boost::make_tuple(lowerBound, lowerBoundDensity, false),
-                       boost::make_tuple(v0Center, v0Density, true);
+            cPoints += ext::make_tuple(lowerBound, lowerBoundDensity, false),
+                       ext::make_tuple(v0Center, v0Density, true);
           }
         break;
         default:
@@ -1011,7 +1011,7 @@ namespace {
         return surface;
     }
 
-    boost::tuple<std::vector<Real>, std::vector<Date>,
+    ext::tuple<std::vector<Real>, std::vector<Date>,
                  ext::shared_ptr<BlackVarianceSurface> >
         createSmoothImpliedVol(const DayCounter& dc, const Calendar& cal) {
 
@@ -1066,7 +1066,7 @@ namespace {
                                      BlackVarianceSurface::ConstantExtrapolation));
         volTS->setInterpolation<Bicubic>();
 
-        return boost::make_tuple(surfaceStrikes, dates, volTS);
+        return ext::make_tuple(surfaceStrikes, dates, volTS);
     }
 }
 
@@ -1117,10 +1117,10 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     const Real lowerBound = rnd.stationary_invcdf(0.01);
 
     const Real beta = 10.0;
-    std::vector<boost::tuple<Real, Real, bool> > critPoints;
-    critPoints.push_back(boost::tuple<Real, Real, bool>(lowerBound, beta, true));
-    critPoints.push_back(boost::tuple<Real, Real, bool>(v0, beta/100, true));
-    critPoints.push_back(boost::tuple<Real, Real, bool>(upperBound, beta, true));
+    std::vector<ext::tuple<Real, Real, bool> > critPoints;
+    critPoints.push_back(ext::tuple<Real, Real, bool>(lowerBound, beta, true));
+    critPoints.push_back(ext::tuple<Real, Real, bool>(v0, beta/100, true));
+    critPoints.push_back(ext::tuple<Real, Real, bool>(upperBound, beta, true));
     const ext::shared_ptr<Fdm1dMesher> varianceMesher(
 		ext::make_shared<Concentrating1dMesher>(lowerBound, upperBound, vGrid, critPoints));
 
@@ -1131,12 +1131,12 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     const ext::shared_ptr<FdmMesherComposite>
         mesher(ext::make_shared<FdmMesherComposite>(equityMesher, varianceMesher));
 
-    const boost::tuple<std::vector<Real>, std::vector<Date>,
+    const ext::tuple<std::vector<Real>, std::vector<Date>,
                  ext::shared_ptr<BlackVarianceSurface> > smoothSurface =
         createSmoothImpliedVol(dayCounter, calendar);
     const ext::shared_ptr<BlackScholesMertonProcess> lvProcess(
 		ext::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS,
-            Handle<BlackVolTermStructure>(smoothSurface.get<2>())));
+        Handle<BlackVolTermStructure>(ext::get<2>(smoothSurface))));
 
     // step two days using non-correlated process
     const Time eT = 2.0/365;
@@ -1177,10 +1177,10 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
 
     const std::vector<Real> ds(denseStrikes, denseStrikes+LENGTH(denseStrikes));
 
-    Matrix surface(ds.size(), smoothSurface.get<1>().size());
+    Matrix surface(ds.size(), ext::get<1>(smoothSurface).size());
     std::vector<Time> times(surface.columns());
 
-    const std::vector<Date> dates = smoothSurface.get<1>();
+    const std::vector<Date> dates = ext::get<1>(smoothSurface);
     ext::shared_ptr<Matrix> m = createLocalVolMatrixFromProcess(
         lvProcess, ds, dates, times);
 
@@ -1267,14 +1267,14 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol() {
     const Handle<YieldTermStructure> qTS(
             flatRate(todaysDate, q, dayCounter));
 
-    boost::tuple<std::vector<Real>, std::vector<Date>,
+    ext::tuple<std::vector<Real>, std::vector<Date>,
             ext::shared_ptr<BlackVarianceSurface> > smoothImpliedVol =
             createSmoothImpliedVol(dayCounter, calendar);
 
-    const std::vector<Real>& strikes = smoothImpliedVol.get<0>();
-    const std::vector<Date>& dates = smoothImpliedVol.get<1>();
+    const std::vector<Real>& strikes = ext::get<0>(smoothImpliedVol);
+    const std::vector<Date>& dates = ext::get<1>(smoothImpliedVol);
     const Handle<BlackVolTermStructure> vTS =
-        Handle<BlackVolTermStructure>(smoothImpliedVol.get<2>());
+        Handle<BlackVolTermStructure>(ext::get<2>(smoothImpliedVol));
 
     const Size xGrid = 101;
     const Size tGrid = 51;
@@ -1567,7 +1567,7 @@ void HestonSLVModelTest::testLocalVolsvSLVPropDensity() {
         flatRate(todaysDate, q, dayCounter));
 
     const Handle<BlackVolTermStructure> vTS = Handle<BlackVolTermStructure>(
-        createSmoothImpliedVol(dayCounter, calendar).get<2>());
+        ext::get<2>(createSmoothImpliedVol(dayCounter, calendar)));
 
     // Heston parameter from implied calibration
     const Real kappa =  2.0;

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -45,7 +45,7 @@
 #include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/experimental/volatility/noarbsabrinterpolation.hpp>
 #include <boost/foreach.hpp>
-#include <boost/tuple/tuple.hpp>
+#include <ql/tuple.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 
@@ -2377,24 +2377,24 @@ void InterpolationTest::testBSplines() {
     const Natural p = 2;
     const BSpline bspline(p, knots.size()-p-2, knots);
 
-    std::vector<boost::tuple<Natural, Real, Real> > referenceValues;
-    referenceValues += boost::make_tuple(0, -0.95, 9.5238095238e-04),
-        boost::make_tuple(0, -0.01, 0.37337142857),
-        boost::make_tuple(0, 0.49, 0.84575238095),
-        boost::make_tuple(0, 1.21, 0.0),
-        boost::make_tuple(1, 1.49, 0.562987654321),
-        boost::make_tuple(1, 1.59, 0.490888888889),
-        boost::make_tuple(2, 1.99, 0.62429409171),
-        boost::make_tuple(3, 1.19, 0.0),
-        boost::make_tuple(3, 1.99, 0.12382936508),
-        boost::make_tuple(3, 3.59, 0.765914285714);
+    std::vector<ext::tuple<Natural, Real, Real> > referenceValues;
+    referenceValues += ext::make_tuple(0, -0.95, 9.5238095238e-04),
+        ext::make_tuple(0, -0.01, 0.37337142857),
+        ext::make_tuple(0, 0.49, 0.84575238095),
+        ext::make_tuple(0, 1.21, 0.0),
+        ext::make_tuple(1, 1.49, 0.562987654321),
+        ext::make_tuple(1, 1.59, 0.490888888889),
+        ext::make_tuple(2, 1.99, 0.62429409171),
+        ext::make_tuple(3, 1.19, 0.0),
+        ext::make_tuple(3, 1.99, 0.12382936508),
+        ext::make_tuple(3, 3.59, 0.765914285714);
 
 
     const Real tol = 1e-10;
     for (Size i=0; i < referenceValues.size(); ++i) {
-        const Natural idx = referenceValues[i].get<0>();
-        const Real x = referenceValues[i].get<1>();
-        const Real expected = referenceValues[i].get<2>();
+        const Natural idx = ext::get<0>(referenceValues[i]);
+        const Real x = ext::get<1>(referenceValues[i]);
+        const Real expected = ext::get<2>(referenceValues[i]);
 
         const Real calculated = bspline(idx, x);
 


### PR DESCRIPTION
implement #871 

The big change is that the C++ standard intentionally does not support foo.get<1>() syntax so those had to be changed to get<1>(foo) syntax.

Also some std::forwards had to be included