### PR TITLE
C++11 modernization — a few minor checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,modernize-use-auto,modernize-use-nullptr,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-pass-by-value,modernize-loop-convert,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
+Checks:          '-*,readability-*,bugprone-*,misc-*,performance-*,modernize-redundant-void-arg,modernize-deprecated-headers,modernize-use-override,modernize-use-auto,modernize-use-nullptr,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-equals-delete,modernize-pass-by-value,modernize-loop-convert,modernize-raw-string-literal,modernize-use-noexcept,modernize-return-braced-init-list,-readability-else-after-return,-readability-named-parameter,-readability-braces-around-statements,-readability-inconsistent-declaration-parameter-name,-readability-isolate-declaration,-readability-magic-numbers,-readability-convert-member-functions-to-static,-bugprone-macro-parentheses,-bugprone-narrowing-conversions,-bugprone-branch-clone,-misc-non-private-member-variables-in-classes,-misc-unused-parameters'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
@@ -7,4 +7,6 @@ FormatStyle:     file
 CheckOptions:
   - key:   modernize-use-default-member-init.UseAssignment
     value: 1
+  - key:   modernize-use-noexcept.ReplacementString
+    value: QL_NOEXCEPT
 ...

--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         */
         virtual Real amount() const = 0;
         //! returns the date that the cash flow trades exCoupon
-        virtual Date exCouponDate() const {return Date();};
+        virtual Date exCouponDate() const { return {}; };
         //! returns true if the cashflow is trading ex-coupon on the refDate
         bool tradingExCoupon(const Date& refDate = Date()) const;
 

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
         cf = previousCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
         if (cf==leg.rend())
-            return Date();
+            return {};
 
         return (*cf)->date();
     }
@@ -135,7 +135,7 @@ namespace QuantLib {
         cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
         if (cf==leg.end())
-            return Date();
+            return {};
 
         return (*cf)->date();
     }
@@ -256,7 +256,7 @@ namespace QuantLib {
             if (cp != nullptr)
                 return cp->accrualStartDate();
         }
-        return Date();
+        return {};
     }
 
     Date CashFlows::accrualEndDate(const Leg& leg,
@@ -271,7 +271,7 @@ namespace QuantLib {
             if (cp != nullptr)
                 return cp->accrualEndDate();
         }
-        return Date();
+        return {};
     }
 
     Date CashFlows::referencePeriodStart(const Leg& leg,
@@ -286,7 +286,7 @@ namespace QuantLib {
             if (cp != nullptr)
                 return cp->referencePeriodStart();
         }
-        return Date();
+        return {};
     }
 
     Date CashFlows::referencePeriodEnd(const Leg& leg,
@@ -301,7 +301,7 @@ namespace QuantLib {
             if (cp != nullptr)
                 return cp->referencePeriodEnd();
         }
-        return Date();
+        return {};
     }
 
     Time CashFlows::accrualPeriod(const Leg& leg,

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -248,7 +248,8 @@ namespace QuantLib {
                                      bool includeSettlementDateFlows,
                                      Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return Date();
+        if (cf==leg.end())
+            return {};
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
@@ -263,7 +264,8 @@ namespace QuantLib {
                                    bool includeSettlementDateFlows,
                                    Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return Date();
+        if (cf==leg.end())
+            return {};
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
@@ -278,7 +280,8 @@ namespace QuantLib {
                                          bool includeSettlementDateFlows,
                                          Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return Date();
+        if (cf==leg.end())
+            return {};
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
@@ -293,7 +296,8 @@ namespace QuantLib {
                                        bool includeSettlementDateFlows,
                                        Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return Date();
+        if (cf==leg.end())
+            return {};
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {

--- a/ql/errors.cpp
+++ b/ql/errors.cpp
@@ -97,9 +97,6 @@ namespace QuantLib {
                                       format(file, line, function, message));
     }
 
-    const char* Error::what() const throw () {
-        return message_->c_str();
-    }
-
+    const char* Error::what() const QL_NOEXCEPT { return message_->c_str(); }
 }
 

--- a/ql/errors.hpp
+++ b/ql/errors.hpp
@@ -52,7 +52,7 @@ namespace QuantLib {
         ~Error() throw() override {}
         #endif
         //! returns the error message.
-        const char* what() const throw() override;
+        const char* what() const QL_NOEXCEPT override;
 
       private:
         ext::shared_ptr<std::string> message_;

--- a/ql/experimental/commodities/dateinterval.hpp
+++ b/ql/experimental/commodities/dateinterval.hpp
@@ -65,9 +65,8 @@ namespace QuantLib {
         DateInterval intersection(const DateInterval& di) const {
             if ((startDate_ < di.startDate_ && endDate_ < di.startDate_) ||
                 (startDate_ > di.endDate_ && endDate_ > di.endDate_))
-                return DateInterval();
-            return DateInterval(std::max(startDate_, di.startDate_),
-                                std::min(endDate_, di.endDate_));
+                return {};
+            return {std::max(startDate_, di.startDate_), std::min(endDate_, di.endDate_)};
         }
 
         bool operator==(const DateInterval& rhs) const {

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -618,8 +618,7 @@ namespace QuantLib {
         lowerPercentile = rankLosses[r];
         upperPercentile = rankLosses[s];
 
-        return ext::tuple<Real, Real, Real>(quantileValue,
-            lowerPercentile, upperPercentile);
+        return {quantileValue, lowerPercentile, upperPercentile};
     }
 
 

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -817,8 +817,7 @@ namespace QuantLib {
                 (12.*suma1*suma1*suma2 - 
                     6.*std::pow(suma1,4.)/suma0)/suma0)/suma0)/suma0;
         }
-        return ext::tuple<Real, Real, Real, Real>(deriv0, deriv2, 
-            deriv3, deriv4);
+        return {deriv0, deriv2, deriv3, deriv4};
     }
 
     template<class CP>
@@ -852,7 +851,7 @@ namespace QuantLib {
             //deriv1 += suma1 / suma0;
             deriv2 += suma2 / suma0 - std::pow(suma1 / suma0 , 2.);
         }
-        return ext::tuple<Real, Real>(deriv0, deriv2);
+        return {deriv0, deriv2};
     }
 
     // ----- Saddle point search ----------------------------------------------

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
@@ -110,7 +110,7 @@ namespace QuantLib {
 
     Date CPICapFloorTermPriceSurface::cpiOptionDateFromTenor(const Period& p) const
     {
-        return Date(calendar().adjust(referenceDate() + p, businessDayConvention()));
+        return calendar().adjust(referenceDate() + p, businessDayConvention());
     }
 
     

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
 
     Date YoYCapFloorTermPriceSurface::yoyOptionDateFromTenor(const Period& p) const
     {
-        return Date(referenceDate()+p);
+        return referenceDate() + p;
     }
 
     Real YoYCapFloorTermPriceSurface::price(const Period &d, const Rate k) const {

--- a/ql/experimental/math/levyflightdistribution.hpp
+++ b/ql/experimental/math/levyflightdistribution.hpp
@@ -131,7 +131,7 @@ namespace QuantLib {
         { return QL_MAX_REAL; }
 
         //! Returns the parameters of the distribution
-        param_type param() const { return param_type(xm_, alpha_); }
+        param_type param() const { return {xm_, alpha_}; }
         //@}
         
         //! Sets the parameters of the distribution

--- a/ql/experimental/math/polarstudenttrng.hpp
+++ b/ql/experimental/math/polarstudenttrng.hpp
@@ -83,10 +83,7 @@ namespace QuantLib {
             u = 2.* uniformGenerator_.next().value - 1.;
             rSqr = v*v + u*u;
         }while(rSqr >= 1.);
-        return sample_type(u * 
-            std::sqrt(degFreedom_ * (std::pow(rSqr, -2./degFreedom_)-1.) 
-                / rSqr),
-            1.);
+        return {u * std::sqrt(degFreedom_ * (std::pow(rSqr, -2. / degFreedom_) - 1.) / rSqr), 1.};
     }
 
 }

--- a/ql/experimental/math/zigguratrng.hpp
+++ b/ql/experimental/math/zigguratrng.hpp
@@ -53,9 +53,8 @@ namespace QuantLib {
       public:
         typedef Sample<Real> sample_type;
         explicit ZigguratRng(unsigned long seed = 0);
-        sample_type next() const {
-            return sample_type(nextGaussian(),1.0);
-        }
+        sample_type next() const { return {nextGaussian(), 1.0}; }
+
       private:
         mutable MersenneTwisterUniformRng mt32_;
         Real nextGaussian() const;

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -402,8 +402,8 @@ namespace QuantLib {
     void Bond::arguments::validate() const {
         QL_REQUIRE(settlementDate != Date(), "no settlement date provided");
         QL_REQUIRE(!cashflows.empty(), "no cash flow provided");
-        for (Size i=0; i<cashflows.size(); ++i)
-            QL_REQUIRE(cashflows[i], "null cash flow provided");
+        for (const auto & cf: cashflows)
+            QL_REQUIRE(cf, "null cash flow provided");
     }
 
 }

--- a/ql/math/initializers.hpp
+++ b/ql/math/initializers.hpp
@@ -75,11 +75,11 @@ private:
 };
 
 inline ArrayProxy operator<<(Array& a, const Real x) {
-    return ArrayProxy(a, x);
+    return {a, x};
 }
 
 inline MatrixProxy operator<<(Matrix& m, const Real x) {
-    return MatrixProxy(m, x);
+    return {m, x};
 }
 
 } // namespace initializers

--- a/ql/math/randomnumbers/boxmullergaussianrng.hpp
+++ b/ql/math/randomnumbers/boxmullergaussianrng.hpp
@@ -83,10 +83,10 @@ namespace QuantLib {
             weight_ = firstWeight_*secondWeight_;
 
             returnFirst_ = false;
-            return sample_type(firstValue_,weight_);
+            return {firstValue_, weight_};
         } else {
             returnFirst_ = true;
-            return sample_type(secondValue_,weight_);
+            return {secondValue_, weight_};
         }
     }
 

--- a/ql/math/randomnumbers/centrallimitgaussianrng.hpp
+++ b/ql/math/randomnumbers/centrallimitgaussianrng.hpp
@@ -65,7 +65,7 @@ namespace QuantLib {
             gaussPoint  += sample.value;
             gaussWeight *= sample.weight;
         }
-        return sample_type(gaussPoint,gaussWeight);
+        return {gaussPoint, gaussWeight};
     }
 
 }

--- a/ql/math/randomnumbers/knuthuniformrng.hpp
+++ b/ql/math/randomnumbers/knuthuniformrng.hpp
@@ -69,7 +69,7 @@ namespace QuantLib {
         double result = (ranf_arr_ptr != ranf_arr_sentinel ?
                          ranf_arr_buf[ranf_arr_ptr++] :
                          ranf_arr_cycle());
-        return sample_type(result,1.0);
+        return {result, 1.0};
     }
 
     inline double KnuthUniformRng::mod_sum(double x, double y) const {

--- a/ql/math/randomnumbers/lecuyeruniformrng.cpp
+++ b/ql/math/randomnumbers/lecuyeruniformrng.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
         // users don't expect endpoint values
         if (result > maxRandom)
             result = (double) maxRandom;
-        return sample_type(result,1.0);
+        return {result, 1.0};
     }
 
 }

--- a/ql/math/randomnumbers/mt19937uniformrng.hpp
+++ b/ql/math/randomnumbers/mt19937uniformrng.hpp
@@ -51,7 +51,7 @@ namespace QuantLib {
                                      const std::vector<unsigned long>& seeds);
         /*! returns a sample with weight 1.0 containing a random number
             in the (0.0, 1.0) interval  */
-        sample_type next() const { return sample_type(nextReal(),1.0); }
+        sample_type next() const { return {nextReal(), 1.0}; }
         //! return a random number in the (0.0, 1.0)-interval
         Real nextReal() const {
             return (Real(nextInt32()) + 0.5)/4294967296.0;

--- a/ql/math/randomnumbers/ranluxuniformrng.hpp
+++ b/ql/math/randomnumbers/ranluxuniformrng.hpp
@@ -49,9 +49,7 @@ namespace QuantLib {
         explicit Ranlux3UniformRng(Size seed = 19780503U)
         : ranlux3_(boost::random::ranlux64_base_01(seed)) {}
 
-        sample_type next() const {
-            return sample_type(ranlux3_(), 1.0);
-        }
+        sample_type next() const { return {ranlux3_(), 1.0}; }
 
       private:
         mutable boost::ranlux64_3_01 ranlux3_;
@@ -64,9 +62,7 @@ namespace QuantLib {
         explicit Ranlux4UniformRng(Size seed = 19780503U)
         : ranlux4_(boost::random::ranlux64_base_01(seed)) {}
 
-        sample_type next() const {
-            return sample_type(ranlux4_(), 1.0);
-        }
+        sample_type next() const { return {ranlux4_(), 1.0}; }
 
       private:
         mutable boost::ranlux64_4_01 ranlux4_;

--- a/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmbackwardsolver.cpp
@@ -43,49 +43,39 @@ namespace QuantLib {
     FdmSchemeDesc::FdmSchemeDesc(FdmSchemeType aType, Real aTheta, Real aMu)
     : type(aType), theta(aTheta), mu(aMu) { }
 
-    FdmSchemeDesc FdmSchemeDesc::Douglas() { 
-        return FdmSchemeDesc(FdmSchemeDesc::DouglasType, 0.5, 0.0);
-    }
-    
+    FdmSchemeDesc FdmSchemeDesc::Douglas() { return {FdmSchemeDesc::DouglasType, 0.5, 0.0}; }
+
     FdmSchemeDesc FdmSchemeDesc::CrankNicolson() {
-        return FdmSchemeDesc(FdmSchemeDesc::CrankNicolsonType, 0.5, 0.0);
+        return {FdmSchemeDesc::CrankNicolsonType, 0.5, 0.0};
     }
 
-    FdmSchemeDesc FdmSchemeDesc::CraigSneyd() {
-        return FdmSchemeDesc(FdmSchemeDesc::CraigSneydType,0.5, 0.5);
-    }
-    
-    FdmSchemeDesc FdmSchemeDesc::ModifiedCraigSneyd() { 
-        return FdmSchemeDesc(FdmSchemeDesc::ModifiedCraigSneydType, 
-                             1.0/3.0, 1.0/3.0);
+    FdmSchemeDesc FdmSchemeDesc::CraigSneyd() { return {FdmSchemeDesc::CraigSneydType, 0.5, 0.5}; }
+
+    FdmSchemeDesc FdmSchemeDesc::ModifiedCraigSneyd() {
+        return {FdmSchemeDesc::ModifiedCraigSneydType, 1.0 / 3.0, 1.0 / 3.0};
     }
     
     FdmSchemeDesc FdmSchemeDesc::Hundsdorfer() {
-        return FdmSchemeDesc(FdmSchemeDesc::HundsdorferType, 
-                             0.5+std::sqrt(3.0)/6, 0.5);
+        return {FdmSchemeDesc::HundsdorferType, 0.5 + std::sqrt(3.0) / 6, 0.5};
     }
     
     FdmSchemeDesc FdmSchemeDesc::ModifiedHundsdorfer() {
-        return FdmSchemeDesc(FdmSchemeDesc::HundsdorferType, 
-                             1.0-std::sqrt(2.0)/2, 0.5);
+        return {FdmSchemeDesc::HundsdorferType, 1.0 - std::sqrt(2.0) / 2, 0.5};
     }
     
     FdmSchemeDesc FdmSchemeDesc::ExplicitEuler() {
-        return FdmSchemeDesc(FdmSchemeDesc::ExplicitEulerType, 0.0, 0.0);
+        return {FdmSchemeDesc::ExplicitEulerType, 0.0, 0.0};
     }
 
     FdmSchemeDesc FdmSchemeDesc::ImplicitEuler() {
-        return FdmSchemeDesc(FdmSchemeDesc::ImplicitEulerType, 0.0, 0.0);
+        return {FdmSchemeDesc::ImplicitEulerType, 0.0, 0.0};
     }
 
     FdmSchemeDesc FdmSchemeDesc::MethodOfLines(Real eps, Real relInitStepSize) {
-        return FdmSchemeDesc(
-            FdmSchemeDesc::MethodOfLinesType, eps, relInitStepSize);
+        return {FdmSchemeDesc::MethodOfLinesType, eps, relInitStepSize};
     }
 
-    FdmSchemeDesc FdmSchemeDesc::TrBDF2() {
-        return FdmSchemeDesc(FdmSchemeDesc::TrBDF2Type, 2 - M_SQRT2, 1e-8);
-    }
+    FdmSchemeDesc FdmSchemeDesc::TrBDF2() { return {FdmSchemeDesc::TrBDF2Type, 2 - M_SQRT2, 1e-8}; }
 
     FdmBackwardSolver::FdmBackwardSolver(
         ext::shared_ptr<FdmLinearOpComposite> map,

--- a/ql/prices.hpp
+++ b/ql/prices.hpp
@@ -106,7 +106,7 @@ namespace QuantLib {
     {
       public:
         Null() = default;
-        operator IntervalPrice() const { return IntervalPrice(); }
+        operator IntervalPrice() const { return {}; }
     };
 
 }

--- a/ql/termstructures/volatility/smilesectionutils.cpp
+++ b/ql/termstructures/volatility/smilesectionutils.cpp
@@ -194,11 +194,11 @@ namespace QuantLib {
     }
 
     std::pair<Real, Real> SmileSectionUtils::arbitragefreeRegion() const {
-        return std::pair<Real, Real>(k_[leftIndex_], k_[rightIndex_]);
+        return {k_[leftIndex_], k_[rightIndex_]};
     }
 
     std::pair<Size, Size> SmileSectionUtils::arbitragefreeIndices() const {
-        return std::pair<Size, Size>(leftIndex_, rightIndex_);
+        return {leftIndex_, rightIndex_};
     }
 
     bool SmileSectionUtils::af(const Size i0, const Size i,

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -176,7 +176,7 @@ namespace QuantLib {
               if (d == 29 && m == February && !isLeap(y))
                   d = 28;
 
-              return Date(d,m,y);
+              return {d, m, y};
           }
           default:
             QL_FAIL("undefined time units");
@@ -773,7 +773,7 @@ namespace QuantLib {
         std::time_t t;
 
         if (std::time(&t) == std::time_t(-1)) // -1 means time() didn't work
-            return Date();
+            return {};
         std::tm *lt = std::localtime(&t);
         return {Day(lt->tm_mday), Month(lt->tm_mon + 1), Year(lt->tm_year + 1900)};
     }

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -791,7 +791,7 @@ namespace QuantLib {
                    "no more than 5 weekday in a given (month, year)");
         Weekday first = Date(1, m, y).weekday();
         Size skip = nth - (dayOfWeek>=first ? 1 : 0);
-        return {(1 + dayOfWeek + skip * 7) - first, m, y};
+        return {Day((1 + dayOfWeek + skip * 7) - first), m, y};
     }
 
     // month formatting

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -162,7 +162,7 @@ namespace QuantLib {
             if (d > length)
                 d = length;
 
-            return Date(d, Month(m), y);
+            return {d, Month(m), y};
           }
           case Years: {
               Day d = date.dayOfMonth();
@@ -775,9 +775,7 @@ namespace QuantLib {
         if (std::time(&t) == std::time_t(-1)) // -1 means time() didn't work
             return Date();
         std::tm *lt = std::localtime(&t);
-        return Date(Day(lt->tm_mday),
-                        Month(lt->tm_mon+1),
-                        Year(lt->tm_year+1900));
+        return {Day(lt->tm_mday), Month(lt->tm_mon + 1), Year(lt->tm_year + 1900)};
     }
 
     Date Date::nextWeekday(const Date& d, Weekday dayOfWeek) {
@@ -793,7 +791,7 @@ namespace QuantLib {
                    "no more than 5 weekday in a given (month, year)");
         Weekday first = Date(1, m, y).weekday();
         Size skip = nth - (dayOfWeek>=first ? 1 : 0);
-        return Date((1 + dayOfWeek + skip*7) - first, m, y);
+        return {(1 + dayOfWeek + skip * 7) - first, m, y};
     }
 
     // month formatting

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -375,7 +375,7 @@ namespace QuantLib {
     class Null<Date> {
       public:
         Null() = default;
-        operator Date() const { return Date(); }
+        operator Date() const { return {}; }
     };
 
 
@@ -418,7 +418,7 @@ namespace QuantLib {
     inline Date Date::endOfMonth(const Date& d) {
         Month m = d.month();
         Year y = d.year();
-        return Date(monthLength(m, isLeap(y)), m, y);
+        return {monthLength(m, isLeap(y)), m, y};
     }
 
     inline bool Date::isEndOfMonth(const Date& d) {

--- a/ql/time/ecb.cpp
+++ b/ql/time/ecb.cpp
@@ -188,7 +188,7 @@ namespace QuantLib {
 
         QL_REQUIRE(i!=knownDates().end(),
                    "ECB dates after " << *(--knownDates().end()) << " are unknown");
-        return Date(*i);
+        return *i;
     }
 
     std::vector<Date> ECB::nextDates(const Date& date) {

--- a/ql/time/period.hpp
+++ b/ql/time/period.hpp
@@ -137,25 +137,19 @@ namespace QuantLib {
 
     template <typename T>
     inline Period operator*(T n, TimeUnit units) {
-        return Period(Integer(n),units);
+        return {Integer(n), units};
     }
 
     template <typename T>
     inline Period operator*(TimeUnit units, T n) {
-        return Period(Integer(n),units);
+        return {Integer(n), units};
     }
 
-    inline Period operator-(const Period& p) {
-        return Period(-p.length(),p.units());
-    }
+    inline Period operator-(const Period& p) { return {-p.length(), p.units()}; }
 
-    inline Period operator*(Integer n, const Period& p) {
-        return Period(n*p.length(),p.units());
-    }
+    inline Period operator*(Integer n, const Period& p) { return {n * p.length(), p.units()}; }
 
-    inline Period operator*(const Period& p, Integer n) {
-        return Period(n*p.length(),p.units());
-    }
+    inline Period operator*(const Period& p, Integer n) { return {n * p.length(), p.units()}; }
 
     inline bool operator==(const Period& p1, const Period& p2) {
         return !(p1 < p2 || p2 < p1);

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -514,7 +514,7 @@ namespace QuantLib {
         if (res!=dates_.end())
             return *res;
         else
-            return Date();
+            return {};
     }
 
     Date Schedule::previousDate(const Date& refDate) const {
@@ -522,7 +522,7 @@ namespace QuantLib {
         if (res!=dates_.begin())
             return *(--res);
         else
-            return Date();
+            return {};
     }
 
     bool Schedule::hasIsRegular() const { return !isRegular_.empty(); }

--- a/ql/utilities/dataparsers.cpp
+++ b/ql/utilities/dataparsers.cpp
@@ -105,7 +105,7 @@ namespace QuantLib {
                     " in '" << str << "'. Error:" << e.what());
         }
 
-        return Period(n, units);
+        return {n, units};
     }
 
     Date DateParser::parseFormatted(const std::string& str,
@@ -131,7 +131,7 @@ namespace QuantLib {
         Month month = static_cast<Month>(io::to_integer(str.substr(5, 2)));
         Integer day = io::to_integer(str.substr(8, 2));
 
-        return Date(day, month, year);
+        return {day, month, year};
     }
 
 }

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -124,15 +124,15 @@ namespace andreasen_huge_volatility_interpl_test {
             &raw[0][0], &raw[nStrikes-1][nMaturities]+1,
             not_zero<Real>()) - nStrikes);
 
-        for (Size i=0; i < LENGTH(raw); ++i) {
-            const Real strike = spot->value()*raw[i][0];
+        for (const auto & i : raw) {
+            const Real strike = spot->value()*i[0];
 
-            for (Size j=1; j < LENGTH(raw[i]); ++j)
-                if (raw[i][j] > QL_EPSILON) {
+            for (Size j=1; j < LENGTH(i); ++j) {
+                if (i[j] > QL_EPSILON) {
                     const Date maturity
                         = today + Period(Size(365*maturityTimes[j-1]), Days);
 
-                    const Volatility impliedVol = raw[i][j];
+                    const Volatility impliedVol = i[j];
 
                     calibrationSet.push_back(std::make_pair(
                         ext::make_shared<VanillaOption>(
@@ -144,6 +144,7 @@ namespace andreasen_huge_volatility_interpl_test {
                         ext::make_shared<SimpleQuote>(impliedVol))
                     );
                 }
+            }
         }
 
         CalibrationData data = { spot, rTS, qTS, calibrationSet };


### PR DESCRIPTION
Added `modernize-raw-string-literal`, `modernize-use-noexcept` and `modernize-return-braced-init-list` checks, which in turn generated the changes.