### PR TITLE
Deprecate the `UnitedStates` constructor that doesn't explicitly specify a market

### DIFF
--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -173,7 +173,15 @@ namespace QuantLib {
                       LiborImpact,    //!< Libor impact calendar
                       FederalReserve  //!< Federal Reserve Bankwire System
         };
-        UnitedStates(Market market = Settlement);
+
+        explicit UnitedStates(Market market);
+
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.24.
+        */
+        QL_DEPRECATED
+        UnitedStates()
+        : UnitedStates(Settlement) {}
     };
 
 }

--- a/test-suite/convertiblebonds.cpp
+++ b/test-suite/convertiblebonds.cpp
@@ -420,7 +420,7 @@ void ConvertibleBondTest::testRegression() {
 
     Date issueDate(23, July, 2008);
     Date maturityDate(1, August, 2013);
-    Calendar calendar = UnitedStates();
+    Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
     Schedule schedule = MakeSchedule().from(issueDate)
                                       .to(maturityDate)
                                       .withTenor(6*Months)

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -170,7 +170,7 @@ void CreditDefaultSwapTest::testCachedMarketValue() {
 
     Settings::instance().evaluationDate() = Date(9,June,2006);
     Date evalDate = Settings::instance().evaluationDate();
-    Calendar calendar = UnitedStates();
+    Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
 
     std::vector<Date> discountDates = {
         evalDate,

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -339,7 +339,7 @@ void DayCounterTest::testActualActualWithSemiannualSchedule() {
 
     using namespace day_counters_test;
 
-    Calendar calendar = UnitedStates();
+    Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
     Date fromDate = Date(10, January, 2017);
     Date firstCoupon = Date(31, August, 2017);
     Date quasiCoupon = Date(28, February, 2017);
@@ -458,7 +458,7 @@ void DayCounterTest::testActualActualWithAnnualSchedule(){
     using namespace day_counters_test;
 
     // Now do an annual schedule
-    Calendar calendar = UnitedStates();
+    Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
     Schedule schedule = MakeSchedule()
         .from(Date(10, January, 2017))
         .withFirstDate(Date(31, August, 2017))

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -500,8 +500,8 @@ void OvernightIndexedSwapTest::testBootstrapRegression() {
                                   Pillar::MaturityDate)));
     }
 
-    PiecewiseYieldCurve<Discount,LogCubic> curve(0, UnitedStates(), helpers, Actual365Fixed(),
-                                                 MonotonicLogCubic());
+    PiecewiseYieldCurve<Discount,LogCubic> curve(0, UnitedStates(UnitedStates::GovernmentBond),
+                                                 helpers, Actual365Fixed(), MonotonicLogCubic());
 
     BOOST_CHECK_NO_THROW(curve.discount(1.0));
 }

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1102,7 +1102,7 @@ void PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate() {
     // note that the calendar should be US+UK here actually, but technically it should also work with
     // the US calendar only
     ext::shared_ptr<RateHelper> helper = ext::make_shared<SwapRateHelper>(
-        0.02, 50 * Years, UnitedStates(), Semiannual, ModifiedFollowing,
+        0.02, 50 * Years, UnitedStates(UnitedStates::GovernmentBond), Semiannual, ModifiedFollowing,
         Thirty360(Thirty360::BondBasis), usdLibor3m);
 
     PiecewiseYieldCurve<Discount, LogLinear> curve(today, std::vector<ext::shared_ptr<RateHelper> >(1, helper),
@@ -1118,7 +1118,7 @@ void PiecewiseYieldCurveTest::testSwapRateHelperSpotDate() {
     ext::shared_ptr<IborIndex> usdLibor3m = ext::make_shared<USDLibor>(3 * Months);
 
     ext::shared_ptr<SwapRateHelper> helper = ext::make_shared<SwapRateHelper>(
-        0.02, 5 * Years, UnitedStates(), Semiannual, ModifiedFollowing,
+        0.02, 5 * Years, UnitedStates(UnitedStates::GovernmentBond), Semiannual, ModifiedFollowing,
         Thirty360(Thirty360::BondBasis), usdLibor3m);
 
     Settings::instance().evaluationDate() = Date(11, October, 2019);
@@ -1467,7 +1467,7 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
     for (map<Period, Real>::const_iterator it = arsFwdPoints.begin(); it != arsFwdPoints.end(); ++it) {
         Handle<Quote> arsFwd(ext::make_shared<SimpleQuote>(it->second));
         instruments.push_back(ext::make_shared<FxSwapRateHelper>(arsFwd, arsSpot, it->first, 2,
-            UnitedStates(), Following, false, true, usdYts));
+            UnitedStates(UnitedStates::GovernmentBond), Following, false, true, usdYts));
     }
 
     // Create the ARS in USD curve with the default IterativeBootstrap.

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -889,7 +889,7 @@ void ScheduleTest::testScheduleAlwaysHasAStartDate() {
                        "always produce a schedule with a start date...");
     // Attempt to establish whether the first coupoun payment date is
     // always the second element of the constructor.
-    Calendar calendar = UnitedStates();
+    Calendar calendar = UnitedStates(UnitedStates::GovernmentBond);
     Schedule schedule = MakeSchedule()
         .from(Date(10, January, 2017))
         .withFirstDate(Date(31, August, 2017))
@@ -945,7 +945,7 @@ void ScheduleTest::testFirstDateOnMaturity() {
         .to(Date(20, December, 2016))
         .withFirstDate(Date(20, December, 2016))
         .withFrequency(Quarterly)
-        .withCalendar(UnitedStates())
+        .withCalendar(UnitedStates(UnitedStates::GovernmentBond))
         .withConvention(Unadjusted)
         .backwards();
 
@@ -960,7 +960,7 @@ void ScheduleTest::testFirstDateOnMaturity() {
         .to(Date(20, December, 2016))
         .withFirstDate(Date(20, December, 2016))
         .withFrequency(Quarterly)
-        .withCalendar(UnitedStates())
+        .withCalendar(UnitedStates(UnitedStates::GovernmentBond))
         .withConvention(Unadjusted)
         .forwards();
 
@@ -974,7 +974,7 @@ void ScheduleTest::testNextToLastDateOnStart() {
         .to(Date(20, December, 2016))
         .withNextToLastDate(Date(20, September, 2016))
         .withFrequency(Quarterly)
-        .withCalendar(UnitedStates())
+        .withCalendar(UnitedStates(UnitedStates::GovernmentBond))
         .withConvention(Unadjusted)
         .backwards();
 
@@ -989,7 +989,7 @@ void ScheduleTest::testNextToLastDateOnStart() {
         .to(Date(20, December, 2016))
         .withNextToLastDate(Date(20, September, 2016))
         .withFrequency(Quarterly)
-        .withCalendar(UnitedStates())
+        .withCalendar(UnitedStates(UnitedStates::GovernmentBond))
         .withConvention(Unadjusted)
         .backwards();
 


### PR DESCRIPTION
Most of the times, the default choice might not be the correct one.  To avoid misunderstandings, the market should be specified.