### PR TITLE
LogCubic convenience classes

### DIFF
--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -306,15 +306,19 @@ namespace QuantLib {
     
     class DefaultLogMixedLinearCubic : public LogMixedLinearCubic {
       public:
-        DefaultLogMixedLinearCubic()
-        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+        DefaultLogMixedLinearCubic(const Size n,
+                                   MixedInterpolation::Behavior behavior
+                                   = MixedInterpolation::ShareRanges)
+        : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Kruger) {}
     };
 
     class MonotonicLogMixedLinearCubic : public LogMixedLinearCubic {
       public:
-        MonotonicLogMixedLinearCubic()
-        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+        MonotonicLogMixedLinearCubic(const Size n,
+                                   MixedInterpolation::Behavior behavior
+                                   = MixedInterpolation::ShareRanges)
+        : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Spline, true,
                               CubicInterpolation::SecondDerivative, 0.0,
                               CubicInterpolation::SecondDerivative, 0.0) {}
@@ -322,8 +326,10 @@ namespace QuantLib {
 
     class KrugerLogMixedLinearCubic: public LogMixedLinearCubic {
       public:
-        KrugerLogMixedLinearCubic()
-        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+        KrugerLogMixedLinearCubic(const Size n,
+                                  MixedInterpolation::Behavior behavior
+                                  = MixedInterpolation::ShareRanges)
+        : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Kruger, false,
                               CubicInterpolation::SecondDerivative, 0.0,
                               CubicInterpolation::SecondDerivative, 0.0) {}

--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -303,6 +303,32 @@ namespace QuantLib {
     };
 
     // convenience classes
+    
+    class DefaultLogMixedLinearCubic : public LogMixedLinearCubic {
+      public:
+        DefaultLogMixedLinearCubic()
+        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+                              CubicInterpolation::Kruger) {}
+    };
+
+    class MonotonicLogMixedLinearCubic : public LogMixedLinearCubic {
+      public:
+        MonotonicLogMixedLinearCubic()
+        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+                              CubicInterpolation::Spline, true,
+                              CubicInterpolation::SecondDerivative, 0.0,
+                              CubicInterpolation::SecondDerivative, 0.0) {}
+    };
+
+    class KrugerLogMixedLinearCubic: public LogMixedLinearCubic {
+      public:
+        KrugerLogMixedLinearCubic()
+        : LogMixedLinearCubic(MixedInterpolation::ShareRanges,
+                              CubicInterpolation::Kruger, false,
+                              CubicInterpolation::SecondDerivative, 0.0,
+                              CubicInterpolation::SecondDerivative, 0.0) {}
+    };
+
 
     class LogMixedLinearCubicNaturalSpline : public LogMixedLinearCubicInterpolation {
       public:

--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -126,6 +126,29 @@ namespace QuantLib {
 
     // convenience classes
 
+    class DefaultLogCubic : public LogCubic {
+      public:
+        DefaultLogCubic()
+        : LogCubic(CubicInterpolation::Kruger) {}
+    };
+
+    class MonotonicLogCubic : public LogCubic {
+      public:
+        MonotonicLogCubic()
+        : LogCubic(CubicInterpolation::Spline, true,
+                   CubicInterpolation::SecondDerivative, 0.0,
+                   CubicInterpolation::SecondDerivative, 0.0) {}
+    };
+
+    class KrugerLog : public LogCubic {
+      public:
+        KrugerLog()
+        : LogCubic(CubicInterpolation::Kruger, false,
+                   CubicInterpolation::SecondDerivative, 0.0,
+                   CubicInterpolation::SecondDerivative, 0.0) {}
+    };
+
+
     class LogCubicNaturalSpline : public LogCubicInterpolation {
       public:
         /*! \pre the \f$ x \f$ values must be sorted. */

--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -306,18 +306,18 @@ namespace QuantLib {
     
     class DefaultLogMixedLinearCubic : public LogMixedLinearCubic {
       public:
-        DefaultLogMixedLinearCubic(const Size n,
-                                   MixedInterpolation::Behavior behavior
-                                   = MixedInterpolation::ShareRanges)
+        explicit DefaultLogMixedLinearCubic(const Size n,
+                                            MixedInterpolation::Behavior behavior
+                                            = MixedInterpolation::ShareRanges)
         : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Kruger) {}
     };
 
     class MonotonicLogMixedLinearCubic : public LogMixedLinearCubic {
       public:
-        MonotonicLogMixedLinearCubic(const Size n,
-                                   MixedInterpolation::Behavior behavior
-                                   = MixedInterpolation::ShareRanges)
+        explicit MonotonicLogMixedLinearCubic(const Size n,
+                                              MixedInterpolation::Behavior behavior
+                                              = MixedInterpolation::ShareRanges)
         : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Spline, true,
                               CubicInterpolation::SecondDerivative, 0.0,
@@ -326,9 +326,9 @@ namespace QuantLib {
 
     class KrugerLogMixedLinearCubic: public LogMixedLinearCubic {
       public:
-        KrugerLogMixedLinearCubic(const Size n,
-                                  MixedInterpolation::Behavior behavior
-                                  = MixedInterpolation::ShareRanges)
+        explicit KrugerLogMixedLinearCubic(const Size n,
+                                           MixedInterpolation::Behavior behavior
+                                           = MixedInterpolation::ShareRanges)
         : LogMixedLinearCubic(n, behavior,
                               CubicInterpolation::Kruger, false,
                               CubicInterpolation::SecondDerivative, 0.0,

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -497,9 +497,7 @@ void OvernightIndexedSwapTest::testBootstrapRegression() {
     }
 
     PiecewiseYieldCurve<Discount,LogCubic> curve(0, UnitedStates(), helpers, Actual365Fixed(),
-                                                 LogCubic(CubicInterpolation::Spline, true,
-                                                          CubicInterpolation::SecondDerivative, 0.0,
-                                                          CubicInterpolation::SecondDerivative, 0.0));
+                                                 MonotonicLogCubic());
 
     BOOST_CHECK_NO_THROW(curve.discount(1.0));
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -672,14 +672,10 @@ void PiecewiseYieldCurveTest::testLogCubicDiscountConsistency() {
 
     testCurveConsistency<Discount,LogCubic,IterativeBootstrap>(
         vars,
-        LogCubic(CubicInterpolation::Spline, true,
-                 CubicInterpolation::SecondDerivative, 0.0,
-                 CubicInterpolation::SecondDerivative, 0.0));
+        MonotonicLogCubic());
     testBMACurveConsistency<Discount,LogCubic,IterativeBootstrap>(
         vars,
-        LogCubic(CubicInterpolation::Spline, true,
-                 CubicInterpolation::SecondDerivative, 0.0,
-                 CubicInterpolation::SecondDerivative, 0.0));
+        MonotonicLogCubic());
 }
 
 void PiecewiseYieldCurveTest::testLogLinearDiscountConsistency() {


### PR DESCRIPTION
Created a few convenience classes for LogCubic and LogMixedLinearCubic interpolators, taking advantage of some sensible parameters set in Quantlib-SWIG.

Fixes #827.