### PR TITLE
Move `Type` enumeration to base `Swap` class

### DIFF
--- a/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -121,7 +121,7 @@ int main(int, char* []) {
         BusinessDayConvention floatingLegConvention = ModifiedFollowing;
         DayCounter fixedLegDayCounter = Thirty360(Thirty360::European);
         Frequency floatingLegFrequency = Semiannual;
-        VanillaSwap::Type type = VanillaSwap::Payer;
+        Swap::Type type = Swap::Payer;
         Rate dummyFixedRate = 0.03;
         ext::shared_ptr<IborIndex> indexSixMonths(new
             Euribor6M(rhTermStructure));

--- a/Examples/CVAIRS/CVAIRS.cpp
+++ b/Examples/CVAIRS/CVAIRS.cpp
@@ -168,9 +168,7 @@ int main(int, char* []) {
         DayCounter fixedLegDayCounter = ActualActual(ActualActual::ISDA);
         DayCounter floatingLegDayCounter = ActualActual(ActualActual::ISDA);
 
-        VanillaSwap::Type swapType = 
-            //VanillaSwap::Receiver ;
-            VanillaSwap::Payer;
+        Swap::Type swapType = Swap::Payer;
         ext::shared_ptr<IborIndex> yieldIndxS(
              new Euribor3M(Handle<YieldTermStructure>(swapTS)));
         std::vector<VanillaSwap> riskySwaps;

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -77,14 +77,14 @@ void printBasket(
         Real vol = helper->volatility()->value();
         Real rate = helper->underlyingSwap()->fixedRate();
         Date expiry = helper->swaption()->exercise()->date(0);
-        VanillaSwap::Type type = helper->swaption()->type();
+        Swap::Type type = helper->swaption()->type();
         std::ostringstream expiryString, endDateString;
         expiryString << expiry;
         endDateString << endDate;
         std::cout << std::setw(20) << expiryString.str() << std::setw(20)
                   << endDateString.str() << std::setw(20) << nominal
                   << std::setw(14) << rate << std::setw(12)
-                  << (type == VanillaSwap::Payer ? "Payer" : "Receiver")
+                  << (type == Swap::Payer ? "Payer" : "Receiver")
                   << std::setw(14) << vol << std::endl;
     }
 }
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
 
         ext::shared_ptr<NonstandardSwap> underlying =
             ext::make_shared<NonstandardSwap>(VanillaSwap(
-                VanillaSwap::Payer, 1.0, fixedSchedule, strike, Thirty360(Thirty360::BondBasis),
+                Swap::Payer, 1.0, fixedSchedule, strike, Thirty360(Thirty360::BondBasis),
                 floatingSchedule, euribor6m, 0.00, Actual360()));
 
         std::vector<Date> exerciseDates;
@@ -355,7 +355,7 @@ int main(int argc, char *argv[]) {
         std::vector<Real> strikes(nominalFixed.size(), strike);
 
         ext::shared_ptr<NonstandardSwap> underlying2(new NonstandardSwap(
-            VanillaSwap::Payer, nominalFixed, nominalFloating, fixedSchedule,
+            Swap::Payer, nominalFixed, nominalFloating, fixedSchedule,
             strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, 1.0, 0.0,
             Actual360()));
         ext::shared_ptr<NonstandardSwaption> swaption2 =
@@ -391,7 +391,7 @@ int main(int argc, char *argv[]) {
                                            0.0); // null the second leg
 
         ext::shared_ptr<NonstandardSwap> underlying3(new NonstandardSwap(
-            VanillaSwap::Receiver, nominalFixed2, nominalFloating2,
+            Swap::Receiver, nominalFixed2, nominalFloating2,
             fixedSchedule, strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m,
             1.0, 0.0, Actual360(), false,
             true)); // final capital exchange
@@ -486,7 +486,7 @@ int main(int argc, char *argv[]) {
                "\nis exercisable on a yearly basis" << std::endl;
 
         ext::shared_ptr<FloatFloatSwap> underlying4(new FloatFloatSwap(
-                VanillaSwap::Payer, 1.0, 1.0, fixedSchedule, swapBase,
+                Swap::Payer, 1.0, 1.0, fixedSchedule, swapBase,
                 Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, Actual360(), false,
                 false, 1.0, 0.0, Null<Real>(), Null<Real>(), 1.0, 0.0010));
 

--- a/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
+++ b/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
@@ -628,7 +628,7 @@ int main(int, char* []) {
         Spread spread = 0.0;
 
         Integer lengthInYears = 5;
-        VanillaSwap::Type swapType = VanillaSwap::Payer;
+        Swap::Type swapType = Swap::Payer;
 
         Date maturity = settlementDate + lengthInYears*Years;
         Schedule fixedSchedule(settlementDate, maturity,

--- a/ql/experimental/averageois/arithmeticaverageois.hpp
+++ b/ql/experimental/averageois/arithmeticaverageois.hpp
@@ -35,7 +35,6 @@ namespace QuantLib {
     //! Arithemtic Average OIS: fix vs arithmetic average of overnight rate
     class ArithmeticAverageOIS : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
         ArithmeticAverageOIS(Type type,
                              Real nominal,
                              const Schedule& fixedLegSchedule,

--- a/ql/experimental/averageois/makearithmeticaverageois.cpp
+++ b/ql/experimental/averageois/makearithmeticaverageois.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
       byApprox_(false),
       mrs_(0.03),
       vol_(0.00),
-      type_(ArithmeticAverageOIS::Payer), nominal_(1.0),
+      type_(Swap::Payer), nominal_(1.0),
       overnightSpread_(0.0),
       fixedDayCount_(overnightIndex->dayCounter()) {}
 
@@ -149,11 +149,11 @@ namespace QuantLib {
     }
 
     MakeArithmeticAverageOIS& MakeArithmeticAverageOIS::receiveFixed(bool flag) {
-        type_ = flag ? ArithmeticAverageOIS::Receiver : ArithmeticAverageOIS::Payer;
+        type_ = flag ? Swap::Receiver : Swap::Payer;
         return *this;
     }
 
-    MakeArithmeticAverageOIS& MakeArithmeticAverageOIS::withType(ArithmeticAverageOIS::Type type) {
+    MakeArithmeticAverageOIS& MakeArithmeticAverageOIS::withType(Swap::Type type) {
         type_ = type;
         return *this;
     }

--- a/ql/experimental/averageois/makearithmeticaverageois.hpp
+++ b/ql/experimental/averageois/makearithmeticaverageois.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         operator ext::shared_ptr<ArithmeticAverageOIS>() const;
 
         MakeArithmeticAverageOIS& receiveFixed(bool flag = true);
-        MakeArithmeticAverageOIS& withType(ArithmeticAverageOIS::Type type);
+        MakeArithmeticAverageOIS& withType(Swap::Type type);
         MakeArithmeticAverageOIS& withNominal(Real n);
 
         MakeArithmeticAverageOIS& withSettlementDays(Natural settlementDays);
@@ -88,7 +88,7 @@ namespace QuantLib {
         Real mrs_;
         Real vol_;
 
-        ArithmeticAverageOIS::Type type_;
+        Swap::Type type_;
         Real nominal_;
 
         Spread overnightSpread_;

--- a/ql/experimental/basismodels/tenorswaptionvts.cpp
+++ b/ql/experimental/basismodels/tenorswaptionvts.cpp
@@ -61,13 +61,13 @@ namespace QuantLib {
                                    Unadjusted, DateGeneration::Backward, false);
         // and swaps
         ext::shared_ptr<VanillaSwap> baseSwap(new VanillaSwap(
-            VanillaSwap::Payer, 1.0, baseFixedSchedule, 1.0, volTS.baseFixedDC_, baseFloatSchedule,
+            Swap::Payer, 1.0, baseFixedSchedule, 1.0, volTS.baseFixedDC_, baseFloatSchedule,
             volTS.baseIndex_, 0.0, volTS.baseIndex_->dayCounter()));
         ext::shared_ptr<VanillaSwap> targSwap(new VanillaSwap(
-            VanillaSwap::Payer, 1.0, baseFixedSchedule, 1.0, volTS.baseFixedDC_, targFloatSchedule,
+            Swap::Payer, 1.0, baseFixedSchedule, 1.0, volTS.baseFixedDC_, targFloatSchedule,
             volTS.targIndex_, 0.0, volTS.targIndex_->dayCounter()));
         ext::shared_ptr<VanillaSwap> finlSwap(new VanillaSwap(
-            VanillaSwap::Payer, 1.0, finlFixedSchedule, 1.0, volTS.targFixedDC_, targFloatSchedule,
+            Swap::Payer, 1.0, finlFixedSchedule, 1.0, volTS.targFixedDC_, targFloatSchedule,
             volTS.targIndex_, 0.0, volTS.targIndex_->dayCounter()));
         // adding engines
         baseSwap->setPricingEngine(

--- a/ql/experimental/swaptions/haganirregularswaptionengine.cpp
+++ b/ql/experimental/swaptions/haganirregularswaptionengine.cpp
@@ -197,7 +197,7 @@ namespace QuantLib {
         Period dummySwapLength = Period(1,Years);
                         
         ext::shared_ptr<VanillaSwap> memberSwap_ = MakeVanillaSwap(dummySwapLength,iborIndex)
-                                                     .withType(VanillaSwap::Type(swap_->type()))
+                                                     .withType(swap_->type())
                                                      .withEffectiveDate(swap_->startDate())
                                                      .withTerminationDate(expiries_[i])
                                                      .withRule(DateGeneration::Backward)
@@ -209,7 +209,7 @@ namespace QuantLib {
         Rate transformedRate = (fairRates_[i]+lambda_)*annuities_[i]/stdAnnuity;
 
         memberSwap_ = MakeVanillaSwap(dummySwapLength,iborIndex,transformedRate)
-                                                     .withType(VanillaSwap::Type(swap_->type()))
+                                                     .withType(swap_->type())
                                                      .withEffectiveDate(swap_->startDate())
                                                      .withTerminationDate(expiries_[i])
                                                      .withRule(DateGeneration::Backward)

--- a/ql/experimental/swaptions/irregularswap.cpp
+++ b/ql/experimental/swaptions/irregularswap.cpp
@@ -228,16 +228,4 @@ namespace QuantLib {
         fairSpread = Null<Spread>();
     }
 
-    std::ostream& operator<<(std::ostream& out,
-                             IrregularSwap::Type t) {
-        switch (t) {
-          case IrregularSwap::Payer:
-            return out << "Payer";
-          case IrregularSwap::Receiver:
-            return out << "Receiver";
-          default:
-            QL_FAIL("unknown IrregularSwap::Type(" << Integer(t) << ")");
-        }
-    }
-
 }

--- a/ql/experimental/swaptions/irregularswap.hpp
+++ b/ql/experimental/swaptions/irregularswap.hpp
@@ -41,7 +41,6 @@ namespace QuantLib {
     //! Irregular swap: fixed vs floating leg
     class IrregularSwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
         class arguments;
         class results;
         class engine;
@@ -118,7 +117,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline IrregularSwap::Type IrregularSwap::type() const {
+    inline Swap::Type IrregularSwap::type() const {
         return type_;
     }
 
@@ -129,9 +128,6 @@ namespace QuantLib {
     inline const Leg& IrregularSwap::floatingLeg() const {
         return legs_[1];
     }
-
-    std::ostream& operator<<(std::ostream& out,
-                             IrregularSwap::Type t);
 
 }
 

--- a/ql/experimental/swaptions/irregularswaption.hpp
+++ b/ql/experimental/swaptions/irregularswaption.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
         //! \name Inspectors
         //@{
         IrregularSettlement::Type settlementType() const { return settlementType_; }
-        IrregularSwap::Type type() const { return swap_->type(); }
+        Swap::Type type() const { return swap_->type(); }
         const ext::shared_ptr<IrregularSwap>& underlyingSwap() const {
             return swap_;
         }

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -34,10 +34,10 @@ namespace QuantLib {
                                                             BusinessDayConvention convention,
                                                             bool endOfMonth,
                                                             const ext::shared_ptr<IborIndex>& idx,
-                                                            VanillaSwap::Type type,
+                                                            Swap::Type type,
                                                             Real notional,
                                                             Spread basis) {
-        bool isPayer = (type == VanillaSwap::Payer);
+        bool isPayer = (type == Swap::Payer);
         Date referenceDate = calendar.adjust(evaluationDate);
         Date earliestDate = calendar.advance(referenceDate, fixingDays * Days, convention);
         Date maturity = earliestDate + tenor;
@@ -86,10 +86,10 @@ namespace QuantLib {
     void CrossCurrencyBasisSwapRateHelper::initializeDates() {
         baseCcyLeg_ = CrossCurrencyBasisSwapRateHelper::buildCrossCurrencyLeg(
             evaluationDate_, tenor_, fixingDays_, calendar_, convention_, endOfMonth_, baseCcyIdx_,
-            VanillaSwap::Receiver);
+            Swap::Receiver);
         quoteCcyLeg_ = CrossCurrencyBasisSwapRateHelper::buildCrossCurrencyLeg(
             evaluationDate_, tenor_, fixingDays_, calendar_, convention_, endOfMonth_, quoteCcyIdx_,
-            VanillaSwap::Payer);
+            Swap::Payer);
 
         earliestDate_ = std::min(baseCcyLeg_->startDate(), quoteCcyLeg_->startDate());
         latestDate_ = std::max(baseCcyLeg_->maturityDate(), quoteCcyLeg_->maturityDate());

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -75,7 +75,7 @@ namespace QuantLib {
                                                            BusinessDayConvention convention,
                                                            bool endOfMonth,
                                                            const ext::shared_ptr<IborIndex>& idx,
-                                                           VanillaSwap::Type type,
+                                                           Swap::Type type,
                                                            Real notional = 1.0,
                                                            Spread basis = 0.0);
         //@}

--- a/ql/instruments/bmaswap.cpp
+++ b/ql/instruments/bmaswap.cpp
@@ -86,7 +86,7 @@ namespace QuantLib {
         return nominal_;
     }
 
-    BMASwap::Type BMASwap::type() const {
+    Swap::Type BMASwap::type() const {
         return type_;
     }
 

--- a/ql/instruments/bmaswap.hpp
+++ b/ql/instruments/bmaswap.hpp
@@ -34,7 +34,9 @@ namespace QuantLib {
     //! swap paying Libor against BMA coupons
     class BMASwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
+        /*! In this constructor, the type (Payer or Receiver) refers
+            to the BMA leg.
+        */
         BMASwap(Type type,
                 Real nominal,
                 // Libor leg
@@ -53,7 +55,7 @@ namespace QuantLib {
         Real liborFraction() const;
         Spread liborSpread() const;
         Real nominal() const;
-        //! "payer" or "receiver" refer to the BMA leg
+        //! "Payer" or "Receiver" refers to the BMA leg
         Type type() const;
         const Leg& bmaLeg() const;
         const Leg& liborLeg() const;

--- a/ql/instruments/cpiswap.cpp
+++ b/ql/instruments/cpiswap.cpp
@@ -215,17 +215,5 @@ namespace QuantLib {
         fairSpread = Null<Spread>();
     }
 
-    std::ostream& operator<<(std::ostream& out,
-                             CPISwap::Type t) {
-        switch (t) {
-            case CPISwap::Payer:
-                return out << "Payer";
-            case CPISwap::Receiver:
-                return out << "Receiver";
-            default:
-                QL_FAIL("unknown CPISwap::Type(" << Integer(t) << ")");
-        }
-    }
-
 }
 

--- a/ql/instruments/cpiswap.hpp
+++ b/ql/instruments/cpiswap.hpp
@@ -65,11 +65,11 @@ namespace QuantLib {
     */
     class CPISwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
         class arguments;
         class results;
         class engine;
 
+        /*! In this swap, the type (Payer or Receiver) refers to the floating leg. */
         CPISwap(Type type,
                 Real nominal,
                 bool subtractInflationNominal,
@@ -188,7 +188,7 @@ namespace QuantLib {
     // inline definitions
 
     // inspectors
-    inline  CPISwap::Type CPISwap::type() const { return type_; }
+    inline  Swap::Type CPISwap::type() const { return type_; }
     inline  Real CPISwap::nominal() const { return nominal_; }
     inline  bool CPISwap::subtractInflationNominal() const { return subtractInflationNominal_; }
 
@@ -218,8 +218,6 @@ namespace QuantLib {
     inline const Leg& CPISwap::floatLeg() const {
         return legs_[1];
     }
-
-    std::ostream& operator<<(std::ostream& out, CPISwap::Type t);
 
 }
 

--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -33,7 +33,7 @@
 
 namespace QuantLib {
 
-    FloatFloatSwap::FloatFloatSwap(const VanillaSwap::Type type,
+    FloatFloatSwap::FloatFloatSwap(const Swap::Type type,
                                    const Real nominal1,
                                    const Real nominal2,
                                    const Schedule& schedule1,
@@ -72,7 +72,7 @@ namespace QuantLib {
         init(paymentConvention1, paymentConvention2);
     }
 
-    FloatFloatSwap::FloatFloatSwap(const VanillaSwap::Type type,
+    FloatFloatSwap::FloatFloatSwap(const Swap::Type type,
                                    std::vector<Real> nominal1,
                                    std::vector<Real> nominal2,
                                    Schedule schedule1,
@@ -373,11 +373,11 @@ namespace QuantLib {
             registerWith(*i);
 
         switch (type_) {
-        case VanillaSwap::Payer:
+        case Swap::Payer:
             payer_[0] = -1.0;
             payer_[1] = +1.0;
             break;
-        case VanillaSwap::Receiver:
+        case Swap::Receiver:
             payer_[0] = +1.0;
             payer_[1] = -1.0;
             break;

--- a/ql/instruments/floatfloatswap.hpp
+++ b/ql/instruments/floatfloatswap.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
         class results;
         class engine;
         FloatFloatSwap(
-            VanillaSwap::Type type,
+            Swap::Type type,
             Real nominal1,
             Real nominal2,
             const Schedule& schedule1,
@@ -69,7 +69,7 @@ namespace QuantLib {
             const boost::optional<BusinessDayConvention>& paymentConvention2 = boost::none);
 
         FloatFloatSwap(
-            VanillaSwap::Type type,
+            Swap::Type type,
             std::vector<Real> nominal1,
             std::vector<Real> nominal2,
             Schedule schedule1,
@@ -93,7 +93,7 @@ namespace QuantLib {
 
         //! \name Inspectors
         //@{
-        VanillaSwap::Type type() const;
+        Swap::Type type() const;
         const std::vector<Real> &nominal1() const;
         const std::vector<Real> &nominal2() const;
 
@@ -135,7 +135,7 @@ namespace QuantLib {
         void init(boost::optional<BusinessDayConvention> paymentConvention1,
                   boost::optional<BusinessDayConvention> paymentConvention2);
         void setupExpired() const override;
-        VanillaSwap::Type type_;
+        Swap::Type type_;
         std::vector<Real> nominal1_, nominal2_;
         Schedule schedule1_, schedule2_;
         ext::shared_ptr<InterestRateIndex> index1_, index2_;
@@ -152,7 +152,7 @@ namespace QuantLib {
     class FloatFloatSwap::arguments : public Swap::arguments {
       public:
         arguments() = default;
-        VanillaSwap::Type type = VanillaSwap::Receiver;
+        Swap::Type type = Swap::Receiver;
         std::vector<Real> nominal1, nominal2;
 
         std::vector<Date> leg1ResetDates, leg1FixingDates, leg1PayDates;
@@ -184,7 +184,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline VanillaSwap::Type FloatFloatSwap::type() const { return type_; }
+    inline Swap::Type FloatFloatSwap::type() const { return type_; }
 
     inline const std::vector<Real> &FloatFloatSwap::nominal1() const {
         return nominal1_;

--- a/ql/instruments/floatfloatswaption.hpp
+++ b/ql/instruments/floatfloatswaption.hpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         Settlement::Method settlementMethod() const {
             return settlementMethod_;
         }
-        VanillaSwap::Type type() const { return swap_->type(); }
+        Swap::Type type() const { return swap_->type(); }
         const ext::shared_ptr<FloatFloatSwap> &underlyingSwap() const {
             return swap_;
         }

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
       rule_(DateGeneration::Backward),
       // any value here for endOfMonth_ would not be actually used
       isDefaultEOM_(true),
-      type_(OvernightIndexedSwap::Payer), nominal_(1.0),
+      type_(Swap::Payer), nominal_(1.0),
       overnightSpread_(0.0),
       fixedDayCount_(overnightIndex->dayCounter()), 
       telescopicValueDates_(false), 
@@ -143,11 +143,11 @@ namespace QuantLib {
     }
 
     MakeOIS& MakeOIS::receiveFixed(bool flag) {
-        type_ = flag ? OvernightIndexedSwap::Receiver : OvernightIndexedSwap::Payer ;
+        type_ = flag ? Swap::Receiver : Swap::Payer ;
         return *this;
     }
 
-    MakeOIS& MakeOIS::withType(OvernightIndexedSwap::Type type) {
+    MakeOIS& MakeOIS::withType(Swap::Type type) {
         type_ = type;
         return *this;
     }

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -47,7 +47,7 @@ namespace QuantLib {
         operator ext::shared_ptr<OvernightIndexedSwap>() const ;
 
         MakeOIS& receiveFixed(bool flag = true);
-        MakeOIS& withType(OvernightIndexedSwap::Type type);
+        MakeOIS& withType(Swap::Type type);
         MakeOIS& withNominal(Real n);
 
         MakeOIS& withSettlementDays(Natural settlementDays);
@@ -93,7 +93,7 @@ namespace QuantLib {
         DateGeneration::Rule rule_;
         bool endOfMonth_, isDefaultEOM_;
 
-        OvernightIndexedSwap::Type type_;
+        Swap::Type type_;
         Real nominal_;
 
         Spread overnightSpread_;

--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -35,14 +35,14 @@ namespace QuantLib {
     : swapIndex_(std::move(swapIndex)), delivery_(Settlement::Physical),
       settlementMethod_(Settlement::PhysicalOTC), optionTenor_(optionTenor),
       optionConvention_(ModifiedFollowing), fixingDate_(Null<Date>()), strike_(strike),
-      underlyingType_(VanillaSwap::Payer), nominal_(1.0) {}
+      underlyingType_(Swap::Payer), nominal_(1.0) {}
 
     MakeSwaption::MakeSwaption(ext::shared_ptr<SwapIndex> swapIndex,
                                const Date& fixingDate,
                                Rate strike)
     : swapIndex_(std::move(swapIndex)), delivery_(Settlement::Physical),
       settlementMethod_(Settlement::PhysicalOTC), optionConvention_(ModifiedFollowing),
-      fixingDate_(fixingDate), strike_(strike), underlyingType_(VanillaSwap::Payer) {}
+      fixingDate_(fixingDate), strike_(strike), underlyingType_(Swap::Payer) {}
 
     MakeSwaption::operator Swaption() const {
         ext::shared_ptr<Swaption> swaption = *this;
@@ -128,7 +128,7 @@ namespace QuantLib {
         return *this;
     }
 
-    MakeSwaption& MakeSwaption::withUnderlyingType(const VanillaSwap::Type type) {
+    MakeSwaption& MakeSwaption::withUnderlyingType(const Swap::Type type) {
         underlyingType_ = type;
         return *this;
     }

--- a/ql/instruments/makeswaption.hpp
+++ b/ql/instruments/makeswaption.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
         MakeSwaption& withSettlementMethod(Settlement::Method settlementMethod);
         MakeSwaption& withOptionConvention(BusinessDayConvention bdc);
         MakeSwaption& withExerciseDate(const Date&);
-        MakeSwaption& withUnderlyingType(VanillaSwap::Type type);
+        MakeSwaption& withUnderlyingType(Swap::Type type);
 
         MakeSwaption& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
@@ -76,7 +76,7 @@ namespace QuantLib {
         mutable ext::shared_ptr<Exercise> exercise_;
 
         Rate strike_;
-        VanillaSwap::Type underlyingType_;
+        Swap::Type underlyingType_;
         Real nominal_;
 
         ext::shared_ptr<PricingEngine> engine_;

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -45,7 +45,7 @@ namespace QuantLib {
       settlementDays_(Null<Natural>()),
       fixedCalendar_(index->fixingCalendar()),
       floatCalendar_(index->fixingCalendar()),
-      type_(VanillaSwap::Payer), nominal_(1.0),
+      type_(Swap::Payer), nominal_(1.0),
       floatTenor_(index->tenor()),
       fixedConvention_(ModifiedFollowing),
       fixedTerminationDateConvention_(ModifiedFollowing),
@@ -199,11 +199,11 @@ namespace QuantLib {
     }
 
     MakeVanillaSwap& MakeVanillaSwap::receiveFixed(bool flag) {
-        type_ = flag ? VanillaSwap::Receiver : VanillaSwap::Payer ;
+        type_ = flag ? Swap::Receiver : Swap::Payer ;
         return *this;
     }
 
-    MakeVanillaSwap& MakeVanillaSwap::withType(VanillaSwap::Type type) {
+    MakeVanillaSwap& MakeVanillaSwap::withType(Swap::Type type) {
         type_ = type;
         return *this;
     }

--- a/ql/instruments/makevanillaswap.hpp
+++ b/ql/instruments/makevanillaswap.hpp
@@ -47,7 +47,7 @@ namespace QuantLib {
         operator ext::shared_ptr<VanillaSwap>() const;
 
         MakeVanillaSwap& receiveFixed(bool flag = true);
-        MakeVanillaSwap& withType(VanillaSwap::Type type);
+        MakeVanillaSwap& withType(Swap::Type type);
         MakeVanillaSwap& withNominal(Real n);
 
         MakeVanillaSwap& withSettlementDays(Natural settlementDays);
@@ -92,7 +92,7 @@ namespace QuantLib {
         Date effectiveDate_, terminationDate_;
         Calendar fixedCalendar_, floatCalendar_;
 
-        VanillaSwap::Type type_;
+        Swap::Type type_;
         Real nominal_;
         Period fixedTenor_, floatTenor_;
         BusinessDayConvention fixedConvention_, fixedTerminationDateConvention_;

--- a/ql/instruments/nonstandardswap.cpp
+++ b/ql/instruments/nonstandardswap.cpp
@@ -33,7 +33,7 @@
 namespace QuantLib {
 
     NonstandardSwap::NonstandardSwap(const VanillaSwap &fromVanilla)
-        : Swap(2), type_((VanillaSwap::Type)fromVanilla.type()),
+        : Swap(2), type_(fromVanilla.type()),
           fixedNominal_(std::vector<Real>(fromVanilla.fixedLeg().size(),
                                           fromVanilla.nominal())),
           floatingNominal_(std::vector<Real>(fromVanilla.floatingLeg().size(),
@@ -54,7 +54,7 @@ namespace QuantLib {
         init();
     }
 
-    NonstandardSwap::NonstandardSwap(const VanillaSwap::Type type,
+    NonstandardSwap::NonstandardSwap(const Swap::Type type,
                                      std::vector<Real> fixedNominal,
                                      const std::vector<Real>& floatingNominal,
                                      Schedule fixedSchedule,
@@ -85,7 +85,7 @@ namespace QuantLib {
         init();
     }
 
-    NonstandardSwap::NonstandardSwap(const VanillaSwap::Type type,
+    NonstandardSwap::NonstandardSwap(const Swap::Type type,
                                      std::vector<Real> fixedNominal,
                                      std::vector<Real> floatingNominal,
                                      Schedule fixedSchedule,
@@ -213,11 +213,11 @@ namespace QuantLib {
             registerWith(*i);
 
         switch (type_) {
-        case VanillaSwap::Payer:
+        case Swap::Payer:
             payer_[0] = -1.0;
             payer_[1] = +1.0;
             break;
-        case VanillaSwap::Receiver:
+        case Swap::Receiver:
             payer_[0] = +1.0;
             payer_[1] = -1.0;
             break;

--- a/ql/instruments/nonstandardswap.hpp
+++ b/ql/instruments/nonstandardswap.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
         class results;
         class engine;
         NonstandardSwap(const VanillaSwap &fromVanilla);
-        NonstandardSwap(VanillaSwap::Type type,
+        NonstandardSwap(Swap::Type type,
                         std::vector<Real> fixedNominal,
                         const std::vector<Real>& floatingNominal,
                         Schedule fixedSchedule,
@@ -57,7 +57,7 @@ namespace QuantLib {
                         bool intermediateCapitalExchange = false,
                         bool finalCapitalExchange = false,
                         boost::optional<BusinessDayConvention> paymentConvention = boost::none);
-        NonstandardSwap(VanillaSwap::Type type,
+        NonstandardSwap(Swap::Type type,
                         std::vector<Real> fixedNominal,
                         std::vector<Real> floatingNominal,
                         Schedule fixedSchedule,
@@ -73,7 +73,7 @@ namespace QuantLib {
                         boost::optional<BusinessDayConvention> paymentConvention = boost::none);
         //! \name Inspectors
         //@{
-        VanillaSwap::Type type() const;
+        Swap::Type type() const;
         const std::vector<Real> &fixedNominal() const;
         const std::vector<Real> &floatingNominal() const;
 
@@ -105,7 +105,7 @@ namespace QuantLib {
       private:
         void init();
         void setupExpired() const override;
-        VanillaSwap::Type type_;
+        Swap::Type type_;
         std::vector<Real> fixedNominal_, floatingNominal_;
         Schedule fixedSchedule_;
         std::vector<Real> fixedRate_;
@@ -126,7 +126,7 @@ namespace QuantLib {
     class NonstandardSwap::arguments : public Swap::arguments {
       public:
         arguments() = default;
-        VanillaSwap::Type type = VanillaSwap::Receiver;
+        Swap::Type type = Swap::Receiver;
         std::vector<Real> fixedNominal, floatingNominal;
 
         std::vector<Date> fixedResetDates;
@@ -162,7 +162,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline VanillaSwap::Type NonstandardSwap::type() const { return type_; }
+    inline Swap::Type NonstandardSwap::type() const { return type_; }
 
     inline const std::vector<Real> &NonstandardSwap::fixedNominal() const {
         return fixedNominal_;

--- a/ql/instruments/nonstandardswaption.hpp
+++ b/ql/instruments/nonstandardswaption.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         Settlement::Method settlementMethod() const {
             return settlementMethod_;
         }
-        VanillaSwap::Type type() const { return swap_->type(); }
+        Swap::Type type() const { return swap_->type(); }
 
         const ext::shared_ptr<NonstandardSwap> &underlyingSwap() const {
             return swap_;

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -40,8 +40,7 @@ namespace QuantLib {
 
     //! Overnight indexed swap: fix vs compounded overnight rate
     class OvernightIndexedSwap : public Swap {
-    public:
-        enum Type { Receiver = -1, Payer = 1 };
+      public:
         OvernightIndexedSwap(Type type,
                              Real nominal,
                              const Schedule& schedule,

--- a/ql/instruments/swap.cpp
+++ b/ql/instruments/swap.cpp
@@ -23,6 +23,7 @@
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <ostream>
 
 namespace QuantLib {
 
@@ -180,6 +181,17 @@ namespace QuantLib {
         startDiscounts.clear();
         endDiscounts.clear();
         npvDateDiscount = Null<DiscountFactor>();
+    }
+
+    std::ostream& operator<<(std::ostream& out, Swap::Type t) {
+        switch (t) {
+          case Swap::Payer:
+            return out << "Payer";
+          case Swap::Receiver:
+            return out << "Receiver";
+          default:
+            QL_FAIL("unknown Swap::Type(" << Integer(t) << ")");
+        }
     }
 
 }

--- a/ql/instruments/swap.hpp
+++ b/ql/instruments/swap.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/instrument.hpp>
 #include <ql/cashflow.hpp>
+#include <iosfwd>
 
 namespace QuantLib {
 
@@ -39,6 +40,15 @@ namespace QuantLib {
     */
     class Swap : public Instrument {
       public:
+        /*! In most cases, the swap has just two legs and can be
+            defined as receiver or payer.
+
+            Its type is usually defined with respect to the leg paying
+            a fixed rate; derived swap classes will document any
+            exceptions to the rule.
+        */
+        enum Type { Receiver = -1, Payer = 1 };
+
         class arguments;
         class results;
         class engine;
@@ -146,6 +156,8 @@ namespace QuantLib {
 
     class Swap::engine : public GenericEngine<Swap::arguments,
                                               Swap::results> {};
+
+    std::ostream& operator<<(std::ostream& out, Swap::Type t);
 
 }
 

--- a/ql/instruments/swaption.hpp
+++ b/ql/instruments/swaption.hpp
@@ -97,7 +97,7 @@ namespace QuantLib {
         Settlement::Method settlementMethod() const {
             return settlementMethod_;
         }
-        VanillaSwap::Type type() const { return swap_->type(); }
+        Swap::Type type() const { return swap_->type(); }
         const ext::shared_ptr<VanillaSwap>& underlyingSwap() const {
             return swap_;
         }

--- a/ql/instruments/vanillaswap.cpp
+++ b/ql/instruments/vanillaswap.cpp
@@ -234,16 +234,4 @@ namespace QuantLib {
         fairSpread = Null<Spread>();
     }
 
-    std::ostream& operator<<(std::ostream& out,
-                             VanillaSwap::Type t) {
-        switch (t) {
-          case VanillaSwap::Payer:
-            return out << "Payer";
-          case VanillaSwap::Receiver:
-            return out << "Receiver";
-          default:
-            QL_FAIL("unknown VanillaSwap::Type(" << Integer(t) << ")");
-        }
-    }
-
 }

--- a/ql/instruments/vanillaswap.hpp
+++ b/ql/instruments/vanillaswap.hpp
@@ -64,7 +64,6 @@ namespace QuantLib {
     */
     class VanillaSwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
         class arguments;
         class results;
         class engine;
@@ -164,7 +163,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline VanillaSwap::Type VanillaSwap::type() const {
+    inline Swap::Type VanillaSwap::type() const {
         return type_;
     }
 
@@ -211,9 +210,6 @@ namespace QuantLib {
     inline const Leg& VanillaSwap::floatingLeg() const {
         return legs_[1];
     }
-
-    std::ostream& operator<<(std::ostream& out,
-                             VanillaSwap::Type t);
 
 }
 

--- a/ql/instruments/yearonyearinflationswap.cpp
+++ b/ql/instruments/yearonyearinflationswap.cpp
@@ -235,7 +235,7 @@ namespace QuantLib {
             case YearOnYearInflationSwap::Receiver:
                 return out << "Receiver";
             default:
-                QL_FAIL("unknown VanillaSwap::Type(" << Integer(t) << ")");
+                QL_FAIL("unknown YearOnYearInflationSwap::Type(" << Integer(t) << ")");
         }
     }
 

--- a/ql/instruments/yearonyearinflationswap.cpp
+++ b/ql/instruments/yearonyearinflationswap.cpp
@@ -227,17 +227,5 @@ namespace QuantLib {
         fairSpread = Null<Spread>();
     }
 
-    std::ostream& operator<<(std::ostream& out,
-                             YearOnYearInflationSwap::Type t) {
-        switch (t) {
-            case YearOnYearInflationSwap::Payer:
-                return out << "Payer";
-            case YearOnYearInflationSwap::Receiver:
-                return out << "Receiver";
-            default:
-                QL_FAIL("unknown YearOnYearInflationSwap::Type(" << Integer(t) << ")");
-        }
-    }
-
 }
 

--- a/ql/instruments/yearonyearinflationswap.hpp
+++ b/ql/instruments/yearonyearinflationswap.hpp
@@ -43,14 +43,9 @@ namespace QuantLib {
         nominal discount factor at time \f$ t \f$, \f$ N \f$ is the
         notional, and \f$ I(t) \f$ is the inflation index value at
         time \f$ t \f$.
-
-        \note These instruments have now been changed to follow
-              typical VanillaSwap type design conventions
-              w.r.t. Schedules etc.
     */
     class YearOnYearInflationSwap : public Swap {
     public:
-        enum Type { Receiver = -1, Payer = 1 };
         class arguments;
         class results;
         class engine;
@@ -152,7 +147,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline YearOnYearInflationSwap::Type YearOnYearInflationSwap::type() const {
+    inline Swap::Type YearOnYearInflationSwap::type() const {
         return type_;
     }
 
@@ -199,15 +194,6 @@ namespace QuantLib {
     inline const Leg& YearOnYearInflationSwap::yoyLeg() const {
         return legs_[1];
     }
-
-    std::ostream& operator<<(std::ostream& out,
-                             YearOnYearInflationSwap::Type t);
-
-
-
-
-
-
 
 }
 

--- a/ql/instruments/zerocouponinflationswap.hpp
+++ b/ql/instruments/zerocouponinflationswap.hpp
@@ -65,9 +65,9 @@ namespace QuantLib {
     */
     class ZeroCouponInflationSwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
         class arguments;
         class engine;
+        /*! In this swap, the type (Payer or Receiver) refers to the inflation leg. */
         ZeroCouponInflationSwap(Type type,
                                 Real nominal,
                                 const Date& startDate, // start date of contract (only)
@@ -84,7 +84,7 @@ namespace QuantLib {
 
         //! \name Inspectors
         //@{
-        //! "payer" or "receiver" refer to the inflation-indexed leg
+        //! "Payer" or "Receiver" refers to the inflation leg
         Type type() const { return type_; }
         Real nominal() const { return nominal_; }
         Date startDate() const { return startDate_; }

--- a/ql/instruments/zerocouponswap.hpp
+++ b/ql/instruments/zerocouponswap.hpp
@@ -70,8 +70,6 @@ namespace QuantLib {
 
     class ZeroCouponSwap : public Swap {
       public:
-        enum Type { Receiver = -1, Payer = 1 };
-
         ZeroCouponSwap(Type type,
                        Real baseNominal,
                        const Date& startDate,

--- a/ql/legacy/libormarketmodels/lfmswaptionengine.cpp
+++ b/ql/legacy/libormarketmodels/lfmswaptionengine.cpp
@@ -62,8 +62,7 @@ namespace QuantLib {
             - dayCounter.yearFraction(referenceDate,
                                       arguments_.fixedResetDates[0]);
 
-        Option::Type w = arguments_.type==VanillaSwap::Payer ?
-                                                Option::Call : Option::Put;
+        Option::Type w = arguments_.type==Swap::Payer ? Option::Call : Option::Put;
         Volatility vol = volatility->volatility(exercise, swapLength,
                                                 fairRate, true);
         results_.value = (swap.fixedLegBPS()/basisPoint) *

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -133,7 +133,7 @@ namespace QuantLib {
             if (j == 0)
                 npv *= -1.0;
         }
-        if (swap_->type() == VanillaSwap::Receiver)
+        if (swap_->type() == Swap::Receiver)
             npv *= -1.0;
 
         return std::max(0.0, npv);

--- a/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
@@ -171,9 +171,9 @@ namespace QuantLib {
         ext::shared_ptr<PricingEngine> swapEngine(
                              new DiscountingSwapEngine(termStructure_, false));
 
-        VanillaSwap::Type type = VanillaSwap::Receiver;
+        Swap::Type type = Swap::Receiver;
 
-        VanillaSwap temp(VanillaSwap::Receiver, nominal_,
+        VanillaSwap temp(Swap::Receiver, nominal_,
                             fixedSchedule, 0.0, fixedLegDayCounter_,
                             floatSchedule, index_, 0.0, floatingLegDayCounter_);
         temp.setPricingEngine(swapEngine);
@@ -183,7 +183,7 @@ namespace QuantLib {
         }
         else {
             exerciseRate_ = strike_;
-            type = strike_ <= forward ? VanillaSwap::Receiver : VanillaSwap::Payer;
+            type = strike_ <= forward ? Swap::Receiver : Swap::Payer;
             // ensure that calibration instrument is out of the money
         }
         swap_ = ext::make_shared<VanillaSwap>(

--- a/ql/models/shortrate/twofactormodels/g2.cpp
+++ b/ql/models/shortrate/twofactormodels/g2.cpp
@@ -220,7 +220,7 @@ namespace QuantLib {
         DayCounter dayCounter = termStructure()->dayCounter();
         Time start = dayCounter.yearFraction(settlement,
                                              arguments.floatingResetDates[0]);
-        Real w = (arguments.type==VanillaSwap::Payer ? 1 : -1 );
+        Real w = (arguments.type==Swap::Payer ? 1 : -1 );
 
         std::vector<Time> fixedPayTimes(arguments.fixedPayDates.size());
         for (Size i=0; i<fixedPayTimes.size(); ++i)

--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -147,8 +147,7 @@ namespace QuantLib {
         vSResults->legNPV[0];
     Real baseSwapNPV = vSResults->value;
 
-    VanillaSwap::Type reversedType = arguments_.type == VanillaSwap::Payer ? 
-        VanillaSwap::Receiver : VanillaSwap::Payer;
+    Swap::Type reversedType = arguments_.type == Swap::Payer ? Swap::Receiver : Swap::Payer;
 
     // Swaplet options summatory:
     while(nextFD != arguments_.fixedPayDates.end()) {

--- a/ql/pricingengines/swap/discretizedswap.cpp
+++ b/ql/pricingengines/swap/discretizedswap.cpp
@@ -106,7 +106,7 @@ namespace QuantLib {
                 for (Size j=0; j<values_.size(); j++) {
                     Real coupon = nominal * (1.0 - bond.values()[j])
                                 + accruedSpread * bond.values()[j];
-                    if (arguments_.type == VanillaSwap::Payer)
+                    if (arguments_.type == Swap::Payer)
                         values_[j] += coupon;
                     else
                         values_[j] -= coupon;
@@ -124,7 +124,7 @@ namespace QuantLib {
                 Real fixedCoupon = arguments_.fixedCoupons[i];
                 for (Size j=0; j<values_.size(); j++) {
                     Real coupon = fixedCoupon*bond.values()[j];
-                    if (arguments_.type == VanillaSwap::Payer)
+                    if (arguments_.type == Swap::Payer)
                         values_[j] -= coupon;
                     else
                         values_[j] += coupon;
@@ -141,7 +141,7 @@ namespace QuantLib {
             Time reset = fixedResetTimes_[i];
             if (useCouponInPostAdjust(reset, t, includeTodaysCashFlows_) && isOnTime(t)) {
                 Real fixedCoupon = arguments_.fixedCoupons[i];
-                if (arguments_.type==VanillaSwap::Payer)
+                if (arguments_.type==Swap::Payer)
                     values_ -= fixedCoupon;
                 else
                     values_ += fixedCoupon;
@@ -156,7 +156,7 @@ namespace QuantLib {
                 Real currentFloatingCoupon = arguments_.floatingCoupons[i];
                 QL_REQUIRE(currentFloatingCoupon != Null<Real>(),
                            "current floating coupon not given");
-                if (arguments_.type == VanillaSwap::Payer)
+                if (arguments_.type == Swap::Payer)
                     values_ += currentFloatingCoupon;
                 else
                     values_ -= currentFloatingCoupon;

--- a/ql/pricingengines/swaption/basketgeneratingengine.hpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.hpp
@@ -85,7 +85,7 @@ namespace QuantLib {
 
         virtual Real underlyingNpv(const Date& expiry, Real y) const = 0;
 
-        virtual VanillaSwap::Type underlyingType() const = 0;
+        virtual Swap::Type underlyingType() const = 0;
 
         virtual const Date underlyingLastDate() const = 0;
 
@@ -103,7 +103,7 @@ namespace QuantLib {
         friend class MatchHelper;
         class MatchHelper : public CostFunction {
           public:
-            MatchHelper(const VanillaSwap::Type type,
+            MatchHelper(const Swap::Type type,
                         const Real npv,
                         const Real delta,
                         const Real gamma,
@@ -225,7 +225,7 @@ namespace QuantLib {
                 return res;
             }
 
-            const VanillaSwap::Type type_;
+            const Swap::Type type_;
             const ext::shared_ptr<Gaussian1dModel> mdl_;
             const ext::shared_ptr<SwapIndex> indexBase_;
             const Date expiry_;

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -301,8 +301,7 @@ namespace QuantLib {
 
         Real stdDev = std::sqrt(variance);
         results_.additionalResults["stdDev"] = stdDev;
-        Option::Type w = (arguments_.type==VanillaSwap::Payer) ?
-                                                Option::Call : Option::Put;
+        Option::Type w = (arguments_.type==Swap::Payer) ? Option::Call : Option::Put;
         results_.value = Spec().value(w, strike, atmForward, stdDev, annuity, displacement);
         
         Time exerciseTime = vol_->timeFromReference(exerciseDate);

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         return npvs(expiry, y, true).second;
     }
 
-    VanillaSwap::Type
-    Gaussian1dFloatFloatSwaptionEngine::underlyingType() const {
+    Swap::Type Gaussian1dFloatFloatSwaptionEngine::underlyingType() const {
         return arguments_.swap->type();
     }
 
@@ -138,7 +137,7 @@ namespace QuantLib {
 
         FloatFloatSwap swap = *arguments_.swap;
         Option::Type type =
-            arguments_.type == VanillaSwap::Payer ? Option::Call : Option::Put;
+            arguments_.type == Swap::Payer ? Option::Call : Option::Put;
 
         Array npv0(2 * integrationPoints_ + 1, 0.0),
             npv1(2 * integrationPoints_ + 1, 0.0); // arrays for npvs of the

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.hpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.hpp
@@ -131,7 +131,7 @@ namespace QuantLib {
 
       protected:
         Real underlyingNpv(const Date& expiry, Real y) const override;
-        VanillaSwap::Type underlyingType() const override;
+        Swap::Type underlyingType() const override;
         const Date underlyingLastDate() const override;
         const Disposable<Array> initialGuess(const Date& expiry) const override;
 

--- a/ql/pricingengines/swaption/gaussian1djamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1djamshidianswaptionengine.cpp
@@ -100,7 +100,7 @@ namespace QuantLib {
                                maxStrike); // this is actually yStar
 
         Option::Type w =
-            arguments_.type == VanillaSwap::Payer ? Option::Put : Option::Call;
+            arguments_.type == Swap::Payer ? Option::Put : Option::Call;
         Size size = arguments_.fixedCoupons.size();
 
         Real value = 0.0;

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
@@ -88,8 +88,7 @@ namespace QuantLib {
         return type * npv;
     }
 
-    VanillaSwap::Type
-    Gaussian1dNonstandardSwaptionEngine::underlyingType() const {
+    Swap::Type Gaussian1dNonstandardSwaptionEngine::underlyingType() const {
         return arguments_.swap->type();
     }
 
@@ -159,7 +158,7 @@ namespace QuantLib {
 
         NonstandardSwap swap = *arguments_.swap;
         Option::Type type =
-            arguments_.type == VanillaSwap::Payer ? Option::Call : Option::Put;
+            arguments_.type == Swap::Payer ? Option::Call : Option::Put;
 
         Array npv0(2 * integrationPoints_ + 1, 0.0),
             npv1(2 * integrationPoints_ + 1, 0.0);

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.hpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.hpp
@@ -122,7 +122,7 @@ namespace QuantLib {
 
       protected:
         Real underlyingNpv(const Date& expiry, Real y) const override;
-        VanillaSwap::Type underlyingType() const override;
+        Swap::Type underlyingType() const override;
         const Date underlyingLastDate() const override;
         const Disposable<Array> initialGuess(const Date& expiry) const override;
 

--- a/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
         VanillaSwap swap = *arguments_.swap;
         Option::Type type =
-            arguments_.type == VanillaSwap::Payer ? Option::Call : Option::Put;
+            arguments_.type == Swap::Payer ? Option::Call : Option::Put;
         const Schedule& fixedSchedule = swap.fixedSchedule();
         const Schedule& floatSchedule = swap.floatingSchedule();
 

--- a/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -101,8 +101,7 @@ namespace QuantLib {
         s1d.setUpperBound(maxStrike);
         Rate rStar = s1d.solve(finder, 1e-8, 0.05, minStrike, maxStrike);
 
-        Option::Type w = arguments_.type==VanillaSwap::Payer ?
-                                                Option::Put : Option::Call;
+        Option::Type w = arguments_.type==Swap::Payer ? Option::Put : Option::Call;
         Size size = arguments_.fixedCoupons.size();
 
         Real value = 0.0;

--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -204,18 +204,18 @@ namespace QuantLib {
         Rate fixedRate = quote()->value();
 
         Real nominal = 1000000.0;   // has to be something but doesn't matter what
-        yyiis_.reset(new YearOnYearInflationSwap(YearOnYearInflationSwap::Payer,
-                                                    nominal,
-                                                    fixedSchedule,
-                                                    fixedRate,
-                                                    dayCounter_,
-                                                    yoySchedule,
-                                                    new_yii,
-                                                    swapObsLag_,
-                                                    spread,
-                                                    dayCounter_,
-                                                    calendar_,  // inflation index does not have a calendar
-                                                    paymentConvention_));
+        yyiis_.reset(new YearOnYearInflationSwap(Swap::Payer,
+                                                 nominal,
+                                                 fixedSchedule,
+                                                 fixedRate,
+                                                 dayCounter_,
+                                                 yoySchedule,
+                                                 new_yii,
+                                                 swapObsLag_,
+                                                 spread,
+                                                 dayCounter_,
+                                                 calendar_,  // inflation index does not have a calendar
+                                                 paymentConvention_));
 
 
         // The instrument takes a standard discounting swap engine.

--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -108,7 +108,7 @@ namespace QuantLib {
         Real nominal = 1000000.0;   // has to be something but doesn't matter what
         Date start = nominalTS->referenceDate();
         zciis_.reset(new ZeroCouponInflationSwap(
-                                ZeroCouponInflationSwap::Payer,
+                                Swap::Payer,
                                 nominal, start, maturity_,
                                 calendar_, paymentConvention_, dayCounter_, K, // fixed side & fixed rate
                                 new_zii, swapObsLag_));

--- a/ql/termstructures/volatility/gaussian1dsmilesection.cpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.cpp
@@ -79,8 +79,8 @@ Real Gaussian1dSmileSection::optionPrice(Rate strike, Option::Type type,
     if (swapIndex_ != nullptr) {
         Swaption s = MakeSwaption(swapIndex_, fixingDate_, strike)
                          .withUnderlyingType(type == Option::Call
-                                                 ? VanillaSwap::Payer
-                                                 : VanillaSwap::Receiver)
+                                                 ? Swap::Payer
+                                                 : Swap::Receiver)
                          .withPricingEngine(engine_);
         Real tmp = s.NPV();
         return tmp / annuity_ * discount;

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -943,15 +943,15 @@ namespace QuantLib {
                           .endOfMonth(iborIndex_->endOfMonth())
                           .backwards();
 
-        swap_ = ext::shared_ptr<BMASwap>(new BMASwap(BMASwap::Payer, 100.0,
-                                                liborSchedule,
-                                                0.75, // arbitrary
-                                                0.0,
-                                                iborIndex_,
-                                                iborIndex_->dayCounter(),
-                                                bmaSchedule,
-                                                clonedIndex,
-                                                bmaDayCount_));
+        swap_ = ext::make_shared<BMASwap>(Swap::Payer, 100.0,
+                                          liborSchedule,
+                                          0.75, // arbitrary
+                                          0.0,
+                                          iborIndex_,
+                                          iborIndex_->dayCounter(),
+                                          bmaSchedule,
+                                          clonedIndex,
+                                          bmaDayCount_);
         swap_->setPricingEngine(ext::shared_ptr<PricingEngine>(new
             DiscountingSwapEngine(iborIndex_->forwardingTermStructure())));
 

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -169,7 +169,7 @@ namespace {
         Schedule floatSchedule(swapStart, swapEnd, Period(6, Months), TARGET(), ModifiedFollowing,
                                ModifiedFollowing, DateGeneration::Backward, false);
         ext::shared_ptr<VanillaSwap> swap(
-            new VanillaSwap(VanillaSwap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(Thirty360::BondBasis),
+            new VanillaSwap(Swap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(Thirty360::BondBasis),
                             floatSchedule, euribor6m, 0.0, euribor6m->dayCounter()));
         swap->setPricingEngine(ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(discYTS)));
         // European exercise and swaption

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -46,7 +46,7 @@ namespace bermudan_swaption_test {
 
         // underlying swap parameters
         Integer startYears, length;
-        VanillaSwap::Type type;
+        Swap::Type type;
         Real nominal;
         BusinessDayConvention fixedConvention, floatingConvention;
         Frequency fixedFrequency, floatingFrequency;
@@ -63,7 +63,7 @@ namespace bermudan_swaption_test {
         CommonVars() {
             startYears = 1;
             length = 5;
-            type = VanillaSwap::Payer;
+            type = Swap::Payer;
             nominal = 1000.0;
             settlementDays = 2;
             fixedConvention = Unadjusted;

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -391,7 +391,7 @@ void CapFloorTest::testParity() {
                 Date maturity = vars.calendar.advance(startDate, length, Years, vars.convention);
                 Schedule schedule(startDate, maturity, Period(vars.frequency), vars.calendar,
                                   vars.convention, vars.convention, DateGeneration::Forward, false);
-                VanillaSwap swap(VanillaSwap::Payer, vars.nominals[0], schedule, strike,
+                VanillaSwap swap(Swap::Payer, vars.nominals[0], schedule, strike,
                                  vars.index->dayCounter(), schedule, vars.index, 0.0,
                                  vars.index->dayCounter());
                 swap.setPricingEngine(
@@ -449,7 +449,7 @@ void CapFloorTest::testATMRate() {
                                << "   floor ATM rate:" << floorATMRate << "\n"
                                << "   relative Error:"
                                << relativeError(capATMRate, floorATMRate, capATMRate) * 100 << "%");
-                VanillaSwap swap(VanillaSwap::Payer, vars.nominals[0],
+                VanillaSwap swap(Swap::Payer, vars.nominals[0],
                                  schedule, floorATMRate,
                                  vars.index->dayCounter(),
                                  schedule, vars.index, 0.0,

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -111,14 +111,14 @@ namespace crosscurrencyratehelpers_test {
             ext::shared_ptr<Swap> baseCcyLeg =
                 CrossCurrencyBasisSwapRateHelper::buildCrossCurrencyLeg(
                     start, Period(q.n, q.units), settlementDays, calendar, businessConvention,
-                    endOfMonth, baseCcyIdx, VanillaSwap::Receiver, baseCcyLegNotional,
+                    endOfMonth, baseCcyIdx, Swap::Receiver, baseCcyLegNotional,
                     baseCcyLegBasis);
             legs.push_back(baseCcyLeg);
 
             ext::shared_ptr<Swap> quoteCcyLeg =
                 CrossCurrencyBasisSwapRateHelper::buildCrossCurrencyLeg(
                     start, Period(q.n, q.units), settlementDays, calendar, businessConvention,
-                    endOfMonth, quoteCcyIdx, VanillaSwap::Payer, quoteCcyLegNotional,
+                    endOfMonth, quoteCcyIdx, Swap::Payer, quoteCcyLegNotional,
                     quoteCcyLegBasis);
             legs.push_back(quoteCcyLeg);
 

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -459,12 +459,12 @@ void InflationTest::testZeroTermStructure() {
 
     ext::shared_ptr<ZeroInflationIndex> zii = ext::dynamic_pointer_cast<ZeroInflationIndex>(ii);
     BOOST_REQUIRE_MESSAGE(zii,"dynamic_pointer_cast to ZeroInflationIndex from UKRPI failed");
-    ZeroCouponInflationSwap nzcis(ZeroCouponInflationSwap::Payer,
-                                     1000000.0,
-                                     evaluationDate,
-                                     zcData[6].date,    // end date = maturity
-                                     calendar, bdc, dc, zcData[6].rate/100.0, // fixed rate
-                                     zii, observationLag);
+    ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                  1000000.0,
+                                  evaluationDate,
+                                  zcData[6].date,    // end date = maturity
+                                  calendar, bdc, dc, zcData[6].rate/100.0, // fixed rate
+                                  zii, observationLag);
 
     // N.B. no coupon pricer because it is not a coupon, effect of inflation curve via
     //      inflation curve attached to the inflation index.
@@ -569,7 +569,7 @@ void InflationTest::testZeroTermStructure() {
 
     ext::shared_ptr<ZeroInflationIndex> ziiyes = ext::dynamic_pointer_cast<ZeroInflationIndex>(iiyes);
     BOOST_REQUIRE_MESSAGE(ziiyes,"dynamic_pointer_cast to ZeroInflationIndex from UKRPI-I failed");
-    ZeroCouponInflationSwap nzcisyes(ZeroCouponInflationSwap::Payer,
+    ZeroCouponInflationSwap nzcisyes(Swap::Payer,
                                      1000000.0,
                                      evaluationDate,
                                      zcData[6].date,    // end date = maturity

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -896,17 +896,17 @@ void InflationTest::testYYTermStructure() {
         .backwards()
         ;
 
-        YearOnYearInflationSwap yyS2(YearOnYearInflationSwap::Payer,
-                                        1000000.0,
-                                        yoySchedule,//fixed schedule, but same as yoy
-                                        yyData[j].rate/100.0,
-                                        dc,
-                                        yoySchedule,
-                                        iir,
-                                        observationLag,
-                                        0.0,        //spread on index
-                                        dc,
-                                        UnitedKingdom());
+        YearOnYearInflationSwap yyS2(Swap::Payer,
+                                     1000000.0,
+                                     yoySchedule,//fixed schedule, but same as yoy
+                                     yyData[j].rate/100.0,
+                                     dc,
+                                     yoySchedule,
+                                     iir,
+                                     observationLag,
+                                     0.0,        //spread on index
+                                     dc,
+                                     UnitedKingdom());
 
         yyS2.setPricingEngine(sppe);
         setCouponPricer(yyS2.yoyLeg(), pricer);
@@ -934,17 +934,17 @@ void InflationTest::testYYTermStructure() {
         .backwards()
         ;
 
-        YearOnYearInflationSwap yyS3(YearOnYearInflationSwap::Payer,
-                                    1000000.0,
-                                    yoySchedule,//fixed schedule, but same as yoy
-                                    yyData[jj].rate/100.0,
-                                    dc,
-                                    yoySchedule,
-                                    iir,
-                                    observationLag,
-                                    0.0,        //spread on index
-                                    dc,
-                                    UnitedKingdom());
+        YearOnYearInflationSwap yyS3(Swap::Payer,
+                                     1000000.0,
+                                     yoySchedule,//fixed schedule, but same as yoy
+                                     yyData[jj].rate/100.0,
+                                     dc,
+                                     yoySchedule,
+                                     iir,
+                                     observationLag,
+                                     0.0,        //spread on index
+                                     dc,
+                                     UnitedKingdom());
 
         yyS3.setPricingEngine(sppe);
         setCouponPricer(yyS3.yoyLeg(), pricer);

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -433,7 +433,7 @@ void InflationCapFloorTest::testParity() {
                     .backwards()
                     ;
 
-                    YearOnYearInflationSwap swap(YearOnYearInflationSwap::Payer, 1000000.0,
+                    YearOnYearInflationSwap swap(Swap::Payer, 1000000.0,
                                                  yoySchedule, // fixed schedule, but same as yoy
                                                  strike, vars.dc, yoySchedule, vars.iir,
                                                  vars.observationLag,

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -735,17 +735,17 @@ void InflationCapFlooredCouponTest::testInstrumentEquality() {
                     .backwards()
                     ;
 
-                    YearOnYearInflationSwap swap(YearOnYearInflationSwap::Payer,
-                                                    1000000.0,
-                                                    yoySchedule,//fixed schedule, but same as yoy
-                                                    0.0,//strikes[j],
-                                                    vars.dc,
-                                                    yoySchedule,
-                                                    vars.iir,
-                                                    vars.observationLag,
-                                                    0.0,        //spread on index
-                                                    vars.dc,
-                                                    UnitedKingdom());
+                    YearOnYearInflationSwap swap(Swap::Payer,
+                                                 1000000.0,
+                                                 yoySchedule,//fixed schedule, but same as yoy
+                                                 0.0,//strikes[j],
+                                                 vars.dc,
+                                                 yoySchedule,
+                                                 vars.iir,
+                                                 vars.observationLag,
+                                                 0.0,        //spread on index
+                                                 vars.dc,
+                                                 UnitedKingdom());
 
                     Handle<YieldTermStructure> hTS(vars.nominalTS);
                     ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -268,7 +268,7 @@ void CPISwapTest::consistency() {
 
     // ZeroInflationSwap aka CPISwap
 
-    CPISwap::Type type = CPISwap::Payer;
+    Swap::Type type = Swap::Payer;
     Real nominal = 1000000.0;
     bool subtractInflationNominal = true;
     // float+spread leg
@@ -411,7 +411,7 @@ void CPISwapTest::zciisconsistency() {
     std::vector<Date> oneDate = {endDate};
     Schedule schOneDate(oneDate, cal, paymentConvention);
 
-    CPISwap::Type stype = CPISwap::Payer;
+    Swap::Type stype = Swap::Payer;
     Real inflationNominal = nominal;
     Real floatNominal = inflationNominal * std::pow(1.0+quote,50);
     bool subtractInflationNominal = true;
@@ -447,7 +447,7 @@ void CPISwapTest::cpibondconsistency() {
 
     // ZeroInflationSwap aka CPISwap
 
-    CPISwap::Type type = CPISwap::Payer;
+    Swap::Type type = Swap::Payer;
     Real nominal = 1000000.0;
     bool subtractInflationNominal = true;
     // float+spread leg

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -387,7 +387,7 @@ void CPISwapTest::zciisconsistency() {
 
     CommonVars common;
 
-    ZeroCouponInflationSwap::Type ztype = ZeroCouponInflationSwap::Payer;
+    Swap::Type ztype = Swap::Payer;
     Real  nominal = 1000000.0;
     Date startDate(common.evaluationDate);
     Date endDate(25, November, 2059);

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -422,7 +422,7 @@ void LiborMarketModelTest::testSwaptionPricing() {
 
             Rate swapRate  = 0.0404;
             ext::shared_ptr<VanillaSwap> forwardSwap(
-                new VanillaSwap(VanillaSwap::Receiver, 1.0,
+                new VanillaSwap(Swap::Receiver, 1.0,
                                 schedule, swapRate, dayCounter,
                                 schedule, index, 0.0, index->dayCounter()));
             forwardSwap->setPricingEngine(ext::shared_ptr<PricingEngine>(
@@ -439,7 +439,7 @@ void LiborMarketModelTest::testSwaptionPricing() {
 
             swapRate = forwardSwap->fairRate();
             forwardSwap = ext::make_shared<VanillaSwap>(
-                VanillaSwap::Receiver, 1.0,
+                                Swap::Receiver, 1.0,
                                 schedule, swapRate, dayCounter,
                                 schedule, index, 0.0, index->dayCounter());
             forwardSwap->setPricingEngine(ext::shared_ptr<PricingEngine>(

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -113,7 +113,7 @@ namespace overnight_indexed_swap_test {
     struct CommonVars {
         // global data
         Date today, settlement;
-        OvernightIndexedSwap::Type type;
+        Swap::Type type;
         Real nominal;
         Calendar calendar;
         Natural settlementDays;
@@ -153,7 +153,7 @@ namespace overnight_indexed_swap_test {
         }
 
         CommonVars() {
-            type = OvernightIndexedSwap::Payer;
+            type = Swap::Payer;
             settlementDays = 2;
             nominal = 100.0;
             fixedEoniaConvention = ModifiedFollowing;

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -616,7 +616,7 @@ namespace piecewise_yield_curve_test {
                               .backwards();
 
 
-            BMASwap swap(BMASwap::Payer, 100.0,
+            BMASwap swap(Swap::Payer, 100.0,
                          liborSchedule, 0.75, 0.0,
                          libor3m, libor3m->dayCounter(),
                          bmaSchedule, bma, vars.bmaDayCounter);

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -373,7 +373,7 @@ void ShortRateModelTest::testSwaps() {
                                    DateGeneration::Forward, false);
             for (double rate : rates) {
 
-                VanillaSwap swap(VanillaSwap::Payer, 1000000.0, fixedSchedule, rate,
+                VanillaSwap swap(Swap::Payer, 1000000.0, fixedSchedule, rate,
                                  Thirty360(Thirty360::BondBasis),
                                  floatSchedule, euribor, 0.0, Actual360());
                 swap.setPricingEngine(ext::shared_ptr<PricingEngine>(

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -44,7 +44,7 @@ namespace swap_test {
     struct CommonVars {
         // global data
         Date today, settlement;
-        VanillaSwap::Type type;
+        Swap::Type type;
         Real nominal;
         Calendar calendar;
         BusinessDayConvention fixedConvention, floatingConvention;
@@ -81,7 +81,7 @@ namespace swap_test {
         }
 
         CommonVars() {
-            type = VanillaSwap::Payer;
+            type = Swap::Payer;
             settlementDays = 2;
             nominal = 100.0;
             fixedConvention = Unadjusted;

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -47,7 +47,7 @@ namespace swaption_test {
     Period lengths[] = { 1*Years, 2*Years, 3*Years,
                          5*Years, 7*Years, 10*Years,
                          15*Years, 20*Years };
-    VanillaSwap::Type type[] = { VanillaSwap::Receiver, VanillaSwap::Payer };
+    Swap::Type type[] = { Swap::Receiver, Swap::Payer };
 
     struct CommonVars {
         // global data
@@ -159,7 +159,7 @@ void SwaptionTest::testStrikeDependency() {
                     values_cash.push_back(swaption_cash->NPV());
                 }
                 // and check that they go the right way
-                if (k == VanillaSwap::Payer) {
+                if (k == Swap::Payer) {
                     auto it = std::adjacent_find(values.begin(), values.end(), std::less<Real>());
                     if (it != values.end()) {
                         Size n = it - values.begin();
@@ -256,7 +256,7 @@ void SwaptionTest::testSpreadDependency() {
                     values_cash.push_back(swaption_cash->NPV());
                 }
                 // and check that they go the right way
-                if (k == VanillaSwap::Payer) {
+                if (k == Swap::Payer) {
                     auto it =
                         std::adjacent_find(values.begin(), values.end(), std::greater<Real>());
                     if (it != values.end()) {
@@ -580,19 +580,19 @@ void SwaptionTest::testCashSettledSwaptions() {
             // Annuity calculated by swap method fixedLegBPS().
             // Fixed leg conventions: Unadjusted, 30/360
             Real annuity_u360 = swap_u360->fixedLegBPS() / 0.0001;
-            annuity_u360 = swap_u360->type()==VanillaSwap::Payer ?
+            annuity_u360 = swap_u360->type()==Swap::Payer ?
                 -annuity_u360 : annuity_u360;
             // Fixed leg conventions: ModifiedFollowing, act/365
             Real annuity_a365 = swap_a365->fixedLegBPS() / 0.0001;
-            annuity_a365 = swap_a365->type()==VanillaSwap::Payer ?
+            annuity_a365 = swap_a365->type()==Swap::Payer ?
                 -annuity_a365 : annuity_a365;
             // Fixed leg conventions: ModifiedFollowing, 30/360
             Real annuity_a360 = swap_a360->fixedLegBPS() / 0.0001;
-            annuity_a360 = swap_a360->type()==VanillaSwap::Payer ?
+            annuity_a360 = swap_a360->type()==Swap::Payer ?
                 -annuity_a360 : annuity_a360;
             // Fixed leg conventions: Unadjusted, act/365
             Real annuity_u365 = swap_u365->fixedLegBPS() / 0.0001;
-            annuity_u365 = swap_u365->type()==VanillaSwap::Payer ?
+            annuity_u365 = swap_u365->type()==Swap::Payer ?
                 -annuity_u365 : annuity_u365;
 
             // Calculation of Modified Annuity (cash settlement)

--- a/test-suite/zerocouponswap.cpp
+++ b/test-suite/zerocouponswap.cpp
@@ -76,7 +76,7 @@ namespace zerocouponswap_test {
             return cpn;
         }
 
-        ext::shared_ptr<ZeroCouponSwap> createZCSwap(ZeroCouponSwap::Type type,
+        ext::shared_ptr<ZeroCouponSwap> createZCSwap(Swap::Type type,
                                                      const Date& start,
                                                      const Date& end,
                                                      Real baseNominal,
@@ -88,14 +88,14 @@ namespace zerocouponswap_test {
             return swap;
         }
 
-        ext::shared_ptr<ZeroCouponSwap> createZCSwap(ZeroCouponSwap::Type type,
+        ext::shared_ptr<ZeroCouponSwap> createZCSwap(Swap::Type type,
                                                      const Date& start,
                                                      const Date& end,
                                                      Real finalPayment) {
             return createZCSwap(type, start, end, baseNominal, finalPayment);
         }
 
-        ext::shared_ptr<ZeroCouponSwap> createZCSwap(ZeroCouponSwap::Type type,
+        ext::shared_ptr<ZeroCouponSwap> createZCSwap(Swap::Type type,
                                                      const Date& start,
                                                      const Date& end) {
             return createZCSwap(type, start, end, finalPayment);
@@ -104,7 +104,7 @@ namespace zerocouponswap_test {
         ext::shared_ptr<ZeroCouponSwap> createZCSwap(const Date& start, 
                                                      const Date& end, 
                                                      Rate fixedRate) {
-            auto swap = ext::make_shared<ZeroCouponSwap>(ZeroCouponSwap::Receiver, baseNominal, 
+            auto swap = ext::make_shared<ZeroCouponSwap>(Swap::Receiver, baseNominal, 
                                                          start, end, fixedRate, dayCount, euribor,
                                                          calendar, businessConvention, paymentDelay);
             swap->setPricingEngine(discountEngine);
@@ -112,13 +112,9 @@ namespace zerocouponswap_test {
         }
     };
 
-    std::string printType(ZeroCouponSwap::Type type) {
-        return type == ZeroCouponSwap::Receiver ? "receiver" : "payer";
-    }
-
     void checkReplicationOfZeroCouponSwapNPV(const Date& start,
                                              const Date& end,
-                                             ZeroCouponSwap::Type type = ZeroCouponSwap::Receiver) {
+                                             Swap::Type type = Swap::Receiver) {
         CommonVars vars;
         const Real tolerance = 1.0e-8;
 
@@ -152,12 +148,12 @@ namespace zerocouponswap_test {
                         << "    expected float leg NPV:    " << expectedFloatLegNPV << "\n"
                         << "    start:    " << start << "\n"
                         << "    end:    " << end << "\n"
-                        << "    type:    " << printType(type) << "\n");
+                        << "    type:    " << type << "\n");
     }
 
     void checkFairFixedPayment(const Date& start,
                                const Date& end,
-                               ZeroCouponSwap::Type type) {
+                               Swap::Type type) {
         CommonVars vars;
         const Real tolerance = 1.0e-8;
 
@@ -173,10 +169,10 @@ namespace zerocouponswap_test {
                         << "    fair fixed payment:    " << fairFixedPayment << "\n"
                         << "    start:    " << start << "\n"
                         << "    end:    " << end << "\n"
-                        << "    type:    " << printType(type) << "\n");
+                        << "    type:    " << type << "\n");
     }
 
-    void checkFairFixedRate(const Date& start, const Date& end, ZeroCouponSwap::Type type) {
+    void checkFairFixedRate(const Date& start, const Date& end, Swap::Type type) {
         CommonVars vars;
         const Real tolerance = 1.0e-8;
 
@@ -192,7 +188,7 @@ namespace zerocouponswap_test {
                         << "    fair fixed rate:    " << fairFixedRate << "\n"
                         << "    start:    " << start << "\n"
                         << "    end:    " << end << "\n"
-                        << "    type:    " << printType(type) << "\n");
+                        << "    type:    " << type << "\n");
     }
 }
 
@@ -203,10 +199,10 @@ void ZeroCouponSwapTest::testInstrumentValuation() {
 
     // Ongoing instrument
     checkReplicationOfZeroCouponSwapNPV(Date(12, February, 2021), Date(12, February, 2041),
-                                        ZeroCouponSwap::Receiver);
+                                        Swap::Receiver);
     // Forward starting instrument
     checkReplicationOfZeroCouponSwapNPV(Date(15, April, 2021), Date(12, February, 2041), 
-                                        ZeroCouponSwap::Payer);
+                                        Swap::Payer);
 
     // Expired instrument
     checkReplicationOfZeroCouponSwapNPV(Date(12, February, 2000), Date(12, February, 2020));
@@ -219,11 +215,11 @@ void ZeroCouponSwapTest::testFairFixedPayment() {
 
     // Ongoing instrument
     checkFairFixedPayment(Date(12, February, 2021), Date(12, February, 2041),
-                          ZeroCouponSwap::Receiver);
+                          Swap::Receiver);
 
     // Spot starting instrument
     checkFairFixedPayment(Date(17, March, 2021), Date(12, February, 2041), 
-                          ZeroCouponSwap::Payer);
+                          Swap::Payer);
 }
 
 void ZeroCouponSwapTest::testFairFixedRate() {
@@ -233,10 +229,10 @@ void ZeroCouponSwapTest::testFairFixedRate() {
 
     // Ongoing instrument
     checkFairFixedRate(Date(12, February, 2021), Date(12, February, 2041),
-                       ZeroCouponSwap::Receiver);
+                       Swap::Receiver);
 
     // Spot starting instrument
-    checkFairFixedRate(Date(17, March, 2021), Date(12, February, 2041), ZeroCouponSwap::Payer);
+    checkFairFixedRate(Date(17, March, 2021), Date(12, February, 2041), Swap::Payer);
 }
 
 void ZeroCouponSwapTest::testFixedPaymentFromRate() {
@@ -276,7 +272,7 @@ void ZeroCouponSwapTest::testArgumentsValidation() {
     Date end(12, February, 2041);
 
     // Negative base nominal
-    BOOST_CHECK_THROW(vars.createZCSwap(ZeroCouponSwap::Payer, start, end, -1.0e6, 1.0e6),
+    BOOST_CHECK_THROW(vars.createZCSwap(Swap::Payer, start, end, -1.0e6, 1.0e6),
                       Error);
 
     // Start date after end date


### PR DESCRIPTION
We had 8 clones of the same enumeration in derived classes, which were too many.