### PR TITLE
Add CMake config scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ set(QL_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries")
 set(QL_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
 set(QL_INSTALL_EXAMPLESDIR "lib/QuantLib/examples" CACHE STRING
     "Installation directory for examples")
+set(QL_INSTALL_CMAKEDIR "lib/cmake/${PACKAGE_NAME}-${PACKAGE_VERSION}" CACHE STRING
+    "Installation directory for CMake scripts")
 
 # Options
 option(QL_BUILD_BENCHMARK "Build benchmark" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(QL_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries")
 set(QL_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
 set(QL_INSTALL_EXAMPLESDIR "lib/QuantLib/examples" CACHE STRING
     "Installation directory for examples")
-set(QL_INSTALL_CMAKEDIR "lib/cmake/${PACKAGE_NAME}-${PACKAGE_VERSION}" CACHE STRING
+set(QL_INSTALL_CMAKEDIR "lib/cmake/${PACKAGE_NAME}" CACHE STRING
     "Installation directory for CMake scripts")
 
 # Options

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,4 +55,4 @@ dist-hook:
 	mkdir -p $(distdir)/cmake
 	cp -p $(srcdir)/cmake/GenerateHeaders.cmake $(distdir)/cmake
 	cp -p $(srcdir)/cmake/Platform.cmake $(distdir)/cmake
-
+	cp -p $(srcdir)/cmake/QuantLibTargets.cmake $(distdir)/cmake

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,4 +55,4 @@ dist-hook:
 	mkdir -p $(distdir)/cmake
 	cp -p $(srcdir)/cmake/GenerateHeaders.cmake $(distdir)/cmake
 	cp -p $(srcdir)/cmake/Platform.cmake $(distdir)/cmake
-	cp -p $(srcdir)/cmake/QuantLibTargets.cmake $(distdir)/cmake
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,4 +55,4 @@ dist-hook:
 	mkdir -p $(distdir)/cmake
 	cp -p $(srcdir)/cmake/GenerateHeaders.cmake $(distdir)/cmake
 	cp -p $(srcdir)/cmake/Platform.cmake $(distdir)/cmake
-
+	cp -p $(srcdir)/cmake/QuantLibConfig.cmake.in $(distdir)/cmake

--- a/cmake/QuantLibConfig.cmake.in
+++ b/cmake/QuantLibConfig.cmake.in
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/QuantLibTargets.cmake")

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2316,6 +2316,7 @@ add_library(ql_library
     ${QL_GENERATED_HEADERS})
 
 set_target_properties(ql_library PROPERTIES
+    EXPORT_NAME ${PACKAGE_NAME}
     OUTPUT_NAME ${PACKAGE_NAME}
     VERSION ${QUANTLIB_VERSION}
     SOVERSION ${QUANTLIB_VERSION_MAJOR})
@@ -2327,8 +2328,9 @@ target_compile_options(ql_library PRIVATE
     ${OpenMP_CXX_FLAGS})
 
 target_include_directories(ql_library PUBLIC
-    ${CMAKE_BINARY_DIR}
-    ${CMAKE_SOURCE_DIR}
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
     ${Boost_INCLUDE_DIRS}
     ${OpenMP_CXX_INCLUDE_DIRS})
 
@@ -2338,7 +2340,7 @@ target_link_directories(ql_library PUBLIC
 target_link_libraries(ql_library PUBLIC
     ${OpenMP_CXX_LIBRARIES})
 
-install(TARGETS ql_library
+install(TARGETS ql_library EXPORT QuantLibTargets
     ARCHIVE DESTINATION ${QL_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${QL_INSTALL_LIBDIR})
 
@@ -2359,3 +2361,32 @@ foreach(file ${QL_GENERATED_HEADERS})
     file(RELATIVE_PATH path ${CMAKE_BINARY_DIR} ${dir})
     install(FILES ${file} DESTINATION "${QL_INSTALL_INCLUDEDIR}/${path}")
 endforeach()
+
+# Install config scripts for people using `find_package(QuantLib::QuantLib CONFIG ...)`
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
+    VERSION ${QL_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+export(EXPORT QuantLibTargets
+    FILE "${CMAKE_BINARY_DIR}/cmake/QuantLibTargets.cmake"
+    NAMESPACE QuantLib::
+)
+configure_file("${PROJECT_SOURCE_DIR}/cmake/QuantLibConfig.cmake.in"
+    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    COPYONLY
+)
+configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/QuantLibConfig.cmake.in"
+    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    INSTALL_DESTINATION "${QL_INSTALL_CMAKEDIR}"
+)
+install(EXPORT QuantLibTargets
+    FILE QuantLibTargets.cmake
+    NAMESPACE QuantLib::
+    DESTINATION "${QL_INSTALL_CMAKEDIR}"
+)
+install(FILES "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
+    DESTINATION "${QL_INSTALL_CMAKEDIR}"
+)

--- a/tools/check_filelists.sh
+++ b/tools/check_filelists.sh
@@ -19,7 +19,7 @@ tar xfz QuantLib-*.tar.gz
 rm QuantLib-*.tar.gz
 cd QuantLib-*
 
-find ql -name '*.[hc]pp' -or -name '*.[hc]' \
+find ql -name '*.[hc]pp' \
 | grep -v 'ql/config\.hpp' | sort > ../../ql.dist.files
 find test-suite -name '*.[hc]pp' \
 | grep -v 'quantlibbenchmark' | grep -v '/main\.cpp' \

--- a/tools/check_filelists.sh
+++ b/tools/check_filelists.sh
@@ -50,7 +50,7 @@ grep -o -E 'Include=".*\.[hc]p*"' test-suite/testsuite.vcxproj.filters \
 # same with CMakelists
 
 # reference files above align only to autotools build system
-grep -o -E '[a-zA-Z0-9_/\.]*\.[hc]p*' ql/CMakeLists.txt \
+grep -o -E '[a-zA-Z0-9_/\.]*\.[hc]p+' ql/CMakeLists.txt \
 | grep -v '/cmake/' | grep -v 'ql/config\.hpp' | sed -e 's|/ql/||' | sed -e 's|^|ql/|' | sort > ql.cmake.files
 
 grep -o -E '[a-zA-Z0-9_/\.]*\.[hc]pp' test-suite/CMakeLists.txt \


### PR DESCRIPTION
Closes #1221 

Added CMake scripts to make QuantLib a config-file package[1].

I followed the documentation in [1] as closely as possible to provide a basic implementation of this feature, but I still found it quite complicated so there may be some small details that could be implemented better.

The change to `ql/CMakeLists.txt` line 2331 is required to fix the issue described in [2], but I wonder, why do we need to add both `${CMAKE_BINARY_DIR}` and `${CMAKE_SOURCE_DIR}` to the include directories? Shouldn't it be one or the other? 

Also, minor note that I set the version compatibility to `AnyNewerVersion`, which basically means that QuantLib will be either backwards compatible or that users are on the hook to fix compilation errors (e.g. due to removed deprecated code) when the version of QuantLib gets upgraded.

[1] https://cmake.org/cmake/help/v3.17/manual/cmake-packages.7.html#config-file-packages
[2] https://stackoverflow.com/questions/25676277/cmake-target-include-directories-prints-an-error-when-i-try-to-add-the-source/25681179