### PR TITLE
Add `-std=c++11` flag to autotools build when required

### DIFF
--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -12,13 +12,11 @@ jobs:
             tag: trusty
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
           - name: "gcc 5.4 (Boost 1.66)"
             shortname: gcc5
             tag: xenial
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
           - name: "gcc 6.3 (Boost 1.66)"
             shortname: gcc6
             tag: zesty
@@ -126,7 +124,6 @@ jobs:
             tag: rolling
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
             configureflags: --enable-std-classes
           - name: "auto_ptr re-enabled"
             shortname: autoptr

--- a/.github/workflows/linux-nondefault.yml
+++ b/.github/workflows/linux-nondefault.yml
@@ -12,7 +12,6 @@ jobs:
             tag: xenial
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
           - name: "gcc 6.3 (Boost 1.66)"
             shortname: gcc6
             tag: zesty

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,13 +12,11 @@ jobs:
             tag: trusty
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
           - name: "gcc 5.4 (Boost 1.66)"
             shortname: gcc5
             tag: xenial
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
           - name: "gcc 6.3 (Boost 1.66)"
             shortname: gcc6
             tag: zesty
@@ -130,7 +128,6 @@ jobs:
             tag: rolling
             cc: gcc
             cxx: g++
-            cxxflags: "-std=c++11"
             configureflags: --enable-std-classes
             tests: true
           - name: "auto_ptr re-enabled"

--- a/.github/workflows/macos-nondefault.yml
+++ b/.github/workflows/macos-nondefault.yml
@@ -9,7 +9,6 @@ jobs:
         include:
           - os: [macos-10.15]
             shortname: default
-            cxxflags: "-std=c++11"
           - os: [macos-10.15]
             shortname: stdclasses
             cxxflags: "-std=c++17"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,10 +9,8 @@ jobs:
         include:
           - os: [macos-10.15]
             shortname: default
-            cxxflags: "-std=c++11"
           - os: [macos-10.15]
             shortname: stdclasses
-            cxxflags: "-std=c++11"
             configureflags: --enable-std-classes
     steps:
     - uses: actions/checkout@v2

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,4 +1,33 @@
 
+# QL_CHECK_CPP11
+# --------------------
+# Check whether C++11 features are supported by default.
+# If not (e.g., with Clang on Mac OS) add -std=c++11
+AC_DEFUN([QL_CHECK_CPP11],
+[AC_MSG_CHECKING([for C++11 support])
+ AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[@%:@include <initializer_list>
+          struct S {
+            int i = 3;
+            double x = 3.5;
+          };
+
+          class C {
+            public:
+              C(int) noexcept;
+              C(std::initializer_list<int>);
+              S f() { return { 2, 1.5 }; }
+          };
+          ]],
+        [[]])],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_RESULT([no: adding -std=c++11 to CXXFLAGS])
+     AC_SUBST([CPP11_CXXFLAGS],["-std=c++11"])
+     AC_SUBST([CXXFLAGS],["${CXXFLAGS} -std=c++11"])
+    ])
+])
+
 # QL_CHECK_BOOST_DEVEL
 # --------------------
 # Check whether the Boost headers are available

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,9 @@ if test "$ql_openmp" = "yes" ; then
    AC_SUBST([CXXFLAGS],["${CXXFLAGS} ${OPENMP_CXXFLAGS}"])
 fi
 
+# Check for C++11 support
+QL_CHECK_CPP11
+
 # Check for Boost components
 QL_CHECK_BOOST
 AM_CONDITIONAL(BOOST_UNIT_TEST_FOUND, test "x${BOOST_UNIT_TEST_LIB}" != "x")

--- a/quantlib-config.in
+++ b/quantlib-config.in
@@ -39,7 +39,7 @@ while test $# -gt 0; do
       echo @PACKAGE_VERSION@
       ;;
     --cflags)
-      echo -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@
+      echo -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP11_CXXFLAGS@
       ;;
     --libs)
       echo -L@libdir@ @BOOST_LIB@ -lQuantLib @OPENMP_CXXFLAGS@ @BOOST_THREAD_LIB@


### PR DESCRIPTION
Fixes #1090.

It can be superseded by adding the desired `-std=` flag to `CXXFLAGS`.