### PR TITLE
Replace boost::unordered_{map,set} with std::unordered_{map,set}

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -18,8 +18,11 @@ if (MSVC)
     # /wd4267
     # Suppress warnings: assignment of 64-bit value to 32-bit QuantLib::Integer (x64)
 
+    # /wd4819
+    # Suppress warnings: The file contains a character that cannot be represented in the current code page
+
     # /wd26812
     # Suppress warnings: "Prefer enum class over enum" (Enum.3)
 
-    add_compile_options(/wd4267 /wd26812)
+    add_compile_options(/wd4267 /wd4819 /wd26812)
 endif()

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -30,7 +30,6 @@
 #include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
 #include <ql/methods/finitedifferences/operators/secondordermixedderivativeop.hpp>
 #include <ql/processes/hestonprocess.hpp>
-#include <boost/unordered/unordered_map.hpp>
 #include <cmath>
 #include <utility>
 

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -49,11 +49,12 @@
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 #include <boost/math/special_functions/erf.hpp>
-#include <boost/unordered_map.hpp>
 #if defined(__GNUC__) &&                                                       \
     (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
 #endif
+
+#include <unordered_map>
 
 namespace QuantLib {
 
@@ -179,10 +180,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
         }
     };
 
-    typedef boost::unordered_map<CachedSwapKey, ext::shared_ptr<VanillaSwap>,
-                                 CachedSwapKeyHasher> CacheType;
-
-    mutable CacheType swapCache_;
+    mutable std::unordered_map<CachedSwapKey, ext::shared_ptr<VanillaSwap>, CachedSwapKeyHasher> swapCache_;
 
   protected:
     // we let derived classes register with the termstructure
@@ -216,7 +214,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
                    const Date &expiry, const Period &tenor) const {
 
         CachedSwapKey k = {index, expiry, tenor};
-        CacheType::iterator i = swapCache_.find(k);
+        auto i = swapCache_.find(k);
         if (i == swapCache_.end()) {
             ext::shared_ptr<VanillaSwap> underlying =
                 index->clone(tenor)->underlyingSwap(expiry);

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -288,9 +288,9 @@ namespace QuantLib {
       Example:
 
       \code{.cpp}
-      #include <boost/unordered_set.hpp>
+      #include <unordered_set>
 
-      boost::unordered_set<Date> set;
+      std::unordered_set<Date> set;
       Date d = Date(1, Jan, 2020); 
 
       set.insert(d);
@@ -457,6 +457,15 @@ namespace QuantLib {
         return (d1.serialNumber() >= d2.serialNumber());
     }
 #endif
+}
+
+namespace std {
+    template<>
+    struct hash<QuantLib::Date> {
+        std::size_t operator()(const QuantLib::Date& d) const {
+            return QuantLib::hash_value(d);
+        }
+    };
 }
 
 #endif

--- a/test-suite/dates.cpp
+++ b/test-suite/dates.cpp
@@ -32,9 +32,8 @@
 #include <ql/time/asx.hpp>
 #include <ql/utilities/dataparsers.hpp>
 
-#include <boost/unordered_set.hpp>
-#include <boost/functional/hash.hpp>
 #include <sstream>
+#include <unordered_set>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -415,7 +414,7 @@ void DateTest::canHash() {
     Date start_date = Date(1, Jan, 2020);
     int nb_tests = 500;
 
-    boost::hash<Date> hasher;
+    std::hash<Date> hasher;
 
     // Check hash values
     for (int i = 0; i < nb_tests; ++i) {
@@ -442,7 +441,7 @@ void DateTest::canHash() {
     }
 
     // Check if Date can be used as unordered_set key
-    boost::unordered_set<Date> set;
+    std::unordered_set<Date> set;
     set.insert(start_date);
 
     if (set.count(start_date) == 0) {


### PR DESCRIPTION
Closes #1270 

- Replace `boost::unordered_map` and `boost::unordered_set` with the `std` equivalents.
- Deprecate unused (within QuantLib) public typedefs.
- Remove unnecessary warning suppression on Linux.
- Add harmless warning suppression on Windows.
