### PR TITLE
Experimental Analytic Discrete Geometric Asian Option Pricer

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -542,6 +542,7 @@
     <ClInclude Include="ql\experimental\amortizingbonds\amortizingfloatingratebond.hpp" />
     <ClInclude Include="ql\experimental\asian\all.hpp" />
     <ClInclude Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.hpp" />
+    <ClInclude Include="ql\experimental\asian\analytic_cont_discr_av_price_heston.hpp" />
     <ClInclude Include="ql\experimental\averageois\all.hpp" />
     <ClInclude Include="ql\experimental\averageois\arithmeticaverageois.hpp" />
     <ClInclude Include="ql\experimental\averageois\arithmeticoisratehelper.hpp" />
@@ -1909,6 +1910,7 @@
     <ClCompile Include="ql\experimental\amortizingbonds\amortizingfixedratebond.cpp" />
     <ClCompile Include="ql\experimental\amortizingbonds\amortizingfloatingratebond.cpp" />
     <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.cpp" />
+    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.cpp" />
     <ClCompile Include="ql\experimental\averageois\arithmeticaverageois.cpp" />
     <ClCompile Include="ql\experimental\averageois\arithmeticoisratehelper.cpp" />
     <ClCompile Include="ql\experimental\averageois\averageoiscouponpricer.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -6286,10 +6286,10 @@
     <ClCompile Include="ql\experimental\mcbasket\pathmultiassetoption.cpp">
       <Filter>experimental\mcbasket</Filter>
     </ClCompile>
-    <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.pp">
+    <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.cpp">
       <Filter>experimental\futures</Filter>
     </ClCompile>
-    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.pp">
+    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.cpp">
       <Filter>experimental\futures</Filter>
     </ClCompile>
     <ClCompile Include="ql\termstructures\volatility\atmadjustedsmilesection.cpp">

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -3336,6 +3336,9 @@
     <ClInclude Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.hpp">
       <Filter>experimental\futures</Filter>
     </ClInclude>
+    <ClInclude Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.hpp">
+      <Filter>experimental\futures</Filter>
+    </ClInclude>
     <ClInclude Include="ql\math\ode\all.hpp">
       <Filter>math\ode</Filter>
     </ClInclude>
@@ -6284,6 +6287,9 @@
       <Filter>experimental\mcbasket</Filter>
     </ClCompile>
     <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.pp">
+      <Filter>experimental\futures</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.pp">
       <Filter>experimental\futures</Filter>
     </ClCompile>
     <ClCompile Include="ql\termstructures\volatility\atmadjustedsmilesection.cpp">

--- a/ql/experimental/asian/Makefile.am
+++ b/ql/experimental/asian/Makefile.am
@@ -4,10 +4,12 @@ AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \
     all.hpp \
-    analytic_cont_geom_av_price_heston.hpp
+    analytic_cont_geom_av_price_heston.hpp \
+    analytic_discr_geom_av_price_heston.hpp
 
 cpp_files = \
-    analytic_cont_geom_av_price_heston.cpp
+    analytic_cont_geom_av_price_heston.cpp \
+    analytic_discr_geom_av_price_heston.cpp
 
 if UNITY_BUILD
 

--- a/ql/experimental/asian/all.hpp
+++ b/ql/experimental/asian/all.hpp
@@ -2,4 +2,5 @@
 /* Add the files to be included into Makefile.am instead. */
 
 #include <ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp>
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
 

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -1,0 +1,217 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Jack Gillett
+ 
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
+
+#include <iostream>
+#include <iomanip>
+
+namespace QuantLib {
+
+    AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::
+        AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(
+            const ext::shared_ptr<HestonProcess>& process)
+    : r0_(0.0), process_(process), integrator_(128) {
+        registerWith(process_);
+
+        v0_ = process_->v0();
+        rho_ = process_->rho();
+        kappa_ = process_->kappa();
+        theta_ = process_->theta();
+        sigma_ = process_->sigma();
+        s0_ = process_->s0();
+        logS0_ = std::log(s0_->value());
+
+        riskFreeRate_ = process_->riskFreeRate();
+        dividendYield_ = process_->dividendYield();
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::F(
+            std::complex<Real>& z1,
+            std::complex<Real>& z2,
+            Time tau) const {
+        std::complex<Real> temp = std::sqrt(kappa_*kappa_-2.0*z1*sigma_*sigma_);
+        if (std::abs(kappa_*kappa_-2.0*sigma_*sigma_) < 1e-8) {
+            return 1.0 + 0.5*(kappa_-z2*sigma_*sigma_);
+        } else {
+            return cosh(0.5*tau*temp) + (kappa_-z2*sigma_*sigma_)*sinh(0.5*tau*temp)/temp;
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::F_tilde(
+            std::complex<Real>& z1,
+            std::complex<Real>& z2,
+            Time tau) const {
+        std::complex<Real> temp = std::sqrt(kappa_*kappa_ - 2.0*z1*sigma_*sigma_);
+        return 0.5*temp*sinh(0.5*tau*temp) + 0.5*(kappa_ - z2*sigma_*sigma_)*cosh(0.5*tau*temp);
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::z(
+            std::complex<Real>& s, std::complex<Real>& w, Size k, Size n) const {
+        double k_ = double(k);
+        double n_ = double(n);
+        std::complex<Real> term1 = (2*rho_*kappa_ - sigma_)*((n_-k_+1)*s + n_*w)/(2*sigma_*n_);
+        std::complex<Real> term2 = (1-rho_*rho_)*pow(((n_-k_+1)*s + n_*w), 2)/(2*n_*n_);
+
+        return term1 + term2;
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::omega(
+            std::complex<Real>& s, std::complex<Real>& w, Size k, Size kStar, Size n) const {
+        if (k==kStar) {
+            return 0;
+        } else if (k==n+1) {
+            return rho_*w/sigma_;
+        } else {
+            return rho_*s/(sigma_*n);
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::a(
+            std::complex<Real>& s,
+            std::complex<Real>& w,
+            Time t, Time T, Size kStar, std::vector<Time>& t_n) const {
+        double kStar_ = double(kStar);
+        double n_ = double(t_n.size());
+        Real temp = (r0_ - rho_*kappa_*theta_/sigma_);
+
+        Time summation = 0.0;
+        for (Size i=kStar+1; i<=t_n.size(); i++) {
+            summation += t_n[i];
+        }
+
+        std::complex<Real> term1 = (s*(n_-kStar_)/n_ + w)*(logS0_ - rho_*v0_/sigma_ - t*temp);
+        std::complex<Real> term2 = temp*(s*summation/n_ + w*T);
+
+        return term1 + term2;
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::omega_tilde(
+            std::complex<Real>& s,
+            std::complex<Real>& w,
+            Size k, Size kStar, Size n, std::vector<Time>& tauK) const {
+        std::complex<Real> omega_k = omega(s, w, k, kStar, n);
+        if (k==n+1) {
+            return omega_k;
+        } else {
+            Time dTauk = tauK[k+1] - tauK[k];
+            std::complex<Real> z_kp1 = z(s, w, k+1, n);
+
+            // omega_tilde calls itself recursivly, so use a lookup map to avoid exponential slowdown
+            std::complex<Real> omega_kp1 = 0.0;
+            std::tuple<Size, Real, Real, Real, Real> location = 
+                std::tuple<Size, Real, Real, Real, Real>(k+1,
+                    std::real(s), std::imag(s), std::real(w), std::imag(w));
+            std::map<std::tuple<Size, Real, Real, Real, Real>,
+                std::complex<Real> >::const_iterator position = omegaTildeLookupTable_.find(location);
+
+            if (position != omegaTildeLookupTable_.end()) {
+                std::complex<Real> value = position->second;
+                omega_kp1 = value;
+            } else {
+                omega_kp1 = omega_tilde(s, w, k+1, kStar, n, tauK);
+            }
+
+            std::complex<Real> ratio = F_tilde(z_kp1,omega_kp1,dTauk)/F_tilde(z_kp1,omega_kp1,dTauk);
+
+            return omega_k + kappa_/pow(sigma_,2) - 0.5*ratio/pow(sigma_,2);
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::Phi(
+            std::complex<Real>& s,
+            std::complex<Real>& w,
+            Time t, Time T, Size kStar, std::vector<Time>& t_n, std::vector<Time>& tauK) const {
+        Size n = t_n.size();
+        std::complex<Real> aTerm = a(s, w, t, T, kStar, t_n);
+        std::complex<Real> omegaTerm = v0_*omega_tilde(s, w, kStar, kStar, n, tauK);
+        Real term3 = kappa_*kappa_*theta_*(T-t)/pow(sigma_,2);
+
+        std::complex<Real> summation = 0.0;
+        for (Size i=kStar+1; i<=n+1; i++) {
+            Real dTau = tauK[i] - tauK[i-1];
+            std::complex<Real> z_k = z(s, w, i, n);
+            std::complex<Real> omega_tilde_k = omega_tilde(s, w, i, kStar, n, tauK);
+
+            summation += std::log(F(z_k, omega_tilde_k, dTau));
+        }
+        std::complex<Real> term4 = 2*kappa_*theta_*summation/pow(sigma_,2);
+
+        return std::exp(aTerm + omegaTerm + term3 - term4);
+}
+
+
+    void AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::calculate() const {
+        QL_REQUIRE(arguments_.averageType == Average::Geometric,
+                   "not a geometric average option");
+        QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
+                   "not an European Option");
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        Real strike = payoff->strike();
+        Date exercise = arguments_.exercise->lastDate();
+
+        Time expiryTime = this->process_->time(exercise);
+        QL_REQUIRE(expiryTime >= 0.0, "Expiry Date cannot be in the past");
+
+        std::vector<Time> fixingTimes, tauK;
+        for (Size i=0; i<arguments_.fixingDates.size(); i++) {
+            fixingTimes.push_back(this->process_->time(arguments_.fixingDates[i]));
+        }
+        std::sort(fixingTimes.begin(), fixingTimes.end());
+
+
+        // TODO: extend to cover seasoned options (discussed in paper)
+        Time startTime = 0.0;
+
+        Size kStar = 0;
+        for (Size i=0; i<fixingTimes.size(); i++) {
+            if (startTime > fixingTimes[i]) {
+                kStar = i+1;
+            } else {
+                tauK.push_back(this->process_->time(arguments_.fixingDates[i]));
+            }
+        }
+
+        // tauK is just a vector of the sorted fixing times from the kStar element
+        // onwards, with t pushed on the front and T pushed on the back!
+        tauK.insert(tauK.begin(), startTime);
+        tauK.push_back(expiryTime);
+
+
+        // Apply the payoff functions
+        Real value = 0.0;
+        switch (payoff->optionType()){
+            case Option::Call:
+                value = 100.0;
+                break;
+            case Option::Put:
+                value = 100.0;
+                break;
+            default:
+                QL_FAIL("unknown option type");
+            }
+
+        results_.value = value;
+    }
+}
+

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -22,7 +22,7 @@
 namespace QuantLib {
 
     // A class to perform the integrations in Eqs (23) and (24)
-    class Integrand {
+    class AdgapIntegrand {
       private:
         Real t_, T_, K_, logK_;
         Size kStar_;
@@ -32,15 +32,15 @@ namespace QuantLib {
         std::complex<Real> i_;
 
       public:
-        Integrand(Real t,
-                  Real T,
-                  Size kStar,
-                  const std::vector<Time>& t_n,
-                  const std::vector<Time>& tauK,
-                  Real K,
-                  const AnalyticDiscreteGeometricAveragePriceAsianHestonEngine* const parent,
-                  Real xiRightLimit) : t_(t), T_(T), K_(K), logK_(std::log(K)), kStar_(kStar), t_n_(t_n),
-                  tauK_(tauK), parent_(parent), xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
+        AdgapIntegrand(Real t,
+                       Real T,
+                       Size kStar,
+                       const std::vector<Time>& t_n,
+                       const std::vector<Time>& tauK,
+                       Real K,
+                       const AnalyticDiscreteGeometricAveragePriceAsianHestonEngine* const parent,
+                       Real xiRightLimit) : t_(t), T_(T), K_(K), logK_(std::log(K)), kStar_(kStar), t_n_(t_n),
+            tauK_(tauK), parent_(parent), xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
 
         double operator()(double xi) const {
             double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
@@ -253,7 +253,8 @@ namespace QuantLib {
         // Calculate the two terms in eq (23) - Phi(1,0) is real (asian forward) but need to type convert
         Real term1 = 0.5 * (std::real(Phi(1,0, startTime, expiryTime, kStar, fixingTimes, tauK)) - strike);
 
-        Integrand integrand = Integrand(startTime, expiryTime, kStar, fixingTimes, tauK, strike, this, xiRightLimit_);
+        AdgapIntegrand integrand = AdgapIntegrand(startTime, expiryTime, kStar, fixingTimes,
+                                                  tauK, strike, this, xiRightLimit_);
         Real term2 = integrator_(integrand) / M_PI;
 
 

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -1,0 +1,124 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Jack Gillett
+ 
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file analytic_cont_geom_av_price.hpp
+    \brief Analytic engine for continuous geometric average price Asian
+           in the Heston model
+*/
+
+#ifndef quantlib_analytic_discrete_geometric_average_price_asian_heston_engine_hpp
+#define quantlib_analytic_discrete_geometric_average_price_asian_heston_engine_hpp
+
+#include <ql/instruments/asianoption.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/math/integrals/gaussianquadratures.hpp>
+#include <ql/exercise.hpp>
+
+namespace QuantLib {
+
+    //! Pricing engine for European discrete geometric average price Asian
+    /*! This class implements a discrete geometric average price
+        Asian option with European exercise under the Heston stochastic
+        vol model where spot and variance follow the processes
+
+        \f[
+        \begin{array}{rcl}
+        dS(t, S)  &=& (r-d) S dt +\sqrt{v} S dW_1 \\
+        dv(t, S)  &=& \kappa (\theta - v) dt + \sigma \sqrt{v} dW_2 \\
+        dW_1 dW_2 &=& \rho dt \\
+        \end{array}
+        \f]
+
+        References:
+
+        Implements the analytical solution for continuous geometric Asian
+        options developed in "A Recursive Method for Discretely Monitored
+        Geometric Asian Option Prices", B. Kim, J. Kim, J. Kim & I. S. Wee,
+        Bull. Korean Math. Soc. 53, 733-749 (2016)
+
+        \ingroup asianengines
+
+        \test
+        - the correctness of the returned value is tested by reproducing
+              results in Tables 1, 2 and 3 of the paper
+
+        \todo handle seasoned options
+    */
+    class AnalyticDiscreteGeometricAveragePriceAsianHestonEngine
+        : public DiscreteAveragingAsianOption::engine {
+      public:
+        explicit AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(
+            const ext::shared_ptr<HestonProcess>& process);
+        void calculate() const;
+
+        // Equation (21) - must be public so the integrand can access it.
+        std::complex<Real> Phi(std::complex<Real>& s,
+                               std::complex<Real>& w,
+                               Time t, Time T, Size kStar, std::vector<Time>& t_n, std::vector<Time>& tauK) const;
+
+      private:
+        // Initial process params
+        Real v0_, rho_, kappa_, theta_, sigma_, logS0_, r0_;
+        Handle<YieldTermStructure> dividendYield_;
+        Handle<YieldTermStructure> riskFreeRate_;
+        Handle<Quote> s0_;
+
+        ext::shared_ptr<HestonProcess> process_;
+
+        // A lookup table for the reuslts of omega_tilde() to avoid repeated calls. The tuple elements
+        // need to support comparison, so the complex numbers are expressed as pairs of reals
+        // TODO: do Reals work for equality checks? Do we need to round them/cast to int ratio a/b?
+        mutable std::map<std::tuple<Size, Real, Real, Real, Real>,
+            std::complex<Real> > omegaTildeLookupTable_;
+
+        // Integrator for equation (23) and (24)
+        GaussLegendreIntegration integrator_;
+
+        // Equation (11)
+        std::complex<Real> F(std::complex<Real>& z1,
+                             std::complex<Real>& z2,
+                             Time tau) const;
+        std::complex<Real> F_tilde(std::complex<Real>& z1,
+                                   std::complex<Real>& z2,
+                                   Time tau) const;
+
+        // Equation (14)
+        std::complex<Real> z(std::complex<Real>& s,
+                             std::complex<Real>& w,
+                             Size k, Size n) const;
+
+        // Equation (15)
+        std::complex<Real> omega(std::complex<Real>& s,
+                                 std::complex<Real>& w,
+                                 Size k, Size kStar, Size n) const;
+
+        // Equation (16)
+        std::complex<Real> a(std::complex<Real>& s,
+                             std::complex<Real>& w,
+                             Time t, Time T, Size kStar, std::vector<Time>& t_n) const;
+
+        // Equation (19)
+        std::complex<Real> omega_tilde(std::complex<Real>& s,
+                                       std::complex<Real>& w,
+                                       Size k, Size kStar, Size n, std::vector<Time>& tauK) const;
+    };
+}
+
+
+#endif

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -519,7 +519,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePrice() {
 }
 
 
-void testDiscreteGeometricAveragePriceHeston(ext::shared_ptr<PricingEngine> engine) {
+void testDiscreteGeometricAveragePriceHeston(ext::shared_ptr<PricingEngine> engine, Real tol[]) {
 
     // data from "A Recursive Method for Discretely Monitored Geometric Asian Option
     // Prices", Kim, Kim, Kim & Wee, Bull. Korean Math. Soc. 53, 733-749, 2016
@@ -527,12 +527,6 @@ void testDiscreteGeometricAveragePriceHeston(ext::shared_ptr<PricingEngine> engi
                       91, 182, 365, 730, 1095};
     Real strikes[] = {90, 90, 90, 90, 90, 90, 100, 100, 100, 100, 100, 100, 110,
                       110, 110, 110, 110, 110};
-
-    // 30-day options need wider tolerance due to uncertainty around what "weekly
-    // fixing" dates mean over a 30-day month!
-    Real tol[] =     {4.0e-2, 2.0e-2, 2.0e-2, 3.0e-2, 3.0e-2, 2.0e-2, 1.0e-1, 1.0e-2,
-                      2.0e-2, 2.0e-2, 2.0e-2, 1.0e-2, 2.0e-2, 1.0e-2, 1.0e-2, 1.0e-2,
-                      1.0e-2, 1.0e-2};
 
     // Prices from Tables 1, 2 and 3
     Real prices[] =  {10.2732, 10.9554, 11.9916, 13.6950, 16.1773, 18.0146, 2.4389,
@@ -544,9 +538,7 @@ void testDiscreteGeometricAveragePriceHeston(ext::shared_ptr<PricingEngine> engi
 
     Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
     ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
-    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
     ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
-    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
 
@@ -595,6 +587,12 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston() {
 
     BOOST_TEST_MESSAGE("Testing analytic discrete geometric average-price Asians under Heston...");
 
+    // 30-day options need wider tolerance due to uncertainty around what "weekly
+    // fixing" dates mean over a 30-day month!
+    Real tol[] =     {3.0e-2, 2.0e-2, 2.0e-2, 2.0e-2, 3.0e-2, 4.0e-2, 8.0e-2, 1.0e-2,
+                      2.0e-2, 3.0e-2, 3.0e-2, 4.0e-2, 2.0e-2, 1.0e-2, 1.0e-2, 2.0e-2,
+                      3.0e-2, 4.0e-2};
+
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
 
@@ -617,13 +615,19 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston() {
     ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> engine(new
         AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(hestonProcess));
 
-    testDiscreteGeometricAveragePriceHeston(engine);
+    testDiscreteGeometricAveragePriceHeston(engine, tol);
 }
 
 
 void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
 
     BOOST_TEST_MESSAGE("Testing MC discrete geometric average-price Asians under Heston...");
+
+    // 30-day options need wider tolerance due to uncertainty around what "weekly
+    // fixing" dates mean over a 30-day month!
+    Real tol[] =     {4.0e-2, 2.0e-2, 2.0e-2, 3.0e-2, 3.0e-2, 2.0e-2, 1.0e-1, 1.0e-2,
+                      2.0e-2, 2.0e-2, 2.0e-2, 1.0e-2, 2.0e-2, 1.0e-2, 1.0e-2, 1.0e-2,
+                      1.0e-2, 1.0e-2};
 
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
@@ -649,7 +653,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
         .withSamples(65535)
         .withSeed(43);
 
-    testDiscreteGeometricAveragePriceHeston(engine);
+    testDiscreteGeometricAveragePriceHeston(engine, tol);
 }
 
 

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -37,6 +37,7 @@
 #include <ql/experimental/exoticoptions/continuousarithmeticasianlevyengine.hpp>
 #include <ql/experimental/exoticoptions/continuousarithmeticasianvecerengine.hpp>
 #include <ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp>
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
 #include <ql/utilities/dataformatters.hpp>
@@ -518,10 +519,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePrice() {
 }
 
 
-
-void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
-
-    BOOST_TEST_MESSAGE("Testing MC discrete geometric average-price Asians under Heston...");
+void testDiscreteGeometricAveragePriceHeston(ext::shared_ptr<PricingEngine> engine) {
 
     // data from "A Recursive Method for Discretely Monitored Geometric Asian Option
     // Prices", Kim, Kim, Kim & Wee, Bull. Korean Math. Soc. 53, 733-749, 2016
@@ -541,11 +539,8 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
                       3.7881, 5.2132, 7.2243, 9.9948, 12.0639, 0.1012, 0.5949, 1.4444,
                       2.9479, 5.3531, 7.3315};
 
-
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
-    Option::Type type(Option::Call);
-    Average::Type averageType = Average::Geometric;
 
     Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
     ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
@@ -554,19 +549,9 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
-    Real kappa = 1.15;
-    Real theta = 0.0348;
-    Real sigma = 0.39;
-    Real rho = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new
-        HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-            spot, v0, kappa, theta, sigma, rho));
-
-    ext::shared_ptr<PricingEngine> engine =
-        MakeMCDiscreteGeometricAPHestonEngine<LowDiscrepancy>(hestonProcess)
-        .withSamples(65535)
-        .withSeed(43);
+    Option::Type type(Option::Call);
+    Average::Type averageType = Average::Geometric;
 
     Real runningAccumulator = 1.0;
     Size pastFixings = 0;
@@ -603,6 +588,68 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
                        std::sqrt(v0), expected, calculated, tolerance);
         }
     }
+}
+
+
+void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston() {
+
+    BOOST_TEST_MESSAGE("Testing analytic discrete geometric average-price Asians under Heston...");
+
+    DayCounter dc = Actual365Fixed();
+    Date today = Settings::instance().evaluationDate();
+
+    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+
+    Real v0 = 0.09;
+    Real kappa = 1.15;
+    Real theta = 0.0348;
+    Real sigma = 0.39;
+    Real rho = -0.64;
+
+    ext::shared_ptr<HestonProcess> hestonProcess(new
+        HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+            spot, v0, kappa, theta, sigma, rho));
+
+    ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> engine(new
+        AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(hestonProcess));
+
+    testDiscreteGeometricAveragePriceHeston(engine);
+}
+
+
+void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
+
+    BOOST_TEST_MESSAGE("Testing MC discrete geometric average-price Asians under Heston...");
+
+    DayCounter dc = Actual365Fixed();
+    Date today = Settings::instance().evaluationDate();
+
+    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+
+    Real v0 = 0.09;
+    Real kappa = 1.15;
+    Real theta = 0.0348;
+    Real sigma = 0.39;
+    Real rho = -0.64;
+
+    ext::shared_ptr<HestonProcess> hestonProcess(new
+        HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+            spot, v0, kappa, theta, sigma, rho));
+
+    ext::shared_ptr<PricingEngine> engine =
+        MakeMCDiscreteGeometricAPHestonEngine<LowDiscrepancy>(hestonProcess)
+        .withSamples(65535)
+        .withSeed(43);
+
+    testDiscreteGeometricAveragePriceHeston(engine);
 }
 
 
@@ -1825,5 +1872,7 @@ test_suite* AsianOptionTest::experimental() {
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testVecerEngine));
     suite->add(QUANTLIB_TEST_CASE(
         &AsianOptionTest::testAnalyticContinuousGeometricAveragePriceHeston));
+    suite->add(QUANTLIB_TEST_CASE(
+        &AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston));
     return suite;
 }

--- a/test-suite/asianoptions.hpp
+++ b/test-suite/asianoptions.hpp
@@ -33,6 +33,7 @@ class AsianOptionTest {
     static void testAnalyticContinuousGeometricAveragePriceGreeks();
     static void testAnalyticContinuousGeometricAveragePriceHeston();
     static void testAnalyticDiscreteGeometricAveragePrice();
+    static void testAnalyticDiscreteGeometricAveragePriceHeston();
     static void testAnalyticDiscreteGeometricAverageStrike();
     static void testMCDiscreteGeometricAveragePrice();
     static void testMCDiscreteGeometricAveragePriceHeston();


### PR DESCRIPTION
An implementation of the procedure developed in "A Recursive Method for Discretely Monitored Geometric Asian Option Prices", B. Kim, J. Kim, J. Kim & I. S. Wee, Bull. Korean Math. Soc. 53, 733-749 (2016) to price discrete geometric asians.

The results are tested against the results presented in the paper.

This pricer will later be used as a control variate for discrete arithmetic asians when priced under Heston.