### PR TITLE
Fix Calibration Errors in G2

### DIFF
--- a/ql/models/shortrate/twofactormodels/g2.cpp
+++ b/ql/models/shortrate/twofactormodels/g2.cpp
@@ -166,7 +166,7 @@ namespace QuantLib {
             SolvingFunction function(lambda, Bb_) ;
             Brent s1d;
             s1d.setMaxEvaluations(1000);
-            Real yb = s1d.solve(function, 1e-6, 0.00, -100.0, 100.0);
+            Real yb = s1d.solve(function, 1e-6, 0.00, -10.0*sigmay_, 10.0*sigmay_);
 
             Real h1 = (yb - muy_)/(sigmay_*txy) -
                 rhoxy_*(x  - mux_)/(sigmax_*txy);
@@ -241,4 +241,3 @@ namespace QuantLib {
     }
 
 }
-


### PR DESCRIPTION
Related to issue #1087.

There has been some issues the lower bound becomes minus infinity as y=-100 is a very low value.

Instead of having the interval, where we solve for y-bar, hard-coded, it is now set to plus/minus 10 standard deviations.