### PR TITLE
Adding a vanilla control variate to the Heston forward start MC pricer

### DIFF
--- a/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
@@ -27,7 +27,13 @@
 
 namespace QuantLib {
 
-    /*! \ingroup forwardengines
+    /*! References:
+
+        Control Variate trade-off considerations discussed in pull request:
+        https://github.com/lballabio/QuantLib/pull/948
+
+        \ingroup forwardengines
+
         \test
         - Heston MC prices for a flat Heston process are
           compared to analytical BS prices with the same

--- a/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
@@ -21,7 +21,9 @@
 #define quantlib_mc_forward_european_heston_engine_hpp
 
 #include <ql/pricingengines/forward/mcforwardvanillaengine.hpp>
+#include <ql/pricingengines/vanilla/analytichestonengine.hpp>
 #include <ql/processes/hestonprocess.hpp>
+#include <ql/models/equity/hestonmodel.hpp>
 
 namespace QuantLib {
 
@@ -56,9 +58,22 @@ namespace QuantLib {
              Size requiredSamples,
              Real requiredTolerance,
              Size maxSamples,
-             BigNatural seed);
+             BigNatural seed,
+             bool controlVariate = false);
       protected:
         ext::shared_ptr<path_pricer_type> pathPricer() const;
+
+        // Use the vanilla option running from t=0 to t=expiryTime with an analytic Heston pricer
+        // as a control variate. Works well if resetTime small.
+        ext::shared_ptr<path_pricer_type> controlPathPricer() const;
+        ext::shared_ptr<PricingEngine> controlPricingEngine() const {
+            ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
+            QL_REQUIRE(process, "Heston-like process required");
+
+            ext::shared_ptr<HestonModel> hestonModel(new HestonModel(process));
+            return ext::shared_ptr<PricingEngine>(new
+                AnalyticHestonEngine(hestonModel));
+        }
     };
 
 
@@ -75,11 +90,12 @@ namespace QuantLib {
         MakeMCForwardEuropeanHestonEngine& withMaxSamples(Size samples);
         MakeMCForwardEuropeanHestonEngine& withSeed(BigNatural seed);
         MakeMCForwardEuropeanHestonEngine& withAntitheticVariate(bool b = true);
+        MakeMCForwardEuropeanHestonEngine& withControlVariate(bool b = false);
         // conversion to pricing engine
         operator ext::shared_ptr<PricingEngine>() const;
       private:
         ext::shared_ptr<P> process_;
-        bool antithetic_;
+        bool antithetic_, controlVariate_;
         Size steps_, stepsPerYear_, samples_, maxSamples_;
         Real tolerance_;
         BigNatural seed_;
@@ -104,8 +120,7 @@ namespace QuantLib {
     // inline definitions
 
     template <class RNG, class S, class P>
-    inline
-    MCForwardEuropeanHestonEngine<RNG,S,P>::MCForwardEuropeanHestonEngine(
+    inline MCForwardEuropeanHestonEngine<RNG,S,P>::MCForwardEuropeanHestonEngine(
              const ext::shared_ptr<P>& process,
              Size timeSteps,
              Size timeStepsPerYear,
@@ -113,7 +128,8 @@ namespace QuantLib {
              Size requiredSamples,
              Real requiredTolerance,
              Size maxSamples,
-             BigNatural seed)
+             BigNatural seed,
+             bool controlVariate)
     : MCForwardVanillaEngine<MultiVariate,RNG,S>(process,
                                                  timeSteps,
                                                  timeStepsPerYear,
@@ -122,12 +138,12 @@ namespace QuantLib {
                                                  requiredSamples,
                                                  requiredTolerance,
                                                  maxSamples,
-                                                 seed) {}
+                                                 seed,
+                                                 controlVariate) {}
 
 
     template <class RNG, class S, class P>
-    inline
-    ext::shared_ptr<typename MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>
+    inline ext::shared_ptr<typename MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>
         MCForwardEuropeanHestonEngine<RNG,S,P>::pathPricer() const {
 
         TimeGrid timeGrid = this->timeGrid();
@@ -159,13 +175,45 @@ namespace QuantLib {
                                                    timeGrid.back())));
     }
 
+    template <class RNG, class S, class P>
+    inline ext::shared_ptr<typename MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>
+        MCForwardEuropeanHestonEngine<RNG,S,P>::controlPathPricer() const {
+
+        // Control variate prices a vanilla option on the path, and compares to analytical Heston
+        // vanilla price. First entry in TimeGrid is 0, so use the existing path pricer reset at 0
+        Size resetIndex = 0;
+        TimeGrid timeGrid = this->timeGrid();
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(
+                this->arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        ext::shared_ptr<EuropeanExercise> exercise =
+            ext::dynamic_pointer_cast<EuropeanExercise>(
+                this->arguments_.exercise);
+        QL_REQUIRE(exercise, "wrong exercise given");
+
+        ext::shared_ptr<P> process =
+            ext::dynamic_pointer_cast<P>(this->process_);
+        QL_REQUIRE(process, "Heston like process required");
+
+        return ext::shared_ptr<typename
+            MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
+                new ForwardEuropeanHestonPathPricer(
+                                        payoff->optionType(),
+                                        this->arguments_.moneyness,
+                                        resetIndex,
+                                        process->riskFreeRate()->discount(
+                                                   timeGrid.back())));
+    }
 
     template <class RNG, class S, class P>
     inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>::MakeMCForwardEuropeanHestonEngine(
              const ext::shared_ptr<P>& process)
     : process_(process), antithetic_(false), steps_(Null<Size>()),
       stepsPerYear_(Null<Size>()), samples_(Null<Size>()), maxSamples_(Null<Size>()),
-      tolerance_(Null<Real>()), seed_(0) {}
+      tolerance_(Null<Real>()), seed_(0), controlVariate_(false) {}
 
     template <class RNG, class S, class P>
     inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>&
@@ -225,8 +273,14 @@ namespace QuantLib {
     }
 
     template <class RNG, class S, class P>
-    inline
-    MakeMCForwardEuropeanHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>()
+    inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>&
+    MakeMCForwardEuropeanHestonEngine<RNG,S,P>::withControlVariate(bool b) {
+        controlVariate_ = b;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>()
                                                                       const {
         QL_REQUIRE(steps_ != Null<Size>() || stepsPerYear_ != Null<Size>(),
                    "number of steps not given");
@@ -240,9 +294,9 @@ namespace QuantLib {
                                                    samples_,
                                                    tolerance_,
                                                    maxSamples_,
-                                                   seed_));
+                                                   seed_,
+                                                   controlVariate_));
     }
-
 }
 
 

--- a/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
@@ -211,9 +211,9 @@ namespace QuantLib {
     template <class RNG, class S, class P>
     inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>::MakeMCForwardEuropeanHestonEngine(
              const ext::shared_ptr<P>& process)
-    : process_(process), antithetic_(false), steps_(Null<Size>()),
+    : process_(process), antithetic_(false), controlVariate_(false), steps_(Null<Size>()),
       stepsPerYear_(Null<Size>()), samples_(Null<Size>()), maxSamples_(Null<Size>()),
-      tolerance_(Null<Real>()), seed_(0), controlVariate_(false) {}
+      tolerance_(Null<Real>()), seed_(0) {}
 
     template <class RNG, class S, class P>
     inline MakeMCForwardEuropeanHestonEngine<RNG,S,P>&

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -775,6 +775,13 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
                .withSamples(numberOfSamples)
                .withSeed(mcSeed);
 
+      ext::shared_ptr<PricingEngine> mcEngineCv
+         = MakeMCForwardEuropeanHestonEngine<PseudoRandom>(hestonProcess)
+               .withSteps(timeSteps)
+               .withSamples(numberOfSamples)
+               .withSeed(mcSeed)
+               .withControlVariate(true);
+
        ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticEngine(
            new AnalyticHestonForwardEuropeanEngine(hestonProcess));
 
@@ -789,12 +796,22 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
 
          option.setPricingEngine(mcEngine);
          Real mcPrice = option.NPV();
-
          Real error = relativeError(analyticPrice, mcPrice, s);
+
          if (error > tolerance) {
                REPORT_FAILURE("testHestonMCVsAnalyticPrices", payoff, exercise, s,
                               q, r, today, vol, moneyness[j], reset,
                               analyticPrice, mcPrice, error, tolerance);
+         }
+
+         option.setPricingEngine(mcEngineCv);
+         Real mcPriceCv = option.NPV();
+
+         Real errorCv = relativeError(analyticPrice, mcPriceCv, s);
+         if (errorCv > tolerance) {
+               REPORT_FAILURE("testHestonMCControlVariateVsAnalyticPrices", payoff, exercise, s,
+                              q, r, today, vol, moneyness[j], reset,
+                              analyticPrice, mcPrice, errorCv, tolerance);
          }
       }
    }


### PR DESCRIPTION
For well-behaved Heston parameters and nearby reset dates, using a vanilla option with the same expiry date and an analytic Heston pricer can provide a significant improvement in MC convergence.

Shown here is an option starting on 24th Nov 2020 and expiring 1 year later, with MC prices with and without CV for several reset dates. As expected, convergence is significantly improved for nearby reset dates, and not much for far away reset dates. Heston params here are v0: 0.09, kappa: 1.15, theta: 0.348, sigma: 0.39, rho: -0.64, and additionally r=0.5%, q=3%, spot=100, k=1.1.

![image](https://user-images.githubusercontent.com/10614716/100536859-5e93ef00-325e-11eb-9c9d-0f63290345f7.png)
![image](https://user-images.githubusercontent.com/10614716/100536871-6e133800-325e-11eb-8837-4333bae50e38.png)

Variance reduction coming from use of control variates is determined mostly by the correlation of the path prices of the two securities and scales as (1-correlation^2), so when correlation is below ~70% the additional work pricing the second security probably outweighs the benefits (eg. Glasserman pg. 187). The reset date at which correlation falls below this level is a strong function of the Heston params, as shown below for two sets of parameters:

![image](https://user-images.githubusercontent.com/10614716/100536968-44a6dc00-325f-11eb-8403-3e804bc202b1.png)




