### PR TITLE
Index::hasHistoricalFixing(fixingDate)

### DIFF
--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -27,9 +27,9 @@
 #ifndef quantlib_index_hpp
 #define quantlib_index_hpp
 
-#include <ql/time/calendar.hpp>
-#include <ql/math/comparison.hpp>
 #include <ql/indexes/indexmanager.hpp>
+#include <ql/math/comparison.hpp>
+#include <ql/time/calendar.hpp>
 
 namespace QuantLib {
 
@@ -58,8 +58,7 @@ namespace QuantLib {
         /*! the date passed as arguments must be the actual calendar
             date of the fixing; no settlement days must be used.
         */
-        virtual Real fixing(const Date& fixingDate,
-                            bool forecastTodaysFixing = false) const = 0;
+        virtual Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const = 0;
         //! returns the fixing TimeSeries
         const TimeSeries<Real>& timeSeries() const {
             return IndexManager::instance().getHistory(name());
@@ -73,21 +72,19 @@ namespace QuantLib {
         /*! the date passed as arguments must be the actual calendar
             date of the fixing; no settlement days must be used.
         */
-        virtual void addFixing(const Date& fixingDate,
-                               Real fixing,
-                               bool forceOverwrite = false);
+        virtual void addFixing(const Date& fixingDate, Real fixing, bool forceOverwrite = false);
         //! stores historical fixings from a TimeSeries
         /*! the dates in the TimeSeries must be the actual calendar
             dates of the fixings; no settlement days must be used.
         */
-        void addFixings(const TimeSeries<Real>& t,
-                        bool forceOverwrite = false);
+        void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false);
         //! stores historical fixings at the given dates
         /*! the dates passed as arguments must be the actual calendar
             dates of the fixings; no settlement days must be used.
         */
         template <class DateIterator, class ValueIterator>
-        void addFixings(DateIterator dBegin, DateIterator dEnd,
+        void addFixings(DateIterator dBegin,
+                        DateIterator dEnd,
                         ValueIterator vBegin,
                         bool forceOverwrite = false) {
             checkNativeFixingsAllowed();
@@ -105,7 +102,7 @@ namespace QuantLib {
                 if (validFixing) {
                     if (missingFixing)
                         h[*(dBegin++)] = *(vBegin++);
-                    else if (close(currentValue,*(vBegin))) {
+                    else if (close(currentValue, *(vBegin))) {
                         ++dBegin;
                         ++vBegin;
                     } else {
@@ -120,18 +117,17 @@ namespace QuantLib {
                 }
             }
             IndexManager::instance().setHistory(tag, h);
-            QL_REQUIRE(noInvalidFixing,
-                       "At least one invalid fixing provided: " <<
-                       invalidDate.weekday() << " " << invalidDate <<
-                       ", " << invalidValue);
-            QL_REQUIRE(noDuplicatedFixing,
-                       "At least one duplicated fixing provided: " <<
-                       duplicatedDate << ", " << duplicatedValue <<
-                       " while " << h[duplicatedDate] <<
-                       " value is already present");
+            QL_REQUIRE(noInvalidFixing, "At least one invalid fixing provided: "
+                                            << invalidDate.weekday() << " " << invalidDate << ", "
+                                            << invalidValue);
+            QL_REQUIRE(noDuplicatedFixing, "At least one duplicated fixing provided: "
+                                               << duplicatedDate << ", " << duplicatedValue
+                                               << " while " << h[duplicatedDate]
+                                               << " value is already present");
         }
         //! clears all stored historical fixings
         void clearFixings();
+
       private:
         //! check if index allows for native fixings
         void checkNativeFixingsAllowed();

--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -54,6 +54,8 @@ namespace QuantLib {
         virtual Calendar fixingCalendar() const = 0;
         //! returns TRUE if the fixing date is a valid one
         virtual bool isValidFixingDate(const Date& fixingDate) const = 0;
+        //! returns whether a historical fixing was stored for the given date
+        bool hasHistoricalFixing(const Date& fixingDate) const;
         //! returns the fixing at the given date
         /*! the date passed as arguments must be the actual calendar
             date of the fixing; no settlement days must be used.
@@ -132,6 +134,10 @@ namespace QuantLib {
         //! check if index allows for native fixings
         void checkNativeFixingsAllowed();
     };
+
+    inline bool Index::hasHistoricalFixing(const Date& fixingDate) const {
+        return IndexManager::instance().hasHistoricalFixing(name(), fixingDate);
+    }
 
 }
 

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -60,4 +60,13 @@ namespace QuantLib {
 
     void IndexManager::clearHistories() { data_.clear(); }
 
+    bool IndexManager::hasHistoricalFixing(const std::string& name, const Date& fixingDate) const {
+        auto const& indexIter = data_.find(to_upper_copy(name));
+        if (indexIter != data_.end()) {
+            return (*indexIter).second.value()[fixingDate] != Null<Real>();
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -62,11 +62,8 @@ namespace QuantLib {
 
     bool IndexManager::hasHistoricalFixing(const std::string& name, const Date& fixingDate) const {
         auto const& indexIter = data_.find(to_upper_copy(name));
-        if (indexIter != data_.end()) {
-            return (*indexIter).second.value()[fixingDate] != Null<Real>();
-        } else {
-            return false;
-        }
+        return (indexIter != data_.end()) &&
+               ((*indexIter).second.value()[fixingDate] != Null<Real>());
     }
 
 }

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -19,12 +19,12 @@
 
 #include <ql/indexes/indexmanager.hpp>
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 #include <boost/algorithm/string/case_conv.hpp>
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
+#    pragma GCC diagnostic pop
 #endif
 
 using boost::algorithm::to_upper_copy;
@@ -36,36 +36,28 @@ namespace QuantLib {
         return data_.find(to_upper_copy(name)) != data_.end();
     }
 
-    const TimeSeries<Real>&
-    IndexManager::getHistory(const string& name) const {
+    const TimeSeries<Real>& IndexManager::getHistory(const string& name) const {
         return data_[to_upper_copy(name)].value();
     }
 
-    void IndexManager::setHistory(const string& name,
-                                  const TimeSeries<Real>& history) {
+    void IndexManager::setHistory(const string& name, const TimeSeries<Real>& history) {
         data_[to_upper_copy(name)] = history;
     }
 
-    ext::shared_ptr<Observable>
-    IndexManager::notifier(const string& name) const {
+    ext::shared_ptr<Observable> IndexManager::notifier(const string& name) const {
         return data_[to_upper_copy(name)];
     }
 
     std::vector<string> IndexManager::histories() const {
         std::vector<string> temp;
         temp.reserve(data_.size());
-        for (history_map::const_iterator i=data_.begin();
-             i!=data_.end(); ++i)
+        for (history_map::const_iterator i = data_.begin(); i != data_.end(); ++i)
             temp.push_back(i->first);
         return temp;
     }
 
-    void IndexManager::clearHistory(const string& name) {
-        data_.erase(to_upper_copy(name));
-    }
+    void IndexManager::clearHistory(const string& name) { data_.erase(to_upper_copy(name)); }
 
-    void IndexManager::clearHistories() {
-        data_.clear();
-    }
+    void IndexManager::clearHistories() { data_.clear(); }
 
 }

--- a/ql/indexes/indexmanager.hpp
+++ b/ql/indexes/indexmanager.hpp
@@ -54,6 +54,8 @@ namespace QuantLib {
         void clearHistory(const std::string& name);
         //! clears all stored fixings
         void clearHistories();
+        //! returns whether a specific historical fixing was stored for the index and date
+        bool hasHistoricalFixing(const std::string& name, const Date& fixingDate) const;
 
       private:
         typedef std::map<std::string, ObservableValue<TimeSeries<Real> > > history_map;

--- a/ql/indexes/indexmanager.hpp
+++ b/ql/indexes/indexmanager.hpp
@@ -24,8 +24,8 @@
 #ifndef quantlib_index_manager_hpp
 #define quantlib_index_manager_hpp
 
-#include <ql/timeseries.hpp>
 #include <ql/patterns/singleton.hpp>
+#include <ql/timeseries.hpp>
 #include <ql/utilities/observablevalue.hpp>
 
 
@@ -35,8 +35,10 @@ namespace QuantLib {
     /*! \note index names are case insensitive */
     class IndexManager : public Singleton<IndexManager> {
         friend class Singleton<IndexManager>;
+
       private:
         IndexManager() {}
+
       public:
         //! returns whether historical fixings were stored for the index
         bool hasHistory(const std::string& name) const;
@@ -52,9 +54,9 @@ namespace QuantLib {
         void clearHistory(const std::string& name);
         //! clears all stored fixings
         void clearHistories();
+
       private:
-        typedef std::map<std::string, ObservableValue<TimeSeries<Real> > >
-                                                                  history_map;
+        typedef std::map<std::string, ObservableValue<TimeSeries<Real> > > history_map;
         mutable history_map data_;
     };
 

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -63,9 +63,54 @@ void IndexTest::testFixingObservability() {
         BOOST_FAIL("Observer was not notified of added BMA fixing");
 }
 
+void IndexTest::testFixingHasHistoricalFixing() {
+    BOOST_TEST_MESSAGE("Testing if index has historical fixings...");
+
+    auto testCase = [](const std::string& indexName, const bool& expected, const bool& testResult) {
+        if (expected != testResult) {
+            BOOST_FAIL("Historical fixing " << (testResult ? "" : "not ") << "found for "
+                                            << indexName << ".");
+        }
+    };
+
+    std::string name;
+    auto fixingFound = true;
+    auto fixingNotFound = false;
+
+    Date today = Date::todaysDate();
+
+    IndexManager::instance().clearHistories();
+
+    auto euribor3M = ext::make_shared<Euribor3M>();
+    auto euribor6M = ext::make_shared<Euribor6M>();
+    auto euribor6M_a = ext::make_shared<Euribor6M>();
+    euribor6M->addFixing(today, 0.01);
+
+    name = euribor3M->name();
+    testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+
+    name = euribor6M->name();
+    testCase(name, fixingFound, euribor6M->hasHistoricalFixing(today));
+    testCase(name, fixingFound, euribor6M_a->hasHistoricalFixing(today));
+    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
+
+    IndexManager::instance().clearHistories();
+
+    name = euribor3M->name();
+    testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+
+    name = euribor6M->name();
+    testCase(name, fixingNotFound, euribor6M->hasHistoricalFixing(today));
+    testCase(name, fixingNotFound, euribor6M_a->hasHistoricalFixing(today));
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+}
+
 
 test_suite* IndexTest::suite() {
     test_suite* suite = BOOST_TEST_SUITE("index tests");
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingObservability));
+    suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingHasHistoricalFixing));
     return suite;
 }

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -19,8 +19,8 @@
 
 #include "indexes.hpp"
 #include "utilities.hpp"
-#include <ql/indexes/ibor/euribor.hpp>
 #include <ql/indexes/bmaindex.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
 #include <ql/utilities/dataformatters.hpp>
 
 using namespace QuantLib;
@@ -35,11 +35,11 @@ void IndexTest::testFixingObservability() {
     Flag f1;
     f1.registerWith(i1);
     f1.lower();
-    
+
     Flag f2;
     f2.registerWith(i2);
     f2.lower();
-    
+
     Date today = Date::todaysDate();
 
     ext::shared_ptr<Index> euribor = ext::make_shared<Euribor6M>();
@@ -69,4 +69,3 @@ test_suite* IndexTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingObservability));
     return suite;
 }
-

--- a/test-suite/indexes.hpp
+++ b/test-suite/indexes.hpp
@@ -28,6 +28,7 @@
 class IndexTest {
   public:
     static void testFixingObservability();
+    static void testFixingHasHistoricalFixing();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
I have added to `ql/cashflows/floatingratecoupon.hpp`
```cpp
        //! whether or not the coupon is already fixed
        virtual bool isFixed() const;
```

to check if the coupon is fixed or not. Before and after the fixing date it is obvious and at the fixing date I am using the approach for the `InterestRateIndex::fixing(...)` here

https://github.com/lballabio/QuantLib/blob/a44b404a3361b625c068173a5c8e0bb9981ea374/ql/indexes/interestrateindex.cpp#L85

I was conservative by not using `c++11` features within the implementation:

```cpp
    bool FloatingRateCoupon::isFixed() const {
        Date fixingDate = this->fixingDate();
        Date today = Settings::instance().evaluationDate();

        /* We compare serialNumber() here in case QL_HIGH_RESOLUTION_DATE is defined
         * to avoid comparing dateTimes(). */
        if (today.serialNumber() != fixingDate.serialNumber()) {
            return (fixingDate.serialNumber() < today.serialNumber());
        } else {
            try {
                // might have been fixed, see InterestRateIndex::fixing(...)
                Rate result = index_->pastFixing(fixingDate);
                return result != Null<Real>();
            } catch (Error&) {
                return false;
            }
        }
    }
```

however the testcase I have written seems to have problems with my `c++11` features only on macos.

Also I am not sure if the implementation needs to be overwritten in derived coupon classes like `IborCoupon`, `OvernightIndexedCoupon` etc.