### PR TITLE
Adding a MC Heston pricer for discrete geometric asian options

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1462,6 +1462,7 @@
     <ClInclude Include="ql\pricingengines\asian\mc_discr_arith_av_price_heston.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mc_discr_arith_av_strike.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mc_discr_geom_av_price.hpp" />
+    <ClInclude Include="ql\pricingengines\asian\mc_discr_geom_av_price_heston.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianengine.hpp" />
     <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianenginebase.hpp" />
     <ClInclude Include="ql\pricingengines\barrier\all.hpp" />
@@ -2511,6 +2512,7 @@
     <ClCompile Include="ql\pricingengines\asian\mc_discr_arith_av_price_heston.cpp" />
     <ClCompile Include="ql\pricingengines\asian\mc_discr_arith_av_strike.cpp" />
     <ClCompile Include="ql\pricingengines\asian\mc_discr_geom_av_price.cpp" />
+    <ClCompile Include="ql\pricingengines\asian\mc_discr_geom_av_price_heston.cpp" />
     <ClCompile Include="ql\pricingengines\barrier\analyticbarrierengine.cpp" />
     <ClCompile Include="ql\pricingengines\barrier\analyticbinarybarrierengine.cpp" />
     <ClCompile Include="ql\pricingengines\barrier\discretizedbarrieroption.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2325,9 +2325,6 @@
     <ClInclude Include="ql\pricingengines\asian\analytic_cont_geom_av_price.hpp">
       <Filter>pricingengines\asian</Filter>
     </ClInclude>
-    <ClInclude Include="ql\pricingengines\asian\analytic_cont_geom_av_price_heston.hpp">
-      <Filter>pricingengines\asian</Filter>
-    </ClInclude>
     <ClInclude Include="ql\pricingengines\asian\analytic_discr_geom_av_price.hpp">
       <Filter>pricingengines\asian</Filter>
     </ClInclude>
@@ -2341,6 +2338,9 @@
       <Filter>pricingengines\asian</Filter>
     </ClInclude>
     <ClInclude Include="ql\pricingengines\asian\mc_discr_geom_av_price.hpp">
+      <Filter>pricingengines\asian</Filter>
+    </ClInclude>
+    <ClInclude Include="ql\pricingengines\asian\mc_discr_geom_av_price_heston.hpp">
       <Filter>pricingengines\asian</Filter>
     </ClInclude>
     <ClInclude Include="ql\pricingengines\asian\mcdiscreteasianengine.hpp">
@@ -5563,9 +5563,6 @@
     <ClCompile Include="ql\pricingengines\asian\analytic_cont_geom_av_price.cpp">
       <Filter>pricingengines\asian</Filter>
     </ClCompile>
-    <ClCompile Include="ql\pricingengines\asian\analytic_cont_geom_av_price_heston.cpp">
-      <Filter>pricingengines\asian</Filter>
-    </ClCompile>
     <ClCompile Include="ql\pricingengines\asian\analytic_discr_geom_av_price.cpp">
       <Filter>pricingengines\asian</Filter>
     </ClCompile>
@@ -5579,6 +5576,9 @@
       <Filter>pricingengines\asian</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\asian\mc_discr_geom_av_price.cpp">
+      <Filter>pricingengines\asian</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\pricingengines\asian\mc_discr_geom_av_price_heston.cpp">
       <Filter>pricingengines\asian</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\barrier\analyticbarrierengine.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -656,6 +656,7 @@ set(QuantLib_SRC
     pricingengines/asian/mc_discr_arith_av_price_heston.cpp
     pricingengines/asian/mc_discr_arith_av_strike.cpp
     pricingengines/asian/mc_discr_geom_av_price.cpp
+    pricingengines/asian/mc_discr_geom_av_price_heston.cpp
     pricingengines/barrier/analyticbarrierengine.cpp
     pricingengines/barrier/analyticbinarybarrierengine.cpp
     pricingengines/barrier/discretizedbarrieroption.cpp
@@ -1905,6 +1906,7 @@ set(QuantLib_HDR
     pricingengines/asian/mc_discr_arith_av_price_heston.hpp
     pricingengines/asian/mc_discr_arith_av_strike.hpp
     pricingengines/asian/mc_discr_geom_av_price.hpp
+    pricingengines/asian/mc_discr_geom_av_price_heston.hpp
     pricingengines/asian/mcdiscreteasianengine.hpp
     pricingengines/asian/mcdiscreteasianenginebase.hpp
     pricingengines/barrier/all.hpp

--- a/ql/pricingengines/asian/Makefile.am
+++ b/ql/pricingengines/asian/Makefile.am
@@ -12,6 +12,7 @@ this_include_HEADERS = \
 	mc_discr_arith_av_price_heston.hpp \
 	mc_discr_arith_av_strike.hpp \
 	mc_discr_geom_av_price.hpp \
+	mc_discr_geom_av_price_heston.hpp \
 	mcdiscreteasianengine.hpp \
 	mcdiscreteasianenginebase.hpp
 
@@ -23,7 +24,8 @@ cpp_files = \
 	mc_discr_arith_av_price.cpp \
 	mc_discr_arith_av_price_heston.cpp \
 	mc_discr_arith_av_strike.cpp \
-	mc_discr_geom_av_price.cpp
+	mc_discr_geom_av_price.cpp \
+	mc_discr_geom_av_price_heston.cpp
 
 if UNITY_BUILD
 

--- a/ql/pricingengines/asian/all.hpp
+++ b/ql/pricingengines/asian/all.hpp
@@ -9,6 +9,7 @@
 #include <ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp>
 #include <ql/pricingengines/asian/mc_discr_arith_av_strike.hpp>
 #include <ql/pricingengines/asian/mc_discr_geom_av_price.hpp>
+#include <ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp>
 #include <ql/pricingengines/asian/mcdiscreteasianengine.hpp>
 #include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
 

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -1,6 +1,8 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
+ Copyright (C) 2020 Jack Gillett
+ 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
 

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp>
+
+namespace QuantLib {
+
+    GeometricAPOHestonPathPricer::GeometricAPOHestonPathPricer(
+                                         Option::Type type,
+                                         Real strike,
+                                         DiscountFactor discount,
+                                         std::vector<Size> fixingIndices,
+                                         Real runningProduct,
+                                         Size pastFixings)
+    : payoff_(type, strike), discount_(discount), fixingIndices_(fixingIndices),
+      runningProduct_(runningProduct), pastFixings_(pastFixings) {
+        QL_REQUIRE(strike>=0.0,
+            "strike less than zero not allowed");
+    }
+
+    Real GeometricAPOHestonPathPricer::operator()(const MultiPath& multiPath) const  {
+        const Path& path = multiPath[0];
+        const Size n = multiPath.pathSize();
+        QL_REQUIRE(n>0, "the path cannot be empty");
+
+        Real averagePrice = 1.0;
+        Real product = runningProduct_;
+        Size fixings = pastFixings_ + fixingIndices_.size();
+
+        // care must be taken not to overflow product
+        Real maxValue = QL_MAX_REAL;
+        for (Size i=0; i<fixingIndices_.size(); i++) {
+            Real price = path[fixingIndices_[i]];
+            if (product < maxValue/price) {
+                product *= price;
+            } else {
+                averagePrice *= std::pow(product, 1.0/fixings);
+                product = price;
+            }
+        }
+
+        averagePrice *= std::pow(product, 1.0/fixings);
+        return discount_ * payoff_(averagePrice);
+    }
+
+}

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
@@ -1,0 +1,254 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file mc_discr_arith_av_price_heston.hpp
+    \brief Heston MC engine for discrete geometric average price Asian
+*/
+
+#ifndef quantlib_mc_discrete_geometric_average_price_asian_heston_engine_hpp
+#define quantlib_mc_discrete_geometric_average_price_asian_heston_engine_hpp
+
+#include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/exercise.hpp>
+
+namespace QuantLib {
+
+    //!  Heston MC pricing engine for discrete geometric average price Asian
+    /*!
+         By default, the MC discretization will use 1 time step per fixing date, but
+         this can be controlled via timeSteps or timeStepsPerYear parameter, which
+         will provide additional timesteps. The grid tries to space as evenly as it
+         can and does not guarantee to match an exact number of steps, the precise
+         grid used can be found in results_.additionalResults["TimeGrid"]
+
+         \ingroup asianengines
+         \test the correctness of the returned value is tested by
+               reproducing results available in literature.
+    */
+    template <class RNG = PseudoRandom,
+              class S = Statistics, class P = HestonProcess>
+    class MCDiscreteGeometricAPHestonEngine
+        : public MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S> {
+      public:
+        typedef typename MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S>::path_generator_type path_generator_type;
+        typedef typename MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S>::path_pricer_type path_pricer_type;
+        typedef typename MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S>::stats_type stats_type;
+        // constructor
+        MCDiscreteGeometricAPHestonEngine(const ext::shared_ptr<P>& process,
+                                          bool antitheticVariate,
+                                          Size requiredSamples,
+                                          Real requiredTolerance,
+                                          Size maxSamples,
+                                          BigNatural seed,
+                                          Size timeSteps = Null<Size>(),
+                                          Size timeStepsPerYear = Null<Size>());
+      protected:
+        ext::shared_ptr<path_pricer_type> pathPricer() const;
+    };
+
+
+    template <class RNG = PseudoRandom,
+              class S = Statistics, class P = HestonProcess>
+    class MakeMCDiscreteGeometricAPHestonEngine {
+      public:
+        explicit MakeMCDiscreteGeometricAPHestonEngine(
+            const ext::shared_ptr<P>& process);
+        // named parameters
+        MakeMCDiscreteGeometricAPHestonEngine& withSamples(Size samples);
+        MakeMCDiscreteGeometricAPHestonEngine& withAbsoluteTolerance(Real tolerance);
+        MakeMCDiscreteGeometricAPHestonEngine& withMaxSamples(Size samples);
+        MakeMCDiscreteGeometricAPHestonEngine& withSeed(BigNatural seed);
+        MakeMCDiscreteGeometricAPHestonEngine& withAntitheticVariate(bool b = true);
+        MakeMCDiscreteGeometricAPHestonEngine& withSteps(Size steps);
+        MakeMCDiscreteGeometricAPHestonEngine& withStepsPerYear(Size steps);
+        // conversion to pricing engine
+        operator ext::shared_ptr<PricingEngine>() const;
+      private:
+        ext::shared_ptr<P> process_;
+        bool antithetic_;
+        Size samples_, maxSamples_, steps_, stepsPerYear_;
+        Real tolerance_;
+        BigNatural seed_;
+    };
+
+    class GeometricAPOHestonPathPricer : public PathPricer<MultiPath> {
+      public:
+        GeometricAPOHestonPathPricer(Option::Type type,
+                                     Real strike,
+                                     DiscountFactor discount,
+                                     std::vector<Size> fixingIndices,
+                                     Real runningProduct = 1.0,
+                                     Size pastFixings = 0);
+        Real operator()(const MultiPath& multiPath) const;
+      private:
+        PlainVanillaPayoff payoff_;
+        DiscountFactor discount_;
+        std::vector<Size> fixingIndices_;
+        Real runningProduct_;
+        Size pastFixings_;
+    };
+
+
+    // inline definitions
+
+    template <class RNG, class S, class P>
+    inline
+    MCDiscreteGeometricAPHestonEngine<RNG,S,P>::MCDiscreteGeometricAPHestonEngine(
+             const ext::shared_ptr<P>& process,
+             bool antitheticVariate,
+             Size requiredSamples,
+             Real requiredTolerance,
+             Size maxSamples,
+             BigNatural seed,
+             Size timeSteps,
+             Size timeStepsPerYear)
+    : MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S>(process,
+                                                             false,
+                                                             antitheticVariate,
+                                                             false,
+                                                             requiredSamples,
+                                                             requiredTolerance,
+                                                             maxSamples,
+                                                             seed,
+                                                             timeSteps,
+                                                             timeStepsPerYear) {
+        QL_REQUIRE(timeSteps == Null<Size>() || timeStepsPerYear == Null<Size>(),
+                   "both time steps and time steps per year were provided");
+    }
+
+    template <class RNG, class S, class P>
+    inline ext::shared_ptr<
+            typename MCDiscreteGeometricAPHestonEngine<RNG,S,P>::path_pricer_type>
+        MCDiscreteGeometricAPHestonEngine<RNG,S,P>::pathPricer() const {
+
+        // Keep track of the fixing indices, the path pricer will need to sum only these
+        TimeGrid timeGrid = this->timeGrid();
+        std::vector<Time> fixingTimes = timeGrid.mandatoryTimes();
+        std::vector<Size> fixingIndexes;
+        for (Size i=0; i<fixingTimes.size(); i++) {
+            fixingIndexes.push_back(timeGrid.closestIndex(fixingTimes[i]));
+        }
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(
+                this->arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        ext::shared_ptr<EuropeanExercise> exercise =
+            ext::dynamic_pointer_cast<EuropeanExercise>(
+                this->arguments_.exercise);
+        QL_REQUIRE(exercise, "wrong exercise given");
+
+        ext::shared_ptr<P> process =
+            ext::dynamic_pointer_cast<P>(this->process_);
+        QL_REQUIRE(process, "Heston like process required");
+
+        return ext::shared_ptr<typename
+            MCDiscreteGeometricAPHestonEngine<RNG,S,P>::path_pricer_type>(
+                new GeometricAPOHestonPathPricer(
+                    payoff->optionType(),
+                    payoff->strike(),
+                    process->riskFreeRate()->discount(exercise->lastDate()),
+                    fixingIndexes,
+                    this->arguments_.runningAccumulator,
+                    this->arguments_.pastFixings));
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::MakeMCDiscreteGeometricAPHestonEngine(
+             const ext::shared_ptr<P>& process)
+    : process_(process), antithetic_(false), samples_(Null<Size>()),
+      maxSamples_(Null<Size>()), steps_(Null<Size>()),
+      stepsPerYear_(Null<Size>()), tolerance_(Null<Real>()), seed_(0) {}
+
+    template<class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withSamples(Size samples) {
+        QL_REQUIRE(tolerance_ == Null<Real>(),
+                   "tolerance already set");
+        samples_ = samples;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withAbsoluteTolerance(
+                                                             Real tolerance) {
+        QL_REQUIRE(samples_ == Null<Size>(),
+                   "number of samples already set");
+        QL_REQUIRE(RNG::allowsErrorEstimate,
+                   "chosen random generator policy "
+                   "does not allow an error estimate");
+        tolerance_ = tolerance;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withMaxSamples(Size samples) {
+        maxSamples_ = samples;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withSeed(BigNatural seed) {
+        seed_ = seed;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withAntitheticVariate(bool b) {
+        antithetic_ = b;
+        return *this;
+    }
+
+    template<class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withSteps(Size steps) {
+        QL_REQUIRE(stepsPerYear_ == Null<Size>(),
+                   "number of steps per year already set");
+        steps_ = steps;
+        return *this;
+    }
+
+    template<class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::withStepsPerYear(Size steps) {
+        QL_REQUIRE(steps_ == Null<Size>(),
+                   "number of steps already set");
+        stepsPerYear_ = steps;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>() const {
+        return ext::shared_ptr<PricingEngine>(new
+            MCDiscreteGeometricAPHestonEngine<RNG,S,P>(process_,
+                                                       antithetic_,
+                                                       samples_,
+                                                       tolerance_,
+                                                       maxSamples_,
+                                                       seed_,
+                                                       steps_,
+                                                       stepsPerYear_));
+    }
+}
+
+#endif

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
@@ -1,6 +1,8 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
+ Copyright (C) 2020 Jack Gillett
+ 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
 

--- a/test-suite/asianoptions.hpp
+++ b/test-suite/asianoptions.hpp
@@ -35,6 +35,7 @@ class AsianOptionTest {
     static void testAnalyticDiscreteGeometricAveragePrice();
     static void testAnalyticDiscreteGeometricAverageStrike();
     static void testMCDiscreteGeometricAveragePrice();
+    static void testMCDiscreteGeometricAveragePriceHeston();
     static void testMCDiscreteArithmeticAveragePrice();
     static void testMCDiscreteArithmeticAveragePriceHeston();
     static void testMCDiscreteArithmeticAverageStrike();


### PR DESCRIPTION
This pricer isn't particularly useful by itself as these options don't trade as far as I know, but we'll need it to implement a control variate for the equivalent arithmetic option pricer once the analytical pricer for these geometric options is implemented (coming soon). It also adds some tests that we will re-use for that pricer, and provides a useful sanity check for the analytical results.