### PR TITLE
Remove check on Boost::uBLAS availability.

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -100,31 +100,6 @@ AC_DEFUN([QL_CHECK_BOOST_VERSION_1_59_OR_HIGHER],
     ])
 ])
 
-
-
-# QL_CHECK_BOOST_UBLAS
-# --------------------
-# Check whether the Boost headers are available
-AC_DEFUN([QL_CHECK_BOOST_UBLAS],
-[AC_MSG_CHECKING([for Boost::uBLAS support])
- AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM(
-        [[@%:@include <boost/version.hpp>
-          @%:@if BOOST_VERSION > 106300
-          @%:@include <boost/serialization/array_wrapper.hpp>
-          @%:@endif
-          @%:@include <boost/numeric/ublas/vector_proxy.hpp>
-          @%:@include <boost/numeric/ublas/triangular.hpp>
-          @%:@include <boost/numeric/ublas/lu.hpp>]],
-        [[]])],
-    [AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])
-     AC_MSG_WARN([Some functionality will be disabled.])
-     AC_DEFINE([QL_NO_UBLAS_SUPPORT],[],
-               [Define this if your compiler does not support Boost::uBLAS.])
-    ])
-])
-
 # QL_CHECK_BOOST_UNIT_TEST
 # ------------------------
 # Check whether the Boost unit-test framework is available
@@ -303,7 +278,6 @@ AC_DEFUN([QL_CHECK_BOOST_TEST_INTERPROCESS],
 AC_DEFUN([QL_CHECK_BOOST],
 [AC_REQUIRE([QL_CHECK_BOOST_DEVEL])
  AC_REQUIRE([QL_CHECK_BOOST_VERSION])
- AC_REQUIRE([QL_CHECK_BOOST_UBLAS])
  AC_REQUIRE([QL_CHECK_BOOST_UNIT_TEST])
 ])
 

--- a/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
@@ -121,11 +121,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmBlackScholesFwdOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapT_.toMatrix());
         return retVal;
     }
-#endif
+
 }

--- a/ql/experimental/finitedifferences/fdmblackscholesfwdop.hpp
+++ b/ql/experimental/finitedifferences/fdmblackscholesfwdop.hpp
@@ -52,9 +52,7 @@ class FdmBlackScholesFwdOp : public FdmLinearOpComposite {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<YieldTermStructure> rTS_, qTS_;

--- a/ql/experimental/finitedifferences/fdmdupire1dop.cpp
+++ b/ql/experimental/finitedifferences/fdmdupire1dop.cpp
@@ -19,10 +19,7 @@
 
 #include <ql/experimental/finitedifferences/fdmdupire1dop.hpp>
 #include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
 #include <boost/numeric/ublas/matrix.hpp>
-#endif
 
 namespace QuantLib {
 
@@ -66,11 +63,10 @@ Disposable<Array> FdmDupire1dOp::preconditioner(const Array &r, Real dt) const {
     return solve_splitting(0, r, dt);
 }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
 Disposable<std::vector<SparseMatrix> > FdmDupire1dOp::toMatrixDecomp() const {
     std::vector<SparseMatrix> retVal(1);
     retVal[0] = mapT_.toMatrix();
     return retVal;
 }
-#endif
+
 }

--- a/ql/experimental/finitedifferences/fdmdupire1dop.hpp
+++ b/ql/experimental/finitedifferences/fdmdupire1dop.hpp
@@ -47,9 +47,7 @@ class FdmDupire1dOp : public FdmLinearOpComposite {
     Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
     Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
 
   private:
     const ext::shared_ptr<FdmMesher> mesher_;

--- a/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
+++ b/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
@@ -102,12 +102,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmExtendedOrnsteinUhlenbeckOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapX_.toMatrix());
         return retVal;
     }
-#endif
 
 }

--- a/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.hpp
+++ b/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.hpp
@@ -54,9 +54,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> process_;

--- a/ql/experimental/finitedifferences/fdmextoujumpop.hpp
+++ b/ql/experimental/finitedifferences/fdmextoujumpop.hpp
@@ -61,9 +61,7 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
       private:
         Disposable<Array> integro(const Array& r) const;
 
@@ -78,23 +76,7 @@ namespace QuantLib {
 
         const TripleBandLinearOp dyMap_;
 
-#if defined(QL_NO_UBLAS_SUPPORT)
-        class IntegroIntegrand {
-          public:
-            IntegroIntegrand(const ext::shared_ptr<LinearInterpolation>& i,
-                             const FdmBoundaryConditionSet& bcSet,
-                             Real y, Real eta);
-            Real operator()(Real u) const;
-            
-          private:
-            const Real y_, eta_;
-            const FdmBoundaryConditionSet& bcSet_;
-            const ext::shared_ptr<LinearInterpolation>& interpl_;
-        };
-            
-#else
         SparseMatrix integroPart_;
-#endif
     };
 }
 

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -224,7 +224,6 @@ namespace QuantLib {
         return v;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > FdmHestonFwdOp::toMatrixDecomp()
         const {
 
@@ -236,5 +235,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.hpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.hpp
@@ -58,9 +58,7 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
       private:
         Disposable<Array> getLeverageFctSlice(Time t1, Time t2) const;
         const FdmSquareRootFwdOp::TransformationType type_;

--- a/ql/experimental/finitedifferences/fdmklugeextouop.cpp
+++ b/ql/experimental/finitedifferences/fdmklugeextouop.cpp
@@ -108,7 +108,6 @@ namespace QuantLib {
         return klugeOp_->solve_splitting(0, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmKlugeExtOUOp::toMatrixDecomp() const {
         const std::vector<SparseMatrix> klugeDecomp
@@ -122,5 +121,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/experimental/finitedifferences/fdmklugeextouop.hpp
+++ b/ql/experimental/finitedifferences/fdmklugeextouop.hpp
@@ -80,9 +80,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
 
         const ext::shared_ptr<FdmMesher> mesher_;

--- a/ql/experimental/finitedifferences/fdmsquarerootfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmsquarerootfwdop.cpp
@@ -332,11 +332,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-    #if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmSquareRootFwdOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapX_->toMatrix());
         return retVal;
     }
-    #endif
+
 }

--- a/ql/experimental/finitedifferences/fdmsquarerootfwdop.hpp
+++ b/ql/experimental/finitedifferences/fdmsquarerootfwdop.hpp
@@ -52,9 +52,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
         Real lowerBoundaryFactor(TransformationType type = Plain) const;
         Real upperBoundaryFactor(TransformationType type = Plain) const;
         Real v(Size i) const;

--- a/ql/experimental/finitedifferences/fdmzabrop.cpp
+++ b/ql/experimental/finitedifferences/fdmzabrop.cpp
@@ -107,7 +107,6 @@ Disposable<Array> FdmZabrOp::preconditioner(const Array &r, Real dt) const {
     return solve_splitting(0, r, dt);
 }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
 Disposable<std::vector<SparseMatrix> > FdmZabrOp::toMatrixDecomp() const {
     std::vector<SparseMatrix> retVal(3);
     retVal[0] = dxMap_.getMap().toMatrix();
@@ -115,5 +114,5 @@ Disposable<std::vector<SparseMatrix> > FdmZabrOp::toMatrixDecomp() const {
     retVal[2] = dxyMap_.toMatrix();
     return retVal;
 }
-#endif
+
 }

--- a/ql/experimental/finitedifferences/fdmzabrop.hpp
+++ b/ql/experimental/finitedifferences/fdmzabrop.hpp
@@ -82,9 +82,7 @@ class FdmZabrOp : public FdmLinearOpComposite {
     Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
     Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
 
   private:
     const Array volatilityValues_;

--- a/ql/experimental/math/laplaceinterpolation.hpp
+++ b/ql/experimental/math/laplaceinterpolation.hpp
@@ -24,8 +24,6 @@
 #ifndef quantlib_laplace_interpolation
 #define quantlib_laplace_interpolation
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
-
 #include <ql/math/matrixutilities/bicgstab.hpp>
 #include <ql/math/matrixutilities/sparsematrix.hpp>
 
@@ -162,5 +160,4 @@ template <class M> void laplaceInterpolation(M &A, Real relTol = 1E-6) {
 
 } // namespace QuantLib
 
-#endif // QL_NO_UBLAS_SUPPORT
 #endif // include guard

--- a/ql/math/matrix.cpp
+++ b/ql/math/matrix.cpp
@@ -38,14 +38,12 @@
 #pragma clang diagnostic ignored "-Wunused-function"
 #endif
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
 #if BOOST_VERSION == 106400
 #include <boost/serialization/array_wrapper.hpp>
 #endif
 #include <boost/numeric/ublas/vector_proxy.hpp>
 #include <boost/numeric/ublas/triangular.hpp>
 #include <boost/numeric/ublas/lu.hpp>
-#endif
 
 #if defined(QL_PATCH_MSVC)
 #pragma warning(pop)
@@ -63,8 +61,6 @@
 namespace QuantLib {
 
     Disposable<Matrix> inverse(const Matrix& m) {
-        #if !defined(QL_NO_UBLAS_SUPPORT)
-
         QL_REQUIRE(m.rows() == m.columns(), "matrix is not square");
 
         boost::numeric::ublas::matrix<Real> a(m.rows(), m.columns());
@@ -99,15 +95,9 @@ namespace QuantLib {
                   retVal.begin());
 
         return retVal;
-
-        #else
-        QL_FAIL("this version of gcc does not support "
-                "the Boost uBLAS library");
-        #endif
     }
 
     Real determinant(const Matrix& m) {
-        #if !defined(QL_NO_UBLAS_SUPPORT)
         QL_REQUIRE(m.rows() == m.columns(), "matrix is not square");
 
         boost::numeric::ublas::matrix<Real> a(m.rows(), m.columns());
@@ -127,10 +117,6 @@ namespace QuantLib {
                 retVal *=  a(i,i);
         }
         return retVal;
-
-        #else
-        QL_FAIL("this version of gcc does not support "
-                "the Boost uBLAS library");
-        #endif
     }
+
 }

--- a/ql/math/matrixutilities/sparseilupreconditioner.cpp
+++ b/ql/math/matrixutilities/sparseilupreconditioner.cpp
@@ -17,10 +17,6 @@ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/qldefines.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
-
 #include <ql/math/matrixutilities/sparseilupreconditioner.hpp>
 #include <ql/math/matrix.hpp>
 
@@ -194,4 +190,3 @@ namespace QuantLib {
 
 }
 
-#endif

--- a/ql/math/matrixutilities/sparseilupreconditioner.hpp
+++ b/ql/math/matrixutilities/sparseilupreconditioner.hpp
@@ -24,10 +24,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #ifndef quantlib_sparse_ilu_preconditioner_hpp
 #define quantlib_sparse_ilu_preconditioner_hpp
 
-#include <ql/qldefines.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
-
 #include <ql/math/array.hpp>
 #include <ql/math/matrixutilities/sparsematrix.hpp>
 
@@ -56,5 +52,4 @@ namespace QuantLib {
 
 }
 
-#endif
 #endif

--- a/ql/math/matrixutilities/sparsematrix.hpp
+++ b/ql/math/matrixutilities/sparsematrix.hpp
@@ -25,9 +25,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #define quantlib_sparse_matrix_hpp
 
 #include <ql/qldefines.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
-
 #include <ql/math/array.hpp>
 
 #if defined(QL_PATCH_MSVC)
@@ -91,5 +88,4 @@ namespace QuantLib {
     }
 }
 
-#endif
 #endif

--- a/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
@@ -26,10 +26,7 @@
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
 #include <ql/methods/finitedifferences/operators/fdm2dblackscholesop.hpp>
 #include <ql/methods/finitedifferences/operators/secondordermixedderivativeop.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
 #include <boost/numeric/ublas/matrix.hpp>
-#endif
 
 namespace QuantLib {
 
@@ -152,7 +149,6 @@ namespace QuantLib {
         return solve_splitting(0, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     Fdm2dBlackScholesOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(3);
@@ -164,5 +160,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdm2dblackscholesop.hpp
+++ b/ql/methods/finitedifferences/operators/fdm2dblackscholesop.hpp
@@ -54,9 +54,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& x, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<GeneralizedBlackScholesProcess> p1_, p2_;

--- a/ql/methods/finitedifferences/operators/fdmbatesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.cpp
@@ -123,10 +123,8 @@ namespace QuantLib {
         return lambda_*(integral-r);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > FdmBatesOp::toMatrixDecomp() const {
         QL_FAIL("not implemented");
     }
-#endif
 
 }

--- a/ql/methods/finitedifferences/operators/fdmbatesop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.hpp
@@ -52,9 +52,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         class IntegroIntegrand {
           public:

--- a/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
@@ -140,11 +140,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmBlackScholesOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapT_.toMatrix());
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmblackscholesop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesop.hpp
@@ -55,9 +55,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<YieldTermStructure> rTS_, qTS_;

--- a/ql/methods/finitedifferences/operators/fdmcevop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcevop.cpp
@@ -85,11 +85,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > FdmCEVOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapT_.toMatrix());
         return retVal;
     }
-#endif
+
 }
 

--- a/ql/methods/finitedifferences/operators/fdmcevop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmcevop.hpp
@@ -57,9 +57,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<YieldTermStructure>& rTS_;
         const Size direction_;

--- a/ql/methods/finitedifferences/operators/fdmcirop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.cpp
@@ -168,7 +168,6 @@ namespace QuantLib {
         return solve_splitting(1, solve_splitting(0, r, dt), dt) ;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmCIROp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(3);
@@ -179,5 +178,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmcirop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmcirop.hpp
@@ -111,9 +111,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         FdmCIREquityPart dxMap_;
         FdmCIRRatesPart dyMap_;

--- a/ql/methods/finitedifferences/operators/fdmg2op.cpp
+++ b/ql/methods/finitedifferences/operators/fdmg2op.cpp
@@ -111,7 +111,6 @@ namespace QuantLib {
         return solve_splitting(direction1_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > FdmG2Op::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(3);
         retVal[0] = mapX_.toMatrix();
@@ -120,6 +119,6 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }
 

--- a/ql/methods/finitedifferences/operators/fdmg2op.hpp
+++ b/ql/methods/finitedifferences/operators/fdmg2op.hpp
@@ -50,9 +50,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const Size direction1_, direction2_;
         const Array x_, y_;

--- a/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
@@ -146,7 +146,6 @@ namespace QuantLib {
         return solve_splitting(0, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmHestonHullWhiteOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(4);
@@ -157,5 +156,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.hpp
@@ -77,9 +77,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const Real v0_, kappa_, theta_, sigma_, rho_;
         const ext::shared_ptr<HullWhite> hwModel_;

--- a/ql/methods/finitedifferences/operators/fdmhestonop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonop.cpp
@@ -194,7 +194,6 @@ namespace QuantLib {
         return solve_splitting(1, solve_splitting(0, r, dt), dt) ;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmHestonOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(3);
@@ -205,5 +204,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmhestonop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonop.hpp
@@ -103,9 +103,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         NinePointLinearOp correlationMap_;
         FdmHestonVariancePart dyMap_;

--- a/ql/methods/finitedifferences/operators/fdmhullwhiteop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhullwhiteop.cpp
@@ -92,12 +92,11 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmHullWhiteOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapT_.toMatrix());
         return retVal;
     }
-#endif
+
 }
 

--- a/ql/methods/finitedifferences/operators/fdmhullwhiteop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmhullwhiteop.hpp
@@ -51,9 +51,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const Size direction_;
         const Array x_;

--- a/ql/methods/finitedifferences/operators/fdmlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearop.hpp
@@ -37,9 +37,7 @@ namespace QuantLib {
         virtual ~FdmLinearOp() = default;
         virtual Disposable<array_type> apply(const array_type& r) const = 0;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         virtual Disposable<SparseMatrix> toMatrix() const = 0;
-#endif
     };
 }
 

--- a/ql/methods/finitedifferences/operators/fdmlinearopcomposite.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearopcomposite.hpp
@@ -28,10 +28,7 @@
 
 #include <ql/math/matrixutilities/sparsematrix.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearop.hpp>
-
-#if !defined(QL_NO_UBLAS_SUPPORT)
 #include <numeric>
-#endif
 
 namespace QuantLib {
 
@@ -51,7 +48,6 @@ namespace QuantLib {
         virtual Disposable<Array> 
             preconditioner(const Array& r, Real s) const = 0;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         virtual Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const {
             QL_FAIL(" ublas representation is not implemented");
         }
@@ -62,7 +58,7 @@ namespace QuantLib {
                                                   SparseMatrix(dcmp.front()));
             return retVal;
         }
-#endif
+
     };
 }
 

--- a/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
@@ -93,11 +93,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmLocalVolFwdOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapT_.toMatrix());
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.hpp
@@ -51,9 +51,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<YieldTermStructure> rTS_, qTS_;

--- a/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
@@ -106,12 +106,10 @@ namespace QuantLib {
         return solve_splitting(direction_, r, dt);
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> >
     FdmOrnsteinUhlenbeckOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(1, mapX_.toMatrix());
         return retVal;
     }
-#endif
 
 }

--- a/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.hpp
@@ -53,9 +53,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<OrnsteinUhlenbeckProcess> process_;

--- a/ql/methods/finitedifferences/operators/fdmsabrop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmsabrop.cpp
@@ -96,7 +96,6 @@ namespace QuantLib {
         return solve_splitting(1, solve_splitting(0, r, dt), dt) ;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<std::vector<SparseMatrix> > FdmSabrOp::toMatrixDecomp() const {
         std::vector<SparseMatrix> retVal(3);
 
@@ -106,5 +105,5 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
+
 }

--- a/ql/methods/finitedifferences/operators/fdmsabrop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmsabrop.hpp
@@ -61,9 +61,8 @@ namespace QuantLib {
         Disposable<Array> solve_splitting(Size direction, const Array& r, Real s) const override;
         Disposable<Array> preconditioner(const Array& r, Real s) const override;
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<std::vector<SparseMatrix> > toMatrixDecomp() const override;
-#endif
+
       private:
         const ext::shared_ptr<YieldTermStructure> rTS_;
 

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -154,7 +154,6 @@ namespace QuantLib {
         return retVal;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<SparseMatrix> NinePointLinearOp::toMatrix() const {
         const ext::shared_ptr<FdmLinearOpLayout> index = mesher_->layout();
         const Size n = index->size();
@@ -174,7 +173,6 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
 
 
     Disposable<NinePointLinearOp>

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -57,9 +57,7 @@ namespace QuantLib {
 
         void swap(NinePointLinearOp& m);
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<SparseMatrix> toMatrix() const override;
-#endif
 
       protected:
         NinePointLinearOp() = default;

--- a/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
@@ -21,9 +21,6 @@
     \brief n-th order derivative linear operator
 */
 
-#include <ql/qldefines.hpp>
-#ifndef QL_NO_UBLAS_SUPPORT
-
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
 #include <ql/methods/finitedifferences/operators/numericaldifferentiation.hpp>
 #include <ql/methods/finitedifferences/operators/nthorderderivativeop.hpp>
@@ -95,4 +92,3 @@ namespace QuantLib {
 
 }
 
-#endif

--- a/ql/methods/finitedifferences/operators/nthorderderivativeop.hpp
+++ b/ql/methods/finitedifferences/operators/nthorderderivativeop.hpp
@@ -24,9 +24,6 @@
 #ifndef quantlib_nth_order_derivative_op_hpp
 #define quantlib_nth_order_derivative_op_hpp
 
-#include <ql/qldefines.hpp>
-#ifndef QL_NO_UBLAS_SUPPORT
-
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearop.hpp>
 
@@ -46,5 +43,4 @@ namespace QuantLib {
     };
 }
 
-#endif
 #endif

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -260,7 +260,6 @@ namespace QuantLib {
         return retVal;
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     Disposable<SparseMatrix> TripleBandLinearOp::toMatrix() const {
         const ext::shared_ptr<FdmLinearOpLayout> index = mesher_->layout();
         const Size n = index->size();
@@ -274,7 +273,6 @@ namespace QuantLib {
 
         return retVal;
     }
-#endif
 
 
     Disposable<Array>

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
@@ -70,9 +70,7 @@ namespace QuantLib {
 
         void swap(TripleBandLinearOp& m);
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
         Disposable<SparseMatrix> toMatrix() const override;
-#endif
 
       protected:
         TripleBandLinearOp() = default;

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -76,10 +76,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
-#if !defined(QL_NO_UBLAS_SUPPORT)
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/operation.hpp>
-#endif
 #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
 #endif
@@ -383,7 +381,6 @@ void FdmLinearOpTest::testSecondDerivativesMapApply() {
 }
 
 void FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids() {
-#ifndef QL_NO_UBLAS_SUPPORT
     BOOST_TEST_MESSAGE("Testing finite differences coefficients...");
 
     const ext::shared_ptr<Fdm1dMesher> mesherX(
@@ -557,7 +554,6 @@ void FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids() {
             }
         }
     }
-#endif
 }
 
 void FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply() {
@@ -1205,7 +1201,6 @@ void FdmLinearOpTest::testFdmHestonHullWhiteOp() {
     }
 }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
 namespace {
     Disposable<Array> axpy(
         const boost::numeric::ublas::compressed_matrix<Real>& A,
@@ -1247,10 +1242,8 @@ namespace {
         return a;
     }
 }
-#endif
 
 void FdmLinearOpTest::testBiCGstab() {
-#if !defined(QL_NO_UBLAS_SUPPORT)
     BOOST_TEST_MESSAGE(
         "Testing bi-conjugated gradient stabilized algorithm...");
 
@@ -1285,11 +1278,9 @@ void FdmLinearOpTest::testBiCGstab() {
                 "\n tolerance:  " << tol <<
                 "\n error:      " << error);
     }
-#endif
 }
 
 void FdmLinearOpTest::testGMRES() {
-#if !defined(QL_NO_UBLAS_SUPPORT)
     BOOST_TEST_MESSAGE("Testing GMRES algorithm...");
 
     const Size n=41, m=21;
@@ -1343,7 +1334,6 @@ void FdmLinearOpTest::testGMRES() {
                 "\n tolerance:  " << tol <<
                 "\n error:      " << errorWithRestart);
     }
-#endif
 }
 
 void FdmLinearOpTest::testCrankNicolsonWithDamping() {
@@ -1439,7 +1429,6 @@ void FdmLinearOpTest::testCrankNicolsonWithDamping() {
 }
 
 void FdmLinearOpTest::testSpareMatrixReference() {
-#ifndef QL_NO_UBLAS_SUPPORT
     BOOST_TEST_MESSAGE("Testing SparseMatrixReference type...");
 
     const Size rows    = 10;
@@ -1480,11 +1469,10 @@ void FdmLinearOpTest::testSpareMatrixReference() {
             }
         }
     }
-#endif
 }
 
 namespace {
-#ifndef QL_NO_UBLAS_SUPPORT
+
     Size nrElementsOfSparseMatrix(const SparseMatrix& m) {
         Size retVal = 0;
         for (SparseMatrix::const_iterator1 i1 = m.begin1();
@@ -1493,11 +1481,10 @@ namespace {
         }
         return retVal;
     }
-#endif
+
 }
 
 void FdmLinearOpTest::testSparseMatrixZeroAssignment() {
-#ifndef QL_NO_UBLAS_SUPPORT
     BOOST_TEST_MESSAGE("Testing assignment to zero in sparse matrix...");
 
     SparseMatrix m(5,5);
@@ -1516,7 +1503,6 @@ void FdmLinearOpTest::testSparseMatrixZeroAssignment() {
     if (nrElementsOfSparseMatrix(m) != 3) {
         BOOST_FAIL("three elements expected");
     }
-#endif
 }
 
 void FdmLinearOpTest::testFdmMesherIntegral() {

--- a/test-suite/marketmodel_smmcapletalphacalibration.cpp
+++ b/test-suite/marketmodel_smmcapletalphacalibration.cpp
@@ -348,9 +348,8 @@ void MarketModelSmmCapletAlphaCalibrationTest::testFunction() {
 // --- Call the desired tests
 test_suite* MarketModelSmmCapletAlphaCalibrationTest::suite() {
     auto* suite = BOOST_TEST_SUITE("SMM Caplet alpha calibration test");
-#if !defined(QL_NO_UBLAS_SUPPORT)
-    suite->add(QUANTLIB_TEST_CASE(
-                    &MarketModelSmmCapletAlphaCalibrationTest::testFunction));
-    #endif
+
+    suite->add(QUANTLIB_TEST_CASE(&MarketModelSmmCapletAlphaCalibrationTest::testFunction));
+
     return suite;
 }

--- a/test-suite/marketmodel_smmcapletcalibration.cpp
+++ b/test-suite/marketmodel_smmcapletcalibration.cpp
@@ -340,9 +340,8 @@ void MarketModelSmmCapletCalibrationTest::testFunction() {
 // --- Call the desired tests
 test_suite* MarketModelSmmCapletCalibrationTest::suite() {
     auto* suite = BOOST_TEST_SUITE("SMM Caplet calibration test");
-#if !defined(QL_NO_UBLAS_SUPPORT)
-    suite->add(QUANTLIB_TEST_CASE(
-                         &MarketModelSmmCapletCalibrationTest::testFunction));
-    #endif
+
+    suite->add(QUANTLIB_TEST_CASE(&MarketModelSmmCapletCalibrationTest::testFunction));
+
     return suite;
 }

--- a/test-suite/marketmodel_smmcaplethomocalibration.cpp
+++ b/test-suite/marketmodel_smmcaplethomocalibration.cpp
@@ -630,14 +630,11 @@ void MarketModelSmmCapletHomoCalibrationTest::testSphereCylinder() {
 test_suite* MarketModelSmmCapletHomoCalibrationTest::suite() {
     auto* suite = BOOST_TEST_SUITE("SMM Caplet homogeneous calibration test");
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     suite->add(QUANTLIB_TEST_CASE(
                      &MarketModelSmmCapletHomoCalibrationTest::testFunction));
     suite->add(QUANTLIB_TEST_CASE(
                &MarketModelSmmCapletHomoCalibrationTest::testPeriodFunction));
-    #endif
 
-    // FLOATING_POINT_EXCEPTION
     suite->add(QUANTLIB_TEST_CASE(
                &MarketModelSmmCapletHomoCalibrationTest::testSphereCylinder));
 

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -677,7 +677,6 @@ void MatricesTest::testIterativeSolvers() {
         }
     }
 
-#if !defined(QL_NO_UBLAS_SUPPORT)
     const Array v = GMRES(MatrixMult(M1), 1, relTol,
         MatrixMult(inverse(M1))).solve(b, b).x;
 
@@ -696,7 +695,6 @@ void MatricesTest::testIterativeSolvers() {
                 << "\n  rel error     : " << norm2(M1*w-b)/norm2(b)
                 << "\n  rel tolerance : " << relTol);
     }
-    #endif
 }
 
 void MatricesTest::testInitializers() {
@@ -722,7 +720,7 @@ void MatricesTest::testInitializers() {
 
 
 namespace {
-    #if !defined(QL_NO_UBLAS_SUPPORT)
+
     typedef std::pair< std::pair< std::vector<Size>, std::vector<Size> >,
                    std::vector<Real> > coordinate_tuple;
 
@@ -739,14 +737,11 @@ namespace {
         return std::make_pair(std::make_pair(row_idx, col_idx), data);
     }
 
-    #endif
 }
 
 void MatricesTest::testSparseMatrixMemory() {
 
     BOOST_TEST_MESSAGE("Testing sparse matrix memory layout...");
-
-    #if !defined(QL_NO_UBLAS_SUPPORT)
 
     SparseMatrix m(8, 4);
     BOOST_CHECK_EQUAL(m.filled1(), 1);
@@ -796,7 +791,6 @@ void MatricesTest::testSparseMatrixMemory() {
 
     BOOST_CHECK_EQUAL(entries, 4);
 
-    #endif
 }
 
 test_suite* MatricesTest::suite() {
@@ -809,11 +803,9 @@ test_suite* MatricesTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testHighamSqrt));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testQRDecomposition));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testQRSolve));
-    #if !defined(QL_NO_UBLAS_SUPPORT)
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testInverse));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testDeterminant));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testSparseMatrixMemory));
-    #endif
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testCholeskyDecomposition));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testMoorePenroseInverse));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testIterativeSolvers));

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -50,8 +50,6 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
-#ifndef QL_NO_UBLAS_SUPPORT
-
 #include <boost/numeric/ublas/banded.hpp>
 
 #if defined(__clang__) || defined(__GNUC__)
@@ -909,12 +907,10 @@ void NthOrderDerivativeOpTest::testMixedSecondOrder9PointsOnUniformGrid() {
                 }
         }
 }
-#endif
+
 
 test_suite* NthOrderDerivativeOpTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("NthOrderDerivativeOp tests");
-
-#ifndef QL_NO_UBLAS_SUPPORT
 
     suite->add(QUANTLIB_TEST_CASE(
         &NthOrderDerivativeOpTest::testSparseMatrixApply));
@@ -948,8 +944,6 @@ test_suite* NthOrderDerivativeOpTest::suite(SpeedLevel speed) {
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&NthOrderDerivativeOpTest::testHigherOrderHestonOptionPricing));
     }
-
-#endif
 
     return suite;
 }

--- a/test-suite/swapforwardmappings.cpp
+++ b/test-suite/swapforwardmappings.cpp
@@ -452,16 +452,13 @@ void SwapForwardMappingsTest::testSwaptionImpliedVolatility()
 test_suite* SwapForwardMappingsTest::suite() {
     auto* suite = BOOST_TEST_SUITE("swap-forward mappings tests");
 
-
     suite->add(QUANTLIB_TEST_CASE(
         &SwapForwardMappingsTest::testSwaptionImpliedVolatility));
 
     suite->add(QUANTLIB_TEST_CASE(
         &SwapForwardMappingsTest::testForwardSwapJacobians));
-// #if !defined(QL_NO_UBLAS_SUPPORT)
-//     suite->add(QUANTLIB_TEST_CASE(
-//         &SwapForwardMappingsTest::testForwardCoterminalMappings));
-// #endif
+    // suite->add(QUANTLIB_TEST_CASE(
+    //     &SwapForwardMappingsTest::testForwardCoterminalMappings));
     return suite;
 }
 

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -869,7 +869,6 @@ void VPPTest::testVPPPricing() {
 }
 
 void VPPTest::testKlugeExtOUMatrixDecomposition() {
-#ifndef QL_NO_UBLAS_SUPPORT
     BOOST_TEST_MESSAGE("Testing KlugeExtOU matrix decomposition...");
 
     using namespace vpp_test;
@@ -962,7 +961,6 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
             }
         }
     }
-#endif
 }
 
 


### PR DESCRIPTION
It was meant for gcc 3.x, which can't support C++11 anyway.