### PR TITLE
Add ESTR Index

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -850,6 +850,7 @@
     <ClInclude Include="ql\indexes\ibor\chflibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\dkklibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\eonia.hpp" />
+    <ClInclude Include="ql\indexes\ibor\estr.hpp" />
     <ClInclude Include="ql\indexes\ibor\euribor.hpp" />
     <ClInclude Include="ql\indexes\ibor\eurlibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\fedfunds.hpp" />
@@ -2120,6 +2121,7 @@
     <ClCompile Include="ql\indexes\bmaindex.cpp" />
     <ClCompile Include="ql\indexes\ibor\bibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\eonia.cpp" />
+    <ClCompile Include="ql\indexes\ibor\estr.cpp" />
     <ClCompile Include="ql\indexes\ibor\euribor.cpp" />
     <ClCompile Include="ql\indexes\ibor\eurlibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\fedfunds.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -645,6 +645,9 @@
     <ClInclude Include="ql\indexes\ibor\eonia.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\ibor\estr.hpp">
+      <Filter>indexes\ibor</Filter>
+    </ClInclude>
     <ClInclude Include="ql\indexes\ibor\euribor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
@@ -4514,6 +4517,9 @@
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\eonia.cpp">
+      <Filter>indexes\ibor</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\ibor\estr.cpp">
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\euribor.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -255,6 +255,7 @@ set(QuantLib_SRC
     indexes/bmaindex.cpp
     indexes/ibor/bibor.cpp
     indexes/ibor/eonia.cpp
+    indexes/ibor/estr.cpp
     indexes/ibor/euribor.cpp
     indexes/ibor/eurlibor.cpp
     indexes/ibor/fedfunds.cpp
@@ -1288,6 +1289,7 @@ set(QuantLib_HDR
     indexes/ibor/chflibor.hpp
     indexes/ibor/dkklibor.hpp
     indexes/ibor/eonia.hpp
+    indexes/ibor/estr.hpp
     indexes/ibor/euribor.hpp
     indexes/ibor/eurlibor.hpp
     indexes/ibor/fedfunds.hpp

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -14,6 +14,7 @@ this_include_HEADERS = \
     chflibor.hpp \
     dkklibor.hpp \
     eonia.hpp \
+    estr.hpp \
     euribor.hpp \
     eurlibor.hpp \
     fedfunds.hpp \
@@ -40,6 +41,7 @@ this_include_HEADERS = \
 cpp_files = \
     bibor.cpp \
     eonia.cpp \
+    estr.hpp \
     euribor.cpp \
     eurlibor.cpp \
     fedfunds.cpp \
@@ -82,4 +84,3 @@ all.hpp: Makefile.am
 	subdirs='$(SUBDIRS)'; for i in $$subdirs; do \
 		echo "#include <${subdir}/$$i/all.hpp>" >> ${srcdir}/$@; \
 	done
-

--- a/ql/indexes/ibor/all.hpp
+++ b/ql/indexes/ibor/all.hpp
@@ -11,6 +11,7 @@
 #include <ql/indexes/ibor/chflibor.hpp>
 #include <ql/indexes/ibor/dkklibor.hpp>
 #include <ql/indexes/ibor/eonia.hpp>
+#include <ql/indexes/ibor/estr.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/indexes/ibor/eurlibor.hpp>
 #include <ql/indexes/ibor/fedfunds.hpp>

--- a/ql/indexes/ibor/estr.cpp
+++ b/ql/indexes/ibor/estr.cpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Magnus Mencke
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/indexes/ibor/estr.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/currencies/europe.hpp>
+
+namespace QuantLib {
+
+    Estr::Estr(const Handle<YieldTermStructure>& h)
+    : OvernightIndex("ESTR", 0, EURCurrency(), TARGET(), Actual360(), h) {}
+
+}

--- a/ql/indexes/ibor/estr.hpp
+++ b/ql/indexes/ibor/estr.hpp
@@ -1,0 +1,40 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Magnus Mencke
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file eonia.hpp
+    \brief %ESTR index
+*/
+
+#ifndef quantlib_estr_hpp
+#define quantlib_estr_hpp
+
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    //! %ESTR (Euro Short-Term Rate) rate fixed by the ECB.
+    class Estr : public OvernightIndex {
+      public:
+        explicit Estr(const Handle<YieldTermStructure>& h =
+                      Handle<YieldTermStructure>());
+    };
+
+}
+
+#endif


### PR DESCRIPTION
Related to #868.

An ESTR index is created as a copy of Eonia. 

One thing I noticed was that the business day convention was hard-coded in `OvernightIndex` as `Following`, while according to [this link](https://www.ecb.europa.eu/pub/pdf/other/ecb.consultation_publication_compounded_term_rates_ESTR202007~0567eaeb98.en.pdf), the business day convention for ESTR is "modified previous". I am however not sure whether this makes any difference.