### PR TITLE
Reduce run time for longest-running test cases.

### DIFF
--- a/.github/workflows/test-times.yml
+++ b/.github/workflows/test-times.yml
@@ -28,6 +28,11 @@ jobs:
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,faster.xml:HRF,message -- --faster
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,fast.xml:HRF,message -- --fast
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,all.xml:HRF,message
+    - name: Save test times
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-reports
+        path: ./all.xml
     - name: Check test times
       run: |
         python ./tools/check_test_times.py

--- a/.github/workflows/test-times.yml
+++ b/.github/workflows/test-times.yml
@@ -28,8 +28,6 @@ jobs:
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,faster.xml:HRF,message -- --faster
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,fast.xml:HRF,message -- --fast
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,all.xml:HRF,message
-    - name: Save test times
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-reports
-        path: ./*.xml
+    - name: Check test times
+      run: |
+        python ./tools/check_test_times.py

--- a/.github/workflows/test-times.yml
+++ b/.github/workflows/test-times.yml
@@ -1,0 +1,35 @@
+name: Check test times
+on: [push, pull_request]
+jobs:
+  check-test-times:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: linux-build-times-${{ github.ref }}-${{ github.head_ref }}-${{ hashFiles('**/*.hpp', '**/*.cpp') }}
+        restore-keys: |
+          linux-build-times-${{ github.ref }}-${{ github.head_ref }}-
+          linux-build-times-${{ github.ref }}-
+          linux-build-times-refs/heads/master-
+          linux-build-times-
+    - name: Setup
+      run: |
+        sudo apt install -y libboost-all-dev autoconf automake libtool ccache
+    - name: Build
+      run: |
+        ./autogen.sh
+        ./configure --disable-static CC="ccache gcc" CXX="ccache g++" CXXFLAGS="-O2 -g0"
+        make -j 2
+    - name: Run tests
+      run: |
+        ./test-suite/quantlib-test-suite --logger=JUNIT,warning,faster.xml:HRF,message -- --faster
+        ./test-suite/quantlib-test-suite --logger=JUNIT,warning,fast.xml:HRF,message -- --fast
+        ./test-suite/quantlib-test-suite --logger=JUNIT,warning,all.xml:HRF,message
+    - name: Save test times
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-reports
+        path: ./*.xml

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -604,21 +604,20 @@ void AmericanOptionTest::testFDShoutNPV() {
     }
 }
 
-test_suite* AmericanOptionTest::suite() {
+test_suite* AmericanOptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("American option tests");
-    suite->add(
-        QUANTLIB_TEST_CASE(&AmericanOptionTest::testBaroneAdesiWhaleyValues));
-    suite->add(
-        QUANTLIB_TEST_CASE(&AmericanOptionTest::testBjerksundStenslandValues));
-    // FLOATING_POINT_EXCEPTION
+
+    suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testBaroneAdesiWhaleyValues));
+    suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testBjerksundStenslandValues));
     suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testJuValues));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testFdValues));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testFdAmericanGreeks));
-    // FLOATING_POINT_EXCEPTION
-    suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testFdShoutGreeks));
     suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testFDShoutNPV));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&AmericanOptionTest::testFdShoutGreeks));
+    }
+
     return suite;
 }
 

--- a/test-suite/americanoption.hpp
+++ b/test-suite/americanoption.hpp
@@ -23,6 +23,7 @@
 #define quantlib_test_american_option_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -36,7 +37,7 @@ class AmericanOptionTest {
     static void testFdAmericanGreeks();
     static void testFdShoutGreeks();
     static void testFDShoutNPV();
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -514,15 +514,23 @@ void testDiscreteGeometricAveragePriceHeston(const ext::shared_ptr<PricingEngine
 
     // data from "A Recursive Method for Discretely Monitored Geometric Asian Option
     // Prices", Kim, Kim, Kim & Wee, Bull. Korean Math. Soc. 53, 733-749, 2016
-    int days[] =    {30, 91, 182, 365, 730, 1095, 30, 91, 182, 365, 730, 1095, 30,
-                      91, 182, 365, 730, 1095};
-    Real strikes[] = {90, 90, 90, 90, 90, 90, 100, 100, 100, 100, 100, 100, 110,
-                      110, 110, 110, 110, 110};
+    int days[] = {
+        30, 91, 182, 365, 730, 1095,
+        30, 91, 182, 365, 730, 1095,
+        30, 91, 182, 365, 730, 1095
+    };
+    Real strikes[] = {
+        90, 90, 90, 90, 90, 90,
+        100, 100, 100, 100, 100, 100,
+        110, 110, 110, 110, 110, 110
+    };
 
     // Prices from Tables 1, 2 and 3
-    Real prices[] =  {10.2732, 10.9554, 11.9916, 13.6950, 16.1773, 18.0146, 2.4389,
-                      3.7881, 5.2132, 7.2243, 9.9948, 12.0639, 0.1012, 0.5949, 1.4444,
-                      2.9479, 5.3531, 7.3315};
+    Real prices[] = {
+        10.2732, 10.9554, 11.9916, 13.6950, 16.1773, 18.0146,
+        2.4389, 3.7881, 5.2132, 7.2243, 9.9948, 12.0639,
+        0.1012, 0.5949, 1.4444, 2.9479, 5.3531, 7.3315
+    };
 
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
@@ -616,9 +624,11 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
 
     // 30-day options need wider tolerance due to uncertainty around what "weekly
     // fixing" dates mean over a 30-day month!
-    Real tol[] =     {4.0e-2, 2.0e-2, 2.0e-2, 3.0e-2, 3.0e-2, 2.0e-2, 1.0e-1, 1.0e-2,
-                      2.0e-2, 2.0e-2, 2.0e-2, 1.0e-2, 2.0e-2, 1.0e-2, 1.0e-2, 1.0e-2,
-                      1.0e-2, 1.0e-2};
+    Real tol[] = {
+        4.0e-2, 2.0e-2, 2.0e-2, 3.0e-2, 3.0e-2, 6.0e-2,
+        1.0e-1, 1.0e-2, 2.0e-2, 2.0e-2, 4.0e-2, 6.0e-2,
+        2.0e-2, 1.0e-2, 1.0e-2, 1.0e-2, 4.0e-2, 6.0e-2
+    };
 
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
@@ -641,7 +651,7 @@ void AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston() {
 
     ext::shared_ptr<PricingEngine> engine =
         MakeMCDiscreteGeometricAPHestonEngine<LowDiscrepancy>(hestonProcess)
-        .withSamples(65535)
+        .withSamples(32767)
         .withSeed(43);
 
     testDiscreteGeometricAveragePriceHeston(engine, tol);
@@ -965,7 +975,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
                 .withSeed(42)
-                .withSamples(32768);
+                .withSamples(8191);
 
         DiscreteAveragingAsianOption option(averageType, runningSum,
                                             pastFixings, fixingDates,
@@ -989,7 +999,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
                 .withSeed(42)
                 .withSteps(48)
-                .withSamples(8192)
+                .withSamples(8191)
                 .withControlVariate(true);
 
         option.setPricingEngine(engine2);
@@ -1039,14 +1049,14 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
     ext::shared_ptr<PricingEngine> engine3 =
         MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
             .withSeed(42)
-            .withSteps(360)
-            .withSamples(32768);
+            .withSteps(180)
+            .withSamples(32767);
 
     ext::shared_ptr<PricingEngine> engine4 =
         MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
             .withSeed(42)
-            .withSteps(360)
-            .withSamples(16384)
+            .withSteps(180)
+            .withSamples(16383)
             .withControlVariate(true);
 
     std::vector<Date> fixingDates(120);
@@ -1057,7 +1067,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
     ext::shared_ptr<Exercise> exercise(new
         EuropeanExercise(fixingDates[119]));
 
-    for (Size i=0; i<5; i++) {
+    for (Size i=0; i<LENGTH(prices); i++) {
         Real strike = strikes[i];
         Real expected = prices[i];
 
@@ -1070,7 +1080,7 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
 
         option.setPricingEngine(engine3);
         Real calculated = option.NPV();
-        Real tolerance = 5.0e-2;
+        Real tolerance = 6.0e-2;
 
         if (std::fabs(calculated-expected) > tolerance) {
             REPORT_FAILURE("value", averageType, runningSum, pastFixings,

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1984,46 +1984,41 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceHeston() {
 
 }
 
-test_suite* AsianOptionTest::suite() {
+test_suite* AsianOptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Asian option tests");
 
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticContinuousGeometricAveragePrice));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticDiscreteGeometricAveragePrice));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticDiscreteGeometricAverageStrike));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testMCDiscreteGeometricAveragePrice));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testMCDiscreteArithmeticAveragePrice));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testMCDiscreteArithmeticAverageStrike));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testPastFixings));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAllFixingsInThePast));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticContinuousGeometricAveragePrice));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticDiscreteGeometricAveragePrice));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticDiscreteGeometricAverageStrike));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testMCDiscreteGeometricAveragePrice));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testMCDiscreteArithmeticAverageStrike));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testPastFixings));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAllFixingsInThePast));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testMCDiscreteArithmeticAveragePrice));
+    }
+
+    if (speed == Slow) {
+        suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testMCDiscreteGeometricAveragePriceHeston));
+        suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston));
+    }
 
     return suite;
 }
 
-test_suite* AsianOptionTest::experimental() {
+test_suite* AsianOptionTest::experimental(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Asian option experimental tests");
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testLevyEngine));
     suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testVecerEngine));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticContinuousGeometricAveragePriceHeston));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AsianOptionTest::testDiscreteGeometricAveragePriceHestonPastFixings));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticContinuousGeometricAveragePriceHeston));
+    suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceHeston));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&AsianOptionTest::testDiscreteGeometricAveragePriceHestonPastFixings));
+    }
+
     return suite;
 }

--- a/test-suite/asianoptions.hpp
+++ b/test-suite/asianoptions.hpp
@@ -23,6 +23,7 @@
 #define quantlib_test_asian_options_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -46,8 +47,8 @@ class AsianOptionTest {
     static void testAllFixingsInThePast();
     static void testLevyEngine();
     static void testVecerEngine();
-    static boost::unit_test_framework::test_suite* suite();
-    static boost::unit_test_framework::test_suite* experimental();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
+    static boost::unit_test_framework::test_suite* experimental(SpeedLevel);
 };
 
 

--- a/test-suite/brownianbridge.cpp
+++ b/test-suite/brownianbridge.cpp
@@ -173,7 +173,7 @@ void BrownianBridgeTest::testPathGeneration() {
 
     Size N = times.size();
 
-    Size samples = 262143;
+    Size samples = 131071;
     unsigned long seed = 42;
     SobolRsg sobol(N, seed);
     InverseCumulativeRsg<SobolRsg,InverseCumulativeNormal> gsg(sobol);
@@ -218,7 +218,7 @@ void BrownianBridgeTest::testPathGeneration() {
     std::vector<Real> mean = stats2.mean();
     Matrix covariance = stats2.covariance();
 
-    Real meanTolerance = 1.5e-5;
+    Real meanTolerance = 3.0e-5;
     Real covTolerance = 3.0e-3;
 
     Real maxMeanError = maxRelDiff(mean.begin(), mean.end(),

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -760,19 +760,13 @@ test_suite* DistributionTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testBivariate));
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testPoisson));
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testCumulativePoisson));
-    suite->add(QUANTLIB_TEST_CASE(
-                            &DistributionTest::testInverseCumulativePoisson));
-    suite->add(QUANTLIB_TEST_CASE(
-                          &DistributionTest::testBivariateCumulativeStudent));
-    suite->add(QUANTLIB_TEST_CASE(
-                   &DistributionTest::testInvCDFviaStochasticCollocation));
+    suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testInverseCumulativePoisson));
+    suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testBivariateCumulativeStudent));
+    suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testInvCDFviaStochasticCollocation));
+    suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testSankaranApproximation));
 
-    suite->add(QUANTLIB_TEST_CASE(
-                   &DistributionTest::testSankaranApproximation));
-
-    if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &DistributionTest::testBivariateCumulativeStudentVsBivariate));
+    if (speed == Slow) {
+        suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testBivariateCumulativeStudentVsBivariate));
     }
 
     return suite;

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -595,7 +595,7 @@ void DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical() {
 
     ext::shared_ptr<PricingEngine> mcdoublebarrierengine;
     mcdoublebarrierengine = MakeMCDoubleBarrierEngine<PseudoRandom>(bsmProcess)
-        .withSteps(10000)
+        .withSteps(5000)
         .withAntitheticVariate()
         .withAbsoluteTolerance(0.5)
         .withSeed(1);
@@ -618,18 +618,20 @@ void DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical() {
     knockOutDoubleBarrierOption.setPricingEngine(analyticdoublebarrierengine);
     analytical = knockOutDoubleBarrierOption.NPV();
 
+    tolerance = 0.01;
+
     mcdoublebarrierengine = MakeMCDoubleBarrierEngine<PseudoRandom>(bsmProcess)
         .withSteps(10000)
         .withAntitheticVariate()
-        .withAbsoluteTolerance(0.005)
-        .withSeed(3);
+        .withAbsoluteTolerance(tolerance)
+        .withSeed(10);
     knockOutDoubleBarrierOption.setPricingEngine(mcdoublebarrierengine);
     monteCarlo = knockOutDoubleBarrierOption.NPV();
 
-    percentageDiff = std::abs(analytical - monteCarlo) / analytical;
+    Real diff = std::abs(analytical - monteCarlo);
 
-    if (percentageDiff > tolerance){
-        REPORT_FAILURE_DOUBLE_BARRIER_MC(analytical, monteCarlo, percentageDiff);
+    if (diff > tolerance){
+        REPORT_FAILURE_DOUBLE_BARRIER_MC(analytical, monteCarlo, diff);
     }
 
 }

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -638,18 +638,19 @@ test_suite* DoubleBarrierOptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("DoubleBarrier");
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &DoubleBarrierOptionTest::testEuropeanHaugValues));
+        suite->add(QUANTLIB_TEST_CASE(&DoubleBarrierOptionTest::testEuropeanHaugValues));
     }
 
     return suite;
 }
 
-test_suite* DoubleBarrierOptionTest::experimental() {
+test_suite* DoubleBarrierOptionTest::experimental(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("DoubleBarrier_experimental");
-    suite->add(QUANTLIB_TEST_CASE(
-                      &DoubleBarrierOptionTest::testVannaVolgaDoubleBarrierValues));
-    suite->add(QUANTLIB_TEST_CASE(
-                   &DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical));
+    suite->add(QUANTLIB_TEST_CASE(&DoubleBarrierOptionTest::testVannaVolgaDoubleBarrierValues));
+
+    if (speed == Slow) {
+        suite->add(QUANTLIB_TEST_CASE(&DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical));
+    }
+
     return suite;
 }

--- a/test-suite/doublebarrieroption.hpp
+++ b/test-suite/doublebarrieroption.hpp
@@ -32,7 +32,7 @@ class DoubleBarrierOptionTest {
     static void testVannaVolgaDoubleBarrierValues();
     static void testMonteCarloDoubleBarrierWithAnalytical();
     static boost::unit_test_framework::test_suite* suite(SpeedLevel);
-    static boost::unit_test_framework::test_suite* experimental();
+    static boost::unit_test_framework::test_suite* experimental(SpeedLevel);
 };
 
 

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -1715,40 +1715,31 @@ void FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher() 
     }
 }
 
-test_suite* FdmLinearOpTest::suite() {
+test_suite* FdmLinearOpTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("linear operator tests");
 
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmLinearOpLayout));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testUniformGridMesher));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFirstDerivativesMapApply));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSecondDerivativesMapApply));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testTripleBandMapSolve));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmLinearOpLayout));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testUniformGridMesher));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFirstDerivativesMapApply));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSecondDerivativesMapApply));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testTripleBandMapSolve));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmHestonBarrier));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmHestonAmerican));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmHestonExpress));
-    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmHestonHullWhiteOp));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testBiCGstab));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testGMRES));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testCrankNicolsonWithDamping));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSpareMatrixReference));
-    suite->add(
-        QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSparseMatrixZeroAssignment));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testCrankNicolsonWithDamping));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSpareMatrixReference));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testSparseMatrixZeroAssignment));
     suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmMesherIntegral));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdmLinearOpTest::testHighInterestRateBlackScholesMesher));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testHighInterestRateBlackScholesMesher));
+    suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&FdmLinearOpTest::testFdmHestonHullWhiteOp));
+    }
 
     return suite;
 }

--- a/test-suite/fdmlinearop.hpp
+++ b/test-suite/fdmlinearop.hpp
@@ -23,6 +23,7 @@
 #define quantlib_test_fdm_linear_op_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -49,7 +50,7 @@ public:
     static void testHighInterestRateBlackScholesMesher();
     static void testLowVolatilityHighDiscreteDividendBlackScholesMesher();
 
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 #endif

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -521,11 +521,14 @@ void FdSabrTest::testBenchOpSabrCase() {
 test_suite* FdSabrTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Finite Difference SABR tests");
 
-    suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrOp));
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrCevPricing));
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrVsVolApproximation));
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testOosterleeTestCaseIV));
     suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testBenchOpSabrCase));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&FdSabrTest::testFdmSabrOp));
+    }
 
     return suite;
 }

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -43,7 +43,7 @@ using namespace boost::unit_test_framework;
 #define REPORT_FAILURE(greekName, payoff, exercise, s, q, r, today, \
                        v, moneyness, reset, expected, calculated, \
                        error, tolerance) \
-    BOOST_FAIL("Forward " << exerciseTypeToString(exercise) << " " \
+    BOOST_ERROR("Forward " << exerciseTypeToString(exercise) << " " \
                << payoff->optionType() << " option with " \
                << payoffTypeToString(payoff) << " payoff:\n" \
                << "    spot value:        " << s << "\n" \
@@ -704,9 +704,9 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
 
    for (auto type : optionTypes) {
 
-       Real tolerance = 1e-4;
+       Real tolerance = 1e-3;
        Size timeSteps = 50;
-       Size numberOfSamples = 131072;
+       Size numberOfSamples = 16383;
        Size mcSeed = 42;
 
        Real q = 0.03;
@@ -754,11 +754,11 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
        ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticEngine(
            new AnalyticHestonForwardEuropeanEngine(hestonProcess));
 
-      Real moneyness[] = { 0.8, 0.9, 1.0, 1.1, 1.2 };
+      Real moneyness[] = { 0.8, 1.0, 1.2 };
 
-      for (double& moneynes : moneyness) {
+      for (double& m : moneyness) {
 
-          ForwardVanillaOption option(moneynes, reset, payoff, exercise);
+          ForwardVanillaOption option(m, reset, payoff, exercise);
 
           option.setPricingEngine(analyticEngine);
           Real analyticPrice = option.NPV();
@@ -769,7 +769,7 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
 
           if (error > tolerance) {
               REPORT_FAILURE("testHestonMCVsAnalyticPrices", payoff, exercise, s, q, r, today, vol,
-                             moneynes, reset, analyticPrice, mcPrice, error, tolerance);
+                             m, reset, analyticPrice, mcPrice, error, tolerance);
           }
 
           option.setPricingEngine(mcEngineCv);
@@ -778,7 +778,7 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
           Real errorCv = relativeError(analyticPrice, mcPriceCv, s);
           if (errorCv > tolerance) {
               REPORT_FAILURE("testHestonMCControlVariateVsAnalyticPrices", payoff, exercise, s, q,
-                             r, today, vol, moneynes, reset, analyticPrice, mcPrice, errorCv,
+                             r, today, vol, m, reset, analyticPrice, mcPrice, errorCv,
                              tolerance);
           }
       }

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -787,16 +787,23 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
 
 
 
-test_suite* ForwardOptionTest::suite() {
+test_suite* ForwardOptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Forward option tests");
+
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testGreeks));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testPerformanceValues));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testPerformanceGreeks));
     suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testGreeksInitialization));
-    suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testMCPrices));
-    suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testHestonMCPrices));
-    suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testHestonAnalyticalVsMCPrices));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testMCPrices));
+    }
+
+    if (speed == Slow) {
+        suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testHestonAnalyticalVsMCPrices));
+        suite->add(QUANTLIB_TEST_CASE(&ForwardOptionTest::testHestonMCPrices));
+    }
 
     return suite;
 }

--- a/test-suite/forwardoption.hpp
+++ b/test-suite/forwardoption.hpp
@@ -21,6 +21,7 @@
 #define quantlib_test_forward_option_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -35,7 +36,7 @@ class ForwardOptionTest {
     static void testMCPrices();
     static void testHestonMCPrices();
     static void testHestonAnalyticalVsMCPrices();
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3228,53 +3228,34 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDAXCalibration));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticVsBlack));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticVsCached));
-    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDifferentIntegrals));
-    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdVanillaVsCached));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testMultipleStrikesEngine));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testMcVsCached));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testAnalyticPiecewiseTimeDependent));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testDAXCalibrationOfTimeDependentModel));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testAlanLewisReferencePrices));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testExpansionOnAlanLewisReference));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testExpansionOnFordeReference));
-    suite->add(QUANTLIB_TEST_CASE(
-                    &HestonModelTest::testAllIntegrationMethods));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticPiecewiseTimeDependent));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDAXCalibrationOfTimeDependentModel));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAlanLewisReferencePrices));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testExpansionOnAlanLewisReference));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testExpansionOnFordeReference));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAllIntegrationMethods));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCosHestonCumulants));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCosHestonEngine));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCharacteristicFct));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testAndersenPiterbargPricing));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testAndersenPiterbargControlVariateIntegrand));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testAndersenPiterbargConvergence));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testPiecewiseTimeDependentComparison));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testPiecewiseTimeDependentChFAsymtotic));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testSmallSigmaExpansion));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testSmallSigmaExpansion4ExpFitting));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testExponentialFitting4StrikesAndMaturities));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAndersenPiterbargPricing));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAndersenPiterbargControlVariateIntegrand));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAndersenPiterbargConvergence));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentComparison));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentChFAsymtotic));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testSmallSigmaExpansion));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testSmallSigmaExpansion4ExpFitting));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testExponentialFitting4StrikesAndMaturities));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testHestonEngineIntegration));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testOptimalControlVariateChoice));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testAsymptoticControlVariate));
-
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testOptimalControlVariateChoice));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAsymptoticControlVariate));
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &HestonModelTest::testFdBarrierVsCached));
+        suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDifferentIntegrals));
+        suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdBarrierVsCached));
+        suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdVanillaVsCached));
     }
 
     if (speed == Slow) {
@@ -3286,7 +3267,6 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
 
 test_suite* HestonModelTest::experimental() {
     auto* suite = BOOST_TEST_SUITE("Heston model experimental tests");
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonModelTest::testAnalyticPDFHestonEngine));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticPDFHestonEngine));
     return suite;
 }

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -2580,47 +2580,32 @@ void HestonSLVModelTest::testDiffusionAndDriftSlvProcess() {
 test_suite* HestonSLVModelTest::experimental(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Heston Stochastic Local Volatility tests");
 
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation));
     suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testSquareRootZeroFlowBC));
     suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testTransformedZeroFlowBC));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testSquareRootEvolveWithStationaryDensity));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testSquareRootFokkerPlanckFwdEquation));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testBarrierPricingViaHestonLocalVol));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testMonteCarloVsFdmPricing));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testLocalVolsvSLVPropDensity));
-    suite->add(QUANTLIB_TEST_CASE(
-        &HestonSLVModelTest::testDiffusionAndDriftSlvProcess));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testSquareRootEvolveWithStationaryDensity));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testSquareRootFokkerPlanckFwdEquation));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBarrierPricingViaHestonLocalVol));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testLocalVolsvSLVPropDensity));
+    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testDiffusionAndDriftSlvProcess));
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &HestonSLVModelTest::testHestonFokkerPlanckFwdEquation));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMonteCarloVsFdmPricing));
     }
 
     if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &HestonSLVModelTest::testMonteCarloCalibration));
-        suite->add(QUANTLIB_TEST_CASE(
-            &HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol));
-        suite->add(QUANTLIB_TEST_CASE(
-            &HestonSLVModelTest::testMoustacheGraph));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testHestonFokkerPlanckFwdEquation));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMonteCarloCalibration));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMoustacheGraph));
     }
 
 //    these tests take very long
-//    suite->add(QUANTLIB_TEST_CASE(
-//        &HestonSLVModelTest::testForwardSkewSLV));
+//    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testForwardSkewSLV));
 //    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testFDMCalibration));
-//    suite->add(QUANTLIB_TEST_CASE(
-//        &HestonSLVModelTest::testBarrierPricingMixedModels));
+//    suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBarrierPricingMixedModels));
 
     return suite;
 }

--- a/test-suite/lookbackoptions.cpp
+++ b/test-suite/lookbackoptions.cpp
@@ -658,19 +658,18 @@ void LookbackOptionTest::testMonteCarloLookback() {
 }
 
 
-test_suite* LookbackOptionTest::suite() {
+test_suite* LookbackOptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Lookback option tests");
 
-    suite->add(QUANTLIB_TEST_CASE(
-                &LookbackOptionTest::testAnalyticContinuousFloatingLookback));
-    suite->add(QUANTLIB_TEST_CASE(
-                &LookbackOptionTest::testAnalyticContinuousFixedLookback));
-    suite->add(QUANTLIB_TEST_CASE(
-                &LookbackOptionTest::testAnalyticContinuousPartialFloatingLookback));
-    suite->add(QUANTLIB_TEST_CASE(
-                &LookbackOptionTest::testAnalyticContinuousPartialFixedLookback));
-    suite->add(QUANTLIB_TEST_CASE(
-                   &LookbackOptionTest::testMonteCarloLookback));
+    suite->add(QUANTLIB_TEST_CASE(&LookbackOptionTest::testAnalyticContinuousFloatingLookback));
+    suite->add(QUANTLIB_TEST_CASE(&LookbackOptionTest::testAnalyticContinuousFixedLookback));
+    suite->add(QUANTLIB_TEST_CASE(&LookbackOptionTest::testAnalyticContinuousPartialFloatingLookback));
+    suite->add(QUANTLIB_TEST_CASE(&LookbackOptionTest::testAnalyticContinuousPartialFixedLookback));
+
+    if (speed == Slow) {
+        suite->add(QUANTLIB_TEST_CASE(&LookbackOptionTest::testMonteCarloLookback));
+    }
+
     return suite;
 }
 

--- a/test-suite/lookbackoptions.hpp
+++ b/test-suite/lookbackoptions.hpp
@@ -21,6 +21,7 @@
 #define quantlib_test_lookback_options_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -32,7 +33,7 @@ class LookbackOptionTest {
     static void testAnalyticContinuousPartialFloatingLookback();
     static void testAnalyticContinuousPartialFixedLookback();
     static void testMonteCarloLookback();
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -4723,8 +4723,6 @@ test_suite* MarketModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testOneStepForwardsAndOptionlets));
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testOneStepNormalForwardsAndOptionlets));
 
-    suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testGreeks));
-
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testAbcdVolatilityIntegration));
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testAbcdVolatilityCompare));
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testAbcdVolatilityFit));
@@ -4738,8 +4736,11 @@ test_suite* MarketModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testCovariance));
 
     if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testGreeks));
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testPathwiseVegas));
+    }
 
+    if (speed == Slow) {
         using namespace market_model_test;
 
         setup();
@@ -4763,9 +4764,7 @@ test_suite* MarketModelTest::suite(SpeedLevel speed) {
         suite->add(QUANTLIB_TEST_CASE([=](){
             MarketModelTest::testCallableSwapAnderson(ExponentialCorrelationAbcdVolatility, todaysForwards.size());
         }));
-    }
 
-    if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testAllMultiStepProducts));
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testCallableSwapNaif));
         suite->add(QUANTLIB_TEST_CASE(&MarketModelTest::testCallableSwapLS));

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1683,21 +1683,16 @@ test_suite *MarkovFunctionalTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Markov functional model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testMfStateProcess));
-    suite->add(QUANTLIB_TEST_CASE(
-        &MarkovFunctionalTest::testKahaleSmileSection));
-    suite->add(QUANTLIB_TEST_CASE(
-        &MarkovFunctionalTest::testBermudanSwaption));
+    suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testKahaleSmileSection));
+    suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testBermudanSwaption));
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &MarkovFunctionalTest::testCalibrationOneInstrumentSet));
-        suite->add(QUANTLIB_TEST_CASE(
-            &MarkovFunctionalTest::testCalibrationTwoInstrumentSets));
+        suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testCalibrationTwoInstrumentSets));
     }
 
     if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &MarkovFunctionalTest::testVanillaEngines));
+        suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testCalibrationOneInstrumentSet));
+        suite->add(QUANTLIB_TEST_CASE(&MarkovFunctionalTest::testVanillaEngines));
     }
 
     return suite;

--- a/test-suite/mclongstaffschwartzengine.cpp
+++ b/test-suite/mclongstaffschwartzengine.cpp
@@ -313,13 +313,15 @@ void MCLongstaffSchwartzEngineTest::testAmericanMaxOption() {
     }
 }
 
-test_suite* MCLongstaffSchwartzEngineTest::suite() {
+test_suite* MCLongstaffSchwartzEngineTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Longstaff Schwartz MC engine tests");
-    // FLOATING_POINT_EXCEPTION
-    suite->add(QUANTLIB_TEST_CASE(
-         &MCLongstaffSchwartzEngineTest::testAmericanOption));
-    suite->add(QUANTLIB_TEST_CASE(
-         &MCLongstaffSchwartzEngineTest::testAmericanMaxOption));
+
+    suite->add(QUANTLIB_TEST_CASE(&MCLongstaffSchwartzEngineTest::testAmericanMaxOption));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&MCLongstaffSchwartzEngineTest::testAmericanOption));
+    }
+
     return suite;
 }
 

--- a/test-suite/mclongstaffschwartzengine.hpp
+++ b/test-suite/mclongstaffschwartzengine.hpp
@@ -21,6 +21,7 @@
 #define quantlib_test_mc_longstaff_schwartz_engine_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -29,7 +30,7 @@ class MCLongstaffSchwartzEngineTest {
   public:
     static void testAmericanOption();
     static void testAmericanMaxOption();
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -473,7 +473,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(StatisticsTest::suite());
     test->add(SwapTest::suite());
     test->add(SwapForwardMappingsTest::suite());
-    test->add(SwaptionTest::suite());
+    test->add(SwaptionTest::suite(speed));
     test->add(SwaptionVolatilityCubeTest::suite());
     test->add(SwaptionVolatilityMatrixTest::suite());
     test->add(TermStructureTest::suite());

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -371,10 +371,10 @@ test_suite* init_unit_test_suite(int, char* []) {
 
     test->add(QUANTLIB_TEST_CASE(startTimer));
 
-    test->add(AmericanOptionTest::suite());
+    test->add(AmericanOptionTest::suite(speed));
     test->add(AndreasenHugeVolatilityInterplTest::suite(speed));
     test->add(ArrayTest::suite());
-    test->add(AsianOptionTest::suite());
+    test->add(AsianOptionTest::suite(speed));
     test->add(AssetSwapTest::suite()); // fails with QL_USE_INDEXED_COUPON
     test->add(AutocovariancesTest::suite());
     test->add(BarrierOptionTest::suite());
@@ -408,12 +408,12 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(ExchangeRateTest::suite());
     test->add(FastFourierTransformTest::suite());
     test->add(FdHestonTest::suite(speed));
-    test->add(FdmLinearOpTest::suite());
+    test->add(FdmLinearOpTest::suite(speed));
     test->add(FdCevTest::suite(speed));
     test->add(FdCIRTest::suite(speed));
     test->add(FdSabrTest::suite(speed));
     test->add(FittedBondDiscountCurveTest::suite());
-    test->add(ForwardOptionTest::suite());
+    test->add(ForwardOptionTest::suite(speed));
     test->add(ForwardRateAgreementTest::suite());
     test->add(FunctionsTest::suite());
     test->add(GARCHTest::suite());
@@ -434,7 +434,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(JumpDiffusionTest::suite());
     test->add(LazyObjectTest::suite());
     test->add(LinearLeastSquaresRegressionTest::suite());
-    test->add(LookbackOptionTest::suite());
+    test->add(LookbackOptionTest::suite(speed));
     test->add(LowDiscrepancyTest::suite());
     test->add(MarketModelTest::suite(speed));
     test->add(MarketModelCmsTest::suite(speed));
@@ -444,7 +444,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(MarketModelSmmCapletHomoCalibrationTest::suite());
     test->add(MarkovFunctionalTest::suite(speed));
     test->add(MatricesTest::suite());
-    test->add(MCLongstaffSchwartzEngineTest::suite());
+    test->add(MCLongstaffSchwartzEngineTest::suite(speed));
     test->add(MersenneTwisterTest::suite());
     test->add(MoneyTest::suite());
     test->add(NumericalDifferentiationTest::suite());
@@ -488,10 +488,10 @@ test_suite* init_unit_test_suite(int, char* []) {
 
     // tests for experimental classes
     test->add(AmortizingBondTest::suite());
-    test->add(AsianOptionTest::experimental());
+    test->add(AsianOptionTest::experimental(speed));
     test->add(BasismodelsTest::suite());
     test->add(BarrierOptionTest::experimental());
-    test->add(DoubleBarrierOptionTest::experimental());
+    test->add(DoubleBarrierOptionTest::experimental(speed));
     test->add(BlackDeltaCalculatorTest::suite());
     test->add(CallableBondTest::suite());
     test->add(CatBondTest::suite());

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -1008,26 +1008,21 @@ void SwaptionTest::testSwaptionDeltaInBachelierModel() {
     checkSwaptionDelta<BachelierSwaptionEngine>(true);
 }
 
-test_suite* SwaptionTest::suite() {
+test_suite* SwaptionTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Swaption tests");
-    // FLOATING_POINT_EXCEPTION
+
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testCashSettledSwaptions));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testStrikeDependency));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testSpreadDependency));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testSpreadTreatment));
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testCachedValue));
-    // FLOATING_POINT_EXCEPTION
-    suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testImpliedVolatility));
-
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testVega));
-
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testSwaptionDeltaInBlackModel));
     suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testSwaptionDeltaInBachelierModel));   
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&SwaptionTest::testImpliedVolatility));
+    };
 
     return suite;
 }

--- a/test-suite/swaption.hpp
+++ b/test-suite/swaption.hpp
@@ -22,6 +22,7 @@
 #define quantlib_test_swaption_hpp
 
 #include <boost/test/unit_test.hpp>
+#include "speedlevel.hpp"
 
 /* remember to document new and/or updated tests in the Doxygen
    comment block of the corresponding class */
@@ -38,7 +39,7 @@ class SwaptionTest {
     static void testSwaptionDeltaInBlackModel();
     static void testSwaptionDeltaInBachelierModel();
 
-    static boost::unit_test_framework::test_suite* suite();
+    static boost::unit_test_framework::test_suite* suite(SpeedLevel);
 };
 
 

--- a/tools/check_test_times.py
+++ b/tools/check_test_times.py
@@ -49,7 +49,7 @@ def check(filename, max_time, action):
 
 errors = check("faster.xml", 3.0, "moved out of the 'Faster' section")
 errors |= check("fast.xml", 8.0, "moved out of the 'Fast' section")
-errors |= check("all.xml", 30.0, "made to run under 30 seconds")
+errors |= check("all.xml", 30.0, "kept under 30 seconds")
 
 if errors:
     sys.exit(1)

--- a/tools/check_test_times.py
+++ b/tools/check_test_times.py
@@ -1,0 +1,47 @@
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+regex1 = re.compile(".*test_case\(&(.*?)__(.*?)\)")
+regex2 = re.compile(".*ext__bind\(&(.*?)__(.*?)__.*\)\)")
+
+
+def parse_simple(t):
+    # test names get mangled - here we extract class and method name
+    m = regex1.match(t.attrib["name"])
+    if m:
+        return m.groups()
+
+
+def parse_bound(t):
+    # same, for the case of tests split in multiple runs
+    m = regex2.match(t.attrib["name"])
+    if m:
+        return m.groups()
+
+
+def extract_test_info(filename):
+    root = ET.parse(filename).getroot()
+    tests = root.findall("testcase")
+    for t in tests:
+        cls, method = parse_simple(t) or parse_bound(t) or (None, None)
+        if method:
+            time = float(t.attrib["time"])
+            yield (cls, method, time)
+
+
+def check(filename, max_time, action):
+    errors = False
+    for cls, method, time in extract_test_info(filename):
+        if time > max_time:
+            print(f"{cls}.{method} ({time:.2f} s) should be {action}")
+            errors = True
+    return errors
+
+
+errors = check("faster.xml", 4.0, "moved out of the 'Faster' section")
+errors |= check("fast.xml", 10.0, "moved out of the 'Fast' section")
+errors |= check("all.xml", 30.0, "made to run under 30 seconds")
+
+if errors:
+    sys.exit(1)


### PR DESCRIPTION
Part of #1015.

This also adds an automated check that monitors the execution times of test cases in the "Faster", "Fast" and "Slow" sections and advises if any should be moved.