### PR TITLE
Add definitions of static class members

### DIFF
--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -252,4 +252,8 @@ namespace QuantLib {
         return Money::Settings::instance().conversionType();
     }
 
+    Money::BaseCurrencyProxy Money::baseCurrency;
+    Money::ConversionTypeProxy Money::conversionType;
+
+
 }


### PR DESCRIPTION
SWIG-Python build was failing  because these were not found

The static class members were introduced by commit d02b9f6d 