### PR TITLE
Suppress C++ code analysis warning C26812 in VS 2019 - Prefer enum class

### DIFF
--- a/ql/config.msvc.hpp
+++ b/ql/config.msvc.hpp
@@ -64,6 +64,12 @@
 #pragma warning(disable : 4267)
 #endif
 
+
+/* suppress C++ code analysis warning C26812 in VS 2019:
+ * Prefer 'enum class' over 'enum' (Enum.3). */
+#pragma warning(disable : 26812)
+
+
 #ifndef _CPPRTTI
 #   error Enable Run-Time Type Info (Property Pages | C/C++ | Language)
 #endif

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -215,12 +215,6 @@
 #endif
 // clang-format on
 
-/* suppress C++ code analysis warning C26812 in VS 2019:
- * Prefer 'enum class' over 'enum' (Enum.3). */
-#if defined(BOOST_MSVC)
-    __pragma(warning(push))            \
-    __pragma(warning(disable : 26812))
-#endif
 
 // until we stop supporting Visual C++ 2013
 #if defined(QL_PATCH_MSVC_2013)

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -215,6 +215,12 @@
 #endif
 // clang-format on
 
+/* suppress C++ code analysis warning C26812 in VS 2019:
+ * Prefer 'enum class' over 'enum' (Enum.3). */
+#if defined(BOOST_MSVC)
+    __pragma(warning(push))            \
+    __pragma(warning(disable : 26812))
+#endif
 
 // until we stop supporting Visual C++ 2013
 #if defined(QL_PATCH_MSVC_2013)


### PR DESCRIPTION
VS 2019 produces a lot of warnings about unscoped enums.

![image](https://user-images.githubusercontent.com/42419984/110360029-80132c80-803e-11eb-8880-e16b1d69e674.png)

As they will remain unscoped this avoids the warning.