### PR TITLE
More functions to support both clean and dirty prices as input parameter

### DIFF
--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -242,6 +242,15 @@ namespace QuantLib {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
+        return dirtyPrice(bond, discountCurve, settlement) - bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const YieldTermStructure& discountCurve,
+                                   Date settlement) {
+        if (settlement == Date())
+            settlement = bond.settlementDate();
+
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
                    "non tradable at " << settlement <<
                    " settlement date (maturity being " <<
@@ -250,7 +259,7 @@ namespace QuantLib {
         Real dirtyPrice = CashFlows::npv(bond.cashflows(), discountCurve,
                                          false, settlement) *
             100.0 / bond.notional(settlement);
-        return dirtyPrice - bond.accruedAmount(settlement);
+        return dirtyPrice;
     }
 
     Real BondFunctions::bps(const Bond& bond,
@@ -271,7 +280,8 @@ namespace QuantLib {
     Rate BondFunctions::atmRate(const Bond& bond,
                                 const YieldTermStructure& discountCurve,
                                 Date settlement,
-                                Real cleanPrice) {
+                                Real price,
+                                const Bond::Price::Type priceType) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
@@ -279,15 +289,23 @@ namespace QuantLib {
                    "non tradable at " << settlement <<
                    " (maturity being " << bond.maturityDate() << ")");
 
-        Real dirtyPrice = cleanPrice==Null<Real>() ? Null<Real>() :
-                          cleanPrice + bond.accruedAmount(settlement);
-        Real currentNotional = bond.notional(settlement);
-        Real npv = dirtyPrice==Null<Real>() ? Null<Real>() :
-                                              dirtyPrice/100.0 * currentNotional;
+        if (price == Null<Real>())
+            return CashFlows::atmRate(bond.cashflows(), discountCurve,
+                                      false, settlement, settlement,
+                                      Null<Real>());
+        else {
+            Real dirtyPrice = price;
 
-        return CashFlows::atmRate(bond.cashflows(), discountCurve,
-                                  false, settlement, settlement,
-                                  npv);
+            if (priceType == Bond::Price::Clean)
+                dirtyPrice += bond.accruedAmount(settlement);
+
+            Real currentNotional = bond.notional(settlement);
+            Real npv = dirtyPrice / 100.0 * currentNotional;
+
+            return CashFlows::atmRate(bond.cashflows(), discountCurve,
+                                      false, settlement, settlement,
+                                      npv);
+        }
     }
 
     Real BondFunctions::cleanPrice(const Bond& bond,
@@ -485,6 +503,19 @@ namespace QuantLib {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
+        return dirtyPrice(bond, d, zSpread, dc, comp, freq, settlement) - bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter& dc,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        if (settlement == Date())
+            settlement = bond.settlementDate();
+
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
                    "non tradable at " << settlement <<
                    " (maturity being " << bond.maturityDate() << ")");
@@ -493,11 +524,27 @@ namespace QuantLib {
                                          zSpread, dc, comp, freq,
                                          false, settlement) *
             100.0 / bond.notional(settlement);
-        return dirtyPrice - bond.accruedAmount(settlement);
+        return dirtyPrice;
     }
 
     Spread BondFunctions::zSpread(const Bond& bond,
                                   Real cleanPrice,
+                                  const ext::shared_ptr<YieldTermStructure>& d,
+                                  const DayCounter& dayCounter,
+                                  Compounding compounding,
+                                  Frequency frequency,
+                                  Date settlement,
+                                  Real accuracy,
+                                  Size maxIterations,
+                                  Rate guess) {
+
+        return zSpread(bond, cleanPrice, Bond::Price::Clean, d, dayCounter, compounding, frequency,
+                       settlement, accuracy, maxIterations, guess);
+    }
+
+    Spread BondFunctions::zSpread(const Bond& bond,
+                                  Real price,
+                                  const Bond::Price::Type priceType,
                                   const ext::shared_ptr<YieldTermStructure>& d,
                                   const DayCounter& dayCounter,
                                   Compounding compounding,
@@ -513,7 +560,9 @@ namespace QuantLib {
                    "non tradable at " << settlement <<
                    " (maturity being " << bond.maturityDate() << ")");
 
-        Real dirtyPrice = cleanPrice + bond.accruedAmount(settlement);
+        Real dirtyPrice = price +
+            (priceType == Bond::Price::Clean ? bond.accruedAmount(settlement) : 0);
+
         dirtyPrice /= 100.0 / bond.notional(settlement);
 
         return CashFlows::zSpread(bond.cashflows(),
@@ -523,5 +572,4 @@ namespace QuantLib {
                                   false, settlement, settlement,
                                   accuracy, maxIterations, guess);
     }
-
 }

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -108,13 +108,17 @@ namespace QuantLib {
         static Real cleanPrice(const Bond& bond,
                                const YieldTermStructure& discountCurve,
                                Date settlementDate = Date());
+        static Real dirtyPrice(const Bond& bond,
+                               const YieldTermStructure& discountCurve,
+                               Date settlementDate = Date());
         static Real bps(const Bond& bond,
                         const YieldTermStructure& discountCurve,
                         Date settlementDate = Date());
         static Rate atmRate(const Bond& bond,
                             const YieldTermStructure& discountCurve,
                             Date settlementDate = Date(),
-                            Real cleanPrice = Null<Real>());
+                            Real price = Null<Real>(),
+                            Bond::Price::Type priceType = Bond::Price::Clean);
         //@}
 
         //! \name Yield (a.k.a. Internal Rate of Return, i.e. IRR) functions
@@ -235,8 +239,29 @@ namespace QuantLib {
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
+        static Real dirtyPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
+                               const DayCounter& dayCounter,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+
+        QL_DEPRECATED
         static Spread zSpread(const Bond& bond,
                               Real cleanPrice,
+                              const ext::shared_ptr<YieldTermStructure>&,
+                              const DayCounter& dayCounter,
+                              Compounding compounding,
+                              Frequency frequency,
+                              Date settlementDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+
+        static Spread zSpread(const Bond& bond,
+                              Real price,
+                              Bond::Price::Type priceType,
                               const ext::shared_ptr<YieldTermStructure>&,
                               const DayCounter& dayCounter,
                               Compounding compounding,


### PR DESCRIPTION
I noticed some more bond functions that currently accept only a clean price. This PR extends them to accept either dirty or clean price and adds the relevant `priceType` parameter.
