### PR TITLE
Add inspectors for some basic properties of overnight-idex futures

### DIFF
--- a/ql/instruments/overnightindexfuture.hpp
+++ b/ql/instruments/overnightindexfuture.hpp
@@ -47,6 +47,9 @@ namespace QuantLib {
 
         Real convexityAdjustment() const;
         bool isExpired() const override;
+        const ext::shared_ptr<OvernightIndex>& overnightIndex() const { return overnightIndex_; }
+        Date valueDate() const { return valueDate_; }
+        Date maturityDate() const { return maturityDate_; }
       private:
         void performCalculations() const override;
         Real rate() const;


### PR DESCRIPTION
It's useful to be able to read these off an individual future, and i don't know of any reason they should be private.