### PR TITLE
small fork/rebase helper action

### DIFF
--- a/.github/workflows/fetchresetforkedrepo
+++ b/.github/workflows/fetchresetforkedrepo
@@ -1,0 +1,28 @@
+# Fetches and resets a forked quantlib repo to luigis master repo 
+name: git fetch reset quantlib fork
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # workflow accepts no Inputs
+
+jobs:
+  gitfetchreset:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the branch. In order for this to work you need to generate a personal accesss token with workflow rights in https://github.com/settings/tokens
+    # and add it under https://github.com/<yourgitname>/QuantLib/settings/secrets/actions/new having name ACTIONS_TOKEN
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.ACTIONS_TOKEN }}
+      
+    # fetch and reset from luigis master repo and afterwards push to forked repo
+    - name: git fetch reset
+      run: |
+        git remote add upstream https://github.com/lballabio/QuantLib.git
+        git fetch upstream master
+        git reset --hard upstream/master
+        git push --force origin master


### PR DESCRIPTION
Dear Luigi!

Since I was tired of 
1) manually comparing git branches and subsequently pulling the upstream (which requires a lot of clicking in github gui) 
2) always being one commit ahead and squashing this away before making my contributions
I have created this little helper action that pulls and rebases a forked quantlib repo from your master repo without the merge commit in one simple action.

I hope I'm not the only one to find that useful.