### PR TITLE
Adjust effective and termination dates for ThirdWednesday Rule

### DIFF
--- a/ql/time/dategenerationrule.cpp
+++ b/ql/time/dategenerationrule.cpp
@@ -34,6 +34,8 @@ namespace QuantLib {
             return out << "Zero";
           case DateGeneration::ThirdWednesday:
             return out << "ThirdWednesday";
+          case DateGeneration::ThirdWednesdayInclusive:
+            return out << "ThirdWednesdayInclusive";
           case DateGeneration::Twentieth:
             return out << "Twentieth";
           case DateGeneration::TwentiethIMM:

--- a/ql/time/dategenerationrule.hpp
+++ b/ql/time/dategenerationrule.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
                                  and termination date. */
             ThirdWednesday,  /*!< All dates but effective date and termination
                                   date are taken to be on the third wednesday
-                                  of their month (with forward calculation.) */
+                                  of their month (with forward calculation. ) */
             ThirdWednesdayInclusive, /*!< All dates including effective date and termination
                                   date are taken to be on the third wednesday
                                   of their month (with forward calculation) */

--- a/ql/time/dategenerationrule.hpp
+++ b/ql/time/dategenerationrule.hpp
@@ -44,8 +44,7 @@ namespace QuantLib {
                                  termination date. */
             Zero,           /*!< No intermediate dates between effective date
                                  and termination date. */
-            ThirdWednesday, /*!< All dates but effective date and termination
-                                 date are taken to be on the third wednesday
+            ThirdWednesday, /*!< All dates are taken to be on the third wednesday
                                  of their month (with forward calculation.) */
             Twentieth,      /*!< All dates but the effective date are
                                  taken to be the twentieth of their

--- a/ql/time/dategenerationrule.hpp
+++ b/ql/time/dategenerationrule.hpp
@@ -46,10 +46,10 @@ namespace QuantLib {
                                  and termination date. */
             ThirdWednesday,  /*!< All dates but effective date and termination
                                   date are taken to be on the third wednesday
-                                  of their month (with forward calculation. ) */
+                                  of their month (with forward calculation.) */
             ThirdWednesdayInclusive, /*!< All dates including effective date and termination
-                                  date are taken to be on the third wednesday
-                                  of their month (with forward calculation) */
+                                          date are taken to be on the third wednesday
+                                          of their month (with forward calculation.) */
             Twentieth,      /*!< All dates but the effective date are
                                  taken to be the twentieth of their
                                  month (used for CDS schedules in

--- a/ql/time/dategenerationrule.hpp
+++ b/ql/time/dategenerationrule.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
                                   of their month (with forward calculation.) */
             ThirdWednesdayInclusive, /*!< All dates including effective date and termination
                                   date are taken to be on the third wednesday
-                                  of their month (with forward calculation.) */
+                                  of their month (with forward calculation) */
             Twentieth,      /*!< All dates but the effective date are
                                  taken to be the twentieth of their
                                  month (used for CDS schedules in

--- a/ql/time/dategenerationrule.hpp
+++ b/ql/time/dategenerationrule.hpp
@@ -44,8 +44,12 @@ namespace QuantLib {
                                  termination date. */
             Zero,           /*!< No intermediate dates between effective date
                                  and termination date. */
-            ThirdWednesday, /*!< All dates are taken to be on the third wednesday
-                                 of their month (with forward calculation.) */
+            ThirdWednesday,  /*!< All dates but effective date and termination
+                                  date are taken to be on the third wednesday
+                                  of their month (with forward calculation.) */
+            ThirdWednesdayInclusive, /*!< All dates including effective date and termination
+                                  date are taken to be on the third wednesday
+                                  of their month (with forward calculation.) */
             Twentieth,      /*!< All dates but the effective date are
                                  taken to be the twentieth of their
                                  month (used for CDS schedules in

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -248,6 +248,7 @@ namespace QuantLib {
           case DateGeneration::Twentieth:
           case DateGeneration::TwentiethIMM:
           case DateGeneration::ThirdWednesday:
+          case DateGeneration::ThirdWednesdayInclusive:
           case DateGeneration::OldCDS:
           case DateGeneration::CDS:
           case DateGeneration::CDS2015:
@@ -349,10 +350,13 @@ namespace QuantLib {
 
         // adjustments
         if (*rule_==DateGeneration::ThirdWednesday)
-            for (Size i=0; i<dates_.size(); ++i)
+            for (Size i=1; i<dates_.size()-1; ++i)
                 dates_[i] = Date::nthWeekday(3, Wednesday,
                                              dates_[i].month(),
                                              dates_[i].year());
+        else if (*rule_ == DateGeneration::ThirdWednesdayInclusive)
+            for (Size i=0; i < dates_.size(); ++i)
+                dates_[i] = Date::nthWeekday(3, Wednesday, dates_[i].month(), dates_[i].year());
 
         if (*endOfMonth_ && calendar_.isEndOfMonth(seed)) {
             // adjust to end of month

--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -349,7 +349,7 @@ namespace QuantLib {
 
         // adjustments
         if (*rule_==DateGeneration::ThirdWednesday)
-            for (Size i=1; i<dates_.size()-1; ++i)
+            for (Size i=0; i<dates_.size(); ++i)
                 dates_[i] = Date::nthWeekday(3, Wednesday,
                                              dates_[i].month(),
                                              dates_[i].year());

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -59,17 +59,15 @@ namespace swap_test {
         
         // utilities
         ext::shared_ptr<VanillaSwap>
-        makeSwap(Integer length, Rate fixedRate, Spread floatingSpread) const {
+        makeSwap(Integer length, Rate fixedRate, Spread floatingSpread, DateGeneration::Rule rule = DateGeneration::Forward) const {
             Date maturity = calendar.advance(settlement,length,Years,
                                              floatingConvention);
             Schedule fixedSchedule(settlement,maturity,Period(fixedFrequency),
-                                   calendar,fixedConvention,fixedConvention,
-                                   DateGeneration::Forward,false);
+                                   calendar,fixedConvention,fixedConvention, rule, false);
             Schedule floatSchedule(settlement,maturity,
                                    Period(floatingFrequency),
                                    calendar,floatingConvention,
-                                   floatingConvention,
-                                   DateGeneration::Forward,false);
+                                   floatingConvention, rule, false);
             ext::shared_ptr<VanillaSwap> swap(
                 new VanillaSwap(type, nominal,
                                 fixedSchedule, fixedRate, fixedDayCount,
@@ -328,6 +326,20 @@ void SwapTest::testCachedValue() {
                     << "    expected:   " << cachedNPV);
 }
 
+void SwapTest::testThirdWednesdayAdjustment() {
+
+    BOOST_TEST_MESSAGE("Testing vanilla-swap calculation of fair fixed rate...");
+
+    using namespace swap_test;
+
+    CommonVars vars;
+
+    ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(1, 0.0, -0.001, DateGeneration::ThirdWednesday);
+    BOOST_REQUIRE(swap->floatingSchedule().startDate() == Date(16, September, 2015),
+                    "Wrong Start Date " << swap->floatingSchedule.startDate());
+    BOOST_REQUIRE(swap->floatingSchedule().endDate() == Date(21, September, 2016),
+                    "Wrong End Date " << swap->floatingSchedule.endDate());
+}
 
 test_suite* SwapTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Swap tests");
@@ -337,6 +349,7 @@ test_suite* SwapTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testSpreadDependency));
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testInArrears));
     suite->add(QUANTLIB_TEST_CASE(&SwapTest::testCachedValue));
+    suite->add(QUANTLIB_TEST_CASE(&SwapTest::testThirdWednesdayAdjustment));
     return suite;
 }
 

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -334,7 +334,7 @@ void SwapTest::testThirdWednesdayAdjustment() {
 
     CommonVars vars;
 
-    ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(1, 0.0, -0.001, DateGeneration::ThirdWednesday);
+    ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(1, 0.0, -0.001, DateGeneration::ThirdWednesdayInclusive);
 
     if (swap->floatingSchedule().startDate() != Date(16, September, 2015)) {
         BOOST_ERROR("Wrong Start Date " << swap->floatingSchedule().startDate());

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -328,17 +328,21 @@ void SwapTest::testCachedValue() {
 
 void SwapTest::testThirdWednesdayAdjustment() {
 
-    BOOST_TEST_MESSAGE("Testing vanilla-swap calculation of fair fixed rate...");
+    BOOST_TEST_MESSAGE("Testing third wednesday adjustment...");
 
     using namespace swap_test;
 
     CommonVars vars;
 
     ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(1, 0.0, -0.001, DateGeneration::ThirdWednesday);
-    BOOST_REQUIRE(swap->floatingSchedule().startDate() == Date(16, September, 2015),
-                    "Wrong Start Date " << swap->floatingSchedule.startDate());
-    BOOST_REQUIRE(swap->floatingSchedule().endDate() == Date(21, September, 2016),
-                    "Wrong End Date " << swap->floatingSchedule.endDate());
+
+    if (swap->floatingSchedule().startDate() != Date(16, September, 2015)) {
+        BOOST_ERROR("Wrong Start Date " << swap->floatingSchedule().startDate());
+    }
+
+     if (swap->floatingSchedule().endDate() != Date(21, September, 2016)) {
+        BOOST_ERROR("Wrong End Date " << swap->floatingSchedule().endDate());
+    }
 }
 
 test_suite* SwapTest::suite() {

--- a/test-suite/swap.hpp
+++ b/test-suite/swap.hpp
@@ -33,6 +33,7 @@ class SwapTest {
     static void testSpreadDependency();
     static void testInArrears();
     static void testCachedValue();
+    static void testThirdWednesdayAdjustment();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Adjust start and end dates to ThirdWednesday as well to follow market practice.

Related Issue: MakeVanillaSwap should adjust the default dates for ThirdWednesday
#833 