### PR TITLE
Deprecate default constructor for Actual/Actual day count convention

### DIFF
--- a/ql/experimental/catbonds/catrisk.cpp
+++ b/ql/experimental/catbonds/catrisk.cpp
@@ -88,7 +88,7 @@ namespace QuantLib {
                 gammaAlpha_(rng_, boost::gamma_distribution<>(alpha)),
                 gammaBeta_(rng_, boost::gamma_distribution<>(beta))
     {
-        ActualActual dayCounter;
+        DayCounter dayCounter = ActualActual(ActualActual::ISDA);
         dayCount_ = dayCounter.dayCount(start, end);
         yearFraction_ = dayCounter.yearFraction(start, end);
     }

--- a/ql/time/daycounters/actualactual.hpp
+++ b/ql/time/daycounters/actualactual.hpp
@@ -91,8 +91,15 @@ namespace QuantLib {
                                                                Convention c, 
                                                                const Schedule& schedule);
       public:
-        ActualActual(Convention c = ActualActual::ISDA, 
-                     const Schedule& schedule = Schedule())
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.23.
+        */
+        QL_DEPRECATED
+        ActualActual()
+        : DayCounter(implementation(ActualActual::ISDA, Schedule())) {}
+
+        explicit ActualActual(Convention c,
+                              const Schedule& schedule = Schedule())
         : DayCounter(implementation(c, schedule)) {}
     };
 

--- a/test-suite/batesmodel.cpp
+++ b/test-suite/batesmodel.cpp
@@ -66,7 +66,7 @@ void BatesModelTest::testAnalyticVsBlack() {
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate = settlementDate + 6*Months;
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -179,7 +179,7 @@ void BatesModelTest::testAnalyticAndMcVsJumpDiffusion() {
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
                                      new PlainVanillaPayoff(Option::Put, 95));
@@ -308,7 +308,7 @@ void BatesModelTest::testAnalyticVsMCPricing() {
     Date settlementDate(30, March, 2007);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(30, March, 2012);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -138,7 +138,7 @@ void CdoTest::testHW(unsigned dataSet) {
     ext::shared_ptr<DefaultProbabilityTermStructure> ptr (
                new FlatHazardRate (asofDate,
                                    hazardRate,
-                                   ActualActual()));
+                                   ActualActual(ActualActual::ISDA)));
     ext::shared_ptr<Pool> pool (new Pool());
     vector<string> names;
     // probability key items

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -1034,7 +1034,7 @@ void DayCounterTest::testIntraday() {
     const Time tol = 100*QL_EPSILON;
 
     const DayCounter dayCounters[]
-        = { ActualActual(), Actual365Fixed(), Actual360() };
+        = { ActualActual(ActualActual::ISDA), Actual365Fixed(), Actual360() };
 
     for (DayCounter dc : dayCounters) {
         const Time expected = ((12*60 + 34)*60 + 17 + 0.231298)

--- a/test-suite/gjrgarchmodel.cpp
+++ b/test-suite/gjrgarchmodel.cpp
@@ -45,7 +45,7 @@ void GJRGARCHModelTest::testEngines() {
        "Testing Monte Carlo GJR-GARCH engine against "
        "analytic GJR-GARCH engine...");
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
 
     const Date today = Date::todaysDate();
     Handle<YieldTermStructure> riskFreeTS(flatRate(today, 0.05, dayCounter));

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -295,7 +295,7 @@ void HestonModelTest::testAnalyticVsBlack() {
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate = settlementDate + 6*Months;
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -366,7 +366,7 @@ void HestonModelTest::testAnalyticVsCached() {
 
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(28, March, 2005);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -468,7 +468,7 @@ void HestonModelTest::testMcVsCached() {
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(28, March, 2005);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -579,7 +579,7 @@ void HestonModelTest::testFdVanillaVsCached() {
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(28, March, 2005);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -721,7 +721,7 @@ void HestonModelTest::testKahlJaeckelCase() {
     Date settlementDate(30, March, 2007);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(30, March, 2017);
 
     const ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -874,7 +874,7 @@ void HestonModelTest::testDifferentIntegrals() {
     const Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
-    const DayCounter dayCounter = ActualActual();
+    const DayCounter dayCounter = ActualActual(ActualActual::ISDA);
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.05, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.03, dayCounter));
@@ -998,7 +998,7 @@ void HestonModelTest::testMultipleStrikesEngine() {
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(28, March, 2006);
 
     ext::shared_ptr<Exercise> exercise(
@@ -1078,7 +1078,7 @@ void HestonModelTest::testAnalyticPiecewiseTimeDependent() {
 
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(28, March, 2005);
 
     ext::shared_ptr<StrikedTypePayoff> payoff(

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -165,7 +165,7 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation() {
 
     SavedSettings backup;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate = Date(28, Dec, 2012);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -694,7 +694,7 @@ namespace {
 
         SavedSettings backup;
 
-        const DayCounter dc = ActualActual();
+        const DayCounter dc = ActualActual(ActualActual::ISDA);
         const Date todaysDate = Date(28, Dec, 2014);
         Settings::instance().evaluationDate() = todaysDate;
 
@@ -1065,7 +1065,7 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
 
     SavedSettings backup;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate = Date(28, Dec, 2012);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -1236,7 +1236,7 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol() {
 
     SavedSettings backup;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, July, 2014);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -1627,7 +1627,7 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
     BOOST_TEST_MESSAGE("Testing calibration via vanilla options...");
 
     SavedSettings backup;
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Nov, 2015);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -1728,7 +1728,7 @@ void HestonSLVModelTest::testBarrierPricingMixedModels() {
     BOOST_TEST_MESSAGE("Testing Barrier pricing with mixed models...");
 
     SavedSettings backup;
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Nov, 2015);
     const Date exerciseDate = todaysDate + Period(1, Years);
     Settings::instance().evaluationDate() = todaysDate;
@@ -1855,7 +1855,7 @@ void HestonSLVModelTest::testMonteCarloVsFdmPricing() {
         "Heston SLV models...");
 
     SavedSettings backup;
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Dec, 2015);
     const Date exerciseDate = todaysDate + Period(1, Years);
     Settings::instance().evaluationDate() = todaysDate;
@@ -1961,7 +1961,7 @@ void HestonSLVModelTest::testMonteCarloCalibration() {
 
     SavedSettings backup;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Jan, 2016);
     const Date maturityDate = todaysDate + Period(1, Years);
     Settings::instance().evaluationDate() = todaysDate;
@@ -2084,7 +2084,7 @@ void HestonSLVModelTest::testForwardSkewSLV() {
 
     SavedSettings backup;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Jan, 2017);
     const Date maturityDate = todaysDate + Period(2, Years);
     Settings::instance().evaluationDate() = todaysDate;
@@ -2343,7 +2343,7 @@ void HestonSLVModelTest::testMoustacheGraph() {
      Foreign Exchange Option Pricing: A Practitioner’s Guide
     */
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Jan, 2016);
     const Date maturityDate = todaysDate + Period(1, Years);
     Settings::instance().evaluationDate() = todaysDate;

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -147,7 +147,7 @@ namespace inflation_capfloor_test {
             }
 
             ext::shared_ptr<YieldTermStructure> nominalFF(
-                new FlatForward(evaluationDate, 0.05, ActualActual()));
+                new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
             nominalTS.linkTo(nominalFF);
 
             // now build the YoY inflation curve

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -156,7 +156,7 @@ namespace inflation_capfloored_coupon_test {
             }
 
             ext::shared_ptr<YieldTermStructure> nominalFF(
-                        new FlatForward(evaluationDate, 0.05, ActualActual()));
+                        new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
             nominalTS.linkTo(nominalFF);
 
             // now build the YoY inflation curve

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -101,7 +101,7 @@ namespace inflation_cpi_bond_test {
             Date today(25, November, 2009);
             evaluationDate = calendar.adjust(today);
             Settings::instance().evaluationDate() = evaluationDate;
-            dayCounter = ActualActual();
+            dayCounter = ActualActual(ActualActual::ISDA);
 
             Date from(20, July, 2007);
             Date to(20, November, 2009);

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -144,8 +144,8 @@ namespace inflation_cpi_capfloor_test {
             fixingDays = 0;
             settlement = calendar.advance(today,settlementDays,Days);
             startDate = settlement;
-            dcZCIIS = ActualActual();
-            dcNominal = ActualActual();
+            dcZCIIS = ActualActual(ActualActual::ISDA);
+            dcNominal = ActualActual(ActualActual::ISDA);
 
             // uk rpi index
             //      fixing data

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -126,8 +126,8 @@ namespace inflation_cpi_swap_test {
             fixingDays = 0;
             settlement = calendar.advance(today,settlementDays,Days);
             startDate = settlement;
-            dcZCIIS = ActualActual();
-            dcNominal = ActualActual();
+            dcZCIIS = ActualActual(ActualActual::ISDA);
+            dcNominal = ActualActual(ActualActual::ISDA);
 
             // uk rpi index
             //      fixing data
@@ -393,7 +393,7 @@ void CPISwapTest::zciisconsistency() {
     Date endDate(25, November, 2059);
     Calendar cal = UnitedKingdom();
     BusinessDayConvention paymentConvention = ModifiedFollowing;
-    DayCounter dummyDC, dc = ActualActual();
+    DayCounter dummyDC, dc = ActualActual(ActualActual::ISDA);
     Period observationLag(2,Months);
 
     Rate quote = 0.03714;

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -77,9 +77,8 @@ namespace libor_market_model_process_test {
             dates.push_back(process->fixingDates()[i+1]);
         }
 
-        return ext::make_shared<CapletVarianceCurve>(
-                         todaysDate, dates,
-                                                 capletVols, ActualActual());
+        return ext::make_shared<CapletVarianceCurve>(todaysDate, dates, capletVols,
+                                                     ActualActual(ActualActual::ISDA));
     }
 
     ext::shared_ptr<LiborForwardModelProcess>

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -391,7 +391,7 @@ void NormalCLVModelTest::testMoustacheGraph() {
      Foreign Exchange Option Pricing: A Practitioner’s Guide
     */
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Aug, 2016);
     const Date maturityDate = todaysDate + Period(1, Years);
     const Time maturityTime = dc.yearFraction(todaysDate, maturityDate);

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -190,12 +190,12 @@ namespace piecewise_yield_curve_test {
             fixedLegFrequency = Annual;
             fixedLegDayCounter = Thirty360();
             bondSettlementDays = 3;
-            bondDayCounter = ActualActual();
+            bondDayCounter = ActualActual(ActualActual::ISDA);
             bondConvention = Following;
             bondRedemption = 100.0;
             bmaFrequency = Quarterly;
             bmaConvention = Following;
-            bmaDayCounter = ActualActual();
+            bmaDayCounter = ActualActual(ActualActual::ISDA);
 
             deposits = LENGTH(depositData);
             fras = LENGTH(fraData);

--- a/test-suite/quotes.cpp
+++ b/test-suite/quotes.cpp
@@ -126,7 +126,7 @@ void QuoteTest::testForwardValueQuoteAndImpliedStdevQuote(){
     BOOST_TEST_MESSAGE(
             "Testing forward-value and implied-standard-deviation quotes...");
     Real forwardRate = .05;
-    DayCounter dc = ActualActual();
+    DayCounter dc = ActualActual(ActualActual::ISDA);
     Calendar calendar = TARGET();
     ext::shared_ptr<SimpleQuote> forwardQuote(new SimpleQuote(forwardRate));
     Handle<Quote> forwardHandle(forwardQuote);

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -92,7 +92,7 @@ void SquareRootCLVModelTest::testSquareRootCLVVanillaPricing() {
     const Date todaysDate(5, Oct, 2016);
     Settings::instance().evaluationDate() = todaysDate;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date maturityDate = todaysDate + Period(3, Months);
     const Time maturity = dc.yearFraction(todaysDate, maturityDate);
 

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -186,7 +186,7 @@ void SwingOptionTest::testExtOUJumpVanillaEngine() {
     const Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date maturityDate = today + Period(12, Months);
     const Time maturity = dc.yearFraction(today, maturityDate);
 
@@ -244,7 +244,7 @@ void SwingOptionTest::testFdBSSwingOption() {
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date maturityDate = settlementDate + Period(12, Months);
 
     Real strike = 30;
@@ -325,7 +325,7 @@ void SwingOptionTest::testExtOUJumpSwingOption() {
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date maturityDate = settlementDate + Period(12, Months);
 
     Real strike = 30;

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -105,7 +105,7 @@ void VPPTest::testGemanRoncoroniProcess() {
 
     const Date today = Date(18, December, 2011);
     Settings::instance().evaluationDate() = today;
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
 
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, 0.03, dc);
 
@@ -221,7 +221,7 @@ void VPPTest::testSimpleExtOUStorageEngine() {
 
     Date settlementDate = Date(18, December, 2011);
     Settings::instance().evaluationDate() = settlementDate;
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date maturityDate = settlementDate + Period(12, Months);
 
     std::vector<Date> exerciseDates(1, settlementDate+Period(1, Days));
@@ -272,7 +272,7 @@ void VPPTest::testKlugeExtOUSpreadOption() {
     Date settlementDate = Date(18, December, 2011);
     Settings::instance().evaluationDate() = settlementDate;
 
-    DayCounter dayCounter = ActualActual();
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date maturityDate = settlementDate + Period(1, Years);
     Time maturity = dayCounter.yearFraction(settlementDate, maturityDate);
 
@@ -407,7 +407,7 @@ void VPPTest::testVPPIntrinsicValue() {
     SavedSettings backup;
 
     const Date today = Date(18, December, 2011);
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     Settings::instance().evaluationDate() = today;
 
     // vpp parameters
@@ -559,7 +559,7 @@ void VPPTest::testVPPPricing() {
     SavedSettings backup;
 
     const Date today = Date(18, December, 2011);
-    const DayCounter dc = ActualActual();
+    const DayCounter dc = ActualActual(ActualActual::ISDA);
     Settings::instance().evaluationDate() = today;
 
     // vpp parameter
@@ -908,7 +908,7 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
 
     const ext::shared_ptr<FdmLinearOpComposite> op(
         new FdmKlugeExtOUOp(mesher, klugeOUProcess,
-                            flatRate(today, 0.0, ActualActual()),
+                            flatRate(today, 0.0, ActualActual(ActualActual::ISDA)),
                             FdmBoundaryConditionSet(), 16));
     op->setTime(0.1, 0.2);
 


### PR DESCRIPTION
One should pass a convention explicitly.