### PR TITLE
C++11 modernization - replace Boost.Timer with std::chrono

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -130,34 +130,32 @@ AC_DEFUN([QL_CHECK_BOOST_UBLAS],
 # ------------------------
 # Check whether the Boost unit-test framework is available
 AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
-[AC_MSG_CHECKING([for Boost.Test, Boost.Timer, Boost.Chrono and Boost.System])
+[AC_MSG_CHECKING([for Boost.Test])
  AC_REQUIRE([AC_PROG_CC])
  ql_original_LIBS=$LIBS
  ql_original_CXXFLAGS=$CXXFLAGS
  CC_BASENAME=`basename $CC`
  CC_VERSION=`echo "__GNUC__ __GNUC_MINOR__" | $CC -E -x c - | tail -n 1 | $SED -e "s/ //"`
- for suffix in "-$CC_BASENAME$CC_VERSION" \
+ for suffix in "" \
+               "-$CC_BASENAME$CC_VERSION" \
                "-$CC_BASENAME" \
-               "" \
                "-mt-$CC_BASENAME$CC_VERSION" \
                "-$CC_BASENAME$CC_VERSION-mt" \
                "-x$CC_BASENAME$CC_VERSION-mt" \
                "-mt-$CC_BASENAME" \
                "-$CC_BASENAME-mt" \
                "-mt" ; do
-     boost_libs="-lboost_unit_test_framework$suffix -lboost_timer$suffix -lboost_system$suffix"
+     boost_libs="-lboost_unit_test_framework$suffix"
      LIBS="$ql_original_LIBS $boost_libs"
      # static version
      CXXFLAGS="$ql_original_CXXFLAGS"
      boost_unit_found=no
      AC_LINK_IFELSE([AC_LANG_SOURCE(
          [@%:@include <boost/test/unit_test.hpp>
-          @%:@include <boost/timer/timer.hpp>
           using namespace boost::unit_test_framework;
           test_suite*
           init_unit_test_suite(int argc, char** argv)
           {
-              boost::timer::auto_cpu_timer t;
               return (test_suite*) 0;
           }
          ])],
@@ -170,51 +168,10 @@ AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
      boost_unit_found=no
      AC_LINK_IFELSE([AC_LANG_SOURCE(
          [@%:@include <boost/test/unit_test.hpp>
-          @%:@include <boost/timer/timer.hpp>
           using namespace boost::unit_test_framework;
           test_suite*
           init_unit_test_suite(int argc, char** argv)
           {
-              boost::timer::auto_cpu_timer t;
-              return (test_suite*) 0;
-          }
-         ])],
-         [boost_unit_found=$boost_libs
-          boost_defines="-DBOOST_TEST_DYN_LINK"
-          break],
-         [])
-     # Boost.Timer might require Boost.Chrono
-     boost_libs="-lboost_unit_test_framework$suffix -lboost_timer$suffix -lboost_chrono$suffix -lboost_system$suffix"
-     LIBS="$ql_original_LIBS $boost_libs"
-     # static version
-     CXXFLAGS="$ql_original_CXXFLAGS"
-     boost_unit_found=no
-     AC_LINK_IFELSE([AC_LANG_SOURCE(
-         [@%:@include <boost/test/unit_test.hpp>
-          @%:@include <boost/timer/timer.hpp>
-          using namespace boost::unit_test_framework;
-          test_suite*
-          init_unit_test_suite(int argc, char** argv)
-          {
-              boost::timer::auto_cpu_timer t;
-              return (test_suite*) 0;
-          }
-         ])],
-         [boost_unit_found=$boost_libs
-          boost_defines=""
-          break],
-         [])
-     # shared version
-     CXXFLAGS="$ql_original_CXXFLAGS -DBOOST_TEST_MAIN -DBOOST_TEST_DYN_LINK"
-     boost_unit_found=no
-     AC_LINK_IFELSE([AC_LANG_SOURCE(
-         [@%:@include <boost/test/unit_test.hpp>
-          @%:@include <boost/timer/timer.hpp>
-          using namespace boost::unit_test_framework;
-          test_suite*
-          init_unit_test_suite(int argc, char** argv)
-          {
-              boost::timer::auto_cpu_timer t;
               return (test_suite*) 0;
           }
          ])],
@@ -248,9 +205,9 @@ AC_DEFUN([QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM],
  ql_original_CXXFLAGS=$CXXFLAGS
  CC_BASENAME=`basename $CC`
  CC_VERSION=`echo "__GNUC__ __GNUC_MINOR__" | $CC -E -x c - | tail -n 1 | $SED -e "s/ //"`
- for suffix in "-$CC_BASENAME$CC_VERSION" \
+ for suffix in "" \
+               "-$CC_BASENAME$CC_VERSION" \
                "-$CC_BASENAME" \
-               "" \
                "-mt-$CC_BASENAME$CC_VERSION" \
                "-$CC_BASENAME$CC_VERSION-mt" \
                "-x$CC_BASENAME$CC_VERSION-mt" \

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -359,7 +359,7 @@ if (USE_BOOST_DYNAMIC_LIBRARIES)
     add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()
 
-find_package (Boost REQUIRED COMPONENTS unit_test_framework timer system OPTIONAL_COMPONENTS chrono)
+find_package (Boost REQUIRED COMPONENTS unit_test_framework)
 
 set (TEST quantlib-test-suite)
 add_executable (${TEST} ${QuantLib-Test_SRC} ${QuantLib-Test_HDR})

--- a/test-suite/paralleltestrunner.hpp
+++ b/test-suite/paralleltestrunner.hpp
@@ -43,16 +43,9 @@
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/interprocess/sync/scoped_lock.hpp>
 #include <boost/interprocess/sync/named_mutex.hpp>
-#include <boost/timer/timer.hpp>
 
 #define BOOST_TEST_NO_MAIN 1
-#if BOOST_VERSION < 107000
-#define timer __TIMER__
 #include <boost/test/included/unit_test.hpp>
-#undef timer
-#else
-#include <boost/test/included/unit_test.hpp>
-#endif
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -61,18 +54,12 @@
 #include <sstream>
 #include <utility>
 #include <fstream>
-
+#include <chrono>
 #include <string>
 #include <cstring>
 #include <cstdlib>
 
 #ifdef BOOST_MSVC
-#  define BOOST_LIB_NAME boost_timer
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
-#  define BOOST_LIB_NAME boost_chrono
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
 #  define BOOST_LIB_NAME boost_system
 #  include <boost/config/auto_link.hpp>
 #  undef BOOST_LIB_NAME
@@ -410,7 +397,7 @@ int main( int argc, char* argv[] )
             message_queue rq(open_only, testResultQueueName);
 
             while (!id.terminate) {
-                boost::timer::cpu_timer t;
+                auto startTime = std::chrono::steady_clock::now();
 
                 #if BOOST_VERSION < 106200
                     BOOST_TEST_FOREACH( test_observer*, to,
@@ -427,8 +414,10 @@ int main( int argc, char* argv[] )
                     framework::run(id.id, false);
                 #endif
 
+                auto stopTime = std::chrono::steady_clock::now();
+                double T = std::chrono::duration_cast<std::chrono::microseconds>(stopTime - startTime).count() * 1e-6;
                 runTimeLogs.push_back(std::make_pair(
-                    framework::get(id.id, TUT_ANY).p_name, t.elapsed().wall));
+                    framework::get(id.id, TUT_ANY).p_name, T));
 
                 output_logstream(log_stream(), oldBuf, logBuf);
 

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -211,7 +211,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
 
-    std::chrono::time_point<std::chrono::steady_clock> start;
+    decltype(std::chrono::steady_clock::now()) start;
 
     void startTimer() {
         start = std::chrono::steady_clock::now();

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -29,8 +29,6 @@
 #include <boost/test/unit_test.hpp>
 #endif
 
-#include <boost/timer/timer.hpp>
-
 /* Use BOOST_MSVC instead of _MSC_VER since some other vendors (Metrowerks,
    for example) also #define _MSC_VER
 */
@@ -41,24 +39,10 @@
 #  define BOOST_LIB_NAME boost_unit_test_framework
 #  include <boost/config/auto_link.hpp>
 #  undef BOOST_LIB_NAME
-#  define BOOST_LIB_NAME boost_timer
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
-#  define BOOST_LIB_NAME boost_chrono
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
-#  define BOOST_LIB_NAME boost_system
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
 #endif
 
-/* uncomment the following lines to unmask floating-point exceptions.
-   See http://www.wilmott.com/messageview.cfm?catid=10&threadid=9481
-*/
-//#  include <float.h>
-//   namespace { unsigned int u = _controlfp(_EM_INEXACT, _MCW_EM); }
-
 #endif
+
 #include "utilities.hpp"
 #include "speedlevel.hpp"
 
@@ -221,22 +205,28 @@
 
 #include <iostream>
 #include <iomanip>
+#include <chrono>
 
 using namespace boost::unit_test_framework;
 
 namespace {
 
-    boost::timer::cpu_timer t;
+    std::chrono::time_point<std::chrono::steady_clock> start;
 
-    void startTimer() { t.start(); }
+    void startTimer() {
+        start = std::chrono::steady_clock::now();
+    }
+
     void stopTimer() {
-        t.stop();
-        std::cout << "\nTests completed in ";
-        double seconds = t.elapsed().wall * 1e-9;
+        auto stop = std::chrono::steady_clock::now();
+
+        double seconds = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() * 1e-3;
         int hours = int(seconds/3600);
         seconds -= hours * 3600;
         int minutes = int(seconds/60);
         seconds -= minutes * 60;
+
+        std::cout << "\nTests completed in ";
         if (hours > 0)
             std::cout << hours << " h ";
         if (hours > 0 || minutes > 0)


### PR DESCRIPTION
This removes a library dependency on Boost.Timer, Boost.System and Boost.Chrono