### PR TITLE
Negative Accrual when trading ex-coupon for inflation coupon

### DIFF
--- a/ql/cashflows/inflationcoupon.cpp
+++ b/ql/cashflows/inflationcoupon.cpp
@@ -71,9 +71,9 @@ namespace QuantLib {
         if (d <= accrualStartDate_ || d > paymentDate_) {
             return 0.0;
         }else if (tradingExCoupon(d)) {
-            return -1*nominal() * rate() *
-            dayCounter().yearFraction(accrualStartDate_,
-                                      std::min(d, accrualEndDate_),
+            return -nominal() * rate() *
+            dayCounter().yearFraction(d,
+                                      std::max(d, accrualEndDate_),
                                       refPeriodStart_,
                                       refPeriodEnd_);
         }

--- a/ql/cashflows/inflationcoupon.cpp
+++ b/ql/cashflows/inflationcoupon.cpp
@@ -70,12 +70,20 @@ namespace QuantLib {
     Real InflationCoupon::accruedAmount(const Date& d) const {
         if (d <= accrualStartDate_ || d > paymentDate_) {
             return 0.0;
-        } else {
-            return nominal() * rate() *
+        }else if (tradingExCoupon(d)) {
+            return -1*nominal() * rate() *
             dayCounter().yearFraction(accrualStartDate_,
                                       std::min(d, accrualEndDate_),
                                       refPeriodStart_,
                                       refPeriodEnd_);
+        }
+        else {
+            return nominal() * rate() *
+                dayCounter().yearFraction(accrualStartDate_,
+                    std::min(d, accrualEndDate_),
+                    refPeriodStart_,
+                    refPeriodEnd_);
+
         }
     }
 


### PR DESCRIPTION
Make accrual negative during the ex-coupon trading period of an inflation coupon.
Template for handling ex-coupon trading matches accruedAmount  method found in  [fixedratecoupon.cpp](https://github.com/lballabio/QuantLib/blob/master/ql/cashflows/fixedratecoupon.cpp) and [floatingratecoupon.cpp](https://github.com/lballabio/QuantLib/blob/master/ql/cashflows/floatingratecoupon.cpp)
Issue reference: #1006 
