### PR TITLE
C++11 modernization — use `auto` keyword

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
+Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,modernize-use-auto,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/ql/cashflow.cpp
+++ b/ql/cashflow.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
     }
 
     void CashFlow::accept(AcyclicVisitor& v) {
-        Visitor<CashFlow>* v1 = dynamic_cast<Visitor<CashFlow>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CashFlow>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/averagebmacoupon.cpp
+++ b/ql/cashflows/averagebmacoupon.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
                          refPeriodStart, refPeriodEnd, dayCounter, false)
     {
         Calendar cal = index->fixingCalendar();
-        Integer fixingDays = Integer(index->fixingDays());
+        auto fixingDays = Integer(index->fixingDays());
         fixingDays += bmaCutoffDays;
         Date fixingStart = cal.advance(startDate, -fixingDays*Days, Preceding);
 
@@ -152,8 +152,7 @@ namespace QuantLib {
     }
 
     void AverageBMACoupon::accept(AcyclicVisitor& v) {
-        Visitor<AverageBMACoupon>* v1 =
-            dynamic_cast<Visitor<AverageBMACoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<AverageBMACoupon>*>(&v);
         if (v1 != 0) {
             v1->visit(*this);
         } else {

--- a/ql/cashflows/capflooredcoupon.cpp
+++ b/ql/cashflows/capflooredcoupon.cpp
@@ -130,8 +130,7 @@ namespace QuantLib {
 
     void CappedFlooredCoupon::accept(AcyclicVisitor& v) {
         typedef FloatingRateCoupon super;
-        Visitor<CappedFlooredCoupon>* v1 =
-            dynamic_cast<Visitor<CappedFlooredCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CappedFlooredCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/capflooredcoupon.hpp
+++ b/ql/cashflows/capflooredcoupon.hpp
@@ -120,8 +120,7 @@ namespace QuantLib {
                        dayCounter, isInArrears, exCouponDate)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
-            Visitor<CappedFlooredIborCoupon>* v1 =
-                dynamic_cast<Visitor<CappedFlooredIborCoupon>*>(&v);
+            auto* v1 = dynamic_cast<Visitor<CappedFlooredIborCoupon>*>(&v);
             if (v1 != 0)
                 v1->visit(*this);
             else
@@ -153,8 +152,7 @@ namespace QuantLib {
                       dayCounter, isInArrears, exCouponDate)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
-            Visitor<CappedFlooredCmsCoupon>* v1 =
-                dynamic_cast<Visitor<CappedFlooredCmsCoupon>*>(&v);
+            auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsCoupon>*>(&v);
             if (v1 != 0)
                 v1->visit(*this);
             else

--- a/ql/cashflows/capflooredinflationcoupon.cpp
+++ b/ql/cashflows/capflooredinflationcoupon.cpp
@@ -147,8 +147,7 @@ namespace QuantLib {
 
     void CappedFlooredYoYInflationCoupon::accept(AcyclicVisitor& v) {
         typedef YoYInflationCoupon super;
-        Visitor<CappedFlooredYoYInflationCoupon>* v1 =
-            dynamic_cast<Visitor<CappedFlooredYoYInflationCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CappedFlooredYoYInflationCoupon>*>(&v);
 
         if (v1 != 0)
             v1->visit(*this);

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -231,9 +231,7 @@ namespace QuantLib {
     Real CashFlows::nominal(const Leg& leg,
                             bool includeSettlementDateFlows,
                             Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0.0;
 
         Date paymentDate = (*cf)->date();
@@ -248,9 +246,7 @@ namespace QuantLib {
     Date CashFlows::accrualStartDate(const Leg& leg,
                                      bool includeSettlementDateFlows,
                                      Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return Date();
 
         Date paymentDate = (*cf)->date();
@@ -265,9 +261,7 @@ namespace QuantLib {
     Date CashFlows::accrualEndDate(const Leg& leg,
                                    bool includeSettlementDateFlows,
                                    Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return Date();
 
         Date paymentDate = (*cf)->date();
@@ -282,9 +276,7 @@ namespace QuantLib {
     Date CashFlows::referencePeriodStart(const Leg& leg,
                                          bool includeSettlementDateFlows,
                                          Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return Date();
 
         Date paymentDate = (*cf)->date();
@@ -299,9 +291,7 @@ namespace QuantLib {
     Date CashFlows::referencePeriodEnd(const Leg& leg,
                                        bool includeSettlementDateFlows,
                                        Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return Date();
 
         Date paymentDate = (*cf)->date();
@@ -316,9 +306,7 @@ namespace QuantLib {
     Time CashFlows::accrualPeriod(const Leg& leg,
                                   bool includeSettlementDateFlows,
                                   Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0;
 
         Date paymentDate = (*cf)->date();
@@ -333,9 +321,7 @@ namespace QuantLib {
     Date::serial_type CashFlows::accrualDays(const Leg& leg,
                                              bool includeSettlementDateFlows,
                                              Date settlementDate) {
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0;
 
         Date paymentDate = (*cf)->date();
@@ -353,9 +339,7 @@ namespace QuantLib {
         if (settlementDate == Date())
             settlementDate = Settings::instance().evaluationDate();
 
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0;
 
         Date paymentDate = (*cf)->date();
@@ -373,9 +357,7 @@ namespace QuantLib {
         if (settlementDate == Date())
             settlementDate = Settings::instance().evaluationDate();
 
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0;
 
         Date paymentDate = (*cf)->date();
@@ -393,9 +375,7 @@ namespace QuantLib {
         if (settlementDate == Date())
             settlementDate = Settings::instance().evaluationDate();
 
-        Leg::const_iterator cf = nextCashFlow(leg,
-                                              includeSettlementDateFlows,
-                                              settlementDate);
+        auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
         if (cf==leg.end()) return 0.0;
 
         Date paymentDate = (*cf)->date();

--- a/ql/cashflows/cmscoupon.cpp
+++ b/ql/cashflows/cmscoupon.cpp
@@ -45,7 +45,7 @@ namespace QuantLib {
       swapIndex_(swapIndex) {}
 
     void CmsCoupon::accept(AcyclicVisitor& v) {
-        Visitor<CmsCoupon>* v1 = dynamic_cast<Visitor<CmsCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CmsCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -75,7 +75,7 @@ namespace QuantLib {
     }
 
     void Coupon::accept(AcyclicVisitor& v) {
-        Visitor<Coupon>* v1 = dynamic_cast<Visitor<Coupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Coupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         index_ = ext::dynamic_pointer_cast<IborIndex>(coupon.index());
         if (!index_) {
             // check if the coupon was right
-            const IborCoupon* c = dynamic_cast<const IborCoupon*>(&coupon);
+            const auto* c = dynamic_cast<const IborCoupon*>(&coupon);
             QL_REQUIRE(c, "IborCoupon required");
             // coupon was right, index is not
             QL_FAIL("IborIndex required");

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
 
 
     void CPICoupon::accept(AcyclicVisitor& v) {
-        Visitor<CPICoupon>* v1 =
-        dynamic_cast<Visitor<CPICoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CPICoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/digitalcmscoupon.cpp
+++ b/ql/cashflows/digitalcmscoupon.cpp
@@ -42,8 +42,7 @@ namespace QuantLib {
 
     void DigitalCmsCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
-        Visitor<DigitalCmsCoupon>* v1 =
-            dynamic_cast<Visitor<DigitalCmsCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DigitalCmsCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/digitalcoupon.cpp
+++ b/ql/cashflows/digitalcoupon.cpp
@@ -281,8 +281,7 @@ namespace QuantLib {
 
     void DigitalCoupon::accept(AcyclicVisitor& v) {
         typedef FloatingRateCoupon super;
-        Visitor<DigitalCoupon>* v1 =
-            dynamic_cast<Visitor<DigitalCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DigitalCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/digitaliborcoupon.cpp
+++ b/ql/cashflows/digitaliborcoupon.cpp
@@ -42,8 +42,7 @@ namespace QuantLib {
 
     void DigitalIborCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
-        Visitor<DigitalIborCoupon>* v1 =
-            dynamic_cast<Visitor<DigitalIborCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DigitalIborCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/dividend.cpp
+++ b/ql/cashflows/dividend.cpp
@@ -24,8 +24,7 @@
 namespace QuantLib {
 
     void Dividend::accept(AcyclicVisitor& v) {
-        Visitor<Dividend>* v1 =
-            dynamic_cast<Visitor<Dividend>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Dividend>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -122,8 +122,7 @@ namespace QuantLib {
     };
 
     inline void FixedRateCoupon::accept(AcyclicVisitor& v) {
-        Visitor<FixedRateCoupon>* v1 =
-            dynamic_cast<Visitor<FixedRateCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FixedRateCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/floatingratecoupon.hpp
+++ b/ql/cashflows/floatingratecoupon.hpp
@@ -143,8 +143,7 @@ namespace QuantLib {
     }
 
     inline void FloatingRateCoupon::accept(AcyclicVisitor& v) {
-        Visitor<FloatingRateCoupon>* v1 =
-            dynamic_cast<Visitor<FloatingRateCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FloatingRateCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -142,8 +142,7 @@ namespace QuantLib {
     }
 
     void IborCoupon::accept(AcyclicVisitor& v) {
-        Visitor<IborCoupon>* v1 =
-            dynamic_cast<Visitor<IborCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<IborCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -87,8 +87,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void IndexedCashFlow::accept(AcyclicVisitor& v) {
-        Visitor<IndexedCashFlow>* v1 =
-        dynamic_cast<Visitor<IndexedCashFlow>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<IndexedCashFlow>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/inflationcoupon.hpp
+++ b/ql/cashflows/inflationcoupon.hpp
@@ -116,8 +116,7 @@ namespace QuantLib {
 
 
     inline void InflationCoupon::accept(AcyclicVisitor& v) {
-        Visitor<InflationCoupon>* v1 =
-        dynamic_cast<Visitor<InflationCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<InflationCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -205,8 +205,7 @@ namespace QuantLib {
     }
 
     void OvernightIndexedCoupon::accept(AcyclicVisitor& v) {
-        Visitor<OvernightIndexedCoupon>* v1 =
-            dynamic_cast<Visitor<OvernightIndexedCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<OvernightIndexedCoupon>*>(&v);
         if (v1 != 0) {
             v1->visit(*this);
         } else {

--- a/ql/cashflows/rangeaccrual.cpp
+++ b/ql/cashflows/rangeaccrual.cpp
@@ -84,8 +84,7 @@ namespace QuantLib {
      }
 
     void RangeAccrualFloatersCoupon::accept(AcyclicVisitor& v) {
-        Visitor<RangeAccrualFloatersCoupon>* v1 =
-            dynamic_cast<Visitor<RangeAccrualFloatersCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<RangeAccrualFloatersCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/simplecashflow.hpp
+++ b/ql/cashflows/simplecashflow.hpp
@@ -88,8 +88,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void SimpleCashFlow::accept(AcyclicVisitor& v) {
-        Visitor<SimpleCashFlow>* v1 =
-            dynamic_cast<Visitor<SimpleCashFlow>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SimpleCashFlow>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -97,8 +96,7 @@ namespace QuantLib {
     }
 
     inline void Redemption::accept(AcyclicVisitor& v) {
-        Visitor<Redemption>* v1 =
-            dynamic_cast<Visitor<Redemption>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Redemption>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -106,8 +104,7 @@ namespace QuantLib {
     }
 
     inline void AmortizingPayment::accept(AcyclicVisitor& v) {
-        Visitor<AmortizingPayment>* v1 =
-            dynamic_cast<Visitor<AmortizingPayment>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<AmortizingPayment>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/cashflows/timebasket.cpp
+++ b/ql/cashflows/timebasket.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         for (Size i = 0; i < sbuckets.size(); i++)
             result[sbuckets[i]] = 0.0;
 
-        for (const_iterator j = begin(); j != end(); ++j) {
+        for (auto j = begin(); j != end(); ++j) {
             Date date = j->first;
             Real value = j->second;
             Date pDate = Null<Date>(), nDate = Null<Date>();

--- a/ql/cashflows/timebasket.hpp
+++ b/ql/cashflows/timebasket.hpp
@@ -74,20 +74,20 @@ namespace QuantLib {
     // inline definitions
 
     inline bool TimeBasket::hasDate(const Date& d) const {
-        const_iterator i = find(d);
+        auto i = find(d);
         return i != end();
     }
 
     inline TimeBasket& TimeBasket::operator+=(const TimeBasket& other) {
         super& self = *this;
-        for (const_iterator j = other.begin(); j != other.end(); ++j)
+        for (auto j = other.begin(); j != other.end(); ++j)
             self[j->first] += j->second;
         return *this;
     }
 
     inline TimeBasket& TimeBasket::operator-=(const TimeBasket& other) {
         super& self = *this;
-        for (const_iterator j = other.begin(); j != other.end(); ++j)
+        for (auto j = other.begin(); j != other.end(); ++j)
             self[j->first] -= j->second;
         return *this;
     }

--- a/ql/cashflows/yoyinflationcoupon.cpp
+++ b/ql/cashflows/yoyinflationcoupon.cpp
@@ -45,8 +45,7 @@ namespace QuantLib {
 
 
     void YoYInflationCoupon::accept(AcyclicVisitor& v) {
-        Visitor<YoYInflationCoupon>* v1 =
-        dynamic_cast<Visitor<YoYInflationCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<YoYInflationCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/currencies/exchangeratemanager.cpp
+++ b/ql/currencies/exchangeratemanager.cpp
@@ -194,8 +194,7 @@ namespace QuantLib {
                                                    const Currency& target,
                                                    const Date& date) const {
         const std::list<Entry>& rates = data_[hash(source,target)];
-        std::list<Entry>::const_iterator i =
-            std::find_if(rates.begin(), rates.end(), valid_at(date));
+        auto i = std::find_if(rates.begin(), rates.end(), valid_at(date));
         return i == rates.end() ?
             (const ExchangeRate*) 0 :
             &(i->rate);

--- a/ql/discretizedasset.hpp
+++ b/ql/discretizedasset.hpp
@@ -227,9 +227,8 @@ namespace QuantLib {
     inline std::vector<Time> DiscretizedOption::mandatoryTimes() const {
         std::vector<Time> times = underlying_->mandatoryTimes();
         // discard negative times...
-        std::vector<Time>::const_iterator i =
-            std::find_if(exerciseTimes_.begin(),exerciseTimes_.end(),
-                         greater_or_equal_to<Time>(0.0));
+        auto i = std::find_if(exerciseTimes_.begin(), exerciseTimes_.end(),
+                              greater_or_equal_to<Time>(0.0));
         // and add the positive ones
         times.insert(times.end(), i, exerciseTimes_.end());
         return times;

--- a/ql/event.cpp
+++ b/ql/event.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
     }
 
     void Event::accept(AcyclicVisitor& v) {
-        Visitor<Event>* v1 = dynamic_cast<Visitor<Event>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Event>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
+++ b/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
@@ -85,8 +85,8 @@ namespace QuantLib {
                 ((Real)superDays.first)/((Real)subDays.second);
             Real maxPeriodRatio =
                 ((Real)superDays.second)/((Real)subDays.first);
-            Integer lowRatio = static_cast<Integer>(std::floor(minPeriodRatio));
-            Integer highRatio = static_cast<Integer>(std::ceil(maxPeriodRatio));
+            auto lowRatio = static_cast<Integer>(std::floor(minPeriodRatio));
+            auto highRatio = static_cast<Integer>(std::ceil(maxPeriodRatio));
 
             try {
                 for(Integer i=lowRatio; i <= highRatio; ++i) {

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -95,8 +95,8 @@ namespace QuantLib {
 
     std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::z(
             const std::complex<Real>& s, const std::complex<Real>& w, Size k, Size n) const {
-        double k_ = double(k);
-        double n_ = double(n);
+        auto k_ = double(k);
+        auto n_ = double(n);
         std::complex<Real> term1 = (2*rho_*kappa_ - sigma_)*((n_-k_+1)*s + n_*w)/(2*sigma_*n_);
         std::complex<Real> term2 = (1-rho_*rho_)*pow(((n_-k_+1)*s + n_*w), 2)/(2*n_*n_);
 
@@ -119,8 +119,8 @@ namespace QuantLib {
             const std::complex<Real>& w,
             Time t, Time T, Size kStar,
             const std::vector<Time>& t_n) const {
-        double kStar_ = double(kStar);
-        double n_ = double(t_n.size());
+        auto kStar_ = double(kStar);
+        auto n_ = double(t_n.size());
         Real temp = -rho_*kappa_*theta_/sigma_;
 
         Time summation = 0.0;

--- a/ql/experimental/averageois/arithmeticaverageois.cpp
+++ b/ql/experimental/averageois/arithmeticaverageois.cpp
@@ -93,7 +93,7 @@ namespace QuantLib {
         }
 
         for (Size j=0; j<2; ++j) {
-            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+            for (auto i = legs_[j].begin(); i != legs_[j].end(); ++i)
                 registerWith(*i);
         }
 

--- a/ql/experimental/averageois/arithmeticoisratehelper.cpp
+++ b/ql/experimental/averageois/arithmeticoisratehelper.cpp
@@ -104,8 +104,7 @@ namespace QuantLib {
     }
 
     void ArithmeticOISRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<ArithmeticOISRateHelper>* v1 =
-            dynamic_cast<Visitor<ArithmeticOISRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<ArithmeticOISRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/barrieroption/doublebarrieroption.cpp
+++ b/ql/experimental/barrieroption/doublebarrieroption.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        DoubleBarrierOption::arguments* moreArgs =
-            dynamic_cast<DoubleBarrierOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<DoubleBarrierOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier_lo = barrier_lo_;

--- a/ql/experimental/barrieroption/quantodoublebarrieroption.cpp
+++ b/ql/experimental/barrieroption/quantodoublebarrieroption.cpp
@@ -59,8 +59,7 @@ namespace QuantLib {
     void QuantoDoubleBarrierOption::fetchResults(
                                       const PricingEngine::results* r) const {
         DoubleBarrierOption::fetchResults(r);
-        const QuantoDoubleBarrierOption::results* quantoResults =
-            dynamic_cast<const QuantoDoubleBarrierOption::results*>(r);
+        const auto* quantoResults = dynamic_cast<const QuantoDoubleBarrierOption::results*>(r);
         QL_ENSURE(quantoResults != 0,
                   "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -228,8 +228,7 @@ namespace QuantLib {
 
    Real CallableBond::NPVSpreadHelper::operator()(Real x) const
    {
-       CallableBond::arguments* args=
-           dynamic_cast<CallableBond::arguments*>(bond_.engine_->getArguments());
+       auto* args = dynamic_cast<CallableBond::arguments*>(bond_.engine_->getArguments());
        // Pops the original value when function finishes
        RestoreVal<Spread> restorer(args->spread);
        args->spread=x;
@@ -436,8 +435,7 @@ namespace QuantLib {
 
         CallableBond::setupArguments(args);
 
-        CallableBond::arguments* arguments =
-            dynamic_cast<CallableBond::arguments*>(args);
+        auto* arguments = dynamic_cast<CallableBond::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "no arguments given");
 

--- a/ql/experimental/callablebonds/treecallablebondengine.cpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.cpp
@@ -72,8 +72,7 @@ namespace QuantLib {
         }
 
         if (s != 0.0) {
-            OneFactorModel::ShortRateTree *sr=
-                dynamic_cast<OneFactorModel::ShortRateTree*>(&(*lattice));
+            auto* sr = dynamic_cast<OneFactorModel::ShortRateTree*>(&(*lattice));
             QL_REQUIRE(sr,
                        "Spread is not supported for trees other than OneFactorModel");
             sr->setSpread(s);

--- a/ql/experimental/catbonds/catbond.cpp
+++ b/ql/experimental/catbonds/catbond.cpp
@@ -38,8 +38,7 @@ namespace QuantLib {
 
     void CatBond::setupArguments(PricingEngine::arguments* args) const {
 
-        CatBond::arguments* arguments =
-            dynamic_cast<CatBond::arguments*>(args);
+        auto* arguments = dynamic_cast<CatBond::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong arguments type");
 
         Bond::setupArguments(args);
@@ -51,8 +50,7 @@ namespace QuantLib {
     void CatBond::fetchResults(const PricingEngine::results* r) const {
         Bond::fetchResults(r);
 
-        const CatBond::results* results =
-            dynamic_cast<const CatBond::results*>(r);
+        const auto* results = dynamic_cast<const CatBond::results*>(r);
         QL_ENSURE(results != 0, "wrong result type");
 
         lossProbability_ = results->lossProbability;

--- a/ql/experimental/commodities/commodity.cpp
+++ b/ql/experimental/commodities/commodity.cpp
@@ -47,8 +47,7 @@ namespace QuantLib {
         Real totalAmount = 0;
 
         out << "secondary costs" << std::endl;
-        for (SecondaryCostAmounts::const_iterator i = secondaryCostAmounts.begin();
-             i != secondaryCostAmounts.end(); ++i) {
+        for (auto i = secondaryCostAmounts.begin(); i != secondaryCostAmounts.end(); ++i) {
             Real amount = i->second.value();
             if (currencyCode.empty())
                 currencyCode = i->second.currency().code();
@@ -90,8 +89,7 @@ namespace QuantLib {
     std::ostream& operator<<(std::ostream& out, const PricingErrors& errors) {
         if (!errors.empty()) {
             out << "*** pricing errors" << std::endl;
-            for (PricingErrors::const_iterator i = errors.begin();
-                 i != errors.end(); ++i)
+            for (auto i = errors.begin(); i != errors.end(); ++i)
                 out << *i << std::endl;
         }
         return out;

--- a/ql/experimental/commodities/commoditycashflow.cpp
+++ b/ql/experimental/commodities/commoditycashflow.cpp
@@ -24,8 +24,7 @@
 namespace QuantLib {
 
     void CommodityCashFlow::accept(AcyclicVisitor& v) {
-        Visitor<CommodityCashFlow>* v1 =
-            dynamic_cast<Visitor<CommodityCashFlow>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CommodityCashFlow>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -40,8 +39,7 @@ namespace QuantLib {
         std::string currencyCode; //= cashFlows[0]->discountedAmount().currency().code();
         Real totalDiscounted = 0;
         Real totalUndiscounted = 0;
-        for (CommodityCashFlows::const_iterator i = cashFlows.begin();
-             i != cashFlows.end(); ++i) {
+        for (auto i = cashFlows.begin(); i != cashFlows.end(); ++i) {
             //const ext::shared_ptr<CommodityCashFlow> cashFlow = *i;
             const ext::shared_ptr<CommodityCashFlow> cashFlow = i->second;
             totalDiscounted += cashFlow->discountedAmount().value();

--- a/ql/experimental/commodities/commodityindex.hpp
+++ b/ql/experimental/commodities/commodityindex.hpp
@@ -71,8 +71,7 @@ namespace QuantLib {
         void addQuotes(const std::map<Date, Real>& quotes) {
             std::string tag = name();
             quotes_ = IndexManager::instance().getHistory(tag);
-            for (std::map<Date, Real>::const_iterator ii = quotes.begin();
-                 ii != quotes.end (); ++ii) {
+            for (auto ii = quotes.begin(); ii != quotes.end(); ++ii) {
                 quotes_[ii->first] = ii->second;
             }
             IndexManager::instance().setHistory(tag, quotes_);
@@ -145,7 +144,7 @@ namespace QuantLib {
     }
 
     inline Real CommodityIndex::price(const Date& date) {
-        std::map<Date, Real>::const_iterator hq = quotes_.find(date);
+        auto hq = quotes_.find(date);
         if (hq->second == Null<Real>()) {
             ++hq;
             if (hq == quotes_.end())

--- a/ql/experimental/commodities/energybasisswap.cpp
+++ b/ql/experimental/commodities/energybasisswap.cpp
@@ -155,8 +155,7 @@ namespace QuantLib {
             Real totalQuantityAmount = 0;
 
             // price each period
-            for (PricingPeriods::const_iterator pi = pricingPeriods_.begin();
-                 pi != pricingPeriods_.end(); ++pi) {
+            for (auto pi = pricingPeriods_.begin(); pi != pricingPeriods_.end(); ++pi) {
                 const ext::shared_ptr<PricingPeriod>& pricingPeriod = *pi;
 
                 Integer periodDayCount = 0;
@@ -234,10 +233,9 @@ namespace QuantLib {
 
                 Real payLegValue = 0;
                 Real receiveLegValue = 0;
-                for (std::map<Date, EnergyDailyPosition>::iterator dpi =
-                         dailyPositions_.find(periodStartDate);
-                     dpi != dailyPositions_.end() &&
-                         dpi->first <= pricingPeriod->endDate(); ++dpi) {
+                for (auto dpi = dailyPositions_.find(periodStartDate);
+                     dpi != dailyPositions_.end() && dpi->first <= pricingPeriod->endDate();
+                     ++dpi) {
                     EnergyDailyPosition& dailyPosition = dpi->second;
                     dailyPosition.quantityAmount = avgDailyQuantityAmount;
                     dailyPosition.riskDelta =

--- a/ql/experimental/commodities/energycommodity.cpp
+++ b/ql/experimental/commodities/energycommodity.cpp
@@ -45,8 +45,7 @@ namespace QuantLib {
             << std::setw(14) << std::right << "delta"
             << std::setw(10) << std::right << "open" << std::endl;
 
-        for (EnergyDailyPositions::const_iterator i = dailyPositions.begin();
-             i != dailyPositions.end(); ++i) {
+        for (auto i = dailyPositions.begin(); i != dailyPositions.end(); ++i) {
             const EnergyDailyPosition& dailyPosition = i->second;
             out << std::setw(4) << io::iso_date(i->first) << "  "
                 << std::setw(12) << std::right << std::fixed
@@ -71,8 +70,7 @@ namespace QuantLib {
 
 
     void EnergyCommodity::setupArguments(PricingEngine::arguments* args) const {
-        EnergyCommodity::arguments* arguments =
-            dynamic_cast<EnergyCommodity::arguments*>(args);
+        auto* arguments = dynamic_cast<EnergyCommodity::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
         //arguments->legs = legs_;
         //arguments->payer = payer_;
@@ -80,8 +78,7 @@ namespace QuantLib {
 
     void EnergyCommodity::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
-        const EnergyCommodity::results* results =
-            dynamic_cast<const EnergyCommodity::results*>(r);
+        const auto* results = dynamic_cast<const EnergyCommodity::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
     }
 

--- a/ql/experimental/commodities/energyswap.cpp
+++ b/ql/experimental/commodities/energyswap.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
     Quantity EnergySwap::quantity() const {
         Real totalQuantityAmount = 0;
-        for (PricingPeriods::const_iterator pi = pricingPeriods_.begin();
-             pi != pricingPeriods_.end(); ++pi) {
+        for (auto pi = pricingPeriods_.begin(); pi != pricingPeriods_.end(); ++pi) {
             totalQuantityAmount += (*pi)->quantity().amount();
         }
         return Quantity(pricingPeriods_[0]->quantity().commodityType(),

--- a/ql/experimental/commodities/energyvanillaswap.cpp
+++ b/ql/experimental/commodities/energyvanillaswap.cpp
@@ -123,8 +123,7 @@ namespace QuantLib {
             Real totalQuantityAmount = 0;
 
             // price each period
-            for (PricingPeriods::const_iterator pi = pricingPeriods_.begin();
-                 pi != pricingPeriods_.end(); ++pi) {
+            for (auto pi = pricingPeriods_.begin(); pi != pricingPeriods_.end(); ++pi) {
                 const ext::shared_ptr<PricingPeriod>& pricingPeriod = *pi;
 
                 QL_REQUIRE(pricingPeriod->quantity().amount() != 0,
@@ -191,10 +190,9 @@ namespace QuantLib {
 
                 Real payLegValue = 0;
                 Real receiveLegValue = 0;
-                for (std::map<Date, EnergyDailyPosition>::iterator dpi =
-                         dailyPositions_.find(periodStartDate);
-                     dpi != dailyPositions_.end() &&
-                         dpi->first <= pricingPeriod->endDate(); ++dpi) {
+                for (auto dpi = dailyPositions_.find(periodStartDate);
+                     dpi != dailyPositions_.end() && dpi->first <= pricingPeriod->endDate();
+                     ++dpi) {
                     EnergyDailyPosition& dailyPosition = dpi->second;
                     dailyPosition.quantityAmount = avgDailyQuantityAmount;
                     dailyPosition.riskDelta =

--- a/ql/experimental/commodities/unitofmeasureconversionmanager.cpp
+++ b/ql/experimental/commodities/unitofmeasureconversionmanager.cpp
@@ -60,8 +60,7 @@ namespace QuantLib {
 
     void UnitOfMeasureConversionManager::add(const UnitOfMeasureConversion& c) {
         // not fast, but hopefully we won't have a lot of entries.
-        for (list<UnitOfMeasureConversion>::iterator i = data_.begin();
-             i != data_.end(); ++i) {
+        for (auto i = data_.begin(); i != data_.end(); ++i) {
             if (matches(*i, c)) {
                 data_.erase(i);
                 break;
@@ -140,8 +139,7 @@ namespace QuantLib {
                                            const UnitOfMeasure& source,
                                            const UnitOfMeasure& target) const {
 
-        for (list<UnitOfMeasureConversion>::const_iterator i = data_.begin();
-             i != data_.end(); ++i) {
+        for (auto i = data_.begin(); i != data_.end(); ++i) {
             if (matches(*i, commodityType, source, target)) {
                 return *i;
             }
@@ -180,8 +178,7 @@ namespace QuantLib {
         // to avoid cycles.
         forbidden.push_back(source.code());
 
-        for (list<UnitOfMeasureConversion>::const_iterator i = data_.begin();
-             i != data_.end(); ++i) {
+        for (auto i = data_.begin(); i != data_.end(); ++i) {
             // we look for conversion data which involve our source unit...
             if (matches(*i, commodityType, source)) {
                 const UnitOfMeasure& other =

--- a/ql/experimental/convertiblebonds/convertiblebond.cpp
+++ b/ql/experimental/convertiblebonds/convertiblebond.cpp
@@ -215,8 +215,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        ConvertibleBond::option::arguments* moreArgs =
-            dynamic_cast<ConvertibleBond::option::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ConvertibleBond::option::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
 
         moreArgs->conversionRatio = conversionRatio_;

--- a/ql/experimental/convertiblebonds/tflattice.hpp
+++ b/ql/experimental/convertiblebonds/tflattice.hpp
@@ -133,11 +133,10 @@ namespace QuantLib {
                    "cannot roll the asset back to" << to
                    << " (it is already at t = " << from << ")");
 
-        DiscretizedConvertible& convertible =
-            dynamic_cast<DiscretizedConvertible&>(asset);
+        auto& convertible = dynamic_cast<DiscretizedConvertible&>(asset);
 
-        Integer iFrom = Integer(this->t_.index(from));
-        Integer iTo = Integer(this->t_.index(to));
+        auto iFrom = Integer(this->t_.index(from));
+        auto iTo = Integer(this->t_.index(to));
 
         for (Integer i=iFrom-1; i>=iTo; --i) {
 

--- a/ql/experimental/coupons/cmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
           index_(index) {}
 
     void CmsSpreadCoupon::accept(AcyclicVisitor &v) {
-        Visitor<CmsSpreadCoupon> *v1 = dynamic_cast<Visitor<CmsSpreadCoupon> *>(&v);
+        auto* v1 = dynamic_cast<Visitor<CmsSpreadCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/coupons/cmsspreadcoupon.hpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.hpp
@@ -90,8 +90,7 @@ namespace QuantLib {
                       dayCounter, isInArrears, exCouponDate)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
-            Visitor<CappedFlooredCmsSpreadCoupon>* v1 =
-                dynamic_cast<Visitor<CappedFlooredCmsSpreadCoupon>*>(&v);
+            auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsSpreadCoupon>*>(&v);
             if (v1 != 0)
                 v1->visit(*this);
             else

--- a/ql/experimental/coupons/digitalcmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/digitalcmsspreadcoupon.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
     void DigitalCmsSpreadCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
-        Visitor<DigitalCmsSpreadCoupon>* v1 =
-            dynamic_cast<Visitor<DigitalCmsSpreadCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DigitalCmsSpreadCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/coupons/strippedcapflooredcoupon.cpp
+++ b/ql/experimental/coupons/strippedcapflooredcoupon.cpp
@@ -79,8 +79,7 @@ namespace QuantLib {
 
     void StrippedCappedFlooredCoupon::accept(AcyclicVisitor &v) {
         underlying_->accept(v);
-        Visitor<StrippedCappedFlooredCoupon> *v1 =
-            dynamic_cast<Visitor<StrippedCappedFlooredCoupon> *>(&v);
+        auto* v1 = dynamic_cast<Visitor<StrippedCappedFlooredCoupon>*>(&v);
         if (v1 != NULL)
             v1->visit(*this);
         else
@@ -113,8 +112,7 @@ namespace QuantLib {
         Leg resultLeg;
         resultLeg.reserve(underlyingLeg_.size());
         ext::shared_ptr<CappedFlooredCoupon> c;
-        for (Leg::const_iterator i = underlyingLeg_.begin();
-             i != underlyingLeg_.end(); ++i) {
+        for (auto i = underlyingLeg_.begin(); i != underlyingLeg_.end(); ++i) {
             if ((c = ext::dynamic_pointer_cast<CappedFlooredCoupon>(*i)) !=
                 NULL) {
                 resultLeg.push_back(

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -69,8 +69,7 @@ namespace QuantLib {
      }
 
     void SubPeriodsCoupon::accept(AcyclicVisitor& v) {
-        Visitor<SubPeriodsCoupon>* v1 =
-            dynamic_cast<Visitor<SubPeriodsCoupon>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SubPeriodsCoupon>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/credit/basket.cpp
+++ b/ql/experimental/credit/basket.cpp
@@ -224,8 +224,7 @@ namespace QuantLib {
     requested ctpty......*/
     Real Basket::exposure(const std::string& name, const Date& d) const {
         //'this->names_' contains duplicates, contrary to 'pool->names'
-        std::vector<std::string>::const_iterator match =  
-            std::find(pool_->names().begin(), pool_->names().end(), name);
+        auto match = std::find(pool_->names().begin(), pool_->names().end(), name);
         QL_REQUIRE(match != pool_->names().end(), "Name not in basket.");
         Real totalNotional = 0.;
         do{

--- a/ql/experimental/credit/cdsoption.cpp
+++ b/ql/experimental/credit/cdsoption.cpp
@@ -90,8 +90,7 @@ namespace QuantLib {
         swap_->setupArguments(args);
         Option::setupArguments(args);
 
-        CdsOption::arguments* arguments =
-            dynamic_cast<CdsOption::arguments*>(args);
+        auto* arguments = dynamic_cast<CdsOption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
@@ -101,8 +100,7 @@ namespace QuantLib {
 
     void CdsOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
-        const CdsOption::results* results =
-            dynamic_cast<const CdsOption::results*>(r);
+        const auto* results = dynamic_cast<const CdsOption::results*>(r);
         QL_ENSURE(results != 0, "wrong results type");
         riskyAnnuity_ = results->riskyAnnuity;
     }

--- a/ql/experimental/credit/defaultevent.cpp
+++ b/ql/experimental/credit/defaultevent.cpp
@@ -30,8 +30,7 @@ namespace QuantLib {
     }
 
     void DefaultEvent::accept(AcyclicVisitor& v) {
-        Visitor<DefaultEvent>* v1 =
-            dynamic_cast<Visitor<DefaultEvent>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DefaultEvent>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -44,8 +43,7 @@ namespace QuantLib {
     }
 
     void DefaultEvent::DefaultSettlement::accept(AcyclicVisitor& v) {
-        Visitor<DefaultEvent::DefaultSettlement>* v1 =
-            dynamic_cast<Visitor<DefaultEvent::DefaultSettlement>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DefaultEvent::DefaultSettlement>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -67,8 +65,7 @@ namespace QuantLib {
         const Real recoveryRate)
     : settlementDate_(date), recoveryRates_(makeIsdaConvMap()) {
         if (seniority == NoSeniority) {
-            for (std::map<Seniority, Real>::iterator i=recoveryRates_.begin();
-                 i != recoveryRates_.end(); ++i) {
+            for (auto i = recoveryRates_.begin(); i != recoveryRates_.end(); ++i) {
                 i->second = recoveryRate;
             }
         } else {
@@ -81,8 +78,7 @@ namespace QuantLib {
         // expensive require cause called often...... fix me
         QL_REQUIRE(sen != NoSeniority,
             "NoSeniority is not valid for recovery rate request.");
-        std::map<Seniority, Real>::const_iterator itmatch =
-            recoveryRates_.find(sen);
+        auto itmatch = recoveryRates_.find(sen);
         if(itmatch != recoveryRates_.end()) {
             return itmatch->second;
         }else{

--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -305,8 +305,7 @@ namespace QuantLib {
             Size poolSize = basket_->size();//move to 'livesize'
             const ext::shared_ptr<Pool>& pool = basket_->pool();
 
-            BigNatural limit = 
-                static_cast<BigNatural>(std::pow(2., (int)(poolSize)));
+            auto limit = static_cast<BigNatural>(std::pow(2., (int)(poolSize)));
 
             // Precalc conditional probabilities
             std::vector<Probability> pDefCond;
@@ -317,10 +316,8 @@ namespace QuantLib {
                     defaultProbability(date), i, mktFactors));
 
             Probability probNEventsOrMore = 0.;
-            for(BigNatural mask = 
-                  static_cast<BigNatural>(std::pow(2., (int)(n))-1);
-                mask < limit; mask++) 
-            {
+            for (auto mask = static_cast<BigNatural>(std::pow(2., (int)(n)) - 1); mask < limit;
+                 mask++) {
                 // cheap permutations
                 boost::dynamic_bitset<> bsetMask(poolSize, mask);
                 if(bsetMask.count() >= n) {

--- a/ql/experimental/credit/distribution.cpp
+++ b/ql/experimental/credit/distribution.cpp
@@ -255,9 +255,7 @@ namespace QuantLib {
         }
 
         // remove losses over detachment point:
-        std::vector<Real>::iterator detachPosit = 
-            std::find_if(x_.begin(), x_.end(), 
-                         greater_than<Real>(detachmentPoint));
+        auto detachPosit = std::find_if(x_.begin(), x_.end(), greater_than<Real>(detachmentPoint));
         if(detachPosit != x_.end())
             x_.erase(detachPosit + 1, x_.end());
 

--- a/ql/experimental/credit/issuer.cpp
+++ b/ql/experimental/credit/issuer.cpp
@@ -75,10 +75,10 @@ namespace QuantLib {
                              ) const
     {
         // to do: the set is ordered, see how to use it to speed this up
-        for(DefaultEventSet::const_iterator itev = events_.begin();
-            // am i really speeding things up with the date comp?
-            itev != events_.end(); // && (*itev)->date() > start;
-            ++itev) {
+        for (auto itev = events_.begin();
+             // am i really speeding things up with the date comp?
+             itev != events_.end(); // && (*itev)->date() > start;
+             ++itev) {
             if((*itev)->matchesDefaultKey(contractKey) &&
                 between(*itev, start, end, includeRefDate))
                 return *itev;
@@ -96,10 +96,10 @@ namespace QuantLib {
     {
         std::vector<ext::shared_ptr<DefaultEvent> > defaults;
         // to do: the set is ordered, see how to use it to speed this up
-        for(DefaultEventSet::const_iterator itev = events_.begin();
-            // am i really speeding things up with the date comp?
-            itev != events_.end(); // && (*itev)->date() > start;
-            ++itev) {
+        for (auto itev = events_.begin();
+             // am i really speeding things up with the date comp?
+             itev != events_.end(); // && (*itev)->date() > start;
+             ++itev) {
             if((*itev)->matchesDefaultKey(contractKey) &&
                 between(*itev, start, end, includeRefDate))
                 defaults.push_back(*itev);

--- a/ql/experimental/credit/nthtodefault.cpp
+++ b/ql/experimental/credit/nthtodefault.cpp
@@ -111,8 +111,7 @@ namespace QuantLib {
     }
 
     void NthToDefault::setupArguments(PricingEngine::arguments* args) const {
-        NthToDefault::arguments* arguments
-            = dynamic_cast<NthToDefault::arguments*>(args);
+        auto* arguments = dynamic_cast<NthToDefault::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
         arguments->basket = basket_;
         arguments->side = side_;
@@ -127,8 +126,7 @@ namespace QuantLib {
     void NthToDefault::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
 
-        const NthToDefault::results* results
-            = dynamic_cast<const NthToDefault::results*>(r);
+        const auto* results = dynamic_cast<const NthToDefault::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
 
         premiumValue_ = results->premiumValue;

--- a/ql/experimental/credit/recoveryratequote.hpp
+++ b/ql/experimental/credit/recoveryratequote.hpp
@@ -96,7 +96,7 @@ namespace QuantLib {
         // TO DO: check Reals are valid, i.e. non Null and within [0-1] range
         std::map<Seniority, Real> isdaMap;
         for(Size i=0; i<N; i++) {
-            Seniority isdaType = Seniority(i);//compiler dependent?
+            auto isdaType = Seniority(i); // compiler dependent?
             isdaMap[isdaType] = arrayIsdaRR[i];
         }
         return isdaMap;

--- a/ql/experimental/credit/recursivelossmodel.hpp
+++ b/ql/experimental/credit/recursivelossmodel.hpp
@@ -343,14 +343,12 @@ namespace QuantLib {
                                                 mktFactor);
             ////// iterate on all possible losses in the distribution:
             std::map<Real, Probability> pDistTemp;
-            std::map<Real, Probability>::iterator distIt =
-                pIndepDistrib.begin();
+            auto distIt = pIndepDistrib.begin();
             while(distIt != pIndepDistrib.end()) {
               ///   update prob if this name does not default
-                std::map<Real, Probability>::iterator matchIt
-                    = pDistTemp.find(distIt->first);
-                if(matchIt != pDistTemp.end()) {
-                    matchIt->second += distIt->second * (1.-pDef);
+              auto matchIt = pDistTemp.find(distIt->first);
+              if (matchIt != pDistTemp.end()) {
+                  matchIt->second += distIt->second * (1. - pDef);
                 }else{
                     pDistTemp.insert(std::make_pair(distIt->first,
                         distIt->second * (1.-pDef)));
@@ -394,12 +392,10 @@ namespace QuantLib {
 
             // iterate on all possible losses in the distribution:
             std::map<Real, Probability> pDistTemp;
-            std::map<Real, Probability>::iterator distIt =
-                pIndepDistrib.begin();
+            auto distIt = pIndepDistrib.begin();
             while(distIt != pIndepDistrib.end()) {
                 // update prob if this name does not default
-                std::map<Real, Probability>::iterator matchIt
-                    = pDistTemp.find(distIt->first);
+                auto matchIt = pDistTemp.find(distIt->first);
                 if(matchIt != pDistTemp.end()) {
                     matchIt->second += distIt->second * (1.-pDef);
                 }else{
@@ -450,8 +446,7 @@ namespace QuantLib {
              unroll below to take profit of the fact that once we go over
              the tranche top the loss amount is fixed:
         */
-        std::map<Real, Probability>::iterator distIt =
-            pIndepDistrib.begin();
+        auto distIt = pIndepDistrib.begin();
 
         while(distIt != pIndepDistrib.end()) {
             Real loss = distIt->first * lossUnit_;
@@ -483,8 +478,7 @@ namespace QuantLib {
              unroll below to take profit of the fact that once we go over
              the tranche top the loss amount is fixed:
         */
-        std::map<Real, Probability>::iterator distIt =
-            pIndepDistrib.begin();
+        auto distIt = pIndepDistrib.begin();
 
         while(distIt != pIndepDistrib.end()) {
             Real loss = distIt->first * lossUnit_;
@@ -508,7 +502,7 @@ namespace QuantLib {
             conditionalLossDistrib(pDefDate, mktFactor);
 
         std::vector<Real> results;
-        std::map<Real, Probability>::iterator distIt = pIndepDistrib.begin();
+        auto distIt = pIndepDistrib.begin();
         while(distIt != pIndepDistrib.end()) {
             //Real loss = distIt->first * loss_unit_
             //                    ;

--- a/ql/experimental/credit/syntheticcdo.cpp
+++ b/ql/experimental/credit/syntheticcdo.cpp
@@ -140,8 +140,7 @@ namespace QuantLib {
     }
 
     void SyntheticCDO::setupArguments(PricingEngine::arguments* args) const {
-        SyntheticCDO::arguments* arguments
-            = dynamic_cast<SyntheticCDO::arguments*>(args);
+        auto* arguments = dynamic_cast<SyntheticCDO::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
         arguments->basket = basket_;
         arguments->side = side_;
@@ -157,8 +156,7 @@ namespace QuantLib {
     void SyntheticCDO::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
 
-        const SyntheticCDO::results* results
-            = dynamic_cast<const SyntheticCDO::results*>(r);
+        const auto* results = dynamic_cast<const SyntheticCDO::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
 
         premiumValue_ = results->premiumValue;
@@ -242,8 +240,7 @@ namespace QuantLib {
 
         MidPointCDOEngine engineIC(discountCurve);
         setupArguments(engineIC.getArguments());
-        const SyntheticCDO::results* results = 
-            dynamic_cast<const SyntheticCDO::results*>(engineIC.getResults());
+        const auto* results = dynamic_cast<const SyntheticCDO::results*>(engineIC.getResults());
 
         // aviod recal of the basket on engine updates through the quote
         basket_->recalculate();

--- a/ql/experimental/exoticoptions/complexchooseroption.cpp
+++ b/ql/experimental/exoticoptions/complexchooseroption.cpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     void ComplexChooserOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
-        ComplexChooserOption::arguments* moreArgs =
-            dynamic_cast<ComplexChooserOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ComplexChooserOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->choosingDate=choosingDate_;
         moreArgs->strikeCall=strikeCall_;

--- a/ql/experimental/exoticoptions/compoundoption.cpp
+++ b/ql/experimental/exoticoptions/compoundoption.cpp
@@ -32,8 +32,7 @@ namespace QuantLib {
     void CompoundOption::setupArguments(PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
 
-        CompoundOption::arguments* moreArgs =
-            dynamic_cast<CompoundOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<CompoundOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->daughterPayoff = daughterPayoff_;
         moreArgs->daughterExercise = daughterExercise_;

--- a/ql/experimental/exoticoptions/continuousarithmeticasianvecerengine.cpp
+++ b/ql/experimental/exoticoptions/continuousarithmeticasianvecerengine.cpp
@@ -182,7 +182,7 @@ namespace QuantLib {
             } // End Time Loop
 
             DownRounding Rounding(0);
-            Integer lowerI = Integer(Rounding( (Z_0-z_min_)/h));
+            auto lowerI = Integer(Rounding((Z_0 - z_min_) / h));
             // Interpolate solution
             Real pv;
 

--- a/ql/experimental/exoticoptions/everestoption.cpp
+++ b/ql/experimental/exoticoptions/everestoption.cpp
@@ -37,8 +37,7 @@ namespace QuantLib {
     void EverestOption::setupArguments(PricingEngine::arguments* args) const {
         MultiAssetOption::setupArguments(args);
 
-        EverestOption::arguments* arguments =
-            dynamic_cast<EverestOption::arguments*>(args);
+        auto* arguments = dynamic_cast<EverestOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->notional = notional_;
@@ -47,8 +46,7 @@ namespace QuantLib {
 
     void EverestOption::fetchResults(const PricingEngine::results* r) const {
         MultiAssetOption::fetchResults(r);
-        const EverestOption::results* results =
-            dynamic_cast<const EverestOption::results*>(r);
+        const auto* results = dynamic_cast<const EverestOption::results*>(r);
         QL_ENSURE(results != 0,
                   "no results returned from pricing engine");
         yield_ = results->yield;

--- a/ql/experimental/exoticoptions/himalayaoption.cpp
+++ b/ql/experimental/exoticoptions/himalayaoption.cpp
@@ -34,8 +34,7 @@ namespace QuantLib {
     void HimalayaOption::setupArguments(PricingEngine::arguments* args) const {
         MultiAssetOption::setupArguments(args);
 
-        HimalayaOption::arguments* arguments =
-            dynamic_cast<HimalayaOption::arguments*>(args);
+        auto* arguments = dynamic_cast<HimalayaOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->fixingDates = fixingDates_;

--- a/ql/experimental/exoticoptions/holderextensibleoption.cpp
+++ b/ql/experimental/exoticoptions/holderextensibleoption.cpp
@@ -37,8 +37,7 @@ namespace QuantLib {
     void HolderExtensibleOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
-        HolderExtensibleOption::arguments* moreArgs =
-            dynamic_cast<HolderExtensibleOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<HolderExtensibleOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->premium = premium_;
         moreArgs->secondExpiryDate = secondExpiryDate_;

--- a/ql/experimental/exoticoptions/margrabeoption.cpp
+++ b/ql/experimental/exoticoptions/margrabeoption.cpp
@@ -57,8 +57,7 @@ namespace QuantLib {
 
         MultiAssetOption::setupArguments(args);
 
-        MargrabeOption::arguments* moreArgs =
-            dynamic_cast<MargrabeOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<MargrabeOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0,
                    "wrong argument type");
 
@@ -78,8 +77,7 @@ namespace QuantLib {
 
     void MargrabeOption::fetchResults(const PricingEngine::results* r) const {
         MultiAssetOption::fetchResults(r);
-        const MargrabeOption::results* results =
-            dynamic_cast<const MargrabeOption::results*>(r);
+        const auto* results = dynamic_cast<const MargrabeOption::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
         delta1_          = results->delta1;
         delta2_          = results->delta2;

--- a/ql/experimental/exoticoptions/pagodaoption.cpp
+++ b/ql/experimental/exoticoptions/pagodaoption.cpp
@@ -35,8 +35,7 @@ namespace QuantLib {
     void PagodaOption::setupArguments(PricingEngine::arguments* args) const {
         MultiAssetOption::setupArguments(args);
 
-        PagodaOption::arguments* arguments =
-            dynamic_cast<PagodaOption::arguments*>(args);
+        auto* arguments = dynamic_cast<PagodaOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->fixingDates = fixingDates_;

--- a/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
+++ b/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
 
-        PartialTimeBarrierOption::arguments* moreArgs =
-            dynamic_cast<PartialTimeBarrierOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<PartialTimeBarrierOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrierRange = barrierRange_;

--- a/ql/experimental/exoticoptions/simplechooseroption.cpp
+++ b/ql/experimental/exoticoptions/simplechooseroption.cpp
@@ -35,8 +35,7 @@ namespace QuantLib {
     void SimpleChooserOption::setupArguments(
                                     PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
-        SimpleChooserOption::arguments* moreArgs =
-            dynamic_cast<SimpleChooserOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<SimpleChooserOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->choosingDate=choosingDate_;
     }

--- a/ql/experimental/exoticoptions/twoassetbarrieroption.cpp
+++ b/ql/experimental/exoticoptions/twoassetbarrieroption.cpp
@@ -33,8 +33,7 @@ namespace QuantLib {
     void TwoAssetBarrierOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         Option::setupArguments(args);
-        TwoAssetBarrierOption::arguments* moreArgs =
-            dynamic_cast<TwoAssetBarrierOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<TwoAssetBarrierOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier = barrier_;

--- a/ql/experimental/exoticoptions/twoassetcorrelationoption.cpp
+++ b/ql/experimental/exoticoptions/twoassetcorrelationoption.cpp
@@ -33,8 +33,7 @@ namespace QuantLib {
     void TwoAssetCorrelationOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         MultiAssetOption::setupArguments(args);
-        TwoAssetCorrelationOption::arguments* moreArgs =
-            dynamic_cast<TwoAssetCorrelationOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<TwoAssetCorrelationOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
 
         moreArgs->X2 = X2_;

--- a/ql/experimental/exoticoptions/writerextensibleoption.cpp
+++ b/ql/experimental/exoticoptions/writerextensibleoption.cpp
@@ -34,8 +34,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
 
-        WriterExtensibleOption::arguments* otherArguments =
-            dynamic_cast<WriterExtensibleOption::arguments*>(args);
+        auto* otherArguments = dynamic_cast<WriterExtensibleOption::arguments*>(args);
         QL_REQUIRE(otherArguments != 0, "wrong arguments type");
 
         otherArguments->payoff2 = payoff2_;

--- a/ql/experimental/finitedifferences/vanillavppoption.cpp
+++ b/ql/experimental/finitedifferences/vanillavppoption.cpp
@@ -70,8 +70,7 @@ namespace QuantLib {
 
         MultiAssetOption::setupArguments(args);
 
-        VanillaVPPOption::arguments* arguments =
-            dynamic_cast<VanillaVPPOption::arguments*>(args);
+        auto* arguments = dynamic_cast<VanillaVPPOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->heatRate       = heatRate_;

--- a/ql/experimental/futures/overnightindexfutureratehelper.cpp
+++ b/ql/experimental/futures/overnightindexfutureratehelper.cpp
@@ -79,8 +79,7 @@ namespace QuantLib {
     }
 
     void OvernightIndexFutureRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<OvernightIndexFutureRateHelper>* v1 =
-            dynamic_cast<Visitor<OvernightIndexFutureRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<OvernightIndexFutureRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
+++ b/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
@@ -173,8 +173,8 @@ namespace QuantLib {
     Volatility KInterpolatedYoYOptionletVolatilitySurface<Interpolator1D>::
     volatilityImpl(Time length,  Rate strike) const {
 
-        Natural years = (Natural)floor(length);
-        Natural days = (Natural)floor((length - years) * 365.0);
+        auto years = (Natural)floor(length);
+        auto days = (Natural)floor((length - years) * 365.0);
         Date d = referenceDate() + Period(years, Years) + Period(days, Days);
 
         return this->volatilityImpl(d, strike);

--- a/ql/experimental/math/convolvedstudentt.cpp
+++ b/ql/experimental/math/convolvedstudentt.cpp
@@ -68,9 +68,9 @@ namespace QuantLib {
             polyConvolved_ =
                 convolveVectorPolynomials(polyConvolved_, polynCharFnc_[i]);
           // trim possible zeros that might have arised:
-          std::vector<Real>::reverse_iterator it = polyConvolved_.rbegin();
-          while(it != polyConvolved_.rend()) {
-              if(*it == 0.) {
+        auto it = polyConvolved_.rbegin();
+        while (it != polyConvolved_.rend()) {
+            if (*it == 0.) {
                 polyConvolved_.pop_back();
                 it = polyConvolved_.rbegin();
               }else{

--- a/ql/experimental/math/piecewiseintegral.hpp
+++ b/ql/experimental/math/piecewiseintegral.hpp
@@ -66,11 +66,9 @@ inline Real PiecewiseIntegral::integrate_h(const ext::function<Real(Real)> &f,
 inline Real PiecewiseIntegral::integrate(const ext::function<Real(Real)> &f,
                                          Real a, Real b) const {
 
-    std::vector<Real>::const_iterator a0 =
-        std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), a);
+    auto a0 = std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), a);
 
-    std::vector<Real>::const_iterator b0 =
-        std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), b);
+    auto b0 = std::lower_bound(criticalPoints_.begin(), criticalPoints_.end(), b);
 
     if (a0 == criticalPoints_.end()) {
         Real tmp = 1.0;
@@ -95,7 +93,7 @@ inline Real PiecewiseIntegral::integrate(const ext::function<Real(Real)> &f,
         }
     }
 
-    for (std::vector<Real>::const_iterator x = a0; x < b0; ++x) {
+    for (auto x = a0; x < b0; ++x) {
         res += integrate_h(f, (*x) * eps_, std::min(*(x + 1) / eps_, b));
     }
 

--- a/ql/experimental/mcbasket/pathmultiassetoption.cpp
+++ b/ql/experimental/mcbasket/pathmultiassetoption.cpp
@@ -41,8 +41,7 @@ namespace QuantLib {
 
     void PathMultiAssetOption::setupArguments(PricingEngine::arguments* args)
                                                                        const {
-        PathMultiAssetOption::arguments* arguments =
-            dynamic_cast<PathMultiAssetOption::arguments*>(args);
+        auto* arguments = dynamic_cast<PathMultiAssetOption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "wrong argument type");
 

--- a/ql/experimental/mcbasket/pathpayoff.hpp
+++ b/ql/experimental/mcbasket/pathpayoff.hpp
@@ -82,7 +82,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void PathPayoff::accept(AcyclicVisitor& v) {
-        Visitor<PathPayoff>* v1 = dynamic_cast<Visitor<PathPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<PathPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/risk/creditriskplus.cpp
+++ b/ql/experimental/risk/creditriskplus.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
         std::map<unsigned long, Real, std::less<unsigned long> >::iterator iter;
 
         for (Size k = 0; k < m_; ++k) {
-            unsigned long exUnit = (unsigned long)(std::floor(0.5 + exposure_[k] / unit_)); // round
+            auto exUnit = (unsigned long)(std::floor(0.5 + exposure_[k] / unit_)); // round
             if (exposure_[k] > 0 && exUnit == 0)
                 exUnit = 1; // but avoid zero exposure
             if (exUnit > maxNu_)

--- a/ql/experimental/swaptions/irregularswap.cpp
+++ b/ql/experimental/swaptions/irregularswap.cpp
@@ -72,8 +72,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        IrregularSwap::arguments* arguments =
-            dynamic_cast<IrregularSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<IrregularSwap::arguments*>(args);
 
         if (arguments == 0) // it's a swap engine...
             return;
@@ -175,8 +174,7 @@ namespace QuantLib {
     void IrregularSwap::fetchResults(const PricingEngine::results* r) const {
         Swap::fetchResults(r);
 
-        const IrregularSwap::results* results =
-            dynamic_cast<const IrregularSwap::results*>(r);
+        const auto* results = dynamic_cast<const IrregularSwap::results*>(r);
         if (results != 0) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;

--- a/ql/experimental/swaptions/irregularswaption.cpp
+++ b/ql/experimental/swaptions/irregularswaption.cpp
@@ -74,8 +74,7 @@ namespace QuantLib {
                 vol_->setValue(x);
                 engine_->calculate();
             }
-            std::map<std::string,boost::any>::const_iterator vega_ =
-                results_->additionalResults.find("vega");
+            auto vega_ = results_->additionalResults.find("vega");
             QL_REQUIRE(vega_ != results_->additionalResults.end(),
                        "vega not provided");
             return boost::any_cast<Real>(vega_->second);
@@ -110,8 +109,7 @@ namespace QuantLib {
 
         swap_->setupArguments(args);
 
-        IrregularSwaption::arguments* arguments =
-            dynamic_cast<IrregularSwaption::arguments*>(args);
+        auto* arguments = dynamic_cast<IrregularSwaption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "wrong argument type");
 

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -134,8 +134,7 @@ namespace QuantLib {
     }
 
     void CrossCurrencyBasisSwapRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<CrossCurrencyBasisSwapRateHelper>* v1 =
-            dynamic_cast<Visitor<CrossCurrencyBasisSwapRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CrossCurrencyBasisSwapRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/termstructures/multicurvesensitivities.hpp
+++ b/ql/experimental/termstructures/multicurvesensitivities.hpp
@@ -74,13 +74,11 @@ public:
       ext::shared_ptr< PiecewiseYieldCurve< ZeroYield, Linear > > curve =
           ext::dynamic_pointer_cast< PiecewiseYieldCurve< ZeroYield, Linear > >(it->second.currentLink());
       QL_REQUIRE(curve != NULL, "Couldn't cast curvename: " << it->first);
-      for (std::vector< ext::shared_ptr< BootstrapHelper< YieldTermStructure > > >::iterator inst =
-               curve->instruments_.begin();
-           inst != curve->instruments_.end(); ++inst) {
-        allQuotes_.push_back((*inst)->quote());
-        std::stringstream tmp;
-        tmp << QuantLib::io::iso_date((*inst)->latestRelevantDate());
-        headers_.push_back(it->first + "_" + tmp.str());
+      for (auto inst = curve->instruments_.begin(); inst != curve->instruments_.end(); ++inst) {
+          allQuotes_.push_back((*inst)->quote());
+          std::stringstream tmp;
+          tmp << QuantLib::io::iso_date((*inst)->latestRelevantDate());
+          headers_.push_back(it->first + "_" + tmp.str());
       }
     }
   }
@@ -108,20 +106,20 @@ private:
 inline void MultiCurveSensitivities::performCalculations() const {
   std::vector< Rate > sensiVector;
   origZeros_ = allZeros();
-  for (std::vector< Handle< Quote > >::const_iterator it = allQuotes_.begin(); it != allQuotes_.end(); ++it) {
-    Rate bps = +1e-4;
-    Rate origQuote = (*it)->value();
-    ext::shared_ptr< SimpleQuote > q = ext::dynamic_pointer_cast< SimpleQuote >((*it).currentLink());
-    q->setValue(origQuote + bps);
-    try {
-      std::vector< Rate > tmp(allZeros());
-      for (Size i = 0; i < tmp.size(); ++i)
-        sensiVector.push_back((tmp[i] - origZeros_[i]) / bps);
-      q->setValue(origQuote);
-    } catch (...) {
-      q->setValue(origQuote);
-      QL_FAIL("Application of shift to quote led to exception.");
-    }
+  for (auto it = allQuotes_.begin(); it != allQuotes_.end(); ++it) {
+      Rate bps = +1e-4;
+      Rate origQuote = (*it)->value();
+      ext::shared_ptr<SimpleQuote> q = ext::dynamic_pointer_cast<SimpleQuote>((*it).currentLink());
+      q->setValue(origQuote + bps);
+      try {
+          std::vector<Rate> tmp(allZeros());
+          for (Size i = 0; i < tmp.size(); ++i)
+              sensiVector.push_back((tmp[i] - origZeros_[i]) / bps);
+          q->setValue(origQuote);
+      } catch (...) {
+          q->setValue(origQuote);
+          QL_FAIL("Application of shift to quote led to exception.");
+      }
   }
   Matrix result(origZeros_.size(), origZeros_.size(), sensiVector.begin(), sensiVector.end());
   sensi_ = result;
@@ -140,12 +138,14 @@ inline Matrix MultiCurveSensitivities::inverseSensitivities() const {
 
 inline std::vector< std::pair< Date, Real > > MultiCurveSensitivities::allNodes() const {
   std::vector< std::pair< Date, Real > > result;
-  for (curvespec::const_iterator it = curves_.begin(); it != curves_.end(); ++it) {
-    ext::shared_ptr< PiecewiseYieldCurve< ZeroYield, Linear > > curve =
-        ext::dynamic_pointer_cast< PiecewiseYieldCurve< ZeroYield, Linear > >(it->second.currentLink());
-    result.reserve(result.size() + curve->nodes().size() - 1);
-    for (std::vector<std::pair<Date, Real> >::const_iterator p = curve->nodes().begin() + 1; p != curve->nodes().end(); ++p)
-      result.push_back(*p);
+  for (auto it = curves_.begin(); it != curves_.end(); ++it) {
+      ext::shared_ptr<PiecewiseYieldCurve<ZeroYield, Linear> > curve =
+          ext::dynamic_pointer_cast<PiecewiseYieldCurve<ZeroYield, Linear> >(
+              it->second.currentLink());
+      result.reserve(result.size() + curve->nodes().size() - 1);
+      for (std::vector<std::pair<Date, Real> >::const_iterator p = curve->nodes().begin() + 1;
+           p != curve->nodes().end(); ++p)
+          result.push_back(*p);
   }
   return result;
 }

--- a/ql/experimental/variancegamma/fftengine.cpp
+++ b/ql/experimental/variancegamma/fftengine.cpp
@@ -40,10 +40,10 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         QL_REQUIRE(payoff, "non-striked payoff given");
 
-        ResultMap::const_iterator r1 = resultMap_.find(arguments_.exercise->lastDate());
+        auto r1 = resultMap_.find(arguments_.exercise->lastDate());
         if (r1 != resultMap_.end())
         {
-            PayoffResultMap::const_iterator r2 = r1->second.find(payoff);
+            auto r2 = r1->second.find(payoff);
             if (r2 != r1->second.end())
             {
                 results_.value = r2->second;
@@ -84,10 +84,8 @@ namespace QuantLib {
         typedef std::vector<ext::shared_ptr<StrikedTypePayoff> > PayoffList;
         typedef std::map<Date, PayoffList> PayoffMap;
         PayoffMap payoffMap;
-        
-        for (std::vector<ext::shared_ptr<Instrument> >::const_iterator optIt = optionList.begin();
-            optIt != optionList.end(); ++optIt)
-        {
+
+        for (auto optIt = optionList.begin(); optIt != optionList.end(); ++optIt) {
             ext::shared_ptr<VanillaOption> option = ext::dynamic_pointer_cast<VanillaOption>(*optIt);
             QL_REQUIRE(option, "instrument must be option");
             QL_REQUIRE(option->exercise()->type() == Exercise::European,
@@ -109,9 +107,7 @@ namespace QuantLib {
 
             // Calculate n large enough for maximum strike, and round up to a power of 2
             Real maxStrike = 0.0;
-            for (PayoffList::const_iterator it = payIt->second.begin();
-                it != payIt->second.end(); ++it)
-            {
+            for (auto it = payIt->second.begin(); it != payIt->second.end(); ++it) {
                 ext::shared_ptr<StrikedTypePayoff> payoff = *it;
 
                 if (payoff->strike() > maxStrike)
@@ -165,9 +161,7 @@ namespace QuantLib {
                 strikes[i] = std::exp(k_u);
             }
 
-            for (PayoffList::const_iterator it = payIt->second.begin();
-                it != payIt->second.end(); ++it)
-            {
+            for (auto it = payIt->second.begin(); it != payIt->second.end(); ++it) {
                 ext::shared_ptr<StrikedTypePayoff> payoff = *it;
 
                 Real callPrice = LinearInterpolation(strikes.begin(), strikes.end(), prices.begin())(payoff->strike());

--- a/ql/experimental/varianceoption/varianceoption.cpp
+++ b/ql/experimental/varianceoption/varianceoption.cpp
@@ -31,8 +31,7 @@ namespace QuantLib {
       startDate_(startDate), maturityDate_(maturityDate) {}
 
     void VarianceOption::setupArguments(PricingEngine::arguments* args) const {
-        VarianceOption::arguments* arguments =
-            dynamic_cast<VarianceOption::arguments*>(args);
+        auto* arguments = dynamic_cast<VarianceOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->payoff = payoff_;

--- a/ql/experimental/volatility/abcdatmvolcurve.cpp
+++ b/ql/experimental/volatility/abcdatmvolcurve.cpp
@@ -93,8 +93,7 @@ namespace QuantLib {
     }
 
     void AbcdAtmVolCurve::accept(AcyclicVisitor& v) {
-        Visitor<AbcdAtmVolCurve>* v1 =
-            dynamic_cast<Visitor<AbcdAtmVolCurve>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<AbcdAtmVolCurve>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/blackatmvolcurve.cpp
+++ b/ql/experimental/volatility/blackatmvolcurve.cpp
@@ -74,8 +74,7 @@ namespace QuantLib {
     }
 
     void BlackAtmVolCurve::accept(AcyclicVisitor& v) {
-        Visitor<BlackAtmVolCurve>* v1 =
-            dynamic_cast<Visitor<BlackAtmVolCurve>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackAtmVolCurve>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/blackvolsurface.cpp
+++ b/ql/experimental/volatility/blackvolsurface.cpp
@@ -49,8 +49,7 @@ namespace QuantLib {
     }
 
     void BlackVolSurface::accept(AcyclicVisitor& v) {
-        Visitor<BlackVolSurface>* v1 =
-            dynamic_cast<Visitor<BlackVolSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVolSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/equityfxvolsurface.cpp
+++ b/ql/experimental/volatility/equityfxvolsurface.cpp
@@ -74,8 +74,7 @@ namespace QuantLib {
     }
 
     void EquityFXVolSurface::accept(AcyclicVisitor& v) {
-        Visitor<EquityFXVolSurface>* v1 =
-            dynamic_cast<Visitor<EquityFXVolSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<EquityFXVolSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/extendedblackvariancecurve.hpp
+++ b/ql/experimental/volatility/extendedblackvariancecurve.hpp
@@ -85,8 +85,7 @@ namespace QuantLib {
     }
 
     inline void ExtendedBlackVarianceCurve::accept(AcyclicVisitor& v) {
-        Visitor<ExtendedBlackVarianceCurve>* v1 =
-            dynamic_cast<Visitor<ExtendedBlackVarianceCurve>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<ExtendedBlackVarianceCurve>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/extendedblackvariancesurface.hpp
+++ b/ql/experimental/volatility/extendedblackvariancesurface.hpp
@@ -81,8 +81,7 @@ namespace QuantLib {
     };
 
     inline void ExtendedBlackVarianceSurface::accept(AcyclicVisitor& v) {
-        Visitor<ExtendedBlackVarianceSurface>* v1 =
-            dynamic_cast<Visitor<ExtendedBlackVarianceSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<ExtendedBlackVarianceSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/interestratevolsurface.cpp
+++ b/ql/experimental/volatility/interestratevolsurface.cpp
@@ -53,8 +53,7 @@ namespace QuantLib {
     }
 
     void InterestRateVolSurface::accept(AcyclicVisitor& v) {
-        Visitor<InterestRateVolSurface>* v1 =
-            dynamic_cast<Visitor<InterestRateVolSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<InterestRateVolSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/sabrvolsurface.cpp
+++ b/ql/experimental/volatility/sabrvolsurface.cpp
@@ -121,7 +121,7 @@ namespace QuantLib {
     ext::shared_ptr<SmileSection>
     SabrVolSurface::smileSectionImpl(Time t) const {
 
-        BigInteger n = BigInteger(t*365.0);
+        auto n = BigInteger(t * 365.0);
         Date d = referenceDate()+n*Days;
         // interpolating on ref smile sections
         std::vector<Volatility> volSpreads = volatilitySpreads(d);
@@ -174,8 +174,7 @@ namespace QuantLib {
     }
 
     void SabrVolSurface::accept(AcyclicVisitor& v) {
-        Visitor<SabrVolSurface>* v1 =
-            dynamic_cast<Visitor<SabrVolSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SabrVolSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -322,8 +322,7 @@ ZabrModel::x(const std::vector<Real> &strikes) const {
 
     QL_REQUIRE(strikes[0] > 0.0 || beta_ < 1.0,
                "strikes must be positive (" << strikes[0] << ") if beta = 1");
-    for (std::vector<Real>::const_iterator i = strikes.begin() + 1;
-         i != strikes.end(); ++i)
+    for (auto i = strikes.begin() + 1; i != strikes.end(); ++i)
         QL_REQUIRE(*i > *(i - 1), "strikes must be strictly ascending ("
                                       << *(i - 1) << "," << *i << ")");
 

--- a/ql/instrument.hpp
+++ b/ql/instrument.hpp
@@ -173,8 +173,7 @@ namespace QuantLib {
 
     inline void Instrument::fetchResults(
                                       const PricingEngine::results* r) const {
-        const Instrument::results* results =
-            dynamic_cast<const Instrument::results*>(r);
+        const auto* results = dynamic_cast<const Instrument::results*>(r);
         QL_ENSURE(results != 0,
                   "no results returned from pricing engine");
 

--- a/ql/instruments/asianoption.cpp
+++ b/ql/instruments/asianoption.cpp
@@ -41,8 +41,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        DiscreteAveragingAsianOption::arguments* moreArgs =
-            dynamic_cast<DiscreteAveragingAsianOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<DiscreteAveragingAsianOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->averageType = averageType_;
         moreArgs->runningAccumulator = runningAccumulator_;
@@ -90,8 +89,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        ContinuousAveragingAsianOption::arguments* moreArgs =
-            dynamic_cast<ContinuousAveragingAsianOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ContinuousAveragingAsianOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->averageType = averageType_;
     }

--- a/ql/instruments/assetswap.cpp
+++ b/ql/instruments/assetswap.cpp
@@ -226,7 +226,7 @@ namespace QuantLib {
             registerWith(*i);
 
         const Leg& bondLeg = bond_->cashflows();
-        for (Leg::const_iterator i=bondLeg.begin(); i<bondLeg.end(); ++i) {
+        for (auto i = bondLeg.begin(); i < bondLeg.end(); ++i) {
             // whatever might be the choice for the discounting engine
             // bond flows on upfrontDate_ must be discarded
             bool upfrontDateBondFlows = false;
@@ -274,8 +274,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        AssetSwap::arguments* arguments =
-            dynamic_cast<AssetSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<AssetSwap::arguments*>(args);
 
         if (arguments == 0) // it's a swap engine...
             return;
@@ -389,8 +388,7 @@ namespace QuantLib {
 
     void AssetSwap::fetchResults(const PricingEngine::results* r) const {
         Swap::fetchResults(r);
-        const AssetSwap::results* results =
-            dynamic_cast<const AssetSwap::results*>(r);
+        const auto* results = dynamic_cast<const AssetSwap::results*>(r);
         if (results != 0) {
             fairSpread_ = results->fairSpread;
             fairCleanPrice_= results->fairCleanPrice;

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        BarrierOption::arguments* moreArgs =
-            dynamic_cast<BarrierOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<BarrierOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier = barrier_;

--- a/ql/instruments/bmaswap.cpp
+++ b/ql/instruments/bmaswap.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
             .withPaymentAdjustment(bmaSchedule.businessDayConvention());
 
         for (Size j=0; j<2; ++j) {
-            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+            for (auto i = legs_[j].begin(); i != legs_[j].end(); ++i)
                 registerWith(*i);
         }
 

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -127,9 +127,7 @@ namespace QuantLib {
         // date, since the first is null.  After the call to
         // lower_bound, *i is the earliest date which is greater or
         // equal than d.  Its index is greater or equal to 1.
-        std::vector<Date>::const_iterator i =
-            std::lower_bound(notionalSchedule_.begin()+1,
-                             notionalSchedule_.end(), d);
+        auto i = std::lower_bound(notionalSchedule_.begin() + 1, notionalSchedule_.end(), d);
         Size index = std::distance(notionalSchedule_.begin(), i);
 
         if (d < notionalSchedule_[index]) {
@@ -289,7 +287,7 @@ namespace QuantLib {
     }
 
     void Bond::setupArguments(PricingEngine::arguments* args) const {
-        Bond::arguments* arguments = dynamic_cast<Bond::arguments*>(args);
+        auto* arguments = dynamic_cast<Bond::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->settlementDate = settlementDate();
@@ -301,8 +299,7 @@ namespace QuantLib {
 
         Instrument::fetchResults(r);
 
-        const Bond::results* results =
-            dynamic_cast<const Bond::results*>(r);
+        const auto* results = dynamic_cast<const Bond::results*>(r);
         QL_ENSURE(results != 0, "wrong result type");
 
         settlementValue_ = results->settlementValue;

--- a/ql/instruments/callabilityschedule.hpp
+++ b/ql/instruments/callabilityschedule.hpp
@@ -63,7 +63,7 @@ namespace QuantLib {
     };
 
     inline void Callability::accept(AcyclicVisitor& v){
-        Visitor<Callability>* v1 = dynamic_cast<Visitor<Callability>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Callability>*>(&v);
         if(v1 != 0)
             v1->visit(*this);
         else

--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -99,8 +99,7 @@ namespace QuantLib {
                 vol_->setValue(x);
                 engine_->calculate();
             }
-            std::map<std::string,boost::any>::const_iterator vega_ =
-                results_->additionalResults.find("vega");
+            auto vega_ = results_->additionalResults.find("vega");
             QL_REQUIRE(vega_ != results_->additionalResults.end(),
                        "vega not provided");
             return boost::any_cast<Real>(vega_->second);
@@ -210,8 +209,7 @@ namespace QuantLib {
     }
 
     void CapFloor::setupArguments(PricingEngine::arguments* args) const {
-        CapFloor::arguments* arguments =
-            dynamic_cast<CapFloor::arguments*>(args);
+        auto* arguments = dynamic_cast<CapFloor::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         Size n = floatingLeg_.size();

--- a/ql/instruments/cliquetoption.cpp
+++ b/ql/instruments/cliquetoption.cpp
@@ -32,8 +32,7 @@ namespace QuantLib {
     void CliquetOption::setupArguments(PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
         // set accrued coupon, last fixing, caps, floors
-        CliquetOption::arguments* moreArgs =
-            dynamic_cast<CliquetOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<CliquetOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0,
                    "wrong engine type");
         moreArgs->resetDates = resetDates_;

--- a/ql/instruments/compositeinstrument.cpp
+++ b/ql/instruments/compositeinstrument.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
     }
 
     bool CompositeInstrument::isExpired() const {
-        for (const_iterator i=components_.begin(); i!=components_.end(); ++i) {
+        for (auto i = components_.begin(); i != components_.end(); ++i) {
             if (!i->first->isExpired())
                 return false;
         }
@@ -52,7 +52,7 @@ namespace QuantLib {
 
     void CompositeInstrument::performCalculations() const {
         NPV_ = 0.0;
-        for (const_iterator i=components_.begin(); i!=components_.end(); ++i) {
+        for (auto i = components_.begin(); i != components_.end(); ++i) {
             NPV_ += i->second * i->first->NPV();
         }
     }

--- a/ql/instruments/cpicapfloor.cpp
+++ b/ql/instruments/cpicapfloor.cpp
@@ -98,7 +98,7 @@ namespace QuantLib {
     void CPICapFloor::setupArguments(PricingEngine::arguments* args) const {
 
         // correct PricingEngine?
-        CPICapFloor::arguments* arguments = dynamic_cast<CPICapFloor::arguments*>(args);
+        auto* arguments = dynamic_cast<CPICapFloor::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type, not CPICapFloor::arguments*");
 
         // data move

--- a/ql/instruments/cpiswap.cpp
+++ b/ql/instruments/cpiswap.cpp
@@ -140,8 +140,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        CPISwap::arguments* arguments =
-        dynamic_cast<CPISwap::arguments*>(args);
+        auto* arguments = dynamic_cast<CPISwap::arguments*>(args);
 
         if (arguments == 0)
             return; // it's a swap engine...
@@ -189,7 +188,7 @@ namespace QuantLib {
 
         Swap::fetchResults(r);
 
-        const CPISwap::results* results = dynamic_cast<const CPISwap::results*>(r);
+        const auto* results = dynamic_cast<const CPISwap::results*>(r);
         if (results != 0) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -198,8 +198,7 @@ namespace QuantLib {
 
 
     bool CreditDefaultSwap::isExpired() const {
-        for (Leg::const_reverse_iterator i = leg_.rbegin();
-                                         i != leg_.rend(); ++i) {
+        for (auto i = leg_.rbegin(); i != leg_.rend(); ++i) {
             if (!(*i)->hasOccurred())
                 return false;
         }
@@ -215,8 +214,7 @@ namespace QuantLib {
 
     void CreditDefaultSwap::setupArguments(
                                        PricingEngine::arguments* args) const {
-        CreditDefaultSwap::arguments* arguments =
-            dynamic_cast<CreditDefaultSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<CreditDefaultSwap::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->side = side_;
@@ -238,8 +236,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
 
-        const CreditDefaultSwap::results* results =
-            dynamic_cast<const CreditDefaultSwap::results*>(r);
+        const auto* results = dynamic_cast<const CreditDefaultSwap::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
 
         fairSpread_ = results->fairSpread;
@@ -367,9 +364,7 @@ namespace QuantLib {
         }
 
         setupArguments(engine->getArguments());
-        const CreditDefaultSwap::results* results =
-            dynamic_cast<const CreditDefaultSwap::results*>(
-                engine->getResults());
+        const auto* results = dynamic_cast<const CreditDefaultSwap::results*>(engine->getResults());
 
         ObjectiveFunction f(targetNPV, *flatRate, *engine, results);
         //very close guess if targetNPV = 0.
@@ -410,9 +405,7 @@ namespace QuantLib {
         }
 
         setupArguments(engine->getArguments());
-        const CreditDefaultSwap::results* results =
-            dynamic_cast<const CreditDefaultSwap::results*>(
-                engine->getResults());
+        const auto* results = dynamic_cast<const CreditDefaultSwap::results*>(engine->getResults());
 
         ObjectiveFunction f(0., *flatRate, *engine, results);
         Rate guess = runningSpread_ / (1 - conventionalRecovery) * 365./360.;

--- a/ql/instruments/dividendbarrieroption.cpp
+++ b/ql/instruments/dividendbarrieroption.cpp
@@ -41,8 +41,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         BarrierOption::setupArguments(args);
 
-        DividendBarrierOption::arguments* arguments =
-            dynamic_cast<DividendBarrierOption::arguments*>(args);
+        auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong engine type");
 
         arguments->cashFlow = cashFlow_;

--- a/ql/instruments/dividendvanillaoption.cpp
+++ b/ql/instruments/dividendvanillaoption.cpp
@@ -82,8 +82,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
 
-        DividendVanillaOption::arguments* arguments =
-            dynamic_cast<DividendVanillaOption::arguments*>(args);
+        auto* arguments = dynamic_cast<DividendVanillaOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong engine type");
 
         arguments->cashFlow = cashFlow_;

--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -326,13 +326,12 @@ namespace QuantLib {
             for (Size i = 0; i < legs_[0].size() - 1; i++) {
                 Real cap = nominal1_[i] - nominal1_[i + 1];
                 if (!close(cap, 0.0)) {
-                    std::vector<ext::shared_ptr<CashFlow> >::iterator it1 =
-                        legs_[0].begin();
+                    auto it1 = legs_[0].begin();
                     std::advance(it1, i + 1);
                     legs_[0].insert(
                         it1, ext::shared_ptr<CashFlow>(
                                  new Redemption(cap, legs_[0][i]->date())));
-                    std::vector<Real>::iterator it2 = nominal1_.begin();
+                    auto it2 = nominal1_.begin();
                     std::advance(it2, i + 1);
                     nominal1_.insert(it2, nominal1_[i]);
                     i++;
@@ -341,13 +340,12 @@ namespace QuantLib {
             for (Size i = 0; i < legs_[1].size() - 1; i++) {
                 Real cap = nominal2_[i] - nominal2_[i + 1];
                 if (!close(cap, 0.0)) {
-                    std::vector<ext::shared_ptr<CashFlow> >::iterator it1 =
-                        legs_[1].begin();
+                    auto it1 = legs_[1].begin();
                     std::advance(it1, i + 1);
                     legs_[1].insert(
                         it1, ext::shared_ptr<CashFlow>(
                                  new Redemption(cap, legs_[1][i]->date())));
-                    std::vector<Real>::iterator it2 = nominal2_.begin();
+                    auto it2 = nominal2_.begin();
                     std::advance(it2, i + 1);
                     nominal2_.insert(it2, nominal2_[i]);
                     i++;
@@ -388,8 +386,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        FloatFloatSwap::arguments *arguments =
-            dynamic_cast<FloatFloatSwap::arguments *>(args);
+        auto* arguments = dynamic_cast<FloatFloatSwap::arguments*>(args);
 
         if (arguments == 0)
             return; // swap engine ... // QL_REQUIRE(arguments != 0, "argument type does not match");

--- a/ql/instruments/floatfloatswaption.cpp
+++ b/ql/instruments/floatfloatswaption.cpp
@@ -41,8 +41,7 @@ namespace QuantLib {
 
         swap_->setupArguments(args);
 
-        FloatFloatSwaption::arguments *arguments =
-            dynamic_cast<FloatFloatSwaption::arguments *>(args);
+        auto* arguments = dynamic_cast<FloatFloatSwaption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "wrong argument type");
 

--- a/ql/instruments/forwardvanillaoption.cpp
+++ b/ql/instruments/forwardvanillaoption.cpp
@@ -33,8 +33,7 @@ namespace QuantLib {
     void ForwardVanillaOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
-        ForwardVanillaOption::arguments* arguments =
-            dynamic_cast<ForwardVanillaOption::arguments*>(args);
+        auto* arguments = dynamic_cast<ForwardVanillaOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->moneyness = moneyness_;
@@ -45,8 +44,7 @@ namespace QuantLib {
     void ForwardVanillaOption::fetchResults(
                                       const PricingEngine::results* r) const {
         OneAssetOption::fetchResults(r);
-        const ForwardVanillaOption::results* results =
-            dynamic_cast<const ForwardVanillaOption::results*>(r);
+        const auto* results = dynamic_cast<const ForwardVanillaOption::results*>(r);
         QL_ENSURE(results != 0,
                   "no results returned from pricing engine");
         delta_       = results->delta;

--- a/ql/instruments/inflationcapfloor.cpp
+++ b/ql/instruments/inflationcapfloor.cpp
@@ -130,8 +130,7 @@ namespace QuantLib {
     }
 
     void YoYInflationCapFloor::setupArguments(PricingEngine::arguments* args) const {
-        YoYInflationCapFloor::arguments* arguments =
-        dynamic_cast<YoYInflationCapFloor::arguments*>(args);
+        auto* arguments = dynamic_cast<YoYInflationCapFloor::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         Size n = yoyLeg_.size();

--- a/ql/instruments/lookbackoption.cpp
+++ b/ql/instruments/lookbackoption.cpp
@@ -34,8 +34,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        ContinuousFloatingLookbackOption::arguments* moreArgs =
-            dynamic_cast<ContinuousFloatingLookbackOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ContinuousFloatingLookbackOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->minmax = minmax_;
     }
@@ -62,8 +61,7 @@ namespace QuantLib {
 
         OneAssetOption::setupArguments(args);
 
-        ContinuousFixedLookbackOption::arguments* moreArgs =
-            dynamic_cast<ContinuousFixedLookbackOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ContinuousFixedLookbackOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->minmax = minmax_;
     }
@@ -92,8 +90,7 @@ namespace QuantLib {
 
         ContinuousFloatingLookbackOption::setupArguments(args);
 
-        ContinuousPartialFloatingLookbackOption::arguments* moreArgs =
-            dynamic_cast<ContinuousPartialFloatingLookbackOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ContinuousPartialFloatingLookbackOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->lambda = lambda_;
         moreArgs->lookbackPeriodEnd = lookbackPeriodEnd_;
@@ -133,8 +130,7 @@ namespace QuantLib {
 
         ContinuousFixedLookbackOption::setupArguments(args);
 
-        ContinuousPartialFixedLookbackOption::arguments* moreArgs =
-            dynamic_cast<ContinuousPartialFixedLookbackOption::arguments*>(args);
+        auto* moreArgs = dynamic_cast<ContinuousPartialFixedLookbackOption::arguments*>(args);
         QL_REQUIRE(moreArgs != 0, "wrong argument type");
         moreArgs->lookbackPeriodStart = lookbackPeriodStart_;
     }

--- a/ql/instruments/makecapfloor.cpp
+++ b/ql/instruments/makecapfloor.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
         // only leaves the last coupon
         if (asOptionlet_ && leg.size() > 1) {
-            Leg::iterator end = leg.end();  // Sun Studio needs an lvalue
+            auto end = leg.end(); // Sun Studio needs an lvalue
             leg.erase(leg.begin(), --end);
         }
 

--- a/ql/instruments/makeyoyinflationcapfloor.cpp
+++ b/ql/instruments/makeyoyinflationcapfloor.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
 
         // only leaves the last coupon
         if (asOptionlet_ && leg.size() > 1) {
-            Leg::iterator end = leg.end();  // Sun Studio needs an lvalue
+            auto end = leg.end(); // Sun Studio needs an lvalue
             leg.erase(leg.begin(), --end);
         }
 

--- a/ql/instruments/multiassetoption.cpp
+++ b/ql/instruments/multiassetoption.cpp
@@ -78,8 +78,7 @@ namespace QuantLib {
 
     void MultiAssetOption::setupArguments(
                                        PricingEngine::arguments* args) const {
-        MultiAssetOption::arguments* arguments =
-            dynamic_cast<MultiAssetOption::arguments*>(args);
+        auto* arguments = dynamic_cast<MultiAssetOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->payoff = payoff_;
@@ -88,7 +87,7 @@ namespace QuantLib {
 
     void MultiAssetOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
-        const Greeks* results = dynamic_cast<const Greeks*>(r);
+        const auto* results = dynamic_cast<const Greeks*>(r);
         QL_ENSURE(results != 0,
                   "no greeks returned from pricing engine");
         delta_          = results->delta;

--- a/ql/instruments/nonstandardswap.cpp
+++ b/ql/instruments/nonstandardswap.cpp
@@ -160,16 +160,15 @@ namespace QuantLib {
             for (Size i = 0; i < legs_[0].size() - 1; i++) {
                 Real cap = fixedNominal_[i] - fixedNominal_[i + 1];
                 if (!close(cap, 0.0)) {
-                    std::vector<ext::shared_ptr<CashFlow> >::iterator it1 =
-                        legs_[0].begin();
+                    auto it1 = legs_[0].begin();
                     std::advance(it1, i + 1);
                     legs_[0].insert(
                         it1, ext::shared_ptr<CashFlow>(
                                  new Redemption(cap, legs_[0][i]->date())));
-                    std::vector<Real>::iterator it2 = fixedNominal_.begin();
+                    auto it2 = fixedNominal_.begin();
                     std::advance(it2, i + 1);
                     fixedNominal_.insert(it2, fixedNominal_[i]);
-                    std::vector<Real>::iterator it3 = fixedRate_.begin();
+                    auto it3 = fixedRate_.begin();
                     std::advance(it3, i + 1);
                     fixedRate_.insert(it3, 0.0);
                     i++;
@@ -178,13 +177,12 @@ namespace QuantLib {
             for (Size i = 0; i < legs_[1].size() - 1; i++) {
                 Real cap = floatingNominal_[i] - floatingNominal_[i + 1];
                 if (!close(cap, 0.0)) {
-                    std::vector<ext::shared_ptr<CashFlow> >::iterator it1 =
-                        legs_[1].begin();
+                    auto it1 = legs_[1].begin();
                     std::advance(it1, i + 1);
                     legs_[1].insert(
                         it1, ext::shared_ptr<CashFlow>(
                                  new Redemption(cap, legs_[1][i]->date())));
-                    std::vector<Real>::iterator it2 = floatingNominal_.begin();
+                    auto it2 = floatingNominal_.begin();
                     std::advance(it2, i + 1);
                     floatingNominal_.insert(it2, floatingNominal_[i]);
                     i++;
@@ -223,8 +221,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        NonstandardSwap::arguments *arguments =
-            dynamic_cast<NonstandardSwap::arguments *>(args);
+        auto* arguments = dynamic_cast<NonstandardSwap::arguments*>(args);
 
         if (arguments == 0)
             return; // swap engine ...

--- a/ql/instruments/nonstandardswaption.cpp
+++ b/ql/instruments/nonstandardswaption.cpp
@@ -53,8 +53,7 @@ namespace QuantLib {
 
         swap_->setupArguments(args);
 
-        NonstandardSwaption::arguments *arguments =
-            dynamic_cast<NonstandardSwaption::arguments *>(args);
+        auto* arguments = dynamic_cast<NonstandardSwaption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "argument types do not match");
 

--- a/ql/instruments/oneassetoption.cpp
+++ b/ql/instruments/oneassetoption.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
 
     void OneAssetOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
-        const Greeks* results = dynamic_cast<const Greeks*>(r);
+        const auto* results = dynamic_cast<const Greeks*>(r);
         QL_ENSURE(results != 0,
                   "no greeks returned from pricing engine");
         /* no check on null values - just copy.
@@ -130,7 +130,7 @@ namespace QuantLib {
         rho_            = results->rho;
         dividendRho_    = results->dividendRho;
 
-        const MoreGreeks* moreResults = dynamic_cast<const MoreGreeks*>(r);
+        const auto* moreResults = dynamic_cast<const MoreGreeks*>(r);
         QL_ENSURE(moreResults != 0,
                   "no more greeks returned from pricing engine");
         /* no check on null values - just copy.

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -88,7 +88,7 @@ namespace QuantLib {
             .withPaymentCalendar(paymentCalendar_);
 
         for (Size j=0; j<2; ++j) {
-            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+            for (auto i = legs_[j].begin(); i != legs_[j].end(); ++i)
                 registerWith(*i);
         }
 

--- a/ql/instruments/payoffs.cpp
+++ b/ql/instruments/payoffs.cpp
@@ -37,8 +37,7 @@ namespace QuantLib {
     }
 
     void NullPayoff::accept(AcyclicVisitor& v) {
-        Visitor<NullPayoff>* v1 =
-            dynamic_cast<Visitor<NullPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<NullPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -82,8 +81,7 @@ namespace QuantLib {
     }
 
     void FloatingTypePayoff::accept(AcyclicVisitor& v) {
-        Visitor<FloatingTypePayoff>* v1 =
-            dynamic_cast<Visitor<FloatingTypePayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FloatingTypePayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -102,8 +100,7 @@ namespace QuantLib {
     }
 
     void PlainVanillaPayoff::accept(AcyclicVisitor& v) {
-        Visitor<PlainVanillaPayoff>* v1 =
-            dynamic_cast<Visitor<PlainVanillaPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<PlainVanillaPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -122,8 +119,7 @@ namespace QuantLib {
     }
 
     void PercentageStrikePayoff::accept(AcyclicVisitor& v) {
-        Visitor<PercentageStrikePayoff>* v1 =
-            dynamic_cast<Visitor<PercentageStrikePayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<PercentageStrikePayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -142,8 +138,7 @@ namespace QuantLib {
     }
 
     void AssetOrNothingPayoff::accept(AcyclicVisitor& v) {
-        Visitor<AssetOrNothingPayoff>* v1 =
-            dynamic_cast<Visitor<AssetOrNothingPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<AssetOrNothingPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -168,8 +163,7 @@ namespace QuantLib {
     }
 
     void CashOrNothingPayoff::accept(AcyclicVisitor& v) {
-        Visitor<CashOrNothingPayoff>* v1 =
-            dynamic_cast<Visitor<CashOrNothingPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CashOrNothingPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -193,8 +187,7 @@ namespace QuantLib {
     }
 
     void GapPayoff::accept(AcyclicVisitor& v) {
-        Visitor<GapPayoff>* v1 =
-            dynamic_cast<Visitor<GapPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<GapPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -206,8 +199,7 @@ namespace QuantLib {
     }
 
     void SuperFundPayoff::accept(AcyclicVisitor& v) {
-        Visitor<SuperFundPayoff>* v1 =
-            dynamic_cast<Visitor<SuperFundPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SuperFundPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -224,8 +216,7 @@ namespace QuantLib {
     }
 
     void SuperSharePayoff::accept(AcyclicVisitor& v) {
-        Visitor<SuperSharePayoff>* v1 =
-            dynamic_cast<Visitor<SuperSharePayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SuperSharePayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/instruments/quantobarrieroption.cpp
+++ b/ql/instruments/quantobarrieroption.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
     void QuantoBarrierOption::fetchResults(
                                       const PricingEngine::results* r) const {
         BarrierOption::fetchResults(r);
-        const QuantoBarrierOption::results* quantoResults =
-            dynamic_cast<const QuantoBarrierOption::results*>(r);
+        const auto* quantoResults = dynamic_cast<const QuantoBarrierOption::results*>(r);
         QL_ENSURE(quantoResults != 0,
                   "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;

--- a/ql/instruments/quantoforwardvanillaoption.cpp
+++ b/ql/instruments/quantoforwardvanillaoption.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
     void QuantoForwardVanillaOption::fetchResults(
                                       const PricingEngine::results* r) const {
         ForwardVanillaOption::fetchResults(r);
-        const QuantoForwardVanillaOption::results* quantoResults =
-            dynamic_cast<const QuantoForwardVanillaOption::results*>(r);
+        const auto* quantoResults = dynamic_cast<const QuantoForwardVanillaOption::results*>(r);
         QL_ENSURE(quantoResults != 0,
                   "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;

--- a/ql/instruments/quantovanillaoption.cpp
+++ b/ql/instruments/quantovanillaoption.cpp
@@ -56,8 +56,7 @@ namespace QuantLib {
     void QuantoVanillaOption::fetchResults(
                                       const PricingEngine::results* r) const {
         OneAssetOption::fetchResults(r);
-        const QuantoVanillaOption::results* quantoResults =
-            dynamic_cast<const QuantoVanillaOption::results*>(r);
+        const auto* quantoResults = dynamic_cast<const QuantoVanillaOption::results*>(r);
         QL_ENSURE(quantoResults != 0,
                   "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;

--- a/ql/instruments/stickyratchet.cpp
+++ b/ql/instruments/stickyratchet.cpp
@@ -48,8 +48,7 @@ namespace QuantLib {
     }
 
     void DoubleStickyRatchetPayoff::accept(AcyclicVisitor& v) {
-        Visitor<DoubleStickyRatchetPayoff>* v1 =
-            dynamic_cast<Visitor<DoubleStickyRatchetPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DoubleStickyRatchetPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/instruments/swap.cpp
+++ b/ql/instruments/swap.cpp
@@ -36,9 +36,9 @@ namespace QuantLib {
         legs_[1] = secondLeg;
         payer_[0] = -1.0;
         payer_[1] =  1.0;
-        for (Leg::iterator i = legs_[0].begin(); i!= legs_[0].end(); ++i)
+        for (auto i = legs_[0].begin(); i != legs_[0].end(); ++i)
             registerWith(*i);
-        for (Leg::iterator i = legs_[1].begin(); i!= legs_[1].end(); ++i)
+        for (auto i = legs_[1].begin(); i != legs_[1].end(); ++i)
             registerWith(*i);
     }
 
@@ -53,7 +53,7 @@ namespace QuantLib {
                    ") and legs (" << legs_.size() << ")");
         for (Size j=0; j<legs_.size(); ++j) {
             if (payer[j]) payer_[j]=-1.0;
-            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+            for (auto i = legs_[j].begin(); i != legs_[j].end(); ++i)
                 registerWith(*i);
         }
     }
@@ -85,7 +85,7 @@ namespace QuantLib {
     }
 
     void Swap::setupArguments(PricingEngine::arguments* args) const {
-        Swap::arguments* arguments = dynamic_cast<Swap::arguments*>(args);
+        auto* arguments = dynamic_cast<Swap::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->legs = legs_;
@@ -95,7 +95,7 @@ namespace QuantLib {
     void Swap::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
 
-        const Swap::results* results = dynamic_cast<const Swap::results*>(r);
+        const auto* results = dynamic_cast<const Swap::results*>(r);
         QL_REQUIRE(results != 0, "wrong result type");
 
         if (!results->legNPV.empty()) {

--- a/ql/instruments/swaption.cpp
+++ b/ql/instruments/swaption.cpp
@@ -95,8 +95,7 @@ namespace QuantLib {
                 vol_->setValue(x);
                 engine_->calculate();
             }
-            std::map<std::string,boost::any>::const_iterator vega_ =
-                results_->additionalResults.find("vega");
+            auto vega_ = results_->additionalResults.find("vega");
             QL_REQUIRE(vega_ != results_->additionalResults.end(),
                        "vega not provided");
             return boost::any_cast<Real>(vega_->second);
@@ -148,8 +147,7 @@ namespace QuantLib {
 
         swap_->setupArguments(args);
 
-        Swaption::arguments* arguments =
-            dynamic_cast<Swaption::arguments*>(args);
+        auto* arguments = dynamic_cast<Swaption::arguments*>(args);
 
         QL_REQUIRE(arguments != 0, "wrong argument type");
 

--- a/ql/instruments/vanillastorageoption.hpp
+++ b/ql/instruments/vanillastorageoption.hpp
@@ -74,8 +74,7 @@ namespace QuantLib {
 
     inline void VanillaStorageOption::setupArguments(
                                 PricingEngine::arguments* args) const {
-        VanillaStorageOption::arguments* arguments =
-            dynamic_cast<VanillaStorageOption::arguments*>(args);
+        auto* arguments = dynamic_cast<VanillaStorageOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->payoff

--- a/ql/instruments/vanillaswap.cpp
+++ b/ql/instruments/vanillaswap.cpp
@@ -83,8 +83,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        VanillaSwap::arguments* arguments =
-            dynamic_cast<VanillaSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<VanillaSwap::arguments*>(args);
 
         if (arguments == 0) // it's a swap engine...
             return;
@@ -183,8 +182,7 @@ namespace QuantLib {
 
         Swap::fetchResults(r);
 
-        const VanillaSwap::results* results =
-            dynamic_cast<const VanillaSwap::results*>(r);
+        const auto* results = dynamic_cast<const VanillaSwap::results*>(r);
         if (results != 0) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;

--- a/ql/instruments/vanillaswingoption.cpp
+++ b/ql/instruments/vanillaswingoption.cpp
@@ -110,8 +110,7 @@ namespace QuantLib {
     }
 
     void VanillaForwardPayoff::accept(AcyclicVisitor& v) {
-        Visitor<VanillaForwardPayoff>* v1 =
-            dynamic_cast<Visitor<VanillaForwardPayoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<VanillaForwardPayoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -132,8 +131,7 @@ namespace QuantLib {
 
     void VanillaSwingOption::setupArguments(
                             PricingEngine::arguments* args) const {
-        VanillaSwingOption::arguments* arguments =
-            dynamic_cast<VanillaSwingOption::arguments*>(args);
+        auto* arguments = dynamic_cast<VanillaSwingOption::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->payoff

--- a/ql/instruments/varianceswap.cpp
+++ b/ql/instruments/varianceswap.cpp
@@ -44,8 +44,7 @@ namespace QuantLib {
     }
 
     void VarianceSwap::setupArguments(PricingEngine::arguments* args) const {
-        VarianceSwap::arguments* arguments =
-            dynamic_cast<VarianceSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<VarianceSwap::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->position = position_;
@@ -57,8 +56,7 @@ namespace QuantLib {
 
     void VarianceSwap::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
-        const VarianceSwap::results* results =
-            dynamic_cast<const VarianceSwap::results*>(r);
+        const auto* results = dynamic_cast<const VarianceSwap::results*>(r);
         variance_ = results->variance;
     }
 

--- a/ql/instruments/yearonyearinflationswap.cpp
+++ b/ql/instruments/yearonyearinflationswap.cpp
@@ -85,8 +85,7 @@ namespace QuantLib {
 
         Swap::setupArguments(args);
 
-        YearOnYearInflationSwap::arguments* arguments =
-        dynamic_cast<YearOnYearInflationSwap::arguments*>(args);
+        auto* arguments = dynamic_cast<YearOnYearInflationSwap::arguments*>(args);
 
         if (arguments == 0) // it's a swap engine...
             return;
@@ -179,8 +178,7 @@ namespace QuantLib {
 
         Swap::fetchResults(r);
 
-        const YearOnYearInflationSwap::results* results =
-        dynamic_cast<const YearOnYearInflationSwap::results*>(r);
+        const auto* results = dynamic_cast<const YearOnYearInflationSwap::results*>(r);
         if (results != 0) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;

--- a/ql/instruments/zerocouponinflationswap.cpp
+++ b/ql/instruments/zerocouponinflationswap.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
             new IndexedCashFlow(nominal,infIndex,baseDate_,obsDate_,infPayDate,growthOnly)));
 
         for (Size j=0; j<2; ++j) {
-            for (Leg::iterator i = legs_[j].begin(); i!= legs_[j].end(); ++i)
+            for (auto i = legs_[j].begin(); i != legs_[j].end(); ++i)
                 registerWith(*i);
         }
 

--- a/ql/math/fastfouriertransform.hpp
+++ b/ql/math/fastfouriertransform.hpp
@@ -87,7 +87,7 @@ namespace QuantLib {
                 typename std::iterator_traits<RandomAccessIterator>::value_type
                                                                        complex;
             const std::size_t order = cs_.size();
-            const std::size_t N = std::size_t(static_cast<std::size_t>(1) << order);
+            const auto N = std::size_t(static_cast<std::size_t>(1) << order);
             std::size_t i = 0;
             for (; inBegin != inEnd; ++i, ++inBegin) {
                 *(out + bit_reverse(i, order)) = *inBegin;

--- a/ql/math/interpolations/abcdinterpolation.hpp
+++ b/ql/math/interpolations/abcdinterpolation.hpp
@@ -100,8 +100,8 @@ namespace QuantLib {
               vegaWeighted_(vegaWeighted) { }
 
             void update() override {
-                std::vector<Real>::const_iterator x = this->xBegin_;
-                std::vector<Real>::const_iterator y = this->yBegin_;
+                auto x = this->xBegin_;
+                auto y = this->yBegin_;
                 std::vector<Real> times, blackVols;
                 for ( ; x!=this->xEnd_; ++x, ++y) {
                     times.push_back(*x);

--- a/ql/math/interpolations/xabrinterpolation.hpp
+++ b/ql/math/interpolations/xabrinterpolation.hpp
@@ -149,7 +149,7 @@ class XABRInterpolationImpl : public Interpolation::templateImpl<I1, I2>,
                 weightsSum += this->weights_.back();
             }
             // weight normalization
-            std::vector<Real>::iterator w = this->weights_.begin();
+            auto w = this->weights_.begin();
             for (; w != this->weights_.end(); ++w)
                 *w /= weightsSum;
         }
@@ -242,7 +242,7 @@ class XABRInterpolationImpl : public Interpolation::templateImpl<I1, I2>,
         Real error, totalError = 0.0;
         I1 x = this->xBegin_;
         I2 y = this->yBegin_;
-        std::vector<Real>::const_iterator w = this->weights_.begin();
+        auto w = this->weights_.begin();
         for (; x != this->xEnd_; ++x, ++y, ++w) {
             error = (value(*x) - *y);
             totalError += error * error * (*w);
@@ -256,7 +256,7 @@ class XABRInterpolationImpl : public Interpolation::templateImpl<I1, I2>,
         I1 x = this->xBegin_;
         Array::iterator r = results.begin();
         I2 y = this->yBegin_;
-        std::vector<Real>::const_iterator w = this->weights_.begin();
+        auto w = this->weights_.begin();
         for (; x != this->xEnd_; ++x, ++r, ++w, ++y) {
             *r = (value(*x) - *y) * std::sqrt(*w);
         }

--- a/ql/math/matrixutilities/sparseilupreconditioner.cpp
+++ b/ql/math/matrixutilities/sparseilupreconditioner.cpp
@@ -80,8 +80,8 @@ namespace QuantLib {
                         nonZeros.push_back(jj);
                         nonZeroEntries.push_back(entry);
                     }
-                    std::set<Integer>::const_iterator iter=uBandSet.begin();
-                    std::set<Integer>::const_iterator end =uBandSet.end();
+                    auto iter = uBandSet.begin();
+                    auto end = uBandSet.end();
                     for (; iter != end; ++iter) {
                         const Real entry = U_(jj,jj+*iter);
                         if(entry > QL_EPSILON || entry < -1.0*QL_EPSILON) {

--- a/ql/math/randomnumbers/seedgenerator.cpp
+++ b/ql/math/randomnumbers/seedgenerator.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
     void SeedGenerator::initialize() {
 
         // firstSeed is chosen based on clock() and used for the first rng
-        unsigned long firstSeed = (unsigned long)(std::time(0));
+        auto firstSeed = (unsigned long)(std::time(0));
         MersenneTwisterUniformRng first(firstSeed);
 
         // secondSeed is as random as it could be

--- a/ql/math/statistics/histogram.cpp
+++ b/ql/math/statistics/histogram.cpp
@@ -148,9 +148,8 @@ namespace QuantLib {
         } else {
             // or ensure they're sorted if given
             std::sort(breaks_.begin(), breaks_.end());
-            std::vector<Real>::iterator end =
-                std::unique(breaks_.begin(),breaks_.end(),
-                            static_cast<bool (*)(Real, Real)>(close_enough));
+            auto end = std::unique(breaks_.begin(), breaks_.end(),
+                                   static_cast<bool (*)(Real, Real)>(close_enough));
             breaks_.resize(end - breaks_.begin());
         }
 

--- a/ql/methods/finitedifferences/finitedifferencemodel.hpp
+++ b/ql/methods/finitedifferences/finitedifferencemodel.hpp
@@ -47,8 +47,7 @@ namespace QuantLib {
                                                           std::vector<Time>())
         : evolver_(L,bcs), stoppingTimes_(stoppingTimes) {
             std::sort(stoppingTimes_.begin(), stoppingTimes_.end());
-            std::vector<Time>::iterator last =
-                std::unique(stoppingTimes_.begin(), stoppingTimes_.end());
+            auto last = std::unique(stoppingTimes_.begin(), stoppingTimes_.end());
             stoppingTimes_.erase(last, stoppingTimes_.end());
         }
         FiniteDifferenceModel(const Evolver& evolver,
@@ -56,8 +55,7 @@ namespace QuantLib {
                                                           std::vector<Time>())
         : evolver_(evolver), stoppingTimes_(stoppingTimes) {
             std::sort(stoppingTimes_.begin(), stoppingTimes_.end());
-            std::vector<Time>::iterator last =
-                std::unique(stoppingTimes_.begin(), stoppingTimes_.end());
+            auto last = std::unique(stoppingTimes_.begin(), stoppingTimes_.end());
             stoppingTimes_.erase(last, stoppingTimes_.end());
         }
         // methods

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -157,8 +157,7 @@ namespace QuantLib {
         QL_REQUIRE(end > start, "end must be larger than start");
 
         std::vector<Real> points, betas;
-        for (std::vector<ext::tuple<Real, Real, bool> >::const_iterator
-                iter = cPoints.begin(); iter != cPoints.end(); ++iter) {
+        for (auto iter = cPoints.begin(); iter != cPoints.end(); ++iter) {
             points.push_back(ext::get<0>(*iter));
             betas.push_back(square<Real>()(ext::get<1>(*iter)*(end-start)));
         }

--- a/ql/methods/finitedifferences/operators/fdmbatesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.cpp
@@ -74,9 +74,8 @@ namespace QuantLib {
     Real FdmBatesOp::IntegroIntegrand::operator()(Real y) const {
         const Real x = x_ + M_SQRT2*delta_*y + nu_;
         Real valueOfDerivative = (*interpl_)(x, true);
-        
-        for (FdmBoundaryConditionSet::const_iterator iter=bcSet_.begin();
-            iter < bcSet_.end(); ++iter) {
+
+        for (auto iter = bcSet_.begin(); iter < bcSet_.end(); ++iter) {
 
             const ext::shared_ptr<FdmDirichletBoundary> dirichlet
                 = ext::dynamic_pointer_cast<FdmDirichletBoundary>(*iter);
@@ -87,7 +86,7 @@ namespace QuantLib {
             valueOfDerivative
                 = dirichlet->applyAfterApplying(x, valueOfDerivative);
         }
-        
+
         return std::exp(-y*y)*valueOfDerivative;
     }
     

--- a/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
@@ -59,7 +59,7 @@ namespace QuantLib {
         const ext::function<Real(Real)> emptyFct;
 
         for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
-            const Integer ix = Integer(iter.coordinates()[direction]);
+            const auto ix = Integer(iter.coordinates()[direction]);
             const Integer offset = std::max(0, hPoints - ix)
                 - std::max(0, hPoints - (nx-((isEven)? 0 : 1) - ix));
 

--- a/ql/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.cpp
@@ -33,8 +33,7 @@ namespace QuantLib {
       calculator_(calculator) {
     
         exerciseTimes_.reserve(exerciseDates.size());
-        for (std::vector<Date>::const_iterator iter = exerciseDates.begin();
-            iter != exerciseDates.end(); ++iter) {
+        for (auto iter = exerciseDates.begin(); iter != exerciseDates.end(); ++iter) {
             exerciseTimes_.push_back(
                              dayCounter.yearFraction(referenceDate, *iter));
         }

--- a/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
@@ -92,8 +92,7 @@ namespace QuantLib {
                              sellPrice + price*maxWithDraw));
 
                 // check if intermediate grid points give a better value
-                std::vector<Real>::const_iterator yIter =
-                    std::upper_bound(y_.begin(), y_.end(), y - maxWithDraw);
+                auto yIter = std::upper_bound(y_.begin(), y_.end(), y - maxWithDraw);
 
                 while (yIter != y_.end() && *yIter < y + maxInject) {
                     if (*yIter != y) {

--- a/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
@@ -39,9 +39,7 @@ namespace QuantLib {
     : conditions_(conditions) {
 
         std::set<Real> allStoppingTimes;
-        for (std::list<std::vector<Time> >::const_iterator
-             iter = stoppingTimes.begin(); iter != stoppingTimes.end();
-             ++iter) {
+        for (auto iter = stoppingTimes.begin(); iter != stoppingTimes.end(); ++iter) {
             allStoppingTimes.insert(iter->begin(), iter->end());
         }
         stoppingTimes_ = std::vector<Time>(allStoppingTimes.begin(),
@@ -58,8 +56,7 @@ namespace QuantLib {
     }
 
     void FdmStepConditionComposite::applyTo(Array& a, Time t) const {
-        for (Conditions::const_iterator iter = conditions_.begin();
-             iter != conditions_.end(); ++iter) {
+        for (auto iter = conditions_.begin(); iter != conditions_.end(); ++iter) {
             (*iter)->applyTo(a, t);
         }
     }

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -131,8 +131,7 @@ namespace QuantLib {
 
         Real npv = 0.0;
         for (Size j = 0; j < 2; j++) {
-            for (Leg::const_iterator i = swap_->leg(j).begin();
-                 i != swap_->leg(j).end(); ++i) {
+            for (auto i = swap_->leg(j).begin(); i != swap_->leg(j).end(); ++i) {
                 npv += ext::dynamic_pointer_cast<Coupon>(*i)
                                     ->accrualStartDate() >= iterExerciseDate
                             ? (*i)->amount() * disTs_->discount((*i)->date())

--- a/ql/methods/finitedifferences/utilities/fdmdirichletboundary.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmdirichletboundary.cpp
@@ -52,8 +52,7 @@ namespace QuantLib {
     }
 
     void FdmDirichletBoundary::applyAfterApplying(Array& x) const {
-        for (std::vector<Size>::const_iterator iter = indices_.begin();
-             iter != indices_.end(); ++iter) {
+        for (auto iter = indices_.begin(); iter != indices_.end(); ++iter) {
             x[*iter] = valueOnBoundary_;
         }
     }

--- a/ql/methods/finitedifferences/utilities/fdmdividendhandler.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmdividendhandler.cpp
@@ -40,14 +40,12 @@ namespace QuantLib {
         dividends_.reserve(schedule.size());
         dividendDates_.reserve(schedule.size());
         dividendTimes_.reserve(schedule.size());
-        for (DividendSchedule::const_iterator iter=schedule.begin();
-              iter!=schedule.end(); ++iter) {
-             dividends_.push_back((*iter)->amount());
-             dividendDates_.push_back((*iter)->date());
-             dividendTimes_.push_back(
-                     dayCounter.yearFraction(referenceDate,(*iter)->date()));
-         }
-      
+        for (auto iter = schedule.begin(); iter != schedule.end(); ++iter) {
+            dividends_.push_back((*iter)->amount());
+            dividendDates_.push_back((*iter)->date());
+            dividendTimes_.push_back(dayCounter.yearFraction(referenceDate, (*iter)->date()));
+        }
+
          Array tmp = mesher_->locations(equityDirection);
          Size spacing = mesher_->layout()->spacing()[equityDirection];
          for (Size i = 0; i < x_.size(); ++i) {
@@ -70,8 +68,7 @@ namespace QuantLib {
     void FdmDividendHandler::applyTo(Array& a, Time t) const {
         Array aCopy(a);
 
-        std::vector<Time>::const_iterator iter
-            = std::find(dividendTimes_.begin(), dividendTimes_.end(), t);
+        auto iter = std::find(dividendTimes_.begin(), dividendTimes_.end(), t);
 
         if (iter != dividendTimes_.end()) {
             const Real dividend = dividends_[iter - dividendTimes_.begin()];

--- a/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
@@ -66,8 +66,7 @@ namespace QuantLib {
                    "values on boundary size (" << values_.size()
                    << ") does not match hypersurface size ("
                    << indices_.size() << ")");
-        for (std::vector<Size>::const_iterator iter = indices_.begin();
-             iter != indices_.end(); ++iter) {
+        for (auto iter = indices_.begin(); iter != indices_.end(); ++iter) {
             a[*iter] = values_[iter - indices_.begin()];
         }
     }

--- a/ql/methods/lattices/lattice.hpp
+++ b/ql/methods/lattices/lattice.hpp
@@ -149,8 +149,8 @@ namespace QuantLib {
                    "cannot roll the asset back to" << to
                    << " (it is already at t = " << from << ")");
 
-        Integer iFrom = Integer(t_.index(from));
-        Integer iTo = Integer(t_.index(to));
+        auto iFrom = Integer(t_.index(from));
+        auto iTo = Integer(t_.index(to));
 
         for (Integer i=iFrom-1; i>=iTo; --i) {
             Array newValues(this->impl().size(i));

--- a/ql/methods/lattices/trinomialtree.cpp
+++ b/ql/methods/lattices/trinomialtree.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             for (Integer j=jMin; j<=jMax; j++) {
                 Real x = x0_ + j*dx_[i];
                 Real m = process->expectation(t, x, dt);
-                Integer temp = Integer(std::floor((m-x0_)/dx_[i+1] + 0.5));
+                auto temp = Integer(std::floor((m - x0_) / dx_[i + 1] + 0.5));
 
                 if (isPositive) {
                     while (x0_+(temp-1)*dx_[i+1]<=0) {

--- a/ql/models/marketmodels/callability/upperboundengine.cpp
+++ b/ql/models/marketmodels/callability/upperboundengine.cpp
@@ -179,8 +179,7 @@ namespace QuantLib {
 
     std::pair<Real,Real> UpperBoundEngine::singlePathValue(Size innerPaths) {
 
-        DecoratedHedge& callable =
-            dynamic_cast<DecoratedHedge&>(composite_.item(4));
+        auto& callable = dynamic_cast<DecoratedHedge&>(composite_.item(4));
         const ExerciseStrategy<CurveState>& strategy = callable.strategy();
 
 

--- a/ql/models/marketmodels/evolvers/lognormalcmswapratepc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalcmswapratepc.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
     }
 
     void LogNormalCmSwapRatePc::setInitialState(const CurveState& cs) {
-        const CMSwapCurveState* cotcs = dynamic_cast<const CMSwapCurveState*>(&cs);
+        const auto* cotcs = dynamic_cast<const CMSwapCurveState*>(&cs);
         const std::vector<Real>& swapRates = cotcs->cmSwapRates(spanningForwards_);
         setCMSwapRates(swapRates);
     }

--- a/ql/models/marketmodels/evolvers/lognormalcotswapratepc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalcotswapratepc.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
 
     void LogNormalCotSwapRatePc::setInitialState(const CurveState& cs) {
         // why??
-        const CoterminalSwapCurveState* cotcs = dynamic_cast<const CoterminalSwapCurveState*>(&cs);
+        const auto* cotcs = dynamic_cast<const CoterminalSwapCurveState*>(&cs);
         const std::vector<Real>& swapRates = cotcs->coterminalSwapRates();
         setCoterminalSwapRates(swapRates);
     }

--- a/ql/models/marketmodels/pathwiseaccountingengine.cpp
+++ b/ql/models/marketmodels/pathwiseaccountingengine.cpp
@@ -107,7 +107,8 @@ namespace QuantLib {
 
         for (Size i=0; i < numberCashFlowTimes_; ++i)
         {
-            std::vector<Time>::const_iterator it = std::upper_bound( evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
+            auto it =
+                std::upper_bound(evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
             if (it != evolutionTimes.begin())
                 --it;
             Size index = it - evolutionTimes.begin();
@@ -435,7 +436,8 @@ namespace QuantLib {
 
         for (Size i=0; i < numberCashFlowTimes_; ++i)
         {
-            std::vector<Time>::const_iterator it = std::upper_bound( evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
+            auto it =
+                std::upper_bound(evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
             if (it != evolutionTimes.begin())
                 --it;
             Size index = it - evolutionTimes.begin();
@@ -833,7 +835,8 @@ namespace QuantLib {
 
         for (Size i=0; i < numberCashFlowTimes_; ++i)
         {
-            std::vector<Time>::const_iterator it = std::upper_bound( evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
+            auto it =
+                std::upper_bound(evolutionTimes.begin(), evolutionTimes.end(), cashFlowTimes[i]);
             if (it != evolutionTimes.begin())
                 --it;
             Size index = it - evolutionTimes.begin();

--- a/ql/models/marketmodels/products/compositeproduct.cpp
+++ b/ql/models/marketmodels/products/compositeproduct.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     }
 
     void MarketModelComposite::reset() {
-        for (iterator i=components_.begin(); i!=components_.end(); ++i) {
+        for (auto i = components_.begin(); i != components_.end(); ++i) {
             i->product->reset();
             i->done = false;
         }
@@ -116,8 +116,7 @@ namespace QuantLib {
         // all information having been collected, we can sort and
         // compact the vector of all cash-flow times...
         std::sort(allCashflowTimes.begin(), allCashflowTimes.end());
-        std::vector<Time>::iterator end = std::unique(allCashflowTimes.begin(),
-                                                      allCashflowTimes.end());
+        auto end = std::unique(allCashflowTimes.begin(), allCashflowTimes.end());
         //std::copy(allCashflowTimes.begin(), end,
         //          std::back_inserter(cashflowTimes_));
         cashflowTimes_.insert(cashflowTimes_.end(),

--- a/ql/models/marketmodels/products/multiproductcomposite.cpp
+++ b/ql/models/marketmodels/products/multiproductcomposite.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     Size MultiProductComposite::numberOfProducts() const {
         Size result = 0;
-        for (const_iterator i=components_.begin(); i!=components_.end(); ++i)
+        for (auto i = components_.begin(); i != components_.end(); ++i)
             result += i->product->numberOfProducts();
         return result;
     }
@@ -32,7 +32,7 @@ namespace QuantLib {
 
     Size MultiProductComposite::maxNumberOfCashFlowsPerProductPerStep() const {
         Size result = 0;
-        for (const_iterator i=components_.begin(); i!=components_.end(); ++i)
+        for (auto i = components_.begin(); i != components_.end(); ++i)
             result = std::max(result,
             i->product
             ->maxNumberOfCashFlowsPerProductPerStep());
@@ -48,7 +48,7 @@ namespace QuantLib {
         bool done = true;
         Size n = 0, offset = 0;
         // for each sub-product...
-        for (iterator i=components_.begin(); i!=components_.end(); ++i, ++n) {
+        for (auto i = components_.begin(); i != components_.end(); ++i, ++n) {
             if (isInSubset_[n][currentIndex_] && !i->done) {
                 // ...make it evolve...
                 bool thisDone = i->product->nextTimeStep(currentState,

--- a/ql/models/marketmodels/products/singleproductcomposite.cpp
+++ b/ql/models/marketmodels/products/singleproductcomposite.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
 
     Size SingleProductComposite::maxNumberOfCashFlowsPerProductPerStep() const {
         Size result = 0;
-        for (const_iterator i=components_.begin(); i!=components_.end(); ++i)
+        for (auto i = components_.begin(); i != components_.end(); ++i)
             result += i->product->maxNumberOfCashFlowsPerProductPerStep();
         return result;
     }
@@ -43,7 +43,7 @@ namespace QuantLib {
         bool done = true;
         Size n = 0, totalCashflows = 0;
         // for each sub-product...
-        for (iterator i=components_.begin(); i!=components_.end(); ++i, ++n) {
+        for (auto i = components_.begin(); i != components_.end(); ++i, ++n) {
             if (isInSubset_[n][currentIndex_] && !i->done) {
                 // ...make it evolve...
                 bool thisDone = i->product->nextTimeStep(currentState,

--- a/ql/models/marketmodels/utilities.cpp
+++ b/ql/models/marketmodels/utilities.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
 
         // ...sort and compact the vector mergedTimes...
         std::sort(allTimes.begin(), allTimes.end());
-        std::vector<Time>::iterator end = std::unique(allTimes.begin(),
-                                                      allTimes.end());
+        auto end = std::unique(allTimes.begin(), allTimes.end());
         //mergedTimes.clear(); // shouldn't be cleared?
         mergedTimes.insert(mergedTimes.end(),
                            allTimes.begin(), end);

--- a/ql/models/parameter.hpp
+++ b/ql/models/parameter.hpp
@@ -167,8 +167,7 @@ namespace QuantLib {
                 values_.clear();
             }
             Real value(const Array&, Time t) const override {
-                std::vector<Time>::const_iterator result =
-                    std::find(times_.begin(), times_.end(), t);
+                auto result = std::find(times_.begin(), times_.end(), t);
                 QL_REQUIRE(result!=times_.end(),
                            "fitting parameter not set!");
                 return values_[result - times_.begin()];

--- a/ql/models/shortrate/onefactormodels/gsr.cpp
+++ b/ql/models/shortrate/onefactormodels/gsr.cpp
@@ -99,8 +99,7 @@ void Gsr::update() {
 void Gsr::updateTimes() const {
     volsteptimes_.clear();
     int j = 0;
-    for (std::vector<Date>::const_iterator i = volstepdates_.begin();
-         i != volstepdates_.end(); ++i, ++j) {
+    for (auto i = volstepdates_.begin(); i != volstepdates_.end(); ++i, ++j) {
         volsteptimes_.push_back(termStructure()->timeFromReference(*i));
         volsteptimesArray_[j] = volsteptimes_[j];
         if (j == 0)

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -101,8 +101,7 @@ namespace QuantLib {
     void MarkovFunctional::updateTimes1() const {
         volsteptimes_.clear();
         int j = 0;
-        for (std::vector<Date>::const_iterator i = volstepdates_.begin();
-             i != volstepdates_.end(); ++i, ++j) {
+        for (auto i = volstepdates_.begin(); i != volstepdates_.end(); ++i, ++j) {
             volsteptimes_.push_back(termStructure()->timeFromReference(*i));
             volsteptimesArray_[j] = volsteptimes_[j];
             if (j == 0)
@@ -123,9 +122,7 @@ namespace QuantLib {
         times_.push_back(0.0);
         modelOutputs_.expiries_.clear();
         modelOutputs_.tenors_.clear();
-        for (std::map<Date, CalibrationPoint>::iterator k =
-                 calibrationPoints_.begin();
-             k != calibrationPoints_.end(); ++k) {
+        for (auto k = calibrationPoints_.begin(); k != calibrationPoints_.end(); ++k) {
             times_.push_back(termStructure()->timeFromReference(k->first));
             modelOutputs_.expiries_.push_back(k->first);
             modelOutputs_.tenors_.push_back(k->second.tenor_);
@@ -178,9 +175,8 @@ namespace QuantLib {
         do {
             Date numeraireKnown = numeraireDate_;
             done = true;
-            for (std::map<Date, CalibrationPoint>::reverse_iterator i =
-                     calibrationPoints_.rbegin();
-                 i != calibrationPoints_.rend() && done; ++i) {
+            for (auto i = calibrationPoints_.rbegin(); i != calibrationPoints_.rend() && done;
+                 ++i) {
                 if (i->second.paymentDates_.back() > numeraireDate_) {
                     numeraireDate_ = i->second.paymentDates_.back();
                     numeraireKnown = i->second.paymentDates_.back();
@@ -312,9 +308,7 @@ namespace QuantLib {
 
         Size pointIndex = 0;
 
-        for (std::map<Date, CalibrationPoint>::reverse_iterator i =
-                 calibrationPoints_.rbegin();
-             i != calibrationPoints_.rend(); ++i) {
+        for (auto i = calibrationPoints_.rbegin(); i != calibrationPoints_.rend(); ++i) {
 
             ext::shared_ptr<SmileSection> smileSection;
             if (i->second.isCaplet_) {
@@ -471,9 +465,7 @@ namespace QuantLib {
 
         int idx = times_.size() - 2;
 
-        for (std::map<Date, CalibrationPoint>::reverse_iterator
-                 i = calibrationPoints_.rbegin();
-             i != calibrationPoints_.rend(); ++i, --idx) {
+        for (auto i = calibrationPoints_.rbegin(); i != calibrationPoints_.rend(); ++i, --idx) {
 
             ext::shared_ptr<CustomSmileSection> mfSec;
             if ((modelSettings_.adjustments_ & ModelSettings::CustomSmile) != 0) {
@@ -662,9 +654,7 @@ namespace QuantLib {
             modelOutputs_.marketRawCallPremium_.clear();
             modelOutputs_.marketRawPutPremium_.clear();
 
-            for (std::map<Date, CalibrationPoint>::iterator i =
-                     calibrationPoints_.begin();
-                 i != calibrationPoints_.end(); ++i) {
+            for (auto i = calibrationPoints_.begin(); i != calibrationPoints_.end(); ++i) {
                 modelOutputs_.atm_.push_back(i->second.atm_);
                 modelOutputs_.annuity_.push_back(i->second.annuity_);
                 ext::shared_ptr<SmileSection> sec = i->second.smileSection_;
@@ -930,8 +920,7 @@ namespace QuantLib {
             return out; // no trace information was collected so no output
         out << std::endl;
         out << "Messages:" << std::endl;
-        for (std::vector<std::string>::const_iterator i = m.messages_.begin();
-             i != m.messages_.end(); ++i)
+        for (auto i = m.messages_.begin(); i != m.messages_.end(); ++i)
             out << (*i) << std::endl;
         out << std::endl << std::setprecision(16);
         out << "Yield termstructure fit:" << std::endl;

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -377,7 +377,7 @@ namespace QuantLib {
     Garch11::calculate(const time_series& quoteSeries,
                        Real alpha, Real beta, Real omega) {
         time_series retval;
-        const_iterator cur = quoteSeries.cbegin();
+        auto cur = quoteSeries.cbegin();
         Real u = cur->second;
         Real sigma2 = u*u;
         while (++cur != quoteSeries.end()) {
@@ -387,7 +387,7 @@ namespace QuantLib {
         }
         sigma2 = omega + alpha * u * u + beta * sigma2;
         --cur;
-        const_iterator prev = cur;
+        auto prev = cur;
         retval[cur->first + (cur->first - (--prev)->first) ] = std::sqrt(sigma2);
         return retval;
     }

--- a/ql/option.hpp
+++ b/ql/option.hpp
@@ -90,8 +90,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void Option::setupArguments(PricingEngine::arguments* args) const {
-        Option::arguments* arguments =
-            dynamic_cast<Option::arguments*>(args);
+        auto* arguments = dynamic_cast<Option::arguments*>(args);
         QL_REQUIRE(arguments != 0, "wrong argument type");
 
         arguments->payoff = payoff_;

--- a/ql/payoff.hpp
+++ b/ql/payoff.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void Payoff::accept(AcyclicVisitor& v) {
-        Visitor<Payoff>* v1 = dynamic_cast<Visitor<Payoff>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<Payoff>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/prices.cpp
+++ b/ql/prices.cpp
@@ -134,8 +134,7 @@ namespace QuantLib {
                                            IntervalPrice::Type t)  {
         std::vector<Real> returnval;
         returnval.reserve(ts.size());
-        for (TimeSeries<IntervalPrice>::const_iterator i = ts.begin();
-             i != ts.end(); ++i) {
+        for (auto i = ts.begin(); i != ts.end(); ++i) {
             returnval.push_back(i->second.value(t));
         }
         return returnval;

--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -190,15 +190,13 @@ namespace QuantLib {
                        "engine does not provide "
                        "control variation pricing engine");
 
-            DiscreteAveragingAsianOption::arguments* controlArguments =
-                dynamic_cast<DiscreteAveragingAsianOption::arguments*>(
-                    controlPE->getArguments());
+            auto* controlArguments =
+                dynamic_cast<DiscreteAveragingAsianOption::arguments*>(controlPE->getArguments());
             *controlArguments = arguments_;
             controlPE->calculate();
 
-            const DiscreteAveragingAsianOption::results* controlResults =
-                dynamic_cast<const DiscreteAveragingAsianOption::results*>(
-                    controlPE->getResults());
+            const auto* controlResults =
+                dynamic_cast<const DiscreteAveragingAsianOption::results*>(controlPE->getResults());
 
             return controlResults->value;
     }

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -163,14 +163,13 @@ namespace QuantLib {
         ext::shared_ptr<StrikedTypePayoff> newPayoff(new
             PlainVanillaPayoff(payoff->optionType(), strike));
 
-        VanillaOption::arguments* controlArguments =
-            dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
+        auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
 
         controlArguments->payoff = newPayoff;
         controlArguments->exercise = this->arguments_.exercise;
         controlPE->calculate();
 
-        const VanillaOption::results* controlResults =
+        const auto* controlResults =
             dynamic_cast<const VanillaOption::results*>(controlPE->getResults());
 
         return controlResults->value;

--- a/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
@@ -116,8 +116,7 @@ namespace QuantLib {
         }
 
         // remove duplicate strikes
-        std::vector<Real>::iterator last =
-            std::unique(strikes.begin(), strikes.end());
+        auto last = std::unique(strikes.begin(), strikes.end());
         strikes.erase(last, strikes.end());
 
         // compute weights
@@ -164,8 +163,7 @@ namespace QuantLib {
                                         new AnalyticEuropeanEngine(process_));
         Real optionsValue = 0.0;
 
-        for (weights_type::const_iterator i = optionWeights.begin();
-             i < optionWeights.end(); ++i) {
+        for (auto i = optionWeights.begin(); i < optionWeights.end(); ++i) {
             ext::shared_ptr<StrikedTypePayoff> payoff = i->first;
             EuropeanOption option(payoff, exercise);
             option.setPricingEngine(optionEngine);

--- a/ql/pricingengines/quanto/quantoengine.hpp
+++ b/ql/pricingengines/quanto/quantoengine.hpp
@@ -116,9 +116,8 @@ namespace QuantLib {
 
         ext::shared_ptr<Engine> originalEngine(new Engine(quantoProcess));
         originalEngine->reset();
-        typename Instr::arguments* originalArguments =
-            dynamic_cast<typename Instr::arguments*>(
-                                              originalEngine->getArguments());
+        auto* originalArguments =
+            dynamic_cast<typename Instr::arguments*>(originalEngine->getArguments());
         QL_REQUIRE(originalArguments, "wrong engine type");
 
         *originalArguments = this->arguments_;
@@ -126,9 +125,8 @@ namespace QuantLib {
         originalArguments->validate();
         originalEngine->calculate();
 
-        const typename Instr::results* originalResults =
-            dynamic_cast<const typename Instr::results*>(
-                                                originalEngine->getResults());
+        const auto* originalResults =
+            dynamic_cast<const typename Instr::results*>(originalEngine->getResults());
         QL_REQUIRE(originalResults, "wrong engine type");
 
         this->results_.value = originalResults->value;

--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -128,8 +128,7 @@ namespace QuantLib {
 
     // Compute fair spread for strike value:
     // copy args into the non risky engine
-    Swap::arguments * noCVAArgs = dynamic_cast<Swap::arguments*>(
-      baseSwapEngine_->getArguments());
+    auto* noCVAArgs = dynamic_cast<Swap::arguments*>(baseSwapEngine_->getArguments());
     QL_REQUIRE(noCVAArgs != 0, "wrong argument type");
 
     noCVAArgs->legs = this->arguments_.legs;
@@ -141,8 +140,7 @@ namespace QuantLib {
     QL_REQUIRE(coupon,"dynamic cast of fixed leg coupon failed.");
     Rate baseSwapRate = coupon->rate();
 
-    const Swap::results * vSResults =  
-        dynamic_cast<const Swap::results *>(baseSwapEngine_->getResults());
+    const auto* vSResults = dynamic_cast<const Swap::results*>(baseSwapEngine_->getResults());
     QL_REQUIRE(vSResults != 0, "wrong result type");
 
     Rate baseSwapFairRate = -baseSwapRate * vSResults->legNPV[1] / 

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -124,16 +124,14 @@ namespace QuantLib {
                       arguments_.leg2FixingDates.end());
         std::sort(events.begin(), events.end());
 
-        std::vector<Date>::iterator it =
-            std::unique(events.begin(), events.end());
+        auto it = std::unique(events.begin(), events.end());
         events.resize(std::distance(events.begin(), it));
 
         // only events on or after expiry are of interest by definition of the
         // deal part that is exericsed into.
 
-        std::vector<Date>::iterator filit =
-            std::upper_bound(events.begin(), events.end(),
-                             expiry - (includeExerciseOnExpiry ? 1 : 0));
+        auto filit = std::upper_bound(events.begin(), events.end(),
+                                      expiry - (includeExerciseOnExpiry ? 1 : 0));
         events.erase(events.begin(), filit);
 
         int idx = events.size() - 1;

--- a/ql/pricingengines/vanilla/fddividendengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendengine.hpp
@@ -50,8 +50,7 @@ namespace QuantLib {
         virtual void setGridLimits() const = 0;
         virtual void executeIntermediateStep(Size step) const = 0;
         Real getDividendAmount(Size i) const {
-            const Dividend *dividend =
-                dynamic_cast<const Dividend *>(this->events_[i].get());
+            const auto* dividend = dynamic_cast<const Dividend*>(this->events_[i].get());
             if (dividend != 0) {
                 return dividend->amount();
             } else {
@@ -140,8 +139,7 @@ namespace QuantLib {
     template <template <class> class Scheme>
     void FDDividendEngineBase<Scheme>::setupArguments(
                                     const PricingEngine::arguments *a) const {
-        const DividendVanillaOption::arguments *args =
-            dynamic_cast<const DividendVanillaOption::arguments *>(a);
+        const auto* args = dynamic_cast<const DividendVanillaOption::arguments*>(a);
         QL_REQUIRE(args, "incorrect argument type");
         std::vector<ext::shared_ptr<Event> > events(args->cashFlow.size());
         std::copy(args->cashFlow.begin(), args->cashFlow.end(),
@@ -211,8 +209,7 @@ namespace QuantLib {
     void FDDividendEngineShiftScale<Scheme>::setGridLimits() const {
         Real underlying = this->process_->stateVariable()->value();
         for (Size i=0; i<this->events_.size(); i++) {
-            const Dividend *dividend =
-                dynamic_cast<const Dividend *>(this->events_[i].get());
+            const auto* dividend = dynamic_cast<const Dividend*>(this->events_[i].get());
             if (dividend == 0)
                 continue;
             if (this->getDividendTime(i) < 0.0) continue;
@@ -227,8 +224,7 @@ namespace QuantLib {
     template <template <class> class Scheme>
     void FDDividendEngineShiftScale<Scheme>::executeIntermediateStep(
                                                              Size step) const{
-        const Dividend *dividend =
-            dynamic_cast<const Dividend *>(this->events_[step].get());
+        const auto* dividend = dynamic_cast<const Dividend*>(this->events_[step].get());
         if (dividend == 0)
             return;
         detail::DividendAdder adder(dividend);

--- a/ql/pricingengines/vanilla/fdmultiperiodengine.hpp
+++ b/ql/pricingengines/vanilla/fdmultiperiodengine.hpp
@@ -61,8 +61,7 @@ namespace QuantLib {
 
         void setupArguments(const PricingEngine::arguments* a) const override {
             FDVanillaEngine::setupArguments(a);
-            const OneAssetOption::arguments *args =
-                dynamic_cast<const OneAssetOption::arguments*>(a);
+            const auto* args = dynamic_cast<const OneAssetOption::arguments*>(a);
             QL_REQUIRE(args, "incorrect argument type");
             events_.clear();
 
@@ -97,8 +96,7 @@ namespace QuantLib {
     template <template <class> class Scheme>
     void FDMultiPeriodEngine<Scheme>::calculate(
                                             PricingEngine::results* r) const {
-        OneAssetOption::results *results =
-            dynamic_cast<OneAssetOption::results *>(r);
+        auto* results = dynamic_cast<OneAssetOption::results*>(r);
         QL_REQUIRE(results, "incorrect argument type");
         Time beginDate, endDate;
         Size dateNumber = stoppingTimes_.size();

--- a/ql/pricingengines/vanilla/fdstepconditionengine.hpp
+++ b/ql/pricingengines/vanilla/fdstepconditionengine.hpp
@@ -60,8 +60,7 @@ namespace QuantLib {
     template <template <class> class Scheme>
     void FDStepConditionEngine<Scheme>::calculate(
                                             PricingEngine::results* r) const {
-        OneAssetOption::results * results =
-            dynamic_cast<OneAssetOption::results *>(r);
+        auto* results = dynamic_cast<OneAssetOption::results*>(r);
         setGridLimits();
         initializeInitialCondition();
         initializeOperator();

--- a/ql/pricingengines/vanilla/fdvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdvanillaengine.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
     void FDVanillaEngine::setupArguments(
                                     const PricingEngine::arguments* a) const {
-        const OneAssetOption::arguments * args =
-            dynamic_cast<const OneAssetOption::arguments *>(a);
+        const auto* args = dynamic_cast<const OneAssetOption::arguments*>(a);
         QL_REQUIRE(args, "incorrect argument type");
         exerciseDate_ = args->exercise->lastDate();
         payoff_ = args->payoff;

--- a/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
+++ b/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
@@ -81,17 +81,15 @@ namespace QuantLib {
 
         AnalyticEuropeanEngine baseEngine(bsProcess);
 
-        VanillaOption::arguments* baseArguments =
-            dynamic_cast<VanillaOption::arguments*>(baseEngine.getArguments());
+        auto* baseArguments = dynamic_cast<VanillaOption::arguments*>(baseEngine.getArguments());
 
         baseArguments->payoff   = arguments_.payoff;
         baseArguments->exercise = arguments_.exercise;
 
         baseArguments->validate();
 
-        const VanillaOption::results* baseResults =
-            dynamic_cast<const VanillaOption::results*>(
-                                                     baseEngine.getResults());
+        const auto* baseResults =
+            dynamic_cast<const VanillaOption::results*>(baseEngine.getResults());
 
         results_.value       = 0.0;
         results_.delta       = 0.0;

--- a/ql/pricingengines/vanilla/mcamericanengine.hpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.hpp
@@ -250,17 +250,15 @@ namespace QuantLib {
                    "engine does not provide "
                    "control variation pricing engine");
 
-        VanillaOption::arguments* controlArguments =
-            dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
+        auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
         *controlArguments = this->arguments_;
         controlArguments->exercise = ext::shared_ptr<Exercise>(
              new EuropeanExercise(this->arguments_.exercise->lastDate()));
 
         controlPE->calculate();
 
-        const VanillaOption::results* controlResults =
-            dynamic_cast<const VanillaOption::results*>(
-                                                     controlPE->getResults());
+        const auto* controlResults =
+            dynamic_cast<const VanillaOption::results*>(controlPE->getResults());
 
         return controlResults->value;
     }

--- a/ql/pricingengines/vanilla/mcvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/mcvanillaengine.hpp
@@ -135,18 +135,15 @@ namespace QuantLib {
                    "engine does not provide "
                    "control variation pricing engine");
 
-        typename Inst::arguments* controlArguments =
-                dynamic_cast<typename Inst::arguments*>(
-                                                   controlPE->getArguments());
+        auto* controlArguments = dynamic_cast<typename Inst::arguments*>(controlPE->getArguments());
 
         QL_REQUIRE(controlArguments, "engine is using inconsistent arguments");
 
         *controlArguments = this->arguments_;
         controlPE->calculate();
 
-        const typename Inst::results* controlResults =
-                dynamic_cast<const typename Inst::results*>(
-                                                     controlPE->getResults());
+        const auto* controlResults =
+            dynamic_cast<const typename Inst::results*>(controlPE->getResults());
         QL_REQUIRE(controlResults,
                    "engine returns an inconsistent result type");
 

--- a/ql/processes/jointstochasticprocess.cpp
+++ b/ql/processes/jointstochasticprocess.cpp
@@ -81,7 +81,7 @@ namespace QuantLib {
     Disposable<Array> JointStochasticProcess::initialValues() const {
         Array retVal(size());
 
-        for (const_iterator iter = l_.begin(); iter != l_.end(); ++iter) {
+        for (auto iter = l_.begin(); iter != l_.end(); ++iter) {
             const Array& pInitValues = (*iter)->initialValues();
 
             std::copy(pInitValues.begin(), pInitValues.end(),
@@ -277,7 +277,7 @@ namespace QuantLib {
 
 
         Array retVal(size());
-        for (const_iterator iter = l_.begin(); iter != l_.end(); ++iter) {
+        for (auto iter = l_.begin(); iter != l_.end(); ++iter) {
             const Size i = iter - l_.begin();
 
             Array dz((*iter)->factors());

--- a/ql/termstructures/bootstraphelper.hpp
+++ b/ql/termstructures/bootstraphelper.hpp
@@ -203,8 +203,7 @@ namespace QuantLib {
 
     template <class TS>
     void BootstrapHelper<TS>::accept(AcyclicVisitor& v) {
-        Visitor<BootstrapHelper<TS> >* v1 =
-            dynamic_cast<Visitor<BootstrapHelper<TS> >*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BootstrapHelper<TS> >*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -160,7 +160,7 @@ template <class Curve> void GlobalBootstrap<Curve>::initialize() const {
     for (Size j = firstAdditionalDate_; j < numberAdditionalDates_; ++j)
         dates.push_back(additionalDates[firstAdditionalDate_ + j]);
     std::sort(dates.begin(), dates.end());
-    std::vector<Date>::iterator it = std::unique(dates.begin(), dates.end());
+    auto it = std::unique(dates.begin(), dates.end());
     QL_REQUIRE(it == dates.end(), "duplicate dates among alive instruments and additional dates");
 
     // build times vector

--- a/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
@@ -122,8 +122,7 @@ namespace QuantLib {
     }
 
     inline void BlackConstantVol::accept(AcyclicVisitor& v) {
-        Visitor<BlackConstantVol>* v1 =
-            dynamic_cast<Visitor<BlackConstantVol>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackConstantVol>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
@@ -102,8 +102,7 @@ namespace QuantLib {
     }
 
     inline void BlackVarianceCurve::accept(AcyclicVisitor& v) {
-        Visitor<BlackVarianceCurve>* v1 =
-            dynamic_cast<Visitor<BlackVarianceCurve>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVarianceCurve>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/blackvariancesurface.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancesurface.hpp
@@ -100,8 +100,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void BlackVarianceSurface::accept(AcyclicVisitor& v) {
-        Visitor<BlackVarianceSurface>* v1 =
-            dynamic_cast<Visitor<BlackVarianceSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVarianceSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
@@ -249,8 +249,7 @@ namespace QuantLib {
     }
 
     inline void BlackVolTermStructure::accept(AcyclicVisitor& v) {
-        Visitor<BlackVolTermStructure>* v1 =
-            dynamic_cast<Visitor<BlackVolTermStructure>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVolTermStructure>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -265,8 +264,7 @@ namespace QuantLib {
     }
 
     inline void BlackVolatilityTermStructure::accept(AcyclicVisitor& v) {
-        Visitor<BlackVolatilityTermStructure>* v1 =
-            dynamic_cast<Visitor<BlackVolatilityTermStructure>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVolatilityTermStructure>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -282,8 +280,7 @@ namespace QuantLib {
     }
 
     inline void BlackVarianceTermStructure::accept(AcyclicVisitor& v) {
-        Visitor<BlackVarianceTermStructure>* v1 =
-            dynamic_cast<Visitor<BlackVarianceTermStructure>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BlackVarianceTermStructure>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/impliedvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/impliedvoltermstructure.hpp
@@ -87,8 +87,7 @@ namespace QuantLib {
     }
 
     inline void ImpliedVolTermStructure::accept(AcyclicVisitor& v) {
-        Visitor<ImpliedVolTermStructure>* v1 =
-            dynamic_cast<Visitor<ImpliedVolTermStructure>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<ImpliedVolTermStructure>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/localconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/localconstantvol.hpp
@@ -107,8 +107,7 @@ namespace QuantLib {
     }
 
     inline void LocalConstantVol::accept(AcyclicVisitor& v) {
-        Visitor<LocalConstantVol>* v1 =
-            dynamic_cast<Visitor<LocalConstantVol>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<LocalConstantVol>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/localvolcurve.hpp
+++ b/ql/termstructures/volatility/equityfx/localvolcurve.hpp
@@ -66,8 +66,7 @@ namespace QuantLib {
     // inline definitions
 
     inline void LocalVolCurve::accept(AcyclicVisitor& v) {
-        Visitor<LocalVolCurve>* v1 =
-            dynamic_cast<Visitor<LocalVolCurve>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<LocalVolCurve>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/localvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.cpp
@@ -75,8 +75,7 @@ namespace QuantLib {
     }
 
     void LocalVolSurface::accept(AcyclicVisitor& v) {
-        Visitor<LocalVolSurface>* v1 =
-            dynamic_cast<Visitor<LocalVolSurface>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<LocalVolSurface>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
+++ b/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
@@ -55,8 +55,7 @@ namespace QuantLib {
     }
 
     void LocalVolTermStructure::accept(AcyclicVisitor& v) {
-        Visitor<LocalVolTermStructure>* v1 =
-            dynamic_cast<Visitor<LocalVolTermStructure>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<LocalVolTermStructure>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -558,8 +558,7 @@ namespace QuantLib {
         atmOptionTimes.insert(atmOptionTimes.end(),
                               optionTimes.begin(), optionTimes.end());
         std::sort(atmOptionTimes.begin(),atmOptionTimes.end());
-        std::vector<Time>::iterator new_end =
-            std::unique(atmOptionTimes.begin(), atmOptionTimes.end());
+        auto new_end = std::unique(atmOptionTimes.begin(), atmOptionTimes.end());
         atmOptionTimes.erase(new_end, atmOptionTimes.end());
 
         std::vector<Time> atmSwapLengths(atmVolStructure->swapLengths());
@@ -575,8 +574,7 @@ namespace QuantLib {
         atmOptionDates.insert(atmOptionDates.end(),
                                 optionDates.begin(), optionDates.end());
         std::sort(atmOptionDates.begin(),atmOptionDates.end());
-        std::vector<Date>::iterator new_end_1 =
-            std::unique(atmOptionDates.begin(), atmOptionDates.end());
+        auto new_end_1 = std::unique(atmOptionDates.begin(), atmOptionDates.end());
         atmOptionDates.erase(new_end_1, atmOptionDates.end());
 
         std::vector<Period> atmSwapTenors = atmVolStructure->swapTenors();
@@ -584,8 +582,7 @@ namespace QuantLib {
         atmSwapTenors.insert(atmSwapTenors.end(),
                              swapTenors.begin(), swapTenors.end());
         std::sort(atmSwapTenors.begin(),atmSwapTenors.end());
-        std::vector<Period>::iterator new_end_2 =
-            std::unique(atmSwapTenors.begin(), atmSwapTenors.end());
+        auto new_end_2 = std::unique(atmSwapTenors.begin(), atmSwapTenors.end());
         atmSwapTenors.erase(new_end_2, atmSwapTenors.end());
 
         createSparseSmiles();

--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -86,8 +86,7 @@ namespace QuantLib {
     }
 
     void BondHelper::accept(AcyclicVisitor& v) {
-        Visitor<BondHelper>* v1 =
-            dynamic_cast<Visitor<BondHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BondHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -149,8 +148,7 @@ namespace QuantLib {
     }
 
     void FixedRateBondHelper::accept(AcyclicVisitor& v) {
-        Visitor<FixedRateBondHelper>* v1 =
-            dynamic_cast<Visitor<FixedRateBondHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FixedRateBondHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -220,8 +218,7 @@ namespace QuantLib {
     }
 
     void CPIBondHelper::accept(AcyclicVisitor& v) {
-        Visitor<CPIBondHelper>* v1 =
-            dynamic_cast<Visitor<CPIBondHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<CPIBondHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -133,8 +133,7 @@ namespace QuantLib {
     }
 
     void OISRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<OISRateHelper>* v1 =
-            dynamic_cast<Visitor<OISRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<OISRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -199,8 +198,7 @@ namespace QuantLib {
     }
 
     void DatedOISRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<DatedOISRateHelper>* v1 =
-            dynamic_cast<Visitor<DatedOISRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DatedOISRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -280,8 +280,7 @@ namespace QuantLib {
     }
 
     void FuturesRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<FuturesRateHelper>* v1 =
-            dynamic_cast<Visitor<FuturesRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FuturesRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -362,8 +361,7 @@ namespace QuantLib {
     }
 
     void DepositRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<DepositRateHelper>* v1 =
-            dynamic_cast<Visitor<DepositRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<DepositRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -671,8 +669,7 @@ namespace QuantLib {
     }
 
     void FraRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<FraRateHelper>* v1 =
-            dynamic_cast<Visitor<FraRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FraRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -904,8 +901,7 @@ namespace QuantLib {
     }
 
     void SwapRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<SwapRateHelper>* v1 =
-            dynamic_cast<Visitor<SwapRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<SwapRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -1006,8 +1002,7 @@ namespace QuantLib {
     }
 
     void BMASwapRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<BMASwapRateHelper>* v1 =
-            dynamic_cast<Visitor<BMASwapRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<BMASwapRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else
@@ -1089,8 +1084,7 @@ namespace QuantLib {
     }
 
     void FxSwapRateHelper::accept(AcyclicVisitor& v) {
-        Visitor<FxSwapRateHelper>* v1 =
-            dynamic_cast<Visitor<FxSwapRateHelper>*>(&v);
+        auto* v1 = dynamic_cast<Visitor<FxSwapRateHelper>*>(&v);
         if (v1 != 0)
             v1->visit(*this);
         else

--- a/ql/time/calendars/saudiarabia.cpp
+++ b/ql/time/calendars/saudiarabia.cpp
@@ -80,8 +80,7 @@ namespace QuantLib {
                                       (Date(20, July, 2021))
                                       (Date(10, July, 2022));
 
-            for (std::vector<Date>::iterator p = EidAlAdha.begin();
-                                             p != EidAlAdha.end(); ++p) {
+            for (auto p = EidAlAdha.begin(); p != EidAlAdha.end(); ++p) {
                 if (d >= *p -1 && d <= *p + 4) {
                     return true;
                 }
@@ -123,8 +122,7 @@ namespace QuantLib {
                                       (Date(26, Feb, 2028))
                                       (Date(14, Feb, 2029));
 
-            for (std::vector<Date>::iterator p = EidAlFitr.begin();
-                                             p != EidAlFitr.end(); ++p) {
+            for (auto p = EidAlFitr.begin(); p != EidAlFitr.end(); ++p) {
                 if (d >= *p -1 && d <= *p + 4) {
                     return true;
                 }

--- a/ql/time/daycounters/actual365fixed.cpp
+++ b/ql/time/daycounters/actual365fixed.cpp
@@ -50,11 +50,11 @@ namespace QuantLib {
 
         Time dcs = daysBetween(d1,d2);
         Time dcc = daysBetween(refPeriodStart,refPeriodEnd);
-        Integer months = Integer(std::lround(12*dcc/365));
+        auto months = Integer(std::lround(12 * dcc / 365));
         QL_REQUIRE(months != 0,
                    "invalid reference period for Act/365 Canadian; "
                    "must be longer than a month");
-        Integer frequency = Integer(12/months);
+        auto frequency = Integer(12 / months);
 
         if (dcs < Integer(365/frequency))
             return dcs/365.0;

--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -31,7 +31,7 @@ namespace QuantLib {
         Integer findCouponsPerYear(const T& impl,
                                    Date refStart, Date refEnd) {
             // This will only work for day counts longer than 15 days.
-            Integer months = (Integer)std::lround(12 * Real(impl.dayCount(refStart, refEnd))/365.0);
+            auto months = (Integer)std::lround(12 * Real(impl.dayCount(refStart, refEnd)) / 365.0);
             return (Integer)std::lround(12.0 / Real(months));
         }
 
@@ -172,8 +172,7 @@ namespace QuantLib {
                    << ", reference period end: " << refPeriodEnd);
 
         // estimate roughly the length in months of a period
-        Integer months =
-            (Integer)std::lround(12*Real(refPeriodEnd-refPeriodStart)/365);
+        auto months = (Integer)std::lround(12 * Real(refPeriodEnd - refPeriodStart) / 365);
 
         // for short periods...
         if (months == 0) {

--- a/ql/time/ecb.cpp
+++ b/ql/time/ecb.cpp
@@ -184,8 +184,7 @@ namespace QuantLib {
                   Settings::instance().evaluationDate() :
                   date);
 
-        std::set<Date>::const_iterator i =
-            std::upper_bound(knownDates().begin(), knownDates().end(), d);
+        auto i = std::upper_bound(knownDates().begin(), knownDates().end(), d);
 
         QL_REQUIRE(i!=knownDates().end(),
                    "ECB dates after " << *(--knownDates().end()) << " are unknown");
@@ -197,8 +196,7 @@ namespace QuantLib {
                   Settings::instance().evaluationDate() :
                   date);
 
-        std::set<Date>::const_iterator i =
-            std::upper_bound(knownDates().begin(), knownDates().end(), d);
+        auto i = std::upper_bound(knownDates().begin(), knownDates().end(), d);
 
         QL_REQUIRE(i!=knownDates().end(),
                    "ECB dates after " << *knownDates().end() << " are unknown");

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -511,7 +511,7 @@ namespace QuantLib {
     }
 
     Date Schedule::nextDate(const Date& refDate) const {
-        std::vector<Date>::const_iterator res = lower_bound(refDate);
+        auto res = lower_bound(refDate);
         if (res!=dates_.end())
             return *res;
         else
@@ -519,7 +519,7 @@ namespace QuantLib {
     }
 
     Date Schedule::previousDate(const Date& refDate) const {
-        std::vector<Date>::const_iterator res = lower_bound(refDate);
+        auto res = lower_bound(refDate);
         if (res!=dates_.begin())
             return *(--res);
         else

--- a/ql/timegrid.cpp
+++ b/ql/timegrid.cpp
@@ -78,8 +78,8 @@ namespace QuantLib {
     }
 
     Size TimeGrid::closestIndex(Time t) const {
-        const_iterator begin = times_.begin(), end = times_.end();
-        const_iterator result = std::lower_bound(begin, end, t);
+        auto begin = times_.begin(), end = times_.end();
+        auto result = std::lower_bound(begin, end, t);
         if (result == begin) {
             return 0;
         } else if (result == end) {

--- a/ql/timegrid.hpp
+++ b/ql/timegrid.hpp
@@ -60,9 +60,8 @@ namespace QuantLib {
             // (even though I'm not sure that I agree.)
             QL_REQUIRE(mandatoryTimes_.front() >= 0.0,
                        "negative times not allowed");
-            std::vector<Time>::iterator e =
-                std::unique(mandatoryTimes_.begin(),mandatoryTimes_.end(),
-                            static_cast<bool (*)(Real, Real)>(close_enough));
+            auto e = std::unique(mandatoryTimes_.begin(), mandatoryTimes_.end(),
+                                 static_cast<bool (*)(Real, Real)>(close_enough));
             mandatoryTimes_.resize(e - mandatoryTimes_.begin());
 
             if (mandatoryTimes_[0] > 0.0)
@@ -92,9 +91,8 @@ namespace QuantLib {
             // (even though I'm not sure that I agree.)
             QL_REQUIRE(mandatoryTimes_.front() >= 0.0,
                        "negative times not allowed");
-            std::vector<Time>::iterator e =
-                std::unique(mandatoryTimes_.begin(),mandatoryTimes_.end(),
-                            static_cast<bool (*)(Real, Real)>(close_enough));
+            auto e = std::unique(mandatoryTimes_.begin(), mandatoryTimes_.end(),
+                                 static_cast<bool (*)(Real, Real)>(close_enough));
             mandatoryTimes_.resize(e - mandatoryTimes_.begin());
 
             Time last = mandatoryTimes_.back();

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -567,7 +567,7 @@ void AmericanOptionTest::testFdShoutGreeks() {
 }
 
 test_suite* AmericanOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("American option tests");
+    auto* suite = BOOST_TEST_SUITE("American option tests");
     suite->add(
         QUANTLIB_TEST_CASE(&AmericanOptionTest::testBaroneAdesiWhaleyValues));
     suite->add(

--- a/test-suite/amortizingbond.cpp
+++ b/test-suite/amortizingbond.cpp
@@ -210,10 +210,8 @@ void AmortizingBondTest::testBrazilianAmortizingFixedRateBond() {
 }
 
 test_suite* AmortizingBondTest::suite() {
-	test_suite* suite = BOOST_TEST_SUITE("Amortizing Bond tests");
-	suite->add(
-		QUANTLIB_TEST_CASE(&AmortizingBondTest::testAmortizingFixedRateBond));
-	suite->add(
-		QUANTLIB_TEST_CASE(&AmortizingBondTest::testBrazilianAmortizingFixedRateBond));
-	return suite;
+    auto* suite = BOOST_TEST_SUITE("Amortizing Bond tests");
+    suite->add(QUANTLIB_TEST_CASE(&AmortizingBondTest::testAmortizingFixedRateBond));
+    suite->add(QUANTLIB_TEST_CASE(&AmortizingBondTest::testBrazilianAmortizingFixedRateBond));
+    return suite;
 }

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -1078,8 +1078,7 @@ void AndreasenHugeVolatilityInterplTest::testFlatVolCalibration() {
 
 
 test_suite* AndreasenHugeVolatilityInterplTest::suite(SpeedLevel speed) {
-    test_suite* suite =
-        BOOST_TEST_SUITE("Andreasen-Huge volatility interpolation tests");
+    auto* suite = BOOST_TEST_SUITE("Andreasen-Huge volatility interpolation tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &AndreasenHugeVolatilityInterplTest::testSingleOptionCalibration));

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -246,7 +246,7 @@ void ArrayTest::testArrayResize() {
 
 
 test_suite* ArrayTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("array tests");
+    auto* suite = BOOST_TEST_SUITE("array tests");
     suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testConstruction));
     suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testArrayFunctions));
     suite->add(QUANTLIB_TEST_CASE(&ArrayTest::testArrayResize));

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -369,7 +369,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePrice() {
     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
 
     std::vector<Date> fixingDates(futureFixings);
-    Integer dt = (Integer)std::lround(360.0/futureFixings);
+    auto dt = (Integer)std::lround(360.0 / futureFixings);
     fixingDates[0] = today + dt;
     for (Size j=1; j<futureFixings; j++)
         fixingDates[j] = fixingDates[j-1] + dt;
@@ -428,7 +428,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAverageStrike() {
     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
 
     std::vector<Date> fixingDates(futureFixings);
-    Integer dt = (Integer)std::lround(360.0/futureFixings);
+    auto dt = (Integer)std::lround(360.0 / futureFixings);
     fixingDates[0] = today + dt;
     for (Size j=1; j<futureFixings; j++)
         fixingDates[j] = fixingDates[j-1] + dt;
@@ -494,7 +494,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePrice() {
     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
 
     std::vector<Date> fixingDates(futureFixings);
-    Integer dt = (Integer)std::lround(360.0/futureFixings);
+    auto dt = (Integer)std::lround(360.0 / futureFixings);
     fixingDates[0] = today + dt;
     for (Size j=1; j<futureFixings; j++)
         fixingDates[j] = fixingDates[j-1] + dt;
@@ -2036,7 +2036,7 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceHeston() {
 }
 
 test_suite* AsianOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Asian option tests");
+    auto* suite = BOOST_TEST_SUITE("Asian option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &AsianOptionTest::testAnalyticContinuousGeometricAveragePrice));
@@ -2067,7 +2067,7 @@ test_suite* AsianOptionTest::suite() {
 }
 
 test_suite* AsianOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Asian option experimental tests");
+    auto* suite = BOOST_TEST_SUITE("Asian option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testLevyEngine));
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testVecerEngine));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -4268,7 +4268,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
 
 
 test_suite* AssetSwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("AssetSwap tests");
+    auto* suite = BOOST_TEST_SUITE("AssetSwap tests");
     suite->add(QUANTLIB_TEST_CASE(&AssetSwapTest::testConsistency));
     suite->add(QUANTLIB_TEST_CASE(&AssetSwapTest::testImpliedValue));
     suite->add(QUANTLIB_TEST_CASE(&AssetSwapTest::testMarketASWSpread));

--- a/test-suite/autocovariances.cpp
+++ b/test-suite/autocovariances.cpp
@@ -85,7 +85,7 @@ void AutocovariancesTest::testAutoCorrelations() {
 }
 
 test_suite* AutocovariancesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("auto-covariance tests");
+    auto* suite = BOOST_TEST_SUITE("auto-covariance tests");
     suite->add(QUANTLIB_TEST_CASE(&AutocovariancesTest::testConvolutions));
     suite->add(QUANTLIB_TEST_CASE(&AutocovariancesTest::testAutoCovariances));
     suite->add(QUANTLIB_TEST_CASE(&AutocovariancesTest::testAutoCorrelations));

--- a/test-suite/barrieroption.cpp
+++ b/test-suite/barrieroption.cpp
@@ -1293,7 +1293,7 @@ void BarrierOptionTest::testDividendBarrierOption() {
 }
 
 test_suite* BarrierOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Barrier option tests");
+    auto* suite = BOOST_TEST_SUITE("Barrier option tests");
     suite->add(QUANTLIB_TEST_CASE(&BarrierOptionTest::testParity));
     suite->add(QUANTLIB_TEST_CASE(&BarrierOptionTest::testHaugValues));
     suite->add(QUANTLIB_TEST_CASE(&BarrierOptionTest::testBabsiriValues));
@@ -1306,7 +1306,7 @@ test_suite* BarrierOptionTest::suite() {
 }
 
 test_suite* BarrierOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Barrier option experimental tests");
+    auto* suite = BOOST_TEST_SUITE("Barrier option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&BarrierOptionTest::testPerturbative));
     suite->add(QUANTLIB_TEST_CASE(
                       &BarrierOptionTest::testVannaVolgaSimpleBarrierValues));

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -423,7 +423,7 @@ void BasismodelsTest::testTenorswaptionvts() {
 
 
 test_suite* BasismodelsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Basismodels tests");
+    auto* suite = BOOST_TEST_SUITE("Basismodels tests");
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testSwaptioncfsContCompSpread));
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testSwaptioncfsSimpleCompSpread));
     suite->add(QUANTLIB_TEST_CASE(&BasismodelsTest::testTenoroptionletvts));

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -1086,7 +1086,7 @@ void BasketOptionTest::test2DPDEGreeks() {
 }
 
 test_suite* BasketOptionTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Basket option tests");
+    auto* suite = BOOST_TEST_SUITE("Basket option tests");
 
     suite->add(QUANTLIB_TEST_CASE(&BasketOptionTest::testEuroTwoValues));
     suite->add(QUANTLIB_TEST_CASE(&BasketOptionTest::testTavellaValues));

--- a/test-suite/batesmodel.cpp
+++ b/test-suite/batesmodel.cpp
@@ -537,7 +537,7 @@ void BatesModelTest::testDAXCalibration() {
 }
 
 test_suite* BatesModelTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Bates model tests");
+    auto* suite = BOOST_TEST_SUITE("Bates model tests");
     suite->add(QUANTLIB_TEST_CASE(&BatesModelTest::testAnalyticVsBlack));
     suite->add(QUANTLIB_TEST_CASE(
                         &BatesModelTest::testAnalyticAndMcVsJumpDiffusion));

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -310,7 +310,7 @@ void BermudanSwaptionTest::testCachedG2Values() {
 }
 
 test_suite* BermudanSwaptionTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Bermudan swaption tests");
+    auto* suite = BOOST_TEST_SUITE("Bermudan swaption tests");
 
     suite->add(QUANTLIB_TEST_CASE(&BermudanSwaptionTest::testCachedValues));
 

--- a/test-suite/binaryoption.cpp
+++ b/test-suite/binaryoption.cpp
@@ -280,7 +280,7 @@ void BinaryOptionTest::testAssetOrNothingHaugValues() {
 }
 
 test_suite* BinaryOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Binary");
+    auto* suite = BOOST_TEST_SUITE("Binary");
     suite->add(QUANTLIB_TEST_CASE(&BinaryOptionTest::testCashOrNothingHaugValues));
     suite->add(QUANTLIB_TEST_CASE(&BinaryOptionTest::testAssetOrNothingHaugValues));
     return suite;

--- a/test-suite/blackdeltacalculator.cpp
+++ b/test-suite/blackdeltacalculator.cpp
@@ -682,7 +682,7 @@ void BlackDeltaCalculatorTest::testAtmCalcs(){
 
 
 test_suite* BlackDeltaCalculatorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Black delta calculator tests");
+    auto* suite = BOOST_TEST_SUITE("Black delta calculator tests");
     suite->add(QUANTLIB_TEST_CASE(&BlackDeltaCalculatorTest::testDeltaValues));
     suite->add(QUANTLIB_TEST_CASE(
                        &BlackDeltaCalculatorTest::testDeltaPriceConsistency));

--- a/test-suite/blackformula.cpp
+++ b/test-suite/blackformula.cpp
@@ -291,8 +291,7 @@ void assertBlackFormulaForwardDerivative(
     Real epsilon = 1.e-10;
     std::string type = optionType == Option::Call ? "Call" : "Put";
 
-    for (std::vector<Real>::const_iterator it = strikes.begin(); it != strikes.end(); ++it)
-    {
+    for (auto it = strikes.begin(); it != strikes.end(); ++it) {
         Real strike = *it;
         Real delta = blackFormulaForwardDerivative(
             optionType, strike, forward, stdDev, discount, displacement);
@@ -384,8 +383,7 @@ void assertBachelierBlackFormulaForwardDerivative(
     Real epsilon = 1.e-10;
     std::string type = optionType == Option::Call ? "Call" : "Put";
 
-    for (std::vector<Real>::const_iterator it = strikes.begin(); it != strikes.end(); ++it)
-    {
+    for (auto it = strikes.begin(); it != strikes.end(); ++it) {
         Real strike = *it;
         Real delta = bachelierBlackFormulaForwardDerivative(
             optionType, strike, forward, stdDev, discount);
@@ -461,7 +459,7 @@ void BlackFormulaTest::testBachelierBlackFormulaForwardDerivativeWithZeroVolatil
 }
 
 test_suite* BlackFormulaTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Black formula tests");
+    auto* suite = BOOST_TEST_SUITE("Black formula tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &BlackFormulaTest::testBachelierImpliedVol));

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -1742,7 +1742,7 @@ void BondTest::testThirty360BondWithSettlementOn31st(){
 }
 
 test_suite* BondTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Bond tests");
+    auto* suite = BOOST_TEST_SUITE("Bond tests");
 
     suite->add(QUANTLIB_TEST_CASE(&BondTest::testYield));
     suite->add(QUANTLIB_TEST_CASE(&BondTest::testAtmRate));

--- a/test-suite/brownianbridge.cpp
+++ b/test-suite/brownianbridge.cpp
@@ -272,7 +272,7 @@ void BrownianBridgeTest::testPathGeneration() {
 }
 
 test_suite* BrownianBridgeTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Brownian bridge tests");
+    auto* suite = BOOST_TEST_SUITE("Brownian bridge tests");
     suite->add(QUANTLIB_TEST_CASE(&BrownianBridgeTest::testVariates));
     suite->add(QUANTLIB_TEST_CASE(&BrownianBridgeTest::testPathGeneration));
     return suite;

--- a/test-suite/businessdayconventions.cpp
+++ b/test-suite/businessdayconventions.cpp
@@ -122,7 +122,7 @@ void BusinessDayConventionTest::testConventions() {
 }
 
 test_suite* BusinessDayConventionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Business day convention tests");
+    auto* suite = BOOST_TEST_SUITE("Business day convention tests");
     suite->add(QUANTLIB_TEST_CASE(&BusinessDayConventionTest::testConventions));
     return suite;
 }

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -2120,8 +2120,7 @@ void CalendarTest::testDayLists() {
     std::vector<Date> holidays = germany.holidayList(firstDate, endDate, true);
     std::vector<Date> businessDays = germany.businessDayList(firstDate, endDate);
 
-    std::vector<Date>::iterator it_holidays = holidays.begin(),
-                                it_businessDays = businessDays.begin();
+    auto it_holidays = holidays.begin(), it_businessDays = businessDays.begin();
     for (Date d = firstDate; d < endDate; d++) {
         if (it_holidays != holidays.end() && it_businessDays != businessDays.end() &&
             d == *it_holidays && d == *it_businessDays) {
@@ -2139,7 +2138,7 @@ void CalendarTest::testDayLists() {
 }
 
 test_suite* CalendarTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Calendar tests");
+    auto* suite = BOOST_TEST_SUITE("Calendar tests");
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testBrazil));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testRussia));

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -579,7 +579,7 @@ void CallableBondTest::testCached() {
 }
 
 test_suite* CallableBondTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Convertible-bond tests");
+    auto* suite = BOOST_TEST_SUITE("Convertible-bond tests");
     suite->add(QUANTLIB_TEST_CASE(&CallableBondTest::testConsistency));
     suite->add(QUANTLIB_TEST_CASE(&CallableBondTest::testInterplay));
     suite->add(QUANTLIB_TEST_CASE(&CallableBondTest::testObservability));

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -238,9 +238,7 @@ void CapFloorTest::testStrikeDependency() {
                 floor_values.push_back(floor->NPV());
             }
             // and check that they go the right way
-            std::vector<Real>::iterator it =
-                std::adjacent_find(cap_values.begin(),cap_values.end(),
-                                   std::less<Real>());
+            auto it = std::adjacent_find(cap_values.begin(), cap_values.end(), std::less<Real>());
             if (it != cap_values.end()) {
                 Size n = it - cap_values.begin();
                 BOOST_FAIL(
@@ -960,7 +958,7 @@ void CapFloorTest::testBachelierOptionLetsDelta() {
 }
 
 test_suite* CapFloorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Cap and floor tests");
+    auto* suite = BOOST_TEST_SUITE("Cap and floor tests");
     suite->add(QUANTLIB_TEST_CASE(&CapFloorTest::testStrikeDependency));
     suite->add(QUANTLIB_TEST_CASE(&CapFloorTest::testConsistency));
     // FLOATING_POINT_EXCEPTION

--- a/test-suite/capflooredcoupon.cpp
+++ b/test-suite/capflooredcoupon.cpp
@@ -253,9 +253,9 @@ void CapFlooredCouponTest::testDecomposition() {
     std::vector<Rate> floors(vars.length,floorstrike);
     std::vector<Rate> floors0 = std::vector<Rate>();
     Rate gearing_p = Rate(0.5);
-    Spread spread_p = Spread(0.002);
+    auto spread_p = Spread(0.002);
     Rate gearing_n = Rate(-1.5);
-    Spread spread_n = Spread(0.12);
+    auto spread_n = Spread(0.12);
     // fixed leg with zero rate
     Leg fixedLeg  =
         vars.makeFixedLeg(vars.startDate,vars.length);
@@ -548,7 +548,7 @@ void CapFlooredCouponTest::testDecomposition() {
 }
 
 test_suite* CapFlooredCouponTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Capped and floored coupon tests");
+    auto* suite = BOOST_TEST_SUITE("Capped and floored coupon tests");
     suite->add(QUANTLIB_TEST_CASE(&CapFlooredCouponTest::testLargeRates));
     suite->add(QUANTLIB_TEST_CASE(&CapFlooredCouponTest::testDecomposition));
     return suite;

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -505,7 +505,7 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
 }
 
 test_suite* CashFlowsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Cash flows tests");
+    auto* suite = BOOST_TEST_SUITE("Cash flows tests");
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testSettings));
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testAccessViolation));
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testDefaultSettlementDate));

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -691,7 +691,7 @@ void CatBondTest::testCatBondWithGeneratedEventsProportional() {
 }
 
 test_suite* CatBondTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("CatBond tests");
+    auto* suite = BOOST_TEST_SUITE("CatBond tests");
 
     suite->add(QUANTLIB_TEST_CASE(&CatBondTest::testEventSetForWholeYears));
     suite->add(QUANTLIB_TEST_CASE(&CatBondTest::testEventSetForIrregularPeriods));

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -371,8 +371,8 @@ void CdoTest::testHW(unsigned dataSet) {
 
 
 test_suite* CdoTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("CDO tests");
-    #ifndef QL_PATCH_SOLARIS
+    auto* suite = BOOST_TEST_SUITE("CDO tests");
+#ifndef QL_PATCH_SOLARIS
     if (speed == Slow) {
         #define BOOST_PP_LOCAL_MACRO(n) \
             suite->add(QUANTLIB_TEST_CASE(ext::bind(&CdoTest::testHW, n)));

--- a/test-suite/cdsoption.cpp
+++ b/test-suite/cdsoption.cpp
@@ -116,7 +116,7 @@ void CdsOptionTest::testCached() {
 
 
 test_suite* CdsOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("range-accrual-swap tests");
+    auto* suite = BOOST_TEST_SUITE("range-accrual-swap tests");
     suite->add(QUANTLIB_TEST_CASE(&CdsOptionTest::testCached));
     return suite;
 }

--- a/test-suite/chooseroption.cpp
+++ b/test-suite/chooseroption.cpp
@@ -157,7 +157,7 @@ void ChooserOptionTest::testAnalyticComplexChooserEngine(){
 }
 
 test_suite* ChooserOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Chooser option tests");
+    auto* suite = BOOST_TEST_SUITE("Chooser option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &ChooserOptionTest::testAnalyticSimpleChooserEngine));

--- a/test-suite/cliquetoption.cpp
+++ b/test-suite/cliquetoption.cpp
@@ -372,7 +372,7 @@ void CliquetOptionTest::testMcPerformance() {
 
 
 test_suite* CliquetOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Cliquet option tests");
+    auto* suite = BOOST_TEST_SUITE("Cliquet option tests");
     suite->add(QUANTLIB_TEST_CASE(&CliquetOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&CliquetOptionTest::testGreeks));
     suite->add(QUANTLIB_TEST_CASE(&CliquetOptionTest::testPerformanceGreeks));

--- a/test-suite/cms.cpp
+++ b/test-suite/cms.cpp
@@ -499,7 +499,7 @@ void CmsTest::testParity() {
 }
 
 test_suite* CmsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Cms tests");
+    auto* suite = BOOST_TEST_SUITE("Cms tests");
     suite->add(QUANTLIB_TEST_CASE(&CmsTest::testFairRate));
     suite->add(QUANTLIB_TEST_CASE(&CmsTest::testCmsSwap));
     suite->add(QUANTLIB_TEST_CASE(&CmsTest::testParity));

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -351,7 +351,7 @@ void CmsSpreadTest::testCouponPricing() {
 }
 
 test_suite* CmsSpreadTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("CmsSpreadTest");
+    auto* suite = BOOST_TEST_SUITE("CmsSpreadTest");
     suite->add(QUANTLIB_TEST_CASE(&CmsSpreadTest::testFixings));
     suite->add(QUANTLIB_TEST_CASE(&CmsSpreadTest::testCouponPricing));
     return suite;

--- a/test-suite/commodityunitofmeasure.cpp
+++ b/test-suite/commodityunitofmeasure.cpp
@@ -134,7 +134,7 @@ void CommodityUnitOfMeasureTest::testDirect() {
 }
 
 test_suite* CommodityUnitOfMeasureTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Commodity Unit Of Measure tests");
+    auto* suite = BOOST_TEST_SUITE("Commodity Unit Of Measure tests");
     suite->add(QUANTLIB_TEST_CASE(&CommodityUnitOfMeasureTest::testDirect));
     return suite;
 }

--- a/test-suite/compiledboostversion.cpp
+++ b/test-suite/compiledboostversion.cpp
@@ -37,7 +37,7 @@ void CompiledBoostVersionTest::test() {
 
 
 test_suite* CompiledBoostVersionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Compiled boost version test");
+    auto* suite = BOOST_TEST_SUITE("Compiled boost version test");
     suite->add(QUANTLIB_TEST_CASE(&CompiledBoostVersionTest::test));
     return suite;
 }

--- a/test-suite/compoundoption.cpp
+++ b/test-suite/compoundoption.cpp
@@ -366,7 +366,7 @@ void CompoundOptionTest::testValues(){
 
 
 test_suite* CompoundOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Compound option tests");
+    auto* suite = BOOST_TEST_SUITE("Compound option tests");
 
     suite->add(QUANTLIB_TEST_CASE(&CompoundOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&CompoundOptionTest::testPutCallParity));

--- a/test-suite/convertiblebonds.cpp
+++ b/test-suite/convertiblebonds.cpp
@@ -459,7 +459,7 @@ void ConvertibleBondTest::testRegression() {
 
 
 test_suite* ConvertibleBondTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Convertible bond tests");
+    auto* suite = BOOST_TEST_SUITE("Convertible bond tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ConvertibleBondTest::testBond));
     suite->add(QUANTLIB_TEST_CASE(&ConvertibleBondTest::testOption));

--- a/test-suite/covariance.cpp
+++ b/test-suite/covariance.cpp
@@ -270,7 +270,7 @@ void CovarianceTest::testCovariance() {
 
 
 test_suite* CovarianceTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Covariance and correlation tests");
+    auto* suite = BOOST_TEST_SUITE("Covariance and correlation tests");
     suite->add(QUANTLIB_TEST_CASE(&CovarianceTest::testCovariance));
     suite->add(QUANTLIB_TEST_CASE(&CovarianceTest::testSalvagingMatrix));
     suite->add(QUANTLIB_TEST_CASE(&CovarianceTest::testRankReduction));

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -756,7 +756,7 @@ void CreditDefaultSwapTest::testAccrualRebateAmounts() {
 }
 
 test_suite* CreditDefaultSwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Credit-default swap tests");
+    auto* suite = BOOST_TEST_SUITE("Credit-default swap tests");
     suite->add(QUANTLIB_TEST_CASE(&CreditDefaultSwapTest::testCachedValue));
     suite->add(QUANTLIB_TEST_CASE(
                               &CreditDefaultSwapTest::testCachedMarketValue));

--- a/test-suite/creditriskplus.cpp
+++ b/test-suite/creditriskplus.cpp
@@ -120,7 +120,7 @@ void CreditRiskPlusTest::testReferenceValues() {
 }
 
 test_suite *CreditRiskPlusTest::suite() {
-    test_suite *suite = BOOST_TEST_SUITE("Credit risk plus tests");
+    auto* suite = BOOST_TEST_SUITE("Credit risk plus tests");
     suite->add(QUANTLIB_TEST_CASE(&CreditRiskPlusTest::testReferenceValues));
     return suite;
 }

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -266,7 +266,7 @@ void CrossCurrencyRateHelpersTest::testBasisSwapsWithCollateralAndBasisInQuoteCc
 }
 
 test_suite* CrossCurrencyRateHelpersTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Cross currency rate helpers tests");
+    auto* suite = BOOST_TEST_SUITE("Cross currency rate helpers tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &CrossCurrencyRateHelpersTest::testBasisSwapsWithCollateralInQuoteAndBasisInBaseCcy));

--- a/test-suite/curvestates.cpp
+++ b/test-suite/curvestates.cpp
@@ -203,7 +203,7 @@ void CurveStatesTest::testCMSwapCurveState() {
 
 // --- Call the desired tests
 test_suite* CurveStatesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Curve States tests");
+    auto* suite = BOOST_TEST_SUITE("Curve States tests");
     //suite->add(QUANTLIB_TEST_CASE(&CurveStatesTest::testLMMCurveState));
     //suite->add(QUANTLIB_TEST_CASE(&CurveStatesTest::testCoterminalSwapCurveState));
     suite->add(QUANTLIB_TEST_CASE(&CurveStatesTest::testCMSwapCurveState));

--- a/test-suite/dates.cpp
+++ b/test-suite/dates.cpp
@@ -479,7 +479,7 @@ void DateTest::canHash() {
 }
 
 test_suite* DateTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Date tests");
+    auto* suite = BOOST_TEST_SUITE("Date tests");
 
     suite->add(QUANTLIB_TEST_CASE(&DateTest::testConsistency));
     suite->add(QUANTLIB_TEST_CASE(&DateTest::ecbDates));

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -70,7 +70,7 @@ namespace day_counters_test {
         const DayCounter& dayCounter, Date start, Date end, Date refStart, Date refEnd) {
         Real referenceDayCount = Real(dayCounter.dayCount(refStart, refEnd));
         // guess how many coupon periods per year:
-        Integer couponsPerYear = (Integer)std::lround(365.0 / referenceDayCount);
+        auto couponsPerYear = (Integer)std::lround(365.0 / referenceDayCount);
         // the above is good enough for annual or semi annual payments.
         return Real(dayCounter.dayCount(start, end))
             / (referenceDayCount*couponsPerYear);
@@ -880,7 +880,7 @@ void DayCounterTest::testIntraday() {
 
 
 test_suite* DayCounterTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Day counter tests");
+    auto* suite = BOOST_TEST_SUITE("Day counter tests");
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActual));
     suite->add(QUANTLIB_TEST_CASE(
                     &DayCounterTest::testActualActualWithSemiannualSchedule));

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -559,7 +559,7 @@ void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
 
 
 test_suite* DefaultProbabilityCurveTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Default-probability curve tests");
+    auto* suite = BOOST_TEST_SUITE("Default-probability curve tests");
     suite->add(QUANTLIB_TEST_CASE(
                        &DefaultProbabilityCurveTest::testDefaultProbability));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/digitalcoupon.cpp
+++ b/test-suite/digitalcoupon.cpp
@@ -1156,7 +1156,7 @@ void DigitalCouponTest::testReplicationType() {
 
 
 test_suite* DigitalCouponTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Digital coupon tests");
+    auto* suite = BOOST_TEST_SUITE("Digital coupon tests");
     suite->add(QUANTLIB_TEST_CASE(&DigitalCouponTest::testAssetOrNothing));
     suite->add(QUANTLIB_TEST_CASE(
                        &DigitalCouponTest::testAssetOrNothingDeepInTheMoney));

--- a/test-suite/digitaloption.cpp
+++ b/test-suite/digitaloption.cpp
@@ -753,7 +753,7 @@ void DigitalOptionTest::testMCCashAtHit() {
 
 
 test_suite* DigitalOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Digital option tests");
+    auto* suite = BOOST_TEST_SUITE("Digital option tests");
     suite->add(QUANTLIB_TEST_CASE(
                &DigitalOptionTest::testCashOrNothingEuropeanValues));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -762,7 +762,7 @@ void DistributionTest::testSankaranApproximation() {
 }
 
 test_suite* DistributionTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Distribution tests");
+    auto* suite = BOOST_TEST_SUITE("Distribution tests");
 
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testNormal));
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testBivariate));

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -1109,7 +1109,7 @@ void DividendOptionTest::testEscrowedDividendModel() {
 }
 
 test_suite* DividendOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Dividend European option tests");
+    auto* suite = BOOST_TEST_SUITE("Dividend European option tests");
     suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testEuropeanValues));
     // Doesn't quite work.  Need to deal with date conventions
     //  suite->add(QUANTLIB_TEST_CASE(&DividendOptionTest::testEuropeanKnownValue));

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -451,7 +451,7 @@ void DoubleBarrierOptionTest::testVannaVolgaDoubleBarrierValues() {
 
         for (Size j=0; j<=1; j++) {
 
-           DoubleBarrier::Type barrierType = static_cast<DoubleBarrier::Type>(j);
+            auto barrierType = static_cast<DoubleBarrier::Type>(j);
 
             spot->setValue(values[i].s);
             qRate->setValue(values[i].q);
@@ -669,7 +669,7 @@ void DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical() {
 }
 
 test_suite* DoubleBarrierOptionTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("DoubleBarrier");
+    auto* suite = BOOST_TEST_SUITE("DoubleBarrier");
 
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(
@@ -680,7 +680,7 @@ test_suite* DoubleBarrierOptionTest::suite(SpeedLevel speed) {
 }
 
 test_suite* DoubleBarrierOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("DoubleBarrier_experimental");
+    auto* suite = BOOST_TEST_SUITE("DoubleBarrier_experimental");
     suite->add(QUANTLIB_TEST_CASE(
                       &DoubleBarrierOptionTest::testVannaVolgaDoubleBarrierValues));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/doublebinaryoption.cpp
+++ b/test-suite/doublebinaryoption.cpp
@@ -251,7 +251,7 @@ void DoubleBinaryOptionTest::testHaugValues() {
 
 
 test_suite* DoubleBinaryOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("DoubleBinary");
+    auto* suite = BOOST_TEST_SUITE("DoubleBinary");
     suite->add(QUANTLIB_TEST_CASE(&DoubleBinaryOptionTest::testHaugValues));
     return suite;
 }

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1785,7 +1785,7 @@ void EuropeanOptionTest::testDouglasVsCrankNicolson() {
 }
 
 test_suite* EuropeanOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("European option tests");
+    auto* suite = BOOST_TEST_SUITE("European option tests");
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testGreekValues));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testGreeks));
@@ -1821,7 +1821,7 @@ test_suite* EuropeanOptionTest::suite() {
 }
 
 test_suite* EuropeanOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("European option experimental tests");
+    auto* suite = BOOST_TEST_SUITE("European option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testFFTEngines));
     return suite;
 }

--- a/test-suite/everestoption.cpp
+++ b/test-suite/everestoption.cpp
@@ -131,7 +131,7 @@ void EverestOptionTest::testCached() {
 
 
 test_suite* EverestOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Everest-option tests");
+    auto* suite = BOOST_TEST_SUITE("Everest-option tests");
     suite->add(QUANTLIB_TEST_CASE(&EverestOptionTest::testCached));
     return suite;
 }

--- a/test-suite/exchangerate.cpp
+++ b/test-suite/exchangerate.cpp
@@ -375,7 +375,7 @@ void ExchangeRateTest::testSmartLookup() {
 }
 
 test_suite* ExchangeRateTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Exchange-rate tests");
+    auto* suite = BOOST_TEST_SUITE("Exchange-rate tests");
     suite->add(QUANTLIB_TEST_CASE(&ExchangeRateTest::testDirect));
     suite->add(QUANTLIB_TEST_CASE(&ExchangeRateTest::testDerived));
     suite->add(QUANTLIB_TEST_CASE(&ExchangeRateTest::testDirectLookup));

--- a/test-suite/extendedtrees.cpp
+++ b/test-suite/extendedtrees.cpp
@@ -376,7 +376,7 @@ void ExtendedTreesTest::testJOSHIBinomialEngines() {
 }
 
 test_suite* ExtendedTreesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("European option extended trees tests");
+    auto* suite = BOOST_TEST_SUITE("European option extended trees tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ExtendedTreesTest::testJRBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&ExtendedTreesTest::testCRRBinomialEngines));

--- a/test-suite/extensibleoptions.cpp
+++ b/test-suite/extensibleoptions.cpp
@@ -149,7 +149,7 @@ void ExtensibleOptionsTest::testAnalyticWriterExtensibleOptionEngine() {
 }
 
 test_suite* ExtensibleOptionsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Extensible option tests");
+    auto* suite = BOOST_TEST_SUITE("Extensible option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
        &ExtensibleOptionsTest::testAnalyticHolderExtensibleOptionEngine));

--- a/test-suite/fastfouriertransform.cpp
+++ b/test-suite/fastfouriertransform.cpp
@@ -105,7 +105,7 @@ void FastFourierTransformTest::testInverse() {
 
 
 test_suite* FastFourierTransformTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("fast fourier transform tests");
+    auto* suite = BOOST_TEST_SUITE("fast fourier transform tests");
     suite->add(QUANTLIB_TEST_CASE(&FastFourierTransformTest::testSimple));
     suite->add(QUANTLIB_TEST_CASE(&FastFourierTransformTest::testInverse));
     return suite;

--- a/test-suite/fdcev.cpp
+++ b/test-suite/fdcev.cpp
@@ -214,7 +214,7 @@ void FdCevTest::testFdmCevOp() {
 
 
 test_suite* FdCevTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Finite Difference CEV tests");
+    auto* suite = BOOST_TEST_SUITE("Finite Difference CEV tests");
 
 
     suite->add(QUANTLIB_TEST_CASE(&FdCevTest::testLocalMartingale));

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -113,7 +113,7 @@ void FdCIRTest::testFdmCIRConvergence() {
 }
 
 test_suite* FdCIRTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Finite Difference CIR tests");
+    auto* suite = BOOST_TEST_SUITE("Finite Difference CIR tests");
 
     suite->add(QUANTLIB_TEST_CASE(&FdCIRTest::testFdmCIRConvergence));
 

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -1005,7 +1005,7 @@ void FdHestonTest::testSpuriousOscillations() {
 }
 
 test_suite* FdHestonTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Finite Difference Heston tests");
+    auto* suite = BOOST_TEST_SUITE("Finite Difference Heston tests");
 
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonVarianceMesher));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBarrier));

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -103,8 +103,7 @@ namespace {
         }
 
         void applyTo(Array& a, Time t) const override {
-            std::vector<Time>::const_iterator iter
-                = std::find(exerciseTimes_.begin(), exerciseTimes_.end(), t);
+            auto iter = std::find(exerciseTimes_.begin(), exerciseTimes_.end(), t);
 
             if (iter != exerciseTimes_.end()) {
                 Size index = std::distance(exerciseTimes_.begin(), iter);
@@ -1753,7 +1752,7 @@ void FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher() 
 }
 
 test_suite* FdmLinearOpTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("linear operator tests");
+    auto* suite = BOOST_TEST_SUITE("linear operator tests");
 
     suite->add(
         QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmLinearOpLayout));

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -531,7 +531,7 @@ void FdSabrTest::testBenchOpSabrCase() {
 }
 
 test_suite* FdSabrTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Finite Difference SABR tests");
+    auto* suite = BOOST_TEST_SUITE("Finite Difference SABR tests");
 
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrOp));
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrCevPricing));

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -199,7 +199,7 @@ void FittedBondDiscountCurveTest::testFlatExtrapolation() {
 
 
 test_suite* FittedBondDiscountCurveTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Fitted bond discount curve tests");
+    auto* suite = BOOST_TEST_SUITE("Fitted bond discount curve tests");
     suite->add(QUANTLIB_TEST_CASE(&FittedBondDiscountCurveTest::testEvaluation));
     suite->add(QUANTLIB_TEST_CASE(&FittedBondDiscountCurveTest::testFlatExtrapolation));
     return suite;

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -820,7 +820,7 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
 
 
 test_suite* ForwardOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Forward option tests");
+    auto* suite = BOOST_TEST_SUITE("Forward option tests");
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testGreeks));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testPerformanceValues));

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -96,7 +96,7 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
 }
 
 test_suite* ForwardRateAgreementTest::suite() {
-        test_suite* suite = BOOST_TEST_SUITE("forward rate agreement");
-        suite->add(QUANTLIB_TEST_CASE(&ForwardRateAgreementTest::testConstructionWithoutACurve));
-        return suite;
+    auto* suite = BOOST_TEST_SUITE("forward rate agreement");
+    suite->add(QUANTLIB_TEST_CASE(&ForwardRateAgreementTest::testConstructionWithoutACurve));
+    return suite;
 }

--- a/test-suite/functions.cpp
+++ b/test-suite/functions.cpp
@@ -310,7 +310,7 @@ void FunctionsTest::testWeightedModifiedBesselFunctions() {
 }
 
 test_suite* FunctionsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Factorial tests");
+    auto* suite = BOOST_TEST_SUITE("Factorial tests");
     suite->add(QUANTLIB_TEST_CASE(&FunctionsTest::testFactorial));
     suite->add(QUANTLIB_TEST_CASE(&FunctionsTest::testGammaFunction));
     suite->add(QUANTLIB_TEST_CASE(&FunctionsTest::testGammaValues));

--- a/test-suite/garch.cpp
+++ b/test-suite/garch.cpp
@@ -189,7 +189,7 @@ void GARCHTest::testCalculation() {
 }
 
 test_suite* GARCHTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("GARCH model tests");
+    auto* suite = BOOST_TEST_SUITE("GARCH model tests");
     suite->add(QUANTLIB_TEST_CASE(&GARCHTest::testCalibration));
     suite->add(QUANTLIB_TEST_CASE(&GARCHTest::testCalculation));
     return suite;

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -351,7 +351,7 @@ void GaussianQuadraturesTest::testGaussLaguerreCosinePolynomial() {
 }
 
 test_suite* GaussianQuadraturesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Gaussian quadratures tests");
+    auto* suite = BOOST_TEST_SUITE("Gaussian quadratures tests");
     suite->add(QUANTLIB_TEST_CASE(&GaussianQuadraturesTest::testJacobi));
     suite->add(QUANTLIB_TEST_CASE(&GaussianQuadraturesTest::testLaguerre));
     suite->add(QUANTLIB_TEST_CASE(&GaussianQuadraturesTest::testHermite));
@@ -366,8 +366,7 @@ test_suite* GaussianQuadraturesTest::suite() {
 }
 
 test_suite* GaussianQuadraturesTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE(
-        "Gaussian quadratures experimental tests");
+    auto* suite = BOOST_TEST_SUITE("Gaussian quadratures experimental tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &GaussianQuadraturesTest::testNonCentralChiSquared));

--- a/test-suite/gjrgarchmodel.cpp
+++ b/test-suite/gjrgarchmodel.cpp
@@ -304,7 +304,7 @@ void GJRGARCHModelTest::testDAXCalibration() {
 }
 
 test_suite* GJRGARCHModelTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("GJR-GARCH model tests");
+    auto* suite = BOOST_TEST_SUITE("GJR-GARCH model tests");
 
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&GJRGARCHModelTest::testDAXCalibration));

--- a/test-suite/gsr.cpp
+++ b/test-suite/gsr.cpp
@@ -286,7 +286,7 @@ void GsrTest::testGsrModel() {
 }
 
 test_suite *GsrTest::suite() {
-    test_suite *suite = BOOST_TEST_SUITE("GSR model tests");
+    auto* suite = BOOST_TEST_SUITE("GSR model tests");
     suite->add(QUANTLIB_TEST_CASE(&GsrTest::testGsrProcess));
     suite->add(QUANTLIB_TEST_CASE(&GsrTest::testGsrModel));
     return suite;

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3265,7 +3265,7 @@ void HestonModelTest::testAsymptoticControlVariate() {
 
 
 test_suite* HestonModelTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Heston model tests");
+    auto* suite = BOOST_TEST_SUITE("Heston model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testBlackCalibration));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDAXCalibration));
@@ -3328,7 +3328,7 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
 }
 
 test_suite* HestonModelTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Heston model experimental tests");
+    auto* suite = BOOST_TEST_SUITE("Heston model experimental tests");
     suite->add(QUANTLIB_TEST_CASE(
         &HestonModelTest::testAnalyticPDFHestonEngine));
     return suite;

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -1608,8 +1608,7 @@ void HestonSLVModelTest::testLocalVolsvSLVPropDensity() {
     const SquareRootProcessRNDCalculator squareRootRndCalculator(
         v0, kappa, theta, sigma);
 
-    for (std::list<HestonSLVFDMModel::LogEntry>::const_iterator iter
-             = logEntries.begin(); iter != logEntries.end(); ++iter) {
+    for (auto iter = logEntries.begin(); iter != logEntries.end(); ++iter) {
 
         const Time t = iter->t;
         if (t > 0.2) {
@@ -2609,8 +2608,7 @@ void HestonSLVModelTest::testDiffusionAndDriftSlvProcess() {
 }
 
 test_suite* HestonSLVModelTest::experimental(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE(
-        "Heston Stochastic Local Volatility tests");
+    auto* suite = BOOST_TEST_SUITE("Heston Stochastic Local Volatility tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation));

--- a/test-suite/himalayaoption.cpp
+++ b/test-suite/himalayaoption.cpp
@@ -127,7 +127,7 @@ void HimalayaOptionTest::testCached() {
 
 
 test_suite* HimalayaOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Himalaya-option tests");
+    auto* suite = BOOST_TEST_SUITE("Himalaya-option tests");
     suite->add(QUANTLIB_TEST_CASE(&HimalayaOptionTest::testCached));
     return suite;
 }

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -1507,7 +1507,7 @@ void HybridHestonHullWhiteProcessTest::testH1HWPricingEngine() {
 }
 
 test_suite* HybridHestonHullWhiteProcessTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Hybrid Heston-HullWhite tests");
+    auto* suite = BOOST_TEST_SUITE("Hybrid Heston-HullWhite tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &HybridHestonHullWhiteProcessTest::testBsmHullWhiteEngine));

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -109,7 +109,7 @@ void IndexTest::testFixingHasHistoricalFixing() {
 
 
 test_suite* IndexTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("index tests");
+    auto* suite = BOOST_TEST_SUITE("index tests");
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingObservability));
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingHasHistoricalFixing));
     return suite;

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -1038,7 +1038,7 @@ void InflationTest::testPeriod() {
 
 test_suite* InflationTest::suite() {
 
-    test_suite* suite = BOOST_TEST_SUITE("Inflation tests");
+    auto* suite = BOOST_TEST_SUITE("Inflation tests");
 
     suite->add(QUANTLIB_TEST_CASE(&InflationTest::testPeriod));
 

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -560,7 +560,7 @@ void InflationCapFloorTest::testCachedValue() {
 
 
 test_suite* InflationCapFloorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Inflation (year-on-year) Cap and floor tests");
+    auto* suite = BOOST_TEST_SUITE("Inflation (year-on-year) Cap and floor tests");
     suite->add(QUANTLIB_TEST_CASE(&InflationCapFloorTest::testConsistency));
     suite->add(QUANTLIB_TEST_CASE(&InflationCapFloorTest::testParity));
     suite->add(QUANTLIB_TEST_CASE(&InflationCapFloorTest::testCachedValue));

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -395,9 +395,9 @@ void InflationCapFlooredCouponTest::testDecomposition() {
     std::vector<Rate> floors(vars.length,floorstrike);
     std::vector<Rate> floors0 = std::vector<Rate>();
     Rate gearing_p = Rate(0.5);
-    Spread spread_p = Spread(0.002);
+    auto spread_p = Spread(0.002);
     Rate gearing_n = Rate(-1.5);
-    Spread spread_n = Spread(0.12);
+    auto spread_n = Spread(0.12);
     // fixed leg with zero rate
     Leg fixedLeg  =
     vars.makeFixedLeg(vars.startDate,vars.length);
@@ -809,7 +809,7 @@ void InflationCapFlooredCouponTest::testInstrumentEquality() {
 
 
 test_suite* InflationCapFlooredCouponTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("YoY inflation capped and floored coupon tests");
+    auto* suite = BOOST_TEST_SUITE("YoY inflation capped and floored coupon tests");
     suite->add(QUANTLIB_TEST_CASE(&InflationCapFlooredCouponTest::testDecomposition));
     suite->add(QUANTLIB_TEST_CASE(&InflationCapFlooredCouponTest::testInstrumentEquality));
     return suite;

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -228,7 +228,7 @@ void InflationCPIBondTest::testCleanPrice() {
 
 
 test_suite* InflationCPIBondTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("CPI bond tests");
+    auto* suite = BOOST_TEST_SUITE("CPI bond tests");
 
     suite->add(QUANTLIB_TEST_CASE(&InflationCPIBondTest::testCleanPrice));
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -461,7 +461,7 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
 
 
 test_suite* InflationCPICapFloorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("CPIswaption tests");
+    auto* suite = BOOST_TEST_SUITE("CPIswaption tests");
 
     suite->add(QUANTLIB_TEST_CASE(&InflationCPICapFloorTest::cpicapfloorpricesurface));
     suite->add(QUANTLIB_TEST_CASE(&InflationCPICapFloorTest::cpicapfloorpricer));

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -543,7 +543,7 @@ void CPISwapTest::cpibondconsistency() {
 
 
 test_suite* CPISwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("CPISwap tests");
+    auto* suite = BOOST_TEST_SUITE("CPISwap tests");
 
     suite->add(QUANTLIB_TEST_CASE(&CPISwapTest::consistency));
     suite->add(QUANTLIB_TEST_CASE(&CPISwapTest::zciisconsistency));

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -417,8 +417,7 @@ void InflationVolTest::testYoYPriceSurfaceToATM() {
 
 
 boost::unit_test_framework::test_suite* InflationVolTest::suite() {
-    boost::unit_test_framework::test_suite* suite
-        = BOOST_TEST_SUITE("yoyOptionletStripper (yoy inflation vol) tests");
+    auto* suite = BOOST_TEST_SUITE("yoyOptionletStripper (yoy inflation vol) tests");
 
     suite->add(QUANTLIB_TEST_CASE(&InflationVolTest::testYoYPriceSurfaceToATM));
     suite->add(QUANTLIB_TEST_CASE(&InflationVolTest::testYoYPriceSurfaceToVol));

--- a/test-suite/instruments.cpp
+++ b/test-suite/instruments.cpp
@@ -114,7 +114,7 @@ void InstrumentTest::testCompositeWhenShiftingDates() {
 }
 
 test_suite* InstrumentTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Instrument tests");
+    auto* suite = BOOST_TEST_SUITE("Instrument tests");
     suite->add(QUANTLIB_TEST_CASE(&InstrumentTest::testObservable));
     suite->add(QUANTLIB_TEST_CASE(
                             &InstrumentTest::testCompositeWhenShiftingDates));

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -568,7 +568,7 @@ void IntegralTest::testRealSiCiIntegrals() {
 }
 
 test_suite* IntegralTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Integration tests");
+    auto* suite = BOOST_TEST_SUITE("Integration tests");
     suite->add(QUANTLIB_TEST_CASE(&IntegralTest::testSegment));
     suite->add(QUANTLIB_TEST_CASE(&IntegralTest::testTrapezoid));
     suite->add(QUANTLIB_TEST_CASE(&IntegralTest::testMidPointTrapezoid));

--- a/test-suite/interestrates.cpp
+++ b/test-suite/interestrates.cpp
@@ -201,7 +201,7 @@ void InterestRateTest::testConversions() {
 }
 
 test_suite* InterestRateTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Interest Rate tests");
+    auto* suite = BOOST_TEST_SUITE("Interest Rate tests");
     suite->add(QUANTLIB_TEST_CASE(&InterestRateTest::testConversions));
     return suite;
 }

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2447,7 +2447,7 @@ void InterpolationTest::testBackwardFlatOnSinglePoint() {
 }
 
 test_suite* InterpolationTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Interpolation tests");
+    auto* suite = BOOST_TEST_SUITE("Interpolation tests");
 
     suite->add(QUANTLIB_TEST_CASE(
                         &InterpolationTest::testSplineOnGenericValues));

--- a/test-suite/jumpdiffusion.cpp
+++ b/test-suite/jumpdiffusion.cpp
@@ -529,7 +529,7 @@ void JumpDiffusionTest::testGreeks() {
 
 
 test_suite* JumpDiffusionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Jump-diffusion tests");
+    auto* suite = BOOST_TEST_SUITE("Jump-diffusion tests");
     suite->add(QUANTLIB_TEST_CASE(&JumpDiffusionTest::testMerton76));
     suite->add(QUANTLIB_TEST_CASE(&JumpDiffusionTest::testGreeks));
     return suite;

--- a/test-suite/lazyobject.cpp
+++ b/test-suite/lazyobject.cpp
@@ -81,7 +81,7 @@ void LazyObjectTest::testForwardingNotifications() {
 
 
 test_suite* LazyObjectTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("LazyObject tests");
+    auto* suite = BOOST_TEST_SUITE("LazyObject tests");
     suite->add(
         QUANTLIB_TEST_CASE(&LazyObjectTest::testDiscardingNotifications));
     suite->add(

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -497,7 +497,7 @@ void LiborMarketModelTest::testSwaptionPricing() {
 
 
 test_suite* LiborMarketModelTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Libor market model tests");
+    auto* suite = BOOST_TEST_SUITE("Libor market model tests");
 
     suite->add(QUANTLIB_TEST_CASE(
                           &LiborMarketModelTest::testSimpleCovarianceModels));

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -337,7 +337,7 @@ void LiborMarketModelProcessTest::testMonteCarloCapletPricing() {
 }
 
 test_suite* LiborMarketModelProcessTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Libor market model process tests");
+    auto* suite = BOOST_TEST_SUITE("Libor market model process tests");
 
     suite->add(QUANTLIB_TEST_CASE(
          &LiborMarketModelProcessTest::testInitialisation));

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -261,8 +261,7 @@ void LinearLeastSquaresRegressionTest::test1dLinearRegression() {
 
 
 test_suite* LinearLeastSquaresRegressionTest::suite() {
-    test_suite* suite =
-        BOOST_TEST_SUITE("linear least squares regression tests");
+    auto* suite = BOOST_TEST_SUITE("linear least squares regression tests");
     suite->add(QUANTLIB_TEST_CASE(
         &LinearLeastSquaresRegressionTest::testRegression));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/lookbackoptions.cpp
+++ b/test-suite/lookbackoptions.cpp
@@ -680,7 +680,7 @@ void LookbackOptionTest::testMonteCarloLookback() {
 
 
 test_suite* LookbackOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Lookback option tests");
+    auto* suite = BOOST_TEST_SUITE("Lookback option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
                 &LookbackOptionTest::testAnalyticContinuousFloatingLookback));

--- a/test-suite/lowdiscrepancysequences.cpp
+++ b/test-suite/lowdiscrepancysequences.cpp
@@ -1093,7 +1093,7 @@ void LowDiscrepancyTest::testSobolSkipping() {
 
 
 test_suite* LowDiscrepancyTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Low-discrepancy sequence tests");
+    auto* suite = BOOST_TEST_SUITE("Low-discrepancy sequence tests");
 
     suite->add(QUANTLIB_TEST_CASE(
            &LowDiscrepancyTest::testRandomizedLattices));

--- a/test-suite/margrabeoption.cpp
+++ b/test-suite/margrabeoption.cpp
@@ -599,7 +599,7 @@ void MargrabeOptionTest::testAmericanExchangeTwoAssets() {
 }
 
 test_suite* MargrabeOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Exchange option tests");
+    auto* suite = BOOST_TEST_SUITE("Exchange option tests");
     suite->add(
         QUANTLIB_TEST_CASE(&MargrabeOptionTest::testEuroExchangeTwoAssets));
     suite->add(

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -4898,7 +4898,7 @@ void MarketModelTest::testCovariance() {
 
 // --- Call the desired tests
 test_suite* MarketModelTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Market-model tests");
+    auto* suite = BOOST_TEST_SUITE("Market-model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testInverseFloater));
 

--- a/test-suite/marketmodel_cms.cpp
+++ b/test-suite/marketmodel_cms.cpp
@@ -529,7 +529,7 @@ void MarketModelCmsTest::testMultiStepCmSwapsAndSwaptions() {
 
 // --- Call the desired tests
 test_suite* MarketModelCmsTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("CMS Market-model tests");
+    auto* suite = BOOST_TEST_SUITE("CMS Market-model tests");
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/marketmodel_smm.cpp
+++ b/test-suite/marketmodel_smm.cpp
@@ -511,7 +511,7 @@ void MarketModelSmmTest::testMultiStepCoterminalSwapsAndSwaptions() {
 
 // --- Call the desired tests
 test_suite* MarketModelSmmTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("SMM Market-model tests");
+    auto* suite = BOOST_TEST_SUITE("SMM Market-model tests");
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/marketmodel_smmcapletalphacalibration.cpp
+++ b/test-suite/marketmodel_smmcapletalphacalibration.cpp
@@ -350,8 +350,8 @@ void MarketModelSmmCapletAlphaCalibrationTest::testFunction() {
 
 // --- Call the desired tests
 test_suite* MarketModelSmmCapletAlphaCalibrationTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("SMM Caplet alpha calibration test");
-    #if !defined(QL_NO_UBLAS_SUPPORT)
+    auto* suite = BOOST_TEST_SUITE("SMM Caplet alpha calibration test");
+#if !defined(QL_NO_UBLAS_SUPPORT)
     suite->add(QUANTLIB_TEST_CASE(
                     &MarketModelSmmCapletAlphaCalibrationTest::testFunction));
     #endif

--- a/test-suite/marketmodel_smmcapletcalibration.cpp
+++ b/test-suite/marketmodel_smmcapletcalibration.cpp
@@ -342,8 +342,8 @@ void MarketModelSmmCapletCalibrationTest::testFunction() {
 
 // --- Call the desired tests
 test_suite* MarketModelSmmCapletCalibrationTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("SMM Caplet calibration test");
-    #if !defined(QL_NO_UBLAS_SUPPORT)
+    auto* suite = BOOST_TEST_SUITE("SMM Caplet calibration test");
+#if !defined(QL_NO_UBLAS_SUPPORT)
     suite->add(QUANTLIB_TEST_CASE(
                          &MarketModelSmmCapletCalibrationTest::testFunction));
     #endif

--- a/test-suite/marketmodel_smmcaplethomocalibration.cpp
+++ b/test-suite/marketmodel_smmcaplethomocalibration.cpp
@@ -633,9 +633,9 @@ void MarketModelSmmCapletHomoCalibrationTest::testSphereCylinder() {
 
 // --- Call the desired tests
 test_suite* MarketModelSmmCapletHomoCalibrationTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("SMM Caplet homogeneous calibration test");
+    auto* suite = BOOST_TEST_SUITE("SMM Caplet homogeneous calibration test");
 
-    #if !defined(QL_NO_UBLAS_SUPPORT)
+#if !defined(QL_NO_UBLAS_SUPPORT)
     suite->add(QUANTLIB_TEST_CASE(
                      &MarketModelSmmCapletHomoCalibrationTest::testFunction));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1751,7 +1751,7 @@ void MarkovFunctionalTest::testBermudanSwaption() {
 }
 
 test_suite *MarkovFunctionalTest::suite(SpeedLevel speed) {
-    test_suite *suite = BOOST_TEST_SUITE("Markov functional model tests");
+    auto* suite = BOOST_TEST_SUITE("Markov functional model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testMfStateProcess));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -756,7 +756,7 @@ void MatricesTest::testInitializers() {
 }
 
 test_suite* MatricesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Matrix tests");
+    auto* suite = BOOST_TEST_SUITE("Matrix tests");
 
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testOrthogonalProjection));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testEigenvectors));

--- a/test-suite/mclongstaffschwartzengine.cpp
+++ b/test-suite/mclongstaffschwartzengine.cpp
@@ -314,7 +314,7 @@ void MCLongstaffSchwartzEngineTest::testAmericanMaxOption() {
 }
 
 test_suite* MCLongstaffSchwartzEngineTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Longstaff Schwartz MC engine tests");
+    auto* suite = BOOST_TEST_SUITE("Longstaff Schwartz MC engine tests");
     // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(
          &MCLongstaffSchwartzEngineTest::testAmericanOption));

--- a/test-suite/mersennetwister.cpp
+++ b/test-suite/mersennetwister.cpp
@@ -483,7 +483,7 @@ void MersenneTwisterTest::testValues() {
 
 
 test_suite* MersenneTwisterTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Mersenne twister tests");
+    auto* suite = BOOST_TEST_SUITE("Mersenne twister tests");
     suite->add(QUANTLIB_TEST_CASE(&MersenneTwisterTest::testValues));
     return suite;
 }

--- a/test-suite/money.cpp
+++ b/test-suite/money.cpp
@@ -123,7 +123,7 @@ void MoneyTest::testAutomated() {
 }
 
 test_suite* MoneyTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Money tests");
+    auto* suite = BOOST_TEST_SUITE("Money tests");
     suite->add(QUANTLIB_TEST_CASE(&MoneyTest::testNone));
     suite->add(QUANTLIB_TEST_CASE(&MoneyTest::testBaseCurrency));
     suite->add(QUANTLIB_TEST_CASE(&MoneyTest::testAutomated));

--- a/test-suite/noarbsabr.cpp
+++ b/test-suite/noarbsabr.cpp
@@ -122,7 +122,7 @@ void NoArbSabrTest::testConsistencyWithHagan() {
 
 
 test_suite* NoArbSabrTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("NoArbSabrModel tests");
+    auto* suite = BOOST_TEST_SUITE("NoArbSabrModel tests");
     suite->add(QUANTLIB_TEST_CASE(&NoArbSabrTest::testAbsorptionMatrix));
     suite->add(QUANTLIB_TEST_CASE(&NoArbSabrTest::testConsistencyWithHagan));
     return suite;

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -551,7 +551,7 @@ void NormalCLVModelTest::testMoustacheGraph() {
 }
 
 test_suite* NormalCLVModelTest::experimental(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("NormalCLVModel tests");
+    auto* suite = BOOST_TEST_SUITE("NormalCLVModel tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &NormalCLVModelTest::testBSCumlativeDistributionFunction));

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -697,7 +697,7 @@ void NthOrderDerivativeOpTest::testHigerOrderAndRichardsonExtrapolationg() {
 #endif
 
 test_suite* NthOrderDerivativeOpTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("NthOrderDerivativeOp tests");
+    auto* suite = BOOST_TEST_SUITE("NthOrderDerivativeOp tests");
 
 #ifndef QL_NO_UBLAS_SUPPORT
 

--- a/test-suite/nthtodefault.cpp
+++ b/test-suite/nthtodefault.cpp
@@ -389,8 +389,8 @@ void NthToDefaultTest::testStudent() {
 }
 
 test_suite* NthToDefaultTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Nth-to-default tests");
-    #ifndef QL_PATCH_SOLARIS
+    auto* suite = BOOST_TEST_SUITE("Nth-to-default tests");
+#ifndef QL_PATCH_SOLARIS
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&NthToDefaultTest::testGauss));
         suite->add(QUANTLIB_TEST_CASE(&NthToDefaultTest::testStudent));

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -318,7 +318,7 @@ void NumericalDifferentiationTest::testCoefficientBasedOnVandermonde() {
 
 
 test_suite* NumericalDifferentiationTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("NumericalDifferentiation tests");
+    auto* suite = BOOST_TEST_SUITE("NumericalDifferentiation tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &NumericalDifferentiationTest::testTabulatedCentralScheme));

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -323,7 +323,7 @@ void ObservableTest::testEmptyObserverList() {
 }
 
 test_suite* ObservableTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Observer tests");
+    auto* suite = BOOST_TEST_SUITE("Observer tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ObservableTest::testObservableSettings));
 

--- a/test-suite/ode.cpp
+++ b/test-suite/ode.cpp
@@ -213,7 +213,7 @@ void OdeTest::testMatrixExponentialOfZero() {
 }
 
 test_suite* OdeTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("ode tests");
+    auto* suite = BOOST_TEST_SUITE("ode tests");
     suite->add(QUANTLIB_TEST_CASE(&OdeTest::testAdaptiveRungeKutta));
     suite->add(QUANTLIB_TEST_CASE(&OdeTest::testMatrixExponential));
     suite->add(QUANTLIB_TEST_CASE(&OdeTest::testMatrixExponentialOfZero));

--- a/test-suite/operators.cpp
+++ b/test-suite/operators.cpp
@@ -227,7 +227,7 @@ void OperatorTest::testBSMOperatorConsistency() {
 
 
 test_suite* OperatorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Operator tests");
+    auto* suite = BOOST_TEST_SUITE("Operator tests");
     suite->add(QUANTLIB_TEST_CASE(&OperatorTest::testTridiagonal));
     // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&OperatorTest::testConsistency));

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -551,7 +551,7 @@ void OptimizersTest::testDifferentialEvolution() {
 }
 
 test_suite* OptimizersTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Optimizers tests");
+    auto* suite = BOOST_TEST_SUITE("Optimizers tests");
 
     suite->add(QUANTLIB_TEST_CASE(&OptimizersTest::test));
     suite->add(QUANTLIB_TEST_CASE(&OptimizersTest::nestedOptimizationTest));

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -104,8 +104,7 @@ struct CommonVars {
                 43956, 44321, 44686, 45051, 45418, 45782, 46147, 46512, 47609,
                 49436, 51263, 53087, 56739, 60392;
 
-            for (std::vector< int >::iterator it = datesTmp.begin();
-                 it != datesTmp.end(); ++it)
+            for (auto it = datesTmp.begin(); it != datesTmp.end(); ++it)
                 dates.push_back(Date(*it));
 
             rates += -0.00292, -0.00292, -0.001441, -0.00117, -0.001204,
@@ -130,8 +129,7 @@ struct CommonVars {
                 49800, 50165, 50530, 50895, 51263, 51627, 51991, 52356, 52722,
                 53087, 54913, 56739, 60392, 64045;
 
-            for (std::vector< int >::iterator it = datesTmp.begin();
-                 it != datesTmp.end(); ++it)
+            for (auto it = datesTmp.begin(); it != datesTmp.end(); ++it)
                 dates.push_back(Date(*it));
 
             rates += 0.000649, 0.000649, 0.000684, 0.000717, 0.000745, 0.000872,
@@ -828,7 +826,7 @@ void OptionletStripperTest::testSwitchStrike() {
 }
 
 test_suite* OptionletStripperTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("OptionletStripper Tests");
+    auto* suite = BOOST_TEST_SUITE("OptionletStripper Tests");
     suite->add(QUANTLIB_TEST_CASE(
                    &OptionletStripperTest::testFlatTermVolatilityStripping1));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -504,7 +504,7 @@ void OvernightIndexedSwapTest::testBootstrapRegression() {
 
 
 test_suite* OvernightIndexedSwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Overnight-indexed swap tests");
+    auto* suite = BOOST_TEST_SUITE("Overnight-indexed swap tests");
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testFairRate));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testFairSpread));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testCachedValue));

--- a/test-suite/pagodaoption.cpp
+++ b/test-suite/pagodaoption.cpp
@@ -127,7 +127,7 @@ void PagodaOptionTest::testCached() {
 
 
 test_suite* PagodaOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Pagoda-option tests");
+    auto* suite = BOOST_TEST_SUITE("Pagoda-option tests");
     suite->add(QUANTLIB_TEST_CASE(&PagodaOptionTest::testCached));
     return suite;
 }

--- a/test-suite/partialtimebarrieroption.cpp
+++ b/test-suite/partialtimebarrieroption.cpp
@@ -127,7 +127,7 @@ void PartialTimeBarrierOptionTest::testAnalyticEngine() {
 
 
 test_suite* PartialTimeBarrierOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Partial-time barrier option tests");
+    auto* suite = BOOST_TEST_SUITE("Partial-time barrier option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
                           &PartialTimeBarrierOptionTest::testAnalyticEngine));

--- a/test-suite/pathgenerator.cpp
+++ b/test-suite/pathgenerator.cpp
@@ -291,7 +291,7 @@ void PathGeneratorTest::testMultiPathGenerator() {
 
 
 test_suite* PathGeneratorTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Path generation tests");
+    auto* suite = BOOST_TEST_SUITE("Path generation tests");
     suite->add(QUANTLIB_TEST_CASE(&PathGeneratorTest::testPathGenerator));
     // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&PathGeneratorTest::testMultiPathGenerator));

--- a/test-suite/period.cpp
+++ b/test-suite/period.cpp
@@ -121,7 +121,7 @@ void PeriodTest::testWeeksDaysAlgebra() {
 }
 
 test_suite* PeriodTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Period tests");
+    auto* suite = BOOST_TEST_SUITE("Period tests");
     suite->add(QUANTLIB_TEST_CASE(&PeriodTest::testYearsMonthsAlgebra));
     suite->add(QUANTLIB_TEST_CASE(&PeriodTest::testWeeksDaysAlgebra));
     return suite;

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1508,7 +1508,7 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
 
 test_suite* PiecewiseYieldCurveTest::suite() {
 
-    test_suite* suite = BOOST_TEST_SUITE("Piecewise yield curve tests");
+    auto* suite = BOOST_TEST_SUITE("Piecewise yield curve tests");
 
     // unstable
     //suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/piecewisezerospreadedtermstructure.cpp
+++ b/test-suite/piecewisezerospreadedtermstructure.cpp
@@ -522,7 +522,7 @@ void PiecewiseZeroSpreadedTermStructureTest::testQuoteChanging() {
 }
 
 test_suite* PiecewiseZeroSpreadedTermStructureTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Interpolated piecewise zero spreaded yield curve tests");
+    auto* suite = BOOST_TEST_SUITE("Interpolated piecewise zero spreaded yield curve tests");
     suite->add(QUANTLIB_TEST_CASE(
         &PiecewiseZeroSpreadedTermStructureTest::testFlatInterpolationLeft));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/quantlibbenchmark.cpp
+++ b/test-suite/quantlibbenchmark.cpp
@@ -329,7 +329,7 @@ test_suite* init_unit_test_suite(int, char*[]) {
     bm.push_back(Benchmark("ShortRateModel::Swaps",
         &ShortRateModelTest::testSwaps, 454.73));
 
-    test_suite* test = BOOST_TEST_SUITE("QuantLib benchmark suite");
+    auto* test = BOOST_TEST_SUITE("QuantLib benchmark suite");
 
     for (std::list<Benchmark>::const_iterator iter = bm.begin();
          iter != bm.end(); ++iter) {

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -366,7 +366,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     BOOST_TEST_MESSAGE(rule);
     BOOST_TEST_MESSAGE(header.str());
     BOOST_TEST_MESSAGE(rule);
-    test_suite* test = BOOST_TEST_SUITE("QuantLib test suite");
+    auto* test = BOOST_TEST_SUITE("QuantLib test suite");
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
 

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -1400,7 +1400,7 @@ void QuantoOptionTest::testAmericanQuantoOption()  {
 }
 
 test_suite* QuantoOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Quanto option tests");
+    auto* suite = BOOST_TEST_SUITE("Quanto option tests");
     suite->add(QUANTLIB_TEST_CASE(&QuantoOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&QuantoOptionTest::testGreeks));
     suite->add(QUANTLIB_TEST_CASE(&QuantoOptionTest::testForwardValues));
@@ -1416,7 +1416,7 @@ test_suite* QuantoOptionTest::suite() {
 }
 
 test_suite* QuantoOptionTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("Experimental quanto option tests");
+    auto* suite = BOOST_TEST_SUITE("Experimental quanto option tests");
     suite->add(QUANTLIB_TEST_CASE(&QuantoOptionTest::testDoubleBarrierValues));
     return suite;
 }

--- a/test-suite/quotes.cpp
+++ b/test-suite/quotes.cpp
@@ -199,7 +199,7 @@ void QuoteTest::testForwardValueQuoteAndImpliedStdevQuote(){
 
 
 test_suite* QuoteTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Quote tests");
+    auto* suite = BOOST_TEST_SUITE("Quote tests");
     suite->add(QUANTLIB_TEST_CASE(&QuoteTest::testObservable));
     suite->add(QUANTLIB_TEST_CASE(&QuoteTest::testObservableHandle));
     suite->add(QUANTLIB_TEST_CASE(&QuoteTest::testDerived));

--- a/test-suite/rangeaccrual.cpp
+++ b/test-suite/rangeaccrual.cpp
@@ -807,7 +807,7 @@ void RangeAccrualTest::testPriceMonotonicityWithRespectToUpperStrike() {
 
 
 test_suite* RangeAccrualTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Range Accrual tests");
+    auto* suite = BOOST_TEST_SUITE("Range Accrual tests");
     suite->add(QUANTLIB_TEST_CASE(&RangeAccrualTest::testInfiniteRange));
     suite->add(QUANTLIB_TEST_CASE(
            &RangeAccrualTest::testPriceMonotonicityWithRespectToLowerStrike));

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -805,7 +805,7 @@ void RiskNeutralDensityCalculatorTest::testCEVCDF() {
 }
 
 test_suite* RiskNeutralDensityCalculatorTest::experimental(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Risk neutral density calculator tests");
+    auto* suite = BOOST_TEST_SUITE("Risk neutral density calculator tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &RiskNeutralDensityCalculatorTest::testDensityAgainstOptionPrices));

--- a/test-suite/riskstats.cpp
+++ b/test-suite/riskstats.cpp
@@ -608,7 +608,7 @@ void RiskStatisticsTest::testResults() {
 
 
 test_suite* RiskStatisticsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Risk statistics tests");
+    auto* suite = BOOST_TEST_SUITE("Risk statistics tests");
     suite->add(QUANTLIB_TEST_CASE(&RiskStatisticsTest::testResults));
     return suite;
 }

--- a/test-suite/rngtraits.cpp
+++ b/test-suite/rngtraits.cpp
@@ -93,7 +93,7 @@ void RngTraitsTest::testCustomPoisson() {
 
 
 test_suite* RngTraitsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("RNG traits tests");
+    auto* suite = BOOST_TEST_SUITE("RNG traits tests");
     suite->add(QUANTLIB_TEST_CASE(&RngTraitsTest::testGaussian));
     suite->add(QUANTLIB_TEST_CASE(&RngTraitsTest::testDefaultPoisson));
     suite->add(QUANTLIB_TEST_CASE(&RngTraitsTest::testCustomPoisson));

--- a/test-suite/rounding.cpp
+++ b/test-suite/rounding.cpp
@@ -166,7 +166,7 @@ void RoundingTest::testCeiling() {
 
 
 test_suite* RoundingTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Rounding tests");
+    auto* suite = BOOST_TEST_SUITE("Rounding tests");
     suite->add(QUANTLIB_TEST_CASE(&RoundingTest::testClosest));
     suite->add(QUANTLIB_TEST_CASE(&RoundingTest::testUp));
     suite->add(QUANTLIB_TEST_CASE(&RoundingTest::testDown));

--- a/test-suite/sampledcurve.cpp
+++ b/test-suite/sampledcurve.cpp
@@ -83,7 +83,7 @@ void SampledCurveTest::testConstruction() {
 }
 
 test_suite* SampledCurveTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("sampled curve tests");
+    auto* suite = BOOST_TEST_SUITE("sampled curve tests");
     suite->add(QUANTLIB_TEST_CASE(&SampledCurveTest::testConstruction));
     return suite;
 }

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -1072,7 +1072,7 @@ void ScheduleTest::testTruncation() {
 }
 
 test_suite* ScheduleTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Schedule tests");
+    auto* suite = BOOST_TEST_SUITE("Schedule tests");
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testDailySchedule));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testEndDateWithEomAdjustment));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -471,7 +471,7 @@ void ShortRateModelTest::testExtendedCoxIngersollRossDiscountFactor() {
 }
 
 test_suite* ShortRateModelTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Short-rate model tests");
+    auto* suite = BOOST_TEST_SUITE("Short-rate model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testCachedHullWhite));
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testCachedHullWhiteFixedReversion));

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -134,7 +134,7 @@ void SofrFuturesTest::testBootstrap() {
 
 
 test_suite* SofrFuturesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("SOFR futures tests");
+    auto* suite = BOOST_TEST_SUITE("SOFR futures tests");
 
     suite->add(QUANTLIB_TEST_CASE(&SofrFuturesTest::testBootstrap));
 

--- a/test-suite/solvers.cpp
+++ b/test-suite/solvers.cpp
@@ -211,7 +211,7 @@ void Solver1DTest::testSecant() {
 
 
 test_suite* Solver1DTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("1-D solver tests");
+    auto* suite = BOOST_TEST_SUITE("1-D solver tests");
     suite->add(QUANTLIB_TEST_CASE(&Solver1DTest::testBrent));
     suite->add(QUANTLIB_TEST_CASE(&Solver1DTest::testBisection));
     suite->add(QUANTLIB_TEST_CASE(&Solver1DTest::testFalsePosition));

--- a/test-suite/spreadoption.cpp
+++ b/test-suite/spreadoption.cpp
@@ -171,7 +171,7 @@ void SpreadOptionTest::testKirkEngine() {
 }
 
 test_suite* SpreadOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Spread option tests");
+    auto* suite = BOOST_TEST_SUITE("Spread option tests");
 
     suite->add(QUANTLIB_TEST_CASE(&SpreadOptionTest::testKirkEngine));
 

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -845,7 +845,7 @@ void SquareRootCLVModelTest::testForwardSkew() {
 
  
 test_suite* SquareRootCLVModelTest::experimental() {
-    test_suite* suite = BOOST_TEST_SUITE("SquareRootCLVModel tests");
+    auto* suite = BOOST_TEST_SUITE("SquareRootCLVModel tests");
 
     suite->add(QUANTLIB_TEST_CASE(
         &SquareRootCLVModelTest::testSquareRootCLVVanillaPricing));

--- a/test-suite/stats.cpp
+++ b/test-suite/stats.cpp
@@ -390,7 +390,7 @@ void StatisticsTest::testIncrementalStatistics() {
 }
 
 test_suite* StatisticsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Statistics tests");
+    auto* suite = BOOST_TEST_SUITE("Statistics tests");
     suite->add(QUANTLIB_TEST_CASE(&StatisticsTest::testStatistics));
     suite->add(QUANTLIB_TEST_CASE(&StatisticsTest::testSequenceStatistics));
     suite->add(QUANTLIB_TEST_CASE(&StatisticsTest::testConvergenceStatistics));

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -181,9 +181,7 @@ void SwapTest::testRateDependency() {
                 swap_values.push_back(swap->NPV());
             }
             // and check that they go the right way
-            std::vector<Real>::iterator it =
-                std::adjacent_find(swap_values.begin(),swap_values.end(),
-                                   std::less<Real>());
+            auto it = std::adjacent_find(swap_values.begin(), swap_values.end(), std::less<Real>());
             if (it != swap_values.end()) {
                 Size n = it - swap_values.begin();
                 BOOST_ERROR(
@@ -220,9 +218,8 @@ void SwapTest::testSpreadDependency() {
                 swap_values.push_back(swap->NPV());
             }
             // and check that they go the right way
-            std::vector<Real>::iterator it =
-                std::adjacent_find(swap_values.begin(),swap_values.end(),
-                                   std::greater<Real>());
+            auto it =
+                std::adjacent_find(swap_values.begin(), swap_values.end(), std::greater<Real>());
             if (it != swap_values.end()) {
                 Size n = it - swap_values.begin();
                 BOOST_ERROR(
@@ -342,7 +339,7 @@ void SwapTest::testCachedValue() {
 
 
 test_suite* SwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Swap tests");
+    auto* suite = BOOST_TEST_SUITE("Swap tests");
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testFairRate));
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testFairSpread));
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testRateDependency));

--- a/test-suite/swapforwardmappings.cpp
+++ b/test-suite/swapforwardmappings.cpp
@@ -453,7 +453,7 @@ void SwapForwardMappingsTest::testSwaptionImpliedVolatility()
 
 
 test_suite* SwapForwardMappingsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("swap-forward mappings tests");
+    auto* suite = BOOST_TEST_SUITE("swap-forward mappings tests");
 
 
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -161,9 +161,7 @@ void SwaptionTest::testStrikeDependency() {
                 }
                 // and check that they go the right way
                 if (type[k]==VanillaSwap::Payer) {
-                    std::vector<Real>::iterator it =
-                        std::adjacent_find(values.begin(), values.end(),
-                                           std::less<Real>());
+                    auto it = std::adjacent_find(values.begin(), values.end(), std::less<Real>());
                     if (it != values.end()) {
                         Size n = it - values.begin();
                         BOOST_ERROR("NPV of Payer swaption with delivery settlement"
@@ -175,9 +173,8 @@ void SwaptionTest::testStrikeDependency() {
                                     "\nvalue:        " << values[n  ] <<" at strike: " << io::rate(strikes[n  ]) <<
                                     "\nvalue:        " << values[n+1] << " at strike: " << io::rate(strikes[n+1]));
                     }
-                    std::vector<Real>::iterator it_cash =
-                        std::adjacent_find(values_cash.begin(), values_cash.end(),
-                                           std::less<Real>());
+                    auto it_cash = std::adjacent_find(values_cash.begin(), values_cash.end(),
+                                                      std::less<Real>());
                     if (it_cash != values_cash.end()) {
                         Size n = it_cash - values_cash.begin();
                         BOOST_ERROR("NPV of Payer swaption with cash settlement"
@@ -190,9 +187,8 @@ void SwaptionTest::testStrikeDependency() {
                                     "\nvalue:        " << values_cash[n+1] << " at strike: " << io::rate(strikes[n+1]));
                     }
                 } else {
-                    std::vector<Real>::iterator it =
-                        std::adjacent_find(values.begin(), values.end(),
-                                           std::greater<Real>());
+                    auto it =
+                        std::adjacent_find(values.begin(), values.end(), std::greater<Real>());
                     if (it != values.end()) {
                         Size n = it - values.begin();
                         BOOST_ERROR("NPV of Receiver swaption with delivery settlement"
@@ -204,9 +200,8 @@ void SwaptionTest::testStrikeDependency() {
                                     "\nvalue:        " << values[n  ] << " at strike: " << io::rate(strikes[n  ]) <<
                                     "\nvalue:        " << values[n+1] << " at strike: " << io::rate(strikes[n+1]));
                     }
-                    std::vector<Real>::iterator it_cash =
-                        std::adjacent_find(values_cash.begin(), values_cash.end(),
-                                           std::greater<Real>());
+                    auto it_cash = std::adjacent_find(values_cash.begin(), values_cash.end(),
+                                                      std::greater<Real>());
                     if (it_cash != values_cash.end()) {
                         Size n = it_cash - values_cash.begin();
                         BOOST_ERROR("NPV of Receiver swaption with cash settlement"
@@ -264,9 +259,8 @@ void SwaptionTest::testSpreadDependency() {
                 }
                 // and check that they go the right way
                 if (type[k]==VanillaSwap::Payer) {
-                    std::vector<Real>::iterator it =
-                        std::adjacent_find(values.begin(), values.end(),
-                                           std::greater<Real>());
+                    auto it =
+                        std::adjacent_find(values.begin(), values.end(), std::greater<Real>());
                     if (it != values.end()) {
                         Size n = it - values.begin();
                         BOOST_ERROR("NPV is decreasing with the spread " <<
@@ -276,9 +270,8 @@ void SwaptionTest::testSpreadDependency() {
                             "\nvalue:         " << values[n  ] << " for spread: " << io::rate(spreads[n]) <<
                             "\nvalue:         " << values[n+1] << " for spread: " << io::rate(spreads[n+1]));
                     }
-                    std::vector<Real>::iterator it_cash =
-                        std::adjacent_find(values_cash.begin(), values_cash.end(),
-                                           std::greater<Real>());
+                    auto it_cash = std::adjacent_find(values_cash.begin(), values_cash.end(),
+                                                      std::greater<Real>());
                     if (it_cash != values_cash.end()) {
                         Size n = it_cash - values_cash.begin();
                         BOOST_ERROR("NPV is decreasing with the spread " <<
@@ -289,9 +282,7 @@ void SwaptionTest::testSpreadDependency() {
                             "\nvalue:  " << values_cash[n+1] << " for spread: " << io::rate(spreads[n+1]));
                     }
                 } else {
-                    std::vector<Real>::iterator it =
-                        std::adjacent_find(values.begin(), values.end(),
-                                           std::less<Real>());
+                    auto it = std::adjacent_find(values.begin(), values.end(), std::less<Real>());
                     if (it != values.end()) {
                         Size n = it - values.begin();
                         BOOST_ERROR("NPV is increasing with the spread " <<
@@ -301,9 +292,8 @@ void SwaptionTest::testSpreadDependency() {
                             "\nvalue:  " << values[n  ] << " for spread: " << io::rate(spreads[n]) <<
                             "\nvalue:  " << values[n+1] << " for spread: " << io::rate(spreads[n+1]));
                     }
-                    std::vector<Real>::iterator it_cash =
-                        std::adjacent_find(values_cash.begin(), values_cash.end(),
-                                           std::less<Real>());
+                    auto it_cash = std::adjacent_find(values_cash.begin(), values_cash.end(),
+                                                      std::less<Real>());
                     if (it_cash != values_cash.end()) {
                         Size n = it_cash - values_cash.begin();
                         BOOST_ERROR("NPV is increasing with the spread " <<
@@ -1073,7 +1063,7 @@ void SwaptionTest::testSwaptionDeltaInBachelierModel() {
 }
 
 test_suite* SwaptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Swaption tests");
+    auto* suite = BOOST_TEST_SUITE("Swaption tests");
     // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testCashSettledSwaptions));
     // FLOATING_POINT_EXCEPTION

--- a/test-suite/swaptionvolatilitycube.cpp
+++ b/test-suite/swaptionvolatilitycube.cpp
@@ -560,7 +560,7 @@ void SwaptionVolatilityCubeTest::testSabrParameters() {
 
 
 test_suite* SwaptionVolatilityCubeTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Swaption Volatility Cube tests");
+    auto* suite = BOOST_TEST_SUITE("Swaption Volatility Cube tests");
 
     // SwaptionVolCubeByLinear reproduces ATM vol with machine precision
     suite->add(QUANTLIB_TEST_CASE(&SwaptionVolatilityCubeTest::testAtmVols));

--- a/test-suite/swaptionvolatilitymatrix.cpp
+++ b/test-suite/swaptionvolatilitymatrix.cpp
@@ -375,7 +375,7 @@ void SwaptionVolatilityMatrixTest::testSwaptionVolMatrixCoherence() {
 }
 
 test_suite* SwaptionVolatilityMatrixTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Swaption Volatility Matrix tests");
+    auto* suite = BOOST_TEST_SUITE("Swaption Volatility Matrix tests");
 
     suite->add(QUANTLIB_TEST_CASE(
               &SwaptionVolatilityMatrixTest::testSwaptionVolMatrixCoherence));

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -165,8 +165,7 @@ void SwingOptionTest::testFdmExponentialJump1dMesher() {
     for (Real x=1e-12; x < 1.0; x*=10) {
         const Real v = mesher.jumpSizeDistribution(x);
 
-        std::vector<Real>::iterator iter
-            = std::lower_bound(path.begin(), path.end(), x);
+        auto iter = std::lower_bound(path.begin(), path.end(), x);
         const Real q = std::distance(path.begin(), iter)/Real(n);
         QL_REQUIRE(std::fabs(q - v) < relTol1
                    || ((v < threshold) && std::fabs(q-v) < relTol2),
@@ -601,7 +600,7 @@ void SwingOptionTest::testKlugeChFVanillaPricing() {
 }
 
 test_suite* SwingOptionTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("Swing-Option Test");
+    auto* suite = BOOST_TEST_SUITE("Swing-Option Test");
 
     suite->add(QUANTLIB_TEST_CASE(
         &SwingOptionTest::testExtendedOrnsteinUhlenbeckProcess));

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -482,7 +482,7 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
 }
 
 test_suite* TermStructureTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Term structure tests");
+    auto* suite = BOOST_TEST_SUITE("Term structure tests");
     suite->add(QUANTLIB_TEST_CASE(&TermStructureTest::testReferenceChange));
     suite->add(QUANTLIB_TEST_CASE(&TermStructureTest::testImplied));
     suite->add(QUANTLIB_TEST_CASE(&TermStructureTest::testImpliedObs));

--- a/test-suite/timegrid.cpp
+++ b/test-suite/timegrid.cpp
@@ -158,8 +158,8 @@ void TimeGridTest::testMandatoryTimes()
 
 test_suite* TimeGridTest::suite()
 {
-    test_suite* suite = BOOST_TEST_SUITE("Timegrid tests");
-    
+    auto* suite = BOOST_TEST_SUITE("Timegrid tests");
+
     suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorAdditionalSteps));
     suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorMandatorySteps));
     suite->add(QUANTLIB_TEST_CASE(&TimeGridTest::testConstructorEvenSteps));

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -47,7 +47,7 @@ void TimeSeriesTest::testConstruction() {
     ts[Date(29, March, 2005)] = 2.3;
     ts[Date(15, March, 2005)] = 0.3;
 
-    TimeSeries<Real>::const_iterator cur = ts.begin();
+    auto cur = ts.begin();
     if (cur->first != Date(15, March, 2005)) {
         BOOST_ERROR("date does not match");
     }
@@ -183,7 +183,7 @@ void TimeSeriesTest::testIterators() {
 }
 
 test_suite* TimeSeriesTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("time series tests");
+    auto* suite = BOOST_TEST_SUITE("time series tests");
     suite->add(QUANTLIB_TEST_CASE(&TimeSeriesTest::testConstruction));
     suite->add(QUANTLIB_TEST_CASE(&TimeSeriesTest::testIntervalPrice));
     suite->add(QUANTLIB_TEST_CASE(&TimeSeriesTest::testIterators));

--- a/test-suite/tqreigendecomposition.cpp
+++ b/test-suite/tqreigendecomposition.cpp
@@ -97,7 +97,7 @@ void TqrEigenDecompositionTest::testEigenVectorDecomposition() {
 }
 
 test_suite* TqrEigenDecompositionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("TQR eigendecomposition tests");
+    auto* suite = BOOST_TEST_SUITE("TQR eigendecomposition tests");
     suite->add(QUANTLIB_TEST_CASE(
                    &TqrEigenDecompositionTest::testEigenValueDecomposition));
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/tracing.cpp
+++ b/test-suite/tracing.cpp
@@ -82,7 +82,7 @@ void TracingTest::testOutput() {
 
 
 test_suite* TracingTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Tracing tests");
+    auto* suite = BOOST_TEST_SUITE("Tracing tests");
 
     suite->add(QUANTLIB_TEST_CASE(&TracingTest::testOutput));
     return suite;

--- a/test-suite/transformedgrid.cpp
+++ b/test-suite/transformedgrid.cpp
@@ -47,7 +47,7 @@ void TransformedGridTest::testConstruction() {
 }
 
 test_suite* TransformedGridTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("transformed grid");
+    auto* suite = BOOST_TEST_SUITE("transformed grid");
     suite->add(QUANTLIB_TEST_CASE(&TransformedGridTest::testConstruction));
     return suite;
 }

--- a/test-suite/twoassetbarrieroption.cpp
+++ b/test-suite/twoassetbarrieroption.cpp
@@ -144,7 +144,7 @@ void TwoAssetBarrierOptionTest::testHaugValues() {
 }
 
 test_suite* TwoAssetBarrierOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Two-asset barrier option tests");
+    auto* suite = BOOST_TEST_SUITE("Two-asset barrier option tests");
     suite->add(QUANTLIB_TEST_CASE(&TwoAssetBarrierOptionTest::testHaugValues));
     return suite;
 }

--- a/test-suite/twoassetcorrelationoption.cpp
+++ b/test-suite/twoassetcorrelationoption.cpp
@@ -83,7 +83,7 @@ void TwoAssetCorrelationOptionTest::testAnalyticEngine() {
 }
 
 test_suite* TwoAssetCorrelationOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Two-asset correlation option tests");
+    auto* suite = BOOST_TEST_SUITE("Two-asset correlation option tests");
 
     suite->add(QUANTLIB_TEST_CASE(
        &TwoAssetCorrelationOptionTest::testAnalyticEngine));

--- a/test-suite/ultimateforwardtermstructure.cpp
+++ b/test-suite/ultimateforwardtermstructure.cpp
@@ -324,7 +324,7 @@ void UltimateForwardTermStructureTest::testObservability() {
 }
 
 test_suite* UltimateForwardTermStructureTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("UFR term structure tests");
+    auto* suite = BOOST_TEST_SUITE("UFR term structure tests");
 
     suite->add(QUANTLIB_TEST_CASE(&UltimateForwardTermStructureTest::testDutchCentralBankRates));
     suite->add(QUANTLIB_TEST_CASE(&UltimateForwardTermStructureTest::testExtrapolatedForward));

--- a/test-suite/variancegamma.cpp
+++ b/test-suite/variancegamma.cpp
@@ -251,7 +251,7 @@ void VarianceGammaTest::testSingularityAtZero() {
 
 
 test_suite* VarianceGammaTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Variance Gamma tests");
+    auto* suite = BOOST_TEST_SUITE("Variance Gamma tests");
 
     suite->add(QUANTLIB_TEST_CASE(&VarianceGammaTest::testVarianceGamma));
     suite->add(QUANTLIB_TEST_CASE(&VarianceGammaTest::testSingularityAtZero));

--- a/test-suite/varianceoption.cpp
+++ b/test-suite/varianceoption.cpp
@@ -110,7 +110,7 @@ void VarianceOptionTest::testIntegralHeston() {
 }
 
 test_suite* VarianceOptionTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Variance option tests");
+    auto* suite = BOOST_TEST_SUITE("Variance option tests");
 
     suite->add(QUANTLIB_TEST_CASE(&VarianceOptionTest::testIntegralHeston));
     return suite;

--- a/test-suite/varianceswaps.cpp
+++ b/test-suite/varianceswaps.cpp
@@ -301,7 +301,7 @@ void VarianceSwapTest::testMCVarianceSwap() {
 }
 
 test_suite* VarianceSwapTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("Variance swap tests");
+    auto* suite = BOOST_TEST_SUITE("Variance swap tests");
 
     suite->add(QUANTLIB_TEST_CASE(
                              &VarianceSwapTest::testReplicatingVarianceSwap));

--- a/test-suite/volatilitymodels.cpp
+++ b/test-suite/volatilitymodels.cpp
@@ -46,7 +46,7 @@ void VolatilityModelsTest::testConstruction() {
 }
 
 test_suite* VolatilityModelsTest::suite() {
-    test_suite* suite = BOOST_TEST_SUITE("volatility models tests");
+    auto* suite = BOOST_TEST_SUITE("volatility models tests");
     suite->add(QUANTLIB_TEST_CASE(&VolatilityModelsTest::testConstruction));
     return suite;
 }

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -976,7 +976,7 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
 
 
 test_suite* VPPTest::suite(SpeedLevel speed) {
-    test_suite* suite = BOOST_TEST_SUITE("VPP Test");
+    auto* suite = BOOST_TEST_SUITE("VPP Test");
 
     suite->add(QUANTLIB_TEST_CASE(&VPPTest::testGemanRoncoroniProcess));
     suite->add(QUANTLIB_TEST_CASE(&VPPTest::testSimpleExtOUStorageEngine));

--- a/test-suite/zabr.cpp
+++ b/test-suite/zabr.cpp
@@ -89,7 +89,7 @@ void ZabrTest::testConsistency() {
 }
 
 test_suite *ZabrTest::suite(SpeedLevel speed) {
-    test_suite *suite = BOOST_TEST_SUITE("Zabr model tests");
+    auto* suite = BOOST_TEST_SUITE("Zabr model tests");
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&ZabrTest::testConsistency));


### PR DESCRIPTION
Added the corresponding clang-tidy check, which in turn provided the automated changes.