### PR TITLE
C++ 11 modernization: replace `ext::bind` with lambdas

### DIFF
--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -257,10 +257,7 @@ namespace QuantLib {
 
     }
 
-    Real NumericHaganPricer::integrate(Real a,
-        Real b, const ConundrumIntegrand& integrand) const {
-
-            using namespace ext::placeholders;
+    Real NumericHaganPricer::integrate(Real a, Real b, const ConundrumIntegrand& integrand) const {
 
             Real result =.0;
             //double abserr =.0;
@@ -292,7 +289,7 @@ namespace QuantLib {
                     Size k = 3;
                     ext::function<Real (Real)> temp = ext::cref(integrand);
                     VariableChange variableChange(temp, a, upperBoundary, k);
-                    f = ext::bind(&VariableChange::value, &variableChange, _1);
+                    f = [&](Real _x) { return variableChange.value(_x); };
                     result = gaussKronrodNonAdaptive(f, .0, 1.0);
                 } else {
                     f = ext::cref(integrand);

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -25,7 +25,6 @@
 #include <ql/experimental/credit/defaultlossmodel.hpp>
 #include <ql/functional.hpp>
 #include <ql/handle.hpp>
-#include <ql/math/functional.hpp>
 #include <algorithm>
 #include <numeric>
 #include <utility>

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -89,7 +89,7 @@ namespace QuantLib {
                 invProbs[iName] = 
                     copula_->inverseCumulativeY(invProbs[iName], iName);
 
-            return copula_->integratedExpectedValue(
+            return copula_->integratedExpectedValueV(
                 [&](const std::vector<Real>& v1) {
                     return lossProbability(date, notionals, invProbs, v1);
                 });

--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -218,15 +218,10 @@ namespace QuantLib {
             if (pUncond < 1.e-10) return 0.;
 
             return integratedExpectedValue(
-              ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                &DefaultLatentModel<copulaPolicy>
-                    ::conditionalDefaultProbabilityInvP,
-                this,
-                inverseCumulativeY(pUncond, iName),
-                iName, 
-                ext::placeholders::_1)
-              ));
+                [&](const std::vector<Real>& v1) {
+                    return conditionalDefaultProbabilityInvP(
+                        inverseCumulativeY(pUncond, iName), iName, v1);
+                });
         }
         /*! Pearsons' default probability correlation. 
             Users should consider specialization on the copula type for specific
@@ -241,14 +236,9 @@ namespace QuantLib {
         */
         Probability probAtLeastNEvents(Size n, const Date& date) const {
             return integratedExpectedValue(
-             ext::function<Real (const std::vector<Real>& v1)>(
-              ext::bind(
-              &DefaultLatentModel<copulaPolicy>::conditionalProbAtLeastNEvents,
-              this,
-              n,
-              ext::cref(date),
-              ext::placeholders::_1)
-             ));
+                [&](const std::vector<Real>& v1) {
+                    return conditionalProbAtLeastNEvents(n, date, v1);
+                });
         }
     };
 
@@ -276,11 +266,8 @@ namespace QuantLib {
         Real E1i1j; // joint default covariance term
         if(iNamei !=iNamej) {
             E1i1j = integratedExpectedValue(
-              ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                &DefaultLatentModel<CP>::condProbProduct,
-                this, invPi, invPj, iNamei, iNamej,
-                ext::placeholders::_1) ));
+                [&](const std::vector<Real>& v1) {
+                    return condProbProduct(invPi, invPj, iNamei, iNamej, v1); });
         }else{
             E1i1j = pi;
         }

--- a/ql/experimental/credit/pool.cpp
+++ b/ql/experimental/credit/pool.cpp
@@ -75,11 +75,10 @@ namespace QuantLib {
     }
 
     Disposable<std::vector<DefaultProbKey> > Pool::defaultKeys() const {
-        using namespace ext::placeholders;
         std::vector<DefaultProbKey> defaultKeys;
-        std::transform(defaultKeys_.begin(), defaultKeys_.end(),
-            std::back_inserter(defaultKeys), ext::bind(
-              &std::map<std::string, DefaultProbKey>::value_type::second, _1));
+        defaultKeys.reserve(defaultKeys_.size());
+        for (const auto & i : defaultKeys_)
+            defaultKeys.push_back(i.second);
         return defaultKeys;
     }
 

--- a/ql/experimental/credit/recursivelossmodel.hpp
+++ b/ql/experimental/credit/recursivelossmodel.hpp
@@ -22,7 +22,6 @@
 
 #include <ql/experimental/credit/constantlosslatentmodel.hpp>
 #include <ql/experimental/credit/defaultlossmodel.hpp>
-#include <ql/functional.hpp>
 #include <map>
 #include <algorithm>
 
@@ -160,17 +159,10 @@ namespace QuantLib {
             basket_->remainingProbabilities(date);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &RecursiveLossModel::expectedConditionalLoss,
-                    this,
-                    ext::cref(uncDefProb),
-                    _1)
-                )
-            );
+            [&](const std::vector<Real>& v1) {
+                return expectedConditionalLoss(uncDefProb, v1);
+            });
             */
-/**/
-        using namespace ext::placeholders;
 
         std::vector<Probability> uncDefProb = 
             basket_->remainingProbabilities(date);
@@ -179,34 +171,21 @@ namespace QuantLib {
            invProb.push_back(copula_->inverseCumulativeY(uncDefProb[i], i));
            ///  invProb.push_back(CP::inverseCumulativeY(uncDefProb[i], i));//<-static call
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &RecursiveLossModel::expectedConditionalLossInvP,
-                    this,
-                    ext::cref(invProb),
-                    _1)
-                )
-            );
-            
+            [&](const std::vector<Real>& v1) {
+                return expectedConditionalLossInvP(invProb, v1);
+            });
     }
 
     template<class CP>
     inline Disposable<std::vector<Real> > 
     RecursiveLossModel<CP>::lossProbability(const Date& date) const {
 
-        using namespace ext::placeholders;
-
         std::vector<Probability> uncDefProb = 
             basket_->remainingProbabilities(date);
         return copula_->integratedExpectedValueV(
-            ext::function<Disposable<std::vector<Real> > (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &RecursiveLossModel::conditionalLossProb,
-                    this,
-                    ext::cref(uncDefProb),
-                    _1)
-                )
-            );
+            [&](const std::vector<Real>& v1) {
+                return conditionalLossProb(uncDefProb, v1);
+            });
     }
 
     // -------------------------------------------------------------------

--- a/ql/experimental/credit/recursivelossmodel.hpp
+++ b/ql/experimental/credit/recursivelossmodel.hpp
@@ -198,7 +198,7 @@ namespace QuantLib {
 
         std::vector<Probability> uncDefProb = 
             basket_->remainingProbabilities(date);
-        return copula_->integratedExpectedValue(
+        return copula_->integratedExpectedValueV(
             ext::function<Disposable<std::vector<Real> > (const std::vector<Real>& v1)>(
                 ext::bind(
                     &RecursiveLossModel::conditionalLossProb,

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -23,7 +23,6 @@
 #include <ql/tuple.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/solvers1d/newton.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/experimental/credit/basket.hpp>
 #include <ql/experimental/credit/defaultlossmodel.hpp>
 #include <ql/experimental/credit/constantlosslatentmodel.hpp>
@@ -388,8 +387,6 @@ namespace QuantLib {
     inline Real SaddlePointLossModel<CP>::CumulantGenerating(
         const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -397,23 +394,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::CumulantGeneratingCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                   s,
-                    _1)
-                )
-            );
+            [&](const std::vector<Real>& v1) {
+                return CumulantGeneratingCond(invUncondProbs, s, v1);
+            });
     }
 
     template<class CP>
     inline Real SaddlePointLossModel<CP>::CumGen1stDerivative(
         const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -421,23 +410,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
        return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::CumGen1stDerivativeCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    s,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return CumGen1stDerivativeCond(invUncondProbs, s, v1);
+           });
     }
 
     template<class CP>
     inline Real SaddlePointLossModel<CP>::CumGen2ndDerivative(
         const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -445,23 +426,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::CumGen2ndDerivativeCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    s,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return CumGen2ndDerivativeCond(invUncondProbs, s, v1);
+           });
     }
 
     template<class CP>
     inline Real SaddlePointLossModel<CP>::CumGen3rdDerivative(
         const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -469,23 +442,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::CumGen3rdDerivativeCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    s,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return CumGen3rdDerivativeCond(invUncondProbs, s, v1);
+           });
     }
 
     template<class CP>
     inline Real SaddlePointLossModel<CP>::CumGen4thDerivative(
         const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -493,23 +458,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::CumGen4thDerivativeCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    s,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return CumGen4thDerivativeCond(invUncondProbs, s, v1);
+           });
     }
 
     template<class CP>
     inline Probability SaddlePointLossModel<CP>::probOverLoss(
         const Date& d, Real trancheLossFract) const 
     {
-        using namespace ext::placeholders;
-
         // avoid computation:
         if (trancheLossFract >= 
             // time dependent soon:
@@ -522,23 +479,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::probOverLossCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    trancheLossFract,
-                    _1)
-                )
-            );
-        }
+           [&](const std::vector<Real>& v1) {
+               return probOverLossCond(invUncondProbs, trancheLossFract, v1);
+           });
+    }
 
     template<class CP>
     inline Probability SaddlePointLossModel<CP>::probOverPortfLoss(
         const Date& d, Real loss) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Probability> invUncondProbs = 
             basket_->remainingProbabilities(d);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -546,23 +495,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::probOverLossPortfCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    loss,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return probOverLossPortfCond(invUncondProbs, loss, v1);
+           });
     }
 
     template<class CP>
     inline Real SaddlePointLossModel<CP>::expectedTrancheLoss(
         const Date& d) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(d);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -570,22 +511,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::conditionalExpectedTrancheLoss,
-                    this,
-                    ext::cref(invUncondProbs),
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return conditionalExpectedTrancheLoss(invUncondProbs, v1);
+           });
     }
 
     template<class CP>
     inline Probability SaddlePointLossModel<CP>::probDensity(
         const Date& d, Real loss) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(d);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -593,23 +527,15 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                    &SaddlePointLossModel<CP>::probDensityCond,
-                    this,
-                    ext::cref(invUncondProbs),
-                    loss,
-                    _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return probDensityCond(invUncondProbs, loss, v1);
+           });
     }
 
     template<class CP>
     inline Disposable<std::vector<Real> > 
     SaddlePointLossModel<CP>::splitVaRLevel(const Date& date, Real s) const 
     {
-        using namespace ext::placeholders;
-
         std::vector<Real> invUncondProbs = 
             basket_->remainingProbabilities(date);
         for(Size i=0; i<invUncondProbs.size(); i++)
@@ -617,16 +543,9 @@ namespace QuantLib {
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
         return copula_->integratedExpectedValueV(
-            ext::function<Disposable<std::vector<Real> > (
-                const std::vector<Real>& v1)>(
-                    ext::bind(
-                        &SaddlePointLossModel<CP>::splitLossCond,
-                        this,
-                    ext::cref(invUncondProbs),
-                        s,
-                        _1)
-                )
-            );
+           [&](const std::vector<Real>& v1) {
+               return splitLossCond(invUncondProbs, s, v1);
+           });
     }
 
 
@@ -1415,8 +1334,6 @@ namespace QuantLib {
     Real SaddlePointLossModel<CP>::expectedShortfall(const Date&d, 
         Probability percProb) const 
     {
-        using namespace ext::placeholders;
-
         // assuming I have the tranched one.
         Real lossPerc = percentile(d, percProb);
 
@@ -1435,15 +1352,9 @@ namespace QuantLib {
 
         // Integrate with the tranche or the portfolio according to the limits.
         return copula_->integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-                ext::bind(
-                  &SaddlePointLossModel<CP>::expectedShortfallFullPortfolioCond,
-                  this,
-                  ext::cref(invUncondProbs),
-                  lossPerc,
-                  _1)
-                )
-            ) / (1.-percProb);
+            [&](const std::vector<Real>& v1) {
+                return expectedShortfallFullPortfolioCond(invUncondProbs, lossPerc, v1);
+            }) / (1.-percProb);
 
     /* test:?
         return std::inner_product(integrESFPartition.begin(), 

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -616,7 +616,7 @@ namespace QuantLib {
             invUncondProbs[i] = 
             copula_->inverseCumulativeY(invUncondProbs[i], i);
 
-        return copula_->integratedExpectedValue(
+        return copula_->integratedExpectedValueV(
             ext::function<Disposable<std::vector<Real> > (
                 const std::vector<Real>& v1)>(
                     ext::bind(

--- a/ql/experimental/credit/spotlosslatentmodel.hpp
+++ b/ql/experimental/credit/spotlosslatentmodel.hpp
@@ -319,7 +319,6 @@ namespace QuantLib {
     inline Real SpotRecoveryLatentModel<CP>::expectedLoss(const Date& d, 
         Size iName) const 
     {
-        using namespace ext::placeholders;
         const ext::shared_ptr<Pool>& pool = basket_->pool();
         Probability pDefUncond =
             pool->get(pool->names()[iName]).
@@ -330,15 +329,9 @@ namespace QuantLib {
         Real invRR = inverseCumulativeY(recoveries_[iName], iName + numNames_);
 
         return integratedExpectedValue(
-            ext::function<Real (const std::vector<Real>& v1)>(
-               ext::bind(
-               &SpotRecoveryLatentModel<CP>::conditionalExpLossRRInv,
-               this,
-               invP,
-               invRR,
-               iName,
-               _1)
-              ));
+            [&](const std::vector<Real>& v){
+                return conditionalExpLossRRInv(invP, invRR, iName, v);
+            });
     }
 
     template<class CP>

--- a/ql/experimental/exoticoptions/analyticpdfhestonengine.cpp
+++ b/ql/experimental/exoticoptions/analyticpdfhestonengine.cpp
@@ -22,7 +22,6 @@
 */
 
 #include <ql/experimental/exoticoptions/analyticpdfhestonengine.hpp>
-#include <ql/functional.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/methods/finitedifferences/utilities/hestonrndcalculator.hpp>
 #include <utility>
@@ -36,8 +35,6 @@ namespace QuantLib {
       model_(std::move(model)) {}
 
     void AnalyticPDFHestonEngine::calculate() const {
-        using namespace ext::placeholders;
-
         // this is an European option pricer
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "not an European option");
@@ -56,10 +53,9 @@ namespace QuantLib {
 
         const Real drift = x0 + std::log(rD/qD);
 
-        results_.value = GaussLobattoIntegral(
-            maxIntegrationIterations_, integrationEps_)(
-            ext::bind(&AnalyticPDFHestonEngine::weightedPayoff, this,_1, t),
-                         -xMax+drift, xMax+drift);
+        results_.value = GaussLobattoIntegral(maxIntegrationIterations_, integrationEps_)(
+            [&](Real _x){ return weightedPayoff(_x, t); },
+            -xMax+drift, xMax+drift);
     }
 
     Real AnalyticPDFHestonEngine::Pv(Real x_t, Time t) const {

--- a/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
@@ -21,7 +21,6 @@
 */
 
 #include <ql/experimental/finitedifferences/fdmvppstepcondition.hpp>
-#include <ql/functional.hpp>
 #include <ql/math/array.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
@@ -44,8 +43,6 @@ namespace QuantLib {
       gasPrice_(std::move(gasPrice)), sparkSpreadPrice_(std::move(sparkSpreadPrice)),
       stateEvolveFcts_(nStates_) {
 
-        using namespace ext::placeholders;
-
         QL_REQUIRE(nStates_ == mesher_->layout()->dim()[stateDirection_],
                    "mesher does not fit to vpp arguments");
 
@@ -53,12 +50,10 @@ namespace QuantLib {
             const Size j = i % (2*tMinUp_ + tMinDown_);
 
             if (j < tMinUp_) {
-                stateEvolveFcts_[i] = ext::function<Real (Real)>(
-                    ext::bind(&FdmVPPStepCondition::evolveAtPMin,this, _1));
+                stateEvolveFcts_[i] = [&](Real x){ return evolveAtPMin(x); };
             }
             else if (j < 2*tMinUp_){
-                stateEvolveFcts_[i] = ext::function<Real (Real)>(
-                    ext::bind(&FdmVPPStepCondition::evolveAtPMax,this, _1));
+                stateEvolveFcts_[i] = [&](Real x) { return evolveAtPMax(x); };
             }
         }
     }

--- a/ql/experimental/math/convolvedstudentt.cpp
+++ b/ql/experimental/math/convolvedstudentt.cpp
@@ -165,8 +165,6 @@ namespace QuantLib {
       accuracy_(accuracy), distrib_(degreesFreedom, factors) { }
 
     Real InverseCumulativeBehrensFisher::operator()(const Probability q) const {
-        using namespace ext::placeholders;
-
         Probability effectiveq;
         Real sign;
         // since the distrib is symmetric solve only on the right side:
@@ -185,10 +183,8 @@ namespace QuantLib {
         // (q is very close to 1.), in a bad combination fails around 1.-1.e-7
         Real xMax = 1.e6;
         return sign *
-            Brent().solve(ext::bind(subtract<Real>(effectiveq),
-                                      ext::bind(
-                &CumulativeBehrensFisher::operator(),
-                distrib_, _1)), accuracy_, (xMin+xMax)/2., xMin, xMax);
+            Brent().solve([&](Real x){ return distrib_(x) - effectiveq; },
+                          accuracy_, (xMin+xMax)/2., xMin, xMax);
     }
 
 }

--- a/ql/experimental/math/convolvedstudentt.cpp
+++ b/ql/experimental/math/convolvedstudentt.cpp
@@ -23,7 +23,6 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/functional.hpp>
-#include <ql/functional.hpp>
 
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic push

--- a/ql/experimental/math/gaussiancopulapolicy.hpp
+++ b/ql/experimental/math/gaussiancopulapolicy.hpp
@@ -85,10 +85,8 @@ namespace QuantLib {
           depending on those values.
         */
         Probability density(const std::vector<Real>& m) const {
-            using namespace ext::placeholders;
-            return std::accumulate(m.begin(), m.end(), Real(1.), 
-                ext::bind(std::multiplies<Real>(), _1, 
-                    ext::bind(density_, _2)));
+            return std::accumulate(m.begin(), m.end(), Real(1.),
+                                   [&](Real x, Real y){ return x*density_(y); });
         }
         /*! Returns the inverse of the cumulative distribution of the (modelled) 
           latent variable (as indexed by iVariable). The normal stability avoids

--- a/ql/experimental/math/gaussiancopulapolicy.hpp
+++ b/ql/experimental/math/gaussiancopulapolicy.hpp
@@ -22,7 +22,6 @@
 
 #include <ql/utilities/disposable.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/functional.hpp>
 #include <vector>
 #include <numeric>
 #include <algorithm>
@@ -111,11 +110,10 @@ namespace QuantLib {
         //to use this (by default) version, the generator must be a uniform one.
         Disposable<std::vector<Real> > 
             allFactorCumulInverter(const std::vector<Real>& probs) const {
-            using namespace ext::placeholders;
             std::vector<Real> result;
             result.resize(probs.size());
-            std::transform(probs.begin(), probs.end(), result.begin(), 
-                ext::bind(&InverseCumulativeNormal::standard_value, _1));
+            std::transform(probs.begin(), probs.end(), result.begin(),
+                           [&](Real p){ return InverseCumulativeNormal::standard_value(p); });
             return result;
         }
     private:

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -25,7 +25,6 @@
 #include <ql/experimental/math/multidimintegrator.hpp>
 #include <ql/math/integrals/trapezoidintegral.hpp>
 #include <ql/math/randomnumbers/randomsequencegenerator.hpp>
-// for template spezs
 #include <ql/experimental/math/gaussiancopulapolicy.hpp>
 #include <ql/experimental/math/tcopulapolicy.hpp>
 #include <ql/math/randomnumbers/boxmullergaussianrng.hpp>
@@ -33,7 +32,6 @@
 #include <ql/experimental/math/polarstudenttrng.hpp>
 #include <ql/handle.hpp>
 #include <ql/quote.hpp>
-#include <ql/functional.hpp>
 #include <vector>
 
 /*! \file latentmodel.hpp

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -596,7 +596,7 @@ namespace QuantLib {
         /*! Integrates an arbitrary vector function over the density domain(i.e.
          computes its expected value).
         */
-        Disposable<std::vector<Real> > integratedExpectedValue(
+        Disposable<std::vector<Real> > integratedExpectedValueV(
             // const ext::function<std::vector<Real>(
             const ext::function<Disposable<std::vector<Real> >(
                 const std::vector<Real>& v1)>& f ) const {

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -588,16 +588,10 @@ namespace QuantLib {
         */
         Real integratedExpectedValue(
             const ext::function<Real(const std::vector<Real>& v1)>& f) const {
-
             // function composition: composes the integrand with the density 
             //   through a product.
-            return 
-                integration()->integrate(
-                    ext::bind(std::multiplies<Real>(), 
-                    ext::bind(&copulaPolicyImpl::density, copula_,
-                              ext::placeholders::_1),
-                              ext::bind(ext::cref(f),
-                                        ext::placeholders::_1)));   
+            return integration()->integrate(
+                [&](const std::vector<Real>& x){ return copula_.density(x) * f(x); });
         }
         /*! Integrates an arbitrary vector function over the density domain(i.e.
          computes its expected value).
@@ -606,13 +600,9 @@ namespace QuantLib {
             // const ext::function<std::vector<Real>(
             const ext::function<Disposable<std::vector<Real> >(
                 const std::vector<Real>& v1)>& f ) const {
-            return 
-                integration()->integrateV(//see note in LMIntegrators base class
-                    ext::bind<Disposable<std::vector<Real> > >(
-                        detail::multiplyV(),
-                        ext::bind(&copulaPolicyImpl::density, copula_,
-                                  ext::placeholders::_1),
-                        ext::bind(ext::cref(f), ext::placeholders::_1)));
+            detail::multiplyV M;
+            return integration()->integrateV(//see note in LMIntegrators base class
+                [&](const std::vector<Real>& x){ return M(copula_.density(x), f(x)); });
         }
     protected:
         // Integrable models must provide their integrator.

--- a/ql/experimental/math/multidimquadrature.hpp
+++ b/ql/experimental/math/multidimquadrature.hpp
@@ -72,10 +72,8 @@ namespace QuantLib {
                     term = f(x_[i]);// potential copy! @#$%^!!!
                     // sum[j] += term[j] * w_[i];
                     std::transform(term.begin(), term.end(), sum.begin(), 
-                        sum.begin(), 
-                        ext::bind(std::plus<Real>(), ext::placeholders::_2,
-                            ext::bind(std::multiplies<Real>(), w_[i],
-                                      ext::placeholders::_1)));
+                                   sum.begin(),
+                                   [&](Real x, Real y){ return w_[i]*x + y; });
                 }
                 return sum;
             }
@@ -136,14 +134,14 @@ namespace QuantLib {
         //    class construction time) handles to the integration entry points
         template<Size levelSpawn>
         void spawnFcts() const {
-            integrationEntries_[levelSpawn-1] = 
-                ext::bind(
-                &GaussianQuadMultidimIntegrator::scalarIntegrator<levelSpawn>, 
-                    this, ext::placeholders::_1, ext::placeholders::_2);
-            integrationEntriesVR_[levelSpawn-1] = 
-                ext::bind(
-                &GaussianQuadMultidimIntegrator::vectorIntegratorVR<levelSpawn>, 
-                    this, ext::placeholders::_1, ext::placeholders::_2);
+            integrationEntries_[levelSpawn-1] =
+                [&](ext::function<Real (const std::vector<Real>&)> f, Real x){
+                    return scalarIntegrator<levelSpawn>(f, x);
+                };
+            integrationEntriesVR_[levelSpawn-1] =
+                [&](const ext::function<detail::DispArray(const std::vector<Real>&)>& f, Real x){
+                    return vectorIntegratorVR<levelSpawn>(f, x);
+                };
             spawnFcts<levelSpawn-1>();
         }
         //@}
@@ -156,12 +154,7 @@ namespace QuantLib {
             const Real mFctr) const 
         {
             varBuffer_[intgDepth-1] = mFctr;
-            return integral_(ext::bind(
-                &GaussianQuadMultidimIntegrator::scalarIntegrator<intgDepth-1>,
-                this,
-                f,
-                ext::placeholders::_1)
-            );
+            return integral_([&](Real x){ return scalarIntegrator<intgDepth-1>(f, x); });
         }
 
         template <int intgDepth>
@@ -170,13 +163,7 @@ namespace QuantLib {
             const Real mFctr) const 
         {
             varBuffer_[intgDepth-1] = mFctr;
-            return 
-              integralV_(ext::bind(
-               &GaussianQuadMultidimIntegrator::vectorIntegratorVR<intgDepth-1>,
-               this,
-               f,
-               ext::placeholders::_1)
-            );
+            return integralV_([&](Real x){ return vectorIntegratorVR<intgDepth-1>(f, x); });
         }
 
         // Same object for all dimensions poses problems when using the 
@@ -209,12 +196,8 @@ namespace QuantLib {
     inline Real GaussianQuadMultidimIntegrator::operator()(
         const ext::function<Real (const std::vector<Real>& v1)>& f) const
     {
-        return integral_(ext::bind(
-                   // integration entry level is selected now
-                   integrationEntries_[dimension_-1],
-                   ext::cref(f),
-                   ext::placeholders::_1)
-                   );
+        // integration entry level is selected now
+        return integral_([&](Real x){ return integrationEntries_[dimension_-1](ext::cref(f), x); });
     }
 
     // Scalar integrand version (merge with vector case?)
@@ -226,12 +209,7 @@ namespace QuantLib {
         // call vector quadrature integration with the function and start 
         // values, kicks in recursion over the dimensions of the integration
         // variable.
-        return integral_(ext::bind(
-                   // integration entry level is selected now
-                   integrationEntries_[dimension_-1],
-                   ext::cref(f),
-                   ext::placeholders::_1)
-                   );
+        return integral_([&](Real x){ return integrationEntries_[dimension_-1](ext::cref(f), x); });
     }
 
     // Vector integrand version
@@ -239,11 +217,7 @@ namespace QuantLib {
     inline detail::DispArray GaussianQuadMultidimIntegrator::integrate<detail::DispArray>(
         const ext::function<detail::DispArray (const std::vector<Real>& v1)>& f) const
     {
-        return integralV_(ext::bind(
-                   ext::cref(integrationEntriesVR_[dimension_-1]),
-                   ext::cref(f),
-                   ext::placeholders::_1)
-                   );
+        return integralV_([&](Real x){ return integrationEntriesVR_[dimension_-1](ext::cref(f), x); });
     } 
 
     //! Terminal integrand; scalar function version
@@ -270,12 +244,14 @@ namespace QuantLib {
     //! Terminal level:
     template<>
     inline void GaussianQuadMultidimIntegrator::spawnFcts<1>() const {
-        integrationEntries_[0] = 
-          ext::bind(&GaussianQuadMultidimIntegrator::scalarIntegrator<1>, 
-          this, ext::placeholders::_1, ext::placeholders::_2);
-        integrationEntriesVR_[0] = 
-         ext::bind(&GaussianQuadMultidimIntegrator::vectorIntegratorVR<1>, 
-         this, ext::placeholders::_1, ext::placeholders::_2);
+        integrationEntries_[0] =
+            [&](ext::function<Real (const std::vector<Real>&)> f, Real x) {
+                return scalarIntegrator<1>(f, x);
+            };
+        integrationEntriesVR_[0] =
+            [&](const ext::function<detail::DispArray(const std::vector<Real>&)>& f, Real x) {
+                return vectorIntegratorVR<1>(f, x);
+            };
     }
 
 }

--- a/ql/experimental/math/multidimquadrature.hpp
+++ b/ql/experimental/math/multidimquadrature.hpp
@@ -244,10 +244,8 @@ namespace QuantLib {
     //! Terminal level:
     template<>
     inline void GaussianQuadMultidimIntegrator::spawnFcts<1>() const {
-        integrationEntries_[0] =
-            [&](ext::function<Real (const std::vector<Real>&)> f, Real x) {
-                return scalarIntegrator<1>(f, x);
-            };
+        integrationEntries_[0] = [&](const ext::function<Real(const std::vector<Real>&)>& f,
+                                     Real x) { return scalarIntegrator<1>(f, x); };
         integrationEntriesVR_[0] =
             [&](const ext::function<detail::DispArray(const std::vector<Real>&)>& f, Real x) {
                 return vectorIntegratorVR<1>(f, x);

--- a/ql/experimental/math/tcopulapolicy.cpp
+++ b/ql/experimental/math/tcopulapolicy.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <ql/experimental/math/tcopulapolicy.hpp>
-#include <ql/functional.hpp>
 #include <numeric>
 #include <algorithm>
 
@@ -73,17 +72,14 @@ namespace QuantLib {
             "Incompatible sample and latent model sizes");
     #endif
 
-        using namespace ext::placeholders;
-
         std::vector<Real> result(probs.size());
         Size indexSystemic = 0;
         std::transform(probs.begin(), probs.begin() + varianceFactors_.size()-1,
-            result.begin(), 
-            ext::bind(&TCopulaPolicy::inverseCumulativeDensity, 
-                                this, _1, indexSystemic++));
+                       result.begin(),
+                       [&](Probability p) { return inverseCumulativeDensity(p, indexSystemic++); });
         std::transform(probs.begin() + varianceFactors_.size()-1, probs.end(),
-            result.begin()+ varianceFactors_.size()-1,
-            ext::bind(&TCopulaPolicy::inverseCumulativeZ, this, _1));
+                       result.begin()+ varianceFactors_.size()-1,
+                       [&](Probability p) { return inverseCumulativeZ(p); });
         return result;
     }
 

--- a/ql/experimental/volatility/noarbsabr.cpp
+++ b/ql/experimental/volatility/noarbsabr.cpp
@@ -21,8 +21,6 @@
 
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/modifiedbessel.hpp>
-#include <ql/functional.hpp>
-
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/assign/std/vector.hpp>
 #include <boost/functional/hash.hpp>

--- a/ql/experimental/volatility/noarbsabr.cpp
+++ b/ql/experimental/volatility/noarbsabr.cpp
@@ -57,8 +57,6 @@ NoArbSabrModel::NoArbSabrModel(const Real expiryTime, const Real forward,
       beta_(beta), nu_(nu), rho_(rho), forward_(forward),
       numericalForward_(forward) {
 
-    using namespace ext::placeholders;
-
     QL_REQUIRE(expiryTime > 0.0 && expiryTime <= detail::NoArbSabrModel::expiryTime_max,
                "expiryTime (" << expiryTime << ") out of bounds");
     QL_REQUIRE(forward > 0.0, "forward (" << forward << ") must be positive");
@@ -105,7 +103,7 @@ NoArbSabrModel::NoArbSabrModel(const Real expiryTime, const Real forward,
         Brent b;
         Real start = std::sqrt(externalForward_ - detail::NoArbSabrModel::strike_min);
         Real tmp =
-            b.solve(ext::bind(&NoArbSabrModel::forwardError, this, _1),
+            b.solve([&](Real x){ return forwardError(x); },
                     detail::NoArbSabrModel::forward_accuracy, start,
                     std::min(detail::NoArbSabrModel::forward_search_step, start / 2.0));
         forward_ = tmp * tmp + detail::NoArbSabrModel::strike_min;

--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -34,7 +34,6 @@
 #include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
 #include <ql/experimental/finitedifferences/fdmdupire1dop.hpp>
 #include <ql/experimental/finitedifferences/fdmzabrop.hpp>
-#include <ql/functional.hpp>
 
 using std::pow;
 
@@ -69,12 +68,10 @@ Real ZabrModel::lognormalVolatility(const Real strike) const {
 
 Disposable<std::vector<Real> >
 ZabrModel::lognormalVolatility(const std::vector<Real> &strikes) const {
-    using namespace ext::placeholders;
     std::vector<Real> x_ = x(strikes);
     std::vector<Real> result(strikes.size());
     std::transform(strikes.begin(), strikes.end(), x_.begin(), result.begin(),
-                   ext::bind(&ZabrModel::lognormalVolatilityHelper,
-                               this, _1, _2));
+                   [&](Real _k, Real _x) { return lognormalVolatilityHelper(_k, _x); });
     return result;
 }
 
@@ -91,12 +88,10 @@ Real ZabrModel::normalVolatility(const Real strike) const {
 
 Disposable<std::vector<Real> >
 ZabrModel::normalVolatility(const std::vector<Real> &strikes) const {
-    using namespace ext::placeholders;
     std::vector<Real> x_ = x(strikes);
     std::vector<Real> result(strikes.size());
     std::transform(strikes.begin(), strikes.end(), x_.begin(), result.begin(),
-                   ext::bind(&ZabrModel::normalVolatilityHelper, this,
-                               _1, _2));
+                   [&](Real _k, Real _x) { return normalVolatilityHelper(_k, _x); });
     return result;
 }
 
@@ -113,12 +108,10 @@ Real ZabrModel::localVolatility(const Real f) const {
 
 Disposable<std::vector<Real> >
 ZabrModel::localVolatility(const std::vector<Real> &f) const {
-    using namespace ext::placeholders;
     std::vector<Real> x_ = x(f);
     std::vector<Real> result(f.size());
     std::transform(f.begin(), f.end(), x_.begin(), result.begin(),
-                   ext::bind(&ZabrModel::localVolatilityHelper, this,
-                               _1, _2));
+                   [&](Real _f, Real _x) { return localVolatilityHelper(_f, _x); });
     return result;
 }
 
@@ -318,7 +311,6 @@ Real ZabrModel::x(const Real strike) const {
 
 Disposable<std::vector<Real> >
 ZabrModel::x(const std::vector<Real> &strikes) const {
-    using namespace ext::placeholders;
 
     QL_REQUIRE(strikes[0] > 0.0 || beta_ < 1.0,
                "strikes must be positive (" << strikes[0] << ") if beta = 1");
@@ -332,7 +324,7 @@ ZabrModel::x(const std::vector<Real> &strikes) const {
                                       // the constructor
     std::vector<Real> y(strikes.size()), result(strikes.size());
     std::transform(strikes.rbegin(), strikes.rend(), y.begin(),
-                   ext::bind(&ZabrModel::y, this, _1));
+                   [&](Real _k) { return this->y(_k); });
 
     if (close(gamma_, 1.0)) {
         for (Size m = 0; m < y.size(); m++) {
@@ -353,7 +345,7 @@ ZabrModel::x(const std::vector<Real> &strikes) const {
             Real y0 = 0.0, u0 = 0.0;
             for (int m = ynz + (dir == -1 ? -1 : 0);
                  dir == -1 ? m >= 0 : m < (int)y.size(); m += dir) {
-                Real u = rk(ext::bind(&ZabrModel::F, this, _1, _2),
+                Real u = rk([&](Real _y, Real _u){ return F(_y, _u); },
                             u0, y0, y[m]);
                 result[y.size() - 1 - m] = u * pow(alpha_, 1.0 - gamma_);
                 u0 = u;

--- a/ql/math/integrals/twodimensionalintegral.hpp
+++ b/ql/math/integrals/twodimensionalintegral.hpp
@@ -46,17 +46,14 @@ namespace QuantLib {
         Real operator()(const ext::function<Real (Real, Real)>& f,
                         const std::pair<Real, Real>& a,
                         const std::pair<Real, Real>& b) const {
-            using namespace ext::placeholders;
-            return (*integratorX_)(
-                 ext::bind(&TwoDimensionalIntegral::g, this, f, _1,
-                             a.second, b.second), a.first, b.first);
+            return (*integratorX_)([&](Real x) { return g(f, x, a.second, b.second); },
+                                   a.first, b.first);
         }
 
       private:
         Real g(const ext::function<Real (Real, Real)>& f,
                Real x, Real a, Real b) const {
-            using namespace ext::placeholders;
-            return (*integratorY_)(ext::bind(f, x, _1), a, b);
+            return (*integratorY_)([&](Real y) { return f(x, y); }, a, b);
         }
 
         const ext::shared_ptr<Integrator> integratorX_, integratorY_;

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -86,8 +86,7 @@ namespace QuantLib {
             ext::bind(&LevenbergMarquardt::fcn, this, _1, _2, _3, _4, _5);
         MINPACK::LmdifCostFunction lmdifJacFunction =
             useCostFunctionsJacobian_
-                ? ext::bind(&LevenbergMarquardt::jacFcn, this, _1, _2, _3,
-                              _4, _5)
+                ? ext::bind(&LevenbergMarquardt::jacFcn, this, _1, _2, _3, _4, _5)
                 : MINPACK::LmdifCostFunction();
         MINPACK::lmdif(m, n, xx.get(), fvec.get(),
                        endCriteria.functionEpsilon(),

--- a/ql/math/optimization/spherecylinder.cpp
+++ b/ql/math/optimization/spherecylinder.cpp
@@ -118,15 +118,12 @@ namespace QuantLib {
                                               Real& y2,
                                               Real& y3) const
     {
-         using namespace ext::placeholders;
-
          Real x1,x2,x3;
          findByProjection(x1,x2,x3);
 
          y1 = BrentMinimize(
                 bottomValue_, x1, topValue_,tolerance, maxIterations,
-                ext::bind(
-                      &SphereCylinderOptimizer::objectiveFunction, this, _1));
+                [&](Real x){ return objectiveFunction(x); });
          y2 =std::sqrt(s_*s_ - (y1-alpha_)*(y1-alpha_));
          y3= std::sqrt(r_*r_ - y1*y1-y2*y2);
     }

--- a/ql/math/optimization/spherecylinder.cpp
+++ b/ql/math/optimization/spherecylinder.cpp
@@ -19,7 +19,6 @@
 
 #include <ql/math/optimization/spherecylinder.hpp>
 #include <ql/errors.hpp>
-#include <ql/functional.hpp>
 #include <algorithm>
 
 namespace QuantLib {

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -34,7 +34,6 @@
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/math/ode/adaptiverungekutta.hpp>
 #include <ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp>
-#include <ql/functional.hpp>
 #include <cmath>
 
 // asinh is missing in WIN32 (and possibly on other compilers)

--- a/ql/methods/finitedifferences/meshers/exponentialjump1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/exponentialjump1dmesher.cpp
@@ -26,7 +26,6 @@
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/math/distributions/gammadistribution.hpp>
 #include <ql/methods/finitedifferences/meshers/exponentialjump1dmesher.hpp>
-#include <ql/functional.hpp>
 
 namespace QuantLib {
     ExponentialJump1dMesher::ExponentialJump1dMesher(
@@ -75,19 +74,14 @@ namespace QuantLib {
     }
 
     Real ExponentialJump1dMesher::jumpSizeDistribution(Real x, Time t) const {
-        using namespace ext::placeholders;
         const Real xmin = std::min(x, 1.0e-100);
 
-        // the typedef is needed to disambiguate the overloaded method
-        typedef Real (ExponentialJump1dMesher::*M)(Real, Time) const;
         return GaussLobattoIntegral(1000000, 1e-12)(
-            ext::bind(M(&ExponentialJump1dMesher::jumpSizeDensity),
-                      this, _1, t),
+            [&](Real _x){ return jumpSizeDensity(_x, t); },
             xmin, std::max(x, xmin));
     }
 
     Real ExponentialJump1dMesher::jumpSizeDistribution(Real x) const {
-        using namespace ext::placeholders;
         const Real a    = jumpIntensity_/beta_;
         const Real xmin = std::min(x, QL_EPSILON);
         const Real gammaValue 
@@ -96,11 +90,8 @@ namespace QuantLib {
         const Real lowerEps = 
             (std::pow(xmin, a)/a - std::pow(xmin, a+1)/(a+1))/gammaValue;
         
-        // the typedef is needed to disambiguate the overloaded method
-        typedef Real (ExponentialJump1dMesher::*M)(Real) const;
         return lowerEps + GaussLobattoIntegral(10000, 1e-12)(
-            ext::bind(M(&ExponentialJump1dMesher::jumpSizeDensity),
-                      this, _1),
+            [&](Real _x){ return jumpSizeDensity(_x); },
             xmin/eta_, std::max(x, xmin/eta_));
     }
 }

--- a/ql/methods/finitedifferences/schemes/methodoflinesscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/methodoflinesscheme.cpp
@@ -17,7 +17,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
  */
 
-#include <ql/functional.hpp>
 #include <ql/math/ode/adaptiverungekutta.hpp>
 #include <ql/methods/finitedifferences/schemes/methodoflinesscheme.hpp>
 #include <utility>
@@ -44,12 +43,11 @@ namespace QuantLib {
     }
 
     void MethodOfLinesScheme::step(array_type& a, Time t) {
-        using namespace ext::placeholders;
         QL_REQUIRE(t-dt_ > -1e-8, "a step towards negative time given");
 
         const std::vector<Real> v =
            AdaptiveRungeKutta<Real>(eps_, relInitStepSize_*dt_)(
-               ext::bind(&MethodOfLinesScheme::apply, this, _1, _2),
+               [&](Time _t, const std::vector<Real>& _u){ return apply(_t, _u); },
                std::vector<Real>(a.begin(), a.end()),
                t, std::max(0.0, t-dt_));
 

--- a/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
+++ b/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
@@ -105,8 +105,6 @@ namespace QuantLib {
 
     template <class TrapezoidalScheme>
     inline void TrBDF2Scheme<TrapezoidalScheme>::step(array_type& fn, Time t) {
-        using namespace ext::placeholders;
-
         QL_REQUIRE(t-dt_ > -1e-8, "a step towards negative time given");
 
         const Time intermediateTimeStep = dt_*alpha_;
@@ -125,12 +123,8 @@ namespace QuantLib {
             fn = map_->solve_splitting(0, f, -beta_);
         }
         else {
-            const ext::function<Disposable<Array>(const Array&)>
-                preconditioner(ext::bind(
-                    &FdmLinearOpComposite::preconditioner, map_, _1, -beta_));
-
-            const ext::function<Disposable<Array>(const Array&)> applyF(
-                ext::bind(&TrBDF2Scheme<TrapezoidalScheme>::apply, this, _1));
+            auto preconditioner = [&](const Array& _a){ return map_->preconditioner(_a, -beta_); };
+            auto applyF = [&](const Array& _a){ return apply(_a); };
 
             if (solverType_ == BiCGstab) {
                 const BiCGStabResult result =

--- a/ql/methods/finitedifferences/utilities/cevrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/cevrndcalculator.cpp
@@ -20,7 +20,6 @@
 /*! \file cevrndcalculator.cpp */
 
 #include <ql/errors.hpp>
-#include <ql/functional.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
@@ -102,17 +101,13 @@ namespace QuantLib {
     }
 
     Real CEVRNDCalculator::invcdf(Real q, Time t) const {
-        using namespace ext::placeholders;
-
         if (delta_ < 2.0) {
             if (f0_ < QL_EPSILON || q < massAtZero(t))
                 return 0.0;
 
             const Real x = InverseCumulativeNormal()(1-q);
 
-            const ext::function<Real(Real)> cdfApprox
-                = ext::bind(&CEVRNDCalculator::sankaranApprox,
-                              this, _1, t, x);
+            auto cdfApprox = [&](Real _c){ return sankaranApprox(_c, t, x); };
 
             const Real y0 = X(f0_)/t;
 

--- a/ql/methods/finitedifferences/utilities/gbsmrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/gbsmrndcalculator.cpp
@@ -22,7 +22,6 @@
            Black-Scholes-Merton model with skew dependent volatility
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
@@ -74,8 +73,6 @@ namespace QuantLib {
     }
 
     Real GBSMRNDCalculator::invcdf(Real q, Time t) const {
-        using namespace ext::placeholders;
-
         const Real fwd = process_->x0()
             / process_->riskFreeRate()->discount(t, true)
             * process_->dividendYield()->discount(t, true);
@@ -100,9 +97,7 @@ namespace QuantLib {
                 << cdf(lower, t) << ", " << cdf(upper, t) << ")");
 
         return Brent().solve(
-            compose(subtract<Real>(q),
-                    ext::function<Real(Real)>(
-                        ext::bind(&GBSMRNDCalculator::cdf, this, _1, t))),
+            [&](Real _k){ return cdf(_k, t) - q; },
             1e-10, 0.5*(lower+upper), lower, upper);
     }
 }

--- a/ql/methods/finitedifferences/utilities/hestonrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/hestonrndcalculator.cpp
@@ -18,7 +18,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/methods/finitedifferences/utilities/bsmrndcalculator.hpp>
@@ -101,7 +100,7 @@ namespace {
                                                                /(1.0-gamma))));
             }
 
-            const HestonParams& p_;
+            const HestonParams p_;
             const Time t_;
             const Real x_, c_inf_;
         };
@@ -127,17 +126,15 @@ namespace {
             CpxPv_Helper(getHestonParams(hestonProcess_), x_t(x, t), t),
             0.0, 1.0)/M_TWOPI;
     }
-	
+
     Real HestonRNDCalculator::cdf(Real x, Time t) const {
-        using namespace ext::placeholders;
+        CpxPv_Helper helper(getHestonParams(hestonProcess_), x_t(x, t), t);
 
-        return GaussLobattoIntegral(
-            maxIntegrationIterations_, 0.1*integrationEps_)(
-            ext::bind(&CpxPv_Helper::p0,
-                CpxPv_Helper(getHestonParams(hestonProcess_), x_t(x,t),t),_1),
+        return GaussLobattoIntegral(maxIntegrationIterations_, 0.1*integrationEps_)(
+            [&](Real p_x){ return helper.p0(p_x); },
             0.0, 1.0)/M_TWOPI + 0.5;
-
     }
+
     Real HestonRNDCalculator::invcdf(Real p, Time t) const {
         const Real v0    = hestonProcess_->v0();
         const Real kappa = hestonProcess_->kappa();

--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -22,7 +22,6 @@
     \brief local volatility risk neutral terminal density calculation
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/integrals/discreteintegrals.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
@@ -126,8 +125,6 @@ namespace QuantLib {
     }
 
     Real LocalVolRNDCalculator::cdf(Real x, Time t) const {
-        using namespace ext::placeholders;
-
         calculate();
 
         // get the left side of the integral
@@ -146,14 +143,15 @@ namespace QuantLib {
         // left or right hand integral
         if (x > 0.5*(xr+xl)) {
             while (pdf(xr, t) > 0.01*localVolProbEps_) xr*=1.1;
+
             return 1.0-GaussLobattoIntegral(maxIter_, 0.1*localVolProbEps_)(
-                ext::bind(&LocalVolRNDCalculator::pdf, this, _1, t), x, xr);
+                [&](Real _x){ return pdf(_x, t); }, x, xr);
         }
         else {
             while (pdf(xl, t) > 0.01*localVolProbEps_) xl*=0.9;
 
             return GaussLobattoIntegral(maxIter_, 0.1*localVolProbEps_)(
-                ext::bind(&LocalVolRNDCalculator::pdf, this, _1, t), xl, x);
+                [&](Real _x){ return pdf(_x, t); }, xl, x);
         }
     }
 

--- a/ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.cpp
@@ -21,9 +21,9 @@
 #include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.hpp>
-#include <ql/functional.hpp>
 
 namespace QuantLib {
+
     RiskNeutralDensityCalculator::InvCDFHelper::InvCDFHelper(
         const RiskNeutralDensityCalculator* calculator,
         Real guess, Real accuracy, Size maxEvaluations,
@@ -34,17 +34,11 @@ namespace QuantLib {
       maxEvaluations_(maxEvaluations),
       stepSize_(stepSize) { }
 
-    Real RiskNeutralDensityCalculator::InvCDFHelper::inverseCDF(Real p, Time t)
-    const {
-        using namespace ext::placeholders;
-
-        const ext::function<Real(Real)> cdf
-            = ext::bind(&RiskNeutralDensityCalculator::cdf,
-                          calculator_, _1, t);
-
+    Real RiskNeutralDensityCalculator::InvCDFHelper::inverseCDF(Real p, Time t) const {
         Brent solver;
         solver.setMaxEvaluations(maxEvaluations_);
-        return solver.solve(compose(subtract<Real>(p), cdf),
+        return solver.solve([&](Real _x){ return calculator_->cdf(_x, t) - p; },
                             accuracy_, guess_, stepSize_);
     }
+
 }

--- a/ql/methods/montecarlo/lsmbasissystem.cpp
+++ b/ql/methods/montecarlo/lsmbasissystem.cpp
@@ -21,9 +21,7 @@
 /*! \file lsmbasissystem.cpp
     \brief utility classes for longstaff schwartz early exercise Monte Carlo
 */
-// lsmbasissystem.hpp
 
-#include <ql/functional.hpp>
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
 #include <numeric>

--- a/ql/methods/montecarlo/lsmbasissystem.cpp
+++ b/ql/methods/montecarlo/lsmbasissystem.cpp
@@ -37,8 +37,6 @@ namespace QuantLib {
         typedef std::vector<ext::function<Real(Real)> > VF_R;
         typedef std::vector<ext::function<Real(Array)> > VF_A;
         typedef std::vector<std::vector<Size> > VV;
-        Real (GaussianOrthogonalPolynomial::*ptr_w)(Size, Real) const =
-            &GaussianOrthogonalPolynomial::weightedValue;
 
         // pow(x, order)
         class MonomialFct {
@@ -109,7 +107,6 @@ namespace QuantLib {
     // LsmBasisSystem static methods
 
     VF_R LsmBasisSystem::pathBasisSystem(Size order, PolynomType polyType) {
-        using namespace ext::placeholders;
         VF_R ret(order+1);
         for (Size i=0; i<=order; ++i) {
             switch (polyType) {
@@ -117,22 +114,40 @@ namespace QuantLib {
                 ret[i] = MonomialFct(i);
                 break;
               case Laguerre:
-                ret[i] = ext::bind(ptr_w, GaussLaguerrePolynomial(), i, _1);
+                {
+                  GaussLaguerrePolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               case Hermite:
-                ret[i] = ext::bind(ptr_w, GaussHermitePolynomial(), i, _1);
+                {
+                  GaussHermitePolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               case Hyperbolic:
-                ret[i] = ext::bind(ptr_w, GaussHyperbolicPolynomial(), i, _1);
+                {
+                  GaussHyperbolicPolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               case Legendre:
-                ret[i] = ext::bind(ptr_w, GaussLegendrePolynomial(), i, _1);
+                {
+                  GaussLegendrePolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               case Chebyshev:
-                ret[i] = ext::bind(ptr_w, GaussChebyshevPolynomial(), i, _1);
+                {
+                  GaussChebyshevPolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               case Chebyshev2nd:
-                ret[i] = ext::bind(ptr_w,GaussChebyshev2ndPolynomial(),i, _1);
+                {
+                  GaussChebyshev2ndPolynomial p;
+                  ret[i] = [=](Real x){ return p.weightedValue(i, x); };
+                }
                 break;
               default:
                 QL_FAIL("unknown regression type");

--- a/ql/pricingengines/basket/mcamericanbasketengine.cpp
+++ b/ql/pricingengines/basket/mcamericanbasketengine.cpp
@@ -18,7 +18,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
 #include <ql/pricingengines/basket/mcamericanbasketengine.hpp>
@@ -38,7 +37,7 @@ namespace QuantLib {
                    || polynomType == LsmBasisSystem::Hyperbolic
                    || polynomType == LsmBasisSystem::Chebyshev2nd,
                    "insufficient polynom type");
-        using namespace ext::placeholders;
+
         const ext::shared_ptr<BasketPayoff> basketPayoff
             = ext::dynamic_pointer_cast<BasketPayoff>(payoff_);
         QL_REQUIRE(basketPayoff, "payoff not a basket payoff");
@@ -50,7 +49,7 @@ namespace QuantLib {
             scalingValue_/=strikePayoff->strike();
         }
 
-        v_.emplace_back(ext::bind(&AmericanBasketPathPricer::payoff, this, _1));
+        v_.emplace_back([&](const Array& state) { return this->payoff(state); });
     }
 
     Array AmericanBasketPathPricer::state(const MultiPath& path,

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -25,7 +25,6 @@
 
 #include <ql/functional.hpp>
 #include <ql/instruments/payoffs.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/discreteintegrals.hpp>
 #include <ql/math/integrals/exponentialintegrals.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
@@ -633,9 +632,9 @@ namespace QuantLib {
             const Real epsilon = enginePtr->andersenPiterbargEpsilon_
                 *M_PI/(std::sqrt(strikePrice*fwdPrice)*riskFreeDiscount);
 
-            const ext::function<Real()> uM = ext::bind(
-                Integration::andersenPiterbargIntegrationLimit,
-                    c_inf, epsilon, v0, term);
+            const ext::function<Real()> uM = [&](){
+                return Integration::andersenPiterbargIntegrationLimit(c_inf, epsilon, v0, term);
+            };
 
             AP_Helper cvHelper(term, fwdPrice, strikePrice,
                 (cpxLog == OptimalCV)
@@ -864,9 +863,7 @@ namespace QuantLib {
         Real maxBound) const {
 
         return AnalyticHestonEngine::Integration::calculate(
-            c_inf, f,
-            ext::bind(&constant<Real, Real>::operator(),
-                constant<Real, Real>(maxBound), 1.0));
+            c_inf, f, [=](){ return maxBound; });
     }
 
     Real AnalyticHestonEngine::Integration::andersenPiterbargIntegrationLimit(

--- a/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
@@ -366,9 +366,9 @@ namespace QuantLib {
 
               const Real c_inf = -(C_u_inf + D_u_inf*v0).real();
 
-              const ext::function<Real()> uM = ext::bind(
-                  Integration::andersenPiterbargIntegrationLimit,
-                      c_inf, epsilon, v0, term);
+              const ext::function<Real()> uM = [=](){
+                  return Integration::andersenPiterbargIntegrationLimit(c_inf, epsilon, v0, term);
+              };
 
               const Real vAvg
                   = (1-std::exp(-kappaAvg*term))*(v0-thetaAvg)

--- a/ql/pricingengines/vanilla/mcamericanengine.cpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.cpp
@@ -22,7 +22,6 @@
 */
 
 #include <ql/errors.hpp>
-#include <ql/functional.hpp>
 #include <ql/instruments/payoffs.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/pricingengines/vanilla/mcamericanengine.hpp>
@@ -43,10 +42,8 @@ namespace QuantLib {
                    || polynomType == LsmBasisSystem::Chebyshev2nd,
                    "insufficient polynom type");
 
-        using namespace ext::placeholders;
-
         // the payoff gives an additional value
-        v_.emplace_back(ext::bind(&AmericanPathPricer::payoff, this, _1));
+        v_.emplace_back([&](Real state){ return this->payoff(state); });
 
         const ext::shared_ptr<StrikedTypePayoff> strikePayoff
             = ext::dynamic_pointer_cast<StrikedTypePayoff>(payoff_);

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -17,7 +17,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/distributions/chisquaredistribution.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/functional.hpp>

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -177,7 +177,6 @@ namespace QuantLib {
 
         Real int_ph(const HestonProcess& process,
                     Real a, Real x, Real y, Real nu_0, Real nu_t, Time t) {
-            using namespace ext::placeholders;
             static const GaussLaguerreIntegration gaussLaguerreIntegration(128);
 
             const Real rho   = process.rho();
@@ -186,8 +185,7 @@ namespace QuantLib {
             const Real x0    = std::log(process.s0()->value());
 
             return gaussLaguerreIntegration(
-                ext::bind(&ph, process, y,
-                            _1, nu_0, nu_t, t))
+                [&](Real u){ return ph(process, y, u, nu_0, nu_t, t); })
                 / std::sqrt(2*M_PI*(1-rho*rho)*y)
                 * std::exp(-0.5*square<Real>()(  x - x0 - a
                                                + y*(0.5-rho*kappa/sigma))
@@ -297,7 +295,6 @@ namespace QuantLib {
         Real cdf_nu_ds(const HestonProcess& process,
                        Real x, Real nu_0, Real nu_t, Time dt,
                        HestonProcess::Discretization discretization) {
-            using namespace ext::placeholders;
             const Real eps = 1e-4;
             const Real u_eps = std::min(100.0,
                 std::max(0.1, cornishFisherEps(process, nu_0, nu_t, dt, eps)));
@@ -316,8 +313,7 @@ namespace QuantLib {
                 return (x < upper)
                     ? std::max(0.0, std::min(1.0,
                         gaussLaguerreIntegration(
-                            ext::bind(&ch, process, x,
-                                        _1, nu_0, nu_t, dt))))
+                            [&](Real u){ return ch(process, x, u, nu_0, nu_t, dt); })))
                     : 1.0;
               }
               case HestonProcess::BroadieKayaExactSchemeLobatto:
@@ -330,8 +326,7 @@ namespace QuantLib {
                 return (x < upper)
                     ? std::max(0.0, std::min(1.0,
                         GaussLobattoIntegral(Null<Size>(), eps)(
-                            ext::bind(&ch, process, x,
-                                        _1, nu_0, nu_t, dt),
+                            [&](Real xi){ return ch(process, x, xi, nu_0, nu_t, dt); },
                             QL_EPSILON, upper)))
                     : 1.0;
               }
@@ -370,7 +365,6 @@ namespace QuantLib {
     }
 
     Real HestonProcess::pdf(Real x, Real v, Time t, Real eps) const {
-         using namespace ext::placeholders;
          const Real k = sigma_*sigma_*(1-std::exp(-kappa_*t))/(4*kappa_);
          const Real a = std::log(  dividendYield_->discount(t)
                                    / riskFreeRate_->discount(t))
@@ -396,8 +390,7 @@ namespace QuantLib {
          upper = 2.0*cornishFisherEps(*this, v0_, v, t,1e-3);
 
          return SegmentIntegral(100)(
-             ext::bind(&int_ph, *this, a, x,
-                         _1, v0_, v, t),
+               [&](Real xi){ return int_ph(*this, a, x, xi, v0_, v, t); },
                QL_EPSILON, upper)
                * boost::math::pdf(
                      boost::math::non_central_chi_squared_distribution<Real>(
@@ -409,8 +402,6 @@ namespace QuantLib {
 
     Disposable<Array> HestonProcess::evolve(Time t0, const Array& x0,
                                             Time dt, const Array& dw) const {
-        using namespace ext::placeholders;
-
         Array retVal(2);
         Real vol, vol2, mu, nu, dy;
 
@@ -541,8 +532,7 @@ namespace QuantLib {
                 std::max(0.0, CumulativeNormalDistribution()(dw[2])));
 
             const Real vds = Brent().solve(
-                ext::bind(&cdf_nu_ds_minus_x, *this, _1,
-                            nu_0, nu_t, dt, discretization_, x),
+                [&](Real xi){ return cdf_nu_ds_minus_x(*this, xi, nu_0, nu_t, dt, discretization_, x); },
                 1e-5, theta_*dt, 0.1*theta_*dt);
 
             const Real vdw

--- a/ql/termstructures/credit/defaultdensitystructure.cpp
+++ b/ql/termstructures/credit/defaultdensitystructure.cpp
@@ -19,7 +19,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/termstructures/credit/defaultdensitystructure.hpp>
 #include <utility>

--- a/ql/termstructures/credit/defaultdensitystructure.cpp
+++ b/ql/termstructures/credit/defaultdensitystructure.cpp
@@ -70,16 +70,10 @@ namespace QuantLib {
     : DefaultProbabilityTermStructure(settlDays, cal, dc, jumps, jumpDates) {}
 
     Probability DefaultDensityStructure::survivalProbabilityImpl(Time t) const {
-        using namespace ext::placeholders;
         static GaussChebyshevIntegration integral(48);
-        // this stores the address of the method to integrate (so that
-        // we don't have to insert its full expression inside the
-        // integral below--it's long enough already)
-        Real (DefaultDensityStructure::*f)(Time) const =
-            &DefaultDensityStructure::defaultDensityImpl;
         // the Gauss-Chebyshev quadratures integrate over [-1,1],
         // hence the remapping (and the Jacobian term t/2)
-        Probability P = 1.0 - integral(remap_t(ext::bind(f,this,_1), t)) * t/2.0;
+        Probability P = 1.0 - integral(remap_t([&](Time tau){ return defaultDensityImpl(tau); }, t)) * t / 2.0;
         //QL_ENSURE(P >= 0.0, "negative survival probability");
         return std::max<Real>(P, 0.0);
     }

--- a/ql/termstructures/credit/hazardratestructure.cpp
+++ b/ql/termstructures/credit/hazardratestructure.cpp
@@ -72,16 +72,10 @@ namespace QuantLib {
     : DefaultProbabilityTermStructure(settlDays, cal, dc, jumps, jumpDates) {}
 
     Probability HazardRateStructure::survivalProbabilityImpl(Time t) const {
-        using namespace ext::placeholders;
         static GaussChebyshevIntegration integral(48);
-        // this stores the address of the method to integrate (so that
-        // we don't have to insert its full expression inside the
-        // integral below--it's long enough already)
-        Real (HazardRateStructure::*f)(Time) const =
-            &HazardRateStructure::hazardRateImpl;
         // the Gauss-Chebyshev quadratures integrate over [-1,1],
         // hence the remapping (and the Jacobian term t/2)
-        return std::exp(-integral(remap(ext::bind(f,this,_1), t)) * t/2.0);
+        return std::exp(-integral(remap([&](Time tau){ return hazardRateImpl(tau); }, t)) * t/2.0);
     }
 
 }

--- a/ql/termstructures/credit/hazardratestructure.cpp
+++ b/ql/termstructures/credit/hazardratestructure.cpp
@@ -21,7 +21,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/termstructures/credit/hazardratestructure.hpp>
 #include <utility>

--- a/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
@@ -89,7 +89,7 @@ namespace QuantLib {
 
         std::transform(arguments_.begin(), arguments_.end(),
                        localVolMatrix->begin(),
-                       ext::bind(&Parameter::operator(), _1, 0.0));
+                       [](const Parameter& p) { return p(0.0); });
 
         localVol_ = ext::make_shared<FixedLocalVolSurface>(
                 referenceDate_,

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -22,7 +22,6 @@
     \brief Black volatility surface back by Heston model
 */
 
-#include <ql/functional.hpp>
 #include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/blackformula.hpp>
@@ -76,7 +75,6 @@ namespace QuantLib {
     }
 
     Volatility HestonBlackVolSurface::blackVolImpl(Time t, Real strike) const {
-        using namespace ext::placeholders;
         const ext::shared_ptr<HestonProcess> process = hestonModel_->process();
 
         const DiscountFactor df = process->riskFreeRate()->discount(t, true);
@@ -117,9 +115,8 @@ namespace QuantLib {
         const Volatility guess = std::sqrt(theta);
         const Real accuracy = std::numeric_limits<Real>::epsilon();
 
-        const ext::function<Real(Real)> f = ext::bind(
-            &blackValue, payoff.optionType(), strike, fwd, t, _1, df, npv);
-
-        return solver.solve(f, accuracy, guess, 0.01);
+        return solver.solve([&](Volatility _v) { return blackValue(payoff.optionType(), strike, fwd,
+                                                                   t, _v, df, npv); },
+                            accuracy, guess, 0.01);
     }
 }

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -36,8 +36,6 @@
 #include <ql/termstructures/volatility/equityfx/hestonblackvolsurface.hpp>
 #include <ql/pricingengines/basket/fd2dblackscholesvanillaengine.hpp>
 #include <ql/utilities/dataformatters.hpp>
-#include <ql/functional.hpp>
-#include <boost/preprocessor/iteration/local.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -1066,15 +1064,12 @@ test_suite* BasketOptionTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&BasketOptionTest::test2DPDEGreeks));
 
     if (speed <= Fast) {
-        #define N_TEST_CASES 5
-        #define BOOST_PP_LOCAL_MACRO(n)                                \
-            suite->add(QUANTLIB_TEST_CASE(                             \
-                ext::bind(&BasketOptionTest::testOneDAmericanValues, \
-                    (n    *LENGTH(oneDataValues))/N_TEST_CASES,        \
-                    ((n+1)*LENGTH(oneDataValues))/N_TEST_CASES)));
-
-        #define BOOST_PP_LOCAL_LIMITS (0, N_TEST_CASES-1)
-        #include BOOST_PP_LOCAL_ITERATE()
+        // unrolled to get different test names
+        suite->add(QUANTLIB_TEST_CASE([=](){ BasketOptionTest::testOneDAmericanValues( 0,  5); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ BasketOptionTest::testOneDAmericanValues( 5, 11); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ BasketOptionTest::testOneDAmericanValues(11, 17); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ BasketOptionTest::testOneDAmericanValues(17, 23); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ BasketOptionTest::testOneDAmericanValues(23, 29); }));
     }
 
     if (speed == Slow) {

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -34,8 +34,6 @@
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/currencies/europe.hpp>
-#include <ql/functional.hpp>
-#include <boost/preprocessor/iteration/local.hpp>
 #include <iomanip>
 #include <iostream>
 
@@ -369,13 +367,15 @@ void CdoTest::testHW(unsigned dataSet) {
 
 test_suite* CdoTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("CDO tests");
-#ifndef QL_PATCH_SOLARIS
-    if (speed == Slow) {
-        #define BOOST_PP_LOCAL_MACRO(n) \
-            suite->add(QUANTLIB_TEST_CASE(ext::bind(&CdoTest::testHW, n)));
 
-        #define BOOST_PP_LOCAL_LIMITS (0, 4)
-        #include BOOST_PP_LOCAL_ITERATE()
+    #ifndef QL_PATCH_SOLARIS
+    if (speed == Slow) {
+        // unrolled to get different test names
+        suite->add(QUANTLIB_TEST_CASE([=](){ CdoTest::testHW(0); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ CdoTest::testHW(1); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ CdoTest::testHW(2); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ CdoTest::testHW(3); }));
+        suite->add(QUANTLIB_TEST_CASE([=](){ CdoTest::testHW(4); }));
     }
     #endif
     return suite;

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -1284,19 +1284,17 @@ void FdmLinearOpTest::testBiCGstab() {
     BOOST_TEST_MESSAGE(
         "Testing bi-conjugated gradient stabilized algorithm...");
 
-    using namespace ext::placeholders;
-
     const Size n=41, m=21;
     const Real theta = 1.0;
     const boost::numeric::ublas::compressed_matrix<Real> a
         = createTestMatrix(n, m, theta);
 
-    const ext::function<Disposable<Array>(const Array&)> matmult(
-                                                ext::bind(&axpy, a, _1));
+    const ext::function<Disposable<Array>(const Array&)> matmult
+        = [&](const Array& _x) { return axpy(a, _x); };
 
     SparseILUPreconditioner ilu(a, 4);
-    ext::function<Disposable<Array>(const Array&)> precond(
-         ext::bind(&SparseILUPreconditioner::apply, &ilu, _1));
+    ext::function<Disposable<Array>(const Array&)> precond
+        = [&](const Array& _x) { return ilu.apply(_x); };
 
     Array b(n*m);
     MersenneTwisterUniformRng rng(1234);
@@ -1324,19 +1322,17 @@ void FdmLinearOpTest::testGMRES() {
 #if !defined(QL_NO_UBLAS_SUPPORT)
     BOOST_TEST_MESSAGE("Testing GMRES algorithm...");
 
-    using namespace ext::placeholders;
-
     const Size n=41, m=21;
     const Real theta = 1.0;
     const boost::numeric::ublas::compressed_matrix<Real> a
         = createTestMatrix(n, m, theta);
 
-    const ext::function<Disposable<Array>(const Array&)> matmult(
-                                                ext::bind(&axpy, a, _1));
+    const ext::function<Disposable<Array>(const Array&)> matmult
+        = [&](const Array& _x) { return axpy(a, _x); };
     
     SparseILUPreconditioner ilu(a, 4);
-    ext::function<Disposable<Array>(const Array&)> precond(
-         ext::bind(&SparseILUPreconditioner::apply, &ilu, _1));
+    ext::function<Disposable<Array>(const Array&)> precond
+        = [&](const Array& _x) { return ilu.apply(_x); };
     
     Array b(n*m);
     MersenneTwisterUniformRng rng(1234);

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -676,14 +676,10 @@ namespace {
         Time maturity, Real eps,
         const ext::shared_ptr<HestonModel>& model) {
 
-        using namespace ext::placeholders;
-
         const AnalyticPDFHestonEngine pdfEngine(model);
         const Real sInit = model->process()->s0()->value();
         const Real xMin = Brent().solve(
-            ext::bind(std::minus<Real>(),
-                ext::bind(&AnalyticPDFHestonEngine::cdf,
-                            &pdfEngine, _1, maturity), eps),
+                        [&](Real x){ return pdfEngine.cdf(x, maturity) - eps; },
                         sInit*1e-3, sInit, sInit*0.001, 1000*sInit);
 
         return xMin;

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -88,7 +88,6 @@
 #include <ql/experimental/processes/hestonslvprocess.hpp>
 #include <ql/experimental/barrieroption/doublebarrieroption.hpp>
 #include <ql/experimental/barrieroption/analyticdoublebarrierbinaryengine.hpp>
-#include <ql/functional.hpp>
 
 #include <boost/assign/std/vector.hpp>
 #include <boost/math/special_functions/gamma.hpp>

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -50,7 +50,6 @@
 #include <ql/pricingengines/vanilla/analytichestonhullwhiteengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.hpp>
-#include <ql/functional.hpp>
 #include <cmath>
 
 using namespace QuantLib;
@@ -628,8 +627,6 @@ void HybridHestonHullWhiteProcessTest::testAnalyticHestonHullWhitePricing() {
 void HybridHestonHullWhiteProcessTest::testCallableEquityPricing() {
     BOOST_TEST_MESSAGE("Testing the pricing of a callable equity product...");
 
-    using namespace ext::placeholders;
-
     SavedSettings backup;
 
     /*
@@ -671,8 +668,7 @@ void HybridHestonHullWhiteProcessTest::testCallableEquityPricing() {
 
     std::vector<Time> times(maturity+1);
     std::transform(schedule.begin(), schedule.end(), times.begin(),
-                   ext::bind(&Actual365Fixed::yearFraction,
-                               dc, today, _1, Date(), Date()));
+                   [&](const Date& d) { return dc.yearFraction(today, d); });
 
     for (Size i=0; i<=maturity; ++i)
         times[i] = static_cast<Time>(i);

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -110,8 +110,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/models/marketmodels/products/multistep/multisteppathwisewrapper.hpp>
 
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <boost/preprocessor/iteration/local.hpp>
-#include <ql/functional.hpp>
 #include <sstream>
 
 using namespace QuantLib;
@@ -4749,26 +4747,29 @@ test_suite* MarketModelTest::suite(SpeedLevel speed) {
 
         setup();
 
-        MarketModelType marketModels[] = {
-            ExponentialCorrelationFlatVolatility,
-            ExponentialCorrelationAbcdVolatility
-        };
-
-        Size testedFactors[] = { 4, 8, todaysForwards.size() };
-        #define BOOST_PP_LOCAL_MACRO(n)                                 \
-            suite->add(QUANTLIB_TEST_CASE(                              \
-                ext::bind(&MarketModelTest::testCallableSwapAnderson, \
-                    marketModels[n/LENGTH(testedFactors)],              \
-                    testedFactors[n%LENGTH(testedFactors)])));
-
-        #define BOOST_PP_LOCAL_LIMITS (0, 5)
-        #include BOOST_PP_LOCAL_ITERATE()
-#include <utility>
+        // unrolled to get different test names
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationFlatVolatility, 4);
+        }));
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationFlatVolatility, 8);
+        }));
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationFlatVolatility, todaysForwards.size());
+        }));
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationAbcdVolatility, 4);
+        }));
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationAbcdVolatility, 8);
+        }));
+        suite->add(QUANTLIB_TEST_CASE([=](){
+            MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationAbcdVolatility, todaysForwards.size());
+        }));
     }
 
     if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &MarketModelTest::testAllMultiStepProducts));
+        suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testAllMultiStepProducts));
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testCallableSwapNaif));
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testCallableSwapLS));
     }

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -284,7 +284,6 @@ namespace normal_clv_model_test {
 void NormalCLVModelTest::testMonteCarloBSOptionPricing() {
     BOOST_TEST_MESSAGE("Testing Monte Carlo BS option pricing...");
 
-    using namespace ext::placeholders;
     using namespace normal_clv_model_test;
 
     SavedSettings backup;
@@ -362,8 +361,8 @@ void NormalCLVModelTest::testMonteCarloBSOptionPricing() {
     }
 
     VanillaOption fdmOption(
-         ext::make_shared<CLVModelPayoff>(
-             payoff->optionType(), payoff->strike(), ext::bind(g, t, _1)),
+         ext::make_shared<CLVModelPayoff>(payoff->optionType(), payoff->strike(),
+                                          [&](Real _x) { return g(t, _x); }),
          exercise);
 
     fdmOption.setPricingEngine(

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -19,7 +19,6 @@
 
 #include "nthorderderivativeop.hpp"
 #include "utilities.hpp"
-#include <ql/functional.hpp>
 #include <ql/math/comparison.hpp>
 #include <ql/math/initializers.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
@@ -418,19 +417,13 @@ namespace {
 
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real dt) const override {
 
-            using namespace ext::placeholders;
             if (direction == direction_) {
                 BiCGStabResult result =
                     QuantLib::BiCGstab(
-                        ext::function<Disposable<Array>(const Array&)>(
-                            ext::bind(
-                                &FdmHeatEquationOp::solve_apply,
-                                this, _1, -dt)),
+                        [&](const Array& a){ return solve_apply(a, -dt); },
                         std::max(Size(10), r.size()), 1e-14,
-                        ext::function<Disposable<Array>(const Array&)>(
-                            ext::bind(&FdmLinearOpComposite::preconditioner,
-                                        this, _1, dt))
-                    ).solve(r, r);
+                        [&](const Array& a){ return preconditioner(a, dt); })
+                        .solve(r, r);
 
                 return result.x;
             }

--- a/test-suite/paralleltestrunner.hpp
+++ b/test-suite/paralleltestrunner.hpp
@@ -32,7 +32,6 @@
 
 #include <ql/types.hpp>
 #include <ql/errors.hpp>
-#include <ql/functional.hpp>
 
 #ifdef VERSION
 /* This comes from ./configure, and for some reason it interferes with
@@ -287,7 +286,7 @@ int main( int argc, char* argv[] )
             // fork worker processes
             boost::thread_group threadGroup;
             for (unsigned i=0; i < nProc; ++i) {
-                threadGroup.create_thread(QuantLib::ext::bind(worker, cmd.str()));
+                threadGroup.create_thread([&]() { worker(cmd.str()); });
             }
 
             struct mutex_remove {
@@ -416,8 +415,7 @@ int main( int argc, char* argv[] )
                 #if BOOST_VERSION < 106200
                     BOOST_TEST_FOREACH( test_observer*, to,
                         framework::impl::s_frk_state().m_observers )
-                        framework::impl::s_frk_state().m_aux_em.vexecute(
-                            ext::bind( &test_observer::test_start, to, 1 ) );
+                        framework::impl::s_frk_state().m_aux_em.vexecute([&](){ to->test_start(1); });
 
                     framework::impl::s_frk_state().execute_test_tree( id.id );
 

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -20,7 +20,6 @@
 
 #include "riskneutraldensitycalculator.hpp"
 #include "utilities.hpp"
-#include <ql/functional.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/functional.hpp>
@@ -493,8 +492,7 @@ void RiskNeutralDensityCalculatorTest::testSquareRootProcessRND() {
 
             const Real cdfCalculated = rndCalculator.cdf(v, t);
             const Real cdfExpected = GaussLobattoIntegral(10000, 0.01*tol)(
-                ext::bind(&SquareRootProcessRNDCalculator::pdf,
-                          &rndCalculator, ext::placeholders::_1, t), 0, v);
+                [&](Real _x) { return rndCalculator.pdf(_x, t); }, 0, v);
 
             if (std::fabs(cdfCalculated - cdfExpected) > tol) {
                 BOOST_FAIL("failed to calculate cdf"
@@ -741,8 +739,7 @@ void RiskNeutralDensityCalculatorTest::testMassAtZeroCEVProcessRND() {
         const Real ax = 15.0*std::sqrt(t)*alpha*std::pow(f0, beta);
 
         const Real calculated = GaussLobattoIntegral(1000, 1e-8)(
-            ext::bind(&CEVRNDCalculator::pdf, calculator, ext::placeholders::_1, t),
-                      std::max(QL_EPSILON, f0-ax), f0+ax) +
+            [&](Real _x) { return calculator->pdf(_x, t); }, std::max(QL_EPSILON, f0-ax), f0+ax) +
             calculator->massAtZero(t);
 
         if (std::fabs(calculated - 1.0) > tol) {

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -90,7 +90,6 @@ void SquareRootCLVModelTest::testSquareRootCLVVanillaPricing() {
     BOOST_TEST_MESSAGE(
         "Testing vanilla option pricing with square-root kernel process...");
 
-    using namespace ext::placeholders;
     using namespace square_root_clv_model;
 
     SavedSettings backup;
@@ -249,8 +248,7 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
                 std::sqrt(sabrVol->blackVariance(m, strike)),
                 rTS->discount(m)).value();
 
-            const CLVModelPayoff clvModelPayoff(
-                optionType, strike, ext::bind(g, t, ext::placeholders::_1));
+            const CLVModelPayoff clvModelPayoff(optionType, strike, [&](Real x) { return g(t, x); });
 
             const ext::function<Real(Real)> f = [&](Real xi) {
                 return clvModelPayoff(xi) * boost::math::pdf(dist, xi);

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -49,7 +49,6 @@
 #include <ql/experimental/finitedifferences/fdhestondoublebarrierengine.hpp>
 #include <ql/experimental/barrieroption/analyticdoublebarrierbinaryengine.hpp>
 #include <ql/experimental/volatility/sabrvoltermstructure.hpp>
-#include <ql/functional.hpp>
 
 #include <boost/assign/std/vector.hpp>
 


### PR DESCRIPTION
Readability improves.  Some `bind` remains, mostly because having to specify the parameter type would make C++11 lambdas more verbose.