### PR TITLE
Templating asian pricing engines on their process type

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1458,6 +1458,7 @@
     <ClInclude Include="ql\pricingengines\asian\mc_discr_arith_av_strike.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mc_discr_geom_av_price.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianengine.hpp" />
+    <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianenginebase.hpp" />
     <ClInclude Include="ql\pricingengines\barrier\all.hpp" />
     <ClInclude Include="ql\pricingengines\barrier\analyticbarrierengine.hpp" />
     <ClInclude Include="ql\pricingengines\barrier\analyticbinarybarrierengine.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2343,6 +2343,9 @@
     <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianengine.hpp">
       <Filter>pricingengines\asian</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianenginebase.hpp">
+      <Filter>pricingengines\asian</Filter>
+    </ClInclude>
     <ClInclude Include="ql\pricingengines\barrier\all.hpp">
       <Filter>pricingengines\barrier</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -1898,6 +1898,7 @@ set(QuantLib_HDR
     pricingengines/asian/mc_discr_arith_av_strike.hpp
     pricingengines/asian/mc_discr_geom_av_price.hpp
     pricingengines/asian/mcdiscreteasianengine.hpp
+    pricingengines/asian/mcdiscreteasianenginebase.hpp
     pricingengines/barrier/all.hpp
     pricingengines/barrier/analyticbarrierengine.hpp
     pricingengines/barrier/analyticbinarybarrierengine.hpp

--- a/ql/pricingengines/asian/Makefile.am
+++ b/ql/pricingengines/asian/Makefile.am
@@ -11,7 +11,8 @@ this_include_HEADERS = \
 	mc_discr_arith_av_price.hpp \
 	mc_discr_arith_av_strike.hpp \
 	mc_discr_geom_av_price.hpp \
-	mcdiscreteasianengine.hpp
+	mcdiscreteasianengine.hpp \
+	mcdiscreteasianenginebase.hpp
 
 cpp_files = \
 	analytic_cont_geom_av_price.cpp \

--- a/ql/pricingengines/asian/all.hpp
+++ b/ql/pricingengines/asian/all.hpp
@@ -9,4 +9,5 @@
 #include <ql/pricingengines/asian/mc_discr_arith_av_strike.hpp>
 #include <ql/pricingengines/asian/mc_discr_geom_av_price.hpp>
 #include <ql/pricingengines/asian/mcdiscreteasianengine.hpp>
+#include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
 

--- a/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
@@ -45,15 +45,15 @@ namespace QuantLib {
     */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteArithmeticAPEngine
-        : public MCDiscreteAveragingAsianEngine<RNG,S> {
+        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
         typedef
-        typename MCDiscreteAveragingAsianEngine<RNG,S>::path_pricer_type
+        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteArithmeticAPEngine(
@@ -105,14 +105,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<RNG,S>(process,
-                                            brownianBridge,
-                                            antitheticVariate,
-                                            controlVariate,
-                                            requiredSamples,
-                                            requiredTolerance,
-                                            maxSamples,
-                                            seed) {}
+    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
+                                                          brownianBridge,
+                                                          antitheticVariate,
+                                                          controlVariate,
+                                                          requiredSamples,
+                                                          requiredTolerance,
+                                                          maxSamples,
+                                                          seed) {}
 
     template <class RNG, class S>
     inline
@@ -172,7 +172,7 @@ namespace QuantLib {
     template <class RNG = PseudoRandom, class S = Statistics>
     class MakeMCDiscreteArithmeticAPEngine {
       public:
-        MakeMCDiscreteArithmeticAPEngine(
+        explicit MakeMCDiscreteArithmeticAPEngine(
             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process);
         // named parameters
         MakeMCDiscreteArithmeticAPEngine& withBrownianBridge(bool b = true);

--- a/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
@@ -27,6 +27,7 @@
 
 #include <ql/pricingengines/asian/mc_discr_geom_av_price.hpp>
 #include <ql/pricingengines/asian/analytic_discr_geom_av_price.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
 #include <ql/exercise.hpp>
 
 namespace QuantLib {
@@ -45,15 +46,15 @@ namespace QuantLib {
     */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteArithmeticAPEngine
-        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
+        : public MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
         typedef
-        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
+        typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteArithmeticAPEngine(
@@ -108,14 +109,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
-                                                          brownianBridge,
-                                                          antitheticVariate,
-                                                          controlVariate,
-                                                          requiredSamples,
-                                                          requiredTolerance,
-                                                          maxSamples,
-                                                          seed) {}
+    : MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>(process,
+                                                              brownianBridge,
+                                                              antitheticVariate,
+                                                              controlVariate,
+                                                              requiredSamples,
+                                                              requiredTolerance,
+                                                              maxSamples,
+                                                              seed) {}
 
     template <class RNG, class S>
     inline

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -33,14 +33,14 @@ namespace QuantLib {
     /*!  \ingroup asianengines */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteArithmeticASEngine
-        : public MCDiscreteAveragingAsianEngine<RNG,S> {
+        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
-        typedef typename MCDiscreteAveragingAsianEngine<RNG,S>::path_pricer_type
+        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteArithmeticASEngine(
@@ -84,14 +84,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<RNG,S>(process,
-                                            brownianBridge,
-                                            antitheticVariate,
-                                            false,
-                                            requiredSamples,
-                                            requiredTolerance,
-                                            maxSamples,
-                                            seed) {}
+    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
+                                                          brownianBridge,
+                                                          antitheticVariate,
+                                                          false,
+                                                          requiredSamples,
+                                                          requiredTolerance,
+                                                          maxSamples,
+                                                          seed) {}
 
     template <class RNG, class S>
     inline
@@ -124,7 +124,7 @@ namespace QuantLib {
     template <class RNG = PseudoRandom, class S = Statistics>
     class MakeMCDiscreteArithmeticASEngine {
       public:
-        MakeMCDiscreteArithmeticASEngine(
+        explicit MakeMCDiscreteArithmeticASEngine(
             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process);
         // named parameters
         MakeMCDiscreteArithmeticASEngine& withBrownianBridge(bool b = true);

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -109,12 +109,16 @@ namespace QuantLib {
                 this->arguments_.exercise);
         QL_REQUIRE(exercise, "wrong exercise given");
 
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+            ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
+                this->process_);
+        QL_REQUIRE(process, "Black-Scholes process required");
+
         return ext::shared_ptr<typename
             MCDiscreteArithmeticASEngine<RNG,S>::path_pricer_type>(
                 new ArithmeticASOPathPricer(
                     payoff->optionType(),
-                    this->process_->riskFreeRate()->discount(
-                                                        exercise->lastDate()),
+                    process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings));
     }

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -24,7 +24,8 @@
 #ifndef quantlib_mc_discrete_arithmetic_average_strike_asian_engine_hpp
 #define quantlib_mc_discrete_arithmetic_average_strike_asian_engine_hpp
 
-#include <ql/pricingengines/asian/mcdiscreteasianengine.hpp>
+#include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
 #include <ql/exercise.hpp>
 
 namespace QuantLib {
@@ -33,14 +34,14 @@ namespace QuantLib {
     /*!  \ingroup asianengines */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteArithmeticASEngine
-        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
+        : public MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
-        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
+        typedef typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteArithmeticASEngine(
@@ -84,14 +85,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
-                                                          brownianBridge,
-                                                          antitheticVariate,
-                                                          false,
-                                                          requiredSamples,
-                                                          requiredTolerance,
-                                                          maxSamples,
-                                                          seed) {}
+    : MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>(process,
+                                                              brownianBridge,
+                                                              antitheticVariate,
+                                                              false,
+                                                              requiredSamples,
+                                                              requiredTolerance,
+                                                              maxSamples,
+                                                              seed) {}
 
     template <class RNG, class S>
     inline

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -41,15 +41,15 @@ namespace QuantLib {
     */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteGeometricAPEngine
-        : public MCDiscreteAveragingAsianEngine<RNG,S> {
+        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
         typedef
-        typename MCDiscreteAveragingAsianEngine<RNG,S>::path_pricer_type
+        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteGeometricAPEngine(
@@ -93,14 +93,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<RNG,S>(process,
-                                            brownianBridge,
-                                            antitheticVariate,
-                                            false,
-                                            requiredSamples,
-                                            requiredTolerance,
-                                            maxSamples,
-                                            seed) {}
+    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
+                                                          brownianBridge,
+                                                          antitheticVariate,
+                                                          false,
+                                                          requiredSamples,
+                                                          requiredTolerance,
+                                                          maxSamples,
+                                                          seed) {}
 
 
 
@@ -135,7 +135,7 @@ namespace QuantLib {
     template <class RNG = PseudoRandom, class S = Statistics>
     class MakeMCDiscreteGeometricAPEngine {
       public:
-        MakeMCDiscreteGeometricAPEngine(
+        explicit MakeMCDiscreteGeometricAPEngine(
             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process);
         // named parameters
         MakeMCDiscreteGeometricAPEngine& withBrownianBridge(bool b = true);

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -120,13 +120,17 @@ namespace QuantLib {
                 this->arguments_.exercise);
         QL_REQUIRE(exercise, "wrong exercise given");
 
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+            ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
+                this->process_);
+        QL_REQUIRE(process, "Black-Scholes process required");
+
         return ext::shared_ptr<typename
             MCDiscreteGeometricAPEngine<RNG,S>::path_pricer_type>(
                 new GeometricAPOPathPricer(
                     payoff->optionType(),
                     payoff->strike(),
-                    this->process_->riskFreeRate()->discount(
-                                                        exercise->lastDate()),
+                    process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings));
     }

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -26,9 +26,10 @@
 #ifndef quantlib_mc_discrete_geometric_average_price_asian_engine_h
 #define quantlib_mc_discrete_geometric_average_price_asian_engine_h
 
-#include <ql/pricingengines/asian/mcdiscreteasianengine.hpp>
+#include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvariancecurve.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
 #include <ql/exercise.hpp>
 
 namespace QuantLib {
@@ -41,15 +42,15 @@ namespace QuantLib {
     */
     template <class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteGeometricAPEngine
-        : public MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S> {
+        : public MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S> {
       public:
         typedef
-        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_generator_type
+        typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_generator_type
             path_generator_type;
         typedef
-        typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::path_pricer_type
+        typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>::stats_type
+        typedef typename MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteGeometricAPEngine(
@@ -93,14 +94,14 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : MCDiscreteAveragingAsianEngine<SingleVariate,RNG,S>(process,
-                                                          brownianBridge,
-                                                          antitheticVariate,
-                                                          false,
-                                                          requiredSamples,
-                                                          requiredTolerance,
-                                                          maxSamples,
-                                                          seed) {}
+    : MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>(process,
+                                                              brownianBridge,
+                                                              antitheticVariate,
+                                                              false,
+                                                              requiredSamples,
+                                                              requiredTolerance,
+                                                              maxSamples,
+                                                              seed) {}
 
 
 

--- a/ql/pricingengines/asian/mcdiscreteasianengine.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianengine.hpp
@@ -33,29 +33,20 @@
 
 namespace QuantLib {
 
-
     //! Pricing engine for discrete average Asians using Monte Carlo simulation
-    /*! \warning control-variate calculation is disabled under VC++6.
+    /*! \deprecated Use MCDiscreteAveragingAsianEngineBase instead.
+                    Deprecated in version 1.21.
 
         \ingroup asianengines
     */
-
-    /*! \deprecated Use MCDiscreteAveragingAsianEngineBase instead.
-                    Deprecated in version 1.21.
-    */
     template<class RNG = PseudoRandom, class S = Statistics>
     class QL_DEPRECATED MCDiscreteAveragingAsianEngine :
-                                public DiscreteAveragingAsianOption::engine,
-                                public McSimulation<SingleVariate,RNG,S> {
+                                public MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S> {
       public:
-        typedef
-        typename McSimulation<SingleVariate,RNG,S>::path_generator_type
-            path_generator_type;
-        typedef typename McSimulation<SingleVariate,RNG,S>::path_pricer_type
-            path_pricer_type;
-        typedef typename McSimulation<SingleVariate,RNG,S>::stats_type
-            stats_type;
-        // constructor
+        typedef typename McSimulation<SingleVariate,RNG,S>::path_generator_type path_generator_type;
+        typedef typename McSimulation<SingleVariate,RNG,S>::path_pricer_type path_pricer_type;
+        typedef typename McSimulation<SingleVariate,RNG,S>::stats_type stats_type;
+
         MCDiscreteAveragingAsianEngine(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
              bool brownianBridge,
@@ -64,119 +55,16 @@ namespace QuantLib {
              Size requiredSamples,
              Real requiredTolerance,
              Size maxSamples,
-             BigNatural seed);
-        void calculate() const {
-            try {
-                McSimulation<SingleVariate,RNG,S>::calculate(
-                                                         requiredTolerance_,
-                                                         requiredSamples_,
-                                                         maxSamples_);
-            } catch (detail::PastFixingsOnly&) {
-                // Ideally, here we could calculate the payoff (which
-                // is fully determine) and write it into the results.
-                // This would probably need a new virtual method that
-                // derived engines should implement.
-                throw;
-            }
-
-            results_.value = this->mcModel_->sampleAccumulator().mean();
-            
-            if (this->controlVariate_) {
-                // control variate might lead to small negative
-                // option values for deep OTM options
-                this->results_.value = std::max(0.0, this->results_.value);
-            }
-                
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
-        }
-      protected:
-        // McSimulation implementation
-        TimeGrid timeGrid() const;
-        ext::shared_ptr<path_generator_type> pathGenerator() const {
-
-            TimeGrid grid = this->timeGrid();
-            typename RNG::rsg_type gen =
-                RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
-        }
-        Real controlVariateValue() const;
-        // data members
-        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
-        Size requiredSamples_, maxSamples_;
-        Real requiredTolerance_;
-        bool brownianBridge_;
-        BigNatural seed_;
-    };
-
-
-    // template definitions
-
-    template<class RNG, class S>
-    inline
-    MCDiscreteAveragingAsianEngine<RNG,S>::MCDiscreteAveragingAsianEngine(
-             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
-             bool brownianBridge,
-             bool antitheticVariate,
-             bool controlVariate,
-             Size requiredSamples,
-             Real requiredTolerance,
-             Size maxSamples,
              BigNatural seed)
-    : McSimulation<SingleVariate,RNG,S>(antitheticVariate, controlVariate),
-      process_(process), requiredSamples_(requiredSamples),
-      maxSamples_(maxSamples), requiredTolerance_(requiredTolerance),
-      brownianBridge_(brownianBridge), seed_(seed) {
-        registerWith(process_);
-    }
-
-    template <class RNG, class S>
-    inline TimeGrid MCDiscreteAveragingAsianEngine<RNG,S>::timeGrid() const {
-
-        Date referenceDate = process_->riskFreeRate()->referenceDate();
-        DayCounter voldc = process_->blackVolatility()->dayCounter();
-        std::vector<Time> fixingTimes;
-        Size i;
-        for (i=0; i<arguments_.fixingDates.size(); i++) {
-            if (arguments_.fixingDates[i]>=referenceDate) {
-                Time t = voldc.yearFraction(referenceDate,
-                    arguments_.fixingDates[i]);
-                fixingTimes.push_back(t);
-            }
-        }
-
-        if (fixingTimes.empty() ||
-            (fixingTimes.size() == 1 && fixingTimes.front() == 0.0))
-            throw detail::PastFixingsOnly();
-
-        return TimeGrid(fixingTimes.begin(), fixingTimes.end());
-    }
-
-    template<class RNG, class S>
-    inline
-    Real MCDiscreteAveragingAsianEngine<RNG,S>::controlVariateValue() const {
-
-        ext::shared_ptr<PricingEngine> controlPE =
-                this->controlPricingEngine();
-            QL_REQUIRE(controlPE,
-                       "engine does not provide "
-                       "control variation pricing engine");
-
-            DiscreteAveragingAsianOption::arguments* controlArguments =
-                dynamic_cast<DiscreteAveragingAsianOption::arguments*>(
-                    controlPE->getArguments());
-            *controlArguments = arguments_;
-            controlPE->calculate();
-
-            const DiscreteAveragingAsianOption::results* controlResults =
-                dynamic_cast<const DiscreteAveragingAsianOption::results*>(
-                    controlPE->getResults());
-
-            return controlResults->value;
-    }
+        : MCDiscreteAveragingAsianEngineBase<SingleVariate,RNG,S>(
+            process, brownianBridge, antitheticVariate, controlVariate,
+            requiredSamples, requiredTolerance, maxSamples, seed),
+          process_(process) {}
+      protected:
+        // This hides the one in the base class and gives it the
+        // "correct" type for existing client code.
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+    };
 
 }
 

--- a/ql/pricingengines/asian/mcdiscreteasianengine.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianengine.hpp
@@ -49,17 +49,18 @@ namespace QuantLib {
 
         \ingroup asianengines
     */
-    template<class RNG = PseudoRandom, class S = Statistics>
+    template<template <class> class MC,
+             class RNG = PseudoRandom, class S = Statistics>
     class MCDiscreteAveragingAsianEngine :
                                 public DiscreteAveragingAsianOption::engine,
-                                public McSimulation<SingleVariate,RNG,S> {
+                                public McSimulation<MC,RNG,S> {
       public:
         typedef
-        typename McSimulation<SingleVariate,RNG,S>::path_generator_type
+        typename McSimulation<MC,RNG,S>::path_generator_type
             path_generator_type;
-        typedef typename McSimulation<SingleVariate,RNG,S>::path_pricer_type
+        typedef typename McSimulation<MC,RNG,S>::path_pricer_type
             path_pricer_type;
-        typedef typename McSimulation<SingleVariate,RNG,S>::stats_type
+        typedef typename McSimulation<MC,RNG,S>::stats_type
             stats_type;
         // constructor
         MCDiscreteAveragingAsianEngine(
@@ -73,10 +74,9 @@ namespace QuantLib {
              BigNatural seed);
         void calculate() const {
             try {
-                McSimulation<SingleVariate,RNG,S>::calculate(
-                                                         requiredTolerance_,
-                                                         requiredSamples_,
-                                                         maxSamples_);
+                McSimulation<MC,RNG,S>::calculate(requiredTolerance_,
+                                                  requiredSamples_,
+                                                  maxSamples_);
             } catch (detail::PastFixingsOnly&) {
                 // Ideally, here we could calculate the payoff (which
                 // is fully determine) and write it into the results.
@@ -121,9 +121,9 @@ namespace QuantLib {
 
     // template definitions
 
-    template<class RNG, class S>
+    template<template <class> class MC, class RNG, class S>
     inline
-    MCDiscreteAveragingAsianEngine<RNG,S>::MCDiscreteAveragingAsianEngine(
+    MCDiscreteAveragingAsianEngine<MC,RNG,S>::MCDiscreteAveragingAsianEngine(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
              bool brownianBridge,
              bool antitheticVariate,
@@ -132,15 +132,15 @@ namespace QuantLib {
              Real requiredTolerance,
              Size maxSamples,
              BigNatural seed)
-    : McSimulation<SingleVariate,RNG,S>(antitheticVariate, controlVariate),
+    : McSimulation<MC,RNG,S>(antitheticVariate, controlVariate),
       process_(process), requiredSamples_(requiredSamples),
       maxSamples_(maxSamples), requiredTolerance_(requiredTolerance),
       brownianBridge_(brownianBridge), seed_(seed) {
         registerWith(process_);
     }
 
-    template <class RNG, class S>
-    inline TimeGrid MCDiscreteAveragingAsianEngine<RNG,S>::timeGrid() const {
+    template <template <class> class MC, class RNG, class S>
+    inline TimeGrid MCDiscreteAveragingAsianEngine<MC,RNG,S>::timeGrid() const {
 
         Date referenceDate = process_->riskFreeRate()->referenceDate();
         DayCounter voldc = process_->blackVolatility()->dayCounter();
@@ -161,9 +161,9 @@ namespace QuantLib {
         return TimeGrid(fixingTimes.begin(), fixingTimes.end());
     }
 
-    template<class RNG, class S>
+    template<template <class> class MC, class RNG, class S>
     inline
-    Real MCDiscreteAveragingAsianEngine<RNG,S>::controlVariateValue() const {
+    Real MCDiscreteAveragingAsianEngine<MC,RNG,S>::controlVariateValue() const {
 
         ext::shared_ptr<PricingEngine> controlPE =
                 this->controlPricingEngine();

--- a/ql/pricingengines/asian/mcdiscreteasianengine.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianengine.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
             stats_type;
         // constructor
         MCDiscreteAveragingAsianEngine(
-             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const ext::shared_ptr<StochasticProcess>& process,
              bool brownianBridge,
              bool antitheticVariate,
              bool controlVariate,
@@ -111,7 +111,7 @@ namespace QuantLib {
         }
         Real controlVariateValue() const;
         // data members
-        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        ext::shared_ptr<StochasticProcess> process_;
         Size requiredSamples_, maxSamples_;
         Real requiredTolerance_;
         bool brownianBridge_;
@@ -124,7 +124,7 @@ namespace QuantLib {
     template<template <class> class MC, class RNG, class S>
     inline
     MCDiscreteAveragingAsianEngine<MC,RNG,S>::MCDiscreteAveragingAsianEngine(
-             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const ext::shared_ptr<StochasticProcess>& process,
              bool brownianBridge,
              bool antitheticVariate,
              bool controlVariate,
@@ -142,14 +142,11 @@ namespace QuantLib {
     template <template <class> class MC, class RNG, class S>
     inline TimeGrid MCDiscreteAveragingAsianEngine<MC,RNG,S>::timeGrid() const {
 
-        Date referenceDate = process_->riskFreeRate()->referenceDate();
-        DayCounter voldc = process_->blackVolatility()->dayCounter();
         std::vector<Time> fixingTimes;
         Size i;
         for (i=0; i<arguments_.fixingDates.size(); i++) {
-            if (arguments_.fixingDates[i]>=referenceDate) {
-                Time t = voldc.yearFraction(referenceDate,
-                    arguments_.fixingDates[i]);
+            Time t = process_->time(arguments_.fixingDates[i]);
+            if (t>=0) {
                 fixingTimes.push_back(t);
             }
         }


### PR DESCRIPTION
I'd like to add a Heston MC pricer for arithmetic asian options, in order to re-use mcdiscreteasianengine.hpp as a parent class I need to template it to the process type (SingleVariate vs. MultiVariate).

Hopefully this commit change won't change any current behaviour. But subsequent work will be easier.