### PR TITLE
Add `QL_CONSTEXPR` macro and avoid some MSVC warnings

### DIFF
--- a/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
         //calculate payoff discount factor assuming continuous compounding
         DiscountFactor discount = riskFreeDiscount(t1);
         Real result = 0;
-        constexpr Real minusInf = -std::numeric_limits<Real>::infinity();
+        QL_CONSTEXPR Real minusInf = -std::numeric_limits<Real>::infinity();
 
         Real y1 = this->y1(payoff->optionType()),
              y2 = this->y2(payoff->optionType());

--- a/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
         //calculate payoff discount factor assuming continuous compounding
         DiscountFactor discount = riskFreeDiscount(t1);
         Real result = 0;
-        Real minusInf=-std::numeric_limits<Real>::infinity();
+        constexpr Real minusInf = -std::numeric_limits<Real>::infinity();
 
         Real y1 = this->y1(payoff->optionType()),
              y2 = this->y2(payoff->optionType());

--- a/ql/math/matrixutilities/svd.cpp
+++ b/ql/math/matrixutilities/svd.cpp
@@ -514,7 +514,7 @@ namespace QuantLib {
     }
 
     Size SVD::rank() const {
-        constexpr Real eps = QL_EPSILON;
+        QL_CONSTEXPR Real eps = QL_EPSILON;
         Real tol = m_*s_[0]*eps;
         Size r = 0;
         for (double i : s_) {

--- a/ql/math/matrixutilities/svd.cpp
+++ b/ql/math/matrixutilities/svd.cpp
@@ -514,7 +514,7 @@ namespace QuantLib {
     }
 
     Size SVD::rank() const {
-        Real eps = QL_EPSILON;
+        constexpr Real eps = QL_EPSILON;
         Real tol = m_*s_[0]*eps;
         Size r = 0;
         for (double i : s_) {

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             product *= path.front();
         }
         // care must be taken not to overflow product
-        constexpr Real maxValue = QL_MAX_REAL;
+        QL_CONSTEXPR Real maxValue = QL_MAX_REAL;
         averagePrice = 1.0;
         for (Size i=1; i<n+1; i++) {
             Real price = path[i];

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             product *= path.front();
         }
         // care must be taken not to overflow product
-        Real maxValue = QL_MAX_REAL;
+        constexpr Real maxValue = QL_MAX_REAL;
         averagePrice = 1.0;
         for (Size i=1; i<n+1; i++) {
             Real price = path[i];

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         Size fixings = pastFixings_ + fixingIndices_.size();
 
         // care must be taken not to overflow product
-        Real maxValue = QL_MAX_REAL;
+        constexpr Real maxValue = QL_MAX_REAL;
         for (unsigned long fixingIndice : fixingIndices_) {
             Real price = path[fixingIndice];
             if (product < maxValue/price) {

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         Size fixings = pastFixings_ + fixingIndices_.size();
 
         // care must be taken not to overflow product
-        constexpr Real maxValue = QL_MAX_REAL;
+        QL_CONSTEXPR Real maxValue = QL_MAX_REAL;
         for (unsigned long fixingIndice : fixingIndices_) {
             Real price = path[fixingIndice];
             if (product < maxValue/price) {

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -219,8 +219,10 @@
 // until we stop supporting Visual C++ 2013
 #if defined(QL_PATCH_MSVC_2013)
 #  define QL_NOEXCEPT
+#  define QL_CONSTEXPR
 #else
 #  define QL_NOEXCEPT noexcept
+#  define QL_CONSTEXPR constexpr
 #endif
 
 

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -220,8 +220,10 @@
 // until we stop supporting Visual C++ 2013
 #if defined(QL_PATCH_MSVC_2013)
 #  define QL_NOEXCEPT
+#  define QL_CONSTEXPR
 #else
 #  define QL_NOEXCEPT noexcept
+#  define QL_CONSTEXPR constexpr
 #endif
 
 

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
         Brent solver;
         solver.setMaxEvaluations(10000);
         const Volatility guess = std::sqrt(theta);
-        constexpr Real accuracy = std::numeric_limits<Real>::epsilon();
+        QL_CONSTEXPR Real accuracy = std::numeric_limits<Real>::epsilon();
 
         return solver.solve([&](Volatility _v) { return blackValue(payoff.optionType(), strike, fwd,
                                                                    t, _v, df, npv); },

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
         Brent solver;
         solver.setMaxEvaluations(10000);
         const Volatility guess = std::sqrt(theta);
-        const Real accuracy = std::numeric_limits<Real>::epsilon();
+        constexpr Real accuracy = std::numeric_limits<Real>::epsilon();
 
         return solver.solve([&](Volatility _v) { return blackValue(payoff.optionType(), strike, fwd,
                                                                    t, _v, df, npv); },

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -192,13 +192,13 @@ void ArrayTest::testArrayFunctions() {
         a[i] = std::sin(Real(i))+1.1;
     }
 
-    const Real exponential = -2.3;
+    constexpr Real exponential = -2.3;
     const Array p = Pow(a, exponential);
     const Array e = Exp(a);
     const Array l = Log(a);
     const Array s = Sqrt(a);
 
-    const Real tol = 10*QL_EPSILON;
+    constexpr Real tol = 10*QL_EPSILON;
     for (Size i=0; i < a.size(); ++i) {
         if (std::fabs(p[i]-std::pow(a[i], exponential)) > tol) {
             BOOST_FAIL("Array function test Pow failed");

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -192,13 +192,13 @@ void ArrayTest::testArrayFunctions() {
         a[i] = std::sin(Real(i))+1.1;
     }
 
-    constexpr Real exponential = -2.3;
+    QL_CONSTEXPR Real exponential = -2.3;
     const Array p = Pow(a, exponential);
     const Array e = Exp(a);
     const Array l = Log(a);
     const Array s = Sqrt(a);
 
-    constexpr Real tol = 10*QL_EPSILON;
+    QL_CONSTEXPR Real tol = 10*QL_EPSILON;
     for (Size i=0; i < a.size(); ++i) {
         if (std::fabs(p[i]-std::pow(a[i], exponential)) > tol) {
             BOOST_FAIL("Array function test Pow failed");

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -219,9 +219,9 @@ void CmsSpreadTest::testCouponPricing() {
     cpn1->setPricer(d.cmsspPricerLn);
 
 #ifndef __FAST_MATH__
-    constexpr Real eqTol = 100*QL_EPSILON;
+    QL_CONSTEXPR Real eqTol = 100*QL_EPSILON;
 #else
-    constexpr Real eqTol = 1e-13;
+    QL_CONSTEXPR Real eqTol = 1e-13;
 #endif
     BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms10y->addFixing(d.refDate, 0.05);

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -219,9 +219,9 @@ void CmsSpreadTest::testCouponPricing() {
     cpn1->setPricer(d.cmsspPricerLn);
 
 #ifndef __FAST_MATH__
-    const Real eqTol = 100*QL_EPSILON;
+    constexpr Real eqTol = 100*QL_EPSILON;
 #else
-    const Real eqTol = 1e-13;
+    constexpr Real eqTol = 1e-13;
 #endif
     BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms10y->addFixing(d.refDate, 0.05);

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2191,7 +2191,7 @@ void InterpolationTest::testLagrangeInterpolation() {
         0.5130076920869246
     };
 
-    const Real tol = 50*QL_EPSILON;
+    constexpr Real tol = 50*QL_EPSILON;
     for (Size i=0; i < 79; ++i) {
         const Real xx = -1.0 + i*0.025;
         const Real calculated = interpl(xx);

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2191,7 +2191,7 @@ void InterpolationTest::testLagrangeInterpolation() {
         0.5130076920869246
     };
 
-    constexpr Real tol = 50*QL_EPSILON;
+    QL_CONSTEXPR Real tol = 50*QL_EPSILON;
     for (Size i=0; i < 79; ++i) {
         const Real xx = -1.0 + i*0.025;
         const Real calculated = interpl(xx);

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -31,7 +31,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
     bool isTheSame(Real a, Real b) {
-        constexpr Real eps = 500*QL_EPSILON;
+        QL_CONSTEXPR Real eps = 500*QL_EPSILON;
 
         if (std::fabs(b) < QL_EPSILON)
             return std::fabs(a) < eps;

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -31,7 +31,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
     bool isTheSame(Real a, Real b) {
-        const Real eps = 500*QL_EPSILON;
+        constexpr Real eps = 500*QL_EPSILON;
 
         if (std::fabs(b) < QL_EPSILON)
             return std::fabs(a) < eps;

--- a/test-suite/ode.cpp
+++ b/test-suite/ode.cpp
@@ -197,8 +197,8 @@ void OdeTest::testMatrixExponentialOfZero() {
 
     Matrix m(3, 3, 0.0);
 
-    const Real tol = 100*QL_EPSILON;
-    const Time t=1.0;
+    constexpr Real tol = 100*QL_EPSILON;
+    constexpr Time t=1.0;
     const Matrix calculated = Expm(m, t);
 
     for (Size i=0; i < calculated.rows(); ++i) {

--- a/test-suite/ode.cpp
+++ b/test-suite/ode.cpp
@@ -197,8 +197,8 @@ void OdeTest::testMatrixExponentialOfZero() {
 
     Matrix m(3, 3, 0.0);
 
-    constexpr Real tol = 100*QL_EPSILON;
-    constexpr Time t=1.0;
+    QL_CONSTEXPR Real tol = 100*QL_EPSILON;
+    QL_CONSTEXPR Time t=1.0;
     const Matrix calculated = Expm(m, t);
 
     for (Size i=0; i < calculated.rows(); ++i) {


### PR DESCRIPTION
`constexpr` is not supported in Visual Studio 2013, hence the need for a macro.