### PR TITLE
Swaps startDate() and maturityDate() should be virtual

### DIFF
--- a/ql/instruments/swap.hpp
+++ b/ql/instruments/swap.hpp
@@ -76,8 +76,8 @@ namespace QuantLib {
         //! \name Additional interface
         //@{
         Size numberOfLegs() const;
-        Date startDate() const;
-        Date maturityDate() const;
+        virtual Date startDate() const;
+        virtual Date maturityDate() const;
         Real legBPS(Size j) const {
             QL_REQUIRE(j<legs_.size(), "leg# " << j << " doesn't exist!");
             calculate();

--- a/ql/instruments/zerocouponinflationswap.hpp
+++ b/ql/instruments/zerocouponinflationswap.hpp
@@ -109,8 +109,8 @@ namespace QuantLib {
         //! "Payer" or "Receiver" refers to the inflation leg
         Type type() const { return type_; }
         Real nominal() const { return nominal_; }
-        virtual Date startDate() const override { return startDate_; }
-        virtual Date maturityDate() const override { return maturityDate_; }
+        Date startDate() const override { return startDate_; }
+        Date maturityDate() const override { return maturityDate_; }
         Calendar fixedCalendar() const { return fixCalendar_; }
         BusinessDayConvention fixedConvention() const {
             return fixConvention_;

--- a/ql/instruments/zerocouponinflationswap.hpp
+++ b/ql/instruments/zerocouponinflationswap.hpp
@@ -109,8 +109,8 @@ namespace QuantLib {
         //! "Payer" or "Receiver" refers to the inflation leg
         Type type() const { return type_; }
         Real nominal() const { return nominal_; }
-        Date startDate() const { return startDate_; }
-        Date maturityDate() const { return maturityDate_; }
+        virtual Date startDate() const override { return startDate_; }
+        virtual Date maturityDate() const override { return maturityDate_; }
         Calendar fixedCalendar() const { return fixCalendar_; }
         BusinessDayConvention fixedConvention() const {
             return fixConvention_;

--- a/ql/instruments/zerocouponswap.hpp
+++ b/ql/instruments/zerocouponswap.hpp
@@ -96,8 +96,8 @@ namespace QuantLib {
         //! "payer" or "receiver" refer to the fixed leg.
         Type type() const { return type_; }
         Real baseNominal() const { return baseNominal_; }
-        virtual Date startDate() const override { return startDate_; }
-        virtual Date maturityDate() const override { return maturityDate_; }
+        Date startDate() const override { return startDate_; }
+        Date maturityDate() const override { return maturityDate_; }
         const ext::shared_ptr<IborIndex>& iborIndex() const { return iborIndex_; }
 
         //! just one cashflow in each leg

--- a/ql/instruments/zerocouponswap.hpp
+++ b/ql/instruments/zerocouponswap.hpp
@@ -96,8 +96,8 @@ namespace QuantLib {
         //! "payer" or "receiver" refer to the fixed leg.
         Type type() const { return type_; }
         Real baseNominal() const { return baseNominal_; }
-        Date startDate() const { return startDate_; }
-        Date maturityDate() const { return maturityDate_; }
+        virtual Date startDate() const override { return startDate_; }
+        virtual Date maturityDate() const override { return maturityDate_; }
         const ext::shared_ptr<IborIndex>& iborIndex() const { return iborIndex_; }
 
         //! just one cashflow in each leg


### PR DESCRIPTION
As
https://github.com/lballabio/QuantLib/blob/9daedddf7c8aeca5d2b271039b9d8d4894a2364b/ql/instruments/swap.hpp#L79-L80
are overwritten in
https://github.com/lballabio/QuantLib/blob/9daedddf7c8aeca5d2b271039b9d8d4894a2364b/ql/instruments/zerocouponswap.hpp#L99-L100
and
https://github.com/lballabio/QuantLib/blob/9daedddf7c8aeca5d2b271039b9d8d4894a2364b/ql/instruments/zerocouponinflationswap.hpp#L112-L113
they should become `virtual`.