### PR TITLE
Disable Disposable class template

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -131,6 +131,13 @@ jobs:
             cxxflags: "-Wno-deprecated-declarations"
             configureflags: --disable-std-unique-ptr
             tests: true
+          - name: "Disposable re-enabled"
+            shortname: disposable
+            tag: rolling
+            cc: gcc
+            cxx: g++
+            configureflags: --enable-disposable
+            tests: true
           - name: "Thread-safe observer enabled"
             shortname: threadsafe
             tag: rolling

--- a/configure.ac
+++ b/configure.ac
@@ -445,6 +445,24 @@ if test "$ql_use_std_classes" = "yes" ; then
 fi
 AC_MSG_RESULT([$ql_use_std_classes])
 
+
+AC_MSG_CHECKING([whether to enable the Disposable class template])
+AC_ARG_ENABLE([disposable],
+              AC_HELP_STRING([--enable-disposable],
+                             [If enabled, the Disposable class template will be used;
+                              this should be no longer necessary in C++11
+                              and might interfere with compiler optimizations.
+                              If disabled (the default) the class will only
+                              be an alias for the underlying type.]),
+              [ql_use_disposable=$enableval],
+              [ql_use_disposable=no])
+if test "$ql_use_disposable" = "yes" ; then
+   AC_DEFINE([QL_USE_DISPOSABLE],[1],
+             [Define this if you want to use the Disposable class template.])
+fi
+AC_MSG_RESULT([$ql_use_disposable])
+
+
 # manual configurations for specific hosts
 case $host in
   powerpc-apple-darwin*)

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -64,14 +64,18 @@ namespace QuantLib {
         Array(Size size, Real value, Real increment);
         Array(const Array&);
         Array(Array&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         Array(const Disposable<Array>&);
+        #endif
         //! creates the array from an iterable sequence
         template <class ForwardIterator>
         Array(ForwardIterator begin, ForwardIterator end);
 
         Array& operator=(const Array&);
         Array& operator=(Array&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         Array& operator=(const Disposable<Array>&);
+        #endif
 
         bool operator==(const Array&) const;
         bool operator!=(const Array&) const;
@@ -243,10 +247,12 @@ namespace QuantLib {
         swap(from);
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline Array::Array(const Disposable<Array>& from)
     : data_((Real*)(0)), n_(0) {
         swap(const_cast<Disposable<Array>&>(from));
     }
+    #endif
 
     namespace detail {
 
@@ -305,10 +311,12 @@ namespace QuantLib {
         return *this;
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline Array& Array::operator=(const Disposable<Array>& from) {
         swap(const_cast<Disposable<Array>&>(from));
         return *this;
     }
+    #endif
 
     inline bool Array::operator==(const Array& to) const {
         return (n_ == to.n_) && std::equal(begin(), end(), to.begin());

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -55,10 +55,14 @@ namespace QuantLib {
         Matrix(Size rows, Size columns, Iterator begin, Iterator end);
         Matrix(const Matrix&);
         Matrix(Matrix&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         Matrix(const Disposable<Matrix>&);
+        #endif
         Matrix& operator=(const Matrix&);
         Matrix& operator=(Matrix&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         Matrix& operator=(const Disposable<Matrix>&);
+        #endif
         //@}
 
         //! \name Algebraic operators
@@ -228,10 +232,12 @@ namespace QuantLib {
         swap(from);
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline Matrix::Matrix(const Disposable<Matrix>& from)
     : data_((Real*)(0)), rows_(0), columns_(0) {
         swap(const_cast<Disposable<Matrix>&>(from));
     }
+    #endif
 
     inline Matrix& Matrix::operator=(const Matrix& from) {
         // strong guarantee
@@ -245,10 +251,12 @@ namespace QuantLib {
         return *this;
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline Matrix& Matrix::operator=(const Disposable<Matrix>& from) {
         swap(const_cast<Disposable<Matrix>&>(from));
         return *this;
     }
+    #endif
 
     inline void Matrix::swap(Matrix& from) {
         using std::swap;

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -110,6 +110,7 @@ namespace QuantLib {
         std::copy(m.a22_.get(), m.a22_.get()+size, a22_.get());
     }
 
+    #ifdef QL_USE_DISPOSABLE
     NinePointLinearOp::NinePointLinearOp(
         const Disposable<NinePointLinearOp>& from) {
         swap(const_cast<Disposable<NinePointLinearOp>&>(from));
@@ -120,6 +121,7 @@ namespace QuantLib {
         swap(const_cast<Disposable<NinePointLinearOp>&>(m));
         return *this;
     }
+    #endif
 
     Disposable<Array> NinePointLinearOp::apply(const Array& u)
         const {

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -41,10 +41,14 @@ namespace QuantLib {
                 const ext::shared_ptr<FdmMesher>& mesher);
         NinePointLinearOp(const NinePointLinearOp& m);
         NinePointLinearOp(NinePointLinearOp&& m) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         NinePointLinearOp(const Disposable<NinePointLinearOp>& m);
+        #endif
         NinePointLinearOp& operator=(const NinePointLinearOp& m);
         NinePointLinearOp& operator=(NinePointLinearOp&& m) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         NinePointLinearOp& operator=(const Disposable<NinePointLinearOp>& m);
+        #endif
 
         Disposable<Array> apply(const Array& r) const;
         Disposable<NinePointLinearOp> mult(const Array& u) const;

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -81,6 +81,7 @@ namespace QuantLib {
     }
 
 
+    #ifdef QL_USE_DISPOSABLE
     TripleBandLinearOp::TripleBandLinearOp(
         const Disposable<TripleBandLinearOp>& from) {
         swap(const_cast<Disposable<TripleBandLinearOp>&>(from));
@@ -91,6 +92,7 @@ namespace QuantLib {
         swap(const_cast<Disposable<TripleBandLinearOp>&>(m));
         return *this;
     }
+    #endif
 
     void TripleBandLinearOp::swap(TripleBandLinearOp& m) {
         std::swap(mesher_, m.mesher_);

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
@@ -41,10 +41,14 @@ namespace QuantLib {
 
         TripleBandLinearOp(const TripleBandLinearOp& m);
         TripleBandLinearOp(TripleBandLinearOp&& m) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         TripleBandLinearOp(const Disposable<TripleBandLinearOp>& m);
+        #endif
         TripleBandLinearOp& operator=(const TripleBandLinearOp& m);
         TripleBandLinearOp& operator=(TripleBandLinearOp&& m) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         TripleBandLinearOp& operator=(const Disposable<TripleBandLinearOp>& m);
+        #endif
 
         Disposable<Array> apply(const Array& r) const;
         Disposable<Array> solve_splitting(const Array& r, Real a,

--- a/ql/methods/finitedifferences/tridiagonaloperator.hpp
+++ b/ql/methods/finitedifferences/tridiagonaloperator.hpp
@@ -70,10 +70,14 @@ namespace QuantLib {
                             const Array& high);
         TridiagonalOperator(const TridiagonalOperator&) = default;
         TridiagonalOperator(TridiagonalOperator&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         TridiagonalOperator(const Disposable<TridiagonalOperator>&);
+        #endif
         TridiagonalOperator& operator=(const TridiagonalOperator&);
         TridiagonalOperator& operator=(TridiagonalOperator&&) QL_NOEXCEPT;
+        #ifdef QL_USE_DISPOSABLE
         TridiagonalOperator& operator=(const Disposable<TridiagonalOperator>&);
+        #endif
         //! \name Operator interface
         //@{
         //! apply operator to a given array
@@ -136,10 +140,12 @@ namespace QuantLib {
         swap(from);
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline TridiagonalOperator::TridiagonalOperator(
                                 const Disposable<TridiagonalOperator>& from) {
         swap(const_cast<Disposable<TridiagonalOperator>&>(from));
     }
+    #endif
 
     inline TridiagonalOperator& TridiagonalOperator::operator=(
                                 const TridiagonalOperator& from) {
@@ -154,11 +160,13 @@ namespace QuantLib {
         return *this;
     }
 
+    #ifdef QL_USE_DISPOSABLE
     inline TridiagonalOperator& TridiagonalOperator::operator=(
                                 const Disposable<TridiagonalOperator>& from) {
         swap(const_cast<Disposable<TridiagonalOperator>&>(from));
         return *this;
     }
+    #endif
 
     inline void TridiagonalOperator::setFirstRow(Real valB,
                                                  Real valC) {

--- a/ql/userconfig.hpp
+++ b/ql/userconfig.hpp
@@ -104,6 +104,13 @@
 //#    define QL_USE_STD_TUPLE
 #endif
 
+/* Define this if you want to use the Disposable class template.
+   This should be no longer necessary in C++11
+   and might interfere with compiler optimizations. */
+#ifndef QL_USE_DISPOSABLE
+//#    define QL_USE_DISPOSABLE
+#endif
+
 /* Define this to enable the parallel unit test runner */
 #ifndef QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER
 //#    define QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER

--- a/ql/utilities/disposable.hpp
+++ b/ql/utilities/disposable.hpp
@@ -28,6 +28,13 @@
 
 namespace QuantLib {
 
+    #ifndef QL_USE_DISPOSABLE
+
+    template <class T>
+    using Disposable = T;
+
+    #else
+
     //! generic disposable object with move semantics
     /*! This class can be used for returning a value by copy. It relies
         on the returned object exposing a <tt>swap(T\&)</tt> method through
@@ -86,6 +93,8 @@ namespace QuantLib {
         this->swap(const_cast<Disposable<T>&>(t));
         return *this;
     }
+
+    #endif
 
 }
 

--- a/ql/utilities/disposable.hpp
+++ b/ql/utilities/disposable.hpp
@@ -35,6 +35,11 @@ namespace QuantLib {
 
     #else
 
+    #pragma message("Warning: enabling the old Disposable class template is deprecated.")
+    #pragma message("    If you're using --enable-disposable in your build")
+    #pragma message("    or if you defined QL_USE_DISPOSABLE in ql/userconfig.hpp,")
+    #pragma message("    please restore the default compilation options in the near future.")
+
     //! generic disposable object with move semantics
     /*! This class can be used for returning a value by copy. It relies
         on the returned object exposing a <tt>swap(T\&)</tt> method through

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -101,6 +101,8 @@ void ArrayTest::testConstruction() {
                         << "\n    copy:      " << a6[i]);
     }
 
+    #ifdef QL_USE_DISPOSABLE
+
     // creation of disposable array
     Array temp1(size, value);
     Disposable<Array> temp2(temp1);
@@ -162,6 +164,8 @@ void ArrayTest::testConstruction() {
                         << "\n    required:  " << value
                         << "\n    resulting: " << a9[i]);
     }
+
+    #endif
 
     // transform
     Array a10(5);


### PR DESCRIPTION
It is now superseded by move constructors, and it gets in the way of RVO and NRVO.

It is still available as a configuration option (in case the change breaks client code), but the default is to alias it to its underlying type.