### PR TITLE
Sub-period coupons revision

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -526,6 +526,7 @@
     <ClInclude Include="ql\cashflows\lineartsrpricer.hpp" />
     <ClInclude Include="ql\cashflows\overnightindexedcoupon.hpp" />
     <ClInclude Include="ql\cashflows\rangeaccrual.hpp" />
+    <ClInclude Include="ql\cashflows\rateaveraging.hpp" />
     <ClInclude Include="ql\cashflows\replication.hpp" />
     <ClInclude Include="ql\cashflows\simplecashflow.hpp" />
     <ClInclude Include="ql\cashflows\timebasket.hpp" />

--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -529,6 +529,7 @@
     <ClInclude Include="ql\cashflows\rateaveraging.hpp" />
     <ClInclude Include="ql\cashflows\replication.hpp" />
     <ClInclude Include="ql\cashflows\simplecashflow.hpp" />
+    <ClInclude Include="ql\cashflows\subperiodcoupon.hpp" />
     <ClInclude Include="ql\cashflows\timebasket.hpp" />
     <ClInclude Include="ql\cashflows\yoyinflationcoupon.hpp" />
     <ClInclude Include="ql\currencies\africa.hpp" />
@@ -617,7 +618,6 @@
     <ClInclude Include="ql\experimental\coupons\proxyibor.hpp" />
     <ClInclude Include="ql\experimental\coupons\quantocouponpricer.hpp" />
     <ClInclude Include="ql\experimental\coupons\strippedcapflooredcoupon.hpp" />
-    <ClInclude Include="ql\experimental\coupons\subperiodcoupons.hpp" />
     <ClInclude Include="ql\experimental\coupons\swapspreadindex.hpp" />
     <ClInclude Include="ql\experimental\credit\all.hpp" />
     <ClInclude Include="ql\experimental\credit\basecorrelationlossmodel.hpp" />
@@ -1900,6 +1900,7 @@
     <ClCompile Include="ql\cashflows\rangeaccrual.cpp" />
     <ClCompile Include="ql\cashflows\replication.cpp" />
     <ClCompile Include="ql\cashflows\simplecashflow.cpp" />
+    <ClCompile Include="ql\cashflows\subperiodcoupon.cpp" />
     <ClCompile Include="ql\cashflows\timebasket.cpp" />
     <ClCompile Include="ql\cashflows\yoyinflationcoupon.cpp" />
     <ClCompile Include="ql\currencies\africa.cpp" />
@@ -1968,7 +1969,6 @@
     <ClCompile Include="ql\experimental\coupons\proxyibor.cpp" />
     <ClCompile Include="ql\experimental\coupons\quantocouponpricer.cpp" />
     <ClCompile Include="ql\experimental\coupons\strippedcapflooredcoupon.cpp" />
-    <ClCompile Include="ql\experimental\coupons\subperiodcoupons.cpp" />
     <ClCompile Include="ql\experimental\coupons\swapspreadindex.cpp" />
     <ClCompile Include="ql\experimental\credit\basecorrelationstructure.cpp" />
     <ClCompile Include="ql\experimental\credit\basket.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -579,6 +579,9 @@
     <ClInclude Include="ql\cashflows\simplecashflow.hpp">
       <Filter>cashflows</Filter>
     </ClInclude>
+    <ClInclude Include="ql\cashflows\subperiodcoupon.hpp">
+      <Filter>cashflows</Filter>
+    </ClInclude>
     <ClInclude Include="ql\cashflows\timebasket.hpp">
       <Filter>cashflows</Filter>
     </ClInclude>
@@ -3048,9 +3051,6 @@
     <ClInclude Include="ql\experimental\coupons\strippedcapflooredcoupon.hpp">
       <Filter>experimental\coupons</Filter>
     </ClInclude>
-    <ClInclude Include="ql\experimental\coupons\subperiodcoupons.hpp">
-      <Filter>experimental\coupons</Filter>
-    </ClInclude>
     <ClInclude Include="ql\experimental\coupons\swapspreadindex.hpp">
       <Filter>experimental\coupons</Filter>
     </ClInclude>
@@ -4475,6 +4475,9 @@
       <Filter>cashflows</Filter>
     </ClCompile>
     <ClCompile Include="ql\cashflows\simplecashflow.cpp">
+      <Filter>cashflows</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\cashflows\subperiodcoupon.cpp">
       <Filter>cashflows</Filter>
     </ClCompile>
     <ClCompile Include="ql\cashflows\timebasket.cpp">
@@ -6107,9 +6110,6 @@
       <Filter>experimental\coupons</Filter>
     </ClCompile>
     <ClCompile Include="ql\experimental\coupons\strippedcapflooredcoupon.cpp">
-      <Filter>experimental\coupons</Filter>
-    </ClCompile>
-    <ClCompile Include="ql\experimental\coupons\subperiodcoupons.cpp">
       <Filter>experimental\coupons</Filter>
     </ClCompile>
     <ClCompile Include="ql\experimental\coupons\swapspreadindex.cpp">

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -570,6 +570,9 @@
     <ClInclude Include="ql\cashflows\rangeaccrual.hpp">
       <Filter>cashflows</Filter>
     </ClInclude>
+    <ClInclude Include="ql\cashflows\rateaveraging.hpp">
+      <Filter>cashflows</Filter>
+    </ClInclude>
     <ClInclude Include="ql\cashflows\replication.hpp">
       <Filter>cashflows</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -30,6 +30,7 @@ set(QuantLib_SRC
     cashflows/replication.cpp
     cashflows/simplecashflow.cpp
     cashflows/timebasket.cpp
+    cashflows/subperiodcoupon.cpp
     cashflows/yoyinflationcoupon.cpp
     currencies/africa.cpp
     currencies/america.cpp
@@ -103,7 +104,6 @@ set(QuantLib_SRC
     experimental/coupons/proxyibor.cpp
     experimental/coupons/quantocouponpricer.cpp
     experimental/coupons/strippedcapflooredcoupon.cpp
-    experimental/coupons/subperiodcoupons.cpp
     experimental/coupons/swapspreadindex.cpp
     experimental/credit/basecorrelationstructure.cpp
     experimental/credit/basket.cpp
@@ -952,6 +952,7 @@ set(QuantLib_HDR
     cashflows/rateaveraging.hpp
     cashflows/replication.hpp
     cashflows/simplecashflow.hpp
+    cashflows/subperiodcoupon.hpp
     cashflows/timebasket.hpp
     cashflows/yoyinflationcoupon.hpp
     compounding.hpp
@@ -1052,7 +1053,6 @@ set(QuantLib_HDR
     experimental/coupons/proxyibor.hpp
     experimental/coupons/quantocouponpricer.hpp
     experimental/coupons/strippedcapflooredcoupon.hpp
-    experimental/coupons/subperiodcoupons.hpp
     experimental/coupons/swapspreadindex.hpp
     experimental/credit/all.hpp
     experimental/credit/basecorrelationlossmodel.hpp

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -949,6 +949,7 @@ set(QuantLib_HDR
     cashflows/lineartsrpricer.hpp
     cashflows/overnightindexedcoupon.hpp
     cashflows/rangeaccrual.hpp
+    cashflows/rateaveraging.hpp
     cashflows/replication.hpp
     cashflows/simplecashflow.hpp
     cashflows/timebasket.hpp

--- a/ql/cashflows/Makefile.am
+++ b/ql/cashflows/Makefile.am
@@ -29,6 +29,7 @@ this_include_HEADERS = \
     lineartsrpricer.hpp \
     overnightindexedcoupon.hpp \
     rangeaccrual.hpp \
+    rateaveraging.hpp \
     replication.hpp \
     simplecashflow.hpp \
     timebasket.hpp \

--- a/ql/cashflows/Makefile.am
+++ b/ql/cashflows/Makefile.am
@@ -32,6 +32,7 @@ this_include_HEADERS = \
     rateaveraging.hpp \
     replication.hpp \
     simplecashflow.hpp \
+    subperiodcoupon.hpp \
     timebasket.hpp \
     yoyinflationcoupon.hpp
 
@@ -63,6 +64,7 @@ cpp_files = \
     rangeaccrual.cpp \
     replication.cpp \
     simplecashflow.cpp \
+    subperiodcoupon.cpp \
     timebasket.cpp \
     yoyinflationcoupon.cpp
 

--- a/ql/cashflows/all.hpp
+++ b/ql/cashflows/all.hpp
@@ -29,6 +29,7 @@
 #include <ql/cashflows/rateaveraging.hpp>
 #include <ql/cashflows/replication.hpp>
 #include <ql/cashflows/simplecashflow.hpp>
+#include <ql/cashflows/subperiodcoupon.hpp>
 #include <ql/cashflows/timebasket.hpp>
 #include <ql/cashflows/yoyinflationcoupon.hpp>
 

--- a/ql/cashflows/all.hpp
+++ b/ql/cashflows/all.hpp
@@ -26,6 +26,7 @@
 #include <ql/cashflows/lineartsrpricer.hpp>
 #include <ql/cashflows/overnightindexedcoupon.hpp>
 #include <ql/cashflows/rangeaccrual.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/cashflows/replication.hpp>
 #include <ql/cashflows/simplecashflow.hpp>
 #include <ql/cashflows/timebasket.hpp>

--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -26,9 +26,9 @@
 #include <ql/cashflows/digitalcoupon.hpp>
 #include <ql/cashflows/digitaliborcoupon.hpp>
 #include <ql/cashflows/rangeaccrual.hpp>
+#include <ql/cashflows/subperiodcoupon.hpp>
 #include <ql/experimental/coupons/cmsspreadcoupon.hpp>        /* internal */
 #include <ql/experimental/coupons/digitalcmsspreadcoupon.hpp> /* internal */
-#include <ql/experimental/coupons/subperiodcoupons.hpp>       /* internal */
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <utility>

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -126,7 +126,7 @@ namespace QuantLib {
                     const Date& refPeriodEnd,
                     const DayCounter& dayCounter,
                     bool telescopicValueDates, 
-                    OvernightAveraging::Type averagingMethod)
+                    RateAveraging::Type averagingMethod)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          overnightIndex->fixingDays(), overnightIndex,
                          gearing, spread,
@@ -196,11 +196,11 @@ namespace QuantLib {
             dt_[i] = dc.yearFraction(valueDates_[i], valueDates_[i+1]);
 
         switch (averagingMethod) {
-            case OvernightAveraging::Simple:
+            case RateAveraging::Simple:
                 setPricer(ext::shared_ptr<FloatingRateCouponPricer>(
                     new ArithmeticAveragedOvernightIndexedCouponPricer(telescopicValueDates)));
                 break;
-            case OvernightAveraging::Compound:
+            case RateAveraging::Compound:
                 setPricer(
                     ext::shared_ptr<FloatingRateCouponPricer>(new OvernightIndexedCouponPricer));
                 break;
@@ -228,7 +228,7 @@ namespace QuantLib {
     OvernightLeg::OvernightLeg(const Schedule& schedule, ext::shared_ptr<OvernightIndex> i)
     : schedule_(schedule), overnightIndex_(std::move(i)), paymentCalendar_(schedule.calendar()),
       paymentAdjustment_(Following), paymentLag_(0), telescopicValueDates_(false),
-      averagingMethod_(OvernightAveraging::Compound) {}
+      averagingMethod_(RateAveraging::Compound) {}
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);
@@ -286,7 +286,7 @@ namespace QuantLib {
         return *this;
     }
 
-    OvernightLeg& OvernightLeg::withAveragingMethod(OvernightAveraging::Type averagingMethod) {
+    OvernightLeg& OvernightLeg::withAveragingMethod(RateAveraging::Type averagingMethod) {
         averagingMethod_ = averagingMethod;
         return *this;
     }

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -29,27 +29,11 @@
 #define quantlib_overnight_indexed_coupon_hpp
 
 #include <ql/cashflows/floatingratecoupon.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/schedule.hpp>
 
 namespace QuantLib {
-
-    //! overnight coupon averaging method
-    /*! It allows to configure how interest is accrued in the overnight coupon.
-    */
-    struct OvernightAveraging {
-        enum Type {
-            Simple,  /*!< Under the simple convention the amount of
-                      interest is calculated by applying the daily
-                      rate to the principal, and the payment due
-                      at the end of the period is the sum of those
-                      amounts. */
-            Compound /*!< Under the compound convention, the additional
-                      amount of interest owed each day is calculated
-                      by applying the rate both to the principal
-                      and the accumulated unpaid interest. */
-        };
-    };
 
     //! overnight coupon
     /*! %Coupon paying the interest, depending on the averaging convention,
@@ -76,7 +60,7 @@ namespace QuantLib {
                     const Date& refPeriodEnd = Date(),
                     const DayCounter& dayCounter = DayCounter(),
                     bool telescopicValueDates = false,
-                    OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                    RateAveraging::Type averagingMethod = RateAveraging::Compound);
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded
@@ -120,7 +104,7 @@ namespace QuantLib {
         OvernightLeg& withSpreads(Spread spread);
         OvernightLeg& withSpreads(const std::vector<Spread>& spreads);
         OvernightLeg& withTelescopicValueDates(bool telescopicValueDates);
-        OvernightLeg& withAveragingMethod(OvernightAveraging::Type averagingMethod);
+        OvernightLeg& withAveragingMethod(RateAveraging::Type averagingMethod);
         operator Leg() const;
       private:
         Schedule schedule_;
@@ -133,7 +117,7 @@ namespace QuantLib {
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
         bool telescopicValueDates_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
     };
 
 }

--- a/ql/cashflows/rateaveraging.hpp
+++ b/ql/cashflows/rateaveraging.hpp
@@ -1,0 +1,52 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file rateaveraging.hpp
+    \brief rate-averaging method
+*/
+
+#ifndef quantlib_rate_averaging_hpp
+#define quantlib_rate_averaging_hpp
+
+#include <ql/qldefines.hpp>
+
+namespace QuantLib {
+
+    //! rate averaging method
+    /*! It allows to configure how interest is accrued in multi-fixing
+        coupons or futures.
+    */
+    struct RateAveraging {
+        enum Type {
+            Simple,  /*!< Under the simple convention the amount of
+                          interest is calculated by applying the
+                          sub-rate to the principal, and the payment
+                          due at the end of the period is the sum of
+                          those amounts. */
+            Compound /*!< Under the compound convention, the
+                          additional amount of interest owed each
+                          period is calculated by applying the rate
+                          both to the principal and the accumulated
+                          unpaid interest. */
+        };
+    };
+
+}
+
+#endif

--- a/ql/cashflows/subperiodcoupon.cpp
+++ b/ql/cashflows/subperiodcoupon.cpp
@@ -18,7 +18,7 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/experimental/coupons/subperiodcoupons.hpp>
+#include <ql/cashflows/subperiodcoupon.hpp>
 #include <ql/cashflows/cashflowvectors.hpp>
 #include <ql/time/schedule.hpp>
 #include <ql/indexes/iborindex.hpp>

--- a/ql/cashflows/subperiodcoupon.hpp
+++ b/ql/cashflows/subperiodcoupon.hpp
@@ -18,12 +18,12 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-/*! \file subperiodcoupons.hpp
+/*! \file subperiodcoupon.hpp
     \brief averaging coupons
 */
 
-#ifndef quantlib_sub_period_coupons_hpp
-#define quantlib_sub_period_coupons_hpp
+#ifndef quantlib_sub_period_coupon_hpp
+#define quantlib_sub_period_coupon_hpp
 
 #include <ql/cashflows/couponpricer.hpp>
 #include <ql/cashflows/floatingratecoupon.hpp>

--- a/ql/experimental/coupons/Makefile.am
+++ b/ql/experimental/coupons/Makefile.am
@@ -10,7 +10,6 @@ this_include_HEADERS = \
     proxyibor.hpp \
     quantocouponpricer.hpp \
     strippedcapflooredcoupon.hpp \
-    subperiodcoupons.hpp \
     swapspreadindex.hpp
 
 cpp_files = \
@@ -20,7 +19,6 @@ cpp_files = \
     proxyibor.cpp \
     quantocouponpricer.cpp \
     strippedcapflooredcoupon.cpp \
-    subperiodcoupons.cpp \
     swapspreadindex.cpp
 
 if UNITY_BUILD

--- a/ql/experimental/coupons/all.hpp
+++ b/ql/experimental/coupons/all.hpp
@@ -7,6 +7,5 @@
 #include <ql/experimental/coupons/proxyibor.hpp>
 #include <ql/experimental/coupons/quantocouponpricer.hpp>
 #include <ql/experimental/coupons/strippedcapflooredcoupon.hpp>
-#include <ql/experimental/coupons/subperiodcoupons.hpp>
 #include <ql/experimental/coupons/swapspreadindex.hpp>
 

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -39,13 +39,12 @@ namespace QuantLib {
                                        const DayCounter& dayCounter,
                                        bool isInArrears,
                                        const Date& exCouponDate,
-                                       SubPeriodAveraging subPeriodAveraging,
                                        Rate rateSpread)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          fixingDays, index, gearing, couponSpread,
                          refPeriodStart, refPeriodEnd, dayCounter, 
                          isInArrears, exCouponDate),
-      subPeriodAveraging_(subPeriodAveraging), rateSpread_(rateSpread) {
+      rateSpread_(rateSpread) {
         Schedule sch = MakeSchedule()
                            .from(startDate)
                            .to(endDate)

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2008 Toyin Akin
+ Copyright (C) 2021 Marcin Rybacki
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -149,8 +149,8 @@ namespace QuantLib {
         return coupon_->gearing() * rate + coupon_->spread();
     }
 
-    SubPeriodsLeg::SubPeriodsLeg(const Schedule& schedule, ext::shared_ptr<IborIndex> i)
-    : schedule_(schedule), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
+    SubPeriodsLeg::SubPeriodsLeg(Schedule schedule, ext::shared_ptr<IborIndex> i)
+    : schedule_(std::move(schedule)), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
       paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(SubPeriodsAveraging::Compound), 
       exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), 
       exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {}

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -149,8 +149,8 @@ namespace QuantLib {
         return coupon_->gearing() * rate + coupon_->spread();
     }
 
-    SubPeriodsLeg::SubPeriodsLeg(Schedule schedule, ext::shared_ptr<IborIndex> i)
-    : schedule_(std::move(schedule)), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
+    SubPeriodsLeg::SubPeriodsLeg(const Schedule &schedule, ext::shared_ptr<IborIndex> i)
+    : schedule_(schedule), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
       paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(SubPeriodsAveraging::Compound), 
       exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), 
       exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {}

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
                 fixingDates_[i] = index->fixingDate(valueDates_[i]);
         }
 
-        // accrual periods
+        // accrual of sub-periods
         dt_.resize(n_);
         const DayCounter& dc = index->dayCounter();
         for (Size i = 0; i < n_; ++i)

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -53,7 +53,6 @@ namespace QuantLib {
                            .withConvention(index->businessDayConvention())
                            .backwards()
                            .endOfMonth(index->endOfMonth());
-
         valueDates_ = sch.dates();
 
         // fixing dates
@@ -91,8 +90,7 @@ namespace QuantLib {
             QL_FAIL("IborIndex required");
         }
 
-        accrualFactor_ = coupon_->accrualPeriod();
-        QL_REQUIRE(accrualFactor_ != 0.0, "null accrual period");
+        QL_REQUIRE(coupon_->accrualPeriod() != 0.0, "null accrual period");
 
         const std::vector<Date>& fixingDates = coupon_->fixingDates();
         Size n = fixingDates.size();
@@ -151,5 +149,156 @@ namespace QuantLib {
         return coupon_->gearing() * rate + coupon_->spread();
     }
 
+    SubPeriodsLeg::SubPeriodsLeg(const Schedule& schedule, ext::shared_ptr<IborIndex> i)
+    : schedule_(schedule), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
+      paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(SubPeriodsAveraging::Compound), 
+      exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), 
+      exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {}
+
+    SubPeriodsLeg& SubPeriodsLeg::withNotionals(Real notional) {
+        notionals_ = std::vector<Real>(1, notional);
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withNotionals(const std::vector<Real>& notionals) {
+        notionals_ = notionals;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withPaymentDayCounter(const DayCounter& dc) {
+        paymentDayCounter_ = dc;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withPaymentAdjustment(BusinessDayConvention convention) {
+        paymentAdjustment_ = convention;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withPaymentCalendar(const Calendar& cal) {
+        paymentCalendar_ = cal;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withPaymentLag(Natural lag) {
+        paymentLag_ = lag;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withFixingDays(Natural fixingDays) {
+        fixingDays_ = std::vector<Natural>(1, fixingDays);
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withFixingDays(const std::vector<Natural>& fixingDays) {
+        fixingDays_ = fixingDays;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withGearings(Real gearing) {
+        gearings_ = std::vector<Real>(1, gearing);
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withGearings(const std::vector<Real>& gearings) {
+        gearings_ = gearings;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withCouponSpreads(Spread spread) {
+        couponSpreads_ = std::vector<Spread>(1, spread);
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withCouponSpreads(const std::vector<Spread>& spreads) {
+        couponSpreads_ = spreads;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withRateSpreads(Spread spread) {
+        rateSpreads_ = std::vector<Spread>(1, spread);
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withRateSpreads(const std::vector<Spread>& spreads) {
+        rateSpreads_ = spreads;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withAveragingMethod(SubPeriodsAveraging::Type averagingMethod) {
+        averagingMethod_ = averagingMethod;
+        return *this;
+    }
+
+    SubPeriodsLeg& SubPeriodsLeg::withExCouponPeriod(const Period& period,
+                                                     const Calendar& cal,
+                                                     BusinessDayConvention convention,
+                                                     bool endOfMonth) {
+        exCouponPeriod_ = period;
+        exCouponCalendar_ = cal;
+        exCouponAdjustment_ = convention;
+        exCouponEndOfMonth_ = endOfMonth;
+        return *this;
+    }
+
+    SubPeriodsLeg::operator Leg() const {
+        Leg cashflows;
+        Calendar calendar = schedule_.calendar();
+        Date refStart, start, refEnd, end, exCouponDate;
+        Date paymentDate;
+
+        Size n = schedule_.size() - 1;
+        QL_REQUIRE(!notionals_.empty(), "no notional given");
+        QL_REQUIRE(notionals_.size() <= n,
+                   "too many nominals (" << notionals_.size() << "), only " << n << " required");
+        QL_REQUIRE(gearings_.size() <= n,
+                   "too many gearings (" << gearings_.size() << "), only " << n << " required");
+        QL_REQUIRE(couponSpreads_.size() <= n,
+                   "too many coupon spreads (" << couponSpreads_.size() << "), only " << n << " required");
+        QL_REQUIRE(rateSpreads_.size() <= n,
+                   "too many rate spreads (" << rateSpreads_.size() << "), only " << n << " required");
+        QL_REQUIRE(fixingDays_.size() <= n,
+                   "too many fixing days (" << fixingDays_.size() << "), only " << n << " required");
+
+        for (Size i = 0; i < n; ++i) {
+            refStart = start = schedule_.date(i);
+            refEnd = end = schedule_.date(i + 1);
+            paymentDate = paymentCalendar_.advance(end, paymentLag_, Days, paymentAdjustment_);
+
+            if (i == 0 && schedule_.hasIsRegular() && !schedule_.isRegular(i + 1))
+                refStart = calendar.adjust(end - schedule_.tenor(), paymentAdjustment_);
+            if (i == n - 1 && schedule_.hasIsRegular() && !schedule_.isRegular(i + 1))
+                refEnd = calendar.adjust(start + schedule_.tenor(), paymentAdjustment_);
+            if (exCouponPeriod_ != Period()) {
+                if (exCouponCalendar_.empty()) {
+                    exCouponDate = calendar.advance(paymentDate, -exCouponPeriod_,
+                                                    exCouponAdjustment_, exCouponEndOfMonth_);
+                } else {
+                    exCouponDate = exCouponCalendar_.advance(
+                        paymentDate, -exCouponPeriod_, exCouponAdjustment_, exCouponEndOfMonth_);
+                }
+            }
+            cashflows.push_back(ext::shared_ptr<CashFlow>(new SubPeriodsCoupon(
+                paymentDate, detail::get(notionals_, i, notionals_.back()), start, end,
+                detail::get(fixingDays_, i, index_->fixingDays()), index_,
+                detail::get(gearings_, i, 1.0), detail::get(couponSpreads_, i, 0.0),
+                detail::get(rateSpreads_, i, 0.0), refStart, refEnd, paymentDayCounter_,
+                exCouponDate)));
+        }
+
+        switch (averagingMethod_) {
+            case SubPeriodsAveraging::Simple:
+                setCouponPricer(cashflows,
+                                ext::shared_ptr<FloatingRateCouponPricer>(new AveragingRatePricer));
+                break;
+            case SubPeriodsAveraging::Compound:
+                setCouponPricer(cashflows, ext::shared_ptr<FloatingRateCouponPricer>(
+                                               new CompoundingRatePricer));
+                break;
+            default:
+                QL_FAIL("unknown compounding convention (" << Integer(averagingMethod_) << ")");
+        }
+        return cashflows;
+    }
 }
 

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -58,6 +58,26 @@ namespace QuantLib {
         observations_ = observationDates_.size();
      }
 
+    SubPeriodsCoupon::SubPeriodsCoupon(const Date& paymentDate,
+                                        Real nominal,
+                                        const Date& startDate,
+                                        const Date& endDate,
+                                        Natural fixingDays,
+                                        const ext::shared_ptr<IborIndex>& index,
+                                        Real gearing,
+                                        Rate couponSpread,
+                                        Rate rateSpread,
+                                        const Date& refPeriodStart,
+                                        const Date& refPeriodEnd,
+                                        const DayCounter& dayCounter,
+                                        bool isInArrears,
+                                        const Date& exCouponDate)
+     : SubPeriodsCoupon(paymentDate, nominal, startDate, endDate, 
+                        fixingDays, index, gearing, couponSpread, 
+                        refPeriodStart, refPeriodEnd, dayCounter, 
+                        isInArrears, exCouponDate, rateSpread) {
+    }
+
     void SubPeriodsCoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<SubPeriodsCoupon>*>(&v);
         if (v1 != nullptr)

--- a/ql/experimental/coupons/subperiodcoupons.cpp
+++ b/ql/experimental/coupons/subperiodcoupons.cpp
@@ -151,7 +151,7 @@ namespace QuantLib {
 
     SubPeriodsLeg::SubPeriodsLeg(const Schedule &schedule, ext::shared_ptr<IborIndex> i)
     : schedule_(schedule), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
-      paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(SubPeriodsAveraging::Compound), 
+      paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(RateAveraging::Compound), 
       exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), 
       exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {}
 
@@ -225,7 +225,7 @@ namespace QuantLib {
         return *this;
     }
 
-    SubPeriodsLeg& SubPeriodsLeg::withAveragingMethod(SubPeriodsAveraging::Type averagingMethod) {
+    SubPeriodsLeg& SubPeriodsLeg::withAveragingMethod(RateAveraging::Type averagingMethod) {
         averagingMethod_ = averagingMethod;
         return *this;
     }
@@ -287,11 +287,11 @@ namespace QuantLib {
         }
 
         switch (averagingMethod_) {
-            case SubPeriodsAveraging::Simple:
+            case RateAveraging::Simple:
                 setCouponPricer(cashflows,
                                 ext::shared_ptr<FloatingRateCouponPricer>(new AveragingRatePricer));
                 break;
-            case SubPeriodsAveraging::Compound:
+            case RateAveraging::Compound:
                 setCouponPricer(cashflows, ext::shared_ptr<FloatingRateCouponPricer>(
                                                new CompoundingRatePricer));
                 break;

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -134,7 +134,7 @@ namespace QuantLib {
     //! helper class building a sequence of overnight coupons
     class SubPeriodsLeg {
       public:
-        SubPeriodsLeg(Schedule schedule, ext::shared_ptr<IborIndex> index);
+        SubPeriodsLeg(const Schedule &schedule, ext::shared_ptr<IborIndex> index);
         SubPeriodsLeg& withNotionals(Real notional);
         SubPeriodsLeg& withNotionals(const std::vector<Real>& notionals);
         SubPeriodsLeg& withPaymentDayCounter(const DayCounter&);

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -68,11 +68,8 @@ namespace QuantLib {
                          Natural fixingDays,
                          const ext::shared_ptr<IborIndex>& index,
                          Real gearing = 1.0,
-                         Rate couponSpread = 0.0, // Spread added to the computed
-                                                  // averaging/compounding rate.
-                         Rate rateSpread = 0.0,   // Spread to be added onto each
-                                                  // fixing within the
-                                                  // averaging/compounding calculation
+                         Rate couponSpread = 0.0,
+                         Rate rateSpread = 0.0,
                          const Date& refPeriodStart = Date(),
                          const Date& refPeriodEnd = Date(),
                          const DayCounter& dayCounter = DayCounter(),

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -1,7 +1,6 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
-
  Copyright (C) 2008 Toyin Akin
  Copyright (C) 2021 Marcin Rybacki
 

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -73,7 +73,6 @@ namespace QuantLib {
                          const DayCounter& dayCounter = DayCounter(),
                          bool isInArrears = false,
                          const Date& exCouponDate = Date(),
-                         SubPeriodAveraging subPeriodAveraging = SubPeriodAveraging::Compound,
                          Rate rateSpread = 0.0 // Spread to be added onto each
                                                // fixing within the
                                                // averaging/compounding calculation
@@ -87,8 +86,6 @@ namespace QuantLib {
             return observationDates_;
         }
 
-        SubPeriodAveraging subPeriodAveraging() const { return subPeriodAveraging_; }
-
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
@@ -96,7 +93,6 @@ namespace QuantLib {
       private:
         std::vector<Date> observationDates_;
         Size observations_;
-        SubPeriodAveraging subPeriodAveraging_;
         Rate rateSpread_;
     };
 

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -43,33 +43,31 @@ namespace QuantLib {
           // The Tenor used within the index object should be 1M for
           // averaging/compounding across three coupons within the
           // coupon period.
-          SubPeriodsCoupon(
-                const Date& paymentDate,
-                Real nominal,
-                const ext::shared_ptr<IborIndex>& index,
-                const Date& startDate,
-                const Date& endDate,
-                Natural fixingDays,
-                const DayCounter& dayCounter,
-                Real gearing,
-                Rate couponSpread, // Spread added to the computed
-                                   // averaging/compounding rate.
-                Rate rateSpread, // Spread to be added onto each
-                                 // fixing within the
-                                 // averaging/compounding calculation
-                const Date& refPeriodStart,
-                const Date& refPeriodEnd);
+        SubPeriodsCoupon(const Date& paymentDate,
+                         Real nominal,
+                         const Date& startDate,
+                         const Date& endDate,
+                         Natural fixingDays,
+                         const ext::shared_ptr<IborIndex>& index,
+                         Real gearing = 1.0,
+                         Rate couponSpread = 0.0, // Spread added to the computed
+                                                  // averaging/compounding rate.
+                         const Date& refPeriodStart = Date(),
+                         const Date& refPeriodEnd = Date(),
+                         const DayCounter& dayCounter = DayCounter(),
+                         bool isInArrears = false,
+                         const Date& exCouponDate = Date(),
+                         Rate rateSpread = 0.0 // Spread to be added onto each
+                                               // fixing within the
+                                               // averaging/compounding calculation
+        );
 
         Spread rateSpread() const { return rateSpread_; }
 
-        Real startTime() const { return startTime_; }
-        Real endTime() const { return endTime_; }
         Size observations() const { return observations_; }
+        
         const std::vector<Date>& observationDates() const {
             return observationDates_;
-        }
-        const std::vector<Real>& observationTimes() const {
-            return observationTimes_;
         }
 
         ext::shared_ptr<Schedule> observationsSchedule() const { return observationsSchedule_; }
@@ -79,14 +77,8 @@ namespace QuantLib {
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-
-        Real startTime_;                               // S
-        Real endTime_;                                 // T
-
         ext::shared_ptr<Schedule> observationsSchedule_;
         std::vector<Date> observationDates_;
-        std::vector<Real> observationTimes_;
-
         Size observations_;
         Rate rateSpread_;
     };
@@ -102,22 +94,15 @@ namespace QuantLib {
 
       protected:
         const SubPeriodsCoupon* coupon_;
-        Real startTime_;
-        Real endTime_;
         Real accrualFactor_;
-        std::vector<Real> observationTimes_;
         std::vector<Real> observationCvg_;
         std::vector<Real> initialValues_;
-
         std::vector<Date> observationIndexStartDates_;
         std::vector<Date> observationIndexEndDates_;
-
-        Size observations_;
         Real discount_;
         Real gearing_;
         Spread spread_;
         Real spreadLegValue_;
-
     };
 
     class AveragingRatePricer: public SubPeriodsPricer {
@@ -131,6 +116,5 @@ namespace QuantLib {
     };
 
 }
-
 
 #endif

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -134,7 +134,7 @@ namespace QuantLib {
     //! helper class building a sequence of overnight coupons
     class SubPeriodsLeg {
       public:
-        SubPeriodsLeg(const Schedule& schedule, ext::shared_ptr<IborIndex> index);
+        SubPeriodsLeg(Schedule schedule, ext::shared_ptr<IborIndex> index);
         SubPeriodsLeg& withNotionals(Real notional);
         SubPeriodsLeg& withNotionals(const std::vector<Real>& notionals);
         SubPeriodsLeg& withPaymentDayCounter(const DayCounter&);

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -32,8 +32,24 @@
 
 namespace QuantLib {
 
+    //! sub-period coupon averaging method
+    /*! It allows to configure how interest is accrued in the sub-period coupon.
+     */
+    struct SubPeriodAveraging {
+        enum Type {
+            Simple,  /*!< Under the simple convention the amount of
+                      interest is calculated by applying the sub-periodic
+                      rate to the principal, and the payment due
+                      at the end of the period is the sum of those
+                      amounts. */
+            Compound /*!< Under the compound convention, the additional
+                      amount of interest owed each sub-period is calculated
+                      by applying the rate both to the principal
+                      and the accumulated unpaid interest. */
+        };
+    };
+
     class IborIndex;
-    class AveragingRatePricer;
 
     class SubPeriodsCoupon: public FloatingRateCoupon {
       public:
@@ -57,6 +73,7 @@ namespace QuantLib {
                          const DayCounter& dayCounter = DayCounter(),
                          bool isInArrears = false,
                          const Date& exCouponDate = Date(),
+                         SubPeriodAveraging subPeriodAveraging = SubPeriodAveraging::Compound,
                          Rate rateSpread = 0.0 // Spread to be added onto each
                                                // fixing within the
                                                // averaging/compounding calculation
@@ -70,16 +87,16 @@ namespace QuantLib {
             return observationDates_;
         }
 
-        ext::shared_ptr<Schedule> observationsSchedule() const { return observationsSchedule_; }
+        SubPeriodAveraging subPeriodAveraging() const { return subPeriodAveraging_; }
 
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-        ext::shared_ptr<Schedule> observationsSchedule_;
         std::vector<Date> observationDates_;
         Size observations_;
+        SubPeriodAveraging subPeriodAveraging_;
         Rate rateSpread_;
     };
 
@@ -97,8 +114,6 @@ namespace QuantLib {
         Real accrualFactor_;
         std::vector<Real> observationCvg_;
         std::vector<Real> initialValues_;
-        std::vector<Date> observationIndexStartDates_;
-        std::vector<Date> observationIndexEndDates_;
         Real discount_;
         Real gearing_;
         Spread spread_;

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -59,21 +59,30 @@ namespace QuantLib {
                          const DayCounter& dayCounter = DayCounter(),
                          const Date& exCouponDate = Date());
 
+        //! \name Inspectors
+        //@{
+        //! fixing dates for the rates to be compounded
+        const std::vector<Date>& fixingDates() const { return fixingDates_; }
+        //! accrual (compounding) periods
+        const std::vector<Time>& dt() const { return dt_; }
+        //! value dates for the rates to be compounded
+        const std::vector<Date>& valueDates() const { return valueDates_; }
+        //! rate spread
         Spread rateSpread() const { return rateSpread_; }
-
-        Size observations() const { return observations_; }
-        
-        const std::vector<Date>& observationDates() const {
-            return observationDates_;
-        }
-
+        //@}
+        //! \name FloatingRateCoupon interface
+        //@{
+        //! the date when the coupon is fully determined
+        Date fixingDate() const override { return fixingDates_.back(); }
+        //@}
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-        std::vector<Date> observationDates_;
-        Size observations_;
+        std::vector<Date> valueDates_, fixingDates_;
+        Size n_;
+        std::vector<Time> dt_;
         Rate rateSpread_;
     };
 
@@ -89,7 +98,6 @@ namespace QuantLib {
       protected:
         const SubPeriodsCoupon* coupon_;
         Real accrualFactor_;
-        std::vector<Real> subPeriodFractions_;
         std::vector<Real> subPeriodFixings_;
     };
 

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -27,27 +27,11 @@
 
 #include <ql/cashflows/couponpricer.hpp>
 #include <ql/cashflows/floatingratecoupon.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/time/schedule.hpp>
 #include <vector>
 
 namespace QuantLib {
-
-    //! sub-periods coupon averaging method
-    /*! It allows to configure how interest is accrued.
-     */
-    struct SubPeriodsAveraging {
-        enum Type {
-            Simple,  /*!< Under the simple convention the amount of
-                      interest is calculated by applying the periodic
-                      rate to the principal, and the payment due
-                      at the end of the period is the sum of those
-                      amounts. */
-            Compound /*!< Under the compound convention, the additional
-                      amount of interest owed each sub-period is calculated
-                      by applying the rate both to the principal
-                      and the accumulated unpaid interest. */
-        };
-    };
 
     class IborIndex;
 
@@ -153,7 +137,7 @@ namespace QuantLib {
                                           const Calendar&,
                                           BusinessDayConvention,
                                           bool endOfMonth = false);
-        SubPeriodsLeg& withAveragingMethod(SubPeriodsAveraging::Type averagingMethod);
+        SubPeriodsLeg& withAveragingMethod(RateAveraging::Type averagingMethod);
         operator Leg() const;
 
       private:
@@ -168,7 +152,7 @@ namespace QuantLib {
         std::vector<Real> gearings_;
         std::vector<Spread> couponSpreads_;
         std::vector<Spread> rateSpreads_;
-        SubPeriodsAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_;

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -3,6 +3,7 @@
 /*
 
  Copyright (C) 2008 Toyin Akin
+ Copyright (C) 2021 Marcin Rybacki
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -32,23 +32,6 @@
 
 namespace QuantLib {
 
-    //! sub-period coupon averaging method
-    /*! It allows to configure how interest is accrued in the sub-period coupon.
-     */
-    struct SubPeriodAveraging {
-        enum Type {
-            Simple,  /*!< Under the simple convention the amount of
-                      interest is calculated by applying the sub-periodic
-                      rate to the principal, and the payment due
-                      at the end of the period is the sum of those
-                      amounts. */
-            Compound /*!< Under the compound convention, the additional
-                      amount of interest owed each sub-period is calculated
-                      by applying the rate both to the principal
-                      and the accumulated unpaid interest. */
-        };
-    };
-
     class IborIndex;
 
     class SubPeriodsCoupon: public FloatingRateCoupon {
@@ -77,6 +60,24 @@ namespace QuantLib {
                                                // fixing within the
                                                // averaging/compounding calculation
         );
+
+        SubPeriodsCoupon(const Date& paymentDate,
+                         Real nominal,
+                         const Date& startDate,
+                         const Date& endDate,
+                         Natural fixingDays,
+                         const ext::shared_ptr<IborIndex>& index,
+                         Real gearing = 1.0,
+                         Rate couponSpread = 0.0, // Spread added to the computed
+                                                  // averaging/compounding rate.
+                         Rate rateSpread = 0.0,   // Spread to be added onto each
+                                                  // fixing within the
+                                                  // averaging/compounding calculation
+                         const Date& refPeriodStart = Date(),
+                         const Date& refPeriodEnd = Date(),
+                         const DayCounter& dayCounter = DayCounter(),
+                         bool isInArrears = false,
+                         const Date& exCouponDate = Date());
 
         Spread rateSpread() const { return rateSpread_; }
 

--- a/ql/experimental/coupons/subperiodcoupons.hpp
+++ b/ql/experimental/coupons/subperiodcoupons.hpp
@@ -51,29 +51,12 @@ namespace QuantLib {
                          Real gearing = 1.0,
                          Rate couponSpread = 0.0, // Spread added to the computed
                                                   // averaging/compounding rate.
+                         Rate rateSpread = 0.0,   // Spread to be added onto each
+                                                  // fixing within the
+                                                  // averaging/compounding calculation
                          const Date& refPeriodStart = Date(),
                          const Date& refPeriodEnd = Date(),
                          const DayCounter& dayCounter = DayCounter(),
-                         bool isInArrears = false,
-                         const Date& exCouponDate = Date(),
-                         Rate rateSpread = 0.0 // Spread to be added onto each
-                                               // fixing within the
-                                               // averaging/compounding calculation
-        );
-
-        SubPeriodsCoupon(const Date& paymentDate,
-                         Real nominal,
-                         const Date& startDate,
-                         const Date& endDate,
-                         Natural fixingDays,
-                         const ext::shared_ptr<IborIndex>& index,
-                         Real gearing = 1.0,
-                         Rate couponSpread = 0.0,
-                         Rate rateSpread = 0.0,
-                         const Date& refPeriodStart = Date(),
-                         const Date& refPeriodEnd = Date(),
-                         const DayCounter& dayCounter = DayCounter(),
-                         bool isInArrears = false,
                          const Date& exCouponDate = Date());
 
         Spread rateSpread() const { return rateSpread_; }
@@ -96,7 +79,7 @@ namespace QuantLib {
 
     class SubPeriodsPricer: public FloatingRateCouponPricer {
       public:
-        Rate swapletRate() const override;
+        Rate swapletPrice() const override;
         Real capletPrice(Rate effectiveCap) const override;
         Rate capletRate(Rate effectiveCap) const override;
         Real floorletPrice(Rate effectiveFloor) const override;
@@ -106,24 +89,19 @@ namespace QuantLib {
       protected:
         const SubPeriodsCoupon* coupon_;
         Real accrualFactor_;
-        std::vector<Real> observationCvg_;
-        std::vector<Real> initialValues_;
-        Real discount_;
-        Real gearing_;
-        Spread spread_;
-        Real spreadLegValue_;
+        std::vector<Real> subPeriodFractions_;
+        std::vector<Real> subPeriodFixings_;
     };
 
     class AveragingRatePricer: public SubPeriodsPricer {
       public:
-        Real swapletPrice() const override;
+        Real swapletRate() const override;
     };
 
     class CompoundingRatePricer: public SubPeriodsPricer {
       public:
-        Real swapletPrice() const override;
+        Real swapletRate() const override;
     };
-
 }
 
 #endif

--- a/ql/indexes/swapindex.cpp
+++ b/ql/indexes/swapindex.cpp
@@ -189,7 +189,7 @@ namespace QuantLib {
         const Currency& currency,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         bool telescopicValueDates,
-        OvernightAveraging::Type averagingMethod)
+        RateAveraging::Type averagingMethod)
     : SwapIndex(familyName,
                 tenor,
                 settlementDays,

--- a/ql/indexes/swapindex.hpp
+++ b/ql/indexes/swapindex.hpp
@@ -25,7 +25,7 @@
 
 #include <ql/indexes/interestrateindex.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/cashflows/overnightindexedcoupon.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 
 namespace QuantLib {
 
@@ -115,7 +115,7 @@ namespace QuantLib {
                   const Currency& currency,
                   const ext::shared_ptr<OvernightIndex>& overnightIndex,
                   bool telescopicValueDates = false,
-                  OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                  RateAveraging::Type averagingMethod = RateAveraging::Compound);
         //! \name Inspectors
         //@{
         ext::shared_ptr<OvernightIndex> overnightIndex() const;
@@ -128,7 +128,7 @@ namespace QuantLib {
       protected:
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         bool telescopicValueDates_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
         // cache data to avoid swap recreation when the same fixing date
         // is used multiple time to forecast changing fixing
         mutable ext::shared_ptr<OvernightIndexedSwap> lastSwap_;

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
       overnightSpread_(0.0),
       fixedDayCount_(overnightIndex->dayCounter()), 
       telescopicValueDates_(false), 
-      averagingMethod_(OvernightAveraging::Compound) {}
+      averagingMethod_(RateAveraging::Compound) {}
 
     MakeOIS::operator OvernightIndexedSwap() const {
         ext::shared_ptr<OvernightIndexedSwap> ois = *this;
@@ -238,7 +238,7 @@ namespace QuantLib {
         return *this;
     }
 
-    MakeOIS& MakeOIS::withAveragingMethod(OvernightAveraging::Type averagingMethod) {
+    MakeOIS& MakeOIS::withAveragingMethod(RateAveraging::Type averagingMethod) {
         averagingMethod_ = averagingMethod;
         return *this;
     }

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -71,7 +71,7 @@ namespace QuantLib {
 
         MakeOIS &withTelescopicValueDates(bool telescopicValueDates);
 
-        MakeOIS& withAveragingMethod(OvernightAveraging::Type averagingMethod);
+        MakeOIS& withAveragingMethod(RateAveraging::Type averagingMethod);
 
         MakeOIS& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
@@ -102,7 +102,7 @@ namespace QuantLib {
         ext::shared_ptr<PricingEngine> engine_;
 
         bool telescopicValueDates_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
     };
 
 }

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -21,6 +21,7 @@
 */
 
 #include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/cashflows/overnightindexedcoupon.hpp>
 #include <ql/instruments/overnightindexedswap.hpp>
 #include <utility>
 
@@ -37,7 +38,7 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates, 
-                                               OvernightAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod)
     : Swap(2), type_(type), nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
       paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
@@ -59,7 +60,7 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates, 
-                                               OvernightAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod)
     : Swap(2), type_(type), nominals_(std::move(nominals)),
       paymentFrequency_(schedule.tenor().frequency()),
       paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -28,7 +28,7 @@
 #define quantlib_overnight_indexed_swap_hpp
 
 #include <ql/instruments/swap.hpp>
-#include <ql/cashflows/overnightindexedcoupon.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/time/daycounter.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
@@ -53,7 +53,7 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         OvernightIndexedSwap(Type type,
                              std::vector<Real> nominals,
@@ -66,7 +66,7 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         //! \name Inspectors
         //@{
@@ -85,7 +85,7 @@ namespace QuantLib {
         const Leg& fixedLeg() const { return legs_[0]; }
         const Leg& overnightLeg() const { return legs_[1]; }
 
-        OvernightAveraging::Type averagingMethod() const { return averagingMethod_; }
+        RateAveraging::Type averagingMethod() const { return averagingMethod_; }
         //@}
 
         //! \name Results
@@ -116,7 +116,7 @@ namespace QuantLib {
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         Spread spread_;
         bool telescopicValueDates_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
     };
 
 

--- a/ql/instruments/overnightindexfuture.cpp
+++ b/ql/instruments/overnightindexfuture.cpp
@@ -20,6 +20,7 @@
 
 #include <ql/instruments/overnightindexfuture.hpp>
 #include <ql/indexes/indexmanager.hpp>
+#include <ql/event.hpp>
 #include <utility>
 
 namespace QuantLib {
@@ -28,7 +29,7 @@ namespace QuantLib {
                                                const Date& valueDate,
                                                const Date& maturityDate,
                                                Handle<Quote> convexityAdjustment,
-                                               OvernightAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod)
     : overnightIndex_(std::move(overnightIndex)), valueDate_(valueDate),
       maturityDate_(maturityDate), convexityAdjustment_(std::move(convexityAdjustment)),
       averagingMethod_(averagingMethod) {
@@ -98,10 +99,10 @@ namespace QuantLib {
 
     Real OvernightIndexFuture::rate() const {
         switch (averagingMethod_) {
-          case OvernightAveraging::Simple:
+          case RateAveraging::Simple:
             return averagedRate();
             break;
-          case OvernightAveraging::Compound:
+          case RateAveraging::Compound:
             return compoundedRate();
             break;
           default:

--- a/ql/instruments/overnightindexfuture.hpp
+++ b/ql/instruments/overnightindexfuture.hpp
@@ -27,7 +27,7 @@
 
 #include <ql/indexes/iborindex.hpp>
 #include <ql/instruments/forward.hpp>
-#include <ql/cashflows/overnightindexedcoupon.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 
 namespace QuantLib {
 
@@ -43,7 +43,7 @@ namespace QuantLib {
             const Date& valueDate,
             const Date& maturityDate,
             Handle<Quote> convexityAdjustment = Handle<Quote>(),
-            OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+            RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         Real convexityAdjustment() const;
         bool isExpired() const override;
@@ -55,7 +55,7 @@ namespace QuantLib {
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         Date valueDate_, maturityDate_;
         Handle<Quote> convexityAdjustment_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
     };
 
 }

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
                                  const Spread overnightSpread,
                                  Pillar::Choice pillar,
                                  Date customPillarDate,
-                                 OvernightAveraging::Type averagingMethod)
+                                 RateAveraging::Type averagingMethod)
     : RelativeDateRateHelper(fixedRate), pillarChoice_(pillar), settlementDays_(settlementDays),
       tenor_(tenor), overnightIndex_(std::move(overnightIndex)),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
@@ -146,7 +146,7 @@ namespace QuantLib {
                                            const ext::shared_ptr<OvernightIndex>& overnightIndex,
                                            Handle<YieldTermStructure> discount,
                                            bool telescopicValueDates, 
-                                           OvernightAveraging::Type averagingMethod)
+                                           RateAveraging::Type averagingMethod)
     : RateHelper(fixedRate), discountHandle_(std::move(discount)),
       telescopicValueDates_(telescopicValueDates), 
       averagingMethod_(averagingMethod) {

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
                       Spread overnightSpread = 0.0,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(), 
-                      OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                      RateAveraging::Type averagingMethod = RateAveraging::Compound);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -83,7 +83,7 @@ namespace QuantLib {
       Calendar paymentCalendar_;
       Period forwardStart_;
       Spread overnightSpread_;
-      OvernightAveraging::Type averagingMethod_;
+      RateAveraging::Type averagingMethod_;
     };
 
     //! Rate helper for bootstrapping over Overnight Indexed Swap rates
@@ -97,7 +97,7 @@ namespace QuantLib {
             // exogenous discounting curve
             Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
             bool telescopicValueDates = false,
-            OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+            RateAveraging::Type averagingMethod = RateAveraging::Compound);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -114,7 +114,7 @@ namespace QuantLib {
         Handle<YieldTermStructure> discountHandle_;
         bool telescopicValueDates_;
         RelinkableHandle<YieldTermStructure> discountRelinkableHandle_;
-        OvernightAveraging::Type averagingMethod_;
+        RateAveraging::Type averagingMethod_;
     };
 
 }

--- a/ql/termstructures/yield/overnightindexfutureratehelper.cpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         const Date& maturityDate,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         const Handle<Quote>& convexityAdjustment,
-        OvernightAveraging::Type averagingMethod)
+        RateAveraging::Type averagingMethod)
     : RateHelper(price) {
         ext::shared_ptr<Payoff> payoff;
         ext::shared_ptr<OvernightIndex> index =
@@ -99,7 +99,7 @@ namespace QuantLib {
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         const Handle<Quote>& convexityAdjustment,
-        OvernightAveraging::Type averagingMethod)
+        RateAveraging::Type averagingMethod)
     : OvernightIndexFutureRateHelper(price,
                                      getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
                                      getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
@@ -122,7 +122,7 @@ namespace QuantLib {
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         Real convexityAdjustment,
-        OvernightAveraging::Type averagingMethod)
+        RateAveraging::Type averagingMethod)
     : OvernightIndexFutureRateHelper(
           Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
           getValidSofrStart(referenceMonth, referenceYear, referenceFreq),

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
                                        const Date& maturityDate,
                                        const ext::shared_ptr<OvernightIndex>& overnightIndex,
                                        const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
-                                       OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                                       RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         //! \name RateHelper interface
         //@{
@@ -73,14 +73,14 @@ namespace QuantLib {
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
                              const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
-                             OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,
                              Year referenceYear,
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
                              Real convexityAdjustment = 0,
-                             OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
     };
 
 }

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -138,6 +138,7 @@ set(QuantLib-Test_SRC
     spreadoption.cpp
     squarerootclvmodel.cpp
     stats.cpp
+    subperiodcoupons.cpp
     swap.cpp
     swapforwardmappings.cpp
     swaption.cpp
@@ -302,6 +303,7 @@ set(QuantLib-Test_HDR
     spreadoption.hpp
     squarerootclvmodel.hpp
     stats.hpp
+    subperiodcoupons.hpp
     swap.hpp
     swapforwardmappings.hpp
     swaption.hpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -136,6 +136,7 @@ QL_TEST_SRCS = \
 	spreadoption.cpp \
 	squarerootclvmodel.cpp \
 	stats.cpp \
+	subperiodcoupons.cpp \
 	swap.cpp \
 	swapforwardmappings.cpp \
 	swaption.cpp \
@@ -296,6 +297,7 @@ QL_TEST_HDRS = \
 	spreadoption.hpp \
 	squarerootclvmodel.hpp \
 	stats.hpp \
+	subperiodcoupons.hpp \
 	swap.hpp \
 	swapforwardmappings.hpp \
 	swaption.hpp \

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -141,7 +141,7 @@ namespace overnight_indexed_swap_test {
                  bool telescopicValueDates,
                  Date effectiveDate = Null<Date>(),
                  Natural paymentLag = 0,
-                 OvernightAveraging::Type averagingMethod = OvernightAveraging::Compound) {
+                 RateAveraging::Type averagingMethod = RateAveraging::Compound) {
             return MakeOIS(length, eoniaIndex, fixedRate, 0 * Days)
                 .withEffectiveDate(effectiveDate == Null<Date>() ? settlement : effectiveDate)
                 .withOvernightLegSpread(spread)
@@ -302,7 +302,7 @@ void OvernightIndexedSwapTest::testCachedValue() {
 
 namespace overnight_indexed_swap_test {
     void testBootstrap(bool telescopicValueDates,
-                       OvernightAveraging::Type averagingMethod,
+                       RateAveraging::Type averagingMethod,
                        Real tolerance = 1.0e-8) {
 
     CommonVars vars;
@@ -379,18 +379,18 @@ namespace overnight_indexed_swap_test {
 
 void OvernightIndexedSwapTest::testBootstrap() {
     BOOST_TEST_MESSAGE("Testing Eonia-swap curve building with daily compounded ON rates...");
-    overnight_indexed_swap_test::testBootstrap(false, OvernightAveraging::Compound);
+    overnight_indexed_swap_test::testBootstrap(false, RateAveraging::Compound);
 }
 
 void OvernightIndexedSwapTest::testBootstrapWithArithmeticAverage() {
     BOOST_TEST_MESSAGE("Testing Eonia-swap curve building with arithmetic average ON rates...");
-    overnight_indexed_swap_test::testBootstrap(false, OvernightAveraging::Simple);
+    overnight_indexed_swap_test::testBootstrap(false, RateAveraging::Simple);
 }
 
 void OvernightIndexedSwapTest::testBootstrapWithTelescopicDates() {
     BOOST_TEST_MESSAGE(
         "Testing Eonia-swap curve building with telescopic value dates and DCON rates...");
-    overnight_indexed_swap_test::testBootstrap(true, OvernightAveraging::Compound);
+    overnight_indexed_swap_test::testBootstrap(true, RateAveraging::Compound);
 }
 
 void OvernightIndexedSwapTest::testBootstrapWithTelescopicDatesAndArithmeticAverage() {
@@ -399,7 +399,7 @@ void OvernightIndexedSwapTest::testBootstrapWithTelescopicDatesAndArithmeticAver
     // Given that we are using an approximation that omits
     // the required convexity correction, a lower tolerance
     // is needed.
-    overnight_indexed_swap_test::testBootstrap(true, OvernightAveraging::Simple, 1.0e-5);
+    overnight_indexed_swap_test::testBootstrap(true, RateAveraging::Simple, 1.0e-5);
 }
 
 void OvernightIndexedSwapTest::testSeasonedSwaps() {

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -182,6 +182,7 @@
 #include "squarerootclvmodel.hpp"
 #include "swingoption.hpp"
 #include "stats.hpp"
+#include "subperiodcoupons.hpp"
 #include "swap.hpp"
 #include "swapforwardmappings.hpp"
 #include "swaption.hpp"
@@ -461,6 +462,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(ShortRateModelTest::suite(speed)); // fails with QL_USE_INDEXED_COUPON
     test->add(Solver1DTest::suite());
     test->add(StatisticsTest::suite());
+    test->add(SubPeriodsCouponTest::suite());
     test->add(SwapTest::suite());
     test->add(SwapForwardMappingsTest::suite());
     test->add(SwaptionTest::suite(speed));

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -36,7 +36,7 @@ namespace {
         Month month;
         Year year;
         Real price;
-        OvernightAveraging::Type averagingMethod;
+        RateAveraging::Type averagingMethod;
     };
 
 }
@@ -51,19 +51,19 @@ void SofrFuturesTest::testBootstrap() {
     Settings::instance().evaluationDate() = today;
 
     const SofrQuotes sofrQuotes[] = {
-        {Monthly, Oct, 2018, 97.8175, OvernightAveraging::Simple},
-        {Monthly, Nov, 2018, 97.770, OvernightAveraging::Simple},
-        {Monthly, Dec, 2018, 97.685, OvernightAveraging::Simple},
-        {Monthly, Jan, 2019, 97.595, OvernightAveraging::Simple},
-        {Monthly, Feb, 2019, 97.590, OvernightAveraging::Simple},
-        {Monthly, Mar, 2019, 97.525, OvernightAveraging::Simple},
-        {Quarterly, Mar, 2019, 97.440, OvernightAveraging::Compound},
-        {Quarterly, Jun, 2019, 97.295, OvernightAveraging::Compound},
-        {Quarterly, Sep, 2019, 97.220, OvernightAveraging::Compound},
-        {Quarterly, Dec, 2019, 97.170, OvernightAveraging::Compound},
-        {Quarterly, Mar, 2020, 97.160, OvernightAveraging::Compound},
-        {Quarterly, Jun, 2020, 97.165, OvernightAveraging::Compound},
-        {Quarterly, Sep, 2020, 97.175, OvernightAveraging::Compound},
+        {Monthly, Oct, 2018, 97.8175, RateAveraging::Simple},
+        {Monthly, Nov, 2018, 97.770, RateAveraging::Simple},
+        {Monthly, Dec, 2018, 97.685, RateAveraging::Simple},
+        {Monthly, Jan, 2019, 97.595, RateAveraging::Simple},
+        {Monthly, Feb, 2019, 97.590, RateAveraging::Simple},
+        {Monthly, Mar, 2019, 97.525, RateAveraging::Simple},
+        {Quarterly, Mar, 2019, 97.440, RateAveraging::Compound},
+        {Quarterly, Jun, 2019, 97.295, RateAveraging::Compound},
+        {Quarterly, Sep, 2019, 97.220, RateAveraging::Compound},
+        {Quarterly, Dec, 2019, 97.170, RateAveraging::Compound},
+        {Quarterly, Mar, 2020, 97.160, RateAveraging::Compound},
+        {Quarterly, Jun, 2020, 97.165, RateAveraging::Compound},
+        {Quarterly, Sep, 2020, 97.175, RateAveraging::Compound},
     };
 
     ext::shared_ptr<OvernightIndex> index = ext::make_shared<Sofr>();

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -1,0 +1,111 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ Copyright (C) 2021 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "subperiodcoupons.hpp"
+#include "utilities.hpp"
+#include <ql/experimental/coupons/subperiodcoupons.hpp>
+#include <ql/cashflows/iborcoupon.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/calendars/target.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace subperiodcoupons_test {
+
+    struct CommonVars {
+
+        Date today, settlement;
+        Calendar calendar;
+        Natural settlementDays;
+        DayCounter dayCount;
+        BusinessDayConvention businessConvention;
+
+        ext::shared_ptr<IborIndex> euribor;
+
+        RelinkableHandle<YieldTermStructure> euriborHandle;
+
+        // cleanup
+        SavedSettings backup;
+        // utilities
+
+        CommonVars() {
+            settlementDays = 2;
+            calendar = TARGET();
+            dayCount = Actual365Fixed();
+            businessConvention = ModifiedFollowing;
+
+            euribor = ext::shared_ptr<IborIndex>(new Euribor6M(euriborHandle));
+
+            today = calendar.adjust(Date::todaysDate());
+            Settings::instance().evaluationDate() = today;
+            settlement = calendar.advance(today, settlementDays, Days);
+
+            euriborHandle.linkTo(flatRate(settlement, 0.007, dayCount));
+        }
+    };
+
+    Leg createIborLeg(const Date& start, 
+        const Date& end, 
+        bool isInArrears = false,
+        Spread spread = 0.0)
+    {
+        CommonVars vars;
+        Schedule sch = MakeSchedule()
+                           .from(start)
+                           .to(end)
+                           .withTenor(vars.euribor->tenor())
+                           .withCalendar(vars.euribor->fixingCalendar())
+                           .withConvention(vars.euribor->businessDayConvention())
+                           .backwards()
+                           .endOfMonth(vars.euribor->endOfMonth());
+        return IborLeg(sch, vars.euribor)
+            .withNotionals(1.0)
+            .withSpreads(spread)
+            .withExCouponPeriod(2 * Days, vars.calendar, vars.businessConvention)
+            .withPaymentLag(1)
+            .inArrears(isInArrears)
+            .withFixingDays(vars.settlementDays);
+    }
+
+    ext::shared_ptr<CashFlow> createSubPeriodsCoupon(const Date& start,
+                                                    const Date& end,
+                                                    bool isInArrears = false,
+                                                    Spread spread = 0.0) {
+        CommonVars vars;
+        Date paymentDate = vars.calendar.advance(end, 1 * Days, vars.businessConvention);
+        Date exCouponDate = vars.calendar.advance(paymentDate, -2 * Days, vars.businessConvention);
+        return ext::shared_ptr<CashFlow>(new SubPeriodsCoupon(
+            paymentDate, 1.0, start, end, vars.settlementDays, vars.euribor, 1.0, spread, 0.0,
+            Date(), Date(), vars.dayCount, isInArrears, exCouponDate));
+    }
+}
+
+void SubPeriodsCouponTest::test() {
+    BOOST_TEST_MESSAGE("...");
+
+}
+
+
+test_suite* SubPeriodsCouponTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("Sub-period coupons tests");
+
+    suite->add(QUANTLIB_TEST_CASE(&SubPeriodsCouponTest::test));
+
+    return suite;
+}

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -52,7 +52,7 @@ namespace subperiodcoupons_test {
 
             euribor = ext::shared_ptr<IborIndex>(new Euribor6M(euriborHandle));
 
-            today = calendar.adjust(Date::todaysDate());
+            today = calendar.adjust(Date(15, March, 2021));
             Settings::instance().evaluationDate() = today;
             settlement = calendar.advance(today, settlementDays, Days);
 
@@ -83,6 +83,14 @@ namespace subperiodcoupons_test {
             .withFixingDays(vars.settlementDays);
     }
 
+    Real sumLegPayments(const Leg& leg)
+    {
+        Real payments = 0.0;
+        std::for_each(leg.begin(), leg.end(),
+                      [&](const ext::shared_ptr<CashFlow>& cf) { payments += cf->amount(); });
+        return payments;
+    }
+
     ext::shared_ptr<CashFlow> createSubPeriodsCoupon(const Date& start,
                                                     const Date& end,
                                                     bool isInArrears = false,
@@ -90,17 +98,39 @@ namespace subperiodcoupons_test {
         CommonVars vars;
         Date paymentDate = vars.calendar.advance(end, 1 * Days, vars.businessConvention);
         Date exCouponDate = vars.calendar.advance(paymentDate, -2 * Days, vars.businessConvention);
-        return ext::shared_ptr<CashFlow>(new SubPeriodsCoupon(
+        ext::shared_ptr<FloatingRateCoupon> cpn(new SubPeriodsCoupon(
             paymentDate, 1.0, start, end, vars.settlementDays, vars.euribor, 1.0, spread, 0.0,
             Date(), Date(), vars.dayCount, isInArrears, exCouponDate));
+        cpn->setPricer(ext::shared_ptr<FloatingRateCouponPricer>(new CompoundingRatePricer()));
+        return cpn;
     }
 }
 
 void SubPeriodsCouponTest::test() {
     BOOST_TEST_MESSAGE("...");
 
-}
+    using namespace subperiodcoupons_test;
 
+    Date start(15, April, 2021);
+    Date end(15, September, 2021);
+
+    Leg iborLeg = createIborLeg(start, end);
+    ext::shared_ptr<CashFlow> subPeriodCpn = createSubPeriodsCoupon(start, end);
+
+    Real tolerance = 1.0e-10;
+
+    Real actualPayment = subPeriodCpn->amount();
+    Real expectedPayment = sumLegPayments(iborLeg);
+
+    if (std::fabs(actualPayment - expectedPayment) > tolerance)
+        BOOST_ERROR("unable to replicate sub-periods coupon payment\n"
+                    << std::setprecision(5) << "    calculated:    " << actualPayment << "\n"
+                    << "    expected:    " << expectedPayment << "\n"
+                    << "    start:    " << start << "\n"
+                    << "    end:    " << end << "\n");
+
+
+}
 
 test_suite* SubPeriodsCouponTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Sub-period coupons tests");

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -60,11 +60,7 @@ namespace subperiodcoupons_test {
         }
     };
 
-    Leg createIborLeg(const Date& start, 
-        const Date& end, 
-        bool isInArrears = false,
-        Spread spread = 0.0)
-    {
+    Leg createIborLeg(const Date& start, const Date& end, Spread spread = 0.0) {
         CommonVars vars;
         Schedule sch = MakeSchedule()
                            .from(start)
@@ -79,7 +75,6 @@ namespace subperiodcoupons_test {
             .withSpreads(spread)
             .withExCouponPeriod(2 * Days, vars.calendar, vars.businessConvention)
             .withPaymentLag(1)
-            .inArrears(isInArrears)
             .withFixingDays(vars.settlementDays);
     }
 
@@ -91,16 +86,14 @@ namespace subperiodcoupons_test {
         return payments;
     }
 
-    ext::shared_ptr<CashFlow> createSubPeriodsCoupon(const Date& start,
-                                                    const Date& end,
-                                                    bool isInArrears = false,
-                                                    Spread spread = 0.0) {
+    ext::shared_ptr<CashFlow>
+    createSubPeriodsCoupon(const Date& start, const Date& end, Spread spread = 0.0) {
         CommonVars vars;
         Date paymentDate = vars.calendar.advance(end, 1 * Days, vars.businessConvention);
         Date exCouponDate = vars.calendar.advance(paymentDate, -2 * Days, vars.businessConvention);
-        ext::shared_ptr<FloatingRateCoupon> cpn(new SubPeriodsCoupon(
-            paymentDate, 1.0, start, end, vars.settlementDays, vars.euribor, 1.0, spread, 0.0,
-            Date(), Date(), vars.dayCount, isInArrears, exCouponDate));
+        ext::shared_ptr<FloatingRateCoupon> cpn(
+            new SubPeriodsCoupon(paymentDate, 1.0, start, end, vars.settlementDays, vars.euribor,
+                                 1.0, spread, 0.0, Date(), Date(), DayCounter(), exCouponDate));
         cpn->setPricer(ext::shared_ptr<FloatingRateCouponPricer>(new CompoundingRatePricer()));
         return cpn;
     }
@@ -112,7 +105,7 @@ void SubPeriodsCouponTest::test() {
     using namespace subperiodcoupons_test;
 
     Date start(15, April, 2021);
-    Date end(15, September, 2021);
+    Date end(15, October, 2021);
 
     Leg iborLeg = createIborLeg(start, end);
     ext::shared_ptr<CashFlow> subPeriodCpn = createSubPeriodsCoupon(start, end);
@@ -128,8 +121,6 @@ void SubPeriodsCouponTest::test() {
                     << "    expected:    " << expectedPayment << "\n"
                     << "    start:    " << start << "\n"
                     << "    end:    " << end << "\n");
-
-
 }
 
 test_suite* SubPeriodsCouponTest::suite() {

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -355,21 +355,31 @@ void SubPeriodsCouponTest::testSubPeriodsLegConsistencyChecks() {
     CommonVars vars;
 
     Date start(18, March, 2021);
-    Date end(18, March, 2022);
-
-    Spread rateSpread = 0.001;
-    Spread couponSpread = 0.002;
+    Date end(18, March, 2031);
 
     SubPeriodsLeg subPeriodLeg =
         vars.createSubPeriodsLeg(start, end, 1 * Years);
 
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withNotionals(std::vector<Real>())), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withNotionals(std::vector<Real>(2, 1.0))), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withFixingDays(std::vector<Natural>(2, 2))), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withGearings(0.0)), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withGearings(std::vector<Real>(2, 1.0))), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withCouponSpreads(std::vector<Spread>(2, 0.0))), Error);
-    BOOST_CHECK_THROW(Leg l(subPeriodLeg.withRateSpreads(std::vector<Spread>(2, 0.0))), Error);
+    BOOST_CHECK_THROW(
+        Leg l0(vars.createSubPeriodsLeg(start, end, 1 * Years).withNotionals(std::vector<Real>())),
+        Error);
+    BOOST_CHECK_THROW(Leg l1(vars.createSubPeriodsLeg(start, end, 1 * Years)
+                                 .withNotionals(std::vector<Real>(11, 1.0))),
+                      Error);
+    BOOST_CHECK_THROW(Leg l2(vars.createSubPeriodsLeg(start, end, 1 * Years)
+                                 .withFixingDays(std::vector<Natural>(11, 2))),
+                      Error);
+    BOOST_CHECK_THROW(Leg l3(vars.createSubPeriodsLeg(start, end, 1 * Years).withGearings(0.0)),
+                      Error);
+    BOOST_CHECK_THROW(Leg l4(vars.createSubPeriodsLeg(start, end, 1 * Years)
+                                 .withGearings(std::vector<Real>(11, 1.0))),
+                      Error);
+    BOOST_CHECK_THROW(Leg l5(vars.createSubPeriodsLeg(start, end, 1 * Years)
+                                 .withCouponSpreads(std::vector<Spread>(11, 0.0))),
+                      Error);
+    BOOST_CHECK_THROW(Leg l6(vars.createSubPeriodsLeg(start, end, 1 * Years)
+                                 .withRateSpreads(std::vector<Spread>(11, 0.0))),
+                      Error);
 }
 
 test_suite* SubPeriodsCouponTest::suite() {

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -37,7 +37,6 @@ namespace subperiodcoupons_test {
         BusinessDayConvention businessConvention;
 
         ext::shared_ptr<IborIndex> euribor;
-
         RelinkableHandle<YieldTermStructure> euriborHandle;
 
         // cleanup
@@ -51,6 +50,7 @@ namespace subperiodcoupons_test {
             businessConvention = ModifiedFollowing;
 
             euribor = ext::shared_ptr<IborIndex>(new Euribor6M(euriborHandle));
+            euribor->addFixing(Date(10, February, 2021), 0.0085);
 
             today = calendar.adjust(Date(15, March, 2021));
             Settings::instance().evaluationDate() = today;
@@ -58,75 +58,116 @@ namespace subperiodcoupons_test {
 
             euriborHandle.linkTo(flatRate(settlement, 0.007, dayCount));
         }
+
+        Leg createIborLeg(const Date& start, const Date& end, Spread spread = 0.0) {
+            Schedule sch = MakeSchedule()
+                               .from(start)
+                               .to(end)
+                               .withTenor(euribor->tenor())
+                               .withCalendar(euribor->fixingCalendar())
+                               .withConvention(euribor->businessDayConvention())
+                               .backwards()
+                               .endOfMonth(euribor->endOfMonth());
+            return IborLeg(sch, euribor)
+                .withNotionals(1.0)
+                .withSpreads(spread)
+                .withExCouponPeriod(2 * Days, calendar, businessConvention)
+                .withPaymentLag(1)
+                .withFixingDays(settlementDays);
+        }
+
+        ext::shared_ptr<CashFlow>
+        createSubPeriodsCoupon(const Date& start, const Date& end, Spread spread = 0.0) {
+            Date paymentDate = calendar.advance(end, 1 * Days, businessConvention);
+            Date exCouponDate = calendar.advance(paymentDate, -2 * Days, businessConvention);
+            ext::shared_ptr<FloatingRateCoupon> cpn(
+                new SubPeriodsCoupon(paymentDate, 1.0, start, end, settlementDays, euribor, 1.0,
+                                     spread, 0.0, Date(), Date(), DayCounter(), exCouponDate));
+            cpn->setPricer(ext::shared_ptr<FloatingRateCouponPricer>(new CompoundingRatePricer()));
+            return cpn;
+        }
     };
 
-    Leg createIborLeg(const Date& start, const Date& end, Spread spread = 0.0) {
-        CommonVars vars;
-        Schedule sch = MakeSchedule()
-                           .from(start)
-                           .to(end)
-                           .withTenor(vars.euribor->tenor())
-                           .withCalendar(vars.euribor->fixingCalendar())
-                           .withConvention(vars.euribor->businessDayConvention())
-                           .backwards()
-                           .endOfMonth(vars.euribor->endOfMonth());
-        return IborLeg(sch, vars.euribor)
-            .withNotionals(1.0)
-            .withSpreads(spread)
-            .withExCouponPeriod(2 * Days, vars.calendar, vars.businessConvention)
-            .withPaymentLag(1)
-            .withFixingDays(vars.settlementDays);
-    }
-
-    Real sumLegPayments(const Leg& leg)
+    Real sumIborLegPayments(const Leg& leg)
     {
         Real payments = 0.0;
-        std::for_each(leg.begin(), leg.end(),
-                      [&](const ext::shared_ptr<CashFlow>& cf) { payments += cf->amount(); });
+        std::for_each(leg.begin(), leg.end(), [&payments](const ext::shared_ptr<CashFlow>& cf) {
+            payments += cf->amount();
+        });
         return payments;
     }
 
-    ext::shared_ptr<CashFlow>
-    createSubPeriodsCoupon(const Date& start, const Date& end, Spread spread = 0.0) {
-        CommonVars vars;
-        Date paymentDate = vars.calendar.advance(end, 1 * Days, vars.businessConvention);
-        Date exCouponDate = vars.calendar.advance(paymentDate, -2 * Days, vars.businessConvention);
-        ext::shared_ptr<FloatingRateCoupon> cpn(
-            new SubPeriodsCoupon(paymentDate, 1.0, start, end, vars.settlementDays, vars.euribor,
-                                 1.0, spread, 0.0, Date(), Date(), DayCounter(), exCouponDate));
-        cpn->setPricer(ext::shared_ptr<FloatingRateCouponPricer>(new CompoundingRatePricer()));
-        return cpn;
+    Real compoundedIborLegPayment(const Leg& leg) {
+        Real compound = 1.0;
+        std::for_each(leg.begin(), leg.end(), [&compound](const ext::shared_ptr<CashFlow>& cf) {
+            auto cpn = ext::dynamic_pointer_cast<IborCoupon>(cf);
+            Real yearFraction = cpn->accrualPeriod();
+            Rate fixing = cpn->indexFixing();
+            compound *= (1.0 + yearFraction * fixing);
+        });
+        return (compound - 1.0);
     }
 }
 
-void SubPeriodsCouponTest::test() {
-    BOOST_TEST_MESSAGE("...");
-
+void testSinglePeriodCouponReplication(const Date& start, const Date& end) {
     using namespace subperiodcoupons_test;
+    CommonVars vars;
 
-    Date start(15, April, 2021);
-    Date end(15, October, 2021);
+    Leg iborLeg = vars.createIborLeg(start, end);
+    ext::shared_ptr<CashFlow> subPeriodCpn = vars.createSubPeriodsCoupon(start, end);
 
-    Leg iborLeg = createIborLeg(start, end);
-    ext::shared_ptr<CashFlow> subPeriodCpn = createSubPeriodsCoupon(start, end);
-
-    Real tolerance = 1.0e-10;
+    Real tolerance = 1.0e-14;
 
     Real actualPayment = subPeriodCpn->amount();
-    Real expectedPayment = sumLegPayments(iborLeg);
+    Real expectedPayment = sumIborLegPayments(iborLeg);
 
     if (std::fabs(actualPayment - expectedPayment) > tolerance)
-        BOOST_ERROR("unable to replicate sub-periods coupon payment\n"
+        BOOST_ERROR("unable to replicate single period coupon payment using sub-periods coupon\n"
                     << std::setprecision(5) << "    calculated:    " << actualPayment << "\n"
                     << "    expected:    " << expectedPayment << "\n"
                     << "    start:    " << start << "\n"
                     << "    end:    " << end << "\n");
 }
 
+void SubPeriodsCouponTest::testRegularSinglePeriodForwardStartingCoupon() {
+    BOOST_TEST_MESSAGE("Testing regular single period forward starting coupon...");
+
+    Date start(15, April, 2021);
+    Date end(15, October, 2021);
+
+    testSinglePeriodCouponReplication(start, end);
+}
+
+void SubPeriodsCouponTest::testRegularSinglePeriodCouponAfterFixing() {
+    BOOST_TEST_MESSAGE("Testing regular single period coupon after fixing...");
+
+    using namespace subperiodcoupons_test;
+
+    Date start(12, February, 2021);
+    Date end(12, August, 2021);
+
+     testSinglePeriodCouponReplication(start, end);
+}
+
+void SubPeriodsCouponTest::testIrregularSinglePeriodCouponAfterFixing() {
+    BOOST_TEST_MESSAGE("Testing regular single period coupon after fixing...");
+
+    using namespace subperiodcoupons_test;
+
+    Date start(12, February, 2021);
+    Date end(12, June, 2021);
+
+    testSinglePeriodCouponReplication(start, end);
+}
+
 test_suite* SubPeriodsCouponTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Sub-period coupons tests");
 
-    suite->add(QUANTLIB_TEST_CASE(&SubPeriodsCouponTest::test));
+    suite->add(
+        QUANTLIB_TEST_CASE(&SubPeriodsCouponTest::testRegularSinglePeriodForwardStartingCoupon));
+    suite->add(QUANTLIB_TEST_CASE(&SubPeriodsCouponTest::testRegularSinglePeriodCouponAfterFixing));
+    suite->add(
+        QUANTLIB_TEST_CASE(&SubPeriodsCouponTest::testIrregularSinglePeriodCouponAfterFixing));
 
     return suite;
 }

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -80,7 +80,7 @@ namespace subperiodcoupons_test {
                                                          const Date& end,
                                                          Spread rateSpread = 0.0,
                                                          Spread couponSpread = 0.0,
-                                                         SubPeriodsAveraging::Type averaging = SubPeriodsAveraging::Compound) {
+                                                         RateAveraging::Type averaging = RateAveraging::Compound) {
             Calendar paymentCalendar = euribor->fixingCalendar();
             BusinessDayConvention paymentBdc = euribor->businessDayConvention();
             Date paymentDate = paymentCalendar.advance(end, 1 * Days, paymentBdc);
@@ -88,7 +88,7 @@ namespace subperiodcoupons_test {
             ext::shared_ptr<FloatingRateCoupon> cpn(new SubPeriodsCoupon(
                 paymentDate, 1.0, start, end, settlementDays, euribor, 1.0, couponSpread,
                 rateSpread, Date(), Date(), DayCounter(), exCouponDate));
-            bool useCompoundedRate = (averaging == SubPeriodsAveraging::Compound);
+            bool useCompoundedRate = (averaging == RateAveraging::Compound);
             if (useCompoundedRate)
                 cpn->setPricer(
                     ext::shared_ptr<FloatingRateCouponPricer>(new CompoundingRatePricer()));
@@ -103,7 +103,7 @@ namespace subperiodcoupons_test {
                                           const Period& cpnFrequency,
                                           Spread rateSpread = 0.0,
                                           Spread couponSpread = 0.0,
-                                          SubPeriodsAveraging::Type averaging = SubPeriodsAveraging::Compound) {
+                                          RateAveraging::Type averaging = RateAveraging::Compound) {
             Schedule sch = MakeSchedule()
                                .from(start)
                                .to(end)
@@ -157,7 +157,7 @@ namespace subperiodcoupons_test {
 void testSinglePeriodCouponReplication(const Date& start,
                                        const Date& end,
                                        Spread rateSpread,
-                                       SubPeriodsAveraging::Type averaging) {
+                                       RateAveraging::Type averaging) {
     using namespace subperiodcoupons_test;
     CommonVars vars;
 
@@ -189,7 +189,7 @@ void testMultipleCompoundedSubPeriodsCouponReplication(const Date& start,
 
     Spread couponSpread = 0.0;
     ext::shared_ptr<CashFlow> subPeriodCpn = vars.createSubPeriodsCoupon(
-        start, end, rateSpread, couponSpread, SubPeriodsAveraging::Compound);
+        start, end, rateSpread, couponSpread, RateAveraging::Compound);
 
     const Real tolerance = 1.0e-14;
 
@@ -214,7 +214,7 @@ void testMultipleAveragedSubPeriodsCouponReplication(const Date& start,
     
     Spread couponSpread = 0.0;
     ext::shared_ptr<CashFlow> subPeriodCpn = vars.createSubPeriodsCoupon(
-        start, end, rateSpread, couponSpread, SubPeriodsAveraging::Simple);
+        start, end, rateSpread, couponSpread, RateAveraging::Simple);
 
     const Real tolerance = 1.0e-14;
 
@@ -229,7 +229,7 @@ void testMultipleAveragedSubPeriodsCouponReplication(const Date& start,
                     << "    end:    " << end << "\n");
 }
 
-void testSubPeriodsLegReplication(SubPeriodsAveraging::Type averaging) {
+void testSubPeriodsLegReplication(RateAveraging::Type averaging) {
     using namespace subperiodcoupons_test;
     CommonVars vars;
 
@@ -269,8 +269,8 @@ void SubPeriodsCouponTest::testRegularSinglePeriodForwardStartingCoupon() {
 
     Spread spread = 0.001;
     // For a single sub-period averaging method should not matter.
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Compound);
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Simple);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Compound);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Simple);
 }
 
 void SubPeriodsCouponTest::testRegularSinglePeriodCouponAfterFixing() {
@@ -281,8 +281,8 @@ void SubPeriodsCouponTest::testRegularSinglePeriodCouponAfterFixing() {
 
     Spread spread = 0.001;
     // For a single sub-period averaging method should not matter.
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Compound);
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Simple);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Compound);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Simple);
 }
 
 void SubPeriodsCouponTest::testIrregularSinglePeriodCouponAfterFixing() {
@@ -293,8 +293,8 @@ void SubPeriodsCouponTest::testIrregularSinglePeriodCouponAfterFixing() {
 
     Spread spread = 0.001;
     // For a single sub-period averaging method should not matter.
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Compound);
-    testSinglePeriodCouponReplication(start, end, spread, SubPeriodsAveraging::Simple);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Compound);
+    testSinglePeriodCouponReplication(start, end, spread, RateAveraging::Simple);
 }
 
 void SubPeriodsCouponTest::testRegularCompoundedForwardStartingCouponWithMultipleSubPeriods() {
@@ -344,8 +344,8 @@ void SubPeriodsCouponTest::testSubPeriodsLegCashFlows() {
     BOOST_TEST_MESSAGE(
         "Testing sub-periods leg replication...");
 
-    testSubPeriodsLegReplication(SubPeriodsAveraging::Compound);
-    testSubPeriodsLegReplication(SubPeriodsAveraging::Simple);
+    testSubPeriodsLegReplication(RateAveraging::Compound);
+    testSubPeriodsLegReplication(RateAveraging::Simple);
 }
 
 void SubPeriodsCouponTest::testSubPeriodsLegConsistencyChecks() {

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -113,7 +113,7 @@ namespace subperiodcoupons_test {
     }
 
     Real averagedIborLegPayment(const Leg& leg) {
-        Real acc = 1.0;
+        Real acc = 0.0;
         std::for_each(leg.begin(), leg.end(), [&acc](const ext::shared_ptr<CashFlow>& cf) {
             auto cpn = ext::dynamic_pointer_cast<IborCoupon>(cf);
             Real yearFraction = cpn->accrualPeriod();

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -18,7 +18,7 @@
 
 #include "subperiodcoupons.hpp"
 #include "utilities.hpp"
-#include <ql/experimental/coupons/subperiodcoupons.hpp>
+#include <ql/cashflows/subperiodcoupon.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/indexes/ibor/euribor.hpp>

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -30,6 +30,8 @@ class SubPeriodsCouponTest {
     static void testRegularSinglePeriodForwardStartingCoupon();
     static void testRegularSinglePeriodCouponAfterFixing();
     static void testIrregularSinglePeriodCouponAfterFixing();
+    static void testRegularCompoundedForwardStartingCouponWithMultipleSubPeriods();
+    static void testRegularAveragedForwardStartingCouponWithMultipleSubPeriods();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_subperiodcoupons_hpp
+#define quantlib_test_subperiodcoupons_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class SubPeriodsCouponTest {
+  public:
+    static void test();
+
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -27,7 +27,9 @@
 
 class SubPeriodsCouponTest {
   public:
-    static void test();
+    static void testRegularSinglePeriodForwardStartingCoupon();
+    static void testRegularSinglePeriodCouponAfterFixing();
+    static void testIrregularSinglePeriodCouponAfterFixing();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -32,6 +32,7 @@ class SubPeriodsCouponTest {
     static void testIrregularSinglePeriodCouponAfterFixing();
     static void testRegularCompoundedForwardStartingCouponWithMultipleSubPeriods();
     static void testRegularAveragedForwardStartingCouponWithMultipleSubPeriods();
+    static void testExCouponCashFlow();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -33,6 +33,7 @@ class SubPeriodsCouponTest {
     static void testRegularCompoundedForwardStartingCouponWithMultipleSubPeriods();
     static void testRegularAveragedForwardStartingCouponWithMultipleSubPeriods();
     static void testExCouponCashFlow();
+    static void testSubPeriodsLegCashFlows();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/subperiodcoupons.hpp
+++ b/test-suite/subperiodcoupons.hpp
@@ -34,6 +34,7 @@ class SubPeriodsCouponTest {
     static void testRegularAveragedForwardStartingCouponWithMultipleSubPeriods();
     static void testExCouponCashFlow();
     static void testSubPeriodsLegCashFlows();
+    static void testSubPeriodsLegConsistencyChecks();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -770,6 +770,7 @@
     <ClCompile Include="spreadoption.cpp" />
     <ClCompile Include="squarerootclvmodel.cpp" />
     <ClCompile Include="stats.cpp" />
+    <ClCompile Include="subperiodcoupons.cpp" />
     <ClCompile Include="swap.cpp" />
     <ClCompile Include="swapforwardmappings.cpp" />
     <ClCompile Include="swaption.cpp" />
@@ -932,6 +933,7 @@
     <ClInclude Include="spreadoption.hpp" />
     <ClInclude Include="squarerootclvmodel.hpp" />
     <ClInclude Include="stats.hpp" />
+    <ClInclude Include="subperiodcoupons.hpp" />
     <ClInclude Include="swap.hpp" />
     <ClInclude Include="swapforwardmappings.hpp" />
     <ClInclude Include="swaption.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -483,6 +483,9 @@
     <ClCompile Include="crosscurrencyratehelpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="subperiodcoupons.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="americanoption.hpp">
@@ -963,6 +966,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="crosscurrencyratehelpers.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="subperiodcoupons.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
In this PR I would like to propose a number of changes in the interface of `SubPeriodsCoupon` class. 
Given that the class was still in the experimental folder and had no unit tests, I took the liberty to refactor the code somewhat more radically, aligning the naming conventions to those in similar classes, notably e.g. `OvernightIndexedCoupon`. 

The list of changes is as follows:
1) Added ex-coupon option to the constructor and rearranged it to become more consistent with other coupon classes.
2) Removed members such as `startTime_`, `endTime_`, which did not seem to be used anywhere and I did not see the need to keep them (but I may be overlooking something).
3) Removed `observationsSchedule_` as `observationsDates_ ` (renamed to `valueDates_`) are already sufficient, I believe.
4) Changed the way the sub-period fractions (`observationCvg_` renamed to --> `dt_`) are calculated, from always assuming that the fraction is the same as the accrual period of the index, to taking the fraction between value dates, even though it may turn out to be irregular. 
5) Simplified `SubPeriodsPricer`. It should still return the same result, but certain steps were not needed, e.g. `swapletPrice` method. Also part of the calculations, such as the sub-period accruals were moved to the coupon constructor. 
6) Added `SubPeriodsAveraging` scoped enum to easily switch between simple and compounded averaging methods. 
7) Added `SubPeriodsLeg` for easier instantiation of the series of coupons.
8) Added a number of unit tests to check the validity of the results.

Looking forward to your feedback.