### PR TITLE
Add missing call to calculate() before before returning the additional results map.

### DIFF
--- a/ql/instrument.hpp
+++ b/ql/instrument.hpp
@@ -215,6 +215,7 @@ namespace QuantLib {
 
     inline const std::map<std::string,boost::any>&
     Instrument::additionalResults() const {
+        calculate();
         return additionalResults_;
     }
 


### PR DESCRIPTION
Add missing call to calculate() before before returning the additional results map.