### PR TITLE
Avoid dangling else in error macros

### DIFF
--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
 
     void CPICouponPricer::setCapletVolatility(
        const Handle<CPIVolatilitySurface>& capletVol) {
-        QL_REQUIRE(!capletVol.empty(),"empty capletVol handle")
+        QL_REQUIRE(!capletVol.empty(),"empty capletVol handle");
         capletVol_ = capletVol;
         registerWith(capletVol_);
     }

--- a/ql/cashflows/inflationcouponpricer.cpp
+++ b/ql/cashflows/inflationcouponpricer.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
 
     void YoYInflationCouponPricer::setCapletVolatility(
        const Handle<YoYOptionletVolatilitySurface>& capletVol) {
-        QL_REQUIRE(!capletVol.empty(),"empty capletVol handle")
+        QL_REQUIRE(!capletVol.empty(),"empty capletVol handle");
         capletVol_ = capletVol;
         registerWith(capletVol_);
     }

--- a/ql/errors.hpp
+++ b/ql/errors.hpp
@@ -60,19 +60,45 @@ namespace QuantLib {
 
 }
 
-/* Fix C4127: conditional expression is constant when wrapping macros
-   with do { ... } while(false); on MSVC
-*/
-#define MULTILINE_MACRO_BEGIN do {
+#define QL_MULTILINE_FAILURE_BEGIN do {
 
+/* Disable warning C4127 (conditional expression is constant) when
+   wrapping macros with the do { ... } while(false) construct on MSVC
+*/
 #if defined(BOOST_MSVC)
-    #define MULTILINE_MACRO_END \
+    #define QL_MULTILINE_FAILURE_END \
         __pragma(warning(push)) \
         __pragma(warning(disable:4127)) \
         } while(false) \
         __pragma(warning(pop))
 #else
-    #define MULTILINE_MACRO_END } while(false)
+    #define QL_MULTILINE_FAILURE_END } while(false)
+#endif
+
+
+/* on MSVC++13 the do { ... } while(false) construct fails inside a
+   for loop without brackets, so we use a dangling else instead */
+#if defined(QL_PATCH_MSVC_2013)
+#define QL_MULTILINE_ASSERTION_BEGIN
+#else
+#define QL_MULTILINE_ASSERTION_BEGIN do {
+#endif
+
+/* Disable warning C4127 (conditional expression is constant) when
+   wrapping macros with the do { ... } while(false) construct on MSVC
+*/
+#if defined(BOOST_MSVC)
+    #if defined(QL_PATCH_MSVC_2013)
+    #define QL_MULTILINE_ASSERTION_END else
+    #else
+    #define QL_MULTILINE_ASSERTION_END \
+        __pragma(warning(push)) \
+        __pragma(warning(disable:4127)) \
+        } while(false) \
+        __pragma(warning(pop))
+    #endif
+#else
+    #define QL_MULTILINE_ASSERTION_END } while(false)
 #endif
 
 
@@ -80,48 +106,52 @@ namespace QuantLib {
     \brief throw an error (possibly with file and line information)
 */
 #define QL_FAIL(message) \
-MULTILINE_MACRO_BEGIN \
+QL_MULTILINE_FAILURE_BEGIN \
     std::ostringstream _ql_msg_stream; \
     _ql_msg_stream << message; \
     throw QuantLib::Error(__FILE__,__LINE__, \
                           BOOST_CURRENT_FUNCTION,_ql_msg_stream.str()); \
-MULTILINE_MACRO_END
+QL_MULTILINE_FAILURE_END
 
 
 /*! \def QL_ASSERT
     \brief throw an error if the given condition is not verified
 */
 #define QL_ASSERT(condition,message) \
+QL_MULTILINE_ASSERTION_BEGIN \
 if (!(condition)) { \
     std::ostringstream _ql_msg_stream; \
     _ql_msg_stream << message; \
     throw QuantLib::Error(__FILE__,__LINE__, \
                           BOOST_CURRENT_FUNCTION,_ql_msg_stream.str()); \
- } else 
-
+} \
+QL_MULTILINE_ASSERTION_END
 
 /*! \def QL_REQUIRE
     \brief throw an error if the given pre-condition is not verified
 */
 #define QL_REQUIRE(condition,message) \
+QL_MULTILINE_ASSERTION_BEGIN \
 if (!(condition)) { \
     std::ostringstream _ql_msg_stream; \
     _ql_msg_stream << message; \
     throw QuantLib::Error(__FILE__,__LINE__, \
                           BOOST_CURRENT_FUNCTION,_ql_msg_stream.str()); \
- } else 
-
+} \
+QL_MULTILINE_ASSERTION_END
 
 /*! \def QL_ENSURE
     \brief throw an error if the given post-condition is not verified
 */
 #define QL_ENSURE(condition,message) \
+QL_MULTILINE_ASSERTION_BEGIN \
 if (!(condition)) { \
     std::ostringstream _ql_msg_stream; \
     _ql_msg_stream << message; \
     throw QuantLib::Error(__FILE__,__LINE__, \
                           BOOST_CURRENT_FUNCTION,_ql_msg_stream.str()); \
- } else 
+} \
+QL_MULTILINE_ASSERTION_END
 
 
 #endif

--- a/ql/experimental/credit/onefactoraffinesurvival.hpp
+++ b/ql/experimental/credit/onefactoraffinesurvival.hpp
@@ -110,7 +110,7 @@ namespace QuantLib {
                 bool extrapolate = false) const
         {
             #if defined(QL_EXTRA_SAFETY_CHECKS)
-                    QL_REQUIRE(tgt >= tFwd, "Incorrect dates ordering.")
+                QL_REQUIRE(tgt >= tFwd, "Incorrect dates ordering.");
             #endif
             checkRange(tFwd, extrapolate);
             checkRange(tgt, extrapolate);
@@ -137,7 +137,7 @@ namespace QuantLib {
       virtual Probability conditionalSurvivalProbabilityImpl(Time tFwd, Time tgt, Real yVal) const;
 
       // HazardRateStructure interface
-      Real hazardRateImpl(Time t) const override {
+      Real hazardRateImpl(Time) const override {
           // no deterministic component
           return 0.;
       }

--- a/ql/experimental/variancegamma/analyticvariancegammaengine.cpp
+++ b/ql/experimental/variancegamma/analyticvariancegammaengine.cpp
@@ -82,7 +82,7 @@ namespace QuantLib {
     VarianceGammaEngine::VarianceGammaEngine(ext::shared_ptr<VarianceGammaProcess> process,
                                              Real absoluteError)
     : process_(std::move(process)), absErr_(absoluteError) {
-        QL_REQUIRE(absErr_ > 0, "absolute error must be positive")
+        QL_REQUIRE(absErr_ > 0, "absolute error must be positive");
         registerWith(process_);
     }
 

--- a/ql/instruments/vanillaswingoption.cpp
+++ b/ql/instruments/vanillaswingoption.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
         QL_REQUIRE(exercise, "no exercise given");
 
         QL_REQUIRE(minExerciseRights <= maxExerciseRights,
-                   "minExerciseRights <= maxExerciseRights")
+                   "minExerciseRights <= maxExerciseRights");
         QL_REQUIRE(exercise->dates().size() >= maxExerciseRights,
                    "number of exercise rights exceeds "
                    "number of exercise dates");

--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -191,7 +191,7 @@ namespace QuantLib {
             }
             bool test(const Array& params) const override {
                 QL_ENSURE(params.size()==low_.size(),
-                          "Number of parameters and boundaries sizes are inconsistent.")
+                          "Number of parameters and boundaries sizes are inconsistent.");
                 for (Size i = 0; i < params.size(); i++) {
                     if ((params[i] < low_[i]) || (params[i] > high_[i]))
                         return false;

--- a/ql/math/randomnumbers/randomizedlds.hpp
+++ b/ql/math/randomnumbers/randomizedlds.hpp
@@ -91,7 +91,7 @@ namespace QuantLib {
         QL_REQUIRE(prsg_.dimension()==dimension_,
                    "generator mismatch: "
                    << dimension_ << "-dim low discrepancy "
-                   << "and " << prsg_.dimension() << "-dim pseudo random")
+                   << "and " << prsg_.dimension() << "-dim pseudo random");
 
         randomizer_ = prsg_.nextSequence();
     }

--- a/ql/methods/finitedifferences/operators/fdmbatesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.cpp
@@ -77,7 +77,7 @@ namespace QuantLib {
                 = ext::dynamic_pointer_cast<FdmDirichletBoundary>(*iter);
 
             QL_REQUIRE(dirichlet, "FdmBatesOp can only deal with Dirichlet "
-                                  "boundary conditions.")
+                                  "boundary conditions.");
 
             valueOfDerivative
                 = dirichlet->applyAfterApplying(x, valueOfDerivative);

--- a/ql/models/marketmodels/marketmodel.cpp
+++ b/ql/models/marketmodels/marketmodel.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
         }
         QL_REQUIRE(i<covariance_.size(),
                    "i (" << i <<
-                   ") must be less than covariance_.size() (" << covariance_.size() << ")")
+                   ") must be less than covariance_.size() (" << covariance_.size() << ")");
         return covariance_[i];
     }
 
@@ -48,7 +48,7 @@ namespace QuantLib {
         }
         QL_REQUIRE(endIndex<covariance_.size(),
                    "endIndex (" << endIndex <<
-                   ") must be less than covariance_.size() (" << covariance_.size() << ")")
+                   ") must be less than covariance_.size() (" << covariance_.size() << ")");
         return totalCovariance_[endIndex];
     }
 

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -144,7 +144,7 @@ namespace detail {
     void IterativeBootstrap<Curve>::setup(Curve* ts) {
         ts_ = ts;
         n_ = ts_->instruments_.size();
-        QL_REQUIRE(n_ > 0, "no bootstrap helpers given")
+        QL_REQUIRE(n_ > 0, "no bootstrap helpers given");
         for (Size j=0; j<n_; ++j)
             ts_->registerWith(ts_->instruments_[j]);
 

--- a/ql/termstructures/volatility/smilesectionutils.cpp
+++ b/ql/termstructures/volatility/smilesectionutils.cpp
@@ -138,7 +138,7 @@ namespace QuantLib {
             centralIndex++;
 
         QL_REQUIRE(centralIndex < k_.size(),
-                   "central index is at right boundary")
+                   "central index is at right boundary");
 
         leftIndex_ = centralIndex;
         rightIndex_ = centralIndex;


### PR DESCRIPTION
At times, the old version of the macros could cause a misleading-intentation warning.

Also, switching to the new version helped find out a number of places in which the semicolon after the macro was missing. Luckily, this resulted in the same effective behavior.

