### PR TITLE
Adding a PTD Heston Process for path generation

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1599,6 +1599,7 @@
     <ClInclude Include="ql\pricingengines\vanilla\mceuropeanengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\mceuropeangjrgarchengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\mceuropeanhestonengine.hpp" />
+    <ClInclude Include="ql\pricingengines\vanilla\mceuropeanptdhestonengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\mchestonhullwhiteengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\mcvanillaengine.hpp" />
     <ClInclude Include="ql\processes\all.hpp" />
@@ -1620,6 +1621,7 @@
     <ClInclude Include="ql\processes\merton76process.hpp" />
     <ClInclude Include="ql\processes\mfstateprocess.hpp" />
     <ClInclude Include="ql\processes\ornsteinuhlenbeckprocess.hpp" />
+    <ClInclude Include="ql\processes\piecewisetimedependenthestonprocess.hpp" />
     <ClInclude Include="ql\processes\squarerootprocess.hpp" />
     <ClInclude Include="ql\processes\stochasticprocessarray.hpp" />
     <ClInclude Include="ql\quotes\all.hpp" />
@@ -2635,6 +2637,7 @@
     <ClCompile Include="ql\processes\merton76process.cpp" />
     <ClCompile Include="ql\processes\mfstateprocess.cpp" />
     <ClCompile Include="ql\processes\ornsteinuhlenbeckprocess.cpp" />
+    <ClCompile Include="ql\processes\piecewisetimedependenthestonprocess.cpp" />
     <ClCompile Include="ql\processes\squarerootprocess.cpp" />
     <ClCompile Include="ql\processes\stochasticprocessarray.cpp" />
     <ClCompile Include="ql\quotes\eurodollarfuturesquote.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2304,6 +2304,9 @@
     <ClInclude Include="ql\processes\ornsteinuhlenbeckprocess.hpp">
       <Filter>processes</Filter>
     </ClInclude>
+    <ClInclude Include="ql\processes\piecewisetimedependenthestonprocess.hpp">
+      <Filter>processes</Filter>
+    </ClInclude>
     <ClInclude Include="ql\processes\squarerootprocess.hpp">
       <Filter>processes</Filter>
     </ClInclude>
@@ -2524,6 +2527,9 @@
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
     <ClInclude Include="ql\pricingengines\vanilla\mceuropeanhestonengine.hpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClInclude>
+    <ClInclude Include="ql\pricingengines\vanilla\mceuropeanptdhestonengine.hpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
     <ClInclude Include="ql\pricingengines\vanilla\mchestonhullwhiteengine.hpp">
@@ -5568,6 +5574,9 @@
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\ornsteinuhlenbeckprocess.cpp">
+      <Filter>processes</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\processes\piecewisetimedependenthestonprocess.cpp">
       <Filter>processes</Filter>
     </ClCompile>
     <ClCompile Include="ql\processes\squarerootprocess.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -769,6 +769,7 @@ set(QuantLib_SRC
     processes/merton76process.cpp
     processes/mfstateprocess.cpp
     processes/ornsteinuhlenbeckprocess.cpp
+    processes/piecewisetimedependenthestonprocess.cpp
     processes/coxingersollrossprocess.cpp
     processes/squarerootprocess.cpp
     processes/stochasticprocessarray.cpp
@@ -2051,6 +2052,7 @@ set(QuantLib_HDR
     pricingengines/vanilla/mceuropeanengine.hpp
     pricingengines/vanilla/mceuropeangjrgarchengine.hpp
     pricingengines/vanilla/mceuropeanhestonengine.hpp
+    pricingengines/vanilla/mceuropeanptdhestonengine.hpp
     pricingengines/vanilla/mchestonhullwhiteengine.hpp
     pricingengines/vanilla/mcvanillaengine.hpp
     processes/all.hpp
@@ -2071,6 +2073,7 @@ set(QuantLib_HDR
     processes/merton76process.hpp
     processes/mfstateprocess.hpp
     processes/ornsteinuhlenbeckprocess.hpp
+    processes/piecewisetimedependenthestonprocess.hpp
     processes/coxingersollrossprocess.hpp
     processes/squarerootprocess.hpp
     processes/stochasticprocessarray.hpp

--- a/ql/pricingengines/vanilla/Makefile.am
+++ b/ql/pricingengines/vanilla/Makefile.am
@@ -46,6 +46,7 @@ this_include_HEADERS = \
     mcdigitalengine.hpp \
     mceuropeanengine.hpp \
     mceuropeanhestonengine.hpp \
+    mceuropeanptdhestonengine.hpp \
     mceuropeangjrgarchengine.hpp \
     mchestonhullwhiteengine.hpp \
     mcvanillaengine.hpp

--- a/ql/pricingengines/vanilla/all.hpp
+++ b/ql/pricingengines/vanilla/all.hpp
@@ -43,6 +43,7 @@
 #include <ql/pricingengines/vanilla/mcdigitalengine.hpp>
 #include <ql/pricingengines/vanilla/mceuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/mceuropeanhestonengine.hpp>
+#include <ql/pricingengines/vanilla/mceuropeanptdhestonengine.hpp>
 #include <ql/pricingengines/vanilla/mceuropeangjrgarchengine.hpp>
 #include <ql/pricingengines/vanilla/mchestonhullwhiteengine.hpp>
 #include <ql/pricingengines/vanilla/mcvanillaengine.hpp>

--- a/ql/pricingengines/vanilla/mceuropeanptdhestonengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeanptdhestonengine.hpp
@@ -1,0 +1,239 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Jack Gillett
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file mceuropeanptdhestonengine.hpp
+    \brief Monte Carlo PTD Heston model engine for European options
+*/
+
+#ifndef quantlib_mc_european_ptd_heston_engine_hpp
+#define quantlib_mc_european_ptd_heston_engine_hpp
+
+#include <ql/pricingengines/vanilla/mcvanillaengine.hpp>
+#include <ql/processes/piecewisetimedependenthestonprocess.hpp>
+#include <utility>
+
+namespace QuantLib {
+
+    //! Monte Carlo PTD Heston-model engine for European options
+    /*! \ingroup vanillaengines
+
+        \test Option prices are compared against the analytic
+              PTD Heston Vanilla pricer
+    */
+    template <class RNG = PseudoRandom,
+              class S = Statistics, class P = PiecewiseTimeDependentHestonProcess>
+    class MCEuropeanPTDHestonEngine
+        : public MCVanillaEngine<MultiVariate,RNG,S> {
+      public:
+        typedef typename MCVanillaEngine<MultiVariate,RNG,S>::path_pricer_type
+            path_pricer_type;
+        MCEuropeanPTDHestonEngine(const ext::shared_ptr<P>&,
+                                  Size timeSteps,
+                                  Size timeStepsPerYear,
+                                  bool antitheticVariate,
+                                  Size requiredSamples,
+                                  Real requiredTolerance,
+                                  Size maxSamples,
+                                  BigNatural seed);
+      protected:
+        ext::shared_ptr<path_pricer_type> pathPricer() const override;
+    };
+
+    //! Monte Carlo Heston European engine factory
+    template <class RNG = PseudoRandom,
+              class S = Statistics, class P = PiecewiseTimeDependentHestonProcess>
+    class MakeMCEuropeanPTDHestonEngine {
+      public:
+        explicit MakeMCEuropeanPTDHestonEngine(ext::shared_ptr<P>);
+        // named parameters
+        MakeMCEuropeanPTDHestonEngine& withSteps(Size steps);
+        MakeMCEuropeanPTDHestonEngine& withStepsPerYear(Size steps);
+        MakeMCEuropeanPTDHestonEngine& withSamples(Size samples);
+        MakeMCEuropeanPTDHestonEngine& withAbsoluteTolerance(Real tolerance);
+        MakeMCEuropeanPTDHestonEngine& withMaxSamples(Size samples);
+        MakeMCEuropeanPTDHestonEngine& withSeed(BigNatural seed);
+        MakeMCEuropeanPTDHestonEngine& withAntitheticVariate(bool b = true);
+        // conversion to pricing engine
+        operator ext::shared_ptr<PricingEngine>() const;
+      private:
+        ext::shared_ptr<P> process_;
+        bool antithetic_;
+        Size steps_, stepsPerYear_, samples_, maxSamples_;
+        Real tolerance_;
+        BigNatural seed_;
+    };
+
+
+    class EuropeanPTDHestonPathPricer : public PathPricer<MultiPath> {
+      public:
+        EuropeanPTDHestonPathPricer(Option::Type type,
+                                 Real strike,
+                                 DiscountFactor discount);
+        Real operator()(const MultiPath& Multipath) const override;
+
+      private:
+        PlainVanillaPayoff payoff_;
+        DiscountFactor discount_;
+    };
+
+
+    // template definitions
+
+    template <class RNG, class S, class P>
+    MCEuropeanPTDHestonEngine<RNG, S, P>::MCEuropeanPTDHestonEngine(
+                const ext::shared_ptr<P>& process,
+                Size timeSteps, Size timeStepsPerYear, bool antitheticVariate,
+                Size requiredSamples, Real requiredTolerance,
+                Size maxSamples, BigNatural seed)
+    : MCVanillaEngine<MultiVariate,RNG,S>(process, timeSteps, timeStepsPerYear,
+                                          false, antitheticVariate, false,
+                                          requiredSamples, requiredTolerance,
+                                          maxSamples, seed) {}
+
+
+    template <class RNG, class S, class P>
+    ext::shared_ptr<
+        typename MCEuropeanPTDHestonEngine<RNG,S,P>::path_pricer_type>
+    MCEuropeanPTDHestonEngine<RNG,S,P>::pathPricer() const {
+
+        ext::shared_ptr<PlainVanillaPayoff> payoff(
+                  ext::dynamic_pointer_cast<PlainVanillaPayoff>(
+                                                    this->arguments_.payoff));
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        ext::shared_ptr<P> process =
+            ext::dynamic_pointer_cast<P>(this->process_);
+        QL_REQUIRE(process, "Heston like process required");
+
+        return ext::shared_ptr<
+            typename MCEuropeanPTDHestonEngine<RNG,S,P>::path_pricer_type>(
+                   new EuropeanPTDHestonPathPricer(
+                                        payoff->optionType(),
+                                        payoff->strike(),
+                                        process->riskFreeRate()->discount(
+                                                   this->timeGrid().back())));
+    }
+
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG, S, P>::MakeMCEuropeanPTDHestonEngine(
+        ext::shared_ptr<P> process)
+    : process_(std::move(process)), antithetic_(false), steps_(Null<Size>()),
+      stepsPerYear_(Null<Size>()), samples_(Null<Size>()), maxSamples_(Null<Size>()),
+      tolerance_(Null<Real>()), seed_(0) {}
+
+    template <class RNG, class S,class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withSteps(Size steps) {
+        QL_REQUIRE(stepsPerYear_ == Null<Size>(),
+                   "number of steps per year already set");
+        steps_ = steps;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withStepsPerYear(Size steps) {
+        QL_REQUIRE(steps_ == Null<Size>(),
+                   "number of steps already set");
+        stepsPerYear_ = steps;
+        return *this;
+    }
+
+    template <class RNG, class S,class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withSamples(Size samples) {
+        QL_REQUIRE(tolerance_ == Null<Real>(),
+                   "tolerance already set");
+        samples_ = samples;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withAbsoluteTolerance(Real tolerance) {
+        QL_REQUIRE(samples_ == Null<Size>(),
+                   "number of samples already set");
+        QL_REQUIRE(RNG::allowsErrorEstimate,
+                   "chosen random generator policy "
+                   "does not allow an error estimate");
+        tolerance_ = tolerance;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withMaxSamples(Size samples) {
+        maxSamples_ = samples;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withSeed(BigNatural seed) {
+        seed_ = seed;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline MakeMCEuropeanPTDHestonEngine<RNG,S,P>&
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::withAntitheticVariate(bool b) {
+        antithetic_ = b;
+        return *this;
+    }
+
+    template <class RNG, class S, class P>
+    inline
+    MakeMCEuropeanPTDHestonEngine<RNG,S,P>::
+    operator ext::shared_ptr<PricingEngine>() const {
+        QL_REQUIRE(steps_ != Null<Size>() || stepsPerYear_ != Null<Size>(),
+                   "number of steps not given");
+        return ext::shared_ptr<PricingEngine>(
+               new MCEuropeanPTDHestonEngine<RNG,S,P>(process_,
+                                                      steps_,
+                                                      stepsPerYear_,
+                                                      antithetic_,
+                                                      samples_, tolerance_,
+                                                      maxSamples_,
+                                                      seed_));
+    }
+
+
+
+    inline EuropeanPTDHestonPathPricer::EuropeanPTDHestonPathPricer(
+                                                 Option::Type type,
+                                                 Real strike,
+                                                 DiscountFactor discount)
+    : payoff_(type, strike), discount_(discount) {
+        QL_REQUIRE(strike>=0.0,
+                   "strike less than zero not allowed");
+    }
+
+    inline Real EuropeanPTDHestonPathPricer::operator()(
+                                           const MultiPath& multiPath) const {
+        const Path& path = multiPath[0];
+        const Size n = multiPath.pathSize();
+        QL_REQUIRE(n>0, "the path cannot be empty");
+
+        return payoff_(path.back()) * discount_;
+    }
+
+}
+
+
+#endif

--- a/ql/processes/Makefile.am
+++ b/ql/processes/Makefile.am
@@ -21,6 +21,7 @@ this_include_HEADERS = \
 	merton76process.hpp \
 	mfstateprocess.hpp \
 	ornsteinuhlenbeckprocess.hpp \
+	piecewisetimedependenthestonprocess.hpp \
 	coxingersollrossprocess.hpp \
 	squarerootprocess.hpp \
 	stochasticprocessarray.hpp
@@ -43,6 +44,7 @@ cpp_files = \
 	merton76process.cpp \
 	mfstateprocess.cpp \
 	ornsteinuhlenbeckprocess.cpp \
+	piecewisetimedependenthestonprocess.cpp \
 	coxingersollrossprocess.cpp \
 	squarerootprocess.cpp \
 	stochasticprocessarray.cpp

--- a/ql/processes/all.hpp
+++ b/ql/processes/all.hpp
@@ -18,6 +18,7 @@
 #include <ql/processes/merton76process.hpp>
 #include <ql/processes/mfstateprocess.hpp>
 #include <ql/processes/ornsteinuhlenbeckprocess.hpp>
+#include <ql/processes/piecewisetimedependenthestonprocess.hpp>
 #include <ql/processes/coxingersollrossprocess.hpp>
 #include <ql/processes/squarerootprocess.hpp>
 #include <ql/processes/stochasticprocessarray.hpp>

--- a/ql/processes/piecewisetimedependenthestonprocess.cpp
+++ b/ql/processes/piecewisetimedependenthestonprocess.cpp
@@ -119,7 +119,7 @@ namespace QuantLib {
                             Time dt,
                             const Array& dw) const {
         Array retVal(2);
-        Real vol, vol2, mu, nu, dy;
+        Real vol, vol2, mu, nu;
 
         const Real sdt = std::sqrt(dt);
         const Real sqrhov = std::sqrt(1.0 - rho_(t0)*rho_(t0));

--- a/ql/processes/piecewisetimedependenthestonprocess.cpp
+++ b/ql/processes/piecewisetimedependenthestonprocess.cpp
@@ -1,0 +1,194 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/math/distributions/chisquaredistribution.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/math/functional.hpp>
+#include <ql/math/integrals/gaussianquadratures.hpp>
+#include <ql/math/integrals/gausslobattointegral.hpp>
+#include <ql/math/integrals/segmentintegral.hpp>
+#include <ql/math/modifiedbessel.hpp>
+#include <ql/math/solvers1d/brent.hpp>
+#include <ql/processes/eulerdiscretization.hpp>
+#include <ql/processes/piecewisetimedependenthestonprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <boost/math/distributions/non_central_chi_squared.hpp>
+#include <complex>
+#include <utility>
+
+namespace QuantLib {
+
+    PiecewiseTimeDependentHestonProcess::PiecewiseTimeDependentHestonProcess(
+                        Handle<YieldTermStructure> riskFreeRate,
+                        Handle<YieldTermStructure> dividendYield,
+                        Handle<Quote> s0,
+                        Real v0,
+                        const Parameter& kappa,
+                        const Parameter& theta,
+                        const Parameter& sigma,
+                        const Parameter& rho,
+                        TimeGrid timeGrid,
+                        Discretization d)
+    : StochasticProcess(ext::shared_ptr<discretization>(new EulerDiscretization)),
+      riskFreeRate_(std::move(riskFreeRate)), dividendYield_(std::move(dividendYield)),
+      s0_(std::move(s0)), v0_(v0), kappa_(kappa), theta_(theta), sigma_(sigma), rho_(rho),
+      discretization_(d) {
+
+        registerWith(riskFreeRate_);
+        registerWith(dividendYield_);
+        registerWith(s0_);
+    }
+
+    Size PiecewiseTimeDependentHestonProcess::size() const {
+        return 2;
+    }
+
+    Size PiecewiseTimeDependentHestonProcess::factors() const {
+        return 2;
+    }
+
+    Disposable<Array> PiecewiseTimeDependentHestonProcess::initialValues() const {
+        Array tmp(2);
+        tmp[0] = s0_->value();
+        tmp[1] = v0_;
+        return tmp;
+    }
+
+    Disposable<Array> PiecewiseTimeDependentHestonProcess::drift(Time t, const Array& x) const {
+        Array tmp(2);
+        const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
+                         : (discretization_ == Reflection) ? - std::sqrt(-x[1])
+                         : 0.0;
+
+        tmp[0] = riskFreeRate_->forwardRate(t, t, Continuous)
+               - dividendYield_->forwardRate(t, t, Continuous)
+               - 0.5 * vol * vol;
+
+        tmp[1] = kappa_(t)*
+           (theta_(t)-((discretization_==PartialTruncation) ? x[1] : vol*vol));
+        return tmp;
+    }
+
+    Disposable<Matrix> PiecewiseTimeDependentHestonProcess::diffusion(Time t, const Array& x) const {
+        /* the instantaneous correlation matrix is
+           |  1     rho(t) |
+           | rho(t)     1  |
+           whose square root (which is used here) is
+           |  1                0       |
+           | rho(t)   sqrt(1-rho(t)^2) |
+        */
+        Matrix tmp(2,2);
+        const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
+                         : (discretization_ == Reflection) ? -std::sqrt(-x[1])
+                         : 1e-8; // set vol to (almost) zero but still
+                                 // expose some correlation information
+        const Real sigma2 = sigma_(t) * vol;
+        const Real sqrhov = std::sqrt(1.0 - rho_(t)*rho_(t));
+
+        tmp[0][0] = vol;             tmp[0][1] = 0.0;
+        tmp[1][0] = rho_(t)*sigma2;  tmp[1][1] = sqrhov*sigma2;
+        return tmp;
+    }
+
+    Disposable<Array> PiecewiseTimeDependentHestonProcess::apply(
+                                              const Array& x0,
+                                              const Array& dx) const {
+        Array tmp(2);
+        tmp[0] = x0[0] * std::exp(dx[0]);
+        tmp[1] = x0[1] + dx[1];
+        return tmp;
+    }
+
+    Disposable<Array> PiecewiseTimeDependentHestonProcess::evolve(
+                            Time t0,
+                            const Array& x0,
+                            Time dt,
+                            const Array& dw) const {
+        Array retVal(2);
+        Real vol, vol2, mu, nu, dy;
+
+        const Real sdt = std::sqrt(dt);
+        const Real sqrhov = std::sqrt(1.0 - rho_(t0)*rho_(t0));
+
+        switch (discretization_) {
+          // For the definition of PartialTruncation, FullTruncation
+          // and Reflection  see Lord, R., R. Koekkoek and D. van Dijk (2006),
+          // "A Comparison of biased simulation schemes for
+          //  stochastic volatility models",
+          // Working Paper, Tinbergen Institute
+          case PartialTruncation:
+            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+            vol2 = sigma_(t0) * vol;
+            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
+                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
+                    - 0.5 * vol * vol;
+            nu = kappa_(t0)*(theta_(t0) - x0[1]);
+
+            retVal[0] = x0[0] * std::exp(mu*dt+vol*dw[0]*sdt);
+            retVal[1] = x0[1] + nu*dt + vol2*sdt*(rho_(t0)*dw[0] + sqrhov*dw[1]);
+            break;
+          case FullTruncation:
+            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+            vol2 = sigma_(t0) * vol;
+            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
+                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
+                    - 0.5 * vol * vol;
+            nu = kappa_(t0)*(theta_(t0) - vol*vol);
+
+            retVal[0] = x0[0] * std::exp(mu*dt+vol*dw[0]*sdt);
+            retVal[1] = x0[1] + nu*dt + vol2*sdt*(rho_(t0)*dw[0] + sqrhov*dw[1]);
+            break;
+          case Reflection:
+            vol = std::sqrt(std::fabs(x0[1]));
+            vol2 = sigma_(t0) * vol;
+            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
+                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
+                    - 0.5 * vol*vol;
+            nu = kappa_(t0)*(theta_(t0) - vol*vol);
+
+            retVal[0] = x0[0]*std::exp(mu*dt+vol*dw[0]*sdt);
+            retVal[1] = vol*vol
+                        +nu*dt + vol2*sdt*(rho_(t0)*dw[0] + sqrhov*dw[1]);
+            break;
+          default:
+            QL_FAIL("unknown discretization schema");
+        }
+
+        return retVal;
+    }
+
+    const Handle<Quote>& PiecewiseTimeDependentHestonProcess::s0() const {
+        return s0_;
+    }
+
+    const Handle<YieldTermStructure>& PiecewiseTimeDependentHestonProcess::dividendYield() const {
+        return dividendYield_;
+    }
+
+    const Handle<YieldTermStructure>& PiecewiseTimeDependentHestonProcess::riskFreeRate() const {
+        return riskFreeRate_;
+    }
+
+    Time PiecewiseTimeDependentHestonProcess::time(const Date& d) const {
+        return riskFreeRate_->dayCounter().yearFraction(
+                                           riskFreeRate_->referenceDate(), d);
+    }
+
+    const TimeGrid& PiecewiseTimeDependentHestonProcess::timeGrid() const {
+        return timeGrid_;
+    }
+}

--- a/ql/processes/piecewisetimedependenthestonprocess.hpp
+++ b/ql/processes/piecewisetimedependenthestonprocess.hpp
@@ -1,0 +1,97 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file piecewisetimedependenthestonprocess.hpp
+    \brief PTD Heston stochastic process
+*/
+
+#ifndef quantlib_piecewise_time_dependent_heston_process_hpp
+#define quantlib_piecewise_time_dependent_heston_process_hpp
+
+#include <ql/stochasticprocess.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/quote.hpp>
+#include <ql/timegrid.hpp>
+#include <ql/models/model.hpp>
+
+namespace QuantLib {
+
+    //! Square-root stochastic-volatility Heston process
+    /*! This class describes the square root stochastic volatility
+        process governed by
+        \f[
+        \begin{array}{rcl}
+        dS(t, S)  &=& \mu S dt + \sqrt{v} S dW_1 \\
+        dv(t, S)  &=& \kappa(t) (\theta(t) - v) dt + \sigma(t) \sqrt{v} dW_2 \\
+        dW_1 dW_2 &=& \rho(t) dt
+        \end{array}
+        where \kappa, \theta, \sigma and \rho are all piecewise
+        constant in time
+        \f]
+
+        \ingroup processes
+    */
+    class PiecewiseTimeDependentHestonProcess : public StochasticProcess {
+      public:
+        enum Discretization { PartialTruncation,
+                              FullTruncation,
+                              Reflection };
+
+        PiecewiseTimeDependentHestonProcess(
+                         Handle<YieldTermStructure> riskFreeRate,
+                         Handle<YieldTermStructure> dividendYield,
+                         Handle<Quote> s0,
+                         Real v0,
+                         const Parameter& kappa, // HestonProcess is kappa, theta... PTD Model is theta, kappa
+                         const Parameter& theta,
+                         const Parameter& sigma,
+                         const Parameter& rho,
+                         TimeGrid timeGrid,
+                         Discretization d = PartialTruncation);
+
+        Size size() const override;
+        Size factors() const override;
+
+        Disposable<Array> initialValues() const override;
+        Disposable<Array> drift(Time t, const Array& x) const override;
+        Disposable<Matrix> diffusion(Time t, const Array& x) const override;
+        Disposable<Array> apply(const Array& x0, const Array& dx) const override;
+        Disposable<Array> evolve(Time t0, const Array& x0, Time dt, const Array& dw) const override;
+
+        Real v0()                const { return v0_; }
+        const Parameter& rho()   const { return rho_; }
+        const Parameter& kappa() const { return kappa_; }
+        const Parameter& theta() const { return theta_; }
+        const Parameter& sigma() const { return sigma_; }
+
+        const Handle<Quote>& s0() const;
+        const TimeGrid& timeGrid() const;
+        const Handle<YieldTermStructure>& dividendYield() const;
+        const Handle<YieldTermStructure>& riskFreeRate() const;
+
+        Time time(const Date&) const override;
+
+      private:
+        Handle<YieldTermStructure> riskFreeRate_, dividendYield_;
+        const TimeGrid timeGrid_;
+        Handle<Quote> s0_;
+        Real v0_;
+        Parameter kappa_, theta_, sigma_, rho_;
+        Discretization discretization_;
+    };
+}
+#endif

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3486,7 +3486,6 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentComparison));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentChFAsymtotic));
-    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentProcess));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testSmallSigmaExpansion));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testSmallSigmaExpansion4ExpFitting));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testExponentialFitting4StrikesAndMaturities));
@@ -3503,6 +3502,7 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testKahlJaeckelCase));
+        suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testPiecewiseTimeDependentProcess));
     }
 
     return suite;

--- a/test-suite/hestonmodel.hpp
+++ b/test-suite/hestonmodel.hpp
@@ -54,6 +54,7 @@ class HestonModelTest {
     static void testPiecewiseTimeDependentChFvsHestonChF();
     static void testPiecewiseTimeDependentComparison();
     static void testPiecewiseTimeDependentChFAsymtotic();
+    static void testPiecewiseTimeDependentProcess();
     static void testSmallSigmaExpansion();
     static void testSmallSigmaExpansion4ExpFitting();
     static void testExponentialFitting4StrikesAndMaturities();


### PR DESCRIPTION
Tested by adding a MC Vanilla PTH Heston pricing engine, and comparing prices for vanilla options to the Analytic PTD Heston Engine. Only a few discretisations implemented for now, but NonCentralChiSquareVariance and QuadraticExponential/QuadraticExponentialMartingale to come later.