### PR TITLE
Adding a control variate to the arithmetic asian MC heston pricer

### DIFF
--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -199,8 +199,11 @@ namespace QuantLib {
 }
 
     void AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::calculate() const {
+        /* this engine cannot really check for the averageType==Geometric
+           since it can be used as control variate for the Arithmetic version
         QL_REQUIRE(arguments_.averageType == Average::Geometric,
                    "not a geometric average option");
+        */
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "not an European Option");
 

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp
@@ -69,9 +69,11 @@ namespace QuantLib {
         void calculate() const;
 
         // Equation (21) - must be public so the integrand can access it.
-        std::complex<Real> Phi(const std::complex<Real> s,
-                               const std::complex<Real> w,
-                               Time t, Time T, Size kStar,
+        std::complex<Real> Phi(std::complex<Real> s,
+                               std::complex<Real> w,
+                               Time t,
+                               Time T,
+                               Size kStar,
                                const std::vector<Time>& t_n,
                                const std::vector<Time>& tauK) const;
 

--- a/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
@@ -38,6 +38,9 @@ namespace QuantLib {
          can and does not guarantee to match an exact number of steps, the precise
          grid used can be found in results_.additionalResults["TimeGrid"]
 
+         Some performance metrics/graphs for the Control Variate are shown in the
+         pull request: https://github.com/lballabio/QuantLib/pull/966
+
          \ingroup asianengines
          \test the correctness of the returned value is tested by
                reproducing results available in literature.

--- a/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
@@ -23,6 +23,8 @@
 #define quantlib_mc_discrete_arithmetic_average_price_asian_heston_engine_hpp
 
 #include <ql/pricingengines/asian/mcdiscreteasianenginebase.hpp>
+#include <ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp>
+#include <ql/experimental/asian/analytic_discr_geom_av_price_heston.hpp>
 #include <ql/processes/hestonprocess.hpp>
 #include <ql/exercise.hpp>
 
@@ -57,9 +59,20 @@ namespace QuantLib {
              Size maxSamples,
              BigNatural seed,
              Size timeSteps = Null<Size>(),
-             Size timeStepsPerYear = Null<Size>());
+             Size timeStepsPerYear = Null<Size>(),
+             bool controlVariate = false);
       protected:
         ext::shared_ptr<path_pricer_type> pathPricer() const;
+
+        // Use the experimental analytic geometric asian option as a control variate.
+        ext::shared_ptr<path_pricer_type> controlPathPricer() const;
+        ext::shared_ptr<PricingEngine> controlPricingEngine() const {
+            ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
+            QL_REQUIRE(process, "Heston-like process required");
+
+            return ext::shared_ptr<PricingEngine>(new
+                AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(process));
+        }
     };
 
 
@@ -77,11 +90,12 @@ namespace QuantLib {
         MakeMCDiscreteArithmeticAPHestonEngine& withAntitheticVariate(bool b = true);
         MakeMCDiscreteArithmeticAPHestonEngine& withSteps(Size steps);
         MakeMCDiscreteArithmeticAPHestonEngine& withStepsPerYear(Size steps);
+        MakeMCDiscreteArithmeticAPHestonEngine& withControlVariate(bool b = false);
         // conversion to pricing engine
         operator ext::shared_ptr<PricingEngine>() const;
       private:
         ext::shared_ptr<P> process_;
-        bool antithetic_;
+        bool antithetic_, controlVariate_;
         Size samples_, maxSamples_, steps_, stepsPerYear_;
         Real tolerance_;
         BigNatural seed_;
@@ -118,11 +132,12 @@ namespace QuantLib {
              Size maxSamples,
              BigNatural seed,
              Size timeSteps,
-             Size timeStepsPerYear)
+             Size timeStepsPerYear,
+             bool controlVariate)
     : MCDiscreteAveragingAsianEngineBase<MultiVariate,RNG,S>(process,
                                                              false,
                                                              antitheticVariate,
-                                                             false,
+                                                             controlVariate,
                                                              requiredSamples,
                                                              requiredTolerance,
                                                              maxSamples,
@@ -172,10 +187,51 @@ namespace QuantLib {
     }
 
     template <class RNG, class S, class P>
+    inline ext::shared_ptr<
+            typename MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>
+        MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::controlPathPricer() const {
+
+        // Keep track of the fixing indices, the path pricer will need to prod only these
+        TimeGrid timeGrid = this->timeGrid();
+        std::vector<Time> fixingTimes = timeGrid.mandatoryTimes();
+        std::vector<Size> fixingIndexes;
+        for (Size i=0; i<fixingTimes.size(); i++) {
+            fixingIndexes.push_back(timeGrid.closestIndex(fixingTimes[i]));
+        }
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(
+                this->arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        ext::shared_ptr<EuropeanExercise> exercise =
+            ext::dynamic_pointer_cast<EuropeanExercise>(
+                this->arguments_.exercise);
+        QL_REQUIRE(exercise, "wrong exercise given");
+
+        ext::shared_ptr<P> process =
+            ext::dynamic_pointer_cast<P>(this->process_);
+        QL_REQUIRE(process, "Heston like process required");
+
+        // TODO: Currently the analytic pricer does not support seasoned asian
+        // options (coming soon). Once that is available, we will be able to
+        // pass seasoning details to the path pricer (NB. NEED to pass them to
+        // the analytic pricer as well in that case).
+
+        return ext::shared_ptr<typename
+            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>(
+                new GeometricAPOHestonPathPricer(
+                    payoff->optionType(),
+                    payoff->strike(),
+                    process->riskFreeRate()->discount(exercise->lastDate()),
+                    fixingIndexes));
+    }
+
+    template <class RNG, class S, class P>
     inline MakeMCDiscreteArithmeticAPHestonEngine<RNG,S,P>::MakeMCDiscreteArithmeticAPHestonEngine(
              const ext::shared_ptr<P>& process)
-    : process_(process), antithetic_(false), samples_(Null<Size>()),
-      maxSamples_(Null<Size>()), steps_(Null<Size>()),
+    : process_(process), antithetic_(false), controlVariate_(false),
+      samples_(Null<Size>()), maxSamples_(Null<Size>()), steps_(Null<Size>()),
       stepsPerYear_(Null<Size>()), tolerance_(Null<Real>()), seed_(0) {}
 
     template<class RNG, class S, class P>
@@ -239,6 +295,13 @@ namespace QuantLib {
         return *this;
     }
 
+    template<class RNG, class S, class P>
+    inline MakeMCDiscreteArithmeticAPHestonEngine<RNG,S,P>&
+    MakeMCDiscreteArithmeticAPHestonEngine<RNG,S,P>::withControlVariate(bool b) {
+        controlVariate_ = b;
+        return *this;
+    }
+
     template <class RNG, class S, class P>
     inline MakeMCDiscreteArithmeticAPHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>() const {
         return ext::shared_ptr<PricingEngine>(new
@@ -249,7 +312,8 @@ namespace QuantLib {
                                                         maxSamples_,
                                                         seed_,
                                                         steps_,
-                                                        stepsPerYear_));
+                                                        stepsPerYear_,
+                                                        controlVariate_));
     }
 }
 

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -895,6 +895,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSeed(42)
                 .withSamples(32768);
 
         DiscreteAveragingAsianOption option(averageType, runningSum,
@@ -917,6 +918,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
         // Also test the control variate version of the pricer
         ext::shared_ptr<PricingEngine> engine2 =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSeed(42)
                 .withSteps(48)
                 .withSamples(pow(2, 13))
                 .withControlVariate(true);
@@ -969,13 +971,13 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
         MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
             .withSeed(42)
             .withSteps(360)
-            .withSamples(65536);
+            .withSamples(32768);
 
     ext::shared_ptr<PricingEngine> engine4 =
         MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
-            .withSeed(342)
+            .withSeed(42)
             .withSteps(360)
-            .withSamples(65536)
+            .withSamples(16384)
             .withControlVariate(true);
 
     std::vector<Date> fixingDates(120);
@@ -999,7 +1001,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         option.setPricingEngine(engine3);
         Real calculated = option.NPV();
-        Real tolerance = 2.0e-12;
+        Real tolerance = 5.0e-2;
 
         if (std::fabs(calculated-expected) > tolerance) {
             REPORT_FAILURE("value", averageType, runningSum, pastFixings,
@@ -1010,7 +1012,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         option.setPricingEngine(engine4);
         calculated = option.NPV();
-        tolerance = 2.0e-12;
+        tolerance = 3.0e-2;
 
         if (std::fabs(calculated-expected) > tolerance) {
             REPORT_FAILURE("value", averageType, runningSum, pastFixings,

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -865,6 +865,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
     Average::Type averageType = Average::Arithmetic;
     Real runningSum = 0.0;
     Size pastFixings = 0;
+
     for (Size l=0; l<LENGTH(cases); l++) {
 
         ext::shared_ptr<StrikedTypePayoff> payoff(new
@@ -913,8 +914,111 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
                         vol, expected, calculated, tolerance);
         }
 
+        // Also test the control variate version of the pricer
+        ext::shared_ptr<PricingEngine> engine2 =
+            MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSteps(48)
+                .withSamples(pow(2, 13))
+                .withControlVariate(true);
+
+        option.setPricingEngine(engine2);
+
+        Real calculatedCV = option.NPV();
+        Real expectedCV = cases[l].result;
+        tolerance = 2.50e-2;
+
+        if (std::fabs(calculatedCV-expectedCV) > tolerance) {
+            REPORT_FAILURE("value", averageType, runningSum, pastFixings,
+                        fixingDates, payoff, exercise, spot->value(),
+                        qRate->value(), rRate->value(), today,
+                        vol, expectedCV, calculatedCV, tolerance);
+        }
     }
 
+    // An additional dataset using the Heston parameters coming from "General lower 
+    // bounds for arithmetic Asian option prices", Applied Mathematical Finance 15(2)
+    // 123-149 (2008), by Albrecher, H., Mayer, P., and Schoutens, W. The numerical
+    // accuracy of prices given in Table 6 is low, but higher accuracy prices for the
+    // same parameters and options are reported by in "Pricing bounds and approximations
+    // for discrete arithmetic Asian options under time-changed Levy processes" by Zeng,
+    // P.P., and Kwok Y.K. (2013) in Table 4.
+    Real strikes[] = {60.0, 80.0, 100.0, 120.0, 140.0};
+    Real prices[] = {42.5990, 29.3698, 18.2360, 10.0565, 4.9609};
+
+    Real v02 = 0.0175;
+    Real kappa2 = 1.5768;
+    Real theta2 = 0.0398;
+    Real sigma2 = 0.5751;
+    Real rho2 = -0.5711;
+
+    DayCounter dc2 = Actual365Fixed();
+
+    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, qRate2, dc2);
+    ext::shared_ptr<SimpleQuote> rRate2(new SimpleQuote(0.03));
+    ext::shared_ptr<YieldTermStructure> rTS2 = flatRate(today, rRate2, dc2);
+
+    ext::shared_ptr<HestonProcess> hestonProcess2(new
+        HestonProcess(Handle<YieldTermStructure>(rTS2),
+        Handle<YieldTermStructure>(qTS2),
+        Handle<Quote>(spot2),
+        v02, kappa2, theta2, sigma2, rho2));
+
+    ext::shared_ptr<PricingEngine> engine3 =
+        MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
+            .withSeed(42)
+            .withSteps(360)
+            .withSamples(65536);
+
+    ext::shared_ptr<PricingEngine> engine4 =
+        MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
+            .withSeed(342)
+            .withSteps(360)
+            .withSamples(65536)
+            .withControlVariate(true);
+
+    std::vector<Date> fixingDates(120);
+    for (Size i=1; i<=120; i++) {
+        fixingDates[i-1] = today + Period(i, Months);
+    }
+
+    ext::shared_ptr<Exercise> exercise(new
+        EuropeanExercise(fixingDates[119]));
+
+    for (Size i=0; i<5; i++) {
+        Real strike = strikes[i];
+        Real expected = prices[i];
+
+        ext::shared_ptr<StrikedTypePayoff> payoff(new
+            PlainVanillaPayoff(Option::Call, strike));
+
+        DiscreteAveragingAsianOption option(averageType, runningSum,
+                                            pastFixings, fixingDates,
+                                            payoff, exercise);
+
+        option.setPricingEngine(engine3);
+        Real calculated = option.NPV();
+        Real tolerance = 2.0e-12;
+
+        if (std::fabs(calculated-expected) > tolerance) {
+            REPORT_FAILURE("value", averageType, runningSum, pastFixings,
+                        fixingDates, payoff, exercise, spot->value(),
+                        qRate2->value(), rRate2->value(), today,
+                        vol, expected, calculated, tolerance);
+        }
+
+        option.setPricingEngine(engine4);
+        calculated = option.NPV();
+        tolerance = 2.0e-12;
+
+        if (std::fabs(calculated-expected) > tolerance) {
+            REPORT_FAILURE("value", averageType, runningSum, pastFixings,
+                        fixingDates, payoff, exercise, spot->value(),
+                        qRate2->value(), rRate2->value(), today,
+                        vol, expected, calculated, tolerance);
+        }
+    }
 }
 
 

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -920,7 +920,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
                 .withSeed(42)
                 .withSteps(48)
-                .withSamples(pow(2, 13))
+                .withSamples(8192)
                 .withControlVariate(true);
 
         option.setPricingEngine(engine2);


### PR DESCRIPTION
Adding the geometric analytic and MC pricers to the MC arithmetic pricer as a control variate - using a geometric asian as a control variate for the arithmetic asian is a classic and powerful example of the technique, given the very high correlation in the path prices of the two instruments (see below).

To make this work I have had to disable the check for geometric average type in the analytic pricer (similar to the BS geometric pricer which also had this disabled). I've also added additional test cases to the test suite.

I have tested for a variety of Heston parameters and the path prices are always highly correlated, as shown for two examples here:
![image](https://user-images.githubusercontent.com/10614716/102221725-708fb600-3f1d-11eb-8e79-ca7f7e7b998c.png)

Convergence is greatly speeded up, MC errors are typically reduced by a factor of over thirty (ie. sqrt(1-rho^2) ). Some examples are shown here:
![image](https://user-images.githubusercontent.com/10614716/102221888-adf44380-3f1d-11eb-922c-3e228e58d47a.png)
