### PR TITLE
Indirect leaks with AddressSanitizer

### DIFF
--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -191,7 +191,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-static ${{ matrix.configureflags }} CC="ccache ${{ matrix.cc }}" CXX="ccache ${{ matrix.cxx }}" CXXFLAGS="-O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }}"
+        ./configure --disable-static ${{ matrix.configureflags }} CC="ccache ${{ matrix.cc }}" CXX="ccache ${{ matrix.cxx }}" CXXFLAGS="-O2 -g0 -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }}"
         make -j 2
     - name: Run tests
       run: |
@@ -207,4 +207,4 @@ jobs:
             echo "namespace QuantLib { ThreadKey sessionId() { return 0; } }" >> test2.cpp
         fi
         make install
-        ${{ matrix.cxx }} -O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }} `quantlib-config --cflags` test1.cpp test2.cpp `quantlib-config --libs`
+        ${{ matrix.cxx }} -O2 -g0 -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }} `quantlib-config --cflags` test1.cpp test2.cpp `quantlib-config --libs`

--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -191,7 +191,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-static ${{ matrix.configureflags }} CC="ccache ${{ matrix.cc }}" CXX="ccache ${{ matrix.cxx }}" CXXFLAGS="-O2 -g0 -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }}"
+        ./configure --disable-static ${{ matrix.configureflags }} CC="ccache ${{ matrix.cc }}" CXX="ccache ${{ matrix.cxx }}" CXXFLAGS="-O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }}"
         make -j 2
     - name: Run tests
       run: |

--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -207,4 +207,4 @@ jobs:
             echo "namespace QuantLib { ThreadKey sessionId() { return 0; } }" >> test2.cpp
         fi
         make install
-        ${{ matrix.cxx }} -O2 -g0 -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }} `quantlib-config --cflags` test1.cpp test2.cpp `quantlib-config --libs`
+        ${{ matrix.cxx }} -O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror ${{ matrix.cxxflags }} `quantlib-config --cflags` test1.cpp test2.cpp `quantlib-config --libs`

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,0 +1,32 @@
+name: Linux build with address sanitizer enabled
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/lballabio/quantlib-devenv:rolling
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: linux-build-sanitizer-${{ github.ref }}-${{ github.head_ref }}-${{ hashFiles('**/*.hpp', '**/*.cpp') }}
+        restore-keys: |
+          linux-build-sanitizer-${{ github.ref }}-${{ github.head_ref }}-
+          linux-build-sanitizer-${{ github.ref }}-
+          linux-build-sanitizer-refs/heads/master-
+          linux-build-sanitizer-
+    - name: Compiler version
+      run: |
+        gcc --version
+    - name: Build
+      run: |
+        ./autogen.sh
+        ./configure --disable-static CC="ccache gcc" CXX="ccache g++" CXXFLAGS="-O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror"
+        make -j 2
+    - name: Run tests
+      run: |
+        ./test-suite/quantlib-test-suite --log_level=message
+    - name: Run examples
+      run: |
+        make check-examples

--- a/ql/pricingengines/lookback/analyticcontinuouspartialfloatinglookback.cpp
+++ b/ql/pricingengines/lookback/analyticcontinuouspartialfloatinglookback.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
 
         Real l1 = std::log(lambda()) / vol;
         Real g1 = l1 / std::sqrt(residualTime());
-        
+
         Real n1 = f_(eta*(d1 - g1));
         Real n2 = f_(eta*(d2 - g1));
 

--- a/ql/pricingengines/lookback/analyticcontinuouspartialfloatinglookback.cpp
+++ b/ql/pricingengines/lookback/analyticcontinuouspartialfloatinglookback.cpp
@@ -123,8 +123,6 @@ namespace QuantLib {
 
         Real l1 = std::log(lambda()) / vol;
         Real g1 = l1 / std::sqrt(residualTime());
-        Real g2;
-        if (!fullLookbackPeriod) g2 = l1 / std::sqrt(residualTime() - lookbackPeriodEndTime());
         
         Real n1 = f_(eta*(d1 - g1));
         Real n2 = f_(eta*(d2 - g1));
@@ -140,6 +138,7 @@ namespace QuantLib {
         Real n4 = 0, n5 = 0, n6 = 0, n7 = 0;
         if (!fullLookbackPeriod)
         {
+            Real g2 = l1 / std::sqrt(residualTime() - lookbackPeriodEndTime());
             n4 = cnbn2(-eta*(d1+g1), eta*(e1 + g2));
             n5 = cnbn2(-eta*(d1-g1), eta*(e1 - g2));
             n6 = cnbn3(eta*-f2, eta*(d2 - g1));

--- a/test-suite/inflationzciisinterpolation.cpp
+++ b/test-suite/inflationzciisinterpolation.cpp
@@ -192,6 +192,9 @@ namespace ZCIIS {
 
         hz.linkTo(result.curve);
 
+        // remove circular reference
+        hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
+
         return result;
     }
 


### PR DESCRIPTION
Closes #1251

- Compile with AddressSanitizer enabled in `linux-full-tests.yml`
- Fix indirect leaks in `inflationzciisinterpolation.cpp`
- Fix minor compiler warning in `analyticcontinuouspartialfloatinglookback.cpp`