### PR TITLE
Automatic indent of preprocessor directives

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,5 +50,6 @@ BreakBeforeTernaryOperators: false
 ConstructorInitializerIndentWidth: 0
 SortUsingDeclarations: false
 IndentCaseLabels: true
+IndentPPDirectives: AfterHash
 
 ...


### PR DESCRIPTION
At the moment there is no clear indent policy for the preprocessor directives. I find it hard to read unindent preprocessors like
```cpp
#if FOO
#if BAR
#include <foo>
#endif
#endif
```

`.clang-format` supports automatic indent using `IndentPPDirectives: AfterHash`
```cpp
#if FOO
#  if BAR
#    include <foo>
#  endif
#endif
```

or `IndentPPDirectives: BeforeHash`
```cpp
#if FOO
  #if BAR
    #include <foo>
  #endif
#endif
```

Personally I prefer `IndentPPDirectives: AfterHash` but the later is okay for me as well.