### PR TITLE
change THBFIX fixing calendar

### DIFF
--- a/ql/indexes/ibor/thbfix.hpp
+++ b/ql/indexes/ibor/thbfix.hpp
@@ -58,9 +58,7 @@ namespace QuantLib {
         : IborIndex("THBFIX", tenor,
                     2,
                     THBCurrency(),
-                    JointCalendar(UnitedKingdom(UnitedKingdom::Exchange),
-                                  JointCalendar(UnitedStates(UnitedStates::LiborImpact),
-                                                Thailand())),
+                    Thailand(),
                     ModifiedFollowing, true,
                     Actual365Fixed(), h) {}
     };


### PR DESCRIPTION
The THBFIX rate observes only the Thailand calendar (they are published also on LIBOR holidays) from the BoT [historical data](https://www.bot.or.th/App/BTWS_STAT/statistics/BOTWEBSTAT.aspx?reportID=909&language=eng). e.g. there were fixing on 27&28 Dec 2021.

Believe it should be changed accordingly in order that derivatives based on it correctly impute their fixing days.