### PR TITLE
Fix TreeSwaptionEngine Mispricing

### DIFF
--- a/ql/instruments/vanillaswap.hpp
+++ b/ql/instruments/vanillaswap.hpp
@@ -144,6 +144,10 @@ namespace QuantLib {
         std::vector<Date> floatingFixingDates;
         std::vector<Date> floatingPayDates;
 
+        std::vector<Date> originalFixedResetDates;
+        std::vector<Date> originalFloatingResetDates;
+        std::vector<Date> originalFixedPayDates;
+
         std::vector<Real> fixedCoupons;
         std::vector<Spread> floatingSpreads;
         std::vector<Real> floatingCoupons;

--- a/ql/pricingengines/swap/discretizedswap.cpp
+++ b/ql/pricingengines/swap/discretizedswap.cpp
@@ -63,21 +63,42 @@ namespace QuantLib {
                 dayCounter.yearFraction(referenceDate,
                                         args.floatingPayDates[i]);
 
-        originalFixedPayTimes_.resize(args.originalFixedPayDates.size());
-        for (Size i = 0; i < originalFixedPayTimes_.size(); ++i)
-            originalFixedPayTimes_[i] =
-                dayCounter.yearFraction(referenceDate, args.originalFixedPayDates[i]);
-
-        originalFixedResetTimes_.resize(args.originalFixedResetDates.size());
-        for (Size i = 0; i < originalFixedResetTimes_.size(); ++i)
-            originalFixedResetTimes_[i] =
-                dayCounter.yearFraction(referenceDate, args.originalFixedResetDates[i]);
-
-        originalFloatingResetTimes_.resize(args.originalFloatingResetDates.size());
-        for (Size i = 0; i < originalFloatingResetTimes_.size(); ++i)
-            originalFloatingResetTimes_[i] =
-                dayCounter.yearFraction(referenceDate, args.originalFloatingResetDates[i]);
-   
+        if (args.originalFixedPayDates.size() > 0) {
+            originalFixedPayTimes_.resize(args.originalFixedPayDates.size());
+            for (Size i = 0; i < originalFixedPayTimes_.size(); ++i)
+                originalFixedPayTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.originalFixedPayDates[i]);
+        } else {
+            originalFixedPayTimes_.resize(args.fixedPayDates.size());
+            for (Size i = 0; i < originalFixedPayTimes_.size(); ++i)
+                originalFixedPayTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.fixedPayDates[i]);
+        }
+        
+        if (args.originalFixedResetDates.size() > 0) {
+            originalFixedResetTimes_.resize(args.originalFixedResetDates.size());
+            for (Size i = 0; i < originalFixedResetTimes_.size(); ++i)
+                originalFixedResetTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.originalFixedResetDates[i]);
+        } else {
+            originalFixedResetTimes_.resize(args.fixedResetDates.size());
+            for (Size i = 0; i < originalFixedResetTimes_.size(); ++i)
+                originalFixedResetTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.fixedResetDates[i]);
+        }
+        
+        if (args.originalFloatingResetDates.size() > 0) {
+            originalFloatingResetTimes_.resize(args.originalFloatingResetDates.size());
+            for (Size i = 0; i < originalFloatingResetTimes_.size(); ++i)
+                originalFloatingResetTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.originalFloatingResetDates[i]);
+        } else {
+            originalFloatingResetTimes_.resize(args.floatingResetDates.size());
+            for (Size i = 0; i < originalFloatingResetTimes_.size(); ++i)
+                originalFloatingResetTimes_[i] =
+                    dayCounter.yearFraction(referenceDate, args.floatingResetDates[i]);
+        }
+        
     }
 
     void DiscretizedSwap::reset(Size size) {

--- a/ql/pricingengines/swap/discretizedswap.hpp
+++ b/ql/pricingengines/swap/discretizedswap.hpp
@@ -48,6 +48,9 @@ namespace QuantLib {
         std::vector<Time> fixedPayTimes_;
         std::vector<Time> floatingResetTimes_;
         std::vector<Time> floatingPayTimes_;
+        std::vector<Time> originalFixedResetTimes_;
+        std::vector<Time> originalFloatingResetTimes_;
+        std::vector<Time> originalFixedPayTimes_;
         bool includeTodaysCashFlows_;
     };
 

--- a/ql/pricingengines/swaption/discretizedswaption.cpp
+++ b/ql/pricingengines/swaption/discretizedswaption.cpp
@@ -49,6 +49,11 @@ namespace QuantLib {
                 dayCounter.yearFraction(referenceDate,
                                         arguments_.exercise->date(i));
 
+        // Backup dates before snapping
+        arguments_.originalFixedPayDates = arguments_.fixedPayDates;
+        arguments_.originalFixedResetDates = arguments_.fixedResetDates;
+        arguments_.originalFloatingResetDates = arguments_.floatingResetDates;
+
         // Date adjustments can get time vectors out of synch.
         // Here, we try and collapse similar dates which could cause
         // a mispricing.

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -118,7 +118,7 @@ void BermudanSwaptionTest::testValuesCloseToExerciseDate() {
     RelinkableHandle<YieldTermStructure> termStructure;
     termStructure.linkTo(ext::make_shared<FlatForward>(today, 0.02, Actual365Fixed()));
 
-    auto makeBermudanSwaption = [&today, &termStructure](Date callDate) {
+    auto makeBermudanSwaption = [&termStructure](Date callDate) {
         auto effectiveDate = Date(15, May, 2025);
         auto index = ext::make_shared<Euribor3M>(termStructure);
         ext::shared_ptr<VanillaSwap> swap = MakeVanillaSwap(Period(10, Years), index, 0.05)

--- a/test-suite/bermudanswaption.hpp
+++ b/test-suite/bermudanswaption.hpp
@@ -28,6 +28,7 @@
 
 class BermudanSwaptionTest {
   public:
+    static void testValuesCloseToExerciseDate();
     static void testCachedValues();
     static void testCachedG2Values();
     static boost::unit_test_framework::test_suite* suite(SpeedLevel);


### PR DESCRIPTION
Mispricing is caused by snapping of floating/fixed reset/pay times to exercise times. In preAdjustValuesImpl() of discretizedswap.cpp, this will cause the snapped floating/fixed reset time t to be onTime() with the exercise time(when rolling back to exercise time), causing extra DiscretizedDiscountBond coupon to be calculated and added to values_ unnecessarily.

The solution for now is to copy the original values of floating/fixed reset/pay times before snapping, and let preAdjustValuesImpl() and postAdjustValuesImpl() in discretizedswap.cpp use these original times that were unsnapped, since the snapped times are still needed in other places of the code to maintain numerical stability. If we could pinpoint where these places are, perhaps a cleaner approach could be taken instead of copying all the times.

Tree calculated values are now much closer to FD values after making this change.

```
Call date          FD   Tree
2030-05-06	10.11	11.04
2030-05-07	10.13	10.98
2030-05-08	10.15	10.92
2030-05-09	10.16	10.85
2030-05-10	10.18	10.78
2030-05-13	10.23	10.69
2030-05-14	10.25	10.83
2030-05-15	10.26	10.96
2030-05-16	28.79	30.78
2030-05-17	28.83	30.78
2030-05-20	28.94	30.88
2030-05-21	28.98	30.90
2030-05-22	29.01	30.78
2030-05-23	29.05	30.97
2030-05-24	29.09	30.99
```

Issue: #1143 