### PR TITLE
CMake: Warnings similar to .github/worksflows/linux.yml

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -22,4 +22,12 @@ if (MSVC)
     # Suppress warnings: "Prefer enum class over enum" (Enum.3)
 
     add_compile_options(/wd4267 /wd26812)
+
+    # warning level 3 and all warnings as errors
+    add_compile_options(/W3 /WX)
+
+else()
+    # warning level in line with the .github/worksflows/linux.yml compile options
+    # for gcc and clang
+    add_compile_options(-Wall -Wno-unknown-pragmas -Werror)
 endif()


### PR DESCRIPTION
This sets the same compiler warning options `-Wall -Wno-unknown-pragmas -Werror` for `gcc` and `clang` for the `cmake` build as in

https://github.com/lballabio/QuantLib/blob/1ae273550696e37a7e83a65c5869de4cbeb5d58b/.github/workflows/linux.yml#L207

On the one hand side these issues need to be fixed anyhow and on the other hand side it makes it easier (for me at least) to find errors when developing under VS and cross-check the other `c++` dialects.

Also the VS build uses comparable switches: `warning level 3 and all warnings as errors`