### PR TITLE
Use correct method to recalculate swap in OIS helper

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -195,7 +195,7 @@ namespace QuantLib {
     Real DatedOISRateHelper::impliedQuote() const {
         QL_REQUIRE(termStructure_ != nullptr, "term structure not set");
         // we didn't register as observers - force calculation
-        swap_->deepUpdate();
+        swap_->recalculate();
         return swap_->fairRate();
     }
 


### PR DESCRIPTION
`deepUpdate` would work by chance because it would cause a notification to reach the instrument. Instead, `recalculate` is the one that expresses the intent directly.