### PR TITLE
CMake: avoid level 3 warnings from MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ option(QL_USE_STD_SHARED_PTR "Use standard smart pointers instead of Boost ones"
 option(QL_USE_STD_UNIQUE_PTR "Use std::unique_ptr instead of std::auto_ptr" ON)
 option(QL_USE_STD_FUNCTION "Use std::function and std::bind instead of Boost ones" OFF)
 option(QL_USE_STD_TUPLE "Use std::tuple instead of boost::tuple" OFF)
+option(QL_MSVC_DISABLE_PARALLEL_BUILDS "Disable the /MP flag for parallel builds using msbuild" OFF)
 
 # Convenience option to activate all STD options
 if (QL_USE_STD_CLASSES)

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -13,6 +13,16 @@ if (MSVC)
         set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     endif()
 
+    add_compile_definitions(NOMINMAX)
+
+    # /wd4267
+    # Suppress warnings: assignment of 64-bit value to 32-bit QuantLib::Integer (x64)
+
+    # /wd26812
+    # Suppress warnings: "Prefer enum class over enum" (Enum.3)
+
+    add_compile_options(/wd4267 /wd26812)
+
     if(NOT QL_MSVC_DISABLE_PARALLEL_BUILDS)
         # enable parallel builds
         add_compile_options(/MP)
@@ -21,8 +31,10 @@ if (MSVC)
     # warning level 3 and all warnings as errors
     add_compile_options(/W3 /WX)
 
-    add_compile_definitions(NOMINMAX)
-    add_compile_definitions(_SCL_SECURE_NO_DEPRECATE)
+    ### Avoid level 3 warnings for the time being.
+    ### However they should be fixed in the long run.
+
+    # caused by ql\time\date.cpp: warning C4996: 'localtime': This function or variable may be unsafe. Consider using localtime_s instead. 
     add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
 
     # caused by macro redefinition 'M_PI' etc. e.g. in ql\methods\finitedifferences\solvers\fdmbackwardsolver.cpp
@@ -40,12 +52,4 @@ if (MSVC)
         # caused by ql/math/functional.hpp (line 271) compiling test-suite\distributions.cpp
         add_compile_definitions(_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)
     endif()
-    
-    # /wd4267
-    # Suppress warnings: assignment of 64-bit value to 32-bit QuantLib::Integer (x64)
-
-    # /wd26812
-    # Suppress warnings: "Prefer enum class over enum" (Enum.3)
-
-    add_compile_options(/wd4267 /wd26812)
 endif()

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -25,6 +25,9 @@ if (MSVC)
     add_compile_definitions(_SCL_SECURE_NO_DEPRECATE)
     add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
 
+    # caused by macro redefinition 'M_PI' etc. e.g. in ql\methods\finitedifferences\solvers\fdmbackwardsolver.cpp
+    add_compile_options(/wd4005)
+
     # prevent warnings when using /std:c++17
     if(CMAKE_CXX_STANDARD GREATER 14)
         # caused by the QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
@@ -36,9 +39,6 @@ if (MSVC)
 
         # caused by ql/math/functional.hpp (line 271) compiling test-suite\distributions.cpp
         add_compile_definitions(_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)
-        
-        # caused by macro redefinition 'M_PI' etc. e.g. in ql\methods\finitedifferences\solvers\fdmbackwardsolver.cpp
-        add_compile_options(/wd4005)
     endif()
     
     # /wd4267

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -13,8 +13,34 @@ if (MSVC)
         set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
     endif()
 
-    add_compile_definitions(NOMINMAX)
+    if(NOT QL_MSVC_DISABLE_PARALLEL_BUILDS)
+        # enable parallel builds
+        add_compile_options(/MP)
+    endif()
 
+    # warning level 3 and all warnings as errors
+    add_compile_options(/W3 /WX)
+
+    add_compile_definitions(NOMINMAX)
+    add_compile_definitions(_SCL_SECURE_NO_DEPRECATE)
+    add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)
+
+    # prevent warnings when using /std:c++17
+    if(CMAKE_CXX_STANDARD GREATER 14)
+        # caused by the QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        add_compile_definitions(BOOST_UNORDERED_USE_ALLOCATOR_TRAITS=2)
+        
+        # caused by #include <boost/numeric/ublas/matrix.hpp> 
+        # in e.g. ql\experimental\finitedifferences\fdmdupire1dop.cpp
+        add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
+
+        # caused by ql/math/functional.hpp (line 271) compiling test-suite\distributions.cpp
+        add_compile_definitions(_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)
+        
+        # caused by macro redefinition 'M_PI' etc. e.g. in ql\methods\finitedifferences\solvers\fdmbackwardsolver.cpp
+        add_compile_options(/wd4005)
+    endif()
+    
     # /wd4267
     # Suppress warnings: assignment of 64-bit value to 32-bit QuantLib::Integer (x64)
 


### PR DESCRIPTION
As mentioned in #1203 `MSVC` has several compiler warnings when level 3 `/W3` is enabled.

Level 3 warnings are however the default for the (non CMake) `QuantLib.sln` solution so we should try to get rid off them in the long run.

Also inline with the `QuantLib.sln` I have enable parallel builds `/MP` which can be turned off by passing `-DQL_MSVC_DISABLE_PARALLEL_BUILDS=ON` to `cmake`.

#### List of warnings together with the reason for it

```cmake
    # caused by ql\time\date.cpp: warning C4996: 'localtime': This function or variable may be unsafe. Consider using localtime_s instead. 
    add_compile_definitions(_CRT_SECURE_NO_DEPRECATE)

    # caused by macro redefinition 'M_PI' etc. e.g. in ql\methods\finitedifferences\solvers\fdmbackwardsolver.cpp
    add_compile_options(/wd4005)

    # prevent warnings when using /std:c++17
    if(CMAKE_CXX_STANDARD GREATER 14)
        # caused by the QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
        add_compile_definitions(BOOST_UNORDERED_USE_ALLOCATOR_TRAITS=2)

        # caused by #include <boost/numeric/ublas/matrix.hpp> 
        # in e.g. ql\experimental\finitedifferences\fdmdupire1dop.cpp
        add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)

        # caused by ql/math/functional.hpp (line 271) compiling test-suite\distributions.cpp
        add_compile_definitions(_SILENCE_CXX17_ADAPTOR_TYPEDEFS_DEPRECATION_WARNING)
    endif()
```

@lballabio: Do you think we should make issues out of each prevented warning so we are aware to fix them?

@pkovacs: Is `add_compile_definitions(BOOST_UNORDERED_USE_ALLOCATOR_TRAITS=2)` just a workaround like the "silencers" `_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING` etc.? Or is it a real fix within Boost for the deprecated c++17 functionality?
