### PR TITLE
More changes for 30/360 day count convention

### DIFF
--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -24,7 +24,7 @@
 namespace QuantLib {
 
     ext::shared_ptr<DayCounter::Impl>
-    Thirty360::implementation(Thirty360::Convention c, bool isLastPeriod) {
+    Thirty360::implementation(Thirty360::Convention c, const Date& terminationDate, bool isLastPeriod) {
         switch (c) {
           case USA:
           case NASD:
@@ -39,7 +39,7 @@ namespace QuantLib {
             return ext::shared_ptr<DayCounter::Impl>(new ISMA_Impl);
           case ISDA:
           case German:
-            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl(isLastPeriod));
+            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl(terminationDate, isLastPeriod));
           default:
             QL_FAIL("unknown 30/360 convention");
         }
@@ -107,7 +107,10 @@ namespace QuantLib {
         if (dd2 == 31) { dd2 = 30; }
 
         if (mm1 == 2 && dd1 == 28 + (Date::isLeap(yy1) ? 1 : 0)) { dd1 = 30; }
-        if (!isLastPeriod_ && mm2 == 2 && dd2 == 28 + (Date::isLeap(yy2) ? 1 : 0)) { dd2 = 30; }
+
+        bool isTerminationDate =
+            terminationDate_ == Date() ? isLastPeriod_ : d2 == terminationDate_;
+        if (!isTerminationDate && mm2 == 2 && dd2 == 28 + (Date::isLeap(yy2) ? 1 : 0)) { dd2 = 30; }
 
         return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
     }

--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -23,11 +23,18 @@
 
 namespace QuantLib {
 
+    namespace {
+
+        bool isLastOfFebruary(Day d, Month m, Year y) {
+            return m == 2 && d == 28 + (Date::isLeap(y) ? 1 : 0);
+        }
+
+    }
+
     ext::shared_ptr<DayCounter::Impl>
     Thirty360::implementation(Thirty360::Convention c, const Date& terminationDate, bool isLastPeriod) {
         switch (c) {
           case USA:
-          case NASD:
             return ext::shared_ptr<DayCounter::Impl>(new US_Impl);
           case European:
           case EurobondBasis:
@@ -40,6 +47,8 @@ namespace QuantLib {
           case ISDA:
           case German:
             return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl(terminationDate, isLastPeriod));
+          case NASD:
+            return ext::shared_ptr<DayCounter::Impl>(new NASD_Impl);
           default:
             QL_FAIL("unknown 30/360 convention");
         }
@@ -48,12 +57,14 @@ namespace QuantLib {
     Date::serial_type Thirty360::US_Impl::dayCount(const Date& d1,
                                                    const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
-        Integer mm1 = d1.month(), mm2 = d2.month();
+        Month mm1 = d1.month(), mm2 = d2.month();
         Year yy1 = d1.year(), yy2 = d2.year();
 
         if (dd1 == 31) { dd1 = 30; }
         if (dd2 == 31 && dd1 >= 30) { dd2 = 30; }
-        if (dd2 == 31 && dd1 < 30) { dd2 = 1; mm2++; }
+
+        if (isLastOfFebruary(dd2, mm2, yy2) && isLastOfFebruary(dd1, mm1, yy1)) { dd2 = 30; }
+        if (isLastOfFebruary(dd1, mm1, yy1)) { dd1 = 30; }
 
         return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
     }
@@ -61,7 +72,7 @@ namespace QuantLib {
     Date::serial_type Thirty360::ISMA_Impl::dayCount(const Date& d1,
                                                      const Date& d2) const {
         Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
-        Integer mm1 = d1.month(), mm2 = d2.month();
+        Month mm1 = d1.month(), mm2 = d2.month();
         Year yy1 = d1.year(), yy2 = d2.year();
 
         if (dd1 == 31) { dd1 = 30; }
@@ -106,11 +117,24 @@ namespace QuantLib {
         if (dd1 == 31) { dd1 = 30; }
         if (dd2 == 31) { dd2 = 30; }
 
-        if (mm1 == 2 && dd1 == 28 + (Date::isLeap(yy1) ? 1 : 0)) { dd1 = 30; }
+        if (isLastOfFebruary(dd1, mm1, yy1)) { dd1 = 30; }
 
         bool isTerminationDate =
             terminationDate_ == Date() ? isLastPeriod_ : d2 == terminationDate_;
-        if (!isTerminationDate && mm2 == 2 && dd2 == 28 + (Date::isLeap(yy2) ? 1 : 0)) { dd2 = 30; }
+        if (!isTerminationDate && isLastOfFebruary(dd2, mm2, yy2)) { dd2 = 30; }
+
+        return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
+    }
+
+    Date::serial_type Thirty360::NASD_Impl::dayCount(const Date& d1,
+                                                     const Date& d2) const {
+        Day dd1 = d1.dayOfMonth(), dd2 = d2.dayOfMonth();
+        Integer mm1 = d1.month(), mm2 = d2.month();
+        Year yy1 = d1.year(), yy2 = d2.year();
+
+        if (dd1 == 31) { dd1 = 30; }
+        if (dd2 == 31 && dd1 >= 30) { dd2 = 30; }
+        if (dd2 == 31 && dd1 < 30) { dd2 = 1; mm2++; }
 
         return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
     }

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -107,23 +107,33 @@ namespace QuantLib {
         };
         class ISDA_Impl : public Thirty360_Impl {
           public:
-            explicit ISDA_Impl(bool isLastPeriod) : isLastPeriod_(isLastPeriod) {}
+            explicit ISDA_Impl(const Date& terminationDate, bool isLastPeriod)
+            : terminationDate_(terminationDate), isLastPeriod_(isLastPeriod) {}
             std::string name() const override { return std::string("30E/360 (ISDA)"); }
             Date::serial_type dayCount(const Date& d1, const Date& d2) const override;
           private:
+            Date terminationDate_;
             bool isLastPeriod_;
         };
-        static ext::shared_ptr<DayCounter::Impl> implementation(Convention c, bool isLastPeriod);
+        static ext::shared_ptr<DayCounter::Impl>
+        implementation(Convention c, const Date& terminationDate, bool isLastPeriod);
       public:
-        /*! \deprecated Use the other constructor.
+        /*! \deprecated Use the constructor taking a convention and possibly a termination date.
                         Deprecated in version 1.23.
         */
         QL_DEPRECATED
         Thirty360()
-        : DayCounter(implementation(Thirty360::BondBasis, false)) {}
+        : DayCounter(implementation(Thirty360::BondBasis, Date(), false)) {}
 
-        explicit Thirty360(Convention c, bool isLastPeriod = false)
-        : DayCounter(implementation(c, isLastPeriod)) {}
+        /*! \deprecated Use the constructor taking a convention and possibly a termination date.
+                        Deprecated in version 1.23.
+        */
+        QL_DEPRECATED
+        Thirty360(Convention c, bool isLastPeriod)
+        : DayCounter(implementation(c, Date(), isLastPeriod)) {}
+
+        explicit Thirty360(Convention c, const Date& terminationDate = Date())
+        : DayCounter(implementation(c, terminationDate, false)) {}
     };
 
 }

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -33,20 +33,21 @@ namespace QuantLib {
     /*! The 30/360 day count can be calculated according to a
         number of conventions.
 
-        US (NASD) convention: if the starting date is the 31st of a
-        month, it becomes equal to the 30th of the same month.
-        If the ending date is the 31st of a month and the starting
-        date is earlier than the 30th of a month, the ending date
-        becomes equal to the 1st of the next month, otherwise the
-        ending date becomes equal to the 30th of the same month.
-        Also known as "30/360", "360/360", or "Bond Basis".
+        US convention: if the starting date is the 31st of a month or
+        the last day of February, it becomes equal to the 30th of the
+        same month.  If the ending date is the 31st of a month and the
+        starting date is the 30th or 31th of a month, the ending date
+        becomes equal to the 30th.  If the ending date is the last of
+        February and the starting date is also the last of February,
+        the ending date becomes equal to the 30th.
+        Also known as "30/360" or "360/360".
 
-        US (ISMA) convention: if the starting date is the 31st of a
+        Bond Basis convention: if the starting date is the 31st of a
         month, it becomes equal to the 30th of the same month.
         If the ending date is the 31st of a month and the starting
         date is the 30th or 31th of a month, the ending date
         also becomes equal to the 30th of the month.
-        Also known as "Bond Basis".
+        Also known as "US (ISMA)".
 
         European convention: starting dates or ending dates that
         occur on the 31st of a month become equal to the 30th of the
@@ -57,10 +58,18 @@ namespace QuantLib {
         occur on February and are greater than 27 become equal to 30
         for computational sake.
 
-        ISDA convention: starting dates or ending dates that
-        occur on the last day of February become equal to 30
-        for computational sake, except for the termination date.
-        Also known as "30E/360 ISDA", "30/360 ISDA", or "30/360 German".
+        ISDA convention: starting or ending dates on the 31st of the
+        month become equal to 30; starting dates or ending dates that
+        occur on the last day of February also become equal to 30,
+        except for the termination date.  Also known as "30E/360
+        ISDA", "30/360 ISDA", or "30/360 German".
+
+        NASD convention: if the starting date is the 31st of a
+        month, it becomes equal to the 30th of the same month.
+        If the ending date is the 31st of a month and the starting
+        date is earlier than the 30th of a month, the ending date
+        becomes equal to the 1st of the next month, otherwise the
+        ending date becomes equal to the 30th of the same month.
 
         \ingroup daycounters
     */
@@ -87,7 +96,7 @@ namespace QuantLib {
         };
         class US_Impl : public Thirty360_Impl {
           public:
-            std::string name() const override { return std::string("30/360 (NASD)"); }
+            std::string name() const override { return std::string("30/360 (US)"); }
             Date::serial_type dayCount(const Date& d1, const Date& d2) const override;
         };
         class ISMA_Impl : public Thirty360_Impl {
@@ -114,6 +123,11 @@ namespace QuantLib {
           private:
             Date terminationDate_;
             bool isLastPeriod_;
+        };
+        class NASD_Impl : public Thirty360_Impl {
+          public:
+            std::string name() const override { return std::string("30/360 (NASD)"); }
+            Date::serial_type dayCount(const Date& d1, const Date& d2) const override;
         };
         static ext::shared_ptr<DayCounter::Impl>
         implementation(Convention c, const Date& terminationDate, bool isLastPeriod);

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -66,6 +66,12 @@ namespace day_counters_test {
         Time result;
     };
 
+    struct Thirty360Case {
+        Date start;
+        Date end;
+        Date::serial_type expected;
+    };
+
     Time ISMAYearFractionWithReferenceDates(
         const DayCounter& dayCounter, Date start, Date end, Date refStart, Date refEnd) {
         Real referenceDayCount = Real(dayCounter.dayCount(refStart, refEnd));
@@ -783,221 +789,214 @@ void DayCounterTest::testThirty365() {
 
 void DayCounterTest::testThirty360_BondBasis() {
 
-    BOOST_TEST_MESSAGE("Testing thirty/360 day counter (Bond Basis)...");
+    BOOST_TEST_MESSAGE("Testing 30/360 day counter (Bond Basis)...");
 
-    // http://www.isda.org/c_and_a/docs/30-360-2006ISDADefs.xls
-    // Source: 2006 ISDA Definitions, Sec. 4.16 (f)
-    // 30/360 (or Bond Basis)
+    // See https://www.isda.org/2008/12/22/30-360-day-count-conventions/
 
     DayCounter dayCounter = Thirty360(Thirty360::BondBasis);
-    std::vector<Date> testStartDates;
-    std::vector<Date> testEndDates;
-    Date::serial_type calculated;
 
-    // ISDA - Example 1: End dates do not involve the last day of February
-    testStartDates.emplace_back(20, August, 2006);
-    testEndDates.emplace_back(20, February, 2007);
-    testStartDates.emplace_back(20, February, 2007);
-    testEndDates.emplace_back(20, August, 2007);
-    testStartDates.emplace_back(20, August, 2007);
-    testEndDates.emplace_back(20, February, 2008);
-    testStartDates.emplace_back(20, February, 2008);
-    testEndDates.emplace_back(20, August, 2008);
-    testStartDates.emplace_back(20, August, 2008);
-    testEndDates.emplace_back(20, February, 2009);
-    testStartDates.emplace_back(20, February, 2009);
-    testEndDates.emplace_back(20, August, 2009);
+    day_counters_test::Thirty360Case data[] = {
+        // Example 1: End dates do not involve the last day of February
+        {Date(20, August, 2006),    Date(20, February, 2007), 180},
+        {Date(20, February, 2007),  Date(20, August, 2007),   180},
+        {Date(20, August, 2007),    Date(20, February, 2008), 180},
+        {Date(20, February, 2008),  Date(20, August, 2008),   180},
+        {Date(20, August, 2008),    Date(20, February, 2009), 180},
+        {Date(20, February, 2009),  Date(20, August, 2009),   180}, 
 
-    // ISDA - Example 2: End dates include some end-February dates
-    testStartDates.emplace_back(31, August, 2006);
-    testEndDates.emplace_back(28, February, 2007);
-    testStartDates.emplace_back(28, February, 2007);
-    testEndDates.emplace_back(31, August, 2007);
-    testStartDates.emplace_back(31, August, 2007);
-    testEndDates.emplace_back(29, February, 2008);
-    testStartDates.emplace_back(29, February, 2008);
-    testEndDates.emplace_back(31, August, 2008);
-    testStartDates.emplace_back(31, August, 2008);
-    testEndDates.emplace_back(28, February, 2009);
-    testStartDates.emplace_back(28, February, 2009);
-    testEndDates.emplace_back(31, August, 2009);
+        // Example 2: End dates include some end-February dates
+        {Date(31, August, 2006),    Date(28, February, 2007), 178},
+        {Date(28, February, 2007),  Date(31, August, 2007),   183},
+        {Date(31, August, 2007),    Date(29, February, 2008), 179},
+        {Date(29, February, 2008),  Date(31, August, 2008),   182},
+        {Date(31, August, 2008),    Date(28, February, 2009), 178},
+        {Date(28, February, 2009),  Date(31, August, 2009),   183},
 
-    //// ISDA - Example 3: Miscellaneous calculations
-    testStartDates.emplace_back(31, January, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(30, January, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(28, February, 2006);
-    testEndDates.emplace_back(3, March, 2006);
-    testStartDates.emplace_back(14, February, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(30, September, 2006);
-    testEndDates.emplace_back(31, October, 2006);
-    testStartDates.emplace_back(31, October, 2006);
-    testEndDates.emplace_back(28, November, 2006);
-    testStartDates.emplace_back(31, August, 2007);
-    testEndDates.emplace_back(28, February, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(28, August, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(30, August, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(31, August, 2008);
-    testStartDates.emplace_back(26, February, 2007);
-    testEndDates.emplace_back(28, February, 2008);
-    testStartDates.emplace_back(26, February, 2007);
-    testEndDates.emplace_back(29, February, 2008);
-    testStartDates.emplace_back(29, February, 2008);
-    testEndDates.emplace_back(28, February, 2009);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(30, March, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(31, March, 2008);
+        // Example 3: Miscellaneous calculations
+        {Date(31, January, 2006),   Date(28, February, 2006),  28},
+        {Date(30, January, 2006),   Date(28, February, 2006),  28},
+        {Date(28, February, 2006),  Date(3, March, 2006),       5},
+        {Date(14, February, 2006),  Date(28, February, 2006),  14},
+        {Date(30, September, 2006), Date(31, October, 2006),   30},
+        {Date(31, October, 2006),   Date(28, November, 2006),  28},
+        {Date(31, August, 2007),    Date(28, February, 2008), 178},
+        {Date(28, February, 2008),  Date(28, August, 2008),   180},
+        {Date(28, February, 2008),  Date(30, August, 2008),   182},
+        {Date(28, February, 2008),  Date(31, August, 2008),   183},
+        {Date(26, February, 2007),  Date(28, February, 2008), 362},
+        {Date(26, February, 2007),  Date(29, February, 2008), 363},
+        {Date(29, February, 2008),  Date(28, February, 2009), 359},
+        {Date(28, February, 2008),  Date(30, March, 2008),     32},
+        {Date(28, February, 2008),  Date(31, March, 2008),     33}
+    };
 
-    Date::serial_type expected[] = { 180, 180, 180, 180, 180, 180,
-                                     178, 183, 179, 182, 178, 183,
-                                     28,  28,   5,  14,  30,  28,
-                                     178, 180, 182, 183, 362, 363,
-                                     359,  32,  33};
-
-    for (Size i = 0; i < testStartDates.size(); i++) {
-        calculated = dayCounter.dayCount(testStartDates[i], testEndDates[i]);
-        if (calculated != expected[i]) {
-                BOOST_ERROR("from " << testStartDates[i]
-                            << " to " << testEndDates[i] << ":\n"
+    for (auto x : data) {
+        Date::serial_type calculated = dayCounter.dayCount(x.start, x.end);
+        if (calculated != x.expected) {
+                BOOST_ERROR("from " << x.start
+                            << " to " << x.end << ":\n"
                             << "    calculated: " << calculated << "\n"
-                            << "    expected:   " << expected[i]);
+                            << "    expected:   " << x.expected);
         }
     }
 }
 
 void DayCounterTest::testThirty360_EurobondBasis() {
 
-    BOOST_TEST_MESSAGE("Testing thirty/360 day counter (Eurobond Basis)...");
+    BOOST_TEST_MESSAGE("Testing 30/360 day counter (Eurobond Basis)...");
 
-    // Source: ISDA 2006 Definitions 4.16 (g)
-    // 30E/360 (or Eurobond Basis)
-    // Based on ICMA (Rule 251) and FBF; this is the version of 30E/360 used by Excel
+    // See https://www.isda.org/2008/12/22/30-360-day-count-conventions/
 
     DayCounter dayCounter = Thirty360(Thirty360::EurobondBasis);
-    std::vector<Date> testStartDates;
-    std::vector<Date> testEndDates;
-    Date::serial_type calculated;
 
-    // ISDA - Example 1: End dates do not involve the last day of February
-    testStartDates.emplace_back(20, August, 2006);
-    testEndDates.emplace_back(20, February, 2007);
-    testStartDates.emplace_back(20, February, 2007);
-    testEndDates.emplace_back(20, August, 2007);
-    testStartDates.emplace_back(20, August, 2007);
-    testEndDates.emplace_back(20, February, 2008);
-    testStartDates.emplace_back(20, February, 2008);
-    testEndDates.emplace_back(20, August, 2008);
-    testStartDates.emplace_back(20, August, 2008);
-    testEndDates.emplace_back(20, February, 2009);
-    testStartDates.emplace_back(20, February, 2009);
-    testEndDates.emplace_back(20, August, 2009);
+    day_counters_test::Thirty360Case data[] = {
+        // Example 1: End dates do not involve the last day of February
+        {Date(20, August, 2006),    Date(20, February, 2007), 180},
+        {Date(20, February, 2007),  Date(20, August, 2007),   180},
+        {Date(20, August, 2007),    Date(20, February, 2008), 180},
+        {Date(20, February, 2008),  Date(20, August, 2008),   180},
+        {Date(20, August, 2008),    Date(20, February, 2009), 180},
+        {Date(20, February, 2009),  Date(20, August, 2009),   180},
 
-    //// ISDA - Example 2: End dates include some end-February dates
-    testStartDates.emplace_back(28, February, 2006);
-    testEndDates.emplace_back(31, August, 2006);
-    testStartDates.emplace_back(31, August, 2006);
-    testEndDates.emplace_back(28, February, 2007);
-    testStartDates.emplace_back(28, February, 2007);
-    testEndDates.emplace_back(31, August, 2007);
-    testStartDates.emplace_back(31, August, 2007);
-    testEndDates.emplace_back(29, February, 2008);
-    testStartDates.emplace_back(29, February, 2008);
-    testEndDates.emplace_back(31, August, 2008);
-    testStartDates.emplace_back(31, August, 2008);
-    testEndDates.emplace_back(28, Feb, 2009);
-    testStartDates.emplace_back(28, February, 2009);
-    testEndDates.emplace_back(31, August, 2009);
-    testStartDates.emplace_back(31, August, 2009);
-    testEndDates.emplace_back(28, Feb, 2010);
-    testStartDates.emplace_back(28, February, 2010);
-    testEndDates.emplace_back(31, August, 2010);
-    testStartDates.emplace_back(31, August, 2010);
-    testEndDates.emplace_back(28, Feb, 2011);
-    testStartDates.emplace_back(28, February, 2011);
-    testEndDates.emplace_back(31, August, 2011);
-    testStartDates.emplace_back(31, August, 2011);
-    testEndDates.emplace_back(29, Feb, 2012);
+        // Example 2: End dates include some end-February dates
+        {Date(28, February, 2006),  Date(31, August, 2006),   182},
+        {Date(31, August, 2006),    Date(28, February, 2007), 178},
+        {Date(28, February, 2007),  Date(31, August, 2007),   182},
+        {Date(31, August, 2007),    Date(29, February, 2008), 179},
+        {Date(29, February, 2008),  Date(31, August, 2008),   181},
+        {Date(31, August, 2008),    Date(28, Feb, 2009),      178},
+        {Date(28, February, 2009),  Date(31, August, 2009),   182},
+        {Date(31, August, 2009),    Date(28, Feb, 2010),      178},
+        {Date(28, February, 2010),  Date(31, August, 2010),   182},
+        {Date(31, August, 2010),    Date(28, Feb, 2011),      178},
+        {Date(28, February, 2011),  Date(31, August, 2011),   182},
+        {Date(31, August, 2011),    Date(29, Feb, 2012),      179},
 
-    //// ISDA - Example 3: Miscellaneous calculations
-    testStartDates.emplace_back(31, January, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(30, January, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(28, February, 2006);
-    testEndDates.emplace_back(3, March, 2006);
-    testStartDates.emplace_back(14, February, 2006);
-    testEndDates.emplace_back(28, February, 2006);
-    testStartDates.emplace_back(30, September, 2006);
-    testEndDates.emplace_back(31, October, 2006);
-    testStartDates.emplace_back(31, October, 2006);
-    testEndDates.emplace_back(28, November, 2006);
-    testStartDates.emplace_back(31, August, 2007);
-    testEndDates.emplace_back(28, February, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(28, August, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(30, August, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(31, August, 2008);
-    testStartDates.emplace_back(26, February, 2007);
-    testEndDates.emplace_back(28, February, 2008);
-    testStartDates.emplace_back(26, February, 2007);
-    testEndDates.emplace_back(29, February, 2008);
-    testStartDates.emplace_back(29, February, 2008);
-    testEndDates.emplace_back(28, February, 2009);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(30, March, 2008);
-    testStartDates.emplace_back(28, February, 2008);
-    testEndDates.emplace_back(31, March, 2008);
+        // Example 3: Miscellaneous calculations
+        {Date(31, January, 2006),   Date(28, February, 2006),  28},
+        {Date(30, January, 2006),   Date(28, February, 2006),  28},
+        {Date(28, February, 2006),  Date(3, March, 2006),       5},
+        {Date(14, February, 2006),  Date(28, February, 2006),  14},
+        {Date(30, September, 2006), Date(31, October, 2006),   30},
+        {Date(31, October, 2006),   Date(28, November, 2006),  28},
+        {Date(31, August, 2007),    Date(28, February, 2008), 178},
+        {Date(28, February, 2008),  Date(28, August, 2008),   180},
+        {Date(28, February, 2008),  Date(30, August, 2008),   182},
+        {Date(28, February, 2008),  Date(31, August, 2008),   182},
+        {Date(26, February, 2007),  Date(28, February, 2008), 362},
+        {Date(26, February, 2007),  Date(29, February, 2008), 363},
+        {Date(29, February, 2008),  Date(28, February, 2009), 359},
+        {Date(28, February, 2008),  Date(30, March, 2008),     32},
+        {Date(28, February, 2008),  Date(31, March, 2008),     32}
+    };
 
-    Date::serial_type expected[] = { 180, 180, 180, 180, 180, 180,
-                                     182, 178, 182, 179, 181, 178,
-                                     182, 178, 182, 178, 182, 179,
-                                     28,  28,   5,  14,  30,  28,
-                                     178, 180, 182, 182, 362, 363,
-                                     359,  32,  32 };
-
-    for (Size i = 0; i < testStartDates.size(); i++) {
-        calculated = dayCounter.dayCount(testStartDates[i], testEndDates[i]);
-        if (calculated != expected[i]) {
-                BOOST_ERROR("from " << testStartDates[i]
-                            << " to " << testEndDates[i] << ":\n"
+    for (auto x : data) {
+        Date::serial_type calculated = dayCounter.dayCount(x.start, x.end);
+        if (calculated != x.expected) {
+                BOOST_ERROR("from " << x.start
+                            << " to " << x.end << ":\n"
                             << "    calculated: " << calculated << "\n"
-                            << "    expected:   " << expected[i]);
+                            << "    expected:   " << x.expected);
         }
     }
 }
 
 
-void DayCounterTest::testThirty360_German() {
-    BOOST_TEST_MESSAGE("Testing 30/360 (German) day counter...");
+void DayCounterTest::testThirty360_ISDA() {
 
-    Thirty360 dayCounter(Thirty360::German);
+    BOOST_TEST_MESSAGE("Testing 30/360 day counter (ISDA)...");
 
-    Date start(5, February, 2020);
-    Date end(29, February, 2020);
+    // See https://www.isda.org/2008/12/22/30-360-day-count-conventions/
 
-    Date::serial_type calculated = dayCounter.dayCount(start, end);
-    Date::serial_type expected = 25;  // 30 - 5, as 29 is adjusted
+    day_counters_test::Thirty360Case data1[] = {
+        // Example 1: End dates do not involve the last day of February
+        {Date(20, August, 2006),    Date(20, February, 2007), 180},
+        {Date(20, February, 2007),  Date(20, August, 2007),   180},
+        {Date(20, August, 2007),    Date(20, February, 2008), 180},
+        {Date(20, February, 2008),  Date(20, August, 2008),   180},
+        {Date(20, August, 2008),    Date(20, February, 2009), 180},
+        {Date(20, February, 2009),  Date(20, August, 2009),   180},
+    };
 
-    if (calculated != expected) {
-        BOOST_ERROR("Day count from " << start
-                    << " to " << end << ":\n"
-                    << "    calculated: " << calculated << "\n"
-                    << "    expected:   " << expected);
+    Date terminationDate = Date(20, August, 2009);
+    Thirty360 dayCounter(Thirty360::ISDA, terminationDate);
+
+    for (auto x : data1) {
+        Date::serial_type calculated = dayCounter.dayCount(x.start, x.end);
+        if (calculated != x.expected) {
+                BOOST_ERROR("from " << x.start
+                            << " to " << x.end << ":\n"
+                            << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << x.expected);
+        }
+    }
+
+    day_counters_test::Thirty360Case data2[] = {
+        // Example 2: End dates include some end-February dates
+        {Date(28, February, 2006),  Date(31, August, 2006),   180},
+        {Date(31, August, 2006),    Date(28, February, 2007), 180},
+        {Date(28, February, 2007),  Date(31, August, 2007),   180},
+        {Date(31, August, 2007),    Date(29, February, 2008), 180},
+        {Date(29, February, 2008),  Date(31, August, 2008),   180},
+        {Date(31, August, 2008),    Date(28, February, 2009), 180},
+        {Date(28, February, 2009),  Date(31, August, 2009),   180},
+        {Date(31, August, 2009),    Date(28, February, 2010), 180},
+        {Date(28, February, 2010),  Date(31, August, 2010),   180},
+        {Date(31, August, 2010),    Date(28, February, 2011), 180},
+        {Date(28, February, 2011),  Date(31, August, 2011),   180},
+        {Date(31, August, 2011),    Date(29, February, 2012), 179},
+    };
+
+    terminationDate = Date(29, February, 2012);
+    dayCounter = Thirty360(Thirty360::ISDA, terminationDate);
+
+    for (auto x : data2) {
+        Date::serial_type calculated = dayCounter.dayCount(x.start, x.end);
+        if (calculated != x.expected) {
+                BOOST_ERROR("from " << x.start
+                            << " to " << x.end << ":\n"
+                            << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << x.expected);
+        }
+    }
+
+    day_counters_test::Thirty360Case data3[] = {
+        // Example 3: Miscellaneous calculations
+        {Date(31, January, 2006),   Date(28, February, 2006),  30},
+        {Date(30, January, 2006),   Date(28, February, 2006),  30},
+        {Date(28, February, 2006),  Date(3, March, 2006),       3},
+        {Date(14, February, 2006),  Date(28, February, 2006),  16},
+        {Date(30, September, 2006), Date(31, October, 2006),   30},
+        {Date(31, October, 2006),   Date(28, November, 2006),  28},
+        {Date(31, August, 2007),    Date(28, February, 2008), 178},
+        {Date(28, February, 2008),  Date(28, August, 2008),   180},
+        {Date(28, February, 2008),  Date(30, August, 2008),   182},
+        {Date(28, February, 2008),  Date(31, August, 2008),   182},
+        {Date(28, February, 2007),  Date(28, February, 2008), 358},
+        {Date(28, February, 2007),  Date(29, February, 2008), 359},
+        {Date(29, February, 2008),  Date(28, February, 2009), 360},
+        {Date(29, February, 2008),  Date(30, March, 2008),     30},
+        {Date(29, February, 2008),  Date(31, March, 2008),     30}
+    };
+
+    terminationDate = Date(29, February, 2008);
+    dayCounter = Thirty360(Thirty360::ISDA, terminationDate);
+
+    for (auto x : data3) {
+        Date::serial_type calculated = dayCounter.dayCount(x.start, x.end);
+        if (calculated != x.expected) {
+                BOOST_ERROR("from " << x.start
+                            << " to " << x.end << ":\n"
+                            << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << x.expected);
+        }
     }
 }
 
 
 void DayCounterTest::testActual365_Canadian() {
 
-    BOOST_TEST_MESSAGE("Testing that Actual 365 (Canadian) throws when needed...");
+    BOOST_TEST_MESSAGE("Testing that Actual/365 (Canadian) throws when needed...");
 
     Actual365Fixed dayCounter(Actual365Fixed::Canadian);
 
@@ -1069,7 +1068,7 @@ test_suite* DayCounterTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty365));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_BondBasis));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_EurobondBasis));
-    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_German));
+    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_ISDA));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActual365_Canadian));
 
 #ifdef QL_HIGH_RESOLUTION_DATE

--- a/test-suite/daycounters.hpp
+++ b/test-suite/daycounters.hpp
@@ -38,7 +38,7 @@ class DayCounterTest {
     static void testThirty365();
     static void testThirty360_BondBasis();
     static void testThirty360_EurobondBasis();
-    static void testThirty360_German();
+    static void testThirty360_ISDA();
     static void testActual365_Canadian();
     static void testIntraday();
     static boost::unit_test_framework::test_suite* suite();


### PR DESCRIPTION
- Added constructor taking termination date used by ISDA convention;
- Fixed US convention; the old one is still available as NASD.