### PR TITLE
Replace boost::array with std::array

### DIFF
--- a/ql/experimental/volatility/sabrvolsurface.cpp
+++ b/ql/experimental/volatility/sabrvolsurface.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
         registerWithMarketData();
     }
 
-    boost::array<Real, 4> SabrVolSurface::sabrGuesses(const Date& d) const {
+    std::array<Real, 4> SabrVolSurface::sabrGuesses(const Date& d) const {
 
         // the guesses for sabr parameters are assumed to be piecewise constant
         if (d<=optionDates_[0]) return sabrGuesses_[0];
@@ -73,7 +73,7 @@ namespace QuantLib {
         return sabrGuesses_[i];
     }
 
-    void SabrVolSurface::updateSabrGuesses(const Date& d, boost::array<Real, 4> newGuesses) const {
+    void SabrVolSurface::updateSabrGuesses(const Date& d, std::array<Real, 4> newGuesses) const {
 
         Size i=0;
         while (i<optionDates_.size() && d<=optionDates_[i])
@@ -123,7 +123,7 @@ namespace QuantLib {
         std::vector<Volatility> volSpreads = volatilitySpreads(d);
 
         // calculate sabr fit
-        boost::array<Real, 4> sabrParameters1 = sabrGuesses(d);
+        std::array<Real, 4> sabrParameters1 = sabrGuesses(d);
 
         ext::shared_ptr<SabrInterpolatedSmileSection> tmp(new
             SabrInterpolatedSmileSection(d,

--- a/ql/experimental/volatility/sabrvolsurface.hpp
+++ b/ql/experimental/volatility/sabrvolsurface.hpp
@@ -28,7 +28,7 @@
 #include <ql/experimental/volatility/blackatmvolcurve.hpp>
 #include <ql/quote.hpp>
 #include <ql/termstructures/volatility/sabrinterpolatedsmilesection.hpp>
-#include <boost/array.hpp>
+#include <array>
 
 namespace QuantLib {
 
@@ -67,7 +67,7 @@ namespace QuantLib {
         std::vector<Volatility> volatilitySpreads(const Period&) const;
         std::vector<Volatility> volatilitySpreads(const Date&) const;
       protected:
-        boost::array<Real, 4> sabrGuesses(const Date&) const;
+        std::array<Real, 4> sabrGuesses(const Date&) const;
       public:
         //@}
         //! \name BlackVolSurface interface
@@ -84,7 +84,7 @@ namespace QuantLib {
       private:
         void registerWithMarketData();
         void checkInputs() const;
-        void updateSabrGuesses(const Date& d, boost::array<Real, 4> newGuesses) const;
+        void updateSabrGuesses(const Date& d, std::array<Real, 4> newGuesses) const;
         Handle<BlackAtmVolCurve> atmCurve_;
         std::vector<Period> optionTenors_;
         std::vector<Time> optionTimes_;
@@ -98,7 +98,7 @@ namespace QuantLib {
         bool isRhoFixed_;
         bool vegaWeighted_;
         //
-        mutable std::vector<boost::array<Real,4> > sabrGuesses_;
+        mutable std::vector<std::array<Real,4>> sabrGuesses_;
     };
 
     // inline


### PR DESCRIPTION
`boost::array` is another type that can be replaced by the C++11 standard library.

It is not used in public scope anywhere, and only once in protected scope. What is the policy on making breaking changes to protected scope - is it allowed? If not, then what are the options for making this change?

If we are going to replace more boost types with the standard library, then I suppose at some point we will need to introduce a macro such as `QL_USE_STD` defaulted to `false` to specify whether to use the boost type or the std type. That way we can deprecate the boost types while allowing people to opt in early to the std types. What do you think?