### PR TITLE
The set-env command is disabled.

### DIFF
--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -3,6 +3,8 @@ on: workflow_dispatch
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     steps:
     - uses: actions/checkout@v2
     - name: Setup


### PR DESCRIPTION
The `set-env` command has been disabled (at least for the windows workflow) by [GitHub](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). It can explicitly be enabled again by these changes.