### PR TITLE
C++11 modernization — use `nullptr` keyword

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,modernize-use-auto,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
+Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,modernize-use-auto,modernize-use-nullptr,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -144,7 +144,8 @@ public:
     typedef ext::function<Real(const Array&)> RealFunc;
     typedef ext::function<Disposable<Array>(const Array&)> ArrayFunc;
     explicit TestFunction(const RealFunc & f, const ArrayFunc & fs = ArrayFunc()) : f_(f), fs_(fs) {}
-    explicit TestFunction(Real(*f)(const Array&), Disposable<Array>(*fs)(const Array&) = NULL) : f_(f), fs_(fs) {}
+    explicit TestFunction(Real (*f)(const Array&), Disposable<Array> (*fs)(const Array&) = nullptr)
+    : f_(f), fs_(fs) {}
     ~TestFunction() override {}
     Real value(const Array& x) const override { return f_(x); }
     Disposable<Array> values(const Array& x) const override {

--- a/ql/cashflow.cpp
+++ b/ql/cashflow.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
 
     void CashFlow::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CashFlow>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Event::accept(v);

--- a/ql/cashflows/averagebmacoupon.cpp
+++ b/ql/cashflows/averagebmacoupon.cpp
@@ -153,7 +153,7 @@ namespace QuantLib {
 
     void AverageBMACoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<AverageBMACoupon>*>(&v);
-        if (v1 != 0) {
+        if (v1 != nullptr) {
             v1->visit(*this);
         } else {
             FloatingRateCoupon::accept(v);

--- a/ql/cashflows/capflooredcoupon.cpp
+++ b/ql/cashflows/capflooredcoupon.cpp
@@ -131,7 +131,7 @@ namespace QuantLib {
     void CappedFlooredCoupon::accept(AcyclicVisitor& v) {
         typedef FloatingRateCoupon super;
         auto* v1 = dynamic_cast<Visitor<CappedFlooredCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/cashflows/capflooredcoupon.hpp
+++ b/ql/cashflows/capflooredcoupon.hpp
@@ -121,7 +121,7 @@ namespace QuantLib {
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredIborCoupon>*>(&v);
-            if (v1 != 0)
+            if (v1 != nullptr)
                 v1->visit(*this);
             else
                 CappedFlooredCoupon::accept(v);
@@ -153,7 +153,7 @@ namespace QuantLib {
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsCoupon>*>(&v);
-            if (v1 != 0)
+            if (v1 != nullptr)
                 v1->visit(*this);
             else
                 CappedFlooredCoupon::accept(v);

--- a/ql/cashflows/capflooredinflationcoupon.cpp
+++ b/ql/cashflows/capflooredinflationcoupon.cpp
@@ -80,16 +80,17 @@ namespace QuantLib {
             const ext::shared_ptr<YoYInflationCouponPricer>& pricer) {
 
         YoYInflationCoupon::setPricer(pricer);
-        if (underlying_ != 0)
+        if (underlying_ != nullptr)
             underlying_->setPricer(pricer);
     }
 
 
     Rate CappedFlooredYoYInflationCoupon::rate() const {
-        Rate swapletRate = underlying_ != 0 ? underlying_->rate() : YoYInflationCoupon::rate();
+        Rate swapletRate =
+            underlying_ != nullptr ? underlying_->rate() : YoYInflationCoupon::rate();
 
         if(isFloored_ || isCapped_) {
-            if (underlying_ != 0) {
+            if (underlying_ != nullptr) {
                 QL_REQUIRE(underlying_->pricer(), "pricer not set");
             } else {
                 QL_REQUIRE(pricer_, "pricer not set");
@@ -98,14 +99,15 @@ namespace QuantLib {
 
         Rate floorletRate = 0.;
         if(isFloored_) {
-            floorletRate = underlying_ != 0 ?
+            floorletRate = underlying_ != nullptr ?
                                underlying_->pricer()->floorletRate(effectiveFloor()) :
                                pricer()->floorletRate(effectiveFloor());
         }
         Rate capletRate = 0.;
         if(isCapped_) {
-            capletRate = underlying_ != 0 ? underlying_->pricer()->capletRate(effectiveCap()) :
-                                            pricer()->capletRate(effectiveCap());
+            capletRate = underlying_ != nullptr ?
+                             underlying_->pricer()->capletRate(effectiveCap()) :
+                             pricer()->capletRate(effectiveCap());
         }
 
         return swapletRate + floorletRate - capletRate;
@@ -149,7 +151,7 @@ namespace QuantLib {
         typedef YoYInflationCoupon super;
         auto* v1 = dynamic_cast<Visitor<CappedFlooredYoYInflationCoupon>*>(&v);
 
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         Date d = Date::maxDate();
         for (Size i=0; i<leg.size(); ++i) {
             ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(leg[i]);
-            if (c != 0)
+            if (c != nullptr)
                 d = std::min(d, c->accrualStartDate());
             else
                 d = std::min(d, leg[i]->date());
@@ -54,7 +54,7 @@ namespace QuantLib {
         Date d = Date::minDate();
         for (Size i=0; i<leg.size(); ++i) {
             ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(leg[i]);
-            if (c != 0)
+            if (c != nullptr)
                 d = std::max(d, c->accrualEndDate());
             else
                 d = std::max(d, leg[i]->date());
@@ -237,7 +237,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->nominal();
         }
         return 0.0;
@@ -252,7 +252,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accrualStartDate();
         }
         return Date();
@@ -267,7 +267,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accrualEndDate();
         }
         return Date();
@@ -282,7 +282,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->referencePeriodStart();
         }
         return Date();
@@ -297,7 +297,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->referencePeriodEnd();
         }
         return Date();
@@ -312,7 +312,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accrualPeriod();
         }
         return 0;
@@ -327,7 +327,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accrualDays();
         }
         return 0;
@@ -345,7 +345,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accruedPeriod(settlementDate);
         }
         return 0;
@@ -363,7 +363,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 return cp->accruedDays(settlementDate);
         }
         return 0;
@@ -382,7 +382,7 @@ namespace QuantLib {
         Real result = 0.0;
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != 0)
+            if (cp != nullptr)
                 result += cp->accruedAmount(settlementDate);
         }
         return result;
@@ -491,7 +491,7 @@ namespace QuantLib {
                     ext::dynamic_pointer_cast<Coupon>(leg[i]);
                 Real df = discountCurve.discount(cf.date());
                 npv += cf.amount() * df;
-                if(cp != NULL)
+                if (cp != nullptr)
                     bps += cp->nominal() * cp->accrualPeriod() * df;
             }
         }
@@ -567,7 +567,7 @@ namespace QuantLib {
             Date refStartDate, refEndDate;
             ext::shared_ptr<Coupon> coupon =
                     ext::dynamic_pointer_cast<Coupon>(cashFlow);
-            if (coupon != 0) {
+            if (coupon != nullptr) {
                 refStartDate = coupon->referencePeriodStart();
                 refEndDate = coupon->referencePeriodEnd();
             } else {
@@ -581,14 +581,13 @@ namespace QuantLib {
                 refEndDate = cashFlowDate;
             }
 
-            if ((coupon != 0) && lastDate != coupon->accrualStartDate()) {
+            if ((coupon != nullptr) && lastDate != coupon->accrualStartDate()) {
                 Time couponPeriod = dc.yearFraction(coupon->accrualStartDate(),
                                                 cashFlowDate, refStartDate, refEndDate);
                 Time accruedPeriod = dc.yearFraction(coupon->accrualStartDate(),
                                                 lastDate, refStartDate, refEndDate);
                 return couponPeriod - accruedPeriod;
-            }
-            else {
+            } else {
                 return dc.yearFraction(lastDate, cashFlowDate,
                                        refStartDate, refEndDate);
             }

--- a/ql/cashflows/cmscoupon.cpp
+++ b/ql/cashflows/cmscoupon.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
     void CmsCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CmsCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);

--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -76,7 +76,7 @@ namespace QuantLib {
 
     void Coupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<Coupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             CashFlow::accept(v);

--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -225,13 +225,13 @@ namespace QuantLib {
             // we might end up here because a CappedFlooredCoupon
             // was directly constructed; we should then check
             // the underlying for consistency with the pricer
-            if (ext::dynamic_pointer_cast<IborCoupon>(c.underlying()) != 0) {
+            if (ext::dynamic_pointer_cast<IborCoupon>(c.underlying()) != nullptr) {
                 QL_REQUIRE(ext::dynamic_pointer_cast<IborCouponPricer>(pricer_),
                            "pricer not compatible with Ibor Coupon");
-            } else if (ext::dynamic_pointer_cast<CmsCoupon>(c.underlying()) != 0) {
+            } else if (ext::dynamic_pointer_cast<CmsCoupon>(c.underlying()) != nullptr) {
                 QL_REQUIRE(ext::dynamic_pointer_cast<CmsCouponPricer>(pricer_),
                            "pricer not compatible with CMS Coupon");
-            } else if (ext::dynamic_pointer_cast<CmsSpreadCoupon>(c.underlying()) != 0) {
+            } else if (ext::dynamic_pointer_cast<CmsSpreadCoupon>(c.underlying()) != nullptr) {
                 QL_REQUIRE(ext::dynamic_pointer_cast<CmsSpreadCouponPricer>(pricer_),
                            "pricer not compatible with CMS spread Coupon");
             }

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -59,7 +59,7 @@ namespace QuantLib {
 
     void CPICoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CPICoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             InflationCoupon::accept(v);

--- a/ql/cashflows/digitalcmscoupon.cpp
+++ b/ql/cashflows/digitalcmscoupon.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
     void DigitalCmsCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
         auto* v1 = dynamic_cast<Visitor<DigitalCmsCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/cashflows/digitalcoupon.cpp
+++ b/ql/cashflows/digitalcoupon.cpp
@@ -282,7 +282,7 @@ namespace QuantLib {
     void DigitalCoupon::accept(AcyclicVisitor& v) {
         typedef FloatingRateCoupon super;
         auto* v1 = dynamic_cast<Visitor<DigitalCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/cashflows/digitalcoupon.hpp
+++ b/ql/cashflows/digitalcoupon.hpp
@@ -131,10 +131,10 @@ namespace QuantLib {
         void accept(AcyclicVisitor&) override;
 
         void setPricer(const ext::shared_ptr<FloatingRateCouponPricer>& pricer) override {
-            if (pricer_ != 0)
+            if (pricer_ != nullptr)
                 unregisterWith(pricer_);
             pricer_ = pricer;
-            if (pricer_ != 0)
+            if (pricer_ != nullptr)
                 registerWith(pricer_);
             update();
             underlying_->setPricer(pricer);

--- a/ql/cashflows/digitaliborcoupon.cpp
+++ b/ql/cashflows/digitaliborcoupon.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
     void DigitalIborCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
         auto* v1 = dynamic_cast<Visitor<DigitalIborCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/cashflows/dividend.cpp
+++ b/ql/cashflows/dividend.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     void Dividend::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<Dividend>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             CashFlow::accept(v);

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -123,7 +123,7 @@ namespace QuantLib {
 
     inline void FixedRateCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FixedRateCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Coupon::accept(v);

--- a/ql/cashflows/floatingratecoupon.cpp
+++ b/ql/cashflows/floatingratecoupon.cpp
@@ -60,10 +60,10 @@ namespace QuantLib {
 
     void FloatingRateCoupon::setPricer(
                 const ext::shared_ptr<FloatingRateCouponPricer>& pricer) {
-        if (pricer_ != 0)
+        if (pricer_ != nullptr)
             unregisterWith(pricer_);
         pricer_ = pricer;
-        if (pricer_ != 0)
+        if (pricer_ != nullptr)
             registerWith(pricer_);
         update();
     }

--- a/ql/cashflows/floatingratecoupon.hpp
+++ b/ql/cashflows/floatingratecoupon.hpp
@@ -144,7 +144,7 @@ namespace QuantLib {
 
     inline void FloatingRateCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FloatingRateCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Coupon::accept(v);

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -143,7 +143,7 @@ namespace QuantLib {
 
     void IborCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<IborCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
 
     inline void IndexedCashFlow::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<IndexedCashFlow>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             CashFlow::accept(v);

--- a/ql/cashflows/inflationcoupon.cpp
+++ b/ql/cashflows/inflationcoupon.cpp
@@ -49,10 +49,10 @@ namespace QuantLib {
 
     void InflationCoupon::setPricer(const ext::shared_ptr<InflationCouponPricer>& pricer) {
         QL_REQUIRE(checkPricerImpl(pricer),"pricer given is wrong type");
-        if (pricer_ != 0)
+        if (pricer_ != nullptr)
             unregisterWith(pricer_);
         pricer_ = pricer;
-        if (pricer_ != 0)
+        if (pricer_ != nullptr)
             registerWith(pricer_);
         update();
     }

--- a/ql/cashflows/inflationcoupon.hpp
+++ b/ql/cashflows/inflationcoupon.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
 
     inline void InflationCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<InflationCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Coupon::accept(v);

--- a/ql/cashflows/inflationcouponpricer.cpp
+++ b/ql/cashflows/inflationcouponpricer.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
         for (Size i=0; i<leg.size(); ++i) {
             ext::shared_ptr<InflationCoupon> c =
                 ext::dynamic_pointer_cast<InflationCoupon>(leg[i]);
-            if (c != 0)
+            if (c != nullptr)
                 c->setPricer(p);
         }
     }

--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
         if (!couponDiscountCurve_.empty())
             registerWith(couponDiscountCurve_);
 
-        if (integrator_ == NULL)
+        if (integrator_ == nullptr)
             integrator_ =
                 ext::make_shared<GaussKronrodNonAdaptive>(1E-10, 5000, 1E-10);
     }

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -206,7 +206,7 @@ namespace QuantLib {
 
     void OvernightIndexedCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<OvernightIndexedCoupon>*>(&v);
-        if (v1 != 0) {
+        if (v1 != nullptr) {
             v1->visit(*this);
         } else {
             FloatingRateCoupon::accept(v);

--- a/ql/cashflows/rangeaccrual.cpp
+++ b/ql/cashflows/rangeaccrual.cpp
@@ -85,7 +85,7 @@ namespace QuantLib {
 
     void RangeAccrualFloatersCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<RangeAccrualFloatersCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);

--- a/ql/cashflows/simplecashflow.hpp
+++ b/ql/cashflows/simplecashflow.hpp
@@ -89,7 +89,7 @@ namespace QuantLib {
 
     inline void SimpleCashFlow::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SimpleCashFlow>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             CashFlow::accept(v);
@@ -97,7 +97,7 @@ namespace QuantLib {
 
     inline void Redemption::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<Redemption>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             SimpleCashFlow::accept(v);
@@ -105,7 +105,7 @@ namespace QuantLib {
 
     inline void AmortizingPayment::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<AmortizingPayment>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             SimpleCashFlow::accept(v);

--- a/ql/cashflows/yoyinflationcoupon.cpp
+++ b/ql/cashflows/yoyinflationcoupon.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
     void YoYInflationCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<YoYInflationCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             InflationCoupon::accept(v);

--- a/ql/currencies/exchangeratemanager.cpp
+++ b/ql/currencies/exchangeratemanager.cpp
@@ -195,9 +195,7 @@ namespace QuantLib {
                                                    const Date& date) const {
         const std::list<Entry>& rates = data_[hash(source,target)];
         auto i = std::find_if(rates.begin(), rates.end(), valid_at(date));
-        return i == rates.end() ?
-            (const ExchangeRate*) 0 :
-            &(i->rate);
+        return i == rates.end() ? (const ExchangeRate*)nullptr : &(i->rate);
     }
 
 }

--- a/ql/event.cpp
+++ b/ql/event.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
 
     void Event::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<Event>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not an event visitor");

--- a/ql/experimental/averageois/arithmeticoisratehelper.cpp
+++ b/ql/experimental/averageois/arithmeticoisratehelper.cpp
@@ -89,7 +89,7 @@ namespace QuantLib {
     }
 
     Real ArithmeticOISRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         swap_->recalculate();
         //return swap_->fairRate();
@@ -105,7 +105,7 @@ namespace QuantLib {
 
     void ArithmeticOISRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<ArithmeticOISRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);

--- a/ql/experimental/averageois/makearithmeticaverageois.cpp
+++ b/ql/experimental/averageois/makearithmeticaverageois.cpp
@@ -110,7 +110,7 @@ namespace QuantLib {
                                       overnightLegSchedule,
                                       overnightSpread_,
                                       mrs_, vol_, byApprox_);
-            if (engine_ == 0) {
+            if (engine_ == nullptr) {
                 Handle<YieldTermStructure> disc =
                                     overnightIndex_->forwardingTermStructure();
                 QL_REQUIRE(!disc.empty(),
@@ -135,7 +135,7 @@ namespace QuantLib {
                                  overnightSpread_,
                                  mrs_, vol_, byApprox_));
 
-        if (engine_ == 0) {
+        if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
                                 overnightIndex_->forwardingTermStructure();
             bool includeSettlementDateFlows = false;

--- a/ql/experimental/barrieroption/doublebarrieroption.cpp
+++ b/ql/experimental/barrieroption/doublebarrieroption.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<DoubleBarrierOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier_lo = barrier_lo_;
         moreArgs->barrier_hi = barrier_hi_;

--- a/ql/experimental/barrieroption/quantodoublebarrieroption.cpp
+++ b/ql/experimental/barrieroption/quantodoublebarrieroption.cpp
@@ -60,8 +60,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         DoubleBarrierOption::fetchResults(r);
         const auto* quantoResults = dynamic_cast<const QuantoDoubleBarrierOption::results*>(r);
-        QL_ENSURE(quantoResults != 0,
-                  "no quanto results returned from pricing engine");
+        QL_ENSURE(quantoResults != nullptr, "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;
         qvega_   = quantoResults->qvega;
         qlambda_ = quantoResults->qlambda;

--- a/ql/experimental/basismodels/swaptioncfs.cpp
+++ b/ql/experimental/basismodels/swaptioncfs.cpp
@@ -109,7 +109,7 @@ namespace QuantLib {
             fixedWeights_.push_back(fixedLeg_[k]->amount());
         for (Size k = 0; k < fixedLeg_.size(); ++k) {
             ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(fixedLeg_[k]);
-            if (coupon != 0)
+            if (coupon != nullptr)
                 annuityWeights_.push_back(coupon->nominal() * coupon->accrualPeriod());
         }
     }

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -418,7 +418,7 @@ namespace QuantLib {
             if (!cashflows_[i]->hasOccurred(settlement,IncludeToday)) {
                 ext::shared_ptr<Coupon> coupon =
                     ext::dynamic_pointer_cast<Coupon>(cashflows_[i]);
-                if (coupon != 0)
+                if (coupon != nullptr)
                     // !!!
                     return coupon->accruedAmount(settlement) /
                            notional(settlement) * 100.0;
@@ -437,7 +437,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<CallableBond::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "no arguments given");
+        QL_REQUIRE(arguments != nullptr, "no arguments given");
 
         Date settlement = arguments->settlementDate;
 

--- a/ql/experimental/callablebonds/treecallablebondengine.cpp
+++ b/ql/experimental/callablebonds/treecallablebondengine.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
         Handle<YieldTermStructure> discountCurve =
-            tsmodel != 0 ? tsmodel->termStructure() : termStructure_;
+            tsmodel != nullptr ? tsmodel->termStructure() : termStructure_;
 
         Date referenceDate = discountCurve->referenceDate();
         DayCounter dayCounter = discountCurve->dayCounter();
@@ -63,7 +63,7 @@ namespace QuantLib {
                                                       dayCounter);
         ext::shared_ptr<Lattice> lattice;
 
-        if (lattice_ != 0) {
+        if (lattice_ != nullptr) {
             lattice = lattice_;
         } else {
             std::vector<Time> times = callableBond.mandatoryTimes();

--- a/ql/experimental/catbonds/catbond.cpp
+++ b/ql/experimental/catbonds/catbond.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
     void CatBond::setupArguments(PricingEngine::arguments* args) const {
 
         auto* arguments = dynamic_cast<CatBond::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong arguments type");
+        QL_REQUIRE(arguments != nullptr, "wrong arguments type");
 
         Bond::setupArguments(args);
 
@@ -51,7 +51,7 @@ namespace QuantLib {
         Bond::fetchResults(r);
 
         const auto* results = dynamic_cast<const CatBond::results*>(r);
-        QL_ENSURE(results != 0, "wrong result type");
+        QL_ENSURE(results != nullptr, "wrong result type");
 
         lossProbability_ = results->lossProbability;
         expectedLoss_ = results->expectedLoss;

--- a/ql/experimental/commodities/commoditycashflow.cpp
+++ b/ql/experimental/commodities/commoditycashflow.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     void CommodityCashFlow::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CommodityCashFlow>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             CashFlow::accept(v);

--- a/ql/experimental/commodities/commoditycurve.cpp
+++ b/ql/experimental/commodities/commoditycurve.cpp
@@ -98,7 +98,7 @@ namespace QuantLib {
     std::ostream& operator<<(std::ostream& out, const CommodityCurve& curve) {
         out << "[" << curve.name_ << "] (" << curve.currency_.code()
             << "/" << curve.unitOfMeasure_.code() << ")";
-        if (curve.basisOfCurve_ != 0)
+        if (curve.basisOfCurve_ != nullptr)
             out << "; basis to (" << (*curve.basisOfCurve_) << ")";
         return out;
     }

--- a/ql/experimental/commodities/commoditycurve.hpp
+++ b/ql/experimental/commodities/commoditycurve.hpp
@@ -191,7 +191,7 @@ namespace QuantLib {
     }
 
     inline Real CommodityCurve::basisOfPriceImpl(Time t) const {
-        if (basisOfCurve_ != 0) {
+        if (basisOfCurve_ != nullptr) {
             Real basisCurvePriceValue = 0;
             try {
                 basisCurvePriceValue =

--- a/ql/experimental/commodities/commodityindex.cpp
+++ b/ql/experimental/commodities/commodityindex.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         registerWith(Settings::instance().evaluationDate());
         registerWith(IndexManager::instance().notifier(name()));
 
-        if (forwardCurve_ != 0)
+        if (forwardCurve_ != nullptr)
             // registerWith(forwardCurve_);
             forwardCurveUomConversionFactor_ =
                 CommodityPricingHelper::calculateUomConversionFactor(
@@ -55,7 +55,7 @@ namespace QuantLib {
         out << "[" << index.name_ << "] ("
             << index.currency_.code() << "/"
             << index.unitOfMeasure_.code() << ")";
-        if (index.forwardCurve_ != 0)
+        if (index.forwardCurve_ != nullptr)
             out << "; forward (" << (*index.forwardCurve_) << ")";
         return out;
     }

--- a/ql/experimental/commodities/commodityindex.hpp
+++ b/ql/experimental/commodities/commodityindex.hpp
@@ -176,7 +176,7 @@ namespace QuantLib {
     }
 
     inline bool CommodityIndex::forwardCurveEmpty() const {
-        if (forwardCurve_ != 0)
+        if (forwardCurve_ != nullptr)
             return forwardCurve_->empty();
         return false;
     }

--- a/ql/experimental/commodities/energycommodity.cpp
+++ b/ql/experimental/commodities/energycommodity.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
 
     void EnergyCommodity::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<EnergyCommodity::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
         //arguments->legs = legs_;
         //arguments->payer = payer_;
     }
@@ -79,7 +79,7 @@ namespace QuantLib {
     void EnergyCommodity::fetchResults(const PricingEngine::results* r) const {
         Instrument::fetchResults(r);
         const auto* results = dynamic_cast<const EnergyCommodity::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
     }
 
     EnergyCommodity::EnergyCommodity(
@@ -147,13 +147,13 @@ namespace QuantLib {
                                            Real totalQuantityValue,
                                            const Date& evaluationDate) const {
         secondaryCostAmounts_.clear();
-        if (secondaryCosts_ != 0) {
+        if (secondaryCosts_ != nullptr) {
             const Currency& baseCurrency =
                 CommoditySettings::instance().currency();
             try {
                 for (SecondaryCosts::const_iterator i = secondaryCosts_->begin();
                      i != secondaryCosts_->end(); ++i) {
-                    if (boost::any_cast<CommodityUnitCost>(&i->second) != 0) {
+                    if (boost::any_cast<CommodityUnitCost>(&i->second) != nullptr) {
                         Real value =
                             calculateUnitCost(
                                 commodityType,
@@ -161,7 +161,7 @@ namespace QuantLib {
                                 evaluationDate) * totalQuantityValue;
                         secondaryCostAmounts_[i->first] =
                             Money(baseCurrency, value);
-                    } else if (boost::any_cast<Money>(&i->second) != 0) {
+                    } else if (boost::any_cast<Money>(&i->second) != nullptr) {
                         const Money& amount = boost::any_cast<Money>(i->second);
                         Real fxConversionFactor =
                             calculateFxConversionFactor(amount.currency(),

--- a/ql/experimental/convertiblebonds/convertiblebond.cpp
+++ b/ql/experimental/convertiblebonds/convertiblebond.cpp
@@ -216,7 +216,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ConvertibleBond::option::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
 
         moreArgs->conversionRatio = conversionRatio_;
 
@@ -243,7 +243,7 @@ namespace QuantLib {
                 ext::shared_ptr<SoftCallability> softCall =
                     ext::dynamic_pointer_cast<SoftCallability>(
                                                              callability_[i]);
-                if (softCall != 0)
+                if (softCall != nullptr)
                     moreArgs->callabilityTriggers.push_back(
                                                          softCall->trigger());
                 else

--- a/ql/experimental/coupons/cmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
 
     void CmsSpreadCoupon::accept(AcyclicVisitor &v) {
         auto* v1 = dynamic_cast<Visitor<CmsSpreadCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);

--- a/ql/experimental/coupons/cmsspreadcoupon.hpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.hpp
@@ -91,7 +91,7 @@ namespace QuantLib {
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsSpreadCoupon>*>(&v);
-            if (v1 != 0)
+            if (v1 != nullptr)
                 v1->visit(*this);
             else
                 CappedFlooredCoupon::accept(v);

--- a/ql/experimental/coupons/digitalcmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/digitalcmsspreadcoupon.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     void DigitalCmsSpreadCoupon::accept(AcyclicVisitor& v) {
         typedef DigitalCoupon super;
         auto* v1 = dynamic_cast<Visitor<DigitalCmsSpreadCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             super::accept(v);

--- a/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
+++ b/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
@@ -210,7 +210,7 @@ namespace QuantLib {
                     swvol->shift(fixingDate_, index_->swapIndex2()->tenor());
             }
 
-            if (swcub == NULL) {
+            if (swcub == nullptr) {
                 // not a cube, just an atm surface given, so we can
                 // not easily convert volatilities and just forbid it
                 QL_REQUIRE(inheritedVolatilityType_,

--- a/ql/experimental/coupons/strippedcapflooredcoupon.cpp
+++ b/ql/experimental/coupons/strippedcapflooredcoupon.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
     Rate StrippedCappedFlooredCoupon::rate() const {
 
-        QL_REQUIRE(underlying_->underlying()->pricer() != NULL, "pricer not set");
+        QL_REQUIRE(underlying_->underlying()->pricer() != nullptr, "pricer not set");
         underlying_->underlying()->pricer()->initialize(*underlying_->underlying());
         Rate floorletRate = 0.0;
         if (underlying_->isFloored())
@@ -80,7 +80,7 @@ namespace QuantLib {
     void StrippedCappedFlooredCoupon::accept(AcyclicVisitor &v) {
         underlying_->accept(v);
         auto* v1 = dynamic_cast<Visitor<StrippedCappedFlooredCoupon>*>(&v);
-        if (v1 != NULL)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);
@@ -113,8 +113,7 @@ namespace QuantLib {
         resultLeg.reserve(underlyingLeg_.size());
         ext::shared_ptr<CappedFlooredCoupon> c;
         for (auto i = underlyingLeg_.begin(); i != underlyingLeg_.end(); ++i) {
-            if ((c = ext::dynamic_pointer_cast<CappedFlooredCoupon>(*i)) !=
-                NULL) {
+            if ((c = ext::dynamic_pointer_cast<CappedFlooredCoupon>(*i)) != nullptr) {
                 resultLeg.push_back(
                     ext::make_shared<StrippedCappedFlooredCoupon>(c));
             } else {

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
 
     void SubPeriodsCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SubPeriodsCoupon>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             FloatingRateCoupon::accept(v);

--- a/ql/experimental/credit/basket.cpp
+++ b/ql/experimental/credit/basket.cpp
@@ -72,10 +72,10 @@ namespace QuantLib {
     void Basket::setLossModel(
         const ext::shared_ptr<DefaultLossModel>& lossModel) {
 
-        if (lossModel_ != 0)
+        if (lossModel_ != nullptr)
             unregisterWith(lossModel_);
         lossModel_ = lossModel;
-        if (lossModel_ != 0) {
+        if (lossModel_ != nullptr) {
             //recovery quotes, defaults(once Issuer is observable)etc might 
             //  trigger us:
             registerWith(lossModel_);
@@ -122,7 +122,7 @@ namespace QuantLib {
             ext::shared_ptr<DefaultEvent> credEvent =
                 pool_->get(pool_->names()[i]).defaultedBetween(refDate_,
                     endDate, pool_->defaultKeys()[i]);
-            if (credEvent != 0) {
+            if (credEvent != nullptr) {
                 /* \todo If the event has not settled one would need to 
                 introduce some model recovery rate (independently of a loss 
                 model) This remains to be done.
@@ -147,7 +147,7 @@ namespace QuantLib {
             ext::shared_ptr<DefaultEvent> credEvent =
                 pool_->get(pool_->names()[i]).defaultedBetween(refDate_,
                     endDate, pool_->defaultKeys()[i]);
-            if (credEvent != 0) {
+            if (credEvent != nullptr) {
                 if(credEvent->hasSettled()) {
                     loss += claim_->amount(credEvent->date(),
                             //notionals_[i],

--- a/ql/experimental/credit/cdsoption.cpp
+++ b/ql/experimental/credit/cdsoption.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<CdsOption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->swap      = swap_;
         arguments->knocksOut = knocksOut_;
@@ -101,7 +101,7 @@ namespace QuantLib {
     void CdsOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
         const auto* results = dynamic_cast<const CdsOption::results*>(r);
-        QL_ENSURE(results != 0, "wrong results type");
+        QL_ENSURE(results != nullptr, "wrong results type");
         riskyAnnuity_ = results->riskyAnnuity;
     }
 

--- a/ql/experimental/credit/defaultevent.cpp
+++ b/ql/experimental/credit/defaultevent.cpp
@@ -31,7 +31,7 @@ namespace QuantLib {
 
     void DefaultEvent::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<DefaultEvent>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Event::accept(v);
@@ -44,7 +44,7 @@ namespace QuantLib {
 
     void DefaultEvent::DefaultSettlement::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<DefaultEvent::DefaultSettlement>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Event::accept(v);

--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -129,7 +129,7 @@ namespace QuantLib {
         }
     protected:
       void update() override {
-          if (basket_ != 0)
+          if (basket_ != nullptr)
               basket_->notifyObservers();
           LatentModel<copulaPolicy>::update();
       }

--- a/ql/experimental/credit/nthtodefault.cpp
+++ b/ql/experimental/credit/nthtodefault.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
 
     void NthToDefault::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<NthToDefault::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
         arguments->basket = basket_;
         arguments->side = side_;
         arguments->premiumLeg = premiumLeg_;
@@ -127,7 +127,7 @@ namespace QuantLib {
         Instrument::fetchResults(r);
 
         const auto* results = dynamic_cast<const NthToDefault::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
 
         premiumValue_ = results->premiumValue;
         protectionValue_ = results->protectionValue;

--- a/ql/experimental/credit/syntheticcdo.cpp
+++ b/ql/experimental/credit/syntheticcdo.cpp
@@ -141,7 +141,7 @@ namespace QuantLib {
 
     void SyntheticCDO::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<SyntheticCDO::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
         arguments->basket = basket_;
         arguments->side = side_;
         arguments->normalizedLeg = normalizedLeg_;
@@ -157,7 +157,7 @@ namespace QuantLib {
         Instrument::fetchResults(r);
 
         const auto* results = dynamic_cast<const SyntheticCDO::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
 
         premiumValue_ = results->premiumValue;
         protectionValue_ = results->protectionValue;

--- a/ql/experimental/exoticoptions/complexchooseroption.cpp
+++ b/ql/experimental/exoticoptions/complexchooseroption.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
         auto* moreArgs = dynamic_cast<ComplexChooserOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->choosingDate=choosingDate_;
         moreArgs->strikeCall=strikeCall_;
         moreArgs->strikePut=strikePut_;

--- a/ql/experimental/exoticoptions/compoundoption.cpp
+++ b/ql/experimental/exoticoptions/compoundoption.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<CompoundOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->daughterPayoff = daughterPayoff_;
         moreArgs->daughterExercise = daughterExercise_;
     }

--- a/ql/experimental/exoticoptions/everestoption.cpp
+++ b/ql/experimental/exoticoptions/everestoption.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
         MultiAssetOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<EverestOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->notional = notional_;
         arguments->guarantee= guarantee_;
@@ -47,8 +47,7 @@ namespace QuantLib {
     void EverestOption::fetchResults(const PricingEngine::results* r) const {
         MultiAssetOption::fetchResults(r);
         const auto* results = dynamic_cast<const EverestOption::results*>(r);
-        QL_ENSURE(results != 0,
-                  "no results returned from pricing engine");
+        QL_ENSURE(results != nullptr, "no results returned from pricing engine");
         yield_ = results->yield;
     }
 

--- a/ql/experimental/exoticoptions/himalayaoption.cpp
+++ b/ql/experimental/exoticoptions/himalayaoption.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         MultiAssetOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<HimalayaOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->fixingDates = fixingDates_;
     }

--- a/ql/experimental/exoticoptions/holderextensibleoption.cpp
+++ b/ql/experimental/exoticoptions/holderextensibleoption.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
         auto* moreArgs = dynamic_cast<HolderExtensibleOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->premium = premium_;
         moreArgs->secondExpiryDate = secondExpiryDate_;
         moreArgs->secondStrike = secondStrike_;

--- a/ql/experimental/exoticoptions/margrabeoption.cpp
+++ b/ql/experimental/exoticoptions/margrabeoption.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
         MultiAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<MargrabeOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0,
-                   "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
 
         moreArgs->Q1 = Q1_;
         moreArgs->Q2 = Q2_;
@@ -78,7 +77,7 @@ namespace QuantLib {
     void MargrabeOption::fetchResults(const PricingEngine::results* r) const {
         MultiAssetOption::fetchResults(r);
         const auto* results = dynamic_cast<const MargrabeOption::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
         delta1_          = results->delta1;
         delta2_          = results->delta2;
         gamma1_          = results->gamma1;

--- a/ql/experimental/exoticoptions/pagodaoption.cpp
+++ b/ql/experimental/exoticoptions/pagodaoption.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
         MultiAssetOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<PagodaOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->fixingDates = fixingDates_;
         arguments->roof = roof_;

--- a/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
+++ b/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<PartialTimeBarrierOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrierRange = barrierRange_;
         moreArgs->barrier = barrier_;

--- a/ql/experimental/exoticoptions/simplechooseroption.cpp
+++ b/ql/experimental/exoticoptions/simplechooseroption.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                                     PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
         auto* moreArgs = dynamic_cast<SimpleChooserOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->choosingDate=choosingDate_;
     }
 

--- a/ql/experimental/exoticoptions/twoassetbarrieroption.cpp
+++ b/ql/experimental/exoticoptions/twoassetbarrieroption.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         Option::setupArguments(args);
         auto* moreArgs = dynamic_cast<TwoAssetBarrierOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier = barrier_;
     }

--- a/ql/experimental/exoticoptions/twoassetcorrelationoption.cpp
+++ b/ql/experimental/exoticoptions/twoassetcorrelationoption.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         MultiAssetOption::setupArguments(args);
         auto* moreArgs = dynamic_cast<TwoAssetCorrelationOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
 
         moreArgs->X2 = X2_;
     }

--- a/ql/experimental/exoticoptions/writerextensibleoption.cpp
+++ b/ql/experimental/exoticoptions/writerextensibleoption.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* otherArguments = dynamic_cast<WriterExtensibleOption::arguments*>(args);
-        QL_REQUIRE(otherArguments != 0, "wrong arguments type");
+        QL_REQUIRE(otherArguments != nullptr, "wrong arguments type");
 
         otherArguments->payoff2 = payoff2_;
         otherArguments->exercise2 = exercise2_;

--- a/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
         const Rate r = rTS_->forwardRate(t1, t2, Continuous).rate();
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
-        if (localVol_ != 0) {
+        if (localVol_ != nullptr) {
             const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
             const FdmLinearOpIterator endIter = layout->end();
 
@@ -76,8 +76,7 @@ namespace QuantLib {
             }
             mapT_.axpyb(Array(1, 1.0), dxMap_.multR(- r + q + 0.5*v),
                         dxxMap_.multR(0.5*v), Array(1, 0.0));
-        }
-        else {
+        } else {
             const Real v
                 = volTS_->blackForwardVariance(t1, t2, strike_)/(t2-t1);
             mapT_.axpyb(Array(1, - r + q + 0.5*v), dxMap_,

--- a/ql/experimental/finitedifferences/fdmexpextouinnervaluecalculator.hpp
+++ b/ql/experimental/finitedifferences/fdmexpextouinnervaluecalculator.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             const Real u = mesher_->location(iter, direction_);
 
             Real f = 0;
-            if (shape_ != 0) {
+            if (shape_ != nullptr) {
                 f = std::lower_bound(shape_->begin(), shape_->end(),
                    std::pair<Time, Real>(t-std::sqrt(QL_EPSILON), 0.0))->second;
             }

--- a/ql/experimental/finitedifferences/fdmextoujumpmodelinnervalue.hpp
+++ b/ql/experimental/finitedifferences/fdmextoujumpmodelinnervalue.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             const Real y = mesher_->location(iter, 1);
 
             Real f = 0;
-            if (shape_ != 0) {
+            if (shape_ != nullptr) {
                 f = std::lower_bound(shape_->begin(), shape_->end(),
                    std::pair<Time, Real>(t-std::sqrt(QL_EPSILON), 0.0))->second;
             }

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -121,7 +121,7 @@ namespace QuantLib {
     void FdmHestonFwdOp::setTime(Time t1, Time t2){
         const Rate r = rTS_->forwardRate(t1, t2, Continuous).rate();
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
-        if (leverageFct_ != 0) {
+        if (leverageFct_ != nullptr) {
             L_ = getLeverageFctSlice(t1, t2);
             Array Lsquare = L_*L_;
             if (type_ == FdmSquareRootFwdOp::Plain) {
@@ -141,8 +141,7 @@ namespace QuantLib {
                     .add(dxMap_->mult(0.5*Exp(2.0*varianceValues_)).multR(Lsquare)),
                               Array());
             }
-        }
-        else {
+        } else {
             if (type_ == FdmSquareRootFwdOp::Plain) {
                 mapX_->axpyb( - r + q + rho_*mixedSigma_ + varianceValues_, *dxMap_,
                         *dxxMap_, Array());
@@ -157,12 +156,11 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmHestonFwdOp::apply(const Array& u) const {
-        if (leverageFct_ != 0) {
+        if (leverageFct_ != nullptr) {
             return mapX_->apply(u)
                     + mapY_->apply(u)
                     + correlation_->apply(L_*u);
-        } 
-        else {
+        } else {
             return mapX_->apply(u)
                     + mapY_->apply(u)
                     + correlation_->apply(u);
@@ -170,11 +168,9 @@ namespace QuantLib {
     }
 
     Disposable<Array> FdmHestonFwdOp::apply_mixed(const Array& u) const{
-        if (leverageFct_ != 0) {
+        if (leverageFct_ != nullptr) {
             return correlation_->apply(L_*u);
-        }
-        else
-        {
+        } else {
             return correlation_->apply(u);
         }
     }

--- a/ql/experimental/finitedifferences/vanillavppoption.cpp
+++ b/ql/experimental/finitedifferences/vanillavppoption.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
         MultiAssetOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<VanillaVPPOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->heatRate       = heatRate_;
         arguments->pMin           = pMin_;

--- a/ql/experimental/futures/overnightindexfutureratehelper.cpp
+++ b/ql/experimental/futures/overnightindexfutureratehelper.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
 
     void OvernightIndexFutureRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<OvernightIndexFutureRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);

--- a/ql/experimental/math/hybridsimulatedannealing.hpp
+++ b/ql/experimental/math/hybridsimulatedannealing.hpp
@@ -94,7 +94,7 @@ namespace QuantLib {
           reAnnealSteps_(reAnnealSteps == 0 ? QL_MAX_INTEGER : reAnnealSteps),
           resetScheme_(resetScheme), resetSteps_(resetSteps == 0 ? QL_MAX_INTEGER : resetSteps),
           localOptimizer_(localOptimizer),
-          optimizeScheme_(localOptimizer != 0 ? optimizeScheme : NoLocalOptimize) {
+          optimizeScheme_(localOptimizer != nullptr ? optimizeScheme : NoLocalOptimize) {
             if (!localOptimizer)
                 localOptimizer.reset(new LevenbergMarquardt);
         }

--- a/ql/experimental/mcbasket/pathmultiassetoption.cpp
+++ b/ql/experimental/mcbasket/pathmultiassetoption.cpp
@@ -27,7 +27,7 @@ namespace QuantLib {
 
     PathMultiAssetOption::PathMultiAssetOption(
                             const ext::shared_ptr<PricingEngine>& engine) {
-        if (engine != 0)
+        if (engine != nullptr)
             setPricingEngine(engine);
     }
 
@@ -43,7 +43,7 @@ namespace QuantLib {
                                                                        const {
         auto* arguments = dynamic_cast<PathMultiAssetOption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff            = pathPayoff();
         arguments->fixingDates       = fixingDates();

--- a/ql/experimental/mcbasket/pathpayoff.hpp
+++ b/ql/experimental/mcbasket/pathpayoff.hpp
@@ -83,7 +83,7 @@ namespace QuantLib {
 
     inline void PathPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<PathPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a path-payoff visitor");

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         void reset(const Interpolation &interp) {
             ext::shared_ptr<InterpolationParameter::Impl> impl =
                 ext::dynamic_pointer_cast<InterpolationParameter::Impl>(impl_);
-            if (impl != 0)
+            if (impl != nullptr)
                 impl->reset(interp);
         }
     };

--- a/ql/experimental/swaptions/irregularswap.cpp
+++ b/ql/experimental/swaptions/irregularswap.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<IrregularSwap::arguments*>(args);
 
-        if (arguments == 0) // it's a swap engine...
+        if (arguments == nullptr) // it's a swap engine...
             return;
 
         arguments->type = type_;
@@ -175,7 +175,7 @@ namespace QuantLib {
         Swap::fetchResults(r);
 
         const auto* results = dynamic_cast<const IrregularSwap::results*>(r);
-        if (results != 0) { // might be a swap engine, so no error is thrown
+        if (results != nullptr) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;
         } else {

--- a/ql/experimental/swaptions/irregularswaption.cpp
+++ b/ql/experimental/swaptions/irregularswaption.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<IrregularSwaption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->swap = swap_;
         arguments->settlementType = settlementType_;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -107,7 +107,7 @@ namespace QuantLib {
     }
 
     Real CrossCurrencyBasisSwapRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         QL_REQUIRE(!collateralHandle_.empty(), "collateral term structure not set");
 
         baseCcyLeg_->recalculate();
@@ -135,7 +135,7 @@ namespace QuantLib {
 
     void CrossCurrencyBasisSwapRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CrossCurrencyBasisSwapRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);

--- a/ql/experimental/termstructures/multicurvesensitivities.hpp
+++ b/ql/experimental/termstructures/multicurvesensitivities.hpp
@@ -73,7 +73,7 @@ public:
     for (curvespec::const_iterator it = curves_.begin(); it != curves_.end(); ++it) {
       ext::shared_ptr< PiecewiseYieldCurve< ZeroYield, Linear > > curve =
           ext::dynamic_pointer_cast< PiecewiseYieldCurve< ZeroYield, Linear > >(it->second.currentLink());
-      QL_REQUIRE(curve != NULL, "Couldn't cast curvename: " << it->first);
+      QL_REQUIRE(curve != nullptr, "Couldn't cast curvename: " << it->first);
       for (auto inst = curve->instruments_.begin(); inst != curve->instruments_.end(); ++inst) {
           allQuotes_.push_back((*inst)->quote());
           std::stringstream tmp;

--- a/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -383,7 +383,7 @@ namespace QuantLib {
 
         ext::shared_ptr<PlainVanillaPayoff> plainPayoff =
             ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
-        if ((plainPayoff != 0) && plainPayoff->optionType() == Option::Call) {
+        if ((plainPayoff != nullptr) && plainPayoff->optionType() == Option::Call) {
             // a specialization for Call options is available
             Real strike = plainPayoff->strike();
             results_.value = IvopOneDim(epsilon, chi, theta, rho,

--- a/ql/experimental/varianceoption/varianceoption.cpp
+++ b/ql/experimental/varianceoption/varianceoption.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
 
     void VarianceOption::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<VarianceOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff = payoff_;
         arguments->notional = notional_;

--- a/ql/experimental/volatility/abcdatmvolcurve.cpp
+++ b/ql/experimental/volatility/abcdatmvolcurve.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
 
     void AbcdAtmVolCurve::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<AbcdAtmVolCurve>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a AbcdAtmVolCurve visitor");

--- a/ql/experimental/volatility/blackatmvolcurve.cpp
+++ b/ql/experimental/volatility/blackatmvolcurve.cpp
@@ -75,7 +75,7 @@ namespace QuantLib {
 
     void BlackAtmVolCurve::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackAtmVolCurve>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a BlackAtmVolCurve visitor");

--- a/ql/experimental/volatility/blackvolsurface.cpp
+++ b/ql/experimental/volatility/blackvolsurface.cpp
@@ -50,7 +50,7 @@ namespace QuantLib {
 
     void BlackVolSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVolSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a BlackVolSurface term structure visitor");

--- a/ql/experimental/volatility/equityfxvolsurface.cpp
+++ b/ql/experimental/volatility/equityfxvolsurface.cpp
@@ -75,7 +75,7 @@ namespace QuantLib {
 
     void EquityFXVolSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<EquityFXVolSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a EquityFXVolSurface term structure visitor");

--- a/ql/experimental/volatility/extendedblackvariancecurve.hpp
+++ b/ql/experimental/volatility/extendedblackvariancecurve.hpp
@@ -86,7 +86,7 @@ namespace QuantLib {
 
     inline void ExtendedBlackVarianceCurve::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<ExtendedBlackVarianceCurve>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVarianceTermStructure::accept(v);

--- a/ql/experimental/volatility/extendedblackvariancesurface.hpp
+++ b/ql/experimental/volatility/extendedblackvariancesurface.hpp
@@ -82,7 +82,7 @@ namespace QuantLib {
 
     inline void ExtendedBlackVarianceSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<ExtendedBlackVarianceSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVarianceTermStructure::accept(v);

--- a/ql/experimental/volatility/interestratevolsurface.cpp
+++ b/ql/experimental/volatility/interestratevolsurface.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
 
     void InterestRateVolSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<InterestRateVolSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVolSurface::accept(v);

--- a/ql/experimental/volatility/sabrvolsurface.cpp
+++ b/ql/experimental/volatility/sabrvolsurface.cpp
@@ -175,7 +175,7 @@ namespace QuantLib {
 
     void SabrVolSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SabrVolSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             InterestRateVolSurface::accept(v);

--- a/ql/functional.hpp
+++ b/ql/functional.hpp
@@ -53,6 +53,7 @@ namespace QuantLib {
         namespace placeholders {
             using namespace std::placeholders;     // NOLINT(misc-unused-using-decls)
         }
+        #define QL_NULL_FUNCTION nullptr
         #else
         using boost::function;                     // NOLINT(misc-unused-using-decls)
         using boost::bind;                         // NOLINT(misc-unused-using-decls)
@@ -73,6 +74,7 @@ namespace QuantLib {
             using ::_9;                            // NOLINT(misc-unused-using-decls)
             #endif
         }
+        #define QL_NULL_FUNCTION 0
         #endif
 
     }

--- a/ql/instrument.hpp
+++ b/ql/instrument.hpp
@@ -132,10 +132,10 @@ namespace QuantLib {
 
     inline void Instrument::setPricingEngine(
                                   const ext::shared_ptr<PricingEngine>& e) {
-        if (engine_ != 0)
+        if (engine_ != nullptr)
             unregisterWith(engine_);
         engine_ = e;
-        if (engine_ != 0)
+        if (engine_ != nullptr)
             registerWith(engine_);
         // trigger (lazy) recalculation and notify observers
         update();
@@ -174,8 +174,7 @@ namespace QuantLib {
     inline void Instrument::fetchResults(
                                       const PricingEngine::results* r) const {
         const auto* results = dynamic_cast<const Instrument::results*>(r);
-        QL_ENSURE(results != 0,
-                  "no results returned from pricing engine");
+        QL_ENSURE(results != nullptr, "no results returned from pricing engine");
 
         NPV_ = results->value;
         errorEstimate_ = results->errorEstimate;

--- a/ql/instruments/asianoption.cpp
+++ b/ql/instruments/asianoption.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<DiscreteAveragingAsianOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->averageType = averageType_;
         moreArgs->runningAccumulator = runningAccumulator_;
         moreArgs->pastFixings = pastFixings_;
@@ -90,7 +90,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ContinuousAveragingAsianOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->averageType = averageType_;
     }
 

--- a/ql/instruments/assetswap.cpp
+++ b/ql/instruments/assetswap.cpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         // and it is a coupon then add the accrued coupon
         if (i<bondLeg.end()-1) {
             ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(*i);
-            if (c != 0) {
+            if (c != nullptr) {
                 ext::shared_ptr<CashFlow> accruedCoupon(new
                     SimpleCashFlow(c->accruedAmount(dealMaturity), finalDate));
                 legs_[0].push_back(accruedCoupon);
@@ -276,7 +276,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<AssetSwap::arguments*>(args);
 
-        if (arguments == 0) // it's a swap engine...
+        if (arguments == nullptr) // it's a swap engine...
             return;
 
         const Leg& fixedCoupons = bondLeg();
@@ -389,7 +389,7 @@ namespace QuantLib {
     void AssetSwap::fetchResults(const PricingEngine::results* r) const {
         Swap::fetchResults(r);
         const auto* results = dynamic_cast<const AssetSwap::results*>(r);
-        if (results != 0) {
+        if (results != nullptr) {
             fairSpread_ = results->fairSpread;
             fairCleanPrice_= results->fairCleanPrice;
             fairNonParRepayment_= results->fairNonParRepayment;

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<BarrierOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier = barrier_;
         moreArgs->rebate = rebate_;

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -288,7 +288,7 @@ namespace QuantLib {
 
     void Bond::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<Bond::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->settlementDate = settlementDate();
         arguments->cashflows = cashflows_;
@@ -300,7 +300,7 @@ namespace QuantLib {
         Instrument::fetchResults(r);
 
         const auto* results = dynamic_cast<const Bond::results*>(r);
-        QL_ENSURE(results != 0, "wrong result type");
+        QL_ENSURE(results != nullptr, "wrong result type");
 
         settlementValue_ = results->settlementValue;
     }
@@ -361,7 +361,7 @@ namespace QuantLib {
         for (Size k = 0; k < cashflows_.size(); ++k) {
             ext::shared_ptr<LazyObject> f =
                 ext::dynamic_pointer_cast<LazyObject>(cashflows_[k]);
-            if (f != 0)
+            if (f != nullptr)
                 f->update();
         }
         update();

--- a/ql/instruments/callabilityschedule.hpp
+++ b/ql/instruments/callabilityschedule.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
     inline void Callability::accept(AcyclicVisitor& v){
         auto* v1 = dynamic_cast<Visitor<Callability>*>(&v);
-        if(v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Event::accept(v);

--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -210,7 +210,7 @@ namespace QuantLib {
 
     void CapFloor::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<CapFloor::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         Size n = floatingLeg_.size();
 
@@ -274,7 +274,7 @@ namespace QuantLib {
             ext::shared_ptr<LazyObject> f =
                 ext::dynamic_pointer_cast<LazyObject>(
                     floatingLeg_[i]);
-            if (f != 0)
+            if (f != nullptr)
                 f->update();
         }
         update();

--- a/ql/instruments/cliquetoption.cpp
+++ b/ql/instruments/cliquetoption.cpp
@@ -33,8 +33,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
         // set accrued coupon, last fixing, caps, floors
         auto* moreArgs = dynamic_cast<CliquetOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0,
-                   "wrong engine type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong engine type");
         moreArgs->resetDates = resetDates_;
     }
 

--- a/ql/instruments/cpicapfloor.cpp
+++ b/ql/instruments/cpicapfloor.cpp
@@ -99,7 +99,7 @@ namespace QuantLib {
 
         // correct PricingEngine?
         auto* arguments = dynamic_cast<CPICapFloor::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type, not CPICapFloor::arguments*");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type, not CPICapFloor::arguments*");
 
         // data move
         arguments->type = type_;

--- a/ql/instruments/cpiswap.cpp
+++ b/ql/instruments/cpiswap.cpp
@@ -142,7 +142,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<CPISwap::arguments*>(args);
 
-        if (arguments == 0)
+        if (arguments == nullptr)
             return; // it's a swap engine...
     }
 
@@ -189,7 +189,7 @@ namespace QuantLib {
         Swap::fetchResults(r);
 
         const auto* results = dynamic_cast<const CPISwap::results*>(r);
-        if (results != 0) { // might be a swap engine, so no error is thrown
+        if (results != nullptr) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;
         } else {

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -215,7 +215,7 @@ namespace QuantLib {
     void CreditDefaultSwap::setupArguments(
                                        PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<CreditDefaultSwap::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->side = side_;
         arguments->notional = notional_;
@@ -237,7 +237,7 @@ namespace QuantLib {
         Instrument::fetchResults(r);
 
         const auto* results = dynamic_cast<const CreditDefaultSwap::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
 
         fairSpread_ = results->fairSpread;
         fairUpfront_ = results->fairUpfront;

--- a/ql/instruments/creditdefaultswap.hpp
+++ b/ql/instruments/creditdefaultswap.hpp
@@ -183,7 +183,7 @@ namespace QuantLib {
         const Date& protectionStartDate() const;
         //! The last date for which defaults will trigger the contract
         const Date& protectionEndDate() const;
-        bool rebatesAccrual() const { return accrualRebate_ != NULL; }
+        bool rebatesAccrual() const { return accrualRebate_ != nullptr; }
         const ext::shared_ptr<SimpleCashFlow>& upfrontPayment() const;
         const ext::shared_ptr<SimpleCashFlow>& accrualRebate() const;
         const Date& tradeDate() const;

--- a/ql/instruments/dividendbarrieroption.cpp
+++ b/ql/instruments/dividendbarrieroption.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         BarrierOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong engine type");
+        QL_REQUIRE(arguments != nullptr, "wrong engine type");
 
         arguments->cashFlow = cashFlow_;
     }

--- a/ql/instruments/dividendvanillaoption.cpp
+++ b/ql/instruments/dividendvanillaoption.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* arguments = dynamic_cast<DividendVanillaOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong engine type");
+        QL_REQUIRE(arguments != nullptr, "wrong engine type");
 
         arguments->cashFlow = cashFlow_;
     }

--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -233,12 +233,12 @@ namespace QuantLib {
         ext::shared_ptr<SwapSpreadIndex> cmsspread2 =
             ext::dynamic_pointer_cast<SwapSpreadIndex>(index2_);
 
-        QL_REQUIRE(ibor1 != NULL || cms1 != NULL || cmsspread1 != NULL,
+        QL_REQUIRE(ibor1 != nullptr || cms1 != nullptr || cmsspread1 != nullptr,
                    "index1 must be ibor or cms or cms spread");
-        QL_REQUIRE(ibor2 != NULL || cms2 != NULL || cmsspread2 != NULL,
+        QL_REQUIRE(ibor2 != nullptr || cms2 != nullptr || cmsspread2 != nullptr,
                    "index2 must be ibor or cms");
 
-        if (ibor1 != 0) {
+        if (ibor1 != nullptr) {
             IborLeg leg(schedule1_, ibor1);
             leg = leg.withNotionals(nominal1_)
                       .withPaymentDayCounter(dayCount1_)
@@ -252,7 +252,7 @@ namespace QuantLib {
             legs_[0] = leg;
         }
 
-        if (ibor2 != 0) {
+        if (ibor2 != nullptr) {
             IborLeg leg(schedule2_, ibor2);
             leg = leg.withNotionals(nominal2_)
                       .withPaymentDayCounter(dayCount2_)
@@ -266,7 +266,7 @@ namespace QuantLib {
             legs_[1] = leg;
         }
 
-        if (cms1 != 0) {
+        if (cms1 != nullptr) {
             CmsLeg leg(schedule1_, cms1);
             leg = leg.withNotionals(nominal1_)
                       .withPaymentDayCounter(dayCount1_)
@@ -280,7 +280,7 @@ namespace QuantLib {
             legs_[0] = leg;
         }
 
-        if (cms2 != 0) {
+        if (cms2 != nullptr) {
             CmsLeg leg(schedule2_, cms2);
             leg = leg.withNotionals(nominal2_)
                       .withPaymentDayCounter(dayCount2_)
@@ -294,7 +294,7 @@ namespace QuantLib {
             legs_[1] = leg;
         }
 
-        if (cmsspread1 != 0) {
+        if (cmsspread1 != nullptr) {
             CmsSpreadLeg leg(schedule1_, cmsspread1);
             leg = leg.withNotionals(nominal1_)
                       .withPaymentDayCounter(dayCount1_)
@@ -308,7 +308,7 @@ namespace QuantLib {
             legs_[0] = leg;
         }
 
-        if (cmsspread2 != 0) {
+        if (cmsspread2 != nullptr) {
             CmsSpreadLeg leg(schedule2_, cmsspread2);
             leg = leg.withNotionals(nominal2_)
                       .withPaymentDayCounter(dayCount2_)
@@ -388,7 +388,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<FloatFloatSwap::arguments*>(args);
 
-        if (arguments == 0)
+        if (arguments == nullptr)
             return; // swap engine ... // QL_REQUIRE(arguments != 0, "argument type does not match");
 
         arguments->type = type_;
@@ -428,7 +428,7 @@ namespace QuantLib {
         for (Size i = 0; i < leg1Coupons.size(); ++i) {
             ext::shared_ptr<FloatingRateCoupon> coupon =
                 ext::dynamic_pointer_cast<FloatingRateCoupon>(leg1Coupons[i]);
-            if (coupon != 0) {
+            if (coupon != nullptr) {
                 arguments->leg1AccrualTimes[i] = coupon->accrualPeriod();
                 arguments->leg1PayDates[i] = coupon->date();
                 arguments->leg1ResetDates[i] = coupon->accrualStartDate();
@@ -444,7 +444,7 @@ namespace QuantLib {
                 ext::shared_ptr<CappedFlooredCoupon> cfcoupon =
                     ext::dynamic_pointer_cast<CappedFlooredCoupon>(
                         leg1Coupons[i]);
-                if (cfcoupon != 0) {
+                if (cfcoupon != nullptr) {
                     arguments->leg1CappedRates[i] = cfcoupon->cap();
                     arguments->leg1FlooredRates[i] = cfcoupon->floor();
                 }
@@ -474,7 +474,7 @@ namespace QuantLib {
         for (Size i = 0; i < leg2Coupons.size(); ++i) {
             ext::shared_ptr<FloatingRateCoupon> coupon =
                 ext::dynamic_pointer_cast<FloatingRateCoupon>(leg2Coupons[i]);
-            if (coupon != 0) {
+            if (coupon != nullptr) {
                 arguments->leg2AccrualTimes[i] = coupon->accrualPeriod();
                 arguments->leg2PayDates[i] = coupon->date();
                 arguments->leg2ResetDates[i] = coupon->accrualStartDate();
@@ -490,7 +490,7 @@ namespace QuantLib {
                 ext::shared_ptr<CappedFlooredCoupon> cfcoupon =
                     ext::dynamic_pointer_cast<CappedFlooredCoupon>(
                         leg2Coupons[i]);
-                if (cfcoupon != 0) {
+                if (cfcoupon != nullptr) {
                     arguments->leg2CappedRates[i] = cfcoupon->cap();
                     arguments->leg2FlooredRates[i] = cfcoupon->floor();
                 }
@@ -570,8 +570,8 @@ namespace QuantLib {
         QL_REQUIRE(nominal2.size() == leg2IsRedemptionFlow.size(),
                    "nominal2 size is different from redemption2 size");
 
-        QL_REQUIRE(index1 != NULL, "index1 is null");
-        QL_REQUIRE(index2 != NULL, "index2 is null");
+        QL_REQUIRE(index1 != nullptr, "index1 is null");
+        QL_REQUIRE(index2 != nullptr, "index2 is null");
     }
 
     void FloatFloatSwap::results::reset() { Swap::results::reset(); }

--- a/ql/instruments/floatfloatswaption.cpp
+++ b/ql/instruments/floatfloatswaption.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<FloatFloatSwaption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->swap = swap_;
         arguments->exercise = exercise_;

--- a/ql/instruments/forwardvanillaoption.cpp
+++ b/ql/instruments/forwardvanillaoption.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         OneAssetOption::setupArguments(args);
         auto* arguments = dynamic_cast<ForwardVanillaOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->moneyness = moneyness_;
         arguments->resetDate = resetDate_;
@@ -45,8 +45,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         OneAssetOption::fetchResults(r);
         const auto* results = dynamic_cast<const ForwardVanillaOption::results*>(r);
-        QL_ENSURE(results != 0,
-                  "no results returned from pricing engine");
+        QL_ENSURE(results != nullptr, "no results returned from pricing engine");
         delta_       = results->delta;
         gamma_       = results->gamma;
         theta_       = results->theta;

--- a/ql/instruments/impliedvolatility.cpp
+++ b/ql/instruments/impliedvolatility.cpp
@@ -44,8 +44,7 @@ namespace QuantLib {
         : engine_(engine), vol_(vol), targetValue_(targetValue) {
             results_ =
                 dynamic_cast<const Instrument::results*>(engine_.getResults());
-            QL_REQUIRE(results_ != 0,
-                       "pricing engine does not supply needed results");
+            QL_REQUIRE(results_ != nullptr, "pricing engine does not supply needed results");
         }
 
         Real PriceError::operator()(Volatility x) const {

--- a/ql/instruments/inflationcapfloor.cpp
+++ b/ql/instruments/inflationcapfloor.cpp
@@ -131,7 +131,7 @@ namespace QuantLib {
 
     void YoYInflationCapFloor::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<YoYInflationCapFloor::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         Size n = yoyLeg_.size();
 

--- a/ql/instruments/lookbackoption.cpp
+++ b/ql/instruments/lookbackoption.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ContinuousFloatingLookbackOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->minmax = minmax_;
     }
 
@@ -62,7 +62,7 @@ namespace QuantLib {
         OneAssetOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ContinuousFixedLookbackOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->minmax = minmax_;
     }
 
@@ -91,7 +91,7 @@ namespace QuantLib {
         ContinuousFloatingLookbackOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ContinuousPartialFloatingLookbackOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->lambda = lambda_;
         moreArgs->lookbackPeriodEnd = lookbackPeriodEnd_;
     }
@@ -131,7 +131,7 @@ namespace QuantLib {
         ContinuousFixedLookbackOption::setupArguments(args);
 
         auto* moreArgs = dynamic_cast<ContinuousPartialFixedLookbackOption::arguments*>(args);
-        QL_REQUIRE(moreArgs != 0, "wrong argument type");
+        QL_REQUIRE(moreArgs != nullptr, "wrong argument type");
         moreArgs->lookbackPeriodStart = lookbackPeriodStart_;
     }
 

--- a/ql/instruments/makecms.cpp
+++ b/ql/instruments/makecms.cpp
@@ -137,7 +137,7 @@ namespace QuantLib {
             .withSpreads(cmsSpread_)
             .withCaps(cmsCap_)
             .withFloors(cmsFloor_);
-        if (couponPricer_ != 0)
+        if (couponPricer_ != nullptr)
             setCouponPricer(cmsLeg, couponPricer_);
 
         Rate usedSpread = iborSpread_;

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
                                       overnightIndex_, overnightSpread_,
                                       paymentLag_, paymentAdjustment_,
                                       paymentCalendar_, telescopicValueDates_);
-            if (engine_ == 0) {
+            if (engine_ == nullptr) {
                 Handle<YieldTermStructure> disc =
                                     overnightIndex_->forwardingTermStructure();
                 QL_REQUIRE(!disc.empty(),
@@ -126,7 +126,7 @@ namespace QuantLib {
                                  paymentLag_, paymentAdjustment_,
                                  paymentCalendar_, telescopicValueDates_));
 
-        if (engine_ == 0) {
+        if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
                                 overnightIndex_->forwardingTermStructure();
             bool includeSettlementDateFlows = false;

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -162,7 +162,7 @@ namespace QuantLib {
                              fixedDayCount,
                              floatSchedule, iborIndex_,
                              floatSpread_, floatDayCount_);
-            if (engine_ == 0) {
+            if (engine_ == nullptr) {
                 Handle<YieldTermStructure> disc =
                                         iborIndex_->forwardingTermStructure();
                 QL_REQUIRE(!disc.empty(),
@@ -185,7 +185,7 @@ namespace QuantLib {
                         floatSchedule,
                         iborIndex_, floatSpread_, floatDayCount_));
 
-        if (engine_ == 0) {
+        if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
                                     iborIndex_->forwardingTermStructure();
             bool includeSettlementDateFlows = false;

--- a/ql/instruments/multiassetoption.cpp
+++ b/ql/instruments/multiassetoption.cpp
@@ -79,7 +79,7 @@ namespace QuantLib {
     void MultiAssetOption::setupArguments(
                                        PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<MultiAssetOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff = payoff_;
         arguments->exercise = exercise_;
@@ -88,8 +88,7 @@ namespace QuantLib {
     void MultiAssetOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
         const auto* results = dynamic_cast<const Greeks*>(r);
-        QL_ENSURE(results != 0,
-                  "no greeks returned from pricing engine");
+        QL_ENSURE(results != nullptr, "no greeks returned from pricing engine");
         delta_          = results->delta;
         gamma_          = results->gamma;
         theta_          = results->theta;

--- a/ql/instruments/nonstandardswap.cpp
+++ b/ql/instruments/nonstandardswap.cpp
@@ -223,7 +223,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<NonstandardSwap::arguments*>(args);
 
-        if (arguments == 0)
+        if (arguments == nullptr)
             return; // swap engine ...
 
         arguments->type = type_;
@@ -242,7 +242,7 @@ namespace QuantLib {
         for (Size i = 0; i < fixedCoupons.size(); ++i) {
             ext::shared_ptr<FixedRateCoupon> coupon =
                 ext::dynamic_pointer_cast<FixedRateCoupon>(fixedCoupons[i]);
-            if (coupon != 0) {
+            if (coupon != nullptr) {
                 arguments->fixedPayDates[i] = coupon->date();
                 arguments->fixedResetDates[i] = coupon->accrualStartDate();
                 arguments->fixedCoupons[i] = coupon->amount();
@@ -282,7 +282,7 @@ namespace QuantLib {
         for (Size i = 0; i < floatingCoupons.size(); ++i) {
             ext::shared_ptr<IborCoupon> coupon =
                 ext::dynamic_pointer_cast<IborCoupon>(floatingCoupons[i]);
-            if (coupon != 0) {
+            if (coupon != nullptr) {
                 arguments->floatingResetDates[i] = coupon->accrualStartDate();
                 arguments->floatingPayDates[i] = coupon->date();
                 arguments->floatingFixingDates[i] = coupon->fixingDate();

--- a/ql/instruments/nonstandardswaption.cpp
+++ b/ql/instruments/nonstandardswaption.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<NonstandardSwaption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "argument types do not match");
+        QL_REQUIRE(arguments != nullptr, "argument types do not match");
 
         arguments->swap = swap_;
         arguments->exercise = exercise_;

--- a/ql/instruments/oneassetoption.cpp
+++ b/ql/instruments/oneassetoption.cpp
@@ -113,8 +113,7 @@ namespace QuantLib {
     void OneAssetOption::fetchResults(const PricingEngine::results* r) const {
         Option::fetchResults(r);
         const auto* results = dynamic_cast<const Greeks*>(r);
-        QL_ENSURE(results != 0,
-                  "no greeks returned from pricing engine");
+        QL_ENSURE(results != nullptr, "no greeks returned from pricing engine");
         /* no check on null values - just copy.
            this allows:
            a) to decide in derived options what to do when null
@@ -131,8 +130,7 @@ namespace QuantLib {
         dividendRho_    = results->dividendRho;
 
         const auto* moreResults = dynamic_cast<const MoreGreeks*>(r);
-        QL_ENSURE(moreResults != 0,
-                  "no more greeks returned from pricing engine");
+        QL_ENSURE(moreResults != nullptr, "no more greeks returned from pricing engine");
         /* no check on null values - just copy.
            this allows:
            a) to decide in derived options what to do when null

--- a/ql/instruments/payoffs.cpp
+++ b/ql/instruments/payoffs.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
     void NullPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<NullPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -82,7 +82,7 @@ namespace QuantLib {
 
     void FloatingTypePayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FloatingTypePayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -101,7 +101,7 @@ namespace QuantLib {
 
     void PlainVanillaPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<PlainVanillaPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -120,7 +120,7 @@ namespace QuantLib {
 
     void PercentageStrikePayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<PercentageStrikePayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -139,7 +139,7 @@ namespace QuantLib {
 
     void AssetOrNothingPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<AssetOrNothingPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -164,7 +164,7 @@ namespace QuantLib {
 
     void CashOrNothingPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CashOrNothingPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);}
@@ -188,7 +188,7 @@ namespace QuantLib {
 
     void GapPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<GapPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -200,7 +200,7 @@ namespace QuantLib {
 
     void SuperFundPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SuperFundPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);
@@ -217,7 +217,7 @@ namespace QuantLib {
 
     void SuperSharePayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SuperSharePayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);

--- a/ql/instruments/quantobarrieroption.cpp
+++ b/ql/instruments/quantobarrieroption.cpp
@@ -59,8 +59,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         BarrierOption::fetchResults(r);
         const auto* quantoResults = dynamic_cast<const QuantoBarrierOption::results*>(r);
-        QL_ENSURE(quantoResults != 0,
-                  "no quanto results returned from pricing engine");
+        QL_ENSURE(quantoResults != nullptr, "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;
         qvega_   = quantoResults->qvega;
         qlambda_ = quantoResults->qlambda;

--- a/ql/instruments/quantoforwardvanillaoption.cpp
+++ b/ql/instruments/quantoforwardvanillaoption.cpp
@@ -59,8 +59,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         ForwardVanillaOption::fetchResults(r);
         const auto* quantoResults = dynamic_cast<const QuantoForwardVanillaOption::results*>(r);
-        QL_ENSURE(quantoResults != 0,
-                  "no quanto results returned from pricing engine");
+        QL_ENSURE(quantoResults != nullptr, "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;
         qvega_   = quantoResults->qvega;
         qlambda_ = quantoResults->qlambda;

--- a/ql/instruments/quantovanillaoption.cpp
+++ b/ql/instruments/quantovanillaoption.cpp
@@ -57,8 +57,7 @@ namespace QuantLib {
                                       const PricingEngine::results* r) const {
         OneAssetOption::fetchResults(r);
         const auto* quantoResults = dynamic_cast<const QuantoVanillaOption::results*>(r);
-        QL_ENSURE(quantoResults != 0,
-                  "no quanto results returned from pricing engine");
+        QL_ENSURE(quantoResults != nullptr, "no quanto results returned from pricing engine");
         qrho_    = quantoResults->qrho;
         qvega_   = quantoResults->qvega;
         qlambda_ = quantoResults->qlambda;

--- a/ql/instruments/stickyratchet.cpp
+++ b/ql/instruments/stickyratchet.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
 
     void DoubleStickyRatchetPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<DoubleStickyRatchetPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             Payoff::accept(v);

--- a/ql/instruments/swap.cpp
+++ b/ql/instruments/swap.cpp
@@ -86,7 +86,7 @@ namespace QuantLib {
 
     void Swap::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<Swap::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->legs = legs_;
         arguments->payer = payer_;
@@ -96,7 +96,7 @@ namespace QuantLib {
         Instrument::fetchResults(r);
 
         const auto* results = dynamic_cast<const Swap::results*>(r);
-        QL_REQUIRE(results != 0, "wrong result type");
+        QL_REQUIRE(results != nullptr, "wrong result type");
 
         if (!results->legNPV.empty()) {
             QL_REQUIRE(results->legNPV.size() == legNPV_.size(),
@@ -163,7 +163,7 @@ namespace QuantLib {
                 ext::shared_ptr<LazyObject> f =
                     ext::dynamic_pointer_cast<LazyObject>(
                         legs_[j][k]);
-                if (f != 0)
+                if (f != nullptr)
                     f->update();
             }
         }

--- a/ql/instruments/swaption.cpp
+++ b/ql/instruments/swaption.cpp
@@ -149,7 +149,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<Swaption::arguments*>(args);
 
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->swap = swap_;
         arguments->settlementType = settlementType_;

--- a/ql/instruments/vanillastorageoption.hpp
+++ b/ql/instruments/vanillastorageoption.hpp
@@ -75,7 +75,7 @@ namespace QuantLib {
     inline void VanillaStorageOption::setupArguments(
                                 PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<VanillaStorageOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff
             = ext::dynamic_pointer_cast<NullPayoff>(payoff_);

--- a/ql/instruments/vanillaswap.cpp
+++ b/ql/instruments/vanillaswap.cpp
@@ -85,7 +85,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<VanillaSwap::arguments*>(args);
 
-        if (arguments == 0) // it's a swap engine...
+        if (arguments == nullptr) // it's a swap engine...
             return;
 
         arguments->type = type_;
@@ -183,7 +183,7 @@ namespace QuantLib {
         Swap::fetchResults(r);
 
         const auto* results = dynamic_cast<const VanillaSwap::results*>(r);
-        if (results != 0) { // might be a swap engine, so no error is thrown
+        if (results != nullptr) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;
         } else {

--- a/ql/instruments/vanillaswingoption.cpp
+++ b/ql/instruments/vanillaswingoption.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
 
     void VanillaForwardPayoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<VanillaForwardPayoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             StrikedTypePayoff::accept(v);
@@ -132,7 +132,7 @@ namespace QuantLib {
     void VanillaSwingOption::setupArguments(
                             PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<VanillaSwingOption::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff
             = ext::dynamic_pointer_cast<StrikedTypePayoff>(payoff_);

--- a/ql/instruments/varianceswap.cpp
+++ b/ql/instruments/varianceswap.cpp
@@ -45,7 +45,7 @@ namespace QuantLib {
 
     void VarianceSwap::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<VarianceSwap::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->position = position_;
         arguments->strike = strike_;

--- a/ql/instruments/yearonyearinflationswap.cpp
+++ b/ql/instruments/yearonyearinflationswap.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
 
         auto* arguments = dynamic_cast<YearOnYearInflationSwap::arguments*>(args);
 
-        if (arguments == 0) // it's a swap engine...
+        if (arguments == nullptr) // it's a swap engine...
             return;
 
         arguments->type = type_;
@@ -179,7 +179,7 @@ namespace QuantLib {
         Swap::fetchResults(r);
 
         const auto* results = dynamic_cast<const YearOnYearInflationSwap::results*>(r);
-        if (results != 0) { // might be a swap engine, so no error is thrown
+        if (results != nullptr) { // might be a swap engine, so no error is thrown
             fairRate_ = results->fairRate;
             fairSpread_ = results->fairSpread;
         } else {

--- a/ql/legacy/libormarketmodels/liborforwardmodel.cpp
+++ b/ql/legacy/libormarketmodels/liborforwardmodel.cpp
@@ -146,7 +146,7 @@ namespace QuantLib {
     // same frequency
     ext::shared_ptr<SwaptionVolatilityMatrix>
         LiborForwardModel::getSwaptionVolatilityMatrix() const {
-        if (swaptionVola != 0) {
+        if (swaptionVola != nullptr) {
             return swaptionVola;
         }
 

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -221,22 +221,22 @@ namespace QuantLib {
     // inline definitions
 
     inline Array::Array(Size size)
-    : data_(size != 0U ? new Real[size] : (Real*)(0)), n_(size) {}
+    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {}
 
     inline Array::Array(Size size, Real value)
-    : data_(size != 0U ? new Real[size] : (Real*)(0)), n_(size) {
+    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {
         std::fill(begin(),end(),value);
     }
 
     inline Array::Array(Size size, Real value, Real increment)
-    : data_(size != 0U ? new Real[size] : (Real*)(0)), n_(size) {
+    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {
         for (iterator i=begin(); i!=end(); ++i, value+=increment)
             *i = value;
     }
 
     inline Array::Array(const Array& from)
-    : data_(from.n_ != 0U ? new Real[from.n_] : (Real*)(0)), n_(from.n_) {
-        #if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
+    : data_(from.n_ != 0U ? new Real[from.n_] : (Real*)nullptr), n_(from.n_) {
+#if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
         if (n_)
         #endif
         std::copy(from.begin(),from.end(),begin());
@@ -268,7 +268,7 @@ namespace QuantLib {
             // Array with a given value, which we do here.
             Size n = begin;
             Real value = end;
-            data_.reset(n ? new Real[n] : (Real*)(0));
+            data_.reset(n ? new Real[n] : (Real*)nullptr);
             n_ = n;
             std::fill(a.begin(),a.end(),value);
         }
@@ -281,7 +281,7 @@ namespace QuantLib {
                                  const boost::false_type&) {
             // true iterators
             Size n = std::distance(begin, end);
-            data_.reset(n ? new Real[n] : (Real*)(0));
+            data_.reset(n ? new Real[n] : (Real*)nullptr);
             n_ = n;
             #if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
             if (n_)

--- a/ql/math/integrals/gaussianquadratures.hpp
+++ b/ql/math/integrals/gaussianquadratures.hpp
@@ -214,8 +214,8 @@ namespace QuantLib {
         explicit TabulatedGaussLegendre(Size n = 20) { order(n); }
         template <class F>
         Real operator() (const F& f) const {
-            QL_ASSERT(w_!=0, "Null weights" );
-            QL_ASSERT(x_!=0, "Null abscissas");
+            QL_ASSERT(w_ != nullptr, "Null weights");
+            QL_ASSERT(x_ != nullptr, "Null abscissas");
             Size startIdx;
             Real val;
 

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -197,31 +197,29 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline Matrix::Matrix()
-    : data_((Real*)(0)), rows_(0), columns_(0) {}
+    inline Matrix::Matrix() : data_((Real*)nullptr), rows_(0), columns_(0) {}
 
     inline Matrix::Matrix(Size rows, Size columns)
-    : data_(rows*columns > 0 ? new Real[rows*columns] : (Real*)(0)),
-      rows_(rows), columns_(columns) {}
+    : data_(rows * columns > 0 ? new Real[rows * columns] : (Real*)nullptr), rows_(rows),
+      columns_(columns) {}
 
     inline Matrix::Matrix(Size rows, Size columns, Real value)
-    : data_(rows*columns > 0 ? new Real[rows*columns] : (Real*)(0)),
-      rows_(rows), columns_(columns) {
+    : data_(rows * columns > 0 ? new Real[rows * columns] : (Real*)nullptr), rows_(rows),
+      columns_(columns) {
         std::fill(begin(),end(),value);
     }
 
     template <class Iterator>
-    inline Matrix::Matrix(Size rows, Size columns,
-                          Iterator begin, Iterator end)
-        : data_(rows * columns > 0 ? new Real[rows * columns] : (Real *)(0)),
-          rows_(rows), columns_(columns) {
+    inline Matrix::Matrix(Size rows, Size columns, Iterator begin, Iterator end)
+    : data_(rows * columns > 0 ? new Real[rows * columns] : (Real*)nullptr), rows_(rows),
+      columns_(columns) {
         std::copy(begin, end, this->begin());
     }
 
     inline Matrix::Matrix(const Matrix& from)
-    : data_(!from.empty() ? new Real[from.rows_*from.columns_] : (Real*)(0)),
+    : data_(!from.empty() ? new Real[from.rows_ * from.columns_] : (Real*)nullptr),
       rows_(from.rows_), columns_(from.columns_) {
-        #if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
+#if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
         if (!from.empty())
         #endif
         std::copy(from.begin(),from.end(),begin());

--- a/ql/math/matrixutilities/bicgstab.cpp
+++ b/ql/math/matrixutilities/bicgstab.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
                p = r;
            }
 
-           pTld = ((M_) != 0 ? M_(p) : p);
+           pTld = ((M_) != nullptr ? M_(p) : p);
            v     = A_(pTld);
 
            alpha = rho/DotProduct(rTld, v);
@@ -75,7 +75,7 @@ namespace QuantLib {
               break;
            }
 
-           sTld = ((M_) != 0 ? M_(s) : s);
+           sTld = ((M_) != nullptr ? M_(s) : s);
            t = A_(sTld);
            omega = DotProduct(t,s)/DotProduct(t,t);
            x += alpha*pTld + omega*sTld;

--- a/ql/math/matrixutilities/bicgstab.cpp
+++ b/ql/math/matrixutilities/bicgstab.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
                p = r;
            }
 
-           pTld = ((M_) != nullptr ? M_(p) : p);
+           pTld = (M_ == QL_NULL_FUNCTION ? p : M_(p));
            v     = A_(pTld);
 
            alpha = rho/DotProduct(rTld, v);
@@ -75,7 +75,7 @@ namespace QuantLib {
               break;
            }
 
-           sTld = ((M_) != nullptr ? M_(s) : s);
+           sTld = (M_ == QL_NULL_FUNCTION ? s : M_(s));
            t = A_(sTld);
            omega = DotProduct(t,s)/DotProduct(t,t);
            x += alpha*pTld + omega*sTld;

--- a/ql/math/matrixutilities/gmres.cpp
+++ b/ql/math/matrixutilities/gmres.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
 
         for (Size j=0; j < maxIter_ && errors.back() >= relTol_; ++j) {
             h.push_back(Array(maxIter_, 0.0));
-            Array w = A_((M_) != nullptr ? M_(v[j]) : v[j]);
+            Array w = A_(M_ == QL_NULL_FUNCTION ? v[j] : M_(v[j]));
 
             for (Size i=0; i <= j; ++i) {
                 h[i][j] = DotProduct(w, v[i]);
@@ -142,7 +142,7 @@ namespace QuantLib {
         Array xm = std::inner_product(
             v.begin(), v.begin()+k, y.begin(), Array(x.size(), 0.0));
 
-        xm = x + ((M_) != nullptr ? M_(xm) : xm);
+        xm = x + (M_ == QL_NULL_FUNCTION ? xm : M_(xm));
 
         GMRESResult result = { errors, xm };
         return result;

--- a/ql/math/matrixutilities/gmres.cpp
+++ b/ql/math/matrixutilities/gmres.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
 
         for (Size j=0; j < maxIter_ && errors.back() >= relTol_; ++j) {
             h.push_back(Array(maxIter_, 0.0));
-            Array w = A_((M_) != 0 ? M_(v[j]) : v[j]);
+            Array w = A_((M_) != nullptr ? M_(v[j]) : v[j]);
 
             for (Size i=0; i <= j; ++i) {
                 h[i][j] = DotProduct(w, v[i]);
@@ -142,7 +142,7 @@ namespace QuantLib {
         Array xm = std::inner_product(
             v.begin(), v.begin()+k, y.begin(), Array(x.size(), 0.0));
 
-        xm = x + ((M_) != 0 ? M_(xm) : xm);
+        xm = x + ((M_) != nullptr ? M_(xm) : xm);
 
         GMRESResult result = { errors, xm };
         return result;

--- a/ql/math/optimization/lmdif.cpp
+++ b/ql/math/optimization/lmdif.cpp
@@ -1375,7 +1375,7 @@ L30:
 *    calculate the jacobian matrix.
 */
 iflag = 2;
-if (jacFcn != 0) // use user supplied jacobian calculation
+if (jacFcn != nullptr) // use user supplied jacobian calculation
     jacFcn(m,n,x,fjac,&iflag);
 else
     fdjac2(m,n,x,fvec,fjac,ldfjac,&iflag,epsfcn,wa4, fcn);

--- a/ql/math/optimization/lmdif.cpp
+++ b/ql/math/optimization/lmdif.cpp
@@ -1375,10 +1375,10 @@ L30:
 *    calculate the jacobian matrix.
 */
 iflag = 2;
-if (jacFcn != nullptr) // use user supplied jacobian calculation
-    jacFcn(m,n,x,fjac,&iflag);
-else
+if (jacFcn == QL_NULL_FUNCTION) // use user supplied jacobian calculation
     fdjac2(m,n,x,fvec,fjac,ldfjac,&iflag,epsfcn,wa4, fcn);
+else
+    jacFcn(m,n,x,fjac,&iflag);
 *nfev += n;
 if(iflag < 0)
     goto L300;

--- a/ql/math/randomnumbers/latticerules.cpp
+++ b/ql/math/randomnumbers/latticerules.cpp
@@ -14467,7 +14467,7 @@ void LatticeRule::getRule(type name, std::vector<Real>& Z, Integer N)
     // put in check that N is a power of 2
 
 
-    const Real* dumbPointer=0;
+    const Real* dumbPointer = nullptr;
 
     switch (name)
     {
@@ -14485,7 +14485,7 @@ void LatticeRule::getRule(type name, std::vector<Real>& Z, Integer N)
 
     }
 
-    QL_REQUIRE(dumbPointer!=0, "unknown lattice rule requested");
+    QL_REQUIRE(dumbPointer != nullptr, "unknown lattice rule requested");
 
 
     std::copy(dumbPointer, dumbPointer+ruleLength,Z.begin());

--- a/ql/math/randomnumbers/seedgenerator.cpp
+++ b/ql/math/randomnumbers/seedgenerator.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
     void SeedGenerator::initialize() {
 
         // firstSeed is chosen based on clock() and used for the first rng
-        auto firstSeed = (unsigned long)(std::time(0));
+        auto firstSeed = (unsigned long)(std::time(nullptr));
         MersenneTwisterUniformRng first(firstSeed);
 
         // secondSeed is as random as it could be

--- a/ql/methods/finitedifferences/finitedifferencemodel.hpp
+++ b/ql/methods/finitedifferences/finitedifferencemodel.hpp
@@ -69,7 +69,7 @@ namespace QuantLib {
                       Time from,
                       Time to,
                       Size steps) {
-            rollbackImpl(a,from,to,steps,(const condition_type*) 0);
+            rollbackImpl(a, from, to, steps, (const condition_type*)nullptr);
         }
         /*! solves the problem between the given times,
             applying a condition at every step.

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
         const Handle<YieldTermStructure> rTS = process->riskFreeRate();
 
         const Handle<YieldTermStructure> qTS =
-            (fdmQuantoHelper) != 0 ?
+            (fdmQuantoHelper) != nullptr ?
                 Handle<YieldTermStructure>(ext::make_shared<QuantoTermStructure>(
                     process->dividendYield(), process->riskFreeRate(),
                     Handle<YieldTermStructure>(fdmQuantoHelper->fTS_), process->blackVolatility(),

--- a/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
@@ -167,7 +167,7 @@ namespace QuantLib {
 
         volaEstimate_ = mesher.volaEstimate();
 
-        if (leverageFct != 0) {
+        if (leverageFct != nullptr) {
             typedef boost::accumulators::accumulator_set<
                 Real, boost::accumulators::stats<
                     boost::accumulators::tag::mean> >

--- a/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
         opX_.setTime(t1, t2);
         opY_.setTime(t1, t2);
 
-        if (localVol1_ != 0) {
+        if (localVol1_ != nullptr) {
             const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
             const FdmLinearOpIterator endIter = layout->end();
 
@@ -99,8 +99,7 @@ namespace QuantLib {
                 }
             }
             corrMapT_ = corrMapTemplate_.mult(vol1*vol2);
-        }
-        else {
+        } else {
             const Real vol1 = p1_
                     ->blackVolatility()->blackForwardVol(t1, t2, p1_->x0());
     
@@ -110,7 +109,7 @@ namespace QuantLib {
             corrMapT_ = corrMapTemplate_
                       .mult(Array(mesher_->layout()->size(), vol1*vol2));
         }
-        
+
         currentForwardRate_ = p1_->riskFreeRate()
                                  ->forwardRate(t1, t2, Continuous).rate();
     }

--- a/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
         const Rate r = rTS_->forwardRate(t1, t2, Continuous).rate();
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
-        if (localVol_ != 0) {
+        if (localVol_ != nullptr) {
             const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
             const FdmLinearOpIterator endIter = layout->end();
 
@@ -80,21 +80,19 @@ namespace QuantLib {
                 }
             }
 
-            if (quantoHelper_ != 0) {
+            if (quantoHelper_ != nullptr) {
                 mapT_.axpyb(r - q - 0.5*v
                     - quantoHelper_->quantoAdjustment(Sqrt(v), t1, t2),
                     dxMap_, dxxMap_.mult(0.5*v), Array(1, -r));
-            }
-            else {
+            } else {
                 mapT_.axpyb(r - q - 0.5*v, dxMap_,
                             dxxMap_.mult(0.5*v), Array(1, -r));
             }
-        }
-        else {
+        } else {
             const Real v
                 = volTS_->blackForwardVariance(t1, t2, strike_)/(t2-t1);
 
-            if (quantoHelper_ != 0) {
+            if (quantoHelper_ != nullptr) {
                 mapT_.axpyb(
                     Array(1, r - q - 0.5*v)
                         - quantoHelper_->quantoAdjustment(
@@ -102,8 +100,7 @@ namespace QuantLib {
                     dxMap_,
                     dxxMap_.mult(0.5*Array(mesher_->layout()->size(), v)),
                     Array(1, -r));
-            }
-            else {
+            } else {
                 mapT_.axpyb(Array(1, r - q - 0.5*v), dxMap_,
                     dxxMap_.mult(0.5*Array(mesher_->layout()->size(), v)),
                     Array(1, -r));

--- a/ql/methods/finitedifferences/operators/fdmhestonop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonop.cpp
@@ -66,13 +66,12 @@ namespace QuantLib {
         L_ = getLeverageFctSlice(t1, t2);
         const Array Lsquare = L_*L_;
 
-        if (quantoHelper_ != 0) {
+        if (quantoHelper_ != nullptr) {
             mapT_.axpyb(r - q - varianceValues_*Lsquare
                 - quantoHelper_->quantoAdjustment(
                     volatilityValues_*L_, t1, t2),
                 dxMap_, dxxMap_.mult(Lsquare), Array(1, -0.5*r));
-        }
-        else {
+        } else {
             mapT_.axpyb(r - q - varianceValues_*Lsquare, dxMap_,
                         dxxMap_.mult(Lsquare), Array(1, -0.5*r));
         }

--- a/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
                                        const ext::shared_ptr<LocalVolTermStructure>& localVol,
                                        Size direction)
     : mesher_(mesher), rTS_(rTS), qTS_(qTS), localVol_(localVol),
-      x_((localVol) != 0 ? Array(Exp(mesher->locations(direction))) : Array()),
+      x_((localVol) != nullptr ? Array(Exp(mesher->locations(direction))) : Array()),
       dxMap_(FirstDerivativeOp(direction, mesher)), dxxMap_(SecondDerivativeOp(direction, mesher)),
       mapT_(direction, mesher), direction_(direction) {}
 

--- a/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
         const ext::shared_ptr<FdmStepConditionComposite>& condition,
         const FdmSchemeDesc& schemeDesc)
     : map_(map), bcSet_(bcSet),
-      condition_((condition) != 0 ?
+      condition_((condition) != nullptr ?
                      condition :
                      ext::make_shared<FdmStepConditionComposite>(
                          std::list<std::vector<Time> >(), FdmStepConditionComposite::Conditions())),

--- a/ql/methods/finitedifferences/tridiagonaloperator.hpp
+++ b/ql/methods/finitedifferences/tridiagonaloperator.hpp
@@ -202,7 +202,7 @@ namespace QuantLib {
     }
 
     inline void TridiagonalOperator::setTime(Time t) {
-        if (timeSetter_ != 0)
+        if (timeSetter_ != nullptr)
             timeSetter_->setTime(t, *this);
     }
 

--- a/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
@@ -51,9 +51,9 @@ namespace QuantLib {
     }
 
     void FdmTimeDepDirichletBoundary::setTime(Time t) {
-        if (valueOnBoundary_ != nullptr) {
+        if (!(valueOnBoundary_ == QL_NULL_FUNCTION)) {
             std::fill(values_.begin(), values_.end(), valueOnBoundary_(t));
-        } else if (valuesOnBoundary_ != nullptr) {
+        } else if (!(valuesOnBoundary_ == QL_NULL_FUNCTION)) {
             values_ = valuesOnBoundary_(t);
         } else {
             QL_FAIL("no boundary values defined");

--- a/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmtimedepdirichletboundary.cpp
@@ -51,12 +51,11 @@ namespace QuantLib {
     }
 
     void FdmTimeDepDirichletBoundary::setTime(Time t) {
-        if (valueOnBoundary_ != 0) {
+        if (valueOnBoundary_ != nullptr) {
             std::fill(values_.begin(), values_.end(), valueOnBoundary_(t));
-        } else if (valuesOnBoundary_ != 0) {
+        } else if (valuesOnBoundary_ != nullptr) {
             values_ = valuesOnBoundary_(t);
-        }
-        else {
+        } else {
             QL_FAIL("no boundary values defined");
         }
     }

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.cpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
                                       const Real y,
                                       const ext::shared_ptr<IborIndex>& iborIdx) const {
 
-        QL_REQUIRE(iborIdx != NULL, "no ibor index given");
+        QL_REQUIRE(iborIdx != nullptr, "no ibor index given");
 
         calculate();
 
@@ -57,7 +57,7 @@ Real Gaussian1dModel::swapRate(const Date& fixing,
                                const Real y,
                                const ext::shared_ptr<SwapIndex>& swapIdx) const {
 
-    QL_REQUIRE(swapIdx != NULL, "no swap index given");
+    QL_REQUIRE(swapIdx != nullptr, "no swap index given");
 
     calculate();
 
@@ -79,7 +79,7 @@ Real Gaussian1dModel::swapRate(const Date& fixing,
 
     ext::shared_ptr<OvernightIndexedSwapIndex> oisIdx =
         ext::dynamic_pointer_cast<OvernightIndexedSwapIndex>(swapIdx);
-    if (oisIdx != NULL) {
+    if (oisIdx != nullptr) {
         floatSched = sched;
     } else {
         floatSched = underlying->floatingSchedule();
@@ -117,7 +117,7 @@ Real Gaussian1dModel::swapAnnuity(const Date& fixing,
                                   const Real y,
                                   const ext::shared_ptr<SwapIndex>& swapIdx) const {
 
-    QL_REQUIRE(swapIdx != NULL, "no swap index given");
+    QL_REQUIRE(swapIdx != nullptr, "no swap index given");
 
     calculate();
 
@@ -252,7 +252,7 @@ Disposable<Array> Gaussian1dModel::yGrid(
 
     // we use that the standard deviation is independent of $x$ here !
 
-    QL_REQUIRE(stateProcess_ != NULL, "state process not set");
+    QL_REQUIRE(stateProcess_ != nullptr, "state process not set");
 
     Array result(2 * gridPoints + 1, 0.0);
 

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -233,7 +233,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
 
 inline ext::shared_ptr<StochasticProcess1D> Gaussian1dModel::stateProcess() const {
 
-    QL_REQUIRE(stateProcess_ != NULL, "state process not set");
+    QL_REQUIRE(stateProcess_ != nullptr, "state process not set");
     return stateProcess_;
 }
 

--- a/ql/models/shortrate/onefactormodels/gsr.cpp
+++ b/ql/models/shortrate/onefactormodels/gsr.cpp
@@ -93,7 +93,7 @@ Gsr::Gsr(const Handle<YieldTermStructure> &termStructure,
 void Gsr::update() {
     if (stateProcess_ != nullptr)
         ext::static_pointer_cast<GsrProcess>(stateProcess_)->flushCache();
-	LazyObject::update();
+    LazyObject::update();
 }
 
 void Gsr::updateTimes() const {

--- a/ql/models/shortrate/onefactormodels/gsr.cpp
+++ b/ql/models/shortrate/onefactormodels/gsr.cpp
@@ -90,8 +90,8 @@ Gsr::Gsr(const Handle<YieldTermStructure> &termStructure,
     initialize(T);
 }
 
-void Gsr::update() { 
-	if (stateProcess_ != NULL)
+void Gsr::update() {
+    if (stateProcess_ != nullptr)
         ext::static_pointer_cast<GsrProcess>(stateProcess_)->flushCache();
 	LazyObject::update();
 }
@@ -111,7 +111,7 @@ void Gsr::updateTimes() const {
                            << volsteptimes_[j - 1] << "@" << (j - 1) << ", "
                            << volsteptimes_[j] << "@" << j << ")");
     }
-    if (stateProcess_ != NULL)
+    if (stateProcess_ != nullptr)
         ext::static_pointer_cast<GsrProcess>(stateProcess_)->flushCache();
 }
 

--- a/ql/option.hpp
+++ b/ql/option.hpp
@@ -91,7 +91,7 @@ namespace QuantLib {
 
     inline void Option::setupArguments(PricingEngine::arguments* args) const {
         auto* arguments = dynamic_cast<Option::arguments*>(args);
-        QL_REQUIRE(arguments != 0, "wrong argument type");
+        QL_REQUIRE(arguments != nullptr, "wrong argument type");
 
         arguments->payoff = payoff_;
         arguments->exercise = exercise_;

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -209,7 +209,7 @@ namespace QuantLib {
 
     inline std::pair<Observer::iterator, bool>
     Observer::registerWith(const ext::shared_ptr<Observable>& h) {
-        if (h != 0) {
+        if (h != nullptr) {
             h->registerObserver(this);
             return observables_.insert(h);
         }
@@ -218,7 +218,7 @@ namespace QuantLib {
 
     inline void
     Observer::registerWithObservables(const ext::shared_ptr<Observer> &o) {
-        if (o != 0) {
+        if (o != nullptr) {
             iterator i;
             for (i = o->observables_.begin(); i != o->observables_.end(); ++i)
                 registerWith(*i);
@@ -227,7 +227,7 @@ namespace QuantLib {
 
     inline
     Size Observer::unregisterWith(const ext::shared_ptr<Observable>& h) {
-        if (h != 0)
+        if (h != nullptr)
             h->unregisterObserver(this);
         return observables_.erase(h);
     }

--- a/ql/payoff.hpp
+++ b/ql/payoff.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
 
     inline void Payoff::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<Payoff>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a payoff visitor");

--- a/ql/pricingengines/americanpayoffatexpiry.cpp
+++ b/ql/pricingengines/americanpayoffatexpiry.cpp
@@ -52,14 +52,14 @@ namespace QuantLib {
         // binary cash-or-nothing payoff?
         ext::shared_ptr<CashOrNothingPayoff> coo =
             ext::dynamic_pointer_cast<CashOrNothingPayoff>(payoff);
-        if (coo != 0) {
+        if (coo != nullptr) {
             K_ = coo->cashPayoff();
         }
 
         // binary asset-or-nothing payoff?
         ext::shared_ptr<AssetOrNothingPayoff> aoo =
             ext::dynamic_pointer_cast<AssetOrNothingPayoff>(payoff);
-        if (aoo != 0) {
+        if (aoo != nullptr) {
             K_ = forward_;
             mu_ += 1.0;
         }

--- a/ql/pricingengines/americanpayoffathit.cpp
+++ b/ql/pricingengines/americanpayoffathit.cpp
@@ -137,7 +137,7 @@ namespace QuantLib {
         // Binary Cash-Or-Nothing payoff?
         ext::shared_ptr<CashOrNothingPayoff> coo =
             ext::dynamic_pointer_cast<CashOrNothingPayoff>(payoff);
-        if (coo != 0) {
+        if (coo != nullptr) {
             K_ = coo->cashPayoff();
             DKDstrike_ = 0.0;
         }
@@ -145,7 +145,7 @@ namespace QuantLib {
         // Binary Asset-Or-Nothing payoff?
         ext::shared_ptr<AssetOrNothingPayoff> aoo =
             ext::dynamic_pointer_cast<AssetOrNothingPayoff>(payoff);
-        if (aoo != 0) {
+        if (aoo != nullptr) {
             if (inTheMoney_) {
                 K_ = spot_;
                 DKDstrike_ = 0.0;
@@ -154,10 +154,6 @@ namespace QuantLib {
                 DKDstrike_ = 1.0;
             }
         }
-
-
-
-
     }
 
 

--- a/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
+++ b/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
@@ -163,14 +163,14 @@ namespace QuantLib {
         // binary cash-or-nothing payoff?
         ext::shared_ptr<CashOrNothingPayoff> coo =
             ext::dynamic_pointer_cast<CashOrNothingPayoff>(payoff_);
-        if (coo != 0) {
+        if (coo != nullptr) {
             K = coo->cashPayoff();
         }
 
         // binary asset-or-nothing payoff?
         ext::shared_ptr<AssetOrNothingPayoff> aoo =
             ext::dynamic_pointer_cast<AssetOrNothingPayoff>(payoff_);
-        if (aoo != 0) {
+        if (aoo != nullptr) {
             mu += 1.0; 
             K = spot * dividendDiscount / discount; // forward
         }

--- a/ql/pricingengines/basket/mcamericanbasketengine.cpp
+++ b/ql/pricingengines/basket/mcamericanbasketengine.cpp
@@ -50,7 +50,7 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> strikePayoff
             = ext::dynamic_pointer_cast<StrikedTypePayoff>(basketPayoff->basePayoff());
 
-        if (strikePayoff != 0) {
+        if (strikePayoff != nullptr) {
             scalingValue_/=strikePayoff->strike();
         }
 

--- a/ql/pricingengines/basket/stulzengine.cpp
+++ b/ql/pricingengines/basket/stulzengine.cpp
@@ -152,7 +152,7 @@ namespace QuantLib {
         Real forward2 = process2_->stateVariable()->value() *
             dividendDiscount2 / riskFreeDiscount;
 
-        if (max_basket != 0) {
+        if (max_basket != nullptr) {
             switch (payoff->optionType()) {
               // euro call on a two asset max basket
               case Option::Call:
@@ -176,7 +176,7 @@ namespace QuantLib {
               default:
                 QL_FAIL("unknown option type");
             }
-        } else if (min_basket != 0) {
+        } else if (min_basket != nullptr) {
             switch (payoff->optionType()) {
               // euro call on a two asset min basket
               case Option::Call:

--- a/ql/pricingengines/capfloor/analyticcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/analyticcapfloorengine.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
 
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
-        if (tsmodel != 0) {
+        if (tsmodel != nullptr) {
             referenceDate = tsmodel->termStructure()->referenceDate();
             dayCounter = tsmodel->termStructure()->dayCounter();
         } else {

--- a/ql/pricingengines/capfloor/gaussian1dcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/gaussian1dcapfloorengine.cpp
@@ -72,7 +72,7 @@ namespace QuantLib {
 
                         for (Size j = 0; j < z.size(); j++) {
                             Real floatingLegNpv;
-                            if (iborIndex != NULL)
+                            if (iborIndex != nullptr)
                                 floatingLegNpv =
                                     arguments_.accrualTimes[i] *
                                     model_->forwardRate(fixingDate, fixingDate,
@@ -144,7 +144,7 @@ namespace QuantLib {
                     } else {
                         for (Size j = 0; j < z.size(); j++) {
                             Real floatingLegNpv;
-                            if (iborIndex != NULL)
+                            if (iborIndex != nullptr)
                                 floatingLegNpv =
                                     arguments_.accrualTimes[i] *
                                     model_->forwardRate(fixingDate, fixingDate,

--- a/ql/pricingengines/capfloor/treecapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/treecapfloorengine.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
-        if (tsmodel != 0) {
+        if (tsmodel != nullptr) {
             referenceDate = tsmodel->termStructure()->referenceDate();
             dayCounter = tsmodel->termStructure()->dayCounter();
         } else {
@@ -63,7 +63,7 @@ namespace QuantLib {
         DiscretizedCapFloor capfloor(arguments_, referenceDate, dayCounter);
         ext::shared_ptr<Lattice> lattice;
 
-        if (lattice_ != 0) {
+        if (lattice_ != nullptr) {
             lattice = lattice_;
         } else {
             std::vector<Time> times = capfloor.mandatoryTimes();

--- a/ql/pricingengines/credit/isdacdsengine.cpp
+++ b/ql/pricingengines/credit/isdacdsengine.cpp
@@ -91,8 +91,7 @@ namespace QuantLib {
                    "ISDA engine not compatible with non accrual paying CDS");
         QL_REQUIRE(arguments_.paysAtDefaultTime,
                    "ISDA engine not compatible with end period payment");
-        QL_REQUIRE(ext::dynamic_pointer_cast<FaceValueClaim>(
-                       arguments_.claim) != NULL,
+        QL_REQUIRE(ext::dynamic_pointer_cast<FaceValueClaim>(arguments_.claim) != nullptr,
                    "ISDA engine not compatible with non face value claim");
 
         Date maturity = arguments_.maturity;

--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -129,7 +129,7 @@ namespace QuantLib {
     // Compute fair spread for strike value:
     // copy args into the non risky engine
     auto* noCVAArgs = dynamic_cast<Swap::arguments*>(baseSwapEngine_->getArguments());
-    QL_REQUIRE(noCVAArgs != 0, "wrong argument type");
+    QL_REQUIRE(noCVAArgs != nullptr, "wrong argument type");
 
     noCVAArgs->legs = this->arguments_.legs;
     noCVAArgs->payer = this->arguments_.payer;
@@ -141,7 +141,7 @@ namespace QuantLib {
     Rate baseSwapRate = coupon->rate();
 
     const auto* vSResults = dynamic_cast<const Swap::results*>(baseSwapEngine_->getResults());
-    QL_REQUIRE(vSResults != 0, "wrong result type");
+    QL_REQUIRE(vSResults != nullptr, "wrong result type");
 
     Rate baseSwapFairRate = -baseSwapRate * vSResults->legNPV[1] / 
         vSResults->legNPV[0];

--- a/ql/pricingengines/swap/treeswapengine.cpp
+++ b/ql/pricingengines/swap/treeswapengine.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
 
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
-        if (tsmodel != 0) {
+        if (tsmodel != nullptr) {
             referenceDate = tsmodel->termStructure()->referenceDate();
             dayCounter = tsmodel->termStructure()->dayCounter();
         } else {
@@ -60,7 +60,7 @@ namespace QuantLib {
         std::vector<Time> times = swap.mandatoryTimes();
 
         ext::shared_ptr<Lattice> lattice;
-        if (lattice_ != 0) {
+        if (lattice_ != nullptr) {
             lattice = lattice_;
         } else {
             TimeGrid timeGrid(times.begin(), times.end(), timeSteps_);

--- a/ql/pricingengines/swaption/basketgeneratingengine.cpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
             Date expiry = exercise->date(i);
             Real rebate = 0.0;
             Date rebateDate = expiry;
-            if (rebEx != NULL) {
+            if (rebEx != nullptr) {
                 rebate = rebEx->rebate(i);
                 rebateDate = rebEx->rebatePaymentDate(i);
             }

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -184,9 +184,9 @@ namespace QuantLib {
         ext::shared_ptr<SwapSpreadIndex> cmsspread2 =
             ext::dynamic_pointer_cast<SwapSpreadIndex>(arguments_.index2);
 
-        QL_REQUIRE(ibor1 != NULL || cms1 != NULL || cmsspread1 != NULL,
+        QL_REQUIRE(ibor1 != nullptr || cms1 != nullptr || cmsspread1 != nullptr,
                    "index1 must be ibor or swap or swap spread index");
-        QL_REQUIRE(ibor2 != NULL || cms2 != NULL || cmsspread2 != NULL,
+        QL_REQUIRE(ibor2 != nullptr || cms2 != nullptr || cmsspread2 != nullptr,
                    "index2 must be ibor or swap or swap spread index");
 
         do {
@@ -458,17 +458,17 @@ namespace QuantLib {
                                 amount = arguments_.leg1Coupons[j];
                             } else {
                                 Real estFixing = 0.0;
-                                if(ibor1 != NULL) {
+                                if (ibor1 != nullptr) {
                                     estFixing = model_->forwardRate(
                                         arguments_.leg1FixingDates[j], event0,
                                         zk, ibor1);
                                 }
-                                if(cms1 != NULL) {
+                                if (cms1 != nullptr) {
                                     estFixing = model_->swapRate(
                                         arguments_.leg1FixingDates[j],
                                         cms1->tenor(), event0, zk, cms1);
                                 }
-                                if (cmsspread1 != NULL)
+                                if (cmsspread1 != nullptr)
                                     estFixing =
                                         cmsspread1->gearing1() *
                                             model_->swapRate(
@@ -542,11 +542,11 @@ namespace QuantLib {
                                 amount = arguments_.leg2Coupons[j];
                             } else {
                                 Real estFixing = 0.0;
-                                if(ibor2 != NULL)
+                                if (ibor2 != nullptr)
                                     estFixing = model_->forwardRate(arguments_.leg2FixingDates[j],event0,zk,ibor2);
-                                if(cms2 != NULL)
+                                if (cms2 != nullptr)
                                     estFixing = model_->swapRate(arguments_.leg2FixingDates[j],cms2->tenor(),event0,zk,cms2);
-                                if (cmsspread2 != NULL)
+                                if (cmsspread2 != nullptr)
                                     estFixing =
                                         cmsspread2->gearing1() *
                                             model_->swapRate(
@@ -602,7 +602,7 @@ namespace QuantLib {
                         Real rebate = 0.0;
                         Real zSpreadDf = 1.0;
                         Date rebateDate = event0;
-                        if (rebatedExercise_ != NULL) {
+                        if (rebatedExercise_ != nullptr) {
                             rebate = rebatedExercise_->rebate(j);
                             rebateDate = rebatedExercise_->rebatePaymentDate(j);
                             zSpreadDf =

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
@@ -415,7 +415,7 @@ namespace QuantLib {
                     Real rebate = 0.0;
                     Real zSpreadDf = 1.0;
                     Date rebateDate = expiry0;
-                    if (rebatedExercise != NULL) {
+                    if (rebatedExercise != nullptr) {
                         rebate = rebatedExercise->rebate(idx);
                         rebateDate = rebatedExercise->rebatePaymentDate(idx);
                         zSpreadDf =

--- a/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
 
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
-        if (tsmodel != 0) {
+        if (tsmodel != nullptr) {
             referenceDate = tsmodel->termStructure()->referenceDate();
             dayCounter = tsmodel->termStructure()->dayCounter();
         } else {

--- a/ql/pricingengines/swaption/treeswaptionengine.cpp
+++ b/ql/pricingengines/swaption/treeswaptionengine.cpp
@@ -66,7 +66,7 @@ namespace QuantLib {
 
         ext::shared_ptr<TermStructureConsistentModel> tsmodel =
             ext::dynamic_pointer_cast<TermStructureConsistentModel>(*model_);
-        if (tsmodel != 0) {
+        if (tsmodel != nullptr) {
             referenceDate = tsmodel->termStructure()->referenceDate();
             dayCounter = tsmodel->termStructure()->dayCounter();
         } else {
@@ -77,7 +77,7 @@ namespace QuantLib {
         DiscretizedSwaption swaption(arguments_, referenceDate, dayCounter);
         ext::shared_ptr<Lattice> lattice;
 
-        if (lattice_ != 0) {
+        if (lattice_ != nullptr) {
             lattice = lattice_;
         } else {
             std::vector<Time> times = swaption.mandatoryTimes();

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -845,14 +845,14 @@ namespace QuantLib {
           case Trapezoid:
           case GaussLobatto:
           case GaussKronrod:
-              if (maxBound != nullptr && maxBound() != Null<Real>())
+              if (!(maxBound == QL_NULL_FUNCTION) && maxBound() != Null<Real>())
                   retVal = (*integrator_)(f, 0.0, maxBound());
               else
                   retVal = (*integrator_)(integrand2(c_inf, f), 0.0, 1.0);
               break;
           case DiscreteTrapezoid:
           case DiscreteSimpson:
-              if (maxBound != nullptr && maxBound() != Null<Real>())
+              if (!(maxBound == QL_NULL_FUNCTION) && maxBound() != Null<Real>())
                   retVal = (*integrator_)(f, 0.0, maxBound());
               else
                   retVal = (*integrator_)(integrand3(c_inf, f), 0.0, 1.0);

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -232,32 +232,21 @@ namespace QuantLib {
     {
     }
 
-    AnalyticHestonEngine::Fj_Helper::Fj_Helper(Real kappa, Real theta,
-        Real sigma, Real v0, Real s0, Real rho,
-        ComplexLogFormula cpxLog,
-        Time term,
-        Real strike,
-        Real ratio,
-        Size j)
-        :
-        j_(j),
-        kappa_(kappa),
-        theta_(theta),
-        sigma_(sigma),
-        v0_(v0),
-        cpxLog_(cpxLog),
-        term_(term),
-        x_(std::log(s0)),
-        sx_(std::log(strike)),
-        dd_(x_-std::log(ratio)),
-        sigma2_(sigma_*sigma_),
-        rsigma_(rho*sigma_),
-        t0_(kappa - ((j== 1)? rho*sigma : 0)),
-        b_(0),
-        g_km1_(0),
-        engine_(0)
-    {
-    }
+    AnalyticHestonEngine::Fj_Helper::Fj_Helper(Real kappa,
+                                               Real theta,
+                                               Real sigma,
+                                               Real v0,
+                                               Real s0,
+                                               Real rho,
+                                               ComplexLogFormula cpxLog,
+                                               Time term,
+                                               Real strike,
+                                               Real ratio,
+                                               Size j)
+    : j_(j), kappa_(kappa), theta_(theta), sigma_(sigma), v0_(v0), cpxLog_(cpxLog), term_(term),
+      x_(std::log(s0)), sx_(std::log(strike)), dd_(x_ - std::log(ratio)), sigma2_(sigma_ * sigma_),
+      rsigma_(rho * sigma_), t0_(kappa - ((j == 1) ? rho * sigma : 0)), b_(0), g_km1_(0),
+      engine_(nullptr) {}
 
 
     Real AnalyticHestonEngine::Fj_Helper::operator()(Real phi) const
@@ -270,7 +259,7 @@ namespace QuantLib {
                       *std::complex<Real>(-phi, (j_== 1)? 1 : -1));
         const std::complex<Real> ex = std::exp(-d*term_);
         const std::complex<Real> addOnTerm =
-            engine_ != 0 ? engine_->addOnTerm(phi, term_, j_) : Real(0.0);
+            engine_ != nullptr ? engine_->addOnTerm(phi, term_, j_) : Real(0.0);
 
         if (cpxLog_ == Gatheral) {
             if (phi != 0.0) {
@@ -387,7 +376,7 @@ namespace QuantLib {
       freq_(std::log(fwd/strike)),
       cpxLog_(cpxLog),
       enginePtr_(enginePtr) {
-        QL_REQUIRE(enginePtr != 0, "pricing engine required");
+        QL_REQUIRE(enginePtr != nullptr, "pricing engine required");
 
         const Real v0    = enginePtr->model_->v0();
         const Real kappa = enginePtr->model_->kappa();
@@ -820,12 +809,11 @@ namespace QuantLib {
     }
 
     Size AnalyticHestonEngine::Integration::numberOfEvaluations() const {
-        if (integrator_ != 0) {
+        if (integrator_ != nullptr) {
             return integrator_->numberOfEvaluations();
-        } else if (gaussianQuadrature_ != 0) {
+        } else if (gaussianQuadrature_ != nullptr) {
             return gaussianQuadrature_->order();
-        }
-        else {
+        } else {
             QL_FAIL("neither Integrator nor GaussianQuadrature given");
         }
     }
@@ -857,14 +845,14 @@ namespace QuantLib {
           case Trapezoid:
           case GaussLobatto:
           case GaussKronrod:
-              if (maxBound != 0 && maxBound() != Null<Real>())
+              if (maxBound != nullptr && maxBound() != Null<Real>())
                   retVal = (*integrator_)(f, 0.0, maxBound());
               else
                   retVal = (*integrator_)(integrand2(c_inf, f), 0.0, 1.0);
               break;
           case DiscreteTrapezoid:
           case DiscreteSimpson:
-              if (maxBound != 0 && maxBound() != Null<Real>())
+              if (maxBound != nullptr && maxBound() != Null<Real>())
                   retVal = (*integrator_)(f, 0.0, maxBound());
               else
                   retVal = (*integrator_)(integrand3(c_inf, f), 0.0, 1.0);

--- a/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
@@ -130,7 +130,7 @@ namespace QuantLib {
           sx_(std::log(strike)),
           dd_(x_-std::log(ratio)),
           enginePtr_(enginePtr) {
-            QL_REQUIRE(enginePtr != 0, "pricing engine required");
+            QL_REQUIRE(enginePtr != nullptr, "pricing engine required");
         }
 
         Real operator()(Real u) const {

--- a/ql/pricingengines/vanilla/fddividendengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendengine.hpp
@@ -51,7 +51,7 @@ namespace QuantLib {
         virtual void executeIntermediateStep(Size step) const = 0;
         Real getDividendAmount(Size i) const {
             const auto* dividend = dynamic_cast<const Dividend*>(this->events_[i].get());
-            if (dividend != 0) {
+            if (dividend != nullptr) {
                 return dividend->amount();
             } else {
                 return 0.0;
@@ -210,7 +210,7 @@ namespace QuantLib {
         Real underlying = this->process_->stateVariable()->value();
         for (Size i=0; i<this->events_.size(); i++) {
             const auto* dividend = dynamic_cast<const Dividend*>(this->events_[i].get());
-            if (dividend == 0)
+            if (dividend == nullptr)
                 continue;
             if (this->getDividendTime(i) < 0.0) continue;
             underlying -= dividend->amount(underlying);
@@ -225,7 +225,7 @@ namespace QuantLib {
     void FDDividendEngineShiftScale<Scheme>::executeIntermediateStep(
                                                              Size step) const{
         const auto* dividend = dynamic_cast<const Dividend*>(this->events_[step].get());
-        if (dividend == 0)
+        if (dividend == nullptr)
             return;
         detail::DividendAdder adder(dividend);
         this->sMin_ = adder(this->sMin_);

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
@@ -68,7 +68,7 @@ namespace QuantLib {
                     ext::dynamic_pointer_cast<PlainVanillaPayoff>(
                                           cachedArgs2results_[i].first.payoff);
 
-                if ((p1 != 0) && p1->strike() == p2->strike() &&
+                if ((p1 != nullptr) && p1->strike() == p2->strike() &&
                     p1->optionType() == p2->optionType()) {
                     QL_REQUIRE(arguments_.cashFlow.empty(),
                                "multiple strikes engine does "

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -156,7 +156,7 @@ namespace QuantLib {
                     ext::dynamic_pointer_cast<PlainVanillaPayoff>(
                                           cachedArgs2results_[i].first.payoff);
 
-                if ((p1 != 0) && p1->strike() == p2->strike() &&
+                if ((p1 != nullptr) && p1->strike() == p2->strike() &&
                     p1->optionType() == p2->optionType()) {
                     QL_REQUIRE(arguments_.cashFlow.empty(),
                                "multiple strikes engine does "

--- a/ql/pricingengines/vanilla/fdvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdvanillaengine.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
 
             ext::shared_ptr<StrikedTypePayoff> striked_payoff =
                 ext::dynamic_pointer_cast<StrikedTypePayoff>(payoff_);
-            Real K = striked_payoff != 0 ? striked_payoff->strike() : process_->x0();
+            Real K = striked_payoff != nullptr ? striked_payoff->strike() : process_->x0();
             Volatility sigma =
                 process_->blackVolatility()->blackVol(exerciseDate_, K);
 

--- a/ql/pricingengines/vanilla/mcamericanengine.cpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> strikePayoff
             = ext::dynamic_pointer_cast<StrikedTypePayoff>(payoff_);
 
-        if (strikePayoff != 0) {
+        if (strikePayoff != nullptr) {
             scalingValue_/=strikePayoff->strike();
         }
     }

--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -189,7 +189,7 @@ namespace QuantLib {
             ext::shared_ptr<BlackConstantVol> constVol =
                 ext::dynamic_pointer_cast<BlackConstantVol>(
                                                           *blackVolatility());
-            if (constVol != 0) {
+            if (constVol != nullptr) {
                 // ok, the local vol is constant too.
                 localVolatility_.linkTo(ext::make_shared<LocalConstantVol>(
                     constVol->referenceDate(),
@@ -203,7 +203,7 @@ namespace QuantLib {
             ext::shared_ptr<BlackVarianceCurve> volCurve =
                 ext::dynamic_pointer_cast<BlackVarianceCurve>(
                                                           *blackVolatility());
-            if (volCurve != 0) {
+            if (volCurve != nullptr) {
                 // ok, we can use the optimized algorithm
                 localVolatility_.linkTo(ext::make_shared<LocalVolCurve>(
                     Handle<BlackVarianceCurve>(volCurve)));

--- a/ql/termstructures/bootstraphelper.hpp
+++ b/ql/termstructures/bootstraphelper.hpp
@@ -148,18 +148,18 @@ namespace QuantLib {
 
     template <class TS>
     BootstrapHelper<TS>::BootstrapHelper(const Handle<Quote>& quote)
-    : quote_(quote), termStructure_(0) {
+    : quote_(quote), termStructure_(nullptr) {
         registerWith(quote_);
     }
 
     template <class TS>
     BootstrapHelper<TS>::BootstrapHelper(Real quote)
     : quote_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(quote)))),
-      termStructure_(0) {}
+      termStructure_(nullptr) {}
 
     template <class TS>
     void BootstrapHelper<TS>::setTermStructure(TS* t) {
-        QL_REQUIRE(t != 0, "null term structure given");
+        QL_REQUIRE(t != nullptr, "null term structure given");
         termStructure_ = t;
     }
 
@@ -204,7 +204,7 @@ namespace QuantLib {
     template <class TS>
     void BootstrapHelper<TS>::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BootstrapHelper<TS> >*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a bootstrap-helper visitor");

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -88,13 +88,13 @@ GlobalBootstrap<Curve>::GlobalBootstrap(Real accuracy)
 
 template <class Curve>
 GlobalBootstrap<Curve>::GlobalBootstrap(
-    const std::vector<ext::shared_ptr<typename Traits::helper> > &additionalHelpers,
-    const boost::function<std::vector<Date>()> &additionalDates,
-    const boost::function<Array()> &additionalErrors,
+    const std::vector<ext::shared_ptr<typename Traits::helper> >& additionalHelpers,
+    const boost::function<std::vector<Date>()>& additionalDates,
+    const boost::function<Array()>& additionalErrors,
     Real accuracy)
-    : ts_(0), accuracy_(accuracy), additionalHelpers_(additionalHelpers),
-      additionalDates_(additionalDates), additionalErrors_(additionalErrors),
-      initialized_(false), validCurve_(false) {}
+: ts_(nullptr), accuracy_(accuracy), additionalHelpers_(additionalHelpers),
+  additionalDates_(additionalDates), additionalErrors_(additionalErrors), initialized_(false),
+  validCurve_(false) {}
 
 template <class Curve> void GlobalBootstrap<Curve>::setup(Curve *ts) {
     ts_ = ts;
@@ -134,7 +134,7 @@ template <class Curve> void GlobalBootstrap<Curve>::initialize() const {
 
     // skip expired additional dates
     std::vector<Date> additionalDates;
-    if (additionalDates_ != 0)
+    if (additionalDates_ != nullptr)
         additionalDates = additionalDates_();
     firstAdditionalDate_ = 0;
     if (!additionalDates.empty()) {
@@ -279,7 +279,7 @@ template <class Curve> void GlobalBootstrap<Curve>::calculate() const {
                 result[i] = ts_->instruments_[firstHelper_ + i]->quote()->value() -
                             ts_->instruments_[firstHelper_ + i]->impliedQuote();
             }
-            if (additionalErrors_ != 0) {
+            if (additionalErrors_ != nullptr) {
                 Array tmp = additionalErrors_();
                 result.resize(numberHelpers_ + tmp.size());
                 for (Size i = 0; i < tmp.size(); ++i) {

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
                           const ext::shared_ptr<Seasonality>& seasonality) {
         // always reset, whether with null or new pointer
         seasonality_ = seasonality;
-        if (seasonality_ != 0) {
+        if (seasonality_ != nullptr) {
             QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with "
                        "inflation term structure");

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -125,11 +125,17 @@ namespace detail {
     // template definitions
 
     template <class Curve>
-    IterativeBootstrap<Curve>::IterativeBootstrap(Real accuracy, Real minValue, Real maxValue,
-        Size maxAttempts, Real maxFactor, Real minFactor, bool dontThrow, Size dontThrowSteps)
-    : accuracy_(accuracy), minValue_(minValue), maxValue_(maxValue),
-      maxAttempts_(maxAttempts), maxFactor_(maxFactor), minFactor_(minFactor), dontThrow_(dontThrow),
-      dontThrowSteps_(dontThrowSteps), ts_(0), initialized_(false), validCurve_(false),
+    IterativeBootstrap<Curve>::IterativeBootstrap(Real accuracy,
+                                                  Real minValue,
+                                                  Real maxValue,
+                                                  Size maxAttempts,
+                                                  Real maxFactor,
+                                                  Real minFactor,
+                                                  bool dontThrow,
+                                                  Size dontThrowSteps)
+    : accuracy_(accuracy), minValue_(minValue), maxValue_(maxValue), maxAttempts_(maxAttempts),
+      maxFactor_(maxFactor), minFactor_(minFactor), dontThrow_(dontThrow),
+      dontThrowSteps_(dontThrowSteps), ts_(nullptr), initialized_(false), validCurve_(false),
       loopRequired_(Interpolator::global) {
         QL_REQUIRE(maxFactor_ >= 1.0, "Expected that maxFactor would be at least 1.0 but got " << maxFactor_);
         QL_REQUIRE(minFactor_ >= 1.0, "Expected that minFactor would be at least 1.0 but got " << minFactor_);

--- a/ql/termstructures/localbootstrap.hpp
+++ b/ql/termstructures/localbootstrap.hpp
@@ -105,12 +105,9 @@ namespace QuantLib {
     // template definitions
 
     template <class Curve>
-    LocalBootstrap<Curve>::LocalBootstrap(Size localisation,
-                                          bool forcePositive,
-                                          Real accuracy)
-    : validCurve_(false), ts_(0), localisation_(localisation),
-      forcePositive_(forcePositive), accuracy_(accuracy)
-    {}
+    LocalBootstrap<Curve>::LocalBootstrap(Size localisation, bool forcePositive, Real accuracy)
+    : validCurve_(false), ts_(nullptr), localisation_(localisation), forcePositive_(forcePositive),
+      accuracy_(accuracy) {}
 
     template <class Curve>
     void LocalBootstrap<Curve>::setup(Curve* ts) {

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -185,7 +185,7 @@ namespace QuantLib {
         callCostFct_(callCostFct) { }
 
         Disposable<Array> values(const Array& sig) const override {
-            if ((putCostFct_ != 0) && (callCostFct_ != 0)) {
+            if ((putCostFct_ != nullptr) && (callCostFct_ != nullptr)) {
                 const Array pv = putCostFct_->values(sig);
                 const Array cv = callCostFct_->values(sig);
 
@@ -194,21 +194,21 @@ namespace QuantLib {
                 std::copy(cv.begin(), cv.end(), retVal.begin() + cv.size());
 
                 return retVal;
-            } else if (putCostFct_ != 0)
+            } else if (putCostFct_ != nullptr)
                 return putCostFct_->values(sig);
-            else if (callCostFct_ != 0)
+            else if (callCostFct_ != nullptr)
                 return callCostFct_->values(sig);
             else
                 QL_FAIL("internal error: cost function not set");
         }
 
         Disposable<Array> initialValues() const {
-            if ((putCostFct_ != 0) && (callCostFct_ != 0))
+            if ((putCostFct_ != nullptr) && (callCostFct_ != nullptr))
                 return 0.5*(  putCostFct_->initialValues()
                             + callCostFct_->initialValues());
-            else if (putCostFct_ != 0)
+            else if (putCostFct_ != nullptr)
                 return putCostFct_->initialValues();
-            else if (callCostFct_ != 0)
+            else if (callCostFct_ != nullptr)
                 return callCostFct_->initialValues();
             else
                 QL_FAIL("internal error: cost function not set");
@@ -460,9 +460,9 @@ namespace QuantLib {
             maxError_ = std::max(maxError_,
                 *std::max_element(vegaDiffs.begin(), vegaDiffs.end()));
 
-            if (putCostFct != 0)
+            if (putCostFct != nullptr)
                 npvPuts = putCostFct->solveFor(dT_[i], sig, npvPuts);
-            if (callCostFct != 0)
+            if (callCostFct != nullptr)
                 npvCalls= callCostFct->solveFor(dT_[i], sig, npvCalls);
         }
 

--- a/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
@@ -123,7 +123,7 @@ namespace QuantLib {
 
     inline void BlackConstantVol::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackConstantVol>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVolatilityTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
@@ -103,7 +103,7 @@ namespace QuantLib {
 
     inline void BlackVarianceCurve::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVarianceCurve>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVarianceTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/blackvariancesurface.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancesurface.hpp
@@ -101,7 +101,7 @@ namespace QuantLib {
 
     inline void BlackVarianceSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVarianceSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVarianceTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
@@ -250,7 +250,7 @@ namespace QuantLib {
 
     inline void BlackVolTermStructure::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVolTermStructure>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a Black-volatility term structure visitor");
@@ -265,7 +265,7 @@ namespace QuantLib {
 
     inline void BlackVolatilityTermStructure::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVolatilityTermStructure>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVolTermStructure::accept(v);
@@ -281,7 +281,7 @@ namespace QuantLib {
 
     inline void BlackVarianceTermStructure::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BlackVarianceTermStructure>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVolTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/impliedvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/impliedvoltermstructure.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
 
     inline void ImpliedVolTermStructure::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<ImpliedVolTermStructure>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BlackVarianceTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/localconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/localconstantvol.hpp
@@ -108,7 +108,7 @@ namespace QuantLib {
 
     inline void LocalConstantVol::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<LocalConstantVol>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             LocalVolTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/localvolcurve.hpp
+++ b/ql/termstructures/volatility/equityfx/localvolcurve.hpp
@@ -67,7 +67,7 @@ namespace QuantLib {
 
     inline void LocalVolCurve::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<LocalVolCurve>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             LocalVolTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/localvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.cpp
@@ -76,7 +76,7 @@ namespace QuantLib {
 
     void LocalVolSurface::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<LocalVolSurface>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             LocalVolTermStructure::accept(v);

--- a/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
+++ b/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
 
     void LocalVolTermStructure::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<LocalVolTermStructure>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             QL_FAIL("not a local-volatility term structure visitor");

--- a/ql/termstructures/volatility/gaussian1dsmilesection.cpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         annuity_ =
             model_->swapAnnuity(fixingDate_, swapIndex_->tenor(), Null<Date>(), 0.0, swapIndex_);
 
-        if (engine_ == NULL) {
+        if (engine_ == nullptr) {
             engine_ = ext::make_shared<Gaussian1dSwaptionEngine>(
                 model_, 64, 7.0, true, false, swapIndex_->discountingTermStructure());
         }
@@ -64,7 +64,7 @@ Gaussian1dSmileSection::Gaussian1dSmileSection(
         iborIndex_->dayCounter().yearFraction(c.startDate(), c.maturityDate()) *
         model_->zerobond(c.maturityDate());
 
-    if (engine_ == NULL) {
+    if (engine_ == nullptr) {
         engine_ = ext::make_shared<Gaussian1dCapFloorEngine>(
             model_, 64, 7.0, true,
             false); // use model curve as discounting curve
@@ -76,7 +76,7 @@ Real Gaussian1dSmileSection::atmLevel() const { return atm_; }
 Real Gaussian1dSmileSection::optionPrice(Rate strike, Option::Type type,
                                          Real discount) const {
 
-    if (swapIndex_ != NULL) {
+    if (swapIndex_ != nullptr) {
         Swaption s = MakeSwaption(swapIndex_, fixingDate_, strike)
                          .withUnderlyingType(type == Option::Call
                                                  ? VanillaSwap::Payer

--- a/ql/termstructures/volatility/swaption/cmsmarket.cpp
+++ b/ql/termstructures/volatility/swaption/cmsmarket.cpp
@@ -174,8 +174,7 @@ namespace QuantLib {
                 ext::shared_ptr<MeanRevertingPricer> p =
                     ext::dynamic_pointer_cast<MeanRevertingPricer>(
                         pricers_[j]);
-                QL_REQUIRE(p != NULL, "mean reverting pricer required at index "
-                                          << j);
+                QL_REQUIRE(p != nullptr, "mean reverting pricer required at index " << j);
                 p->setMeanReversion(meanReversionQuote);
             }
         }

--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -67,7 +67,7 @@ namespace QuantLib {
     }
 
     Real BondHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         bond_->recalculate();
 
@@ -87,7 +87,7 @@ namespace QuantLib {
 
     void BondHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BondHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BootstrapHelper<YieldTermStructure>::accept(v);
@@ -149,7 +149,7 @@ namespace QuantLib {
 
     void FixedRateBondHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FixedRateBondHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BondHelper::accept(v);
@@ -219,7 +219,7 @@ namespace QuantLib {
 
     void CPIBondHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CPIBondHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             BondHelper::accept(v);

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -329,13 +329,13 @@ namespace QuantLib {
                                              const Handle<YieldTermStructure>& discountCurve,
                                              const Real minCutoffTime,
                                              const Real maxCutoffTime)
-    : FittedBondDiscountCurve::FittingMethod(method != 0 ? method->constrainAtZero() : true,
-                                             method != 0 ? method->weights() : Array(),
-                                             method != 0 ? method->optimizationMethod() :
-                                                           ext::shared_ptr<OptimizationMethod>(),
-                                             method != 0 ? method->l2() : Array(),
-                                             minCutoffTime,
-                                             maxCutoffTime),
+    : FittedBondDiscountCurve::FittingMethod(
+          method != nullptr ? method->constrainAtZero() : true,
+          method != nullptr ? method->weights() : Array(),
+          method != nullptr ? method->optimizationMethod() : ext::shared_ptr<OptimizationMethod>(),
+          method != nullptr ? method->l2() : Array(),
+          minCutoffTime,
+          maxCutoffTime),
       method_(method), discountingCurve_(discountCurve) {
         QL_REQUIRE(method, "Fitting method is empty");
         QL_REQUIRE(!discountingCurve_.empty(), "Discounting curve cannot be empty");

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -126,7 +126,7 @@ namespace QuantLib {
     }
 
     Real OISRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         swap_->recalculate();
         return swap_->fairRate();
@@ -134,7 +134,7 @@ namespace QuantLib {
 
     void OISRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<OISRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -191,7 +191,7 @@ namespace QuantLib {
     }
 
     Real DatedOISRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         swap_->deepUpdate();
         return swap_->fairRate();
@@ -199,7 +199,7 @@ namespace QuantLib {
 
     void DatedOISRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<DatedOISRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -264,7 +264,7 @@ namespace QuantLib {
     }
 
     Real FuturesRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         Rate forwardRate = (termStructure_->discount(earliestDate_) /
             termStructure_->discount(maturityDate_) - 1.0) / yearFraction_;
         Rate convAdj = convAdj_.empty() ? 0.0 : convAdj_->value();
@@ -281,7 +281,7 @@ namespace QuantLib {
 
     void FuturesRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FuturesRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -332,7 +332,7 @@ namespace QuantLib {
     }
 
     Real DepositRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // the forecast fixing flag is set to true because
         // we do not want to take fixing into account
         return iborIndex_->fixing(fixingDate_, true);
@@ -362,7 +362,7 @@ namespace QuantLib {
 
     void DepositRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<DepositRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -580,7 +580,7 @@ namespace QuantLib {
     }
 
     Real FraRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         if (useIndexedCoupon_)
             return iborIndex_->fixing(fixingDate_, true);
         else
@@ -670,7 +670,7 @@ namespace QuantLib {
 
     void FraRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FraRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -887,7 +887,7 @@ namespace QuantLib {
     }
 
     Real SwapRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         swap_->recalculate();
         // weak implementation... to be improved
@@ -902,7 +902,7 @@ namespace QuantLib {
 
     void SwapRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SwapRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -995,7 +995,7 @@ namespace QuantLib {
     }
 
     Real BMASwapRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
         swap_->recalculate();
         return swap_->fairLiborFraction();
@@ -1003,7 +1003,7 @@ namespace QuantLib {
 
     void BMASwapRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<BMASwapRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);
@@ -1052,7 +1052,7 @@ namespace QuantLib {
     }
 
     Real FxSwapRateHelper::impliedQuote() const {
-        QL_REQUIRE(termStructure_ != 0, "term structure not set");
+        QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
 
         QL_REQUIRE(!collHandle_.empty(), "collateral term structure not set");
 
@@ -1085,7 +1085,7 @@ namespace QuantLib {
 
     void FxSwapRateHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FxSwapRateHelper>*>(&v);
-        if (v1 != 0)
+        if (v1 != nullptr)
             v1->visit(*this);
         else
             RateHelper::accept(v);

--- a/ql/utilities/clone.hpp
+++ b/ql/utilities/clone.hpp
@@ -92,7 +92,7 @@ namespace QuantLib {
 
     template <class T>
     inline Clone<T>::Clone(const Clone<T>& t)
-    : ptr_(t.empty() ? (T*)(0) : t->clone().release()) {}
+    : ptr_(t.empty() ? (T*)nullptr : t->clone().release()) {}
 
     template <class T>
     inline Clone<T>::Clone(Clone<T>&& t) QL_NOEXCEPT {
@@ -111,7 +111,7 @@ namespace QuantLib {
 
     template <class T>
     inline Clone<T>& Clone<T>::operator=(const Clone<T>& t) {
-        ptr_.reset(t.empty() ? (T*)(0) : t->clone().release());
+        ptr_.reset(t.empty() ? (T*)nullptr : t->clone().release());
         return *this;
     }
 

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -428,8 +428,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg.front());
     ext::shared_ptr<FixedRateCoupon> lastCpn =
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg.back());
-    BOOST_REQUIRE(firstCpn != NULL);
-    BOOST_REQUIRE(lastCpn != NULL);
+    BOOST_REQUIRE(firstCpn != nullptr);
+    BOOST_REQUIRE(lastCpn != nullptr);
     BOOST_CHECK_EQUAL(firstCpn->referencePeriodStart(), Date(25, Mar, 2017));
     BOOST_CHECK_EQUAL(firstCpn->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpn->referencePeriodStart(), Date(25, Sep, 2020));
@@ -439,8 +439,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg2.front());
     ext::shared_ptr<FixedRateCoupon> lastCpn2 =
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg2.back());
-    BOOST_REQUIRE(firstCpn2 != NULL);
-    BOOST_REQUIRE(lastCpn2 != NULL);
+    BOOST_REQUIRE(firstCpn2 != nullptr);
+    BOOST_REQUIRE(lastCpn2 != nullptr);
     BOOST_CHECK_EQUAL(firstCpn2->referencePeriodStart(), Date(25, Mar, 2017));
     BOOST_CHECK_EQUAL(firstCpn2->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpn2->referencePeriodStart(), Date(25, Sep, 2020));
@@ -450,8 +450,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg3.front());
     ext::shared_ptr<FixedRateCoupon> lastCpn3 =
         ext::dynamic_pointer_cast<FixedRateCoupon>(leg3.back());
-    BOOST_REQUIRE(firstCpn3 != NULL);
-    BOOST_REQUIRE(lastCpn3 != NULL);
+    BOOST_REQUIRE(firstCpn3 != nullptr);
+    BOOST_REQUIRE(lastCpn3 != nullptr);
     BOOST_CHECK_EQUAL(firstCpn3->referencePeriodStart(), Date(15, Sep, 2017));
     BOOST_CHECK_EQUAL(firstCpn3->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpn3->referencePeriodStart(), Date(25, Sep, 2020));
@@ -474,8 +474,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf.front());
     ext::shared_ptr<FloatingRateCoupon> lastCpnF =
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf.back());
-    BOOST_REQUIRE(firstCpnF != NULL);
-    BOOST_REQUIRE(lastCpnF != NULL);
+    BOOST_REQUIRE(firstCpnF != nullptr);
+    BOOST_REQUIRE(lastCpnF != nullptr);
     BOOST_CHECK_EQUAL(firstCpnF->referencePeriodStart(), Date(25, Mar, 2017));
     BOOST_CHECK_EQUAL(firstCpnF->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpnF->referencePeriodStart(), Date(25, Sep, 2020));
@@ -485,8 +485,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf2.front());
     ext::shared_ptr<FloatingRateCoupon> lastCpnF2 =
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf2.back());
-    BOOST_REQUIRE(firstCpnF2 != NULL);
-    BOOST_REQUIRE(lastCpnF2 != NULL);
+    BOOST_REQUIRE(firstCpnF2 != nullptr);
+    BOOST_REQUIRE(lastCpnF2 != nullptr);
     BOOST_CHECK_EQUAL(firstCpnF2->referencePeriodStart(), Date(25, Mar, 2017));
     BOOST_CHECK_EQUAL(firstCpnF2->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpnF2->referencePeriodStart(), Date(25, Sep, 2020));
@@ -496,8 +496,8 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf3.front());
     ext::shared_ptr<FloatingRateCoupon> lastCpnF3 =
         ext::dynamic_pointer_cast<FloatingRateCoupon>(legf3.back());
-    BOOST_REQUIRE(firstCpnF3 != NULL);
-    BOOST_REQUIRE(lastCpnF3 != NULL);
+    BOOST_REQUIRE(firstCpnF3 != nullptr);
+    BOOST_REQUIRE(lastCpnF3 != nullptr);
     BOOST_CHECK_EQUAL(firstCpnF3->referencePeriodStart(), Date(15, Sep, 2017));
     BOOST_CHECK_EQUAL(firstCpnF3->referencePeriodEnd(), Date(25, Sep, 2017));
     BOOST_CHECK_EQUAL(lastCpnF3->referencePeriodStart(), Date(25, Sep, 2020));

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3241,7 +3241,8 @@ void HestonModelTest::testAsymptoticControlVariate() {
             const ext::shared_ptr<AnalyticHestonEngine> analyticHestonEngine =
                 ext::dynamic_pointer_cast<AnalyticHestonEngine>(engine);
 
-            if ((analyticHestonEngine != 0) && analyticHestonEngine->numberOfEvaluations() > 5000) {
+            if ((analyticHestonEngine != nullptr) &&
+                analyticHestonEngine->numberOfEvaluations() > 5000) {
                 BOOST_ERROR("too many function valuation needed "
                         << "\n  moneyness      : " << moneyness
                         << "\n  evaluations    : "

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -326,7 +326,7 @@ void CPISwapTest::consistency() {
 
         ext::shared_ptr<CPICoupon>
         zic = ext::dynamic_pointer_cast<CPICoupon>(zisV.cpiLeg()[i]);
-        if (zic != 0) {
+        if (zic != nullptr) {
             if (zic->fixingDate() < (common.evaluationDate - Period(1,Months))) {
                 fixedIndex->addFixing(zic->fixingDate(), cpiFix[i],true);
             }
@@ -354,7 +354,7 @@ void CPISwapTest::consistency() {
 
         ext::shared_ptr<CPICoupon>
             zicV = ext::dynamic_pointer_cast<CPICoupon>(zisV.cpiLeg()[i]);
-        if (zicV != 0) {
+        if (zicV != nullptr) {
             Real diff = fabs( zicV->rate() - (fixedRate*(zicV->indexFixing()/baseCPI)) );
             QL_REQUIRE(diff<1e-8,"failed "<<i<<"th coupon reconstruction as "
                        << (fixedRate*(zicV->indexFixing()/baseCPI)) << " vs rate = "
@@ -505,7 +505,7 @@ void CPISwapTest::cpibondconsistency() {
 
         ext::shared_ptr<CPICoupon>
         zic = ext::dynamic_pointer_cast<CPICoupon>(zisV.cpiLeg()[i]);
-        if (zic != 0) {
+        if (zic != nullptr) {
             if (zic->fixingDate() < (common.evaluationDate - Period(1,Months))) {
                 fixedIndex->addFixing(zic->fixingDate(), cpiFix[i],true);
             }

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -4655,39 +4655,36 @@ void MarketModelTest::testStochVolForwardsAndOptionlets() {
                               Real trueValue =0.0;
                               Size evaluations =0;
 
-                              AnalyticHestonEngine::doCalculation(1.0, // no discounting
-                                             1.0 ,// no discounting
-                                             todaysForwards[i]+displacement,
-                                             todaysForwards[i]+displacement,
-                                             rateTimes[i],
-                                             kappa,
-                                             theta,
-                                             sigma,
-                                             v1,
-                                             rho,
-                                             *payoff,
-                                             AnalyticHestonEngine::Integration::gaussLaguerre(),
-//                                             AnalyticHestonEngine::Integration::gaussLobatto(1e-8, 1e-8),
-                                             AnalyticHestonEngine::Gatheral,
-                                             0,
-                                             trueValue,
-                                             evaluations);
+                              AnalyticHestonEngine::doCalculation(
+                                  1.0, // no discounting
+                                  1.0, // no discounting
+                                  todaysForwards[i] + displacement,
+                                  todaysForwards[i] + displacement, rateTimes[i], kappa, theta,
+                                  sigma, v1, rho, *payoff,
+                                  AnalyticHestonEngine::Integration::gaussLaguerre(),
+                                  //                                             AnalyticHestonEngine::Integration::gaussLobatto(1e-8,
+                                  //                                             1e-8),
+                                  AnalyticHestonEngine::Gatheral, nullptr, trueValue, evaluations);
 
 
-                                trueValue *= accruals[i]*todaysDiscounts[i+1];
+                              trueValue *= accruals[i] * todaysDiscounts[i + 1];
 
-                       //        trueValue =
-                      //                              BlackCalculator(displacedPayoffs[i],
-                      //                                                todaysForwards[i]+displacement,
-                      //                                             volatilities[i]*std::sqrt(rateTimes[i]),
-                     //                                              todaysDiscounts[i+1]*accruals[i]).value();
+                              //        trueValue =
+                              //                              BlackCalculator(displacedPayoffs[i],
+                              //                                                todaysForwards[i]+displacement,
+                              //                                             volatilities[i]*std::sqrt(rateTimes[i]),
+                              //                                              todaysDiscounts[i+1]*accruals[i]).value();
 
 
-                                Real error = results[i+ accruals.size()] - trueValue;
-                                Real errorSds = error/ errors[i];
+                              Real error = results[i + accruals.size()] - trueValue;
+                              Real errorSds = error / errors[i];
 
-                                if (fabs(errorSds) > 4)
-                                    BOOST_FAIL("error in sds: " << errorSds << " for caplet " << i << " in SV LMM test. True value:" << trueValue << ", actual value: " << results[i+ accruals.size()] << " , standard error " << errors[i]);
+                              if (fabs(errorSds) > 4)
+                                  BOOST_FAIL("error in sds: "
+                                             << errorSds << " for caplet " << i
+                                             << " in SV LMM test. True value:" << trueValue
+                                             << ", actual value: " << results[i + accruals.size()]
+                                             << " , standard error " << errors[i]);
 
 
 
@@ -4874,7 +4871,7 @@ void MarketModelTest::testCovariance() {
               default:
                 BOOST_FAIL("Unknown model " << modelNames[k]);
             }
-            if (model != 0) {
+            if (model != nullptr) {
                 for(Size i=0;i<evolTimes[l].size();i++) {
                     Matrix cov = model->covariance(i);
                     Real dt = evolTimes[l][i] - (i>0 ? evolTimes[l][i-1] : 0.0);


### PR DESCRIPTION
Added the corresponding clang-tidy check, which in turn provided the automated changes.