### PR TITLE
Update obsolete call to `PiecewiseYieldCurve` constructor

### DIFF
--- a/ql/models/marketmodels/historicalforwardratesanalysis.hpp
+++ b/ql/models/marketmodels/historicalforwardratesanalysis.hpp
@@ -125,8 +125,7 @@ namespace QuantLib {
 
         // Bootstrap the yield curve at the currentDate
         Natural settlementDays = 0;
-        IterativeBootstrap<PiecewiseYieldCurve<Traits, Interpolator> > bootstrap(
-            yieldCurveAccuracy);
+        PiecewiseYieldCurve<Traits, Interpolator>::bootstrap_type bootstrap(yieldCurveAccuracy);
         PiecewiseYieldCurve<Traits, Interpolator> yc(settlementDays,
                                                      cal,
                                                      rateHelpers,

--- a/ql/models/marketmodels/historicalforwardratesanalysis.hpp
+++ b/ql/models/marketmodels/historicalforwardratesanalysis.hpp
@@ -125,7 +125,7 @@ namespace QuantLib {
 
         // Bootstrap the yield curve at the currentDate
         Natural settlementDays = 0;
-        PiecewiseYieldCurve<Traits, Interpolator>::bootstrap_type bootstrap(yieldCurveAccuracy);
+        typename PiecewiseYieldCurve<Traits, Interpolator>::bootstrap_type bootstrap(yieldCurveAccuracy);
         PiecewiseYieldCurve<Traits, Interpolator> yc(settlementDays,
                                                      cal,
                                                      rateHelpers,

--- a/ql/models/marketmodels/historicalforwardratesanalysis.hpp
+++ b/ql/models/marketmodels/historicalforwardratesanalysis.hpp
@@ -125,14 +125,16 @@ namespace QuantLib {
 
         // Bootstrap the yield curve at the currentDate
         Natural settlementDays = 0;
+        IterativeBootstrap<PiecewiseYieldCurve<Traits, Interpolator> > bootstrap(
+            yieldCurveAccuracy);
         PiecewiseYieldCurve<Traits, Interpolator> yc(settlementDays,
                                                      cal,
                                                      rateHelpers,
                                                      yieldCurveDayCounter,
                                                      std::vector<Handle<Quote> >(),
                                                      std::vector<Date>(),
-                                                     yieldCurveAccuracy,
-                                                     i);
+                                                     i,
+                                                     bootstrap);
 
         // start with a valid business date
         Date currentDate = cal.advance(startDate, 1*Days, Following);


### PR DESCRIPTION
The deprecated PiecewiseYieldCurve constructor that accepted the accuracy was recently removed. This instantiation has to be fixed.

Unfortunately I don't know much about this class so cannot contribute a test case.