### PR TITLE
Fixed parameter types

### DIFF
--- a/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -76,7 +76,7 @@ namespace QuantLib {
             void setPoint(const Date& optionDate,
                           const Period& swapTenor,
                           Time optionTime,
-                          Time swapLengths,
+                          Time swapLength,
                           const std::vector<Real>& point);
             void setLayer(Size i,
                           const Matrix& x);
@@ -1029,10 +1029,12 @@ namespace QuantLib {
         points_[i] = x;
     }
 
-    template<class Model> void SwaptionVolCube1x<Model>::Cube::setPoint(
-                            const Date& optionDate, const Period& swapTenor,
-                            const Real optionTime, const Time swapLength,
-                            const std::vector<Real>& point)
+    template <class Model>
+    void SwaptionVolCube1x<Model>::Cube::setPoint(const Date& optionDate,
+                                                  const Period& swapTenor,
+                                                  Time optionTime,
+                                                  Time swapLength,
+                                                  const std::vector<Real>& point)
     {
         const bool expandOptionTimes =
             !(std::binary_search(optionTimes_.begin(),optionTimes_.end(),optionTime));


### PR DESCRIPTION
The parameter types and names do not match between declaration and definition.

Probably there is no test case so that the template is actually used and compiled.

Found this more by change working on [Avoids current warnings on MSVC ](https://github.com/lballabio/QuantLib-SWIG/pull/402)