### PR TITLE
Required nominal != 0.0 within MakeVanillaSwap when calculating the fair rate.

### DIFF
--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -156,6 +156,7 @@ namespace QuantLib {
 
         Rate usedFixedRate = fixedRate_;
         if (fixedRate_ == Null<Rate>()) {
+            QL_REQUIRE(nominal_ != 0.0, "Cannot determine fair rate for zero nominal.");
             VanillaSwap temp(type_, nominal_,
                              fixedSchedule,
                              0.0, // fixed rate

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -156,8 +156,7 @@ namespace QuantLib {
 
         Rate usedFixedRate = fixedRate_;
         if (fixedRate_ == Null<Rate>()) {
-            QL_REQUIRE(nominal_ != 0.0, "Cannot determine fair rate for zero nominal.");
-            VanillaSwap temp(type_, nominal_,
+            VanillaSwap temp(type_, 100.00,
                              fixedSchedule,
                              0.0, // fixed rate
                              fixedDayCount,


### PR DESCRIPTION
Within our test framework we test against `MakeVanillaSwap(...).withNominal(0.00);`.

When we want to create a fair `VanillaSwap` we get `fairRate() == NaN` here

https://github.com/lballabio/QuantLib/blob/d237af5c6b81da618244ae550ce97a56050fe333/ql/instruments/makevanillaswap.cpp#L178

which goes back to

https://github.com/lballabio/QuantLib/blob/d237af5c6b81da618244ae550ce97a56050fe333/ql/instruments/vanillaswap.cpp#L199

where obviously `legBPS_[0] == 0.0` and the division by zero leads to `NaN`. I think `NaN` is VS C++, other compiler might treat `DivByZero` differently.

Therefore I have added `QL_REQUIRE(nominal_ != 0.0, "Cannot determine fair rate for zero nominal.");` before starting calculating the fair rate.