### PR TITLE
Fix IborCoupon and Money data races

### DIFF
--- a/Examples/CDS/CDS.cpp
+++ b/Examples/CDS/CDS.cpp
@@ -269,8 +269,9 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
 
     // check if indexed coupon is defined (it should not to be 100% consistent with
     // the ISDA spec)
-    if (!IborCoupon::usingAtParCoupons()) {
-        std::cout << "Warning: IborCoupon::usingAtParCoupons() == false is used, "
+    if (!IborCoupon::Settings::instance().usingAtParCoupons()) {
+        std::cout << "Warning: IborCoupon::Settings::instance().usingAtParCoupons() "
+                  << "== false is used, "
                   << "which is not precisely consistent with the specification "
                   << "of the ISDA rate curve." << std::endl;
     }
@@ -484,7 +485,7 @@ void example03() {
                                               false, actual360);
 
     // this index is probably not important since we are not using
-    // IborCoupon::usingAtParCoupons() == false 
+    // IborCoupon::Settings::instance().usingAtParCoupons() == false
     // - define it "isda compliant" anyway
     ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<IborIndex>(
         "IsdaIbor", 6 * Months, 2, EURCurrency(), WeekendsOnly(),

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -158,11 +158,7 @@ namespace QuantLib {
          usingAtParCoupons_ = false;
     }
 
-    const bool & IborCoupon::Settings::usingAtParCoupons() const {
-        return usingAtParCoupons_;
-    }
-
-    bool & IborCoupon::Settings::usingAtParCoupons() {
+    bool IborCoupon::Settings::usingAtParCoupons() const {
         return usingAtParCoupons_;
     }
 

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -95,11 +95,6 @@ namespace QuantLib {
         friend class Singleton<IborCoupon::Settings>;
       private:
         Settings();
-        // disable copy/move
-        Settings(const Settings &) = delete;
-        Settings & operator=(const Settings &) = delete;
-        Settings(Settings &&) = delete;
-        Settings & operator=(Settings &&) = delete;
 
       public:
         //! When called, IborCoupons are created as indexed coupons instead of par coupons.

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -73,18 +73,24 @@ namespace QuantLib {
         Time spanningTime_;
 
       public:
-        //! IborCoupon::Settings forward declaration
+        // IborCoupon::Settings forward declaration
         class Settings;
-        //! deprecated: use IborCouponSettings::Settings::createAtParCoupons instead
+        /*! \deprecated Use IborCouponSettings::Settings::instance().createAtParCoupons() instead
+                        Deprecated in version 1.24.
+        */
         QL_DEPRECATED static void createAtParCoupons();
-        //! deprecated: use IborCouponSettings::Settings::createIndexedCoupons instead
+        /*! \deprecated Use IborCouponSettings::Settings::instance().createIndexedCoupons() instead
+                        Deprecated in version 1.24.
+        */
         QL_DEPRECATED static void createIndexedCoupons();
-        //! deprecated: use IborCouponSettings::Settings::usingAtParCoupons instead
+        /*! \deprecated Use IborCouponSettings::Settings::instance().usingAtParCoupons() instead
+                        Deprecated in version 1.24.
+        */
         QL_DEPRECATED static bool usingAtParCoupons();
     };
 
 
-    //! IborCoupon::Settings: nested class for IborCoupon per-session settings
+    //! Per-session settings for IborCoupon class
     class IborCoupon::Settings : public Singleton<IborCoupon::Settings> {
         friend class Singleton<IborCoupon::Settings>;
       private:

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -31,6 +31,7 @@
 
 #include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/indexes/iborindex.hpp>
+#include <ql/patterns/singleton.hpp>
 #include <ql/time/schedule.hpp>
 
 namespace QuantLib {
@@ -72,27 +73,44 @@ namespace QuantLib {
         Time spanningTime_;
 
       public:
-        /*! When called, IborCoupons are created as indexed coupons instead of par coupons. This
-         * method must be called before any IborCoupon is created, otherwise an exception is thrown.
-         */
-        static void createAtParCoupons();
-
-        /*! When called, IborCoupons are created as par coupons instead of indexed coupons. This
-         * method must be called before any IborCoupon is created, otherwise an exception is thrown.
-         */
-        static void createIndexedCoupons();
-
-        /*! If true the IborCoupons are created as par coupons and vice versa.
-         *  The default depends on the compiler flag QL_USE_INDEXED_COUPON and can be overwritten by
-         *  createAtParCoupons() and createIndexedCoupons()
-        */
-        static bool usingAtParCoupons() { return usingAtParCoupons_; }
-
-      private:
-        static bool constructorWasNotCalled_;
-        static bool usingAtParCoupons_;
+        //! IborCoupon::Settings forward declaration
+        class Settings;
+        //! deprecated: use IborCouponSettings::Settings::createAtParCoupons instead
+        QL_DEPRECATED static void createAtParCoupons();
+        //! deprecated: use IborCouponSettings::Settings::createIndexedCoupons instead
+        QL_DEPRECATED static void createIndexedCoupons();
+        //! deprecated: use IborCouponSettings::Settings::usingAtParCoupons instead
+        QL_DEPRECATED static bool usingAtParCoupons();
     };
 
+
+    //! IborCoupon::Settings: nested class for IborCoupon per-session settings
+    class IborCoupon::Settings : public Singleton<IborCoupon::Settings> {
+        friend class Singleton<IborCoupon::Settings>;
+      private:
+        Settings();
+        // disable copy/move
+        Settings(const Settings &) = delete;
+        Settings & operator=(const Settings &) = delete;
+        Settings(Settings &&) = delete;
+        Settings & operator=(Settings &&) = delete;
+
+      public:
+        //! When called, IborCoupons are created as indexed coupons instead of par coupons.
+        void createAtParCoupons();
+
+        //! When called, IborCoupons are created as par coupons instead of indexed coupons.
+        void createIndexedCoupons();
+
+        /*! If true the IborCoupons are created as par coupons and vice versa.
+            The default depends on the compiler flag QL_USE_INDEXED_COUPON and can be overwritten by
+            createAtParCoupons() and createIndexedCoupons() */
+        const bool & usingAtParCoupons() const;
+        bool & usingAtParCoupons();
+
+      private:
+        bool usingAtParCoupons_;
+    };
 
     //! helper class building a sequence of capped/floored ibor-rate coupons
     class IborLeg {

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -111,8 +111,7 @@ namespace QuantLib {
         /*! If true the IborCoupons are created as par coupons and vice versa.
             The default depends on the compiler flag QL_USE_INDEXED_COUPON and can be overwritten by
             createAtParCoupons() and createIndexedCoupons() */
-        const bool & usingAtParCoupons() const;
-        bool & usingAtParCoupons();
+        bool usingAtParCoupons() const;
 
       private:
         bool usingAtParCoupons_;

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -25,9 +25,6 @@
 
 namespace QuantLib {
 
-    Money::ConversionType Money::conversionType = Money::NoConversion;
-    Currency Money::baseCurrency = Currency();
-
     namespace {
 
         void convertTo(Money& m, const Currency& target) {
@@ -40,21 +37,24 @@ namespace QuantLib {
         }
 
         void convertToBase(Money& m) {
-            QL_REQUIRE(!Money::baseCurrency.empty(), "no base currency set");
-            convertTo(m, Money::baseCurrency);
+            const auto & base_currency =
+                Money::Settings::instance().baseCurrency();
+            QL_REQUIRE(!base_currency.empty(), "no base currency set");
+            convertTo(m, base_currency);
         }
 
     }
 
     Money& Money::operator+=(const Money& m) {
+        const auto & conversion_type = Settings::instance().conversionType();
         if (currency_ == m.currency_) {
             value_ += m.value_;
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             convertToBase(*this);
             Money tmp = m;
             convertToBase(tmp);
             *this += tmp;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m;
             convertTo(tmp, currency_);
             *this += tmp;
@@ -65,14 +65,15 @@ namespace QuantLib {
     }
 
     Money& Money::operator-=(const Money& m) {
+        const auto & conversion_type = Settings::instance().conversionType();
         if (currency_ == m.currency_) {
             value_ -= m.value_;
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             convertToBase(*this);
             Money tmp = m;
             convertToBase(tmp);
             *this -= tmp;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m;
             convertTo(tmp, currency_);
             *this -= tmp;
@@ -83,15 +84,17 @@ namespace QuantLib {
     }
 
     Decimal operator/(const Money& m1, const Money& m2) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return m1.value()/m2.value();
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return tmp1/tmp2;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return m1/tmp;
@@ -101,15 +104,17 @@ namespace QuantLib {
     }
 
     bool operator==(const Money& m1, const Money& m2) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return m1.value() == m2.value();
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return tmp1 == tmp2;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return m1 == tmp;
@@ -119,15 +124,17 @@ namespace QuantLib {
     }
 
     bool operator<(const Money& m1, const Money& m2) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return m1.value() < m2.value();
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return tmp1 < tmp2;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return m1 < tmp;
@@ -137,15 +144,17 @@ namespace QuantLib {
     }
 
     bool operator<=(const Money& m1, const Money& m2) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return m1.value() <= m2.value();
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return tmp1 <= tmp2;
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return m1 <= tmp;
@@ -155,15 +164,17 @@ namespace QuantLib {
     }
 
     bool close(const Money& m1, const Money& m2, Size n) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return close(m1.value(),m2.value(),n);
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return close(tmp1,tmp2,n);
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return close(m1,tmp,n);
@@ -173,15 +184,17 @@ namespace QuantLib {
     }
 
     bool close_enough(const Money& m1, const Money& m2, Size n) {
+        const auto & conversion_type =
+            Money::Settings::instance().conversionType();
         if (m1.currency() == m2.currency()) {
             return close_enough(m1.value(),m2.value(),n);
-        } else if (Money::conversionType == Money::BaseCurrencyConversion) {
+        } else if (conversion_type == Money::BaseCurrencyConversion) {
             Money tmp1 = m1;
             convertToBase(tmp1);
             Money tmp2 = m2;
             convertToBase(tmp2);
             return close_enough(tmp1,tmp2,n);
-        } else if (Money::conversionType == Money::AutomatedConversion) {
+        } else if (conversion_type == Money::AutomatedConversion) {
             Money tmp = m2;
             convertTo(tmp, m1.currency());
             return close_enough(m1,tmp,n);
@@ -200,4 +213,29 @@ namespace QuantLib {
                           % m.currency().symbol();
     }
 
+    Money::Settings::Settings() :
+        conversionType_(Money::NoConversion),
+        baseCurrency_(Currency())
+    {
+    }
+
+    const Money::ConversionType & Money::Settings::conversionType() const
+    {
+        return conversionType_;
+    }
+
+    Money::ConversionType & Money::Settings::conversionType()
+    {
+        return conversionType_;
+    }
+
+    const Currency & Money::Settings::baseCurrency() const
+    {
+        return baseCurrency_;
+    }
+
+    Currency & Money::Settings::baseCurrency()
+    {
+        return baseCurrency_;
+    }
 }

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -253,7 +253,7 @@ namespace QuantLib {
         return *this;
     }
 
-    Money::ConversionTypeProxy::operator ConversionType() const {
+    Money::ConversionTypeProxy::operator Money::ConversionType() const {
         return Money::Settings::instance().conversionType();
     }
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -238,4 +238,23 @@ namespace QuantLib {
     {
         return baseCurrency_;
     }
+
+    Money::BaseCurrencyProxy& Money::BaseCurrencyProxy::operator=(const Currency& c) {
+        Money::Settings::instance().baseCurrency() = c;
+        return *this;
+    }
+
+    Money::BaseCurrencyProxy::operator Currency() const {
+        return Money::Settings::instance().baseCurrency();
+    }
+
+    Money::ConversionTypeProxy& Money::ConversionTypeProxy::operator=(ConversionType t) {
+        Money::Settings::instance().conversionType() = t;
+        return *this;
+    }
+
+    Money::ConversionTypeProxy::operator ConversionType() const {
+        return Money::Settings::instance().conversionType();
+    }
+
 }

--- a/ql/money.hpp
+++ b/ql/money.hpp
@@ -26,6 +26,7 @@
 #define quantlib_money_hpp
 
 #include <ql/currency.hpp>
+#include <ql/patterns/singleton.hpp>
 #include <utility>
 
 namespace QuantLib {
@@ -76,14 +77,36 @@ namespace QuantLib {
                                          currency of the first
                                          operand */
         };
-        static ConversionType conversionType;
-        static Currency baseCurrency;
+        //! Money::Settings forward declaration
+        class Settings;
         //@}
       private:
         Decimal value_ = 0.0;
         Currency currency_;
     };
 
+    //! Money::Settings: nested class for Money per-session settings
+    class Money::Settings : public Singleton<Money::Settings> {
+        friend class Singleton<Money::Settings>;
+      private:
+        Settings();
+        // disable copy/move
+        Settings(const Settings &) = delete;
+        Settings & operator=(const Settings &) = delete;
+        Settings(Settings &&) = delete;
+        Settings & operator=(Settings &&) = delete;
+
+      public:
+        const Money::ConversionType & conversionType() const;
+        Money::ConversionType & conversionType();
+
+        const Currency & baseCurrency() const;
+        Currency & baseCurrency();
+
+      private:
+        Money::ConversionType conversionType_;
+        Currency baseCurrency_;
+    };
 
     // More arithmetics and comparisons
 

--- a/ql/money.hpp
+++ b/ql/money.hpp
@@ -77,15 +77,38 @@ namespace QuantLib {
                                          currency of the first
                                          operand */
         };
-        //! Money::Settings forward declaration
+        // Money::Settings forward declaration
         class Settings;
         //@}
       private:
         Decimal value_ = 0.0;
         Currency currency_;
+
+        // temporary support for old syntax
+        struct BaseCurrencyProxy {
+          public:
+            BaseCurrencyProxy& operator=(const Currency&);
+            operator Currency() const;
+        };
+
+        struct ConversionTypeProxy {
+          public:
+            ConversionTypeProxy& operator=(Money::ConversionType);
+            operator ConversionType() const;
+        };
+
+      public:
+        /*! \deprecated Use Money::Settings::instance().baseCurrency() instead.
+                        Deprecated in version 1.24.
+        */
+        QL_DEPRECATED static BaseCurrencyProxy baseCurrency;
+        /*! \deprecated Use Money::Settings::instance().conversionType() instead.
+                        Deprecated in version 1.24.
+        */
+        QL_DEPRECATED static ConversionTypeProxy conversionType;
     };
 
-    //! Money::Settings: nested class for Money per-session settings
+    //! Per-session settings for the Money class
     class Money::Settings : public Singleton<Money::Settings> {
         friend class Singleton<Money::Settings>;
       private:

--- a/ql/money.hpp
+++ b/ql/money.hpp
@@ -94,7 +94,7 @@ namespace QuantLib {
         struct ConversionTypeProxy {
           public:
             ConversionTypeProxy& operator=(Money::ConversionType);
-            operator ConversionType() const;
+            operator Money::ConversionType() const;
         };
 
       public:

--- a/ql/money.hpp
+++ b/ql/money.hpp
@@ -113,11 +113,6 @@ namespace QuantLib {
         friend class Singleton<Money::Settings>;
       private:
         Settings();
-        // disable copy/move
-        Settings(const Settings &) = delete;
-        Settings & operator=(const Settings &) = delete;
-        Settings(Settings &&) = delete;
-        Settings & operator=(Settings &&) = delete;
 
       public:
         const Money::ConversionType & conversionType() const;

--- a/ql/patterns/singleton.hpp
+++ b/ql/patterns/singleton.hpp
@@ -45,7 +45,6 @@
 
 #include <ql/shared_ptr.hpp>
 #include <ql/types.hpp>
-#include <boost/noncopyable.hpp>
 #include <map>
 
 namespace QuantLib {
@@ -93,10 +92,16 @@ namespace QuantLib {
         \ingroup patterns
     */
     template <class T, class Global = std::integral_constant<bool, false> >
-    class Singleton : private boost::noncopyable {
+    class Singleton {
       private:
+        // disable copy/move
+        Singleton(const Singleton&) = delete;
+        Singleton(Singleton&&) = delete;
+        Singleton& operator=(const Singleton&) = delete;
+        Singleton& operator=(Singleton&&) = delete;
+
 #ifdef QL_ENABLE_SESSIONS
-        // construct on first use to avoid static initialization order fiasko
+        // construct on first use to avoid static initialization order fiasco
         static std::map<ThreadKey, ext::shared_ptr<T> >& m_instances() {
             static std::map<ThreadKey, ext::shared_ptr<T> > instances;
             return instances;

--- a/ql/pricingengines/credit/isdacdsengine.hpp
+++ b/ql/pricingengines/credit/isdacdsengine.hpp
@@ -86,7 +86,7 @@ namespace QuantLib {
             specifications.
 
             To be precisely consistent with the ISDA specification
-                static bool IborCoupon::usingAtParCoupons();
+                bool IborCoupon::Settings::usingAtParCoupons();
             must be true. This is not checked in order not to
             kill the engine completely in this case.
 

--- a/ql/userconfig.hpp
+++ b/ql/userconfig.hpp
@@ -54,7 +54,7 @@
 #endif
 
 /* Define this to use indexed coupons instead of par coupons in floating
-   legs as the default in 'static bool IborCoupon::usingAtParCoupons();'. */
+   legs as the default in 'bool IborCoupon::Settings::usingAtParCoupons();'. */
 #ifndef QL_USE_INDEXED_COUPON
 //#   define QL_USE_INDEXED_COUPON
 #endif

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -512,6 +512,8 @@ void AssetSwapTest::testImpliedValue() {
 
     using namespace asset_swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Calendar bondCalendar = TARGET();
@@ -560,7 +562,7 @@ void AssetSwapTest::testImpliedValue() {
     // directly. The same kind of discrepancy will occur for a multi
     // curve set up, which we do not test here.
     Real tolerance2;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance2 = 1.0e-2;
     else
         tolerance2 = 1.0e-13;
@@ -882,6 +884,8 @@ void AssetSwapTest::testMarketASWSpread() {
 
     using namespace asset_swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Calendar bondCalendar = TARGET();
@@ -933,7 +937,7 @@ void AssetSwapTest::testMarketASWSpread() {
 
     // see comment above
     Real tolerance2;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance2 = 1.0e-4;
     else
         tolerance2 = 1.0e-13;
@@ -1646,6 +1650,8 @@ void AssetSwapTest::testGenericBondImplied() {
 
     using namespace asset_swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Calendar bondCalendar = TARGET();
@@ -1694,7 +1700,7 @@ void AssetSwapTest::testGenericBondImplied() {
 
     // see comment above
     Real tolerance2;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance2 = 1.0e-2;
     else
         tolerance2 = 1.0e-13;
@@ -2039,6 +2045,8 @@ void AssetSwapTest::testMASWWithGenericBond() {
 
     using namespace asset_swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Calendar bondCalendar = TARGET();
@@ -2097,7 +2105,7 @@ void AssetSwapTest::testMASWWithGenericBond() {
 
     // see comment above
     Real tolerance2; 
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance2 = 1.0e-4;
     else
         tolerance2 = 1.0e-13;

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -155,6 +155,7 @@ namespace {
     }
 
     void testSwaptioncfs(bool contTenorSpread) {
+        const auto & iborcoupon_settings = IborCoupon::Settings::instance();
         // market data and floating rate index
         Handle<YieldTermStructure> discYTS = getYTS(terms, discRates);
         Handle<YieldTermStructure> proj6mYTS = getYTS(terms, proj6mRates);
@@ -210,7 +211,7 @@ namespace {
         // so we need to relax the tolerance to a level at which it will only
         // catch large errors.
         Real tol2;
-        if (!IborCoupon::usingAtParCoupons())
+        if (!iborcoupon_settings.usingAtParCoupons())
             tol2 = 0.02;
         else
             tol2 = tol;

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -114,6 +114,8 @@ void BermudanSwaptionTest::testCachedValues() {
 
     using namespace bermudan_swaption_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     vars.today = Date(15, February, 2002);
@@ -150,7 +152,7 @@ void BermudanSwaptionTest::testCachedValues() {
 
     Real itmValue,    atmValue,    otmValue;
     Real itmValueFdm, atmValueFdm, otmValueFdm;
-    if (!IborCoupon::usingAtParCoupons()) {
+    if (!iborcoupon_settings.usingAtParCoupons()) {
         itmValue    = 42.2413,    atmValue = 12.8789,    otmValue = 2.4759;
         itmValueFdm = 42.2111, atmValueFdm = 12.8879, otmValueFdm = 2.44443;
     } else {
@@ -206,7 +208,7 @@ void BermudanSwaptionTest::testCachedValues() {
     exercise =
         ext::shared_ptr<Exercise>(new BermudanExercise(exerciseDates));
 
-    if (!IborCoupon::usingAtParCoupons()) {
+    if (!iborcoupon_settings.usingAtParCoupons()) {
         itmValue = 42.1917; atmValue = 12.7788; otmValue = 2.4388;
     } else {
         itmValue = 42.1974; atmValue = 12.7825; otmValue = 2.4399;
@@ -238,6 +240,8 @@ void BermudanSwaptionTest::testCachedG2Values() {
         "Testing Bermudan swaption with G2 model against cached values...");
 
     using namespace bermudan_swaption_test;
+
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
 
     CommonVars vars;
 
@@ -273,7 +277,7 @@ void BermudanSwaptionTest::testCachedG2Values() {
         ext::make_shared<TreeSwaptionEngine>(g2Model, 50));
 
     Real expectedFdm[5], expectedTree[5];
-    if (!IborCoupon::usingAtParCoupons()) {
+    if (!iborcoupon_settings.usingAtParCoupons()) {
         Real tmpExpectedFdm[]  = { 103.231, 54.6519, 20.0475, 5.26941, 1.07097 };
         Real tmpExpectedTree[] = { 103.253, 54.6685, 20.1399, 5.40517, 1.10642 };
         std::copy(tmpExpectedFdm,  tmpExpectedFdm + 5,  expectedFdm);

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -879,6 +879,8 @@ void BondTest::testCachedFloating() {
 
     using namespace bonds_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Date today(22,November,2004);
@@ -921,7 +923,7 @@ void BondTest::testCachedFloating() {
     setCouponPricer(bond1.cashflows(),pricer);
 
     Real cachedPrice1;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice1 = 99.874645;
     else
         cachedPrice1 = 99.874646;
@@ -952,7 +954,7 @@ void BondTest::testCachedFloating() {
     setCouponPricer(bond2.cashflows(),pricer);
 
     Real cachedPrice2;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice2 = 97.955904;
     else
         cachedPrice2 = 97.955904;
@@ -987,7 +989,7 @@ void BondTest::testCachedFloating() {
     setCouponPricer(bond3.cashflows(),pricer);
 
     Real cachedPrice3;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice3 = 98.495458;
     else
         cachedPrice3 = 98.495459;
@@ -1014,7 +1016,7 @@ void BondTest::testCachedFloating() {
     setCouponPricer(bond4.cashflows(), pricer);
 
     Real cachedPrice4;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice4 = 98.892346;
     else
         cachedPrice4 = 98.892055;

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -561,6 +561,8 @@ void CapFloorTest::testCachedValue() {
 
     using namespace capfloor_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Date cachedToday(14,March,2002),
@@ -575,7 +577,7 @@ void CapFloorTest::testCachedValue() {
                                                             0.03,0.20);
 
     Real cachedCapNPV, cachedFloorNPV ;
-    if (!IborCoupon::usingAtParCoupons()) {
+    if (!iborcoupon_settings.usingAtParCoupons()) {
         // index fixing price
         cachedCapNPV   = 6.87630307745,
         cachedFloorNPV = 2.65796764715;
@@ -607,6 +609,8 @@ void CapFloorTest::testCachedValueFromOptionLets() {
 
     using namespace capfloor_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Date cachedToday(14,March,2002),
@@ -626,7 +630,7 @@ void CapFloorTest::testCachedValueFromOptionLets() {
          calculatedFloorletsNPV = 0.0;
 
     Real cachedCapNPV, cachedFloorNPV;
-    if (IborCoupon::usingAtParCoupons()) {
+    if (iborcoupon_settings.usingAtParCoupons()) {
         cachedCapNPV = 6.87570026732;
         cachedFloorNPV = 2.65812927959;
     } else {

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -505,12 +505,13 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
 }
 
 test_suite* CashFlowsTest::suite() {
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
     auto* suite = BOOST_TEST_SUITE("Cash flows tests");
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testSettings));
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testAccessViolation));
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testDefaultSettlementDate));
     suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testExCouponDates));
-    if (IborCoupon::usingAtParCoupons())
+    if (iborcoupon_settings.usingAtParCoupons())
         suite->add(QUANTLIB_TEST_CASE(&CashFlowsTest::testNullFixingDays));
 
     suite->add(QUANTLIB_TEST_CASE(

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -209,6 +209,8 @@ void CatBondTest::testRiskFreeAgainstFloatingRateBond() {
 
     using namespace catbonds_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     Date today(22,November,2004);
@@ -270,7 +272,7 @@ void CatBondTest::testRiskFreeAgainstFloatingRateBond() {
     setCouponPricer(catBond1.cashflows(),pricer);
 
     Real cachedPrice1;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice1 = 99.874645;
     else
         cachedPrice1 = 99.874646;
@@ -317,7 +319,7 @@ void CatBondTest::testRiskFreeAgainstFloatingRateBond() {
     setCouponPricer(catBond2.cashflows(),pricer);
 
     Real cachedPrice2; 
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice2 = 97.955904;
     else
         cachedPrice2 = 97.955904;
@@ -365,7 +367,7 @@ void CatBondTest::testRiskFreeAgainstFloatingRateBond() {
     setCouponPricer(catBond3.cashflows(),pricer);
 
     Real cachedPrice3;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedPrice3 = 98.495458;
     else
         cachedPrice3 = 98.495459;

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -575,6 +575,8 @@ void CreditDefaultSwapTest::testIsdaEngine() {
     BOOST_TEST_MESSAGE(
         "Testing ISDA engine calculations for credit-default swaps...");
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     SavedSettings backup;
 
     Date tradeDate(21, May, 2009);
@@ -666,7 +668,7 @@ void CreditDefaultSwapTest::testIsdaEngine() {
                              -4702034.688,
                              -4042340.999};
     Real tolerance;
-    if (IborCoupon::usingAtParCoupons()) {
+    if (iborcoupon_settings.usingAtParCoupons()) {
         tolerance = 1.0e-6;
     } else {
         /* The risk-free curve is a bit off. We might skip the tests

--- a/test-suite/exchangerate.cpp
+++ b/test-suite/exchangerate.cpp
@@ -39,7 +39,7 @@ void ExchangeRateTest::testDirect() {
     Money m1 = 50000.0 * EUR;
     Money m2 = 100000.0 * USD;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     Money calculated = eur_usd.exchange(m1);
     Money expected(m1.value()*eur_usd.rate(), USD);
@@ -74,7 +74,7 @@ void ExchangeRateTest::testDerived() {
     Money m1 = 50000.0 * GBP;
     Money m2 = 100000.0 * USD;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     Money calculated = derived.exchange(m1);
     Money expected(m1.value()*eur_usd.rate()/eur_gbp.rate(), USD);
@@ -112,7 +112,7 @@ void ExchangeRateTest::testDirectLookup() {
     Money m1 = 50000.0 * EUR;
     Money m2 = 100000.0 * USD;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     ExchangeRate eur_usd = rateManager.lookup(EUR, USD,
                                               Date(4,August,2004),
@@ -182,7 +182,7 @@ void ExchangeRateTest::testTriangulatedLookup() {
     Money m1 = 50000000.0 * ITL;
     Money m2 = 100000.0 * USD;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     ExchangeRate itl_usd = rateManager.lookup(ITL, USD,
                                               Date(4,August,2004));
@@ -273,7 +273,7 @@ void ExchangeRateTest::testSmartLookup() {
     Money m5 = 100000.0 * SEK;
     Money m6 = 100000.0 * JPY;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     // two-rate chain
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -263,6 +263,8 @@ void CPISwapTest::consistency() {
 
     using namespace inflation_cpi_swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     // check inflation leg vs calculation directly from inflation TS
     CommonVars common;
 
@@ -361,7 +363,7 @@ void CPISwapTest::consistency() {
     Real diff = fabs(1-zisV.NPV()/4191660.0);
     
     Real max_diff;
-    if (IborCoupon::usingAtParCoupons())
+    if (iborcoupon_settings.usingAtParCoupons())
         max_diff = 1e-5;
     else
         max_diff = 3e-5;

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -191,11 +191,13 @@ void LiborMarketModelTest::testCapletPricing() {
 
     using namespace libor_market_model_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     SavedSettings backup;
 
     const Size size = 10;
     Real tolerance;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance = 1e-5;
     else
         tolerance = 1e-12;
@@ -352,13 +354,15 @@ void LiborMarketModelTest::testSwaptionPricing() {
 
     using namespace libor_market_model_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     SavedSettings backup;
 
     const Size size  = 10;
     const Size steps = 8*size;
 
     Real tolerance;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance = 1e-6;
     else
         tolerance = 1e-12;

--- a/test-suite/money.cpp
+++ b/test-suite/money.cpp
@@ -37,7 +37,7 @@ void MoneyTest::testNone() {
     Money m2 = 100000.0 * EUR;
     Money m3 = 500000.0 * EUR;
 
-    Money::conversionType = Money::NoConversion;
+    Money::Settings::instance().conversionType() = Money::NoConversion;
 
     Money calculated = m1*3.0 + 2.5*m2 - m3/5.0;
     Decimal x = m1.value()*3.0 + 2.5*m2.value() - m3.value()/5.0;
@@ -68,17 +68,18 @@ void MoneyTest::testBaseCurrency() {
     ExchangeRateManager::instance().add(eur_usd);
     ExchangeRateManager::instance().add(eur_gbp);
 
-    Money::conversionType = Money::BaseCurrencyConversion;
-    Money::baseCurrency = EUR;
+    auto & money_settings = Money::Settings::instance();
+    money_settings.conversionType() = Money::BaseCurrencyConversion;
+    money_settings.baseCurrency() = EUR;
 
     Money calculated = m1*3.0 + 2.5*m2 - m3/5.0;
 
-    Rounding round = Money::baseCurrency.rounding();
+    Rounding round = money_settings.baseCurrency().rounding();
     Decimal x = round(m1.value()*3.0/eur_gbp.rate()) + 2.5*m2.value()
               - round(m3.value()/(5.0*eur_usd.rate()));
     Money expected(x, EUR);
 
-    Money::conversionType = Money::NoConversion;
+    money_settings.conversionType() = Money::NoConversion;
 
     if (calculated != expected) {
         BOOST_FAIL("Wrong result: \n"
@@ -104,7 +105,8 @@ void MoneyTest::testAutomated() {
     ExchangeRateManager::instance().add(eur_usd);
     ExchangeRateManager::instance().add(eur_gbp);
 
-    Money::conversionType = Money::AutomatedConversion;
+    auto & money_settings = Money::Settings::instance();
+    money_settings.conversionType() = Money::AutomatedConversion;
 
     Money calculated = (m1*3.0 + 2.5*m2) - m3/5.0;
 
@@ -113,7 +115,7 @@ void MoneyTest::testAutomated() {
               - round((m3.value()/5.0)*eur_gbp.rate()/eur_usd.rate());
     Money expected(x, GBP);
 
-    Money::conversionType = Money::NoConversion;
+    money_settings.conversionType() = Money::NoConversion;
 
     if (calculated != expected) {
         BOOST_FAIL("Wrong result: \n"

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -789,6 +789,8 @@ void OptionletStripperTest::testSwitchStrike() {
 
     using namespace optionlet_stripper_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
     Settings::instance().evaluationDate() = Date(28, October, 2013);
     vars.setCapFloorTermVolSurface();
@@ -804,7 +806,7 @@ void OptionletStripperTest::testSwitchStrike() {
                                Null< Rate >(), vars.accuracy));
 
     Real expected;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         expected = 0.02981258;
     else
         expected = 0.02981223;
@@ -821,7 +823,7 @@ void OptionletStripperTest::testSwitchStrike() {
     yieldTermStructure.linkTo(ext::make_shared< FlatForward >(
         0, vars.calendar, 0.05, vars.dayCounter));
 
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         expected = 0.0499381;
     else
         expected = 0.0499371;

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1506,6 +1506,8 @@ test_suite* PiecewiseYieldCurveTest::suite() {
 
     auto* suite = BOOST_TEST_SUITE("Piecewise yield curve tests");
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     // unstable
     //suite->add(QUANTLIB_TEST_CASE(
     //             &PiecewiseYieldCurveTest::testLogCubicDiscountConsistency));
@@ -1546,7 +1548,7 @@ test_suite* PiecewiseYieldCurveTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(
                &PiecewiseYieldCurveTest::testSwapRateHelperSpotDate));
 
-    if (IborCoupon::usingAtParCoupons()) {
+    if (iborcoupon_settings.usingAtParCoupons()) {
         // This regression test didn't work with indexed coupons anyway.
         suite->add(QUANTLIB_TEST_CASE(
                &PiecewiseYieldCurveTest::testBadPreviousCurve));

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -60,6 +60,8 @@ void ShortRateModelTest::testCachedHullWhite() {
 
     using namespace short_rate_models_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     SavedSettings backup;
     IndexHistoryCleaner cleaner;
 
@@ -101,7 +103,7 @@ void ShortRateModelTest::testCachedHullWhite() {
 
     // Check and print out results
     Real cachedA, cachedSigma;
-    if (!IborCoupon::usingAtParCoupons()) {
+    if (!iborcoupon_settings.usingAtParCoupons()) {
         cachedA = 0.0463679, cachedSigma = 0.00579831;
     } else {
         cachedA = 0.0464041, cachedSigma = 0.00579912;
@@ -134,6 +136,8 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
     BOOST_TEST_MESSAGE("Testing Hull-White calibration with fixed reversion against cached values...");
 
     using namespace short_rate_models_test;
+
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
 
     SavedSettings backup;
     IndexHistoryCleaner cleaner;
@@ -178,7 +182,7 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
 
     // Check and print out results
     Real cachedA, cachedSigma;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedA = 0.05, cachedSigma = 0.00585835;
     else
         cachedA = 0.05, cachedSigma = 0.00585858;
@@ -212,6 +216,8 @@ void ShortRateModelTest::testCachedHullWhite2() {
                        "values using swaptions without start delay...");
 
     using namespace short_rate_models_test;
+
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
 
     SavedSettings backup;
     IndexHistoryCleaner cleaner;
@@ -261,7 +267,7 @@ void ShortRateModelTest::testCachedHullWhite2() {
     // JamshidianEngine not accounting for the delay between option
     // expiry and underlying start
     Real cachedA, cachedSigma;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         cachedA = 0.0481608, cachedSigma = 0.00582493;
     else
         cachedA = 0.0482063, cachedSigma = 0.00582687;
@@ -291,6 +297,8 @@ void ShortRateModelTest::testCachedHullWhite2() {
 
 void ShortRateModelTest::testSwaps() {
     BOOST_TEST_MESSAGE("Testing Hull-White swap pricing against known values...");
+
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
 
     SavedSettings backup;
     IndexHistoryCleaner cleaner;
@@ -346,7 +354,7 @@ void ShortRateModelTest::testSwaps() {
                                         new TreeVanillaSwapEngine(model,120));
 
     Real tolerance;
-    if (!IborCoupon::usingAtParCoupons())
+    if (!iborcoupon_settings.usingAtParCoupons())
         tolerance = 4.0e-3;
     else
         tolerance = 1.0e-8;

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -299,6 +299,8 @@ void SwapTest::testCachedValue() {
 
     using namespace swap_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     vars.today = Date(17,June,2002);
@@ -316,7 +318,7 @@ void SwapTest::testCachedValue() {
                     << "    expected:   " << 2);
 
     Real cachedNPV;  
-    if (IborCoupon::usingAtParCoupons())
+    if (iborcoupon_settings.usingAtParCoupons())
         cachedNPV = -5.872863313209;
     else
         cachedNPV = -5.872342992212;

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -379,6 +379,8 @@ void SwaptionTest::testCachedValue() {
 
     using namespace swaption_test;
 
+    const auto & iborcoupon_settings = IborCoupon::Settings::instance();
+
     CommonVars vars;
 
     vars.today = Date(13, March, 2002);
@@ -398,7 +400,7 @@ void SwaptionTest::testCachedValue() {
         vars.makeSwaption(swap, exerciseDate, 0.20);
 
     Real cachedNPV;
-    if (IborCoupon::usingAtParCoupons())
+    if (iborcoupon_settings.usingAtParCoupons())
         cachedNPV = 0.036418158579;
     else
         cachedNPV = 0.036421429684;


### PR DESCRIPTION
Here's a fix for #1146.  I added both `IborCoupon::Settings` and `Money::Settings` as nested classes per @ralfkonrad's  suggestion.   I deprecated the original static methods -- which still work -- they simply use the new singletons.   The test suite and example code changes are simply to use the new apis.   The `Money` class unfortunately did not use static methods, but static vars instead (ouch), so I did the best that I could with that.

I tested locally with `QL_USE_INDEXED_COUPON` off and then on. 

Phil