### PR TITLE
Add Normal Volatility SABR Calculation

### DIFF
--- a/ql/experimental/volatility/noarbsabrsmilesection.cpp
+++ b/ql/experimental/volatility/noarbsabrsmilesection.cpp
@@ -89,9 +89,9 @@ Real NoArbSabrSmileSection::volatilityImpl(Rate strike) const {
     }
     if (impliedVol == 0.0)
         // fall back on Hagan 2002 expansion
-        impliedVol =
+        impliedVol = 
             unsafeSabrVolatility(strike, forward_, exerciseTime(), params_[0],
-                                 params_[1], params_[2], params_[3]);
+                                 params_[1], params_[2], params_[3], volatilityType());
 
     return impliedVol;
 }

--- a/ql/termstructures/volatility/sabr.hpp
+++ b/ql/termstructures/volatility/sabr.hpp
@@ -29,10 +29,11 @@
 #define quantlib_sabr_hpp
 
 #include <ql/types.hpp>
+#include <ql/termstructures/volatility/volatilitytype.hpp>
 
 namespace QuantLib {
 
-    Real unsafeSabrVolatility(Rate strike,
+    Real unsafeSabrLogNormalVolatility(Rate strike,
                               Rate forward,
                               Time expiryTime,
                               Real alpha,
@@ -47,7 +48,25 @@ namespace QuantLib {
                               Real beta,
                               Real nu,
                               Real rho,
-                              Real shift);
+                              Real shift,
+                              VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
+
+    Real unsafeSabrNormalVolatility(Rate strike,
+                                    Rate forward,
+                                    Time expiryTime,
+                                    Real alpha,
+                                    Real beta,
+                                    Real nu,
+                                    Real rho);
+
+    Real unsafeSabrVolatility(Rate strike,
+                              Rate forward,
+                              Time expiryTime,
+                              Real alpha,
+                              Real beta,
+                              Real nu,
+                              Real rho,
+                              VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
 
     Real sabrVolatility(Rate strike,
                         Rate forward,
@@ -55,7 +74,8 @@ namespace QuantLib {
                         Real alpha,
                         Real beta,
                         Real nu,
-                        Real rho);
+                        Real rho,
+                        VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
 
     Real shiftedSabrVolatility(Rate strike,
                                  Rate forward,
@@ -64,7 +84,8 @@ namespace QuantLib {
                                  Real beta,
                                  Real nu,
                                  Real rho,
-                                 Real shift);
+                                 Real shift,
+                                 VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
 
     Real sabrFlochKennedyVolatility(Rate strike,
                                     Rate forward,

--- a/ql/termstructures/volatility/sabrsmilesection.cpp
+++ b/ql/termstructures/volatility/sabrsmilesection.cpp
@@ -62,13 +62,13 @@ namespace QuantLib {
      Real SabrSmileSection::varianceImpl(Rate strike) const {
         strike = std::max(0.00001 - shift(),strike);
         Volatility vol = unsafeShiftedSabrVolatility(
-            strike, forward_, exerciseTime(), alpha_, beta_, nu_, rho_, shift_);
+            strike, forward_, exerciseTime(), alpha_, beta_, nu_, rho_, shift_, volatilityType());
         return vol * vol * exerciseTime();
      }
 
      Real SabrSmileSection::volatilityImpl(Rate strike) const {
         strike = std::max(0.00001 - shift(),strike);
         return unsafeShiftedSabrVolatility(strike, forward_, exerciseTime(),
-                                           alpha_, beta_, nu_, rho_, shift_);
+                                           alpha_, beta_, nu_, rho_, shift_, volatilityType());
      }
 }

--- a/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -247,11 +247,6 @@ namespace QuantLib {
       useMaxError_(useMaxError), maxGuesses_(maxGuesses), backwardFlat_(backwardFlat),
       cutoffStrike_(cutoffStrike) {
 
-        // the current implementations are all lognormal, if we have
-        // a normal one, we can move this check to the implementing classes
-        QL_REQUIRE(atmVolStructure->volatilityType() == ShiftedLognormal,
-                   "vol cubes of type 1 require a lognormal atm surface");
-
         if (maxErrorTolerance != Null<Rate>()) {
             maxErrorTolerance_ = maxErrorTolerance;
         } else{


### PR DESCRIPTION
Implement SABR calculations for Normal volatity according to the formula in [PDF](https://www2.deloitte.com/content/dam/Deloitte/global/Documents/Financial-Services/be-aers-fsi-sabr-sensitivities.pdf)

Related Issue: #1164 