### PR TITLE
New interface for seasoned Asian options

### DIFF
--- a/ql/instruments/asianoption.cpp
+++ b/ql/instruments/asianoption.cpp
@@ -20,8 +20,8 @@
 
 #include <ql/instruments/asianoption.hpp>
 #include <ql/time/date.hpp>
-#include <utility>
 #include <ql/settings.hpp>
+#include <utility>
 
 namespace QuantLib {
 
@@ -60,9 +60,7 @@ namespace QuantLib {
     : OneAssetOption(payoff, exercise),
       averageType_(averageType), runningAccumulator_(0.0), pastFixings_(0),
       fixingDates_(fixingDates), allPastFixingsProvided_(true),
-      allPastFixings_(allPastFixings) {
-        std::sort(fixingDates_.begin(), fixingDates_.end());
-    }
+      allPastFixings_(allPastFixings) {}
 
     void DiscreteAveragingAsianOption::setupArguments(
                                        PricingEngine::arguments* args) const {

--- a/ql/instruments/asianoption.hpp
+++ b/ql/instruments/asianoption.hpp
@@ -58,6 +58,10 @@ namespace QuantLib {
       public:
         class arguments;
         class engine;
+        /*! This constructor takes the running sum or product of past fixings,
+            depending on the average type.  The fixing dates passed here can be
+            only the future ones.
+        */
         DiscreteAveragingAsianOption(Average::Type averageType,
                                      Real runningAccumulator,
                                      Size pastFixings,
@@ -65,13 +69,13 @@ namespace QuantLib {
                                      const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                      const ext::shared_ptr<Exercise>& exercise);
 
-        // Providing a constructor that takes fixings as a vector of reals, defaulting to an empty
-        // vector representing an unseasoned option. This interface works slightly differently to
-        // the previous interface:
-        //    - This constructor expects ALL fixingDates to be provided, including those in the past
-        //    - It will compare to evaluation date before pricing to determine which are historic
-        //    - It will take the first N values from allPastFixings and ignore the remainder
-        //    - If not enogh fixings are provided for this date, it will raise an error
+        /*! This constructor takes past fixings as a vector, defaulting to an empty
+            vector representing an unseasoned option.  This constructor expects *all* fixing dates
+            to be provided, including those in the past, and to be already sorted.  During the
+            calculations, the option will compare them to the evaluation date to determine which
+            are historic; it will then take as many values from allPastFixings as needed and ignore
+            the others.  If not enough fixings are provided, it will raise an error.
+        */
         DiscreteAveragingAsianOption(Average::Type averageType,
                                      std::vector<Date> fixingDates,
                                      const ext::shared_ptr<StrikedTypePayoff>& payoff,

--- a/ql/instruments/asianoption.hpp
+++ b/ql/instruments/asianoption.hpp
@@ -64,6 +64,15 @@ namespace QuantLib {
                                      std::vector<Date> fixingDates,
                                      const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                      const ext::shared_ptr<Exercise>& exercise);
+
+        // Providing a constructor that takes past fixings as a vector of reals,
+        // defaulting to an empty vector representing an unseasoned option
+        DiscreteAveragingAsianOption(Average::Type averageType,
+                                     std::vector<Date> fixingDates,
+                                     const ext::shared_ptr<StrikedTypePayoff>& payoff,
+                                     const ext::shared_ptr<Exercise>& exercise,
+                                     const std::vector<Real>& allPastFixings = std::vector<Real>());
+
         void setupArguments(PricingEngine::arguments*) const override;
 
       protected:
@@ -71,6 +80,12 @@ namespace QuantLib {
         Real runningAccumulator_;
         Size pastFixings_;
         std::vector<Date> fixingDates_;
+
+        // For backwards compatibility with the traditional interface, we keep track of
+        // whether this option was initialised using the full array of seasoned fixings
+        // (even if empty) or if a pastFixings and a runningAccumulator was provided
+        bool allPastFixingsProvided_;
+        std::vector<Real> allPastFixings_;
     };
 
     //! Extra %arguments for single-asset discrete-average Asian option
@@ -79,12 +94,16 @@ namespace QuantLib {
       public:
         arguments() : averageType(Average::Type(-1)),
                       runningAccumulator(Null<Real>()),
-                      pastFixings(Null<Size>()) {}
+                      pastFixings(Null<Size>()),
+                      allPastFixingsProvided(false),
+                      allPastFixings(std::vector<Real>()) {}
         void validate() const override;
         Average::Type averageType;
         Real runningAccumulator;
         Size pastFixings;
         std::vector<Date> fixingDates;
+        std::vector<Real> allPastFixings;
+        bool allPastFixingsProvided;
     };
 
     //! Extra %arguments for single-asset continuous-average Asian option

--- a/ql/instruments/asianoption.hpp
+++ b/ql/instruments/asianoption.hpp
@@ -65,8 +65,13 @@ namespace QuantLib {
                                      const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                      const ext::shared_ptr<Exercise>& exercise);
 
-        // Providing a constructor that takes past fixings as a vector of reals,
-        // defaulting to an empty vector representing an unseasoned option
+        // Providing a constructor that takes fixings as a vector of reals, defaulting to an empty
+        // vector representing an unseasoned option. This interface works slightly differently to
+        // the previous interface:
+        //    - This constructor expects ALL fixingDates to be provided, including those in the past
+        //    - It will compare to evaluation date before pricing to determine which are historic
+        //    - It will take the first N values from allPastFixings and ignore the remainder
+        //    - If not enogh fixings are provided for this date, it will raise an error
         DiscreteAveragingAsianOption(Average::Type averageType,
                                      std::vector<Date> fixingDates,
                                      const ext::shared_ptr<StrikedTypePayoff>& payoff,

--- a/ql/instruments/asianoption.hpp
+++ b/ql/instruments/asianoption.hpp
@@ -99,16 +99,12 @@ namespace QuantLib {
       public:
         arguments() : averageType(Average::Type(-1)),
                       runningAccumulator(Null<Real>()),
-                      pastFixings(Null<Size>()),
-                      allPastFixingsProvided(false),
-                      allPastFixings(std::vector<Real>()) {}
+                      pastFixings(Null<Size>()) {}
         void validate() const override;
         Average::Type averageType;
         Real runningAccumulator;
         Size pastFixings;
         std::vector<Date> fixingDates;
-        bool allPastFixingsProvided;
-        std::vector<Real> allPastFixings;
     };
 
     //! Extra %arguments for single-asset continuous-average Asian option

--- a/ql/instruments/asianoption.hpp
+++ b/ql/instruments/asianoption.hpp
@@ -102,8 +102,8 @@ namespace QuantLib {
         Real runningAccumulator;
         Size pastFixings;
         std::vector<Date> fixingDates;
-        std::vector<Real> allPastFixings;
         bool allPastFixingsProvided;
+        std::vector<Real> allPastFixings;
     };
 
     //! Extra %arguments for single-asset continuous-average Asian option

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1480,6 +1480,36 @@ void AsianOptionTest::testPastFixings() {
              << "\n  with fixings:    " << price2);
     }
 
+    // Test past-fixings-as-a-vector interface
+
+    std::vector<Real> allPastFixings = {spot->value() * 0.8, spot->value() * 0.8};
+
+    DiscreteAveragingAsianOption option1a(Average::Arithmetic, fixingDates1,
+                                          payoff, exercise);
+
+    DiscreteAveragingAsianOption option2a(Average::Arithmetic, fixingDates2,
+                                          payoff, exercise, allPastFixings);
+
+    option1a.setPricingEngine(engine);
+    option2a.setPricingEngine(engine);
+
+    Real price1a = option1a.NPV();
+    Real price2a = option2a.NPV();
+
+    if (not close(price1, price1a)) {
+        BOOST_ERROR(
+             "Unseasoned option prices do not match in old and new interface"
+             << "\n  Old Interface: " << price1
+             << "\n  New Interface: " << price1a);
+    }
+
+    if (not close(price2, price2a)) {
+        BOOST_ERROR(
+             "Seasoned option prices do not match in old and new interface"
+             << "\n  Old Interface: " << price2
+             << "\n  New Interface: " << price2a);
+    }
+
     // MC arithmetic average-strike
 
     engine =

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1496,14 +1496,14 @@ void AsianOptionTest::testPastFixings() {
     Real price1a = option1a.NPV();
     Real price2a = option2a.NPV();
 
-    if (not close(price1, price1a)) {
+    if (std::fabs(price1 - price1a) > 1e-8) {
         BOOST_ERROR(
              "Unseasoned option prices do not match in old and new interface"
              << "\n  Old Interface: " << price1
              << "\n  New Interface: " << price1a);
     }
 
-    if (not close(price2, price2a)) {
+    if (std::fabs(price2 - price2a) > 1e-8) {
         BOOST_ERROR(
              "Seasoned option prices do not match in old and new interface"
              << "\n  Old Interface: " << price2


### PR DESCRIPTION
Provide all fixings as an array (with default empty array for unseasoned options).

Two useful things:

1. Checks that the pastFixings and runningAccumulator arguments make sense (discussed in linked issue)
2. Provides a way of creating an asian by passing all past fixings in, and the pastFixings/runningAccumulator is calculated correctly for the averaging type. Passing in no variable here defaults to unseasoned (so you can create an unseasoned asian this way without having to pass in 0 and 1.0/0.0 as currently)

Closes #968
Closes #241 
