### PR TITLE
Initial commit for Analytic Discrete Geometric Average Asian pricer

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -542,6 +542,7 @@
     <ClInclude Include="ql\experimental\amortizingbonds\amortizingfloatingratebond.hpp" />
     <ClInclude Include="ql\experimental\asian\all.hpp" />
     <ClInclude Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.hpp" />
+    <ClInclude Include="ql\experimental\asian\analytic_cont_discr_av_price_heston.hpp" />
     <ClInclude Include="ql\experimental\averageois\all.hpp" />
     <ClInclude Include="ql\experimental\averageois\arithmeticaverageois.hpp" />
     <ClInclude Include="ql\experimental\averageois\arithmeticoisratehelper.hpp" />
@@ -1909,6 +1910,7 @@
     <ClCompile Include="ql\experimental\amortizingbonds\amortizingfixedratebond.cpp" />
     <ClCompile Include="ql\experimental\amortizingbonds\amortizingfloatingratebond.cpp" />
     <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.cpp" />
+    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.cpp" />
     <ClCompile Include="ql\experimental\averageois\arithmeticaverageois.cpp" />
     <ClCompile Include="ql\experimental\averageois\arithmeticoisratehelper.cpp" />
     <ClCompile Include="ql\experimental\averageois\averageoiscouponpricer.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -3336,6 +3336,9 @@
     <ClInclude Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.hpp">
       <Filter>experimental\futures</Filter>
     </ClInclude>
+    <ClInclude Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.hpp">
+      <Filter>experimental\futures</Filter>
+    </ClInclude>
     <ClInclude Include="ql\math\ode\all.hpp">
       <Filter>math\ode</Filter>
     </ClInclude>
@@ -6283,7 +6286,10 @@
     <ClCompile Include="ql\experimental\mcbasket\pathmultiassetoption.cpp">
       <Filter>experimental\mcbasket</Filter>
     </ClCompile>
-    <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.pp">
+    <ClCompile Include="ql\experimental\asian\analytic_cont_geom_av_price_heston.cpp">
+      <Filter>experimental\futures</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\experimental\asian\analytic_discr_geom_av_price_heston.cpp">
       <Filter>experimental\futures</Filter>
     </ClCompile>
     <ClCompile Include="ql\termstructures\volatility\atmadjustedsmilesection.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -48,6 +48,7 @@ set(QuantLib_SRC
     experimental/amortizingbonds/amortizingfixedratebond.cpp
     experimental/amortizingbonds/amortizingfloatingratebond.cpp
     experimental/asian/analytic_cont_geom_av_price_heston.cpp
+    experimental/asian/analytic_discr_geom_av_price_heston.cpp
     experimental/averageois/arithmeticaverageois.cpp
     experimental/averageois/arithmeticoisratehelper.cpp
     experimental/averageois/averageoiscouponpricer.cpp
@@ -973,6 +974,7 @@ set(QuantLib_HDR
     experimental/amortizingbonds/amortizingfixedratebond.hpp
     experimental/amortizingbonds/amortizingfloatingratebond.hpp
     experimental/asian/analytic_cont_geom_av_price_heston.hpp
+    experimental/asian/analytic_discr_geom_av_price_heston.hpp
     experimental/averageois/all.hpp
     experimental/averageois/arithmeticaverageois.hpp
     experimental/averageois/arithmeticoisratehelper.hpp

--- a/ql/experimental/asian/Makefile.am
+++ b/ql/experimental/asian/Makefile.am
@@ -4,10 +4,12 @@ AM_CPPFLAGS = -I${top_builddir} -I${top_srcdir}
 this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \
     all.hpp \
-    analytic_cont_geom_av_price_heston.hpp
+    analytic_cont_geom_av_price_heston.hpp \
+    analytic_discr_geom_av_price_heston.hpp
 
 cpp_files = \
-    analytic_cont_geom_av_price_heston.cpp
+    analytic_cont_geom_av_price_heston.cpp \
+    analytic_discr_geom_av_price_heston.cpp
 
 if UNITY_BUILD
 

--- a/ql/experimental/asian/all.hpp
+++ b/ql/experimental/asian/all.hpp
@@ -2,4 +2,5 @@
 /* Add the files to be included into Makefile.am instead. */
 
 #include <ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp>
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
 

--- a/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
@@ -21,28 +21,33 @@
 
 namespace QuantLib {
 
-    class Integrand {
-      private:
-        Real t_, T_, K_, logK_;
-        Size cutoff_;
-        const AnalyticContinuousGeometricAveragePriceAsianHestonEngine* const parent_;
-        Real xiRightLimit_;
-        std::complex<Real> i_;
+    namespace {
+        class Integrand {
+          private:
+            Real t_, T_, K_, logK_;
+            Size cutoff_;
+            const AnalyticContinuousGeometricAveragePriceAsianHestonEngine* const parent_;
+            Real xiRightLimit_;
+            std::complex<Real> i_;
 
-      public:
-        Integrand(Real T,
-                  Size cutoff,
-                  Real K,
-                  const AnalyticContinuousGeometricAveragePriceAsianHestonEngine* const parent,
-                  Real xiRightLimit) : t_(0.0), T_(T), K_(K), logK_(std::log(K)), cutoff_(cutoff), parent_(parent),
-                                       xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
+          public:
+            Integrand(Real T,
+                      Size cutoff,
+                      Real K,
+                      const AnalyticContinuousGeometricAveragePriceAsianHestonEngine* const parent,
+                      Real xiRightLimit) : t_(0.0), T_(T), K_(K), logK_(std::log(K)), cutoff_(cutoff),
+                parent_(parent), xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
 
-        double operator()(double xi) const {
-            double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
-            std::complex<Real> inner = parent_->Phi(1.0 + xiDash*i_, 0, T_, t_, cutoff_) - K_*parent_->Phi(xiDash*i_, 0, T_, t_, cutoff_);
-            return 0.5*xiRightLimit_*std::real(inner * std::exp(-xiDash*logK_*i_) / (xiDash*i_));
-        }
-    };
+            double operator()(double xi) const {
+                double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
+
+                std::complex<Real> inner1 = parent_->Phi(1.0 + xiDash*i_, 0, T_, t_, cutoff_);
+                std::complex<Real> inner2 = - K_*parent_->Phi(xiDash*i_, 0, T_, t_, cutoff_);
+
+                return 0.5*xiRightLimit_*std::real((inner1 + inner2) * std::exp(-xiDash*logK_*i_) / (xiDash*i_));
+            }
+        };
+    }
 
     class DcfIntegrand {
       private:
@@ -89,29 +94,29 @@ namespace QuantLib {
     }
 
     std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::z1_f(
-            std::complex<Real> s, std::complex<Real> w, Real T) const {
+            const std::complex<Real>& s, const std::complex<Real>& w, Real T) const {
         return s*s*(1-rho_*rho_)/(2*T*T);
     }
 
     std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::z2_f(
-            std::complex<Real> s, std::complex<Real> w, Real T) const {
+            const std::complex<Real>& s, const std::complex<Real>& w, Real T) const {
         return s*(2*rho_*kappa_ - sigma_)/(2*sigma_*T) + s*w*(1-rho_*rho_)/T;
     }
 
     std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::z3_f(
-            std::complex<Real> s, std::complex<Real> w, Real T) const {
+            const std::complex<Real>& s, const std::complex<Real>& w, Real T) const {
         return s*rho_/(sigma_*T) + 0.5*w*(2*rho_*kappa_ - sigma_)/sigma_ + 0.5*w*w*(1-rho_*rho_);
     }
 
     std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::z4_f(
-            std::complex<Real> s, std::complex<Real> w) const {
+            const std::complex<Real>& s, const std::complex<Real>& w) const {
         return w*rho_/sigma_;
     }
 
-    std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::f(std::complex<Real> z1,
-                                                                                   std::complex<Real> z2,
-                                                                                   std::complex<Real> z3,
-                                                                                   std::complex<Real> z4,
+    std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::f(const std::complex<Real>& z1,
+                                                                                   const std::complex<Real>& z2,
+                                                                                   const std::complex<Real>& z3,
+                                                                                   const std::complex<Real>& z4,
                                                                                    int n, // Can't use Size here as n can be negative
                                                                                    Real tau) const {;
         std::complex<Real> result;
@@ -153,10 +158,10 @@ namespace QuantLib {
 
     std::pair<std::complex<Real>, std::complex<Real> >
         AnalyticContinuousGeometricAveragePriceAsianHestonEngine::F_F_tilde(
-            std::complex<Real> z1,
-            std::complex<Real> z2,
-            std::complex<Real> z3,
-            std::complex<Real> z4,
+            const std::complex<Real>& z1,
+            const std::complex<Real>& z2,
+            const std::complex<Real>& z3,
+            const std::complex<Real>& z4,
             Real tau,
             Size cutoff) const {
         std::complex<Real> temp = 0.0;
@@ -175,8 +180,8 @@ namespace QuantLib {
     };
 
     std::complex<Real> AnalyticContinuousGeometricAveragePriceAsianHestonEngine::Phi(
-            std::complex<Real> s,
-            std::complex<Real> w,
+            const std::complex<Real>& s,
+            const std::complex<Real>& w,
             Real T,
             Real t,
             Size cutoff) const {

--- a/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
@@ -21,7 +21,7 @@
 
 namespace QuantLib {
 
-    namespace {
+    namespace Acgap {
         class Integrand {
           private:
             Real t_, T_, K_, logK_;
@@ -246,7 +246,7 @@ namespace QuantLib {
         // Calculate the two terms in eq (29) - Phi(1,0) is real (asian forward) but need to type convert
         Real term1 = 0.5 * (std::real(Phi(1,0, T, t, summationCutoff_)) - strike);
 
-        Integrand integrand = Integrand(T, summationCutoff_, strike, this, xiRightLimit_);
+        Acgap::Integrand integrand = Acgap::Integrand(T, summationCutoff_, strike, this, xiRightLimit_);
         Real term2 = integrator_(integrand) / M_PI;
 
         // Apply the payoff functions

--- a/ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp
@@ -72,7 +72,9 @@ namespace QuantLib {
 
         // Phi, defined in eq (25). Must be public so the integrand can access it (Could
         // use friend functions I think, but perhaps overkill?)
-        std::complex<Real> Phi(std::complex<Real> s, std::complex<Real> w, Real T, Real t = 0.0, Size cutoff = 50) const;
+        std::complex<Real> Phi(const std::complex<Real>& s,
+                               const std::complex<Real>& w,
+                               Real T, Real t = 0.0, Size cutoff = 50) const;
 
       private:
         // Initial process params
@@ -99,25 +101,25 @@ namespace QuantLib {
 
 
         // Equations (13)
-        std::complex<Real> z1_f(std::complex<Real> s, std::complex<Real> w, Real T) const;
-        std::complex<Real> z2_f(std::complex<Real> s, std::complex<Real> w, Real T) const;
-        std::complex<Real> z3_f(std::complex<Real> s, std::complex<Real> w, Real T) const;
-        std::complex<Real> z4_f(std::complex<Real> s, std::complex<Real> w) const;
+        std::complex<Real> z1_f(const std::complex<Real>& s, const std::complex<Real>& w, Real T) const;
+        std::complex<Real> z2_f(const std::complex<Real>& s, const std::complex<Real>& w, Real T) const;
+        std::complex<Real> z3_f(const std::complex<Real>& s, const std::complex<Real>& w, Real T) const;
+        std::complex<Real> z4_f(const std::complex<Real>& s, const std::complex<Real>& w) const;
 
         // Equations (19), (20)
         std::pair<std::complex<Real>, std::complex<Real> > F_F_tilde(
-                                        std::complex<Real> z1,
-                                        std::complex<Real> z2,
-                                        std::complex<Real> z3,
-                                        std::complex<Real> z4,
+                                        const std::complex<Real>& z1,
+                                        const std::complex<Real>& z2,
+                                        const std::complex<Real>& z3,
+                                        const std::complex<Real>& z4,
                                         Real tau,
                                         Size cutoff = 50) const;
 
         // Equation (21)
-        std::complex<Real> f(std::complex<Real> z1,
-                             std::complex<Real> z2,
-                             std::complex<Real> z3,
-                             std::complex<Real> z4,
+        std::complex<Real> f(const std::complex<Real>& z1,
+                             const std::complex<Real>& z2,
+                             const std::complex<Real>& z3,
+                             const std::complex<Real>& z4,
                              int n,
                              Real tau) const;
     };

--- a/ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_cont_geom_av_price_heston.hpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2020 Jack Gillett
- 
+
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
 
@@ -99,6 +99,9 @@ namespace QuantLib {
         // Integrator for equation (29)
         GaussLegendreIntegration integrator_;
 
+        // Integrands
+        class Integrand;
+        class DcfIntegrand;
 
         // Equations (13)
         std::complex<Real> z1_f(const std::complex<Real>& s, const std::complex<Real>& w, Real T) const;

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -21,7 +21,7 @@
 
 namespace QuantLib {
 
-    namespace {
+    namespace Adgap {
         // A class to perform the integrations in Eqs (23) and (24)
         class Integrand {
           private:
@@ -256,8 +256,8 @@ namespace QuantLib {
         // Calculate the two terms in eq (23) - Phi(1,0) is real (asian forward) but need to type convert
         Real term1 = 0.5 * (std::real(Phi(1,0, startTime, expiryTime, kStar, fixingTimes, tauK)) - strike);
 
-        Integrand integrand = Integrand(startTime, expiryTime, kStar, fixingTimes,
-                                        tauK, strike, this, xiRightLimit_);
+        Adgap::Integrand integrand = Adgap::Integrand(startTime, expiryTime, kStar, fixingTimes,
+                                                      tauK, strike, this, xiRightLimit_);
         Real term2 = integrator_(integrand) / M_PI;
 
 

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -1,0 +1,285 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Jack Gillett
+ 
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
+
+namespace QuantLib {
+
+    // A class to perform the integrations in Eqs (23) and (24)
+    class AdgapIntegrand {
+      private:
+        Real t_, T_, K_, logK_;
+        Size kStar_;
+        const std::vector<Time> t_n_, tauK_;
+        const AnalyticDiscreteGeometricAveragePriceAsianHestonEngine* const parent_;
+        Real xiRightLimit_;
+        std::complex<Real> i_;
+
+      public:
+        AdgapIntegrand(Real t,
+                       Real T,
+                       Size kStar,
+                       const std::vector<Time>& t_n,
+                       const std::vector<Time>& tauK,
+                       Real K,
+                       const AnalyticDiscreteGeometricAveragePriceAsianHestonEngine* const parent,
+                       Real xiRightLimit) : t_(t), T_(T), K_(K), logK_(std::log(K)), kStar_(kStar), t_n_(t_n),
+            tauK_(tauK), parent_(parent), xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
+
+        double operator()(double xi) const {
+            double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
+
+            std::complex<Real> inner1 = parent_->Phi(1.0 + xiDash*i_, 0, t_, T_, kStar_, t_n_, tauK_);
+            std::complex<Real> inner2 = -K_*parent_->Phi(xiDash*i_, 0, t_, T_, kStar_, t_n_, tauK_);
+
+            return 0.5*xiRightLimit_*std::real((inner1 + inner2) * std::exp(-xiDash*logK_*i_) / (xiDash*i_));
+        }
+    };
+
+    AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::
+        AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(
+            const ext::shared_ptr<HestonProcess>& process,
+            Real xiRightLimit)
+    : process_(process), xiRightLimit_(xiRightLimit), integrator_(128) {
+        registerWith(process_);
+
+        v0_ = process_->v0();
+        rho_ = process_->rho();
+        kappa_ = process_->kappa();
+        theta_ = process_->theta();
+        sigma_ = process_->sigma();
+        s0_ = process_->s0();
+        logS0_ = std::log(s0_->value());
+
+        riskFreeRate_ = process_->riskFreeRate();
+        dividendYield_ = process_->dividendYield();
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::F(
+            std::complex<Real>& z1,
+            std::complex<Real>& z2,
+            Time tau) const {
+        std::complex<Real> temp = std::sqrt(kappa_*kappa_-2.0*z1*sigma_*sigma_);
+        if (std::abs(kappa_*kappa_-2.0*sigma_*sigma_) < 1e-8) {
+            return 1.0 + 0.5*(kappa_-z2*sigma_*sigma_);
+        } else {
+            return cosh(0.5*tau*temp) + (kappa_-z2*sigma_*sigma_)*sinh(0.5*tau*temp)/temp;
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::F_tilde(
+            std::complex<Real>& z1,
+            std::complex<Real>& z2,
+            Time tau) const {
+        std::complex<Real> temp = std::sqrt(kappa_*kappa_ - 2.0*z1*sigma_*sigma_);
+        return 0.5*temp*sinh(0.5*tau*temp) + 0.5*(kappa_ - z2*sigma_*sigma_)*cosh(0.5*tau*temp);
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::z(
+            std::complex<Real>& s, std::complex<Real>& w, Size k, Size n) const {
+        double k_ = double(k);
+        double n_ = double(n);
+        std::complex<Real> term1 = (2*rho_*kappa_ - sigma_)*((n_-k_+1)*s + n_*w)/(2*sigma_*n_);
+        std::complex<Real> term2 = (1-rho_*rho_)*pow(((n_-k_+1)*s + n_*w), 2)/(2*n_*n_);
+
+        return term1 + term2;
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::omega(
+            std::complex<Real>& s, std::complex<Real>& w, Size k, Size kStar, Size n) const {
+        if (k==kStar) {
+            return 0;
+        } else if (k==n+1) {
+            return rho_*w/sigma_;
+        } else {
+            return rho_*s/(sigma_*n);
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::a(
+            std::complex<Real>& s,
+            std::complex<Real>& w,
+            Time t, Time T, Size kStar,
+            const std::vector<Time>& t_n) const {
+        double kStar_ = double(kStar);
+        double n_ = double(t_n.size());
+        Real temp = -rho_*kappa_*theta_/sigma_;
+
+        Time summation = 0.0;
+        Real summation2 = 0.0;
+        for (Size i=kStar+1; i<=t_n.size(); i++) {
+            summation += t_n[i-1];
+            summation2 += tkr_tk_[i-1];
+        }
+        // This is Eq (16) modified for non-constant rates
+        std::complex<Real> term1 = (s*(n_-kStar_)/n_ + w)*(logS0_ - rho_*v0_/sigma_ - t*temp - tr_t_);
+        std::complex<Real> term2 = temp*(s*summation/n_ + w*T) + w*Tr_T_ + summation2*s/n_;
+
+        return term1 + term2;
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::omega_tilde(
+            std::complex<Real>& s,
+            std::complex<Real>& w,
+            Size k, Size kStar, Size n,
+            const std::vector<Time>& tauK) const {
+        std::complex<Real> omega_k = omega(s, w, k, kStar, n);
+        if (k==n+1) {
+            return omega_k;
+        } else {
+            Time dTauk = tauK[k+1] - tauK[k];
+            std::complex<Real> z_kp1 = z(s, w, k+1, n);
+
+            // omega_tilde calls itself recursivly, use lookup map to avoid extreme slowdown when k large
+            std::complex<Real> omega_kp1 = 0.0;
+
+            std::map<Size, std::complex<Real> >::const_iterator position = omegaTildeLookupTable_.find(k+1);
+
+            if (position != omegaTildeLookupTable_.end()) {
+                std::complex<Real> value = position->second;
+                omega_kp1 = value;
+            } else {
+                omega_kp1 = omega_tilde(s, w, k+1, kStar, n, tauK);
+            }
+
+            std::complex<Real> ratio = F_tilde(z_kp1,omega_kp1,dTauk)/F(z_kp1,omega_kp1,dTauk);
+            std::complex<Real> result = omega_k + kappa_/pow(sigma_,2) - 2.0*ratio/pow(sigma_,2);
+
+            // Store this value in our mutable lookup map
+            omegaTildeLookupTable_[k] = result;
+
+            return result;
+        }
+    }
+
+    std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::Phi(
+            std::complex<Real> s,
+            std::complex<Real> w,
+            Time t, Time T, Size kStar,
+            const std::vector<Time>& t_n,
+            const std::vector<Time>& tauK) const {
+
+        // Clear the mutable lookup map before evaluating Phi
+        omegaTildeLookupTable_ = std::map<Size, std::complex<Real> >();
+
+        Size n = t_n.size();
+        std::complex<Real> aTerm = a(s, w, t, T, kStar, t_n);
+        std::complex<Real> omegaTerm = v0_*omega_tilde(s, w, kStar, kStar, n, tauK);
+        Real term3 = kappa_*kappa_*theta_*(T-t)/pow(sigma_,2);
+
+        std::complex<Real> summation = 0.0;
+        for (Size i=kStar+1; i<=n+1; i++) {
+            Real dTau = tauK[i] - tauK[i-1];
+            std::complex<Real> z_k = z(s, w, i, n);
+            std::complex<Real> omega_tilde_k = omega_tilde(s, w, i, kStar, n, tauK);
+
+            summation += std::log(F(z_k, omega_tilde_k, dTau));
+        }
+        std::complex<Real> term4 = 2*kappa_*theta_*summation/pow(sigma_,2);
+
+        return std::exp(aTerm + omegaTerm + term3 - term4);
+}
+
+    void AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::calculate() const {
+        QL_REQUIRE(arguments_.averageType == Average::Geometric,
+                   "not a geometric average option");
+        QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
+                   "not an European Option");
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        Real strike = payoff->strike();
+        Date exercise = arguments_.exercise->lastDate();
+
+        Time expiryTime = this->process_->time(exercise);
+        QL_REQUIRE(expiryTime >= 0.0, "Expiry Date cannot be in the past");
+
+        Real expiryDcf = riskFreeRate_->discount(expiryTime);
+
+        std::vector<Time> fixingTimes, tauK;
+        for (Size i=0; i<arguments_.fixingDates.size(); i++) {
+            fixingTimes.push_back(this->process_->time(arguments_.fixingDates[i]));
+        }
+        std::sort(fixingTimes.begin(), fixingTimes.end());
+
+
+        // TODO: extend to cover seasoned options (discussed in paper)
+        Time startTime = 0.0;
+
+
+        Size kStar = 0;
+        for (Size i=0; i<fixingTimes.size(); i++) {
+            if (startTime > fixingTimes[i]) {
+                kStar = i+1;
+            } else {
+                tauK.push_back(this->process_->time(arguments_.fixingDates[i]));
+            }
+        }
+
+        // tauK is just a vector of the sorted fixing times from the kStar element
+        // onwards, with t pushed on the front and T pushed on the back!
+        tauK.insert(tauK.begin(), startTime);
+        tauK.push_back(expiryTime);
+
+        // Need the log of some discount factors to calculate the r-adjusted a factor (Eq 16)
+        tr_t_ = 0;
+        Tr_T_ = 0;
+        tkr_tk_ = std::vector<Real>();
+        tr_t_ = -std::log(riskFreeRate_->discount(startTime) / dividendYield_->discount(startTime));
+        Tr_T_ = -std::log(riskFreeRate_->discount(expiryTime) / dividendYield_->discount(expiryTime));
+        for (Size i=0; i<fixingTimes.size(); i++) {
+            tkr_tk_.push_back(-std::log(riskFreeRate_->discount(fixingTimes[i]) 
+                                        / dividendYield_->discount(fixingTimes[i])));
+        }
+
+        // Calculate the two terms in eq (23) - Phi(1,0) is real (asian forward) but need to type convert
+        Real term1 = 0.5 * (std::real(Phi(1,0, startTime, expiryTime, kStar, fixingTimes, tauK)) - strike);
+
+        AdgapIntegrand integrand = AdgapIntegrand(startTime, expiryTime, kStar, fixingTimes,
+                                                  tauK, strike, this, xiRightLimit_);
+        Real term2 = integrator_(integrand) / M_PI;
+
+
+        // Apply the payoff functions
+        Real value = 0.0;
+        switch (payoff->optionType()){
+            case Option::Call:
+                value = expiryDcf * (term1 + term2);
+                break;
+            case Option::Put:
+                value = expiryDcf * (-term1 + term2);
+                break;
+            default:
+                QL_FAIL("unknown option type");
+            }
+
+        results_.value = value;
+
+        results_.additionalResults["dcf"] = expiryDcf;
+        results_.additionalResults["s0"] = s0_->value();
+        results_.additionalResults["strike"] = strike;
+        results_.additionalResults["expiryTime"] = expiryTime;
+        results_.additionalResults["term1"] = term1;
+        results_.additionalResults["term2"] = term2;
+        results_.additionalResults["xiRightLimit"] = xiRightLimit_;
+    }
+}
+

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -1,0 +1,137 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2020 Jack Gillett
+ 
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file analytic_cont_geom_av_price.hpp
+    \brief Analytic engine for continuous geometric average price Asian
+           in the Heston model
+*/
+
+#ifndef quantlib_analytic_discrete_geometric_average_price_asian_heston_engine_hpp
+#define quantlib_analytic_discrete_geometric_average_price_asian_heston_engine_hpp
+
+#include <ql/instruments/asianoption.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/math/integrals/gaussianquadratures.hpp>
+#include <ql/exercise.hpp>
+
+namespace QuantLib {
+
+    //! Pricing engine for European discrete geometric average price Asian
+    /*! This class implements a discrete geometric average price
+        Asian option with European exercise under the Heston stochastic
+        vol model where spot and variance follow the processes
+
+        \f[
+        \begin{array}{rcl}
+        dS(t, S)  &=& (r-d) S dt +\sqrt{v} S dW_1 \\
+        dv(t, S)  &=& \kappa (\theta - v) dt + \sigma \sqrt{v} dW_2 \\
+        dW_1 dW_2 &=& \rho dt \\
+        \end{array}
+        \f]
+
+        References:
+
+        Implements the analytical solution for continuous geometric Asian
+        options developed in "A Recursive Method for Discretely Monitored
+        Geometric Asian Option Prices", B. Kim, J. Kim, J. Kim & I. S. Wee,
+        Bull. Korean Math. Soc. 53, 733-749 (2016)
+
+        \ingroup asianengines
+
+        \test
+        - the correctness of the returned value is tested by reproducing
+              results in Tables 1, 2 and 3 of the paper
+
+        \todo handle seasoned options
+    */
+    class AnalyticDiscreteGeometricAveragePriceAsianHestonEngine
+        : public DiscreteAveragingAsianOption::engine {
+      public:
+        explicit AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(
+            const ext::shared_ptr<HestonProcess>& process,
+            Real xiRightLimit = 100.0);
+        void calculate() const;
+
+        // Equation (21) - must be public so the integrand can access it.
+        std::complex<Real> Phi(std::complex<Real> s,
+                               std::complex<Real> w,
+                               Time t, Time T, Size kStar,
+                               const std::vector<Time>& t_n,
+                               const std::vector<Time>& tauK) const;
+
+      private:
+        // Initial process params
+        Real v0_, rho_, kappa_, theta_, sigma_, logS0_;
+        Handle<YieldTermStructure> dividendYield_;
+        Handle<YieldTermStructure> riskFreeRate_;
+        Handle<Quote> s0_;
+
+        ext::shared_ptr<HestonProcess> process_;
+
+        // A lookup table for the reuslts of omega_tilde() to avoid repeated calls for given Phi call
+        mutable std::map<Size, std::complex<Real> > omegaTildeLookupTable_;
+
+        // Cutoff parameter for integral in Eqs (23) and (24)
+        Size xiRightLimit_;
+
+        // Integrator for equation (23) and (24)
+        GaussLegendreIntegration integrator_;
+
+        // We need to set up several variables inside calculate as they depend on fixing times. Rather
+        // than pass them between a, omega, F etc. which makes for very messy method signatures, we
+        // make them mutable class properties instead.
+        mutable Real tr_t_;
+        mutable Real Tr_T_;
+        mutable std::vector<Real> tkr_tk_;
+
+        // Equation (11)
+        std::complex<Real> F(std::complex<Real>& z1,
+                             std::complex<Real>& z2,
+                             Time tau) const;
+
+        std::complex<Real> F_tilde(std::complex<Real>& z1,
+                                   std::complex<Real>& z2,
+                                   Time tau) const;
+
+        // Equation (14)
+        std::complex<Real> z(std::complex<Real>& s,
+                             std::complex<Real>& w,
+                             Size k, Size n) const;
+
+        // Equation (15)
+        std::complex<Real> omega(std::complex<Real>& s,
+                                 std::complex<Real>& w,
+                                 Size k, Size kStar, Size n) const;
+
+        // Equation (16)
+        std::complex<Real> a(std::complex<Real>& s,
+                             std::complex<Real>& w,
+                             Time t, Time T, Size kStar,
+                             const std::vector<Time>& t_n) const;
+
+        // Equation (19)
+        std::complex<Real> omega_tilde(std::complex<Real>& s,
+                                       std::complex<Real>& w,
+                                       Size k, Size kStar, Size n,
+                                       const std::vector<Time>& tauK) const;
+    };
+}
+
+
+#endif

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -69,8 +69,8 @@ namespace QuantLib {
         void calculate() const;
 
         // Equation (21) - must be public so the integrand can access it.
-        std::complex<Real> Phi(std::complex<Real> s,
-                               std::complex<Real> w,
+        std::complex<Real> Phi(const std::complex<Real> s,
+                               const std::complex<Real> w,
                                Time t, Time T, Size kStar,
                                const std::vector<Time>& t_n,
                                const std::vector<Time>& tauK) const;
@@ -101,33 +101,33 @@ namespace QuantLib {
         mutable std::vector<Real> tkr_tk_;
 
         // Equation (11)
-        std::complex<Real> F(std::complex<Real>& z1,
-                             std::complex<Real>& z2,
+        std::complex<Real> F(const std::complex<Real>& z1,
+                             const std::complex<Real>& z2,
                              Time tau) const;
 
-        std::complex<Real> F_tilde(std::complex<Real>& z1,
-                                   std::complex<Real>& z2,
+        std::complex<Real> F_tilde(const std::complex<Real>& z1,
+                                   const std::complex<Real>& z2,
                                    Time tau) const;
 
         // Equation (14)
-        std::complex<Real> z(std::complex<Real>& s,
-                             std::complex<Real>& w,
+        std::complex<Real> z(const std::complex<Real>& s,
+                             const std::complex<Real>& w,
                              Size k, Size n) const;
 
         // Equation (15)
-        std::complex<Real> omega(std::complex<Real>& s,
-                                 std::complex<Real>& w,
+        std::complex<Real> omega(const std::complex<Real>& s,
+                                 const std::complex<Real>& w,
                                  Size k, Size kStar, Size n) const;
 
         // Equation (16)
-        std::complex<Real> a(std::complex<Real>& s,
-                             std::complex<Real>& w,
+        std::complex<Real> a(const std::complex<Real>& s,
+                             const std::complex<Real>& w,
                              Time t, Time T, Size kStar,
                              const std::vector<Time>& t_n) const;
 
         // Equation (19)
-        std::complex<Real> omega_tilde(std::complex<Real>& s,
-                                       std::complex<Real>& w,
+        std::complex<Real> omega_tilde(const std::complex<Real>& s,
+                                       const std::complex<Real>& w,
                                        Size k, Size kStar, Size n,
                                        const std::vector<Time>& tauK) const;
     };

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2020 Jack Gillett
- 
+
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
 
@@ -92,6 +92,9 @@ namespace QuantLib {
 
         // Integrator for equation (23) and (24)
         GaussLegendreIntegration integrator_;
+
+        // Integrand
+        class Integrand;
 
         // We need to set up several variables inside calculate as they depend on fixing times. Rather
         // than pass them between a, omega, F etc. which makes for very messy method signatures, we

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
         mutable std::map<Size, std::complex<Real> > omegaTildeLookupTable_;
 
         // Cutoff parameter for integral in Eqs (23) and (24)
-        Size xiRightLimit_;
+        Real xiRightLimit_;
 
         // Integrator for equation (23) and (24)
         GaussLegendreIntegration integrator_;

--- a/test-suite/asianoptions.hpp
+++ b/test-suite/asianoptions.hpp
@@ -33,6 +33,7 @@ class AsianOptionTest {
     static void testAnalyticContinuousGeometricAveragePriceGreeks();
     static void testAnalyticContinuousGeometricAveragePriceHeston();
     static void testAnalyticDiscreteGeometricAveragePrice();
+    static void testAnalyticDiscreteGeometricAveragePriceHeston();
     static void testAnalyticDiscreteGeometricAverageStrike();
     static void testMCDiscreteGeometricAveragePrice();
     static void testMCDiscreteGeometricAveragePriceHeston();


### PR DESCRIPTION
An implementation of the procedure developed in "[A Recursive Method for Discretely Monitored Geometric Asian Option Prices](https://koreauniv.pure.elsevier.com/en/publications/a-recursive-method-for-discretely-monitored-geometric-asian-optio)", B. Kim, J. Kim, J. Kim & I. S. Wee, Bull. Korean Math. Soc. 53, 733-749 (2016) to price discrete geometric asians.

The results are tested against the results presented in the paper.

This pricer will later be used as a control variate for discrete arithmetic asians when priced under Heston.