### PR TITLE
Fix typo in FuturesRateHelper.

### DIFF
--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -194,7 +194,7 @@ namespace QuantLib {
                            "end date (" << iborEndDate <<
                            ") must be greater than start date (" <<
                            iborStartDate << ")");
-                latestRelevantDate_ = iborEndDate;
+                maturityDate_ = iborEndDate;
             }
             break;
           default:


### PR DESCRIPTION
This is just to fix a typo in the `FuturesRateHelper` that came up on [this](https://quant.stackexchange.com/a/63695/50869) quant.stackexchange post.

I was going to add the logic in this constructor to a private method because it is identical to that of the `FuturesRateHelper(const Handle<Quote>& price, const Date& iborStartDate, const Date& iborEndDate, const DayCounter& dayCounter, Handle<Quote> convexityAdjustment = Handle<Quote>(), Futures::Type type = Futures::IMM);` constructor and could be shared. The same could be done for the other 2 constructor pairs i.e. giving 3 private methods. Not sure if it would be desirable though so left it as is for now.