### PR TITLE
Adding AtmSpot calculation to the BlackDeltaCalculator

### DIFF
--- a/ql/experimental/fx/blackdeltacalculator.cpp
+++ b/ql/experimental/fx/blackdeltacalculator.cpp
@@ -179,6 +179,10 @@ namespace QuantLib {
         Real res=0.0;
 
         switch(atmT) {
+          case DeltaVolQuote::AtmSpot:
+            res=spot_;
+            break;
+
           case DeltaVolQuote::AtmDeltaNeutral:
             if(dt_==DeltaVolQuote::Spot || dt_==DeltaVolQuote::Fwd){
                 res=fExpPos_;


### PR DESCRIPTION
AtmSpot is missing in the BlackDeltaCalculator for FX quote conventions. Currently, requesting atmStrike() with this atm convention returns "invalid atm type"