### PR TITLE
Set QL_BOOST_COMPONENTS to empty string by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,14 @@ if (NOT DEFINED QL_BOOST_VERSION)
 endif()
 
 if (NOT DEFINED QL_BOOST_COMPONENTS)
-    # Boost thread and unit_test_framework needed for tests and benchmark
+    set(QL_BOOST_COMPONENTS "")
+    # Boost unit_test_framework needed for tests and benchmark
     if (QL_BUILD_TEST_SUITE OR QL_BUILD_BENCHMARK)
-        set(QL_BOOST_COMPONENTS thread unit_test_framework)
-    else()
-        set(QL_BOOST_COMPONENTS thread)
+        set(QL_BOOST_COMPONENTS "${QL_BOOST_COMPONENTS};unit_test_framework")
+    endif()
+    # Boost thread needed for sessions, singleton thread-safe init and thread-safe observer pattern
+    if(QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
+        set(QL_BOOST_COMPONENTS "${QL_BOOST_COMPONENTS};thread")
     endif()
 endif()
 


### PR DESCRIPTION
As discussed on the [quantlib-users](https://sourceforge.net/p/quantlib/mailman/message/37593432/) mailing list, in the default configuration no pre-compiled Boost libraries are needed, so updating the required components for the CMake build accordingly.