### PR TITLE
Remove Forward inheritance by ForwardRateAgreement

### DIFF
--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -246,6 +246,9 @@ int main(int, char* []) {
                                                        fraDayCounter,
                                                        Simple)
                  << endl;
+            cout << "FRA amount [should be zero]: "
+                 << myFRA.amount()
+                 << endl;
             cout << "FRA NPV [should be zero]: "
                  << myFRA.NPV()
                  << endl
@@ -324,6 +327,9 @@ int main(int, char* []) {
                  << discountingTermStructure->zeroRate(fraMaturityDate,
                                                        fraDayCounter,
                                                        Simple)
+                 << endl;
+            cout << "FRA amount [should be positive]: "
+                 << myFRA.amount()
                  << endl;
             cout << "FRA NPV [should be positive]: "
                  << myFRA.NPV()

--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -188,7 +188,6 @@ int main(int, char* []) {
             euribor3m->businessDayConvention();
         Position::Type fraFwdType = Position::Long;
         Real fraNotional = 100.0;
-        const Integer FraTermMonths = 3;
         Integer monthsToStart[] = { 1, 2, 3, 6, 9 };
 
         euriborTermStructure.linkTo(fraTermStructure);
@@ -205,13 +204,9 @@ int main(int, char* []) {
                                        settlementDate,monthsToStart[i],Months,
                                        fraBusinessDayConvention);
 
-            Date fraMaturityDate = fraCalendar.advance(
-                                            fraValueDate,FraTermMonths,Months,
-                                            fraBusinessDayConvention);
-
             Rate fraStrikeRate = threeMonthFraQuote[monthsToStart[i]];
 
-            ForwardRateAgreement myFRA(fraValueDate, fraMaturityDate,
+            ForwardRateAgreement myFRA(fraValueDate,
                                        fraFwdType,fraStrikeRate,
                                        fraNotional, euribor3m,
                                        discountingTermStructure);
@@ -268,14 +263,10 @@ int main(int, char* []) {
                                        settlementDate,monthsToStart[i],Months,
                                        fraBusinessDayConvention);
 
-            Date fraMaturityDate = fraCalendar.advance(
-                                            fraValueDate,FraTermMonths,Months,
-                                            fraBusinessDayConvention);
-
             Rate fraStrikeRate =
                 threeMonthFraQuote[monthsToStart[i]] - BpsShift;
 
-            ForwardRateAgreement myFRA(fraValueDate, fraMaturityDate,
+            ForwardRateAgreement myFRA(fraValueDate,
                                        fraFwdType, fraStrikeRate,
                                        fraNotional, euribor3m,
                                        discountingTermStructure);

--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -228,24 +228,6 @@ int main(int, char* []) {
             cout << "FRA market quote: "
                  << io::rate(threeMonthFraQuote[monthsToStart[i]])
                  << endl;
-            cout << "FRA spot value: "
-                 << myFRA.spotValue()
-                 << endl;
-            cout << "FRA forward value: "
-                 << myFRA.forwardValue()
-                 << endl;
-            cout << "FRA implied Yield: "
-                 << myFRA.impliedYield(myFRA.spotValue(),
-                                       myFRA.forwardValue(),
-                                       settlementDate,
-                                       Simple,
-                                       fraDayCounter)
-                 << endl;
-            cout << "market Zero Rate: "
-                 << discountingTermStructure->zeroRate(fraMaturityDate,
-                                                       fraDayCounter,
-                                                       Simple)
-                 << endl;
             cout << "FRA amount [should be zero]: "
                  << myFRA.amount()
                  << endl;
@@ -309,24 +291,6 @@ int main(int, char* []) {
                  << endl;
             cout << "FRA market quote: "
                  << io::rate(threeMonthFraQuote[monthsToStart[i]])
-                 << endl;
-            cout << "FRA spot value: "
-                 << myFRA.spotValue()
-                 << endl;
-            cout << "FRA forward value: "
-                 << myFRA.forwardValue()
-                 << endl;
-            cout << "FRA implied Yield: "
-                 << myFRA.impliedYield(myFRA.spotValue(),
-                                       myFRA.forwardValue(),
-                                       settlementDate,
-                                       Simple,
-                                       fraDayCounter)
-                 << endl;
-            cout << "market Zero Rate: "
-                 << discountingTermStructure->zeroRate(fraMaturityDate,
-                                                       fraDayCounter,
-                                                       Simple)
                  << endl;
             cout << "FRA amount [should be positive]: "
                  << myFRA.amount()

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -35,9 +35,9 @@ namespace QuantLib {
     : 
       fraType_(type), notionalAmount_(notionalAmount), index_(index),
       useIndexedCoupon_(useIndexedCoupon), dayCounter_(std::move(index->dayCounter())),
-      calendar_(std::move(index->fixingCalendar())),
+      calendar_(index->fixingCalendar()),
       businessDayConvention_(index->businessDayConvention()), settlementDays_(index->fixingDays()),
-      payoff_(std::move(ext::shared_ptr<Payoff>())), valueDate_(valueDate),
+      payoff_(ext::shared_ptr<Payoff>()), valueDate_(valueDate),
       maturityDate_(maturityDate), discountCurve_(std::move(discountCurve)) {
 
         maturityDate_ = calendar_.adjust(maturityDate_, businessDayConvention_);

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -23,6 +23,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     ForwardRateAgreement::ForwardRateAgreement(
                            const Date& valueDate,
                            const Date& maturityDate,
@@ -32,13 +34,11 @@ namespace QuantLib {
                            const ext::shared_ptr<IborIndex>& index,
                            const Handle<YieldTermStructure>& discountCurve,
                            bool useIndexedCoupon)
-    : 
-      fraType_(type), notionalAmount_(notionalAmount), index_(index),
+    : fraType_(type), notionalAmount_(notionalAmount), index_(index),
       useIndexedCoupon_(useIndexedCoupon), dayCounter_(std::move(index->dayCounter())),
       calendar_(index->fixingCalendar()),
       businessDayConvention_(index->businessDayConvention()), settlementDays_(index->fixingDays()),
-      payoff_(ext::shared_ptr<Payoff>()), valueDate_(valueDate),
-      maturityDate_(maturityDate), discountCurve_(std::move(discountCurve)) {
+      valueDate_(valueDate), maturityDate_(maturityDate), discountCurve_(std::move(discountCurve)) {
 
         maturityDate_ = calendar_.adjust(maturityDate_, businessDayConvention_);
 
@@ -53,12 +53,14 @@ namespace QuantLib {
         Real strike = notionalAmount_ *
                       strikeForwardRate_.compoundFactor(valueDate_,
                                                         maturityDate_);
+
         payoff_ = ext::shared_ptr<Payoff>(new ForwardTypePayoff(fraType_,
                                                                   strike));
         // incomeDiscountCurve_ is irrelevant to an FRA
         incomeDiscountCurve_ = discountCurve_;
         // income is irrelevant to FRA - set it to zero
         underlyingIncome_ = 0.0;
+
         registerWith(index_);
     }
 
@@ -67,13 +69,14 @@ namespace QuantLib {
                                  settlementDays_, Days);
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
+
     Date ForwardRateAgreement::fixingDate() const {
-        return calendar_.advance(valueDate_,
-                                 -static_cast<Integer>(settlementDays_), Days);
+        return index_->fixingDate(valueDate_);
     }
 
     bool ForwardRateAgreement::isExpired() const {
-        return detail::simple_event(valueDate_).hasOccurred(settlementDate());
+        return detail::simple_event(valueDate_).hasOccurred();
     }
 
     Real ForwardRateAgreement::spotIncome(
@@ -118,8 +121,10 @@ namespace QuantLib {
 
         NPV_ = amount_ * discount->discount(valueDate_);
 
+        QL_DEPRECATED_DISABLE_WARNING
         underlyingSpotValue_ = spotValue();
         underlyingIncome_    = 0.0;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     void ForwardRateAgreement::calculateForwardRate() const {
@@ -147,6 +152,8 @@ namespace QuantLib {
         amount_ = notionalAmount_ * sign * (F - K) * T / (1.0 + F * T);
     }
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     Real ForwardRateAgreement::forwardValue() const {
         calculate();
         return (underlyingSpotValue_ - underlyingIncome_) / discountCurve_->discount(maturityDate_);
@@ -164,4 +171,5 @@ namespace QuantLib {
         return InterestRate::impliedRate(compoundingFactor, dayCounter, comp, Annual, t);
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 }

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -17,9 +17,10 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/instruments/forwardrateagreement.hpp>
-#include <ql/indexes/iborindex.hpp>
 #include <ql/event.hpp>
+#include <ql/indexes/iborindex.hpp>
+#include <ql/instruments/forwardrateagreement.hpp>
+#include <utility>
 
 namespace QuantLib {
 
@@ -31,13 +32,13 @@ namespace QuantLib {
                                                Rate strikeForwardRate,
                                                Real notionalAmount,
                                                const ext::shared_ptr<IborIndex>& index,
-                                               const Handle<YieldTermStructure>& discountCurve,
+                                               Handle<YieldTermStructure> discountCurve,
                                                bool useIndexedCoupon)
     : fraType_(type), notionalAmount_(notionalAmount), index_(index),
       useIndexedCoupon_(useIndexedCoupon), dayCounter_(index->dayCounter()),
       calendar_(index->fixingCalendar()), businessDayConvention_(index->businessDayConvention()),
       settlementDays_(index->fixingDays()), valueDate_(valueDate), maturityDate_(maturityDate),
-      discountCurve_(discountCurve) {
+      discountCurve_(std::move(discountCurve)) {
 
         maturityDate_ = calendar_.adjust(maturityDate_, businessDayConvention_);
 

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -64,6 +64,15 @@ namespace QuantLib {
         registerWith(index_);
     }
 
+    ForwardRateAgreement::ForwardRateAgreement(const Date& valueDate,
+                                               Position::Type type,
+                                               Rate strikeForwardRate,
+                                               Real notionalAmount,
+                                               const ext::shared_ptr<IborIndex>& index,
+                                               Handle<YieldTermStructure> discountCurve)
+    : ForwardRateAgreement(valueDate, index->maturityDate(valueDate), type, strikeForwardRate,
+                           notionalAmount, index, std::move(discountCurve), true) {}
+
     Date ForwardRateAgreement::settlementDate() const {
         return calendar_.advance(Settings::instance().evaluationDate(),
                                  settlementDays_, Days);

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -32,13 +32,13 @@ namespace QuantLib {
                            const ext::shared_ptr<IborIndex>& index,
                            const Handle<YieldTermStructure>& discountCurve,
                            bool useIndexedCoupon)
-    : dayCounter_(std::move(index->dayCounter())), calendar_(std::move(index->fixingCalendar())),
+    : 
+      fraType_(type), notionalAmount_(notionalAmount), index_(index),
+      useIndexedCoupon_(useIndexedCoupon), dayCounter_(std::move(index->dayCounter())),
+      calendar_(std::move(index->fixingCalendar())),
       businessDayConvention_(index->businessDayConvention()), settlementDays_(index->fixingDays()),
       payoff_(std::move(ext::shared_ptr<Payoff>())), valueDate_(valueDate),
-      maturityDate_(maturityDate),
-      discountCurve_(std::move(discountCurve)),
-      fraType_(type), notionalAmount_(notionalAmount), index_(index),
-      useIndexedCoupon_(useIndexedCoupon) {
+      maturityDate_(maturityDate), discountCurve_(std::move(discountCurve)) {
 
         maturityDate_ = calendar_.adjust(maturityDate_, businessDayConvention_);
 

--- a/ql/instruments/forwardrateagreement.cpp
+++ b/ql/instruments/forwardrateagreement.cpp
@@ -25,20 +25,19 @@ namespace QuantLib {
 
     QL_DEPRECATED_DISABLE_WARNING
 
-    ForwardRateAgreement::ForwardRateAgreement(
-                           const Date& valueDate,
-                           const Date& maturityDate,
-                           Position::Type type,
-                           Rate strikeForwardRate,
-                           Real notionalAmount,
-                           const ext::shared_ptr<IborIndex>& index,
-                           const Handle<YieldTermStructure>& discountCurve,
-                           bool useIndexedCoupon)
+    ForwardRateAgreement::ForwardRateAgreement(const Date& valueDate,
+                                               const Date& maturityDate,
+                                               Position::Type type,
+                                               Rate strikeForwardRate,
+                                               Real notionalAmount,
+                                               const ext::shared_ptr<IborIndex>& index,
+                                               const Handle<YieldTermStructure>& discountCurve,
+                                               bool useIndexedCoupon)
     : fraType_(type), notionalAmount_(notionalAmount), index_(index),
-      useIndexedCoupon_(useIndexedCoupon), dayCounter_(std::move(index->dayCounter())),
-      calendar_(index->fixingCalendar()),
-      businessDayConvention_(index->businessDayConvention()), settlementDays_(index->fixingDays()),
-      valueDate_(valueDate), maturityDate_(maturityDate), discountCurve_(std::move(discountCurve)) {
+      useIndexedCoupon_(useIndexedCoupon), dayCounter_(index->dayCounter()),
+      calendar_(index->fixingCalendar()), businessDayConvention_(index->businessDayConvention()),
+      settlementDays_(index->fixingDays()), valueDate_(valueDate), maturityDate_(maturityDate),
+      discountCurve_(discountCurve) {
 
         maturityDate_ = calendar_.adjust(maturityDate_, businessDayConvention_);
 

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -76,6 +76,13 @@ namespace QuantLib {
             const ext::shared_ptr<IborIndex>& index,
             Handle<YieldTermStructure> discountCurve = Handle<YieldTermStructure>(),
             bool useIndexedCoupon = true);
+        ForwardRateAgreement(
+            const Date& valueDate,
+            Position::Type type,
+            Rate strikeForwardRate,
+            Real notionalAmount,
+            const ext::shared_ptr<IborIndex>& index,
+            Handle<YieldTermStructure> discountCurve = Handle<YieldTermStructure>());
         //! \name Calculations
         //@{
         //! A FRA expires/settles on the value date

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -30,6 +30,8 @@ namespace QuantLib {
 
     class IborIndex;
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     //! %Forward rate agreement (FRA) class
     /*! 1. Unlike the forward contract conventions on carryable
            financial assets (stocks, bonds, commodities), the
@@ -80,41 +82,55 @@ namespace QuantLib {
         bool isExpired() const override;
         //! The payoff on the value date
         Real amount() const;
-        /*! This returns evaluationDate + settlementDays (not FRA
-            valueDate).
+
+        /*! \deprecated This used to be inherited from Forward, but it's not correct for FRAs.
+                        Deprecated in version 1.25.
         */
+        QL_DEPRECATED
         Date settlementDate() const;
+
         const Calendar& calendar() const;
         BusinessDayConvention businessDayConvention() const;
         const DayCounter& dayCounter() const;
         //! term structure relevant to the contract (e.g. repo curve)
         Handle<YieldTermStructure> discountCurve() const;
-        //! term structure that discounts the underlying's income cash flows
+
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         Handle<YieldTermStructure> incomeDiscountCurve() const;
+
         Date fixingDate() const;
-        /*!  Income is zero for a FRA */
+
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         Real spotIncome(const Handle<YieldTermStructure>& incomeDiscountCurve) const;
-        //! Spot value (NPV) of the underlying loan
-        /*! This has always a positive value (asset), even if short the FRA */
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         Real spotValue() const;
+
         //! Returns the relevant forward rate associated with the FRA term
         InterestRate forwardRate() const;
 
-        /*! Simple yield calculation based on underlying spot and
-            forward values, taking into account underlying income.
-            When \f$ t>0 \f$, call with:
-            underlyingSpotValue=spotValue(t),
-            forwardValue=strikePrice, to get current yield. For a
-            repo, if \f$ t=0 \f$, impliedYield should reproduce the
-            spot repo rate. For FRA's, this should reproduce the
-            relevant zero rate at the FRA's maturityDate_;
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
         */
+        QL_DEPRECATED
         InterestRate impliedYield(Real underlyingSpotValue,
                                   Real forwardValue,
                                   Date settlementDate,
                                   Compounding compoundingConvention,
                                   const DayCounter& dayCounter);
 
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         virtual Real forwardValue() const;
         //@}
 
@@ -130,23 +146,43 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> index_;
         bool useIndexedCoupon_;
 
-        /*! derived classes must set this, typically via spotIncome() */
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         mutable Real underlyingIncome_;
-        /*! derived classes must set this, typically via spotValue() */
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         mutable Real underlyingSpotValue_;
+
         DayCounter dayCounter_;
         Calendar calendar_;
         BusinessDayConvention businessDayConvention_;
-        Natural settlementDays_;
-        ext::shared_ptr<Payoff> payoff_;
-        /*! valueDate = settlement date (date the fwd contract starts
-            accruing)
+
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
         */
+        QL_DEPRECATED
+        Natural settlementDays_;
+
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        ext::shared_ptr<Payoff> payoff_;
+
+        //! the valueDate is the date the underlying index starts accruing and the FRA is settled.
         Date valueDate_;
-        //! maturityDate of the forward contract or delivery date of underlying
+        //! maturityDate of the underlying index; not the date the FRA is settled.
         Date maturityDate_;
         Handle<YieldTermStructure> discountCurve_;
-        /*! must set this in derived classes, based on particular underlying */
+
+        /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         Handle<YieldTermStructure> incomeDiscountCurve_;
 
       private:
@@ -154,6 +190,8 @@ namespace QuantLib {
         void calculateAmount() const;
         mutable Real amount_;
     };
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     inline const Calendar& ForwardRateAgreement::calendar() const { return calendar_; }
 
@@ -168,7 +206,9 @@ namespace QuantLib {
     }
 
     inline Handle<YieldTermStructure> ForwardRateAgreement::incomeDiscountCurve() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return incomeDiscountCurve_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -67,15 +67,15 @@ namespace QuantLib {
     */
     class ForwardRateAgreement: public Instrument {
       public:
-        ForwardRateAgreement(const Date& valueDate,
-                             const Date& maturityDate,
-                             Position::Type type,
-                             Rate strikeForwardRate,
-                             Real notionalAmount,
-                             const ext::shared_ptr<IborIndex>& index,
-                             const Handle<YieldTermStructure>& discountCurve =
-                                                 Handle<YieldTermStructure>(),
-                             bool useIndexedCoupon = true);
+        ForwardRateAgreement(
+            const Date& valueDate,
+            const Date& maturityDate,
+            Position::Type type,
+            Rate strikeForwardRate,
+            Real notionalAmount,
+            const ext::shared_ptr<IborIndex>& index,
+            Handle<YieldTermStructure> discountCurve = Handle<YieldTermStructure>(),
+            bool useIndexedCoupon = true);
         //! \name Calculations
         //@{
         //! A FRA expires/settles on the value date

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -48,23 +48,12 @@ namespace QuantLib {
         3. Choose position type = Short for an "FRA sale" (future short
            loan, long deposit [lender])
 
-        4. If strike is given in the constructor, can calculate the NPV
-           of the contract via NPV().
-
-        5. If forward rate is desired/unknown, it can be obtained via
-           forwardRate(). In this case, the strike variable in the
-           constructor is irrelevant and will be ignored.
-
         <b>Example: </b>
         \link FRA.cpp
         valuation of a forward-rate agreement
         \endlink
 
         \todo Add preconditions and tests
-
-        \todo Should put an instance of ForwardRateAgreement in the
-              FraRateHelper to ensure consistency with the piecewise
-              yield curve.
 
         \todo Differentiate between BBA (British)/AFB (French)
               [assumed here] and ABA (Australian) banker conventions
@@ -87,8 +76,10 @@ namespace QuantLib {
                              bool useIndexedCoupon = true);
         //! \name Calculations
         //@{
-        /*! A FRA expires/settles on the valueDate */
+        //! A FRA expires/settles on the value date
         bool isExpired() const override;
+        //! The payoff on the value date
+        Real amount() const;
         /*! This returns evaluationDate + settlementDays (not FRA
             valueDate).
         */
@@ -160,6 +151,8 @@ namespace QuantLib {
 
       private:
         void calculateForwardRate() const;
+        void calculateAmount() const;
+        mutable Real amount_;
     };
 
     inline const Calendar& ForwardRateAgreement::calendar() const { return calendar_; }


### PR DESCRIPTION
As a starter for issue #1216 , I have removed the inheritance of Forward class by ForwardRateAgreement to inherit from Instrument class directly. I have also duplicated all the non-overriden methods in Forward class for now, until we figure out which methods can be removed/depercated.