### PR TITLE
make floating rate coupons lazy

### DIFF
--- a/ql/cashflows/capflooredcoupon.hpp
+++ b/ql/cashflows/capflooredcoupon.hpp
@@ -60,6 +60,15 @@ namespace QuantLib {
                   const ext::shared_ptr<FloatingRateCoupon>& underlying,
                   Rate cap = Null<Rate>(),
                   Rate floor = Null<Rate>());
+        //! \name Observer interface
+        //@{
+        void deepUpdate() override;
+        //@}
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        void alwaysForwardNotifications() override;
+        //@}
         //! \name Coupon interface
         //@{
         Rate rate() const override;
@@ -73,10 +82,6 @@ namespace QuantLib {
         Rate effectiveCap() const;
         //! effective floor of fixing
         Rate effectiveFloor() const;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
         //! \name Visitability
         //@{

--- a/ql/cashflows/digitalcoupon.hpp
+++ b/ql/cashflows/digitalcoupon.hpp
@@ -95,6 +95,15 @@ namespace QuantLib {
                       bool nakedOption = false);
 
         //@}
+        //! \name Obverver interface
+        //@{
+        void deepUpdate() override;
+        //@}
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        void alwaysForwardNotifications() override;
+        //@}
         //! \name Coupon interface
         //@{
         Rate rate() const override;
@@ -121,10 +130,6 @@ namespace QuantLib {
            (multiplied by: nominal*accrualperiod*discount is the NPV of the option)
         */
         Rate putOptionRate() const;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
         //! \name Visitability
         //@{

--- a/ql/cashflows/floatingratecoupon.cpp
+++ b/ql/cashflows/floatingratecoupon.cpp
@@ -92,9 +92,14 @@ namespace QuantLib {
     }
 
     Rate FloatingRateCoupon::rate() const {
+        calculate();
+        return rate_;
+    }
+
+    void FloatingRateCoupon::performCalculations() const {
         QL_REQUIRE(pricer_, "pricer not set");
         pricer_->initialize(*this);
-        return pricer_->swapletRate();
+        rate_ = pricer_->swapletRate();
     }
 
     Real FloatingRateCoupon::price(const Handle<YieldTermStructure>& discountingCurve) const {

--- a/ql/cashflows/floatingratecoupon.hpp
+++ b/ql/cashflows/floatingratecoupon.hpp
@@ -31,6 +31,7 @@
 
 #include <ql/cashflows/coupon.hpp>
 #include <ql/patterns/visitor.hpp>
+#include <ql/patterns/lazyobject.hpp>
 #include <ql/time/daycounter.hpp>
 #include <ql/handle.hpp>
 
@@ -41,8 +42,7 @@ namespace QuantLib {
     class FloatingRateCouponPricer;
 
     //! base floating-rate coupon class
-    class FloatingRateCoupon : public Coupon,
-                               public Observer {
+    class FloatingRateCoupon : public Coupon, public LazyObject {
       public:
         FloatingRateCoupon(const Date& paymentDate,
                            Real nominal,
@@ -58,6 +58,10 @@ namespace QuantLib {
                            bool isInArrears = false,
                            const Date& exCouponDate = Date());
 
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        //@}
         //! \name CashFlow interface
         //@{
         Real amount() const override { return rate() * accrualPeriod() * nominal(); }
@@ -93,11 +97,6 @@ namespace QuantLib {
         bool isInArrears() const { return isInArrears_; }
         //@}
 
-        //! \name Observer interface
-        //@{
-        void update() override { notifyObservers(); }
-        //@}
-
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
@@ -115,6 +114,7 @@ namespace QuantLib {
         Spread spread_;
         bool isInArrears_;
         ext::shared_ptr<FloatingRateCouponPricer> pricer_;
+        mutable Real rate_;
     };
 
     // inline definitions

--- a/ql/event.hpp
+++ b/ql/event.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
     /*! This class acts as a base class for the actual
         event implementations.
     */
-    class Event : public Observable {
+    class Event : public virtual Observable {
       public:
         ~Event() override = default;
         //! \name Event interface

--- a/ql/experimental/coupons/strippedcapflooredcoupon.cpp
+++ b/ql/experimental/coupons/strippedcapflooredcoupon.cpp
@@ -34,11 +34,16 @@ namespace QuantLib {
               underlying->referencePeriodEnd(), underlying->dayCounter(),
               underlying->isInArrears()),
           underlying_(underlying) {
-        registerWith(underlying);
+        registerWith(underlying_);
+        underlying_->alwaysForwardNotifications();
     }
 
-    Rate StrippedCappedFlooredCoupon::rate() const {
+    void StrippedCappedFlooredCoupon::deepUpdate() {
+        update();
+        underlying_->deepUpdate();
+    }
 
+    void StrippedCappedFlooredCoupon::performCalculations() const {
         QL_REQUIRE(underlying_->underlying()->pricer() != nullptr, "pricer not set");
         underlying_->underlying()->pricer()->initialize(*underlying_->underlying());
         Rate floorletRate = 0.0;
@@ -53,9 +58,13 @@ namespace QuantLib {
         // if the underlying is collared we return the value of the embedded
         // collar, otherwise the value of a long floor or a long cap respectively
 
-        return (underlying_->isFloored() && underlying_->isCapped())
-                   ? floorletRate - capletRate
-                   : floorletRate + capletRate;
+        rate_ = (underlying_->isFloored() && underlying_->isCapped()) ? floorletRate - capletRate :
+                                                                        floorletRate + capletRate;
+    }
+
+    Rate StrippedCappedFlooredCoupon::rate() const {
+        calculate();
+        return rate_;
     }
 
     Rate StrippedCappedFlooredCoupon::convexityAdjustment() const {
@@ -75,8 +84,6 @@ namespace QuantLib {
     Rate StrippedCappedFlooredCoupon::effectiveFloor() const {
         return underlying_->effectiveFloor();
     }
-
-    void StrippedCappedFlooredCoupon::update() { notifyObservers(); }
 
     void StrippedCappedFlooredCoupon::accept(AcyclicVisitor &v) {
         underlying_->accept(v);

--- a/ql/experimental/coupons/strippedcapflooredcoupon.hpp
+++ b/ql/experimental/coupons/strippedcapflooredcoupon.hpp
@@ -34,6 +34,15 @@ namespace QuantLib {
 
         explicit StrippedCappedFlooredCoupon(const ext::shared_ptr<CappedFlooredCoupon> &underlying);
 
+        //! \name Obverver interface
+        //@{
+        void deepUpdate() override;
+        //@}
+
+        //! \name LazyObject interface
+        //@{
+        void performCalculations() const override;
+        //@}
         //! Coupon interface
         Rate rate() const override;
         Rate convexityAdjustment() const override;
@@ -45,9 +54,6 @@ namespace QuantLib {
         Rate effectiveCap() const;
         //! effective floor
         Rate effectiveFloor() const;
-
-        //! Observer interface
-        void update() override;
 
         //! Visitability
         void accept(AcyclicVisitor&) override;

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -352,11 +352,20 @@ namespace QuantLib {
         redemptions_.push_back(redemption);
     }
 
+    void Bond::alwaysForwardNotifications() {
+        for (auto& cashflow : cashflows_) {
+            if(auto lazy = ext::dynamic_pointer_cast<LazyObject>(cashflow)) {
+                lazy->alwaysForwardNotifications();
+            }
+        }
+        LazyObject::alwaysForwardNotifications();
+    }
+
     void Bond::deepUpdate() {
         for (auto& cashflow : cashflows_) {
-            ext::shared_ptr<LazyObject> f = ext::dynamic_pointer_cast<LazyObject>(cashflow);
-            if (f != nullptr)
-                f->update();
+            if(auto lazy = ext::dynamic_pointer_cast<LazyObject>(cashflow)) {
+                lazy->deepUpdate();
+            }
         }
         update();
     }

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -104,6 +104,10 @@ namespace QuantLib {
         //@{
         bool isExpired() const override;
         //@}
+        //! \name LazyObject interface
+        //@{
+        void alwaysForwardNotifications() override;
+        //@}
         //! \name Observable interface
         //@{
         void deepUpdate() override;

--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -269,9 +269,8 @@ namespace QuantLib {
 
     void CapFloor::deepUpdate() {
         for (auto& i : floatingLeg_) {
-            ext::shared_ptr<LazyObject> f = ext::dynamic_pointer_cast<LazyObject>(i);
-            if (f != nullptr)
-                f->update();
+            if(auto lazy = ext::dynamic_pointer_cast<LazyObject>(i))
+                lazy->deepUpdate();
         }
         update();
     }

--- a/ql/instruments/floatfloatswaption.cpp
+++ b/ql/instruments/floatfloatswaption.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
     : Option(ext::shared_ptr<Payoff>(), exercise), swap_(std::move(swap)),
       settlementType_(delivery), settlementMethod_(settlementMethod) {
         registerWith(swap_);
-        registerWithObservables(swap_);
+        swap_->alwaysForwardNotifications();
     }
 
     bool FloatFloatSwaption::isExpired() const {

--- a/ql/instruments/nonstandardswaption.cpp
+++ b/ql/instruments/nonstandardswaption.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     : Option(ext::shared_ptr<Payoff>(), exercise), swap_(std::move(swap)),
       settlementType_(delivery), settlementMethod_(settlementMethod) {
         registerWith(swap_);
-        registerWithObservables(swap_);
+        swap_->alwaysForwardNotifications();
     }
 
     bool NonstandardSwaption::isExpired() const {

--- a/ql/instruments/swap.cpp
+++ b/ql/instruments/swap.cpp
@@ -65,7 +65,6 @@ namespace QuantLib {
       startDiscounts_(legs, 0.0), endDiscounts_(legs, 0.0),
       npvDateDiscount_(0.0) {}
 
-
     bool Swap::isExpired() const {
         for (const auto& leg : legs_) {
             Leg::const_iterator i;
@@ -161,12 +160,21 @@ namespace QuantLib {
     void Swap::deepUpdate() {
         for (auto& leg : legs_) {
             for (auto& k : leg) {
-                ext::shared_ptr<LazyObject> f = ext::dynamic_pointer_cast<LazyObject>(k);
-                if (f != nullptr)
-                    f->update();
+                if (auto lazy = ext::dynamic_pointer_cast<LazyObject>(k))
+                    lazy->deepUpdate();
             }
         }
         update();
+    }
+
+    void Swap::alwaysForwardNotifications() {
+        for (auto& leg : legs_) {
+            for (auto& k : leg) {
+                if (auto lazy = ext::dynamic_pointer_cast<LazyObject>(k))
+                    lazy->alwaysForwardNotifications();
+            }
+        }
+        LazyObject::alwaysForwardNotifications();
     }
 
     void Swap::arguments::validate() const {

--- a/ql/instruments/swap.hpp
+++ b/ql/instruments/swap.hpp
@@ -63,6 +63,10 @@ namespace QuantLib {
         Swap(const std::vector<Leg>& legs,
              const std::vector<bool>& payer);
         //@}
+        //! \name LazyObject interface
+        //@{
+        void alwaysForwardNotifications() override;
+        //@}
         //! \name Observable interface
         //@{
         void deepUpdate() override;

--- a/ql/instruments/swaption.cpp
+++ b/ql/instruments/swaption.cpp
@@ -136,7 +136,13 @@ namespace QuantLib {
     : Option(ext::shared_ptr<Payoff>(), exercise), swap_(std::move(swap)),
       settlementType_(delivery), settlementMethod_(settlementMethod) {
         registerWith(swap_);
-        registerWithObservables(swap_);
+        // a swaption engine might not calculate the underlying swap
+        swap_->alwaysForwardNotifications();
+    }
+
+    void Swaption::deepUpdate() {
+        swap_->deepUpdate();
+        update();
     }
 
     bool Swaption::isExpired() const {

--- a/ql/instruments/swaption.hpp
+++ b/ql/instruments/swaption.hpp
@@ -86,6 +86,10 @@ namespace QuantLib {
                  const ext::shared_ptr<Exercise>& exercise,
                  Settlement::Type delivery = Settlement::Physical,
                  Settlement::Method settlementMethod = Settlement::PhysicalOTC);
+        //! \name Observer interface
+        //@{
+        void deepUpdate() override;
+        //@}
         //! \name Instrument interface
         //@{
         bool isExpired() const override;

--- a/ql/patterns/lazyobject.hpp
+++ b/ql/patterns/lazyobject.hpp
@@ -77,12 +77,18 @@ namespace QuantLib {
             recalculation, this object would again forward the first
             notification received.
 
+            The method should be overridden in derived classes which
+            contain nested lazy objects. It should then call the method
+            on itself and the nested lazy objects to ensure that
+            notifications from the nested objects are always forwarded
+            all the way through the observable chain.
+
             \warning Forwarding all notifications will cause a
                      performance hit, and should be used only when
                      discarding notifications cause an incorrect
                      behavior.
         */
-        void alwaysForwardNotifications();
+        virtual void alwaysForwardNotifications();
       protected:
         /*! This method performs all needed calculations by calling
             the <i><b>performCalculations</b></i> method.

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -115,8 +115,12 @@ namespace QuantLib {
 
         /*! register with all observables of a given observer. Note
             that this does not include registering with the observer
-            itself. */
-        void registerWithObservables(const ext::shared_ptr<Observer>&);
+            itself.
+
+            \deprecated consider using LazyObject::alwaysForwardNotifications() instead,
+            the registration with the next-level observables was just a workaround for that.
+        */
+        QL_DEPRECATED void registerWithObservables(const ext::shared_ptr<Observer>&);
         Size unregisterWith(const ext::shared_ptr<Observable>&);
         void unregisterWithAll();
 

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -128,7 +128,7 @@ namespace QuantLib {
     Real OISRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->recalculate();
+        swap_->deepUpdate();
         return swap_->fairRate();
     }
 

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -883,7 +883,7 @@ namespace QuantLib {
     Real SwapRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->recalculate();
+        swap_->deepUpdate();
         // weak implementation... to be improved
         static const Spread basisPoint = 1.0e-4;
         Real floatingLegNPV = swap_->floatingLegNPV();
@@ -986,7 +986,7 @@ namespace QuantLib {
     Real BMASwapRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->recalculate();
+        swap_->deepUpdate();
         return swap_->fairLiborFraction();
     }
 


### PR DESCRIPTION
This MR picks up issue #415 and is similar to earlier MRs #427 and #465, which we rolled back due to possible performance issues. I can not reproduce these issues any more in the current version of ORE with underlying QuantLib 1.22. On the other hand we are seeing performance problems with some instruments referencing CMS Coupons due to multiple calls to the coupon's `amount()` method without the actual need to recalculate the coupon.

One additional note: Making `FloatingRateCoupon` a `LazyObject` highlights a problem that we saw earlier because of the observability chain `Swaption` => `Swap` => `Coupon`: If a swaption engine does not recalculate the underlying swap, the swaption will receive only the first notification from the swap if an underlying market variable changes. This leads e.g. to missing sensitivities if calculated by bumping the relevant market quotes. The workaround so far was to register the swaption with the swap's coupons directly via `registerWithObservables(swap_)`.

This won't work any more, if the coupons are lazy objects themselves forwarding only the first notification. I guess what we _really_ want is to forward any notifications from the Swap to the Swaption by calling `swap_.alwaysForwardNotifications()` and at the same time rely on a recursive behaviour of this method, so that nested lazy objects forward their notifications as well. This is the reason why I made `alwaysForwardNotifications()` virtual. I believe we can deprecate `registerWithObservables()` now because its only purpose was the workaround described above.