### PR TITLE
Do not rely on inflation curves for index interpolation

### DIFF
--- a/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
@@ -24,6 +24,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     CPICapFloorTermPriceSurface::CPICapFloorTermPriceSurface(
         Real nominal,
         Real baseRate, // avoids an uncontrolled crash if index has no TS
@@ -106,6 +108,8 @@ namespace QuantLib {
             QL_REQUIRE( cfStrikes_[i] > cfStrikes_[i-1],
                         "cfStrikes not increasing");
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
 
 
     Date CPICapFloorTermPriceSurface::cpiOptionDateFromTenor(const Period& p) const

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -86,6 +86,7 @@ namespace QuantLib {
         //@{
         Period observationLag() const override;
         Date baseDate() const override;
+        bool indexIsInterpolated() const override;
         //@}
 
         //! is based on
@@ -204,7 +205,6 @@ namespace QuantLib {
             mutable Interpolation2D capPrice_, floorPrice_;
             mutable Interpolator2D interpolator2d_;
     };
-
 
 
     // template definitions, for some reason DOXYGEN doesn't like the first one
@@ -350,7 +350,7 @@ namespace QuantLib {
         return floorPrice_(t,k);
     }
 
-    // inline
+    // inline definitions
 
     inline Period CPICapFloorTermPriceSurface::observationLag() const {
         return zeroInflationIndex()->zeroInflationTermStructure()->observationLag();
@@ -367,6 +367,12 @@ namespace QuantLib {
     inline BusinessDayConvention
     CPICapFloorTermPriceSurface::businessDayConvention() const {
         return bdc_;
+    }
+
+    inline bool CPICapFloorTermPriceSurface::indexIsInterpolated() const {
+        QL_DEPRECATED_DISABLE_WARNING
+        return indexIsInterpolated_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
@@ -22,6 +22,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     YoYCapFloorTermPriceSurface::YoYCapFloorTermPriceSurface(
         Natural fixingDays,
         const Period& lag,
@@ -99,6 +101,8 @@ namespace QuantLib {
             QL_REQUIRE( cfStrikes_[i] > cfStrikes_[i-1],
                         "cfStrikes not increasing");
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     Date YoYCapFloorTermPriceSurface::yoyOptionDateFromTenor(const Period& p) const
     {

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -55,11 +55,7 @@ namespace QuantLib {
                                     const Matrix& cPrice,
                                     const Matrix& fPrice);
 
-        //-! inflation term structure interface
-        //-@{
-        //- virtual Date maxDate() { return yoy_->maxDate();}
-        //- virtual Date baseDate() { return yoy_->baseDate();}
-        //-@}
+        bool indexIsInterpolated() const override;
 
         //! atm yoy swaps from put-call parity on cap/floor data
         /*! uses interpolation (on surface price data), yearly maturities. */
@@ -231,6 +227,13 @@ namespace QuantLib {
     };
 
 
+    // inline definitions
+
+    inline bool YoYCapFloorTermPriceSurface::indexIsInterpolated() const {
+        QL_DEPRECATED_DISABLE_WARNING
+        return indexIsInterpolated_;
+        QL_DEPRECATED_ENABLE_WARNING
+    }
 
     // template definitions
 

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -77,7 +77,7 @@ namespace QuantLib {
         registerWith(zeroInflation_);
     }
 
-    Rate ZeroInflationIndex::fixing(const Date& aFixingDate,
+    Real ZeroInflationIndex::fixing(const Date& aFixingDate,
                                     bool /*forecastTodaysFixing*/) const {
         if (!needsForecast(aFixingDate)) {
             std::pair<Date,Date> lim = inflationPeriod(aFixingDate, frequency_);
@@ -151,7 +151,7 @@ namespace QuantLib {
     }
 
 
-    Rate ZeroInflationIndex::forecastFixing(const Date& fixingDate) const {
+    Real ZeroInflationIndex::forecastFixing(const Date& fixingDate) const {
         // the term structure is relative to the fixing value at the base date.
         Date baseDate = zeroInflation_->baseDate();
         QL_REQUIRE(!needsForecast(baseDate),

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -89,7 +89,7 @@ namespace QuantLib {
             publication but the inflation swaps may take as their base
             the index 3 months before.
         */
-        Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override = 0;
+        Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override = 0;
 
         /*! this method creates all the "fixings" for the relevant
             period of the index.  E.g. for monthly indices it will put
@@ -160,7 +160,7 @@ namespace QuantLib {
         /*! \warning the forecastTodaysFixing parameter (required by
                      the Index interface) is currently ignored.
         */
-        Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
+        Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
         //@}
         //! \name Other methods
         //@{
@@ -170,7 +170,7 @@ namespace QuantLib {
         //@}
       private:
         bool needsForecast(const Date& fixingDate) const;
-        Rate forecastFixing(const Date& fixingDate) const;
+        Real forecastFixing(const Date& fixingDate) const;
         Handle<ZeroInflationTermStructure> zeroInflation_;
     };
 

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -44,12 +44,7 @@ namespace QuantLib {
 
         // start of curve data
         static Date initialDate(const ZeroInflationTermStructure* t) {
-            if (t->indexIsInterpolated()) {
-                return t->referenceDate() - t->observationLag();
-            } else {
-                return inflationPeriod(t->referenceDate() - t->observationLag(),
-                                       t->frequency()).first;
-            }
+            return inflationPeriod(t->referenceDate() - t->observationLag(), t->frequency()).first;
         }
         // value at reference date
         static Rate initialValue(const ZeroInflationTermStructure* t) {

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -120,13 +120,11 @@ namespace QuantLib {
                    "first data date is not in base period, date: "
                        << dates_[0] << " not within [" << lim.first << "," << lim.second << "]");
 
-        // by convention, if the index is not interpolated we pull all the dates
-        // back to the start of their inflationPeriods
+        // by convention, we pull all the dates
+        // back to the start of their inflation periods
         // otherwise the time calculations will be inconsistent
-        if (!indexIsInterpolated_) {
-            for (auto& date : dates_) {
-                date = inflationPeriod(date, frequency).first;
-            }
+        for (auto& date : dates_) {
+            date = inflationPeriod(date, frequency).first;
         }
 
         QL_REQUIRE(this->data_.size() == dates_.size(),
@@ -171,21 +169,13 @@ namespace QuantLib {
 
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::baseDate() const {
-        // if indexIsInterpolated we fixed the dates in the constructor
         return dates_.front();
     }
 
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::maxDate() const {
-        Date d;
-        if (indexIsInterpolated()) {
-            d = dates_.back();
-        } else {
-            d = inflationPeriod(dates_.back(), frequency()).second;
-        }
-        return d;
+        return inflationPeriod(dates_.back(), frequency()).second;
     }
-
 
     template <class T>
     inline Rate InterpolatedZeroInflationCurve<T>::zeroRateImpl(Time t) const {

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -45,6 +45,20 @@ namespace QuantLib {
                                        const DayCounter& dayCounter,
                                        const Period& lag,
                                        Frequency frequency,
+                                       std::vector<Date> dates,
+                                       const std::vector<Rate>& rates,
+                                       const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       const Calendar& calendar,
+                                       const DayCounter& dayCounter,
+                                       const Period& lag,
+                                       Frequency frequency,
                                        bool indexIsInterpolated,
                                        std::vector<Date> dates,
                                        const std::vector<Rate>& rates,
@@ -81,10 +95,22 @@ namespace QuantLib {
                                        const DayCounter& dayCounter,
                                        const Period& lag,
                                        Frequency frequency,
+                                       Rate baseZeroRate,
+                                       const Interpolator &interpolator = Interpolator());
+
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       const Calendar& calendar,
+                                       const DayCounter& dayCounter,
+                                       const Period& lag,
+                                       Frequency frequency,
                                        bool indexIsInterpolated,
                                        Rate baseZeroRate,
-                                       const Interpolator &interpolator
-                                                            = Interpolator());
+                                       const Interpolator &interpolator = Interpolator());
     };
 
     typedef InterpolatedZeroInflationCurve<Linear> ZeroInflationCurve;
@@ -92,6 +118,21 @@ namespace QuantLib {
 
 
     // template definitions
+
+    QL_DEPRECATED_DISABLE_WARNING
+
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::InterpolatedZeroInflationCurve(
+        const Date& referenceDate,
+        const Calendar& calendar,
+        const DayCounter& dayCounter,
+        const Period& lag,
+        Frequency frequency,
+        std::vector<Date> dates,
+        const std::vector<Rate>& rates,
+        const Interpolator& interpolator)
+    : InterpolatedZeroInflationCurve(referenceDate, calendar, dayCounter, lag,
+                                     frequency, dates, rates, false) {}
 
     template <class Interpolator>
     InterpolatedZeroInflationCurve<Interpolator>::InterpolatedZeroInflationCurve(
@@ -158,6 +199,20 @@ namespace QuantLib {
                                    const DayCounter& dayCounter,
                                    const Period& lag,
                                    Frequency frequency,
+                                   Rate baseZeroRate,
+                                   const Interpolator& interpolator)
+    :  ZeroInflationTermStructure(referenceDate, calendar, dayCounter,
+                                  baseZeroRate, lag, frequency),
+       InterpolatedCurve<Interpolator>(interpolator) {
+    }
+
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::
+    InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   const Period& lag,
+                                   Frequency frequency,
                                    bool indexIsInterpolated,
                                    Rate baseZeroRate,
                                    const Interpolator& interpolator)
@@ -166,6 +221,7 @@ namespace QuantLib {
        InterpolatedCurve<Interpolator>(interpolator) {
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::baseDate() const {

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
                                        const DayCounter& dayCounter,
                                        const Period& lag,
                                        Frequency frequency,
-                                       std::vector<Date> dates,
+                                       const std::vector<Date>& dates,
                                        const std::vector<Rate>& rates,
                                        const Interpolator& interpolator = Interpolator());
 
@@ -128,11 +128,11 @@ namespace QuantLib {
         const DayCounter& dayCounter,
         const Period& lag,
         Frequency frequency,
-        std::vector<Date> dates,
+        const std::vector<Date>& dates,
         const std::vector<Rate>& rates,
         const Interpolator& interpolator)
-    : InterpolatedZeroInflationCurve(referenceDate, calendar, dayCounter, lag,
-                                     frequency, dates, rates, false) {}
+    : InterpolatedZeroInflationCurve(
+          referenceDate, calendar, dayCounter, lag, frequency, dates, rates, false) {}
 
     template <class Interpolator>
     InterpolatedZeroInflationCurve<Interpolator>::InterpolatedZeroInflationCurve(

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -56,6 +56,32 @@ namespace QuantLib {
             const DayCounter& dayCounter,
             const Period& lag,
             Frequency frequency,
+            Rate baseZeroRate,
+            std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
+            Real accuracy = 1.0e-12,
+            const Interpolator& i = Interpolator())
+        : base_curve(referenceDate,
+                     calendar,
+                     dayCounter,
+                     lag,
+                     frequency,
+                     baseZeroRate,
+                     i),
+          instruments_(std::move(instruments)), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        PiecewiseZeroInflationCurve(
+            const Date& referenceDate,
+            const Calendar& calendar,
+            const DayCounter& dayCounter,
+            const Period& lag,
+            Frequency frequency,
             bool indexIsInterpolated,
             Rate baseZeroRate,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,

--- a/ql/termstructures/inflation/seasonality.cpp
+++ b/ql/termstructures/inflation/seasonality.cpp
@@ -202,7 +202,8 @@ namespace QuantLib {
         if (isZeroRate) {
             Rate factorBase = this->seasonalityFactor(curveBaseDate);
             Real seasonalityAt = factorAt / factorBase;
-            Time timeFromCurveBase = dc.yearFraction(curveBaseDate, atDate);
+            std::pair<Date,Date> p = inflationPeriod(atDate,frequency());
+            Time timeFromCurveBase = dc.yearFraction(curveBaseDate, p.first);
             f = std::pow(seasonalityAt, 1/timeFromCurveBase);
         }
         else {

--- a/ql/termstructures/inflation/seasonality.cpp
+++ b/ql/termstructures/inflation/seasonality.cpp
@@ -124,8 +124,7 @@ namespace QuantLib {
         // curveBaseDate and effective fixing date. This means that we should retrieve
         // the input seasonality adjustments when we look at I_{SA}(t) / I_{NSA}(t).
         Date curveBaseDate = iTS.baseDate();
-        Date effectiveFixingDate = iTS.indexIsInterpolated() ? d : 
-            inflationPeriod(d, iTS.frequency()).first;
+        Date effectiveFixingDate = inflationPeriod(d, iTS.frequency()).first;
         
         return seasonalityCorrection(r, effectiveFixingDate, iTS.dayCounter(), curveBaseDate, true);
     }

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -33,8 +33,8 @@ namespace QuantLib {
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
     : TermStructure(dayCounter),
-      observationLag_(observationLag), frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
-      baseRate_(baseRate) {
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(indexIsInterpolated) {
         setSeasonality(seasonality);
     }
 
@@ -48,9 +48,8 @@ namespace QuantLib {
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
     : TermStructure(referenceDate, calendar, dayCounter),
-      observationLag_(observationLag),
-      frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
-      baseRate_(baseRate) {
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(indexIsInterpolated) {
         setSeasonality(seasonality);
     }
 
@@ -64,9 +63,8 @@ namespace QuantLib {
                                         const DayCounter &dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
     : TermStructure(settlementDays, calendar, dayCounter),
-      observationLag_(observationLag),
-      frequency_(frequency), indexIsInterpolated_(indexIsInterpolated),
-      baseRate_(baseRate) {
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(indexIsInterpolated) {
         setSeasonality(seasonality);
     }
 

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -165,16 +165,10 @@ namespace QuantLib {
             Rate z2 = zeroRateImpl(t2);
             zeroRate = z1 + (z2-z1) * (dt/dp);
         } else {
-            if (indexIsInterpolated()) {
-                InflationTermStructure::checkRange(d-useLag, extrapolate);
-                Time t = timeFromReference(d-useLag);
-                zeroRate = zeroRateImpl(t);
-            } else {
-                std::pair<Date,Date> dd = inflationPeriod(d-useLag, frequency());
-                InflationTermStructure::checkRange(dd.first, extrapolate);
-                Time t = timeFromReference(dd.first);
-                zeroRate = zeroRateImpl(t);
-            }
+            std::pair<Date,Date> dd = inflationPeriod(d-useLag, frequency());
+            InflationTermStructure::checkRange(dd.first, extrapolate);
+            Time t = timeFromReference(dd.first);
+            zeroRate = zeroRateImpl(t);
         }
 
         if (hasSeasonality()) {

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -29,6 +29,47 @@ namespace QuantLib {
                                         Rate baseRate,
                                         const Period& observationLag,
                                         Frequency frequency,
+                                        const DayCounter& dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(dayCounter),
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(false) {
+        setSeasonality(seasonality);
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        const Date& referenceDate,
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
+                                        const Calendar& calendar,
+                                        const DayCounter& dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(referenceDate, calendar, dayCounter),
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(false) {
+        setSeasonality(seasonality);
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        Natural settlementDays,
+                                        const Calendar& calendar,
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
+                                        const DayCounter &dayCounter,
+                                        const ext::shared_ptr<Seasonality> &seasonality)
+    : TermStructure(settlementDays, calendar, dayCounter),
+      observationLag_(observationLag), frequency_(frequency),
+      baseRate_(baseRate), indexIsInterpolated_(false) {
+        setSeasonality(seasonality);
+    }
+
+
+    InflationTermStructure::InflationTermStructure(
+                                        Rate baseRate,
+                                        const Period& observationLag,
+                                        Frequency frequency,
                                         bool indexIsInterpolated,
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
@@ -102,6 +143,40 @@ namespace QuantLib {
     }
 
 
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(baseZeroRate, observationLag, frequency,
+                             dayCounter, seasonality) {}
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    const Date& referenceDate,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(referenceDate, baseZeroRate, observationLag, frequency,
+                             calendar, dayCounter, seasonality) {}
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                    Natural settlementDays,
+                                    const Calendar& calendar,
+                                    const DayCounter& dayCounter,
+                                    Rate baseZeroRate,
+                                    const Period& observationLag,
+                                    Frequency frequency,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseZeroRate, observationLag, frequency,
+                             dayCounter, seasonality) {}
+
+    QL_DEPRECATED_DISABLE_WARNING
+
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                     const DayCounter& dayCounter,
                                     Rate baseZeroRate,
@@ -110,8 +185,7 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const ext::shared_ptr<Seasonality> &seasonality)
     : InflationTermStructure(baseZeroRate, observationLag, frequency, indexIsInterpolated,
-                             dayCounter, seasonality) {
-    }
+                             dayCounter, seasonality) {}
 
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                     const Date& referenceDate,
@@ -123,8 +197,7 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const ext::shared_ptr<Seasonality> &seasonality)
     : InflationTermStructure(referenceDate, baseZeroRate, observationLag, frequency, indexIsInterpolated,
-                             calendar, dayCounter, seasonality) {
-    }
+                             calendar, dayCounter, seasonality) {}
 
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                     Natural settlementDays,
@@ -136,8 +209,9 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const ext::shared_ptr<Seasonality> &seasonality)
     : InflationTermStructure(settlementDays, calendar, baseZeroRate, observationLag, frequency, indexIsInterpolated,
-                             dayCounter, seasonality) {
-    }
+                             dayCounter, seasonality) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     Rate ZeroInflationTermStructure::zeroRate(const Date &d, const Period& instObsLag,
                                               bool forceLinearInterpolation,
@@ -182,6 +256,8 @@ namespace QuantLib {
     }
 
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     const DayCounter& dayCounter,
                                     Rate baseYoYRate,
@@ -215,6 +291,8 @@ namespace QuantLib {
                                     const ext::shared_ptr<Seasonality> &seasonality)
     : InflationTermStructure(settlementDays, calendar, baseYoYRate, observationLag,
                              frequency, indexIsInterpolated, dayCounter, seasonality) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
 
 
     Rate YoYInflationTermStructure::yoyRate(const Date &d, const Period& instObsLag,

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -28,6 +28,7 @@
 #include <ql/termstructures/inflation/seasonality.hpp>
 
 namespace QuantLib {
+
     class InflationIndex;
 
     QL_DEPRECATED_DISABLE_WARNING
@@ -69,8 +70,17 @@ namespace QuantLib {
         //! by default, for the maturity requested assuming this lag.
         virtual Period observationLag() const;
         virtual Frequency frequency() const;
-        virtual bool indexIsInterpolated() const;
         virtual Rate baseRate() const;
+
+        /*! \deprecated Don't use this method.  Inflation indexes no
+                        longer rely on the curve for interpolation.
+                        Coupons that need to interpolate between two
+                        index fixings should do so explicitly.
+                        Curves can return flat rates over an inflation period.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        virtual bool indexIsInterpolated() const;
 
         //! minimum (base) date
         /*! Important in inflation since it starts before nominal
@@ -90,7 +100,7 @@ namespace QuantLib {
                         should be passed one explicitly.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED 
+        QL_DEPRECATED
         virtual Handle<YieldTermStructure> nominalTermStructure() const;
 
         //! Functions to set and get seasonality.
@@ -121,8 +131,16 @@ namespace QuantLib {
         ext::shared_ptr<Seasonality> seasonality_;
         Period observationLag_;
         Frequency frequency_;
-        bool indexIsInterpolated_;
         mutable Rate baseRate_;
+        /*! \deprecated Don't use this data member.  Inflation indexes
+                        no longer rely on the curve for interpolation,
+                        and coupons that need to interpolate between two
+                        index fixings should do so explicitly.
+                        Curves can return flat rates over an inflation period.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        bool indexIsInterpolated_;
         /*! \deprecated Don't use this data member.  If you're
                         inheriting from InflationTermStructure, don't
                         have your class take a nominal curve.  Objects
@@ -131,7 +149,7 @@ namespace QuantLib {
                         explicitly.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED 
+        QL_DEPRECATED
         Handle<YieldTermStructure> nominalTermStructure_;
     };
 
@@ -254,6 +272,8 @@ namespace QuantLib {
         Rate yoyRate(Time t,
                      bool extrapolate = false) const;
         //@}
+
+        bool indexIsInterpolated() const override;
       protected:
         //! to be defined in derived classes
         virtual Rate yoyRateImpl(Time time) const = 0;
@@ -283,19 +303,21 @@ namespace QuantLib {
     }
 
     inline bool InflationTermStructure::indexIsInterpolated() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return indexIsInterpolated_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     inline Rate InflationTermStructure::baseRate() const {
         return baseRate_;
     }
 
-    QL_DEPRECATED_DISABLE_WARNING
     inline Handle<YieldTermStructure>
     InflationTermStructure::nominalTermStructure() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return nominalTermStructure_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
-    QL_DEPRECATED_ENABLE_WARNING
 
     inline ext::shared_ptr<Seasonality> InflationTermStructure::seasonality() const {
         return seasonality_;
@@ -303,6 +325,12 @@ namespace QuantLib {
 
     inline bool InflationTermStructure::hasSeasonality() const {
         return static_cast<bool>(seasonality_);
+    }
+
+    inline bool YoYInflationTermStructure::indexIsInterpolated() const {
+        QL_DEPRECATED_DISABLE_WARNING
+        return indexIsInterpolated_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -42,9 +42,39 @@ namespace QuantLib {
         InflationTermStructure(Rate baseRate,
                                const Period& observationLag,
                                Frequency frequency,
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        InflationTermStructure(const Date& referenceDate,
+                               Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
+                               const Calendar& calendar = Calendar(),
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        InflationTermStructure(Natural settlementDays,
+                               const Calendar& calendar,
+                               Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
+                               const DayCounter& dayCounter = DayCounter(),
+                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        InflationTermStructure(Rate baseRate,
+                               const Period& observationLag,
+                               Frequency frequency,
                                bool indexIsInterpolated,
                                const DayCounter& dayCounter = DayCounter(),
                                const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         InflationTermStructure(const Date& referenceDate,
                                Rate baseRate,
                                const Period& observationLag,
@@ -53,6 +83,11 @@ namespace QuantLib {
                                const Calendar& calendar = Calendar(),
                                const DayCounter& dayCounter = DayCounter(),
                                const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Rate baseRate,
@@ -166,19 +201,55 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
+                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        ZeroInflationTermStructure(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   const ext::shared_ptr<Seasonality>& seasonality = ext::shared_ptr<Seasonality>());
+
+        ZeroInflationTermStructure(Natural settlementDays,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        ZeroInflationTermStructure(const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
                                    bool indexIsInterpolated,
                                    const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
 
-        ZeroInflationTermStructure(
-            const Date& referenceDate,
-            const Calendar& calendar,
-            const DayCounter& dayCounter,
-            Rate baseZeroRate,
-            const Period& lag,
-            Frequency frequency,
-            bool indexIsInterpolated,
-            const ext::shared_ptr<Seasonality>& seasonality = ext::shared_ptr<Seasonality>());
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
+        ZeroInflationTermStructure(const Date& referenceDate,
+                                   const Calendar& calendar,
+                                   const DayCounter& dayCounter,
+                                   Rate baseZeroRate,
+                                   const Period& lag,
+                                   Frequency frequency,
+                                   bool indexIsInterpolated,
+                                   const ext::shared_ptr<Seasonality>& seasonality = ext::shared_ptr<Seasonality>());
 
+        /*! \deprecated Use the constructor without the
+                        indexIsInterpolated parameter.
+                        Deprecated in version 1.25.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -537,19 +537,10 @@ void InflationTest::testZeroTermStructure() {
 
     pZITSyes->recalculate();
 
-    // For interpolated fixings, the zero rates on the curve match the data only approximately.
+    // For interpolated fixings, the zero rates on the curve no longer match the data.
     // The helpers still give the correct implied rates, of course.
-    Real eps2 = 0.0001;
     forceLinearInterpolation = false;   // still
     for (Size i=0; i<zcData.size(); i++) {
-        BOOST_CHECK_MESSAGE(std::fabs(zcData[i].rate/100.0
-                    - pZITSyes->zeroRate(zcData[i].date, observationLagyes, forceLinearInterpolation)) < eps2,
-                    "ZITS INTERPOLATED zeroRate != instrument "
-                    << pZITSyes->zeroRate(zcData[i].date, observationLagyes, forceLinearInterpolation)
-                    << " date " << zcData[i].date << " observationLagyes " << observationLagyes
-                    << " vs " << zcData[i].rate/100.0
-                    << " interpolation: " << iiyes->interpolated()
-                    << " forceLinearInterpolation " << forceLinearInterpolation);
         BOOST_CHECK_MESSAGE(std::fabs(helpersyes[i]->impliedQuote()
                         - zcData[i].rate/100.0) < eps,
                     "ZITS INTERPOLATED implied quote != instrument "

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -397,8 +397,7 @@ void InflationTest::testZeroTermStructure() {
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
                         new PiecewiseZeroInflationCurve<Linear>(
                         evaluationDate, calendar, dc, observationLag,
-                        frequency, ii->interpolated(), baseZeroRate,
-                        helpers));
+                        frequency, baseZeroRate, helpers));
     pZITS->recalculate();
 
     // first check that the zero rates on the curve match the data
@@ -532,8 +531,7 @@ void InflationTest::testZeroTermStructure() {
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITSyes(
             new PiecewiseZeroInflationCurve<Linear>(
             evaluationDate, calendar, dc, observationLagyes,
-            frequency, iiyes->interpolated(), baseZeroRate,
-            helpersyes));
+            frequency, baseZeroRate, helpersyes));
 
     pZITSyes->recalculate();
 

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -157,8 +157,7 @@ namespace inflation_cpi_bond_test {
             cpiTS.linkTo(ext::shared_ptr<ZeroInflationTermStructure>(
                   new PiecewiseZeroInflationCurve<Linear>(
                          evaluationDate, calendar, dayCounter, observationLag,
-                         ii->frequency(),ii->interpolated(), baseZeroRate,
-                         helpers)));
+                         ii->frequency(), baseZeroRate, helpers)));
         }
 
         // teardown

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -265,8 +265,7 @@ namespace inflation_cpi_capfloor_test {
             ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pCPIts(
                                 new PiecewiseZeroInflationCurve<Linear>(
                                     evaluationDate, calendar, dcZCIIS, observationLag,
-                                    ii->frequency(),ii->interpolated(), baseZeroRate,
-                                    helpers));
+                                    ii->frequency(), baseZeroRate, helpers));
             pCPIts->recalculate();
             cpiUK.linkTo(pCPIts);
             hii.linkTo(ii);

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -243,8 +243,7 @@ namespace inflation_cpi_swap_test {
             ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pCPIts(
                                 new PiecewiseZeroInflationCurve<Linear>(
                                     evaluationDate, calendar, dcZCIIS, observationLag,
-                                    ii->frequency(),ii->interpolated(), baseZeroRate,
-                                    helpers));
+                                    ii->frequency(), baseZeroRate, helpers));
             pCPIts->recalculate();
             cpiTS = ext::dynamic_pointer_cast<ZeroInflationTermStructure>(pCPIts);
 

--- a/test-suite/inflationzciisinterpolation.cpp
+++ b/test-suite/inflationzciisinterpolation.cpp
@@ -161,7 +161,7 @@ namespace ZCIIS {
         ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
             new PiecewiseZeroInflationCurve<Linear>(setup.evaluationDate, setup.calendar, setup.dc,
                                                     setup.observationLag, frequency,
-                                                    index->interpolated(), baseZeroRate, helpers));
+                                                    baseZeroRate, helpers));
         pZITS->recalculate();
 
         return pZITS;


### PR DESCRIPTION
Part of the road to #1050.

After this change, the interpolation of future index fixings is performed in `ZeroInflationIndex` itself and no longer delegated to the inflation curve.

In turn, this allows simplification of the curve code, since now calls to its methods done through the index only ask for rates at the start of inflation periods; this effectively reduces the curve behavior to the case in which `indexIsInterpolated` is false, allowing to remove the other branch.  Furthermore, the `indexIsInterpolated` method and constructor parameter were deprecated.

For coupons that already took care of interpolation (as in the case of `CPICoupon` and `ZeroInflationCashFlow` when `observationInterpolation` was `Flat` or `Linear`) this should not change the results.  In other cases, figures will change but should be more correct as the interpolation is now performed according to market conventions.

When `indexIsInterpolated` is true, it is now no longer true that the zero rate extracted from the curve equals the quoted swap rate.  Of course, quoted swap rates are still repriced correctly after bootstrap; but that mathematical property is no longer forced on the curve.

Year-on-year inflation indexes and curves are not affected by the changes.