### PR TITLE
Remove redundant arguments from `SofrFutureRateHelper` constructor

### DIFF
--- a/ql/termstructures/yield/overnightindexfutureratehelper.cpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.cpp
@@ -19,6 +19,7 @@
 */
 
 #include <ql/termstructures/yield/overnightindexfutureratehelper.hpp>
+#include <ql/indexes/ibor/sofr.hpp>
 #include <ql/utilities/null_deleter.hpp>
 
 namespace QuantLib {
@@ -26,7 +27,7 @@ namespace QuantLib {
     namespace {
 
         Date getValidSofrStart(Month month, Year year, Frequency freq) {
-            return freq == Monthly ? 
+            return freq == Monthly ?
                 UnitedStates(UnitedStates::GovernmentBond).adjust(Date(1, month, year)) :
                 Date::nthWeekday(3, Wednesday, month, year);
         }
@@ -91,8 +92,8 @@ namespace QuantLib {
     Real OvernightIndexFutureRateHelper::convexityAdjustment() const {
         return future_->convexityAdjustment();
     }
-    
-    QL_DEPRECATED
+
+
     SofrFutureRateHelper::SofrFutureRateHelper(
         const Handle<Quote>& price,
         Month referenceMonth,
@@ -115,8 +116,7 @@ namespace QuantLib {
                        "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
         }
     }
-    
-    QL_DEPRECATED
+
     SofrFutureRateHelper::SofrFutureRateHelper(
         Real price,
         Month referenceMonth,
@@ -146,12 +146,11 @@ namespace QuantLib {
         Month referenceMonth,
         Year referenceYear,
         Frequency referenceFreq,
-        const ext::shared_ptr<OvernightIndex>& overnightIndex,
         const Handle<Quote>& convexityAdjustment)
-        : OvernightIndexFutureRateHelper(price,
+    : OvernightIndexFutureRateHelper(price,
             getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
             getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
-            overnightIndex,
+            ext::make_shared<Sofr>(),
             convexityAdjustment,
             referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
@@ -168,13 +167,12 @@ namespace QuantLib {
         Month referenceMonth,
         Year referenceYear,
         Frequency referenceFreq,
-        const ext::shared_ptr<OvernightIndex>& overnightIndex,
         Real convexityAdjustment)
-        : OvernightIndexFutureRateHelper(
+    : OvernightIndexFutureRateHelper(
             Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
             getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
             getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
-            overnightIndex,
+            ext::make_shared<Sofr>(),
             Handle<Quote>(ext::make_shared<SimpleQuote>(convexityAdjustment)),
             referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,

--- a/ql/termstructures/yield/overnightindexfutureratehelper.cpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.cpp
@@ -91,7 +91,8 @@ namespace QuantLib {
     Real OvernightIndexFutureRateHelper::convexityAdjustment() const {
         return future_->convexityAdjustment();
     }
-
+    
+    QL_DEPRECATED
     SofrFutureRateHelper::SofrFutureRateHelper(
         const Handle<Quote>& price,
         Month referenceMonth,
@@ -99,21 +100,66 @@ namespace QuantLib {
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         const Handle<Quote>& convexityAdjustment,
-        [[deprecated("infer averaging method from frequency")]]
         RateAveraging::Type averagingMethod)
     : OvernightIndexFutureRateHelper(price,
                                      getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
                                      getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
                                      overnightIndex,
                                      convexityAdjustment,
-                                     //averagingMethod
-                                     referenceFreq == Quarterly? RateAveraging::Compound : RateAveraging::Simple) {
+                                     averagingMethod) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
                    "only monthly and quarterly SOFR futures accepted");
         if (referenceFreq == Quarterly) {
             QL_REQUIRE(referenceMonth == Mar || referenceMonth == Jun || referenceMonth == Sep ||
                            referenceMonth == Dec,
                        "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
+        }
+    }
+    
+    QL_DEPRECATED
+    SofrFutureRateHelper::SofrFutureRateHelper(
+        Real price,
+        Month referenceMonth,
+        Year referenceYear,
+        Frequency referenceFreq,
+        const ext::shared_ptr<OvernightIndex>& overnightIndex,
+        Real convexityAdjustment,
+        RateAveraging::Type averagingMethod)
+    : OvernightIndexFutureRateHelper(
+          Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
+          getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
+          getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
+          overnightIndex,
+          Handle<Quote>(ext::make_shared<SimpleQuote>(convexityAdjustment)),
+          averagingMethod) {
+        QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
+                   "only monthly and quarterly SOFR futures accepted");
+        if (referenceFreq == Quarterly) {
+            QL_REQUIRE(referenceMonth == Mar || referenceMonth == Jun || referenceMonth == Sep ||
+                           referenceMonth == Dec,
+                       "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
+        }
+    }
+
+    SofrFutureRateHelper::SofrFutureRateHelper(
+        const Handle<Quote>& price,
+        Month referenceMonth,
+        Year referenceYear,
+        Frequency referenceFreq,
+        const ext::shared_ptr<OvernightIndex>& overnightIndex,
+        const Handle<Quote>& convexityAdjustment)
+        : OvernightIndexFutureRateHelper(price,
+            getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
+            getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
+            overnightIndex,
+            convexityAdjustment,
+            referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
+        QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
+            "only monthly and quarterly SOFR futures accepted");
+        if (referenceFreq == Quarterly) {
+            QL_REQUIRE(referenceMonth == Mar || referenceMonth == Jun || referenceMonth == Sep ||
+                referenceMonth == Dec,
+                "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
         }
     }
 
@@ -123,24 +169,20 @@ namespace QuantLib {
         Year referenceYear,
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
-        Real convexityAdjustment,
-        [[deprecated("infer averaging method from frequency")]]
-        RateAveraging::Type averagingMethod)
-    : OvernightIndexFutureRateHelper(
-          Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
-          getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
-          getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
-          overnightIndex,
-          Handle<Quote>(ext::make_shared<SimpleQuote>(convexityAdjustment)),
-          //averagingMethod
-          referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
+        Real convexityAdjustment)
+        : OvernightIndexFutureRateHelper(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
+            getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
+            getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
+            overnightIndex,
+            Handle<Quote>(ext::make_shared<SimpleQuote>(convexityAdjustment)),
+            referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
-                   "only monthly and quarterly SOFR futures accepted");
+            "only monthly and quarterly SOFR futures accepted");
         if (referenceFreq == Quarterly) {
             QL_REQUIRE(referenceMonth == Mar || referenceMonth == Jun || referenceMonth == Sep ||
-                           referenceMonth == Dec,
-                       "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
+                referenceMonth == Dec,
+                "quarterly SOFR futures can only start in Mar,Jun,Sep,Dec");
         }
     }
-
 }

--- a/ql/termstructures/yield/overnightindexfutureratehelper.cpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.cpp
@@ -99,13 +99,15 @@ namespace QuantLib {
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         const Handle<Quote>& convexityAdjustment,
+        [[deprecated("infer averaging method from frequency")]]
         RateAveraging::Type averagingMethod)
     : OvernightIndexFutureRateHelper(price,
                                      getValidSofrStart(referenceMonth, referenceYear, referenceFreq),
                                      getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
                                      overnightIndex,
                                      convexityAdjustment,
-                                     averagingMethod) {
+                                     //averagingMethod
+                                     referenceFreq == Quarterly? RateAveraging::Compound : RateAveraging::Simple) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
                    "only monthly and quarterly SOFR futures accepted");
         if (referenceFreq == Quarterly) {
@@ -122,6 +124,7 @@ namespace QuantLib {
         Frequency referenceFreq,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         Real convexityAdjustment,
+        [[deprecated("infer averaging method from frequency")]]
         RateAveraging::Type averagingMethod)
     : OvernightIndexFutureRateHelper(
           Handle<Quote>(ext::make_shared<SimpleQuote>(price)),
@@ -129,7 +132,8 @@ namespace QuantLib {
           getValidSofrEnd(referenceMonth, referenceYear, referenceFreq),
           overnightIndex,
           Handle<Quote>(ext::make_shared<SimpleQuote>(convexityAdjustment)),
-          averagingMethod) {
+          //averagingMethod
+          referenceFreq == Quarterly ? RateAveraging::Compound : RateAveraging::Simple) {
         QL_REQUIRE(referenceFreq == Quarterly || referenceFreq == Monthly,
                    "only monthly and quarterly SOFR futures accepted");
         if (referenceFreq == Quarterly) {

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -67,6 +67,9 @@ namespace QuantLib {
     */
     class SofrFutureRateHelper : public OvernightIndexFutureRateHelper {
       public:
+        /*! \deprecated Use the constructor without index and averaging method.
+                        Deprecated in version 1.25.
+        */
         QL_DEPRECATED
         SofrFutureRateHelper(const Handle<Quote>& price,
                              Month referenceMonth,
@@ -75,6 +78,10 @@ namespace QuantLib {
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
                              const Handle<Quote>& convexityAdjustment,
                              RateAveraging::Type averagingMethod);
+
+        /*! \deprecated Use the constructor without index and averaging method.
+                        Deprecated in version 1.25.
+        */
         QL_DEPRECATED
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,
@@ -85,17 +92,16 @@ namespace QuantLib {
                              RateAveraging::Type averagingMethod);
 
         SofrFutureRateHelper(const Handle<Quote>& price,
-            Month referenceMonth,
-            Year referenceYear,
-            Frequency referenceFreq,
-            const ext::shared_ptr<OvernightIndex>& overnightIndex,
-            const Handle<Quote>& convexityAdjustment = Handle<Quote>());
+                             Month referenceMonth,
+                             Year referenceYear,
+                             Frequency referenceFreq,
+                             const Handle<Quote>& convexityAdjustment = Handle<Quote>());
+
         SofrFutureRateHelper(Real price,
-            Month referenceMonth,
-            Year referenceYear,
-            Frequency referenceFreq,
-            const ext::shared_ptr<OvernightIndex>& overnightIndex,
-            Real convexityAdjustment = 0);
+                             Month referenceMonth,
+                             Year referenceYear,
+                             Frequency referenceFreq,
+                             Real convexityAdjustment = 0);
     };
 
 }

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -67,22 +67,35 @@ namespace QuantLib {
     */
     class SofrFutureRateHelper : public OvernightIndexFutureRateHelper {
       public:
+        QL_DEPRECATED
         SofrFutureRateHelper(const Handle<Quote>& price,
                              Month referenceMonth,
                              Year referenceYear,
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                             const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
-                             [[deprecated("infer averaging method from frequency")]]
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             const Handle<Quote>& convexityAdjustment,
+                             RateAveraging::Type averagingMethod);
+        QL_DEPRECATED
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,
                              Year referenceYear,
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                             Real convexityAdjustment = 0,
-                             [[deprecated("infer averaging method from frequency")]]
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             Real convexityAdjustment,
+                             RateAveraging::Type averagingMethod);
+
+        SofrFutureRateHelper(const Handle<Quote>& price,
+            Month referenceMonth,
+            Year referenceYear,
+            Frequency referenceFreq,
+            const ext::shared_ptr<OvernightIndex>& overnightIndex,
+            const Handle<Quote>& convexityAdjustment = Handle<Quote>());
+        SofrFutureRateHelper(Real price,
+            Month referenceMonth,
+            Year referenceYear,
+            Frequency referenceFreq,
+            const ext::shared_ptr<OvernightIndex>& overnightIndex,
+            Real convexityAdjustment = 0);
     };
 
 }

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -73,6 +73,7 @@ namespace QuantLib {
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
                              const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+                             [[deprecated("infer averaging method from frequency")]]
                              RateAveraging::Type averagingMethod = RateAveraging::Compound);
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,
@@ -80,6 +81,7 @@ namespace QuantLib {
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
                              Real convexityAdjustment = 0,
+                             [[deprecated("infer averaging method from frequency")]]
                              RateAveraging::Type averagingMethod = RateAveraging::Compound);
     };
 

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -89,8 +89,7 @@ void SofrFuturesTest::testBootstrap() {
     std::vector<ext::shared_ptr<RateHelper> > helpers;
     for (const auto& sofrQuote : sofrQuotes) {
         helpers.push_back(ext::make_shared<SofrFutureRateHelper>(
-            sofrQuote.price, sofrQuote.month, sofrQuote.year, sofrQuote.freq,
-            index, 0.0));
+            sofrQuote.price, sofrQuote.month, sofrQuote.year, sofrQuote.freq));
     }
 
     ext::shared_ptr<PiecewiseYieldCurve<Discount, Linear> > curve =

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -90,7 +90,7 @@ void SofrFuturesTest::testBootstrap() {
     for (const auto& sofrQuote : sofrQuotes) {
         helpers.push_back(ext::make_shared<SofrFutureRateHelper>(
             sofrQuote.price, sofrQuote.month, sofrQuote.year, sofrQuote.freq,
-            index, 0.0, sofrQuote.averagingMethod));
+            index, 0.0));
     }
 
     ext::shared_ptr<PiecewiseYieldCurve<Discount, Linear> > curve =


### PR DESCRIPTION
Futures with monthly frequency use averaging rate, while with quarterly frequency use compouding. The constructor taking the averaging method explicitly can be deprecated.