### PR TITLE
Exposing the Heston SLV mixingFactor parameter to Heston FD barrier o…

### DIFF
--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -37,14 +37,16 @@ namespace QuantLib {
             const ext::shared_ptr<HestonModel>& model,
             Size tGrid, Size xGrid, Size vGrid, Size dampingSteps,
             const FdmSchemeDesc& schemeDesc,
-            const ext::shared_ptr<LocalVolTermStructure>& leverageFct)
+            const ext::shared_ptr<LocalVolTermStructure>& leverageFct,
+            const Real mixingFactor)
     : GenericModelEngine<HestonModel,
                         DividendBarrierOption::arguments,
                         DividendBarrierOption::results>(model),
       tGrid_(tGrid), xGrid_(xGrid), 
       vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc),
-      leverageFct_(leverageFct) {
+      leverageFct_(leverageFct),
+      mixingFactor_(mixingFactor) {
     }
 
     void FdHestonBarrierEngine::calculate() const {
@@ -59,7 +61,7 @@ namespace QuantLib {
 
         const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
             = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
-                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps);
+                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -138,7 +140,7 @@ namespace QuantLib {
 
         ext::shared_ptr<FdmHestonSolver> solver(ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
@@ -57,7 +57,8 @@ namespace QuantLib {
             Size vGrid = 50, Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
             const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                = ext::shared_ptr<LocalVolTermStructure>());
+                = ext::shared_ptr<LocalVolTermStructure>(),
+            Real mixingFactor = 1.0);
 
         void calculate() const;
 
@@ -65,6 +66,7 @@ namespace QuantLib {
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
+        const Real mixingFactor_;
     };
 
 

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -35,14 +35,16 @@ namespace QuantLib {
             const ext::shared_ptr<HestonModel>& model,
             Size tGrid, Size xGrid, Size vGrid, Size dampingSteps,
             const FdmSchemeDesc& schemeDesc,
-            const ext::shared_ptr<LocalVolTermStructure>& leverageFct)
+            const ext::shared_ptr<LocalVolTermStructure>& leverageFct,
+            const Real mixingFactor)
     : GenericModelEngine<HestonModel,
                         DividendBarrierOption::arguments,
                         DividendBarrierOption::results>(model),
       tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), 
       dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc),
-      leverageFct_(leverageFct) {
+      leverageFct_(leverageFct),
+      mixingFactor_(mixingFactor) {
     }
 
     void FdHestonRebateEngine::calculate() const {
@@ -57,7 +59,7 @@ namespace QuantLib {
 
         const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
             = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
-                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps);
+                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -128,7 +130,7 @@ namespace QuantLib {
 
         ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestonrebateengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.hpp
@@ -52,7 +52,8 @@ namespace QuantLib {
             Size vGrid = 50, Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
             const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                = ext::shared_ptr<LocalVolTermStructure>());
+                = ext::shared_ptr<LocalVolTermStructure>(),
+            Real mixingFactor = 1.0);
 
         void calculate() const;
 
@@ -60,6 +61,7 @@ namespace QuantLib {
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
+        const Real mixingFactor_;
     };
 
 


### PR DESCRIPTION
…ption engines (FdHestonBarrierEngine, FdHestonRebateEngine).

The mixingFactor is used in the literature to calibrate vol dynamics between local and stochastic limits to correctly price first-generation exotics like barriers (eg. https://arxiv.org/pdf/1911.00877.pdf), so exposing it to these engines is highly useful.