### PR TITLE
Rework defaults for `CPICoupon` constructors.

### DIFF
--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -38,12 +38,10 @@ namespace QuantLib {
     */
     class CPICouponPricer : public InflationCouponPricer {
       public:
-        CPICouponPricer() = default;
+        explicit CPICouponPricer(Handle<YieldTermStructure> nominalTermStructure = Handle<YieldTermStructure>());
 
-        explicit CPICouponPricer(Handle<YieldTermStructure> nominalTermStructure);
-
-        CPICouponPricer(Handle<CPIVolatilitySurface> capletVol,
-                        Handle<YieldTermStructure> nominalTermStructure);
+        explicit CPICouponPricer(Handle<CPIVolatilitySurface> capletVol,
+                                 Handle<YieldTermStructure> nominalTermStructure = Handle<YieldTermStructure>());
 
         virtual Handle<CPIVolatilitySurface> capletVolatility() const{
             return capletVol_;


### PR DESCRIPTION
This allows passing a vol surface without a discount curve (which is only needed for `Price()` methods).