### PR TITLE
Forcing specification of timeSteps for MC Arithmetic Asian Heston Pricer

### DIFF
--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/pricingengines/mcsimulation.hpp>
 #include <ql/instruments/asianoption.hpp>
+#include <ql/exercise.hpp>
 
 namespace QuantLib {
 
@@ -98,6 +99,9 @@ namespace QuantLib {
             if (RNG::allowsErrorEstimate)
             results_.errorEstimate =
                 this->mcModel_->sampleAccumulator().errorEstimate();
+
+            // Allow inspection of the timeGrid via additional results
+            this->results_.additionalResults["TimeGrid"] = this->timeGrid();
         }
       protected:
         // McSimulation implementation

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -751,7 +751,6 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
-                .withSteps(12)
                 .withSamples(32768);
 
         DiscreteAveragingAsianOption option(averageType, runningSum,

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -751,6 +751,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSteps(12)
                 .withSamples(32768);
 
         DiscreteAveragingAsianOption option(averageType, runningSum,


### PR DESCRIPTION
I was investigating the behaviour of the recently-added MC Arithmetic Asian Heston Pricer (https://github.com/lballabio/QuantLib/pull/941), and realised I'd overlooked allowing user to specify number of time steps used in the discretization. By default, it just uses one per fixing, but user might wish to create a more finely grained mesh. For BS it's not important as the propagator distributions are gaussian, but for Heston things are not so straightforward.

I have a proposal here that will fix, but there are a couple of issues to consider:

1) In this adjustment, I've made it compulsory to specify number of steps (for Heston). Perhaps this is too strict, and it should default to the number of fixings, with an option to specify additional steps?

2) This change will break the existing implementation of the MC Heston pricer, but as it's only ten days old I thought this was a price worth paying to keep `timeSteps` and `timeStepsPerYear` in the same place in the parameter list as they live for other similar classes, but this too could easily be changed