### PR TITLE
Exposing the Heston SLV mixingFactor parameter to Heston FD Double Ba…

### DIFF
--- a/ql/experimental/finitedifferences/fdhestondoublebarrierengine.cpp
+++ b/ql/experimental/finitedifferences/fdhestondoublebarrierengine.cpp
@@ -35,14 +35,16 @@ namespace QuantLib {
             const ext::shared_ptr<HestonModel>& model,
             Size tGrid, Size xGrid, Size vGrid, Size dampingSteps,
             const FdmSchemeDesc& schemeDesc,
-            const ext::shared_ptr<LocalVolTermStructure>& leverageFct)
+            const ext::shared_ptr<LocalVolTermStructure>& leverageFct,
+            const Real mixingFactor)
     : GenericModelEngine<HestonModel,
                          DoubleBarrierOption::arguments,
                          DoubleBarrierOption::results>(model),
       tGrid_(tGrid), xGrid_(xGrid),
       vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc),
-      leverageFct_(leverageFct) {
+      leverageFct_(leverageFct),
+      mixingFactor_(mixingFactor) {
     }
 
     void FdHestonDoubleBarrierEngine::calculate() const {
@@ -60,7 +62,7 @@ namespace QuantLib {
 
         const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
             = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
-                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps);
+                  vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -111,7 +113,7 @@ namespace QuantLib {
 
         ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/experimental/finitedifferences/fdhestondoublebarrierengine.hpp
+++ b/ql/experimental/finitedifferences/fdhestondoublebarrierengine.hpp
@@ -51,7 +51,8 @@ namespace QuantLib {
             Size vGrid = 50, Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
             const ext::shared_ptr<LocalVolTermStructure>& leverageFct
-                = ext::shared_ptr<LocalVolTermStructure>());
+                = ext::shared_ptr<LocalVolTermStructure>(),
+            Real mixingFactor = 1.0);
 
         void calculate() const;
 
@@ -59,6 +60,7 @@ namespace QuantLib {
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
+        const Real mixingFactor_;
     };
 
 


### PR DESCRIPTION
…rrier Engine

Also adding mixingFactor to experimental FdHestonDoubleBarrierEngine (the single barrier FD engines had this added previously: https://github.com/lballabio/QuantLib/pull/917)

The mixingFactor is used in the literature to calibrate vol dynamics between local and stochastic limits to correctly price first-generation exotics like double barriers (eg. https://arxiv.org/pdf/1911.00877.pdf), so exposing it to these engines is useful.