### PR TITLE
A few changes to 30/360 day count convention

### DIFF
--- a/Examples/CDS/CDS.cpp
+++ b/Examples/CDS/CDS.cpp
@@ -275,44 +275,46 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
                   << "of the ISDA rate curve." << std::endl;
     }
 
+    DayCounter thirty360 = Thirty360(Thirty360::BondBasis);
+
     ext::shared_ptr<SwapRateHelper> sw2y = ext::make_shared<SwapRateHelper>(
-        0.002230, 2 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.002230, 2 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw3y = ext::make_shared<SwapRateHelper>(
-        0.002760, 3 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.002760, 3 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw4y = ext::make_shared<SwapRateHelper>(
-        0.003530, 4 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.003530, 4 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw5y = ext::make_shared<SwapRateHelper>(
-        0.004520, 5 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.004520, 5 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw6y = ext::make_shared<SwapRateHelper>(
-        0.005720, 6 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.005720, 6 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw7y = ext::make_shared<SwapRateHelper>(
-        0.007050, 7 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.007050, 7 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw8y = ext::make_shared<SwapRateHelper>(
-        0.008420, 8 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.008420, 8 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw9y = ext::make_shared<SwapRateHelper>(
-        0.009720, 9 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.009720, 9 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw10y = ext::make_shared<SwapRateHelper>(
-        0.010900, 10 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.010900, 10 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw12y = ext::make_shared<SwapRateHelper>(
-        0.012870, 12 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.012870, 12 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw15y = ext::make_shared<SwapRateHelper>(
-        0.014970, 15 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.014970, 15 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw20y = ext::make_shared<SwapRateHelper>(
-        0.017000, 20 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.017000, 20 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw30y = ext::make_shared<SwapRateHelper>(
-        0.018210, 30 * Years, TARGET(), Annual, ModifiedFollowing, Thirty360(),
+        0.018210, 30 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
 
     std::vector<ext::shared_ptr<RateHelper> > isdaRateHelper;
@@ -453,82 +455,85 @@ void example03() {
 
     Settings::instance().evaluationDate() = tradeDate;
 
+    DayCounter actual360 = Actual360();
+    DayCounter thirty360 = Thirty360(Thirty360::BondBasis);
+
     ext::shared_ptr<DepositRateHelper> dp1m =
         ext::make_shared<DepositRateHelper>(0.00445, 1 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
     ext::shared_ptr<DepositRateHelper> dp2m =
         ext::make_shared<DepositRateHelper>(0.00949, 2 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
     ext::shared_ptr<DepositRateHelper> dp3m =
         ext::make_shared<DepositRateHelper>(0.01234, 3 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
     ext::shared_ptr<DepositRateHelper> dp6m =
         ext::make_shared<DepositRateHelper>(0.01776, 6 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
     ext::shared_ptr<DepositRateHelper> dp9m =
         ext::make_shared<DepositRateHelper>(0.01935, 9 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
     ext::shared_ptr<DepositRateHelper> dp1y =
         ext::make_shared<DepositRateHelper>(0.02084, 12 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
-                                              false, Actual360());
+                                              false, actual360);
 
     // this index is probably not important since we are not using
     // IborCoupon::usingAtParCoupons() == false 
     // - define it "isda compliant" anyway
     ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<IborIndex>(
         "IsdaIbor", 6 * Months, 2, EURCurrency(), WeekendsOnly(),
-        ModifiedFollowing, false, Actual360());
+        ModifiedFollowing, false, actual360);
 
     ext::shared_ptr<SwapRateHelper> sw2y = ext::make_shared<SwapRateHelper>(
-        0.01652, 2 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.01652, 2 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw3y = ext::make_shared<SwapRateHelper>(
-        0.02018, 3 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02018, 3 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw4y = ext::make_shared<SwapRateHelper>(
-        0.02303, 4 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02303, 4 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw5y = ext::make_shared<SwapRateHelper>(
-        0.02525, 5 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02525, 5 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw6y = ext::make_shared<SwapRateHelper>(
-        0.02696, 6 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02696, 6 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw7y = ext::make_shared<SwapRateHelper>(
-        0.02825, 7 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02825, 7 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw8y = ext::make_shared<SwapRateHelper>(
-        0.02931, 8 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.02931, 8 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw9y = ext::make_shared<SwapRateHelper>(
-        0.03017, 9 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03017, 9 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw10y = ext::make_shared<SwapRateHelper>(
-        0.03092, 10 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03092, 10 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw11y = ext::make_shared<SwapRateHelper>(
-        0.03160, 11 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03160, 11 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw12y = ext::make_shared<SwapRateHelper>(
-        0.03231, 12 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03231, 12 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw15y = ext::make_shared<SwapRateHelper>(
-        0.03367, 15 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03367, 15 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw20y = ext::make_shared<SwapRateHelper>(
-        0.03419, 20 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03419, 20 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw25y = ext::make_shared<SwapRateHelper>(
-        0.03411, 25 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03411, 25 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
     ext::shared_ptr<SwapRateHelper> sw30y = ext::make_shared<SwapRateHelper>(
-        0.03412, 30 * Years, WeekendsOnly(), Annual, ModifiedFollowing, Thirty360(),
+        0.03412, 30 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
 
     std::vector<ext::shared_ptr<RateHelper> > isdaYieldHelpers;

--- a/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -86,7 +86,7 @@ int main(int, char* []) {
 
         std::vector<Real> coupons(1, 0.05);
 
-        DayCounter bondDayCount = Thirty360();
+        DayCounter bondDayCount = Thirty360(Thirty360::BondBasis);
 
         Integer callLength[] = { 2, 4 };  // Call dates, years 2, 4.
         Integer putLength[] = { 3 }; // Put dates year 3

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
 
         ext::shared_ptr<NonstandardSwap> underlying =
             ext::make_shared<NonstandardSwap>(VanillaSwap(
-                VanillaSwap::Payer, 1.0, fixedSchedule, strike, Thirty360(),
+                VanillaSwap::Payer, 1.0, fixedSchedule, strike, Thirty360(Thirty360::BondBasis),
                 floatingSchedule, euribor6m, 0.00, Actual360()));
 
         std::vector<Date> exerciseDates;
@@ -356,7 +356,7 @@ int main(int argc, char *argv[]) {
 
         ext::shared_ptr<NonstandardSwap> underlying2(new NonstandardSwap(
             VanillaSwap::Payer, nominalFixed, nominalFloating, fixedSchedule,
-            strikes, Thirty360(), floatingSchedule, euribor6m, 1.0, 0.0,
+            strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, 1.0, 0.0,
             Actual360()));
         ext::shared_ptr<NonstandardSwaption> swaption2 =
             ext::make_shared<NonstandardSwaption>(underlying2, exercise);
@@ -392,7 +392,7 @@ int main(int argc, char *argv[]) {
 
         ext::shared_ptr<NonstandardSwap> underlying3(new NonstandardSwap(
             VanillaSwap::Receiver, nominalFixed2, nominalFloating2,
-            fixedSchedule, strikes, Thirty360(), floatingSchedule, euribor6m,
+            fixedSchedule, strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m,
             1.0, 0.0, Actual360(), false,
             true)); // final capital exchange
 
@@ -487,7 +487,7 @@ int main(int argc, char *argv[]) {
 
         ext::shared_ptr<FloatFloatSwap> underlying4(new FloatFloatSwap(
                 VanillaSwap::Payer, 1.0, 1.0, fixedSchedule, swapBase,
-                Thirty360(), floatingSchedule, euribor6m, Actual360(), false,
+                Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, Actual360(), false,
                 false, 1.0, 0.0, Null<Real>(), Null<Real>(), 1.0, 0.0010));
 
         ext::shared_ptr<FloatFloatSwaption> swaption4 =

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -152,7 +152,7 @@ namespace QuantLib {
                    const Real baseCPI,
                    const Period& observationLag)
     : schedule_(schedule), index_(std::move(index)), baseCPI_(baseCPI),
-      observationLag_(observationLag), paymentDayCounter_(Thirty360()),
+      observationLag_(observationLag), paymentDayCounter_(Thirty360(Thirty360::BondBasis)),
       paymentAdjustment_(ModifiedFollowing), paymentCalendar_(schedule.calendar()),
       fixingDays_(std::vector<Natural>(1, 0)), observationInterpolation_(CPI::AsIndex),
       subtractInflationNominal_(true), spreads_(std::vector<Real>(1, 0)) {}

--- a/ql/instruments/makeyoyinflationcapfloor.cpp
+++ b/ql/instruments/makeyoyinflationcapfloor.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     : capFloorType_(capFloorType), length_(length), calendar_(std::move(cal)),
       index_(std::move(index)), observationLag_(observationLag), strike_(Null<Rate>()),
       firstCapletExcluded_(false), asOptionlet_(false), effectiveDate_(Date()),
-      dayCounter_(Thirty360()), roll_(ModifiedFollowing), fixingDays_(0), nominal_(1000000.0) {}
+      dayCounter_(Thirty360(Thirty360::BondBasis)), roll_(ModifiedFollowing), fixingDays_(0), nominal_(1000000.0) {}
 
     MakeYoYInflationCapFloor::operator YoYInflationCapFloor() const {
         ext::shared_ptr<YoYInflationCapFloor> capfloor = *this;

--- a/ql/time/daycounters/simpledaycounter.cpp
+++ b/ql/time/daycounters/simpledaycounter.cpp
@@ -22,7 +22,7 @@
 
 namespace QuantLib {
 
-    namespace { DayCounter fallback = Thirty360(); }
+    namespace { DayCounter fallback = Thirty360(Thirty360::BondBasis); }
 
     Date::serial_type SimpleDayCounter::Impl::dayCount(const Date& d1,
                                                        const Date& d2) const {

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -115,7 +115,14 @@ namespace QuantLib {
         };
         static ext::shared_ptr<DayCounter::Impl> implementation(Convention c, bool isLastPeriod);
       public:
-        Thirty360(Convention c = Thirty360::BondBasis, bool isLastPeriod = false)
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.23.
+        */
+        QL_DEPRECATED
+        Thirty360()
+        : DayCounter(implementation(Thirty360::BondBasis, false)) {}
+
+        Thirty360(Convention c, bool isLastPeriod = false)
         : DayCounter(implementation(c, isLastPeriod)) {}
     };
 

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -122,7 +122,7 @@ namespace QuantLib {
         Thirty360()
         : DayCounter(implementation(Thirty360::BondBasis, false)) {}
 
-        Thirty360(Convention c, bool isLastPeriod = false)
+        explicit Thirty360(Convention c, bool isLastPeriod = false)
         : DayCounter(implementation(c, isLastPeriod)) {}
     };
 

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -733,7 +733,7 @@ void AssetSwapTest::testImpliedValue() {
     ext::shared_ptr<Bond> cmsBond1(
                           new CmsRateBond(settlementDays, vars.faceAmount,
                                           cmsBondSchedule1,
-                                          vars.swapIndex, Thirty360(),
+                                          vars.swapIndex, Thirty360(Thirty360::BondBasis),
                                           Following, fixingDays,
                                           std::vector<Real>(1,1.0),
                                           std::vector<Spread>(1,0.0),
@@ -777,7 +777,7 @@ void AssetSwapTest::testImpliedValue() {
                               DateGeneration::Backward, false);
     ext::shared_ptr<Bond> cmsBond2(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(),
+                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
@@ -1127,7 +1127,7 @@ void AssetSwapTest::testMarketASWSpread() {
                               DateGeneration::Backward, false);
     ext::shared_ptr<Bond> cmsBond1(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                    vars.swapIndex, Thirty360(),
+                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
@@ -1180,7 +1180,7 @@ void AssetSwapTest::testMarketASWSpread() {
                               DateGeneration::Backward, false);
     ext::shared_ptr<Bond> cmsBond2(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(),
+                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
@@ -1499,7 +1499,7 @@ void AssetSwapTest::testZSpread() {
                               DateGeneration::Backward, false);
     ext::shared_ptr<Bond> cmsBond1(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                    vars.swapIndex, Thirty360(),
+                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
@@ -1539,7 +1539,7 @@ void AssetSwapTest::testZSpread() {
                               DateGeneration::Backward, false);
     ext::shared_ptr<Bond> cmsBond2(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(),
+                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
@@ -1878,7 +1878,7 @@ void AssetSwapTest::testGenericBondImplied() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withCaps(0.055)
         .withFloors(0.025)
@@ -1926,7 +1926,7 @@ void AssetSwapTest::testGenericBondImplied() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withGearings(0.84)
         .inArrears(inArrears);
@@ -2307,7 +2307,7 @@ void AssetSwapTest::testMASWWithGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withCaps(0.055)
         .withFloors(0.025)
@@ -2366,7 +2366,7 @@ void AssetSwapTest::testMASWWithGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withGearings(0.84)
         .inArrears(inArrears);
@@ -2719,7 +2719,7 @@ void AssetSwapTest::testZSpreadWithGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withCaps(0.055)
         .withFloors(0.025)
@@ -2766,7 +2766,7 @@ void AssetSwapTest::testZSpreadWithGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withGearings(0.84)
         .inArrears(inArrears);
@@ -3188,7 +3188,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withCaps(0.055)
         .withFloors(0.025)
@@ -3206,7 +3206,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBond() {
     // equivalent specialized cms bond
     ext::shared_ptr<Bond> cmsSpecializedBond1(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                vars.swapIndex, Thirty360(),
+                vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
@@ -3258,7 +3258,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBond() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withGearings(0.84)
         .inArrears(inArrears);
@@ -3275,7 +3275,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBond() {
     // equivalent specialized cms bond
     ext::shared_ptr<Bond> cmsSpecializedBond2(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                vars.swapIndex, Thirty360(),
+                vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(), std::vector<Rate>(),
@@ -3890,7 +3890,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withCaps(0.055)
         .withFloors(0.025)
@@ -3908,7 +3908,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
     // equivalent specialized cms bond
     ext::shared_ptr<Bond> cmsSpecializedBond1(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                vars.swapIndex, Thirty360(),
+                vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
@@ -3993,7 +3993,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
                               DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
         .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360())
+        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
         .withFixingDays(fixingDays)
         .withGearings(0.84)
         .inArrears(inArrears);
@@ -4010,7 +4010,7 @@ void AssetSwapTest::testSpecializedBondVsGenericBondUsingAsw() {
     // equivalent specialized cms bond
     ext::shared_ptr<Bond> cmsSpecializedBond2(new
         CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                vars.swapIndex, Thirty360(),
+                vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(), std::vector<Rate>(),

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -169,7 +169,7 @@ namespace {
         Schedule floatSchedule(swapStart, swapEnd, Period(6, Months), TARGET(), ModifiedFollowing,
                                ModifiedFollowing, DateGeneration::Backward, false);
         ext::shared_ptr<VanillaSwap> swap(
-            new VanillaSwap(VanillaSwap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(),
+            new VanillaSwap(VanillaSwap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(Thirty360::BondBasis),
                             floatSchedule, euribor6m, 0.0, euribor6m->dayCounter()));
         swap->setPricingEngine(ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(discYTS)));
         // European exercise and swaption
@@ -337,7 +337,7 @@ void BasismodelsTest::testTenorswaptionvts() {
     {
         ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS(
             new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
-                                 Period(1, Years), Thirty360(), Thirty360()));
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
         // 6m vols should be slightly larger then 3m vols due to basis
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {
@@ -356,7 +356,7 @@ void BasismodelsTest::testTenorswaptionvts() {
     {
         ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2(
             new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor6m, Period(1, Years),
-                                 Period(1, Years), Thirty360(), Thirty360()));
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
         // 6m vols to 6m vols should yield initiial vols
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {
@@ -377,10 +377,10 @@ void BasismodelsTest::testTenorswaptionvts() {
     {
         ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS(
             new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
-                                 Period(1, Years), Thirty360(), Thirty360()));
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
         ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2(new TenorSwaptionVTS(
             RelinkableHandle<SwaptionVolatilityStructure>(euribor3mSwVTS), discYTS, euribor3m,
-            euribor6m, Period(1, Years), Period(1, Years), Thirty360(), Thirty360()));
+            euribor6m, Period(1, Years), Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
         // 6m vols to 6m vols should yield initiial vols
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -70,7 +70,7 @@ namespace bermudan_swaption_test {
             floatingConvention = ModifiedFollowing;
             fixedFrequency = Annual;
             floatingFrequency = Semiannual;
-            fixedDayCount = Thirty360();
+            fixedDayCount = Thirty360(Thirty360::BondBasis);
             index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
             calendar = index->fixingCalendar();
             today = calendar.adjust(Date::todaysDate());

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -106,7 +106,7 @@ void BondTest::testYield() {
     Natural settlementDays = 3;
     Real coupons[] = { 0.02, 0.05, 0.08 };
     Frequency frequencies[] = { Semiannual, Annual };
-    DayCounter bondDayCount = Thirty360();
+    DayCounter bondDayCount = Thirty360(Thirty360::BondBasis);
     BusinessDayConvention accrualConvention = Unadjusted;
     BusinessDayConvention paymentConvention = ModifiedFollowing;
     Real redemption = 100.0;
@@ -205,7 +205,7 @@ void BondTest::testAtmRate() {
     Natural settlementDays = 3;
     Real coupons[] = { 0.02, 0.05, 0.08 };
     Frequency frequencies[] = { Semiannual, Annual };
-    DayCounter bondDayCount = Thirty360();
+    DayCounter bondDayCount = Thirty360(Thirty360::BondBasis);
     BusinessDayConvention accrualConvention = Unadjusted;
     BusinessDayConvention paymentConvention = ModifiedFollowing;
     Real redemption = 100.0;
@@ -269,7 +269,7 @@ void BondTest::testZspread() {
     Natural settlementDays = 3;
     Real coupons[] = { 0.02, 0.05, 0.08 };
     Frequency frequencies[] = { Semiannual, Annual };
-    DayCounter bondDayCount = Thirty360();
+    DayCounter bondDayCount = Thirty360(Thirty360::BondBasis);
     BusinessDayConvention accrualConvention = Unadjusted;
     BusinessDayConvention paymentConvention = ModifiedFollowing;
     Real redemption = 100.0;
@@ -1073,7 +1073,7 @@ void BondTest::testBrazilianCached() {
     prices[5] = 1026.19716497;
 
     std::vector<InterestRate> couponRates(1);
-    couponRates[0] = InterestRate(0.1, Thirty360(), Compounded,Annual);
+    couponRates[0] = InterestRate(0.1, Thirty360(Thirty360::BondBasis), Compounded,Annual);
 
     for (Size bondIndex = 0; bondIndex < maturityDates.size(); bondIndex++) {
 

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -125,7 +125,7 @@ void CallableBondTest::testInterplay() {
                          vars.calendar.advance(vars.issueDate(),6,Years)));
 
     CallableZeroCouponBond bond(3, 100.0, vars.calendar,
-                                vars.maturityDate(), Thirty360(),
+                                vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention, 100.0,
                                 vars.issueDate(), callabilities);
     bond.setPricingEngine(engine);
@@ -150,7 +150,7 @@ void CallableBondTest::testInterplay() {
                          vars.calendar.advance(vars.issueDate(),8,Years)));
 
     bond = CallableZeroCouponBond(3, 100.0, vars.calendar,
-                                  vars.maturityDate(), Thirty360(),
+                                  vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                   vars.rollingConvention, 100.0,
                                   vars.issueDate(), callabilities);
     bond.setPricingEngine(engine);
@@ -180,7 +180,7 @@ void CallableBondTest::testInterplay() {
                          vars.calendar.advance(vars.issueDate(),6,Years)));
 
     bond = CallableZeroCouponBond(3, 100.0, vars.calendar,
-                                  vars.maturityDate(), Thirty360(),
+                                  vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                   vars.rollingConvention, 100.0,
                                   vars.issueDate(), callabilities);
     bond.setPricingEngine(engine);
@@ -205,7 +205,7 @@ void CallableBondTest::testInterplay() {
                          vars.calendar.advance(vars.issueDate(),8,Years)));
 
     bond = CallableZeroCouponBond(3, 100.0, vars.calendar,
-                                  vars.maturityDate(), Thirty360(),
+                                  vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                   vars.rollingConvention, 100.0,
                                   vars.issueDate(), callabilities);
     bond.setPricingEngine(engine);
@@ -241,7 +241,7 @@ void CallableBondTest::testConsistency() {
     std::vector<Rate> coupons(1, 0.05);
 
     FixedRateBond bond(3, 100.0, schedule,
-                       coupons, Thirty360());
+                       coupons, Thirty360(Thirty360::BondBasis));
     bond.setPricingEngine(
                ext::make_shared<DiscountingBondEngine>(vars.termStructure));
 
@@ -266,14 +266,14 @@ void CallableBondTest::testConsistency() {
                                 *(vars.model), timeSteps, vars.termStructure);
 
     CallableFixedRateBond callable(3, 100.0, schedule,
-                                   coupons, Thirty360(),
+                                   coupons, Thirty360(Thirty360::BondBasis),
                                    vars.rollingConvention,
                                    100.0, vars.issueDate(),
                                    callabilities);
     callable.setPricingEngine(engine);
 
     CallableFixedRateBond puttable(3, 100.0, schedule,
-                                   coupons, Thirty360(),
+                                   coupons, Thirty360(Thirty360::BondBasis),
                                    vars.rollingConvention,
                                    100.0, vars.issueDate(),
                                    puttabilities);
@@ -333,7 +333,7 @@ void CallableBondTest::testObservability() {
     }
 
     CallableZeroCouponBond bond(3, 100.0, vars.calendar,
-                                vars.maturityDate(), Thirty360(),
+                                vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention, 100.0,
                                 vars.issueDate(), callabilities);
 
@@ -380,18 +380,18 @@ void CallableBondTest::testDegenerate() {
                                   vars.maturityDate(),
                                   vars.rollingConvention);
     FixedRateBond couponBond(3, 100.0, schedule,
-                             coupons, Thirty360());
+                             coupons, Thirty360(Thirty360::BondBasis));
 
     // no callability
     CallabilitySchedule callabilities;
 
     CallableZeroCouponBond bond1(3, 100.0, vars.calendar,
-                                 vars.maturityDate(), Thirty360(),
+                                 vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                  vars.rollingConvention, 100.0,
                                  vars.issueDate(), callabilities);
 
     CallableFixedRateBond bond2(3, 100.0, schedule,
-                                coupons, Thirty360(),
+                                coupons, Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention,
                                 100.0, vars.issueDate(),
                                 callabilities);
@@ -441,12 +441,12 @@ void CallableBondTest::testDegenerate() {
     }
 
     bond1 = CallableZeroCouponBond(3, 100.0, vars.calendar,
-                                   vars.maturityDate(), Thirty360(),
+                                   vars.maturityDate(), Thirty360(Thirty360::BondBasis),
                                    vars.rollingConvention, 100.0,
                                    vars.issueDate(), callabilities);
 
     bond2 = CallableFixedRateBond(3, 100.0, schedule,
-                                  coupons, Thirty360(),
+                                  coupons, Thirty360(Thirty360::BondBasis),
                                   vars.rollingConvention,
                                   100.0, vars.issueDate(),
                                   callabilities);
@@ -522,7 +522,7 @@ void CallableBondTest::testCached() {
 
     double storedPrice1 = 110.60975477;
     CallableFixedRateBond bond1(3, 100.0, schedule,
-                                coupons, Thirty360(),
+                                coupons, Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention,
                                 100.0, vars.issueDate(),
                                 callabilities);
@@ -537,7 +537,7 @@ void CallableBondTest::testCached() {
 
     double storedPrice2 = 115.16559362;
     CallableFixedRateBond bond2(3, 100.0, schedule,
-                                coupons, Thirty360(),
+                                coupons, Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention,
                                 100.0, vars.issueDate(),
                                 puttabilities);
@@ -552,7 +552,7 @@ void CallableBondTest::testCached() {
 
     double storedPrice3 = 110.97509625;
     CallableFixedRateBond bond3(3, 100.0, schedule,
-                                coupons, Thirty360(),
+                                coupons, Thirty360(Thirty360::BondBasis),
                                 vars.rollingConvention,
                                 100.0, vars.issueDate(),
                                 all_exercises);

--- a/test-suite/capflooredcoupon.cpp
+++ b/test-suite/capflooredcoupon.cpp
@@ -92,7 +92,7 @@ namespace capfloored_coupon_test {
             std::vector<Rate> coupons(length, 0.0);
             return FixedRateLeg(schedule)
                 .withNotionals(nominals)
-                .withCouponRates(coupons, Thirty360());
+                .withCouponRates(coupons, Thirty360(Thirty360::BondBasis));
         }
 
         Leg makeFloatingLeg(const Date& startDate,

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -219,7 +219,7 @@ void CreditDefaultSwapTest::testCachedMarketValue() {
         ext::shared_ptr<YieldTermStructure>(
             new DiscountCurve(discountDates, dfs, curveDayCounter)));
 
-    DayCounter dayCounter = Thirty360();
+    DayCounter dayCounter = Thirty360(Thirty360::BondBasis);
     std::vector<Date> dates = {
         evalDate,
         calendar.advance(evalDate, 6, Months, ModifiedFollowing),
@@ -259,7 +259,7 @@ void CreditDefaultSwapTest::testCachedMarketValue() {
         ext::shared_ptr<DefaultProbabilityTermStructure>(
                new InterpolatedHazardRateCurve<BackwardFlat>(dates,
                                                              hazardRates,
-                                                             Thirty360())));
+                                                             Thirty360(Thirty360::BondBasis))));
 
     // Testing credit default swap
 
@@ -624,7 +624,7 @@ void CreditDefaultSwapTest::testIsdaEngine() {
                                       swap_quotes[i], swap_tenors[i] * Years,
                                       WeekendsOnly(),
                                       Semiannual,
-                                      ModifiedFollowing, Thirty360(), isda_ibor
+                                      ModifiedFollowing, Thirty360(Thirty360::BondBasis), isda_ibor
                                       )
             );
     }

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -163,7 +163,7 @@ namespace {
         Frequency frequency = Quarterly;
         BusinessDayConvention convention = Following;
         DateGeneration::Rule rule = DateGeneration::TwentiethIMM;
-        DayCounter dayCounter = Thirty360();
+        DayCounter dayCounter = Thirty360(Thirty360::BondBasis);
         Real recoveryRate = 0.4;
 
         RelinkableHandle<YieldTermStructure> discountCurve;
@@ -185,7 +185,7 @@ namespace {
         piecewiseCurve.linkTo(
             ext::shared_ptr<DefaultProbabilityTermStructure>(
                 new PiecewiseDefaultCurve<T,I>(today, helpers,
-                                               Thirty360())));
+                                               Thirty360(Thirty360::BondBasis))));
 
         Real notional = 1.0;
         double tolerance = 1.0e-6;
@@ -265,7 +265,7 @@ namespace {
         piecewiseCurve.linkTo(
             ext::shared_ptr<DefaultProbabilityTermStructure>(
                 new PiecewiseDefaultCurve<T,I>(today, helpers,
-                                               Thirty360())));
+                                               Thirty360(Thirty360::BondBasis))));
 
         Real notional = 1.0;
         double tolerance = 1.0e-6;
@@ -371,7 +371,7 @@ void DefaultProbabilityCurveTest::testSingleInstrumentBootstrap() {
     Frequency frequency = Quarterly;
     BusinessDayConvention convention = Following;
     DateGeneration::Rule rule = DateGeneration::TwentiethIMM;
-    DayCounter dayCounter = Thirty360();
+    DayCounter dayCounter = Thirty360(Thirty360::BondBasis);
     Real recoveryRate = 0.4;
 
     RelinkableHandle<YieldTermStructure> discountCurve;

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -364,7 +364,7 @@ void InflationTest::testZeroTermStructure() {
     };
 
     Period observationLag = Period(2,Months);
-    DayCounter dc = Thirty360();
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
     std::vector<ext::shared_ptr<BootstrapHelper<ZeroInflationTermStructure> > > helpers =
     makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
@@ -854,7 +854,7 @@ void InflationTest::testYYTermStructure() {
     };
 
     Period observationLag = Period(2,Months);
-    DayCounter dc = Thirty360();
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
 
     // now build the helpers ...
     std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > helpers =

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -123,7 +123,7 @@ namespace inflation_capfloor_test {
             settlementDays = 0;
             fixingDays = 0;
             settlement = calendar.advance(today,settlementDays,Days);
-            dc = Thirty360();
+            dc = Thirty360(Thirty360::BondBasis);
 
             // yoy index
             //      fixing data

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -132,7 +132,7 @@ namespace inflation_capfloored_coupon_test {
             fixingDays = 0;
             settlement = calendar.advance(today,settlementDays,Days);
             startDate = settlement;
-            dc = Thirty360();
+            dc = Thirty360(Thirty360::BondBasis);
 
             // yoy index
             //      fixing data

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -1399,25 +1399,25 @@ void MarkovFunctionalTest::testCalibrationTwoInstrumentSets() {
         new SwaptionHelper(1 * Years, 4 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[0]))),
-                           iborIndex1, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            flatYts_)));
     calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(2 * Years, 3 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[1]))),
-                           iborIndex1, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            flatYts_)));
     calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(3 * Years, 2 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[2]))),
-                           iborIndex1, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            flatYts_)));
     calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(4 * Years, 1 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols1[3]))),
-                           iborIndex1, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            flatYts_)));
 
     ext::shared_ptr<MarkovFunctional> mf1(new MarkovFunctional(
@@ -1525,25 +1525,25 @@ void MarkovFunctionalTest::testCalibrationTwoInstrumentSets() {
         new SwaptionHelper(1 * Years, 4 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[0]))),
-                           iborIndex2, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            md0Yts_)));
     calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(2 * Years, 3 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[1]))),
-                           iborIndex2, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            md0Yts_)));
     calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(3 * Years, 2 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[2]))),
-                           iborIndex2, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            md0Yts_)));
     calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
         new SwaptionHelper(4 * Years, 1 * Years,
                            Handle<Quote>(ext::shared_ptr<Quote>(
                                new SimpleQuote(calibrationHelperVols2[3]))),
-                           iborIndex2, 1 * Years, Thirty360(), Actual360(),
+                           iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
                            md0Yts_)));
 
     ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine2(

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -164,7 +164,7 @@ namespace overnight_indexed_swap_test {
             eoniaIndex = ext::make_shared<Eonia>(eoniaTermStructure);
             fixedSwapConvention = ModifiedFollowing;
             fixedSwapFrequency = Annual;
-            fixedSwapDayCount = Thirty360();
+            fixedSwapDayCount = Thirty360(Thirty360::BondBasis);
             swapIndex = ext::shared_ptr<IborIndex>(new Euribor3M(swapTermStructure));
             calendar = eoniaIndex->fixingCalendar();
             today = Date(5, February, 2009);

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -188,7 +188,7 @@ namespace piecewise_yield_curve_test {
             settlement = calendar.advance(today,settlementDays,Days);
             fixedLegConvention = Unadjusted;
             fixedLegFrequency = Annual;
-            fixedLegDayCounter = Thirty360();
+            fixedLegDayCounter = Thirty360(Thirty360::BondBasis);
             bondSettlementDays = 3;
             bondDayCounter = ActualActual();
             bondConvention = Following;
@@ -1102,7 +1102,8 @@ void PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate() {
     // note that the calendar should be US+UK here actually, but technically it should also work with
     // the US calendar only
     ext::shared_ptr<RateHelper> helper = ext::make_shared<SwapRateHelper>(
-        0.02, 50 * Years, UnitedStates(), Semiannual, ModifiedFollowing, Thirty360(), usdLibor3m);
+        0.02, 50 * Years, UnitedStates(), Semiannual, ModifiedFollowing,
+        Thirty360(Thirty360::BondBasis), usdLibor3m);
 
     PiecewiseYieldCurve<Discount, LogLinear> curve(today, std::vector<ext::shared_ptr<RateHelper> >(1, helper),
                                                    Actual365Fixed());
@@ -1117,7 +1118,8 @@ void PiecewiseYieldCurveTest::testSwapRateHelperSpotDate() {
     ext::shared_ptr<IborIndex> usdLibor3m = ext::make_shared<USDLibor>(3 * Months);
 
     ext::shared_ptr<SwapRateHelper> helper = ext::make_shared<SwapRateHelper>(
-        0.02, 5 * Years, UnitedStates(), Semiannual, ModifiedFollowing, Thirty360(), usdLibor3m);
+        0.02, 5 * Years, UnitedStates(), Semiannual, ModifiedFollowing,
+        Thirty360(Thirty360::BondBasis), usdLibor3m);
 
     Settings::instance().evaluationDate() = Date(11, October, 2019);
 
@@ -1161,7 +1163,8 @@ void PiecewiseYieldCurveTest::testBadPreviousCurve() {
     ext::shared_ptr<Euribor> euribor1m(new Euribor1M);
     for (auto& i : data) {
         helpers.push_back(ext::make_shared<SwapRateHelper>(
-            i.rate, Period(i.n, i.units), TARGET(), Monthly, Unadjusted, Thirty360(), euribor1m));
+            i.rate, Period(i.n, i.units), TARGET(), Monthly, Unadjusted,
+            Thirty360(Thirty360::BondBasis), euribor1m));
     }
 
     Date today = Date(12, October, 2017);
@@ -1187,7 +1190,7 @@ void PiecewiseYieldCurveTest::testBadPreviousCurve() {
         Period tenor = i.n * i.units;
 
         VanillaSwap swap = MakeVanillaSwap(tenor, index, 0.0)
-            .withFixedLegDayCount(Thirty360())
+            .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
             .withFixedLegTenor(Period(1, Months))
             .withFixedLegConvention(Unadjusted);
         swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(h));
@@ -1354,9 +1357,9 @@ void PiecewiseYieldCurveTest::testGlobalBootstrap() {
 
     Size swapTenors[] = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 20, 25, 30, 35, 40, 45, 50};
     for (Size i = 0; i < 19; ++i) {
-        helpers.push_back(ext::make_shared<SwapRateHelper>(refMktRate[13 + i] / 100.0,
-                                                           swapTenors[i] * Years, TARGET(), Annual,
-                                                           ModifiedFollowing, Thirty360(), index));
+        helpers.push_back(ext::make_shared<SwapRateHelper>(
+            refMktRate[13 + i] / 100.0, swapTenors[i] * Years, TARGET(), Annual, ModifiedFollowing,
+            Thirty360(Thirty360::BondBasis), index));
     }
 
     // global bootstrap constraints

--- a/test-suite/rangeaccrual.cpp
+++ b/test-suite/rangeaccrual.cpp
@@ -214,7 +214,7 @@ namespace range_accrual_test {
             swapSettlementDays = 2;
             fixedLegFrequency = Annual;
             fixedLegConvention = Unadjusted;
-            fixedLegDayCounter = Thirty360();
+            fixedLegDayCounter = Thirty360(Thirty360::BondBasis);
             ext::shared_ptr<SwapIndex> swapIndexBase(new
                 EuriborSwapIsdaFixA(2*Years, termStructure));
 

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -84,7 +84,7 @@ void ShortRateModelTest::testCachedHullWhite() {
         ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
         ext::shared_ptr<BlackCalibrationHelper> helper(
             new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
-                               index, Period(1, Years), Thirty360(), Actual360(), termStructure));
+                               index, Period(1, Years), Thirty360(Thirty360::BondBasis), Actual360(), termStructure));
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -159,7 +159,8 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
         ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
         ext::shared_ptr<BlackCalibrationHelper> helper(
             new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
-                               index, Period(1, Years), Thirty360(), Actual360(), termStructure));
+                               index, Period(1, Years), Thirty360(Thirty360::BondBasis),
+                               Actual360(), termStructure));
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -239,7 +240,8 @@ void ShortRateModelTest::testCachedHullWhite2() {
         ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
         ext::shared_ptr<BlackCalibrationHelper> helper(
             new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
-                               index0, Period(1, Years), Thirty360(), Actual360(), termStructure));
+                               index0, Period(1, Years), Thirty360(Thirty360::BondBasis),
+                               Actual360(), termStructure));
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -371,7 +373,8 @@ void ShortRateModelTest::testSwaps() {
                                    DateGeneration::Forward, false);
             for (double rate : rates) {
 
-                VanillaSwap swap(VanillaSwap::Payer, 1000000.0, fixedSchedule, rate, Thirty360(),
+                VanillaSwap swap(VanillaSwap::Payer, 1000000.0, fixedSchedule, rate,
+                                 Thirty360(Thirty360::BondBasis),
                                  floatSchedule, euribor, 0.0, Actual360());
                 swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
                                    new DiscountingSwapEngine(termStructure)));

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -88,7 +88,7 @@ namespace swap_test {
             floatingConvention = ModifiedFollowing;
             fixedFrequency = Annual;
             floatingFrequency = Semiannual;
-            fixedDayCount = Thirty360();
+            fixedDayCount = Thirty360(Thirty360::BondBasis);
             index = ext::shared_ptr<IborIndex>(new
                 Euribor(Period(floatingFrequency), termStructure));
             calendar = index->fixingCalendar();

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -104,7 +104,7 @@ namespace swaption_test {
             nominal = 1000000.0;
             fixedConvention = Unadjusted;
             fixedFrequency = Annual;
-            fixedDayCount = Thirty360();
+            fixedDayCount = Thirty360(Thirty360::BondBasis);
 
             index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
             floatingConvention = index->businessDayConvention();
@@ -511,7 +511,7 @@ void SwaptionTest::testCashSettledSwaptions() {
                                      DateGeneration::Forward, true);
             ext::shared_ptr<VanillaSwap> swap_u360(
                 new VanillaSwap(type[0], vars.nominal,
-                                fixedSchedule_u,strike,Thirty360(),
+                                fixedSchedule_u,strike,Thirty360(Thirty360::BondBasis),
                                 floatSchedule,vars.index,0.0,
                                 vars.index->dayCounter()));
 
@@ -530,7 +530,7 @@ void SwaptionTest::testCashSettledSwaptions() {
                                      DateGeneration::Forward, true);
             ext::shared_ptr<VanillaSwap> swap_a360(
                 new VanillaSwap(type[0],vars.nominal,
-                                fixedSchedule_a,strike,Thirty360(),
+                                fixedSchedule_a,strike,Thirty360(Thirty360::BondBasis),
                                 floatSchedule,vars.index,0.0,
                                 vars.index->dayCounter()));
 
@@ -559,12 +559,12 @@ void SwaptionTest::testCashSettledSwaptions() {
             Handle<YieldTermStructure> termStructure_u360(
                 ext::shared_ptr<YieldTermStructure>(
                     new FlatForward(vars.settlement,swap_u360->fairRate(),
-                                    Thirty360(),Compounded,
+                                    Thirty360(Thirty360::BondBasis),Compounded,
                                     vars.fixedFrequency)));
             Handle<YieldTermStructure> termStructure_a360(
                 ext::shared_ptr<YieldTermStructure>(
                     new FlatForward(vars.settlement,swap_a360->fairRate(),
-                                    Thirty360(),Compounded,
+                                    Thirty360(Thirty360::BondBasis),Compounded,
                                     vars.fixedFrequency)));
             Handle<YieldTermStructure> termStructure_u365(
                 ext::shared_ptr<YieldTermStructure>(
@@ -939,7 +939,7 @@ void checkSwaptionDelta(bool useBachelierVol)
                             MakeVanillaSwap(length, idx, strike)
                                 .withEffectiveDate(startDate)
                                 .withFixedLegTenor(1 * Years)
-                                .withFixedLegDayCount(Thirty360())
+                                .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
                                 .withFloatingLegSpread(0.0)
                                 .withType(type[h]);
                         underlying->setPricingEngine(swapEngine);

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -103,7 +103,7 @@ namespace term_structures_test {
                     SwapRateHelper(swapData[i].rate/100,
                                    swapData[i].n*swapData[i].units,
                                    calendar,
-                                   Annual, Unadjusted, Thirty360(),
+                                   Annual, Unadjusted, Thirty360(Thirty360::BondBasis),
                                    index));
             }
             termStructure = ext::shared_ptr<YieldTermStructure>(new

--- a/test-suite/variancegamma.cpp
+++ b/test-suite/variancegamma.cpp
@@ -223,7 +223,7 @@ void VarianceGammaTest::testSingularityAtZero() {
 
     Date valuation(1,Jan,2017);
     Date maturity(10,Jan,2017);
-    DayCounter discountCounter = Thirty360();
+    DayCounter discountCounter = Thirty360(Thirty360::BondBasis);
 
     Settings::instance().evaluationDate() = valuation;
 


### PR DESCRIPTION
- Added ISMA convention (similar to NASD but doesn't adjust to next month);
- `BondBasis` is now, correctly, an alias to ISMA;
- `German` is now also called ISDA;
- reordered code to model logic more closely;
- deprecated default constructor; a convention should always be passed explicitly.