### PR TITLE
Modified ExponentialSplinesFitting to handle variable coeffs and fixed kappa

### DIFF
--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -275,6 +275,19 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts6);
 
+        //Fixed kappa, and 7 coefficients
+        ExponentialSplinesFitting exponentialSplinesFixed(constrainAtZero,7,0.02);
+
+        ext::shared_ptr<FittedBondDiscountCurve> ts7(
+                        new FittedBondDiscountCurve(curveSettlementDays,
+                                                    calendar, 
+                                                    instrumentsA, 
+                                                    dc, 
+                                                    exponentialSplinesFixed, 
+                                                    tolerance, 
+                                                    max));
+
+        printOutput("(g) exponential splines, fixed kappa", ts7);
 
         cout << "Output par rates for each curve. In this case, "
              << endl
@@ -290,7 +303,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -333,7 +347,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts5,keyDates,dc)  << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts6,keyDates,dc) << endl;
+                 << 100.*parRate(*ts6,keyDates,dc) << " | "
+                 // Exponential, fixed kappa
+                 << setw(6) << fixed << setprecision(3) 
+                 << 100. *parRate(*ts7, keyDates, dc) << endl;
         }
 
         cout << endl << endl << endl;
@@ -362,6 +379,8 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts6);
 
+        printOutput("(g) exponential spline, fixed kappa", ts7);
+
         cout << endl
              << endl;
 
@@ -374,7 +393,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -417,7 +437,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts5,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts6,keyDates,dc) << endl;
+                 << 100.*parRate(*ts6,keyDates,dc) << " | "
+                 // exponential, fixed kappa
+                 << setw(6) << fixed << setprecision(3) 
+                 << 100. * parRate(*ts7, keyDates, dc) << endl;
         }
 
         cout << endl << endl << endl;
@@ -512,6 +535,17 @@ int main(int, char* []) {
 
         printOutput("(f) Nelson-Siegel spreaded", ts66);
 
+        ext::shared_ptr<FittedBondDiscountCurve> ts77(
+                        new FittedBondDiscountCurve(curveSettlementDays, 
+                                                    calendar, 
+                                                    instrumentsA, 
+                                                    dc, 
+                                                    exponentialSplinesFixed, 
+                                                    tolerance, 
+                                                    max));
+
+        printOutput("(g) exponential, fixed kappa", ts77);
+
         cout << setw(6) << "tenor" << " | "
              << setw(6) << "coupon" << " | "
              << setw(6) << "bstrap" << " | "
@@ -520,7 +554,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -563,7 +598,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts55,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts66,keyDates,dc) << endl;
+                 << 100.*parRate(*ts66,keyDates,dc) << " | "
+                 // exponential, fixed kappa
+                 << setw(6) << fixed << setprecision(3) 
+                 << 100. *parRate(*ts77, keyDates, dc) << endl;
         }
 
 
@@ -602,7 +640,8 @@ int main(int, char* []) {
              << setw(6) << "(c)" << " | "
              << setw(6) << "(d)" << " | "
              << setw(6) << "(e)" << " | "
-             << setw(6) << "(f)" << endl;
+             << setw(6) << "(f)" << " | "
+             << setw(6) << "(g)" << endl;
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
@@ -645,7 +684,10 @@ int main(int, char* []) {
                  << 100.*parRate(*ts55,keyDates,dc) << " | "
                  // Nelson-Siegel Spreaded
                  << setw(6) << fixed << setprecision(3)
-                 << 100.*parRate(*ts66,keyDates,dc) << endl;
+                 << 100.*parRate(*ts66,keyDates,dc) << " | "
+                 // exponential spline, fixed kappa
+                 << setw(6) << fixed << setprecision(3) 
+                 << 100. *parRate(*ts77, keyDates, dc) << endl;
         }
 
         return 0;

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
           constrainAtZero, weights, optimizationMethod, l2, minCutoffTime, maxCutoffTime),
           numCoeffs_(numCoeffs), fixedKappa_(fixedKappa) 
     {
-        if (numCoeffs_ <= 0)
-            numCoeffs_ = 9;
+        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
@@ -51,8 +50,7 @@ namespace QuantLib {
                                                  minCutoffTime, maxCutoffTime),
           numCoeffs_(numCoeffs),fixedKappa_(fixedKappa) 
     {
-        if (numCoeffs_ <= 0) 
-            numCoeffs_ = 9;
+        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
@@ -62,8 +60,7 @@ namespace QuantLib {
     : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, ext::shared_ptr<OptimizationMethod>(), Array(),0.0,QL_MAX_REAL),
           numCoeffs_(numCoeffs), fixedKappa_(fixedKappa)
     {
-        if (numCoeffs_ <= 0)
-            numCoeffs_ = 9;
+        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     QL_UNIQUE_OR_AUTO_PTR<FittedBondDiscountCurve::FittingMethod>

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -72,7 +72,7 @@ namespace QuantLib {
     Size ExponentialSplinesFitting::size() const {
         Size N = constrainAtZero_ ? numCoeffs_ : numCoeffs_ + 1;
         
-        return (fixedKappa_ != QL_NULL_REAL) ? N-1 : N; //One fewer optimization parameters if kappa is fixed
+        return (fixedKappa_ != Null<Real>()) ? N-1 : N; //One fewer optimization parameters if kappa is fixed
     }
 
     DiscountFactor ExponentialSplinesFitting::discountFunction(const Array& x,
@@ -80,7 +80,7 @@ namespace QuantLib {
         DiscountFactor d = 0.0;
         Size N = size();
         //Use the interal fixedKappa_ member if non-zero, otherwise take kappa from the passed x[] array
-        Real kappa = (fixedKappa_ != QL_NULL_REAL) ? fixedKappa_: x[N-1];
+        Real kappa = (fixedKappa_ != Null<Real>()) ? fixedKappa_: x[N-1];
         Real coeff = 0;
 
         if (!constrainAtZero_) {

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -41,14 +41,10 @@ namespace QuantLib {
         and A. Shapiro (2001): "Merrill Lynch Exponential Spline
         Model." Merrill Lynch Working Paper
 
+        \f$ \kappa \f$ can be passed a fixed value, in which case it
+        is excluded from optimization.
+
         \warning convergence may be slow
-    */
-    /*
-        Edited David Sansom 21-Nov-20: Added the option of using a variable number of c_i parameters
-        and the ability to fix kappa and thus exclude it from the optimization.
-        If kappa is fixed at zero it is included in the optimization
-        Amended existing two constructors and added a third
-        Added members for number of c_i parameters and fixed kappa
     */
     class ExponentialSplinesFitting
         : public FittedBondDiscountCurve::FittingMethod {

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -43,6 +43,13 @@ namespace QuantLib {
 
         \warning convergence may be slow
     */
+    /*
+        Edited David Sansom 21-Nov-20: Added the option of using a variable number of c_i parameters
+        and the ability to fix kappa and thus exclude it from the optimization.
+        If kappa is fixed at zero it is included in the optimization
+        Amended existing two constructors and added a third
+        Added members for number of c_i parameters and fixed kappa
+    */
     class ExponentialSplinesFitting
         : public FittedBondDiscountCurve::FittingMethod {
       public:
@@ -52,18 +59,30 @@ namespace QuantLib {
                                       ext::shared_ptr<OptimizationMethod>(),
                                   const Array& l2 = Array(),
                                   Real minCutoffTime = 0.0,
-                                  Real maxCutoffTime = QL_MAX_REAL);
+                                  Real maxCutoffTime = QL_MAX_REAL,
+                                  Size numCoeffs = 9,
+                                  Real fixedKappa = QL_NULL_REAL);
         ExponentialSplinesFitting(bool constrainAtZero,
                                   const Array& weights,
                                   const Array& l2,
                                   Real minCutoffTime = 0.0,
-                                  Real maxCutoffTime = QL_MAX_REAL);
+                                  Real maxCutoffTime = QL_MAX_REAL,
+                                  Size numCoeffs = 9,
+                                  Real fixedKappa = QL_NULL_REAL);
+        ExponentialSplinesFitting(bool constrainAtZero, 
+                                  Size numCoeffs, 
+                                  Real fixedKappa, 
+                                  const Array& weights = Array() );
+
+
         #if defined(QL_USE_STD_UNIQUE_PTR)
         std::unique_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
         #else
         std::auto_ptr<FittedBondDiscountCurve::FittingMethod> clone() const;
         #endif
       private:
+        Natural numCoeffs_;
+        Real fixedKappa_;
         Size size() const;
         DiscountFactor discountFunction(const Array& x, Time t) const;
     };

--- a/ql/termstructures/yield/nonlinearfittingmethods.hpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.hpp
@@ -61,14 +61,14 @@ namespace QuantLib {
                                   Real minCutoffTime = 0.0,
                                   Real maxCutoffTime = QL_MAX_REAL,
                                   Size numCoeffs = 9,
-                                  Real fixedKappa = QL_NULL_REAL);
+                                  Real fixedKappa = Null<Real>());
         ExponentialSplinesFitting(bool constrainAtZero,
                                   const Array& weights,
                                   const Array& l2,
                                   Real minCutoffTime = 0.0,
                                   Real maxCutoffTime = QL_MAX_REAL,
                                   Size numCoeffs = 9,
-                                  Real fixedKappa = QL_NULL_REAL);
+                                  Real fixedKappa = Null<Real>());
         ExponentialSplinesFitting(bool constrainAtZero, 
                                   Size numCoeffs, 
                                   Real fixedKappa, 


### PR DESCRIPTION
In practical use it is sometimes easier (& quicker) to use fewer than the standard 9 coefficients, and also to fix Kappa (as the fit is relatively insensitive to this variable). These mods add new default parameters to the existing ExponentialSplinesFitting constructor, and an additional reduced constructor for defining the number of parameters and a fix for Kappa. New member variables have been added to hold the number of coefficients and the value for the fixed Kappa. If a fixed Kappa has been provided (tested as not QL_NULL_REAL) then this value is used in the discountFunction() implementation.

The example/test app FittedBondDiscountCurve has been amended to include this additional fitting method.

If other fitting methods would benefit from fixing parameters that are currently optimized, perhaps the FittingMethod base class should be modified instead, and allow a more general mechanism for providing fixed parameters? I have not done that here as (a) I was interested in exponential splines, and (b) I don't know enough about the other methods to assess whether this is useful.