### PR TITLE
allow to include QuantLib as cmake subproject

### DIFF
--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2183,132 +2183,132 @@ set(QL_HEADERS
 )
 
 set(QL_CONFIGURED_HEADERS
-    ${CMAKE_BINARY_DIR}/ql/config.hpp
-    ${CMAKE_BINARY_DIR}/ql/qldefines.hpp
-    ${CMAKE_BINARY_DIR}/ql/version.hpp)
+    ${PROJECT_BINARY_DIR}/ql/config.hpp
+    ${PROJECT_BINARY_DIR}/ql/qldefines.hpp
+    ${PROJECT_BINARY_DIR}/ql/version.hpp)
 
 set(QL_GENERATED_HEADERS
-    ${CMAKE_BINARY_DIR}/ql/quantlib.hpp
-    ${CMAKE_BINARY_DIR}/ql/cashflows/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/currencies/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/amortizingbonds/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/asian/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/averageois/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/barrieroption/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/basismodels/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/callablebonds/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/catbonds/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/commodities/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/coupons/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/credit/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/exoticoptions/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/finitedifferences/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/forward/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/fx/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/inflation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/lattices/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/math/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/mcbasket/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/models/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/processes/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/risk/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/shortrate/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/swaptions/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/termstructures/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/variancegamma/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/varianceoption/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/experimental/volatility/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/indexes/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/indexes/ibor/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/indexes/inflation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/indexes/swap/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/instruments/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/instruments/bonds/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/legacy/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/legacy/libormarketmodels/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/copulas/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/distributions/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/integrals/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/interpolations/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/matrixutilities/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/ode/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/optimization/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/randomnumbers/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/solvers1d/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/math/statistics/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/meshers/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/operators/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/schemes/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/solvers/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/stepconditions/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/finitedifferences/utilities/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/lattices/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/methods/montecarlo/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/equity/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/browniangenerators/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/callability/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/correlations/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/curvestates/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/driftcomputation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/evolvers/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/evolvers/volprocesses/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/models/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/pathwisegreeks/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/products/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/products/multistep/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/products/onestep/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/marketmodels/products/pathwise/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/shortrate/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/shortrate/calibrationhelpers/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/shortrate/onefactormodels/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/shortrate/twofactormodels/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/models/volatility/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/patterns/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/asian/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/barrier/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/basket/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/bond/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/capfloor/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/cliquet/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/credit/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/forward/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/inflation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/lookback/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/quanto/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/swap/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/swaption/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/pricingengines/vanilla/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/processes/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/quotes/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/credit/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/inflation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/capfloor/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/equityfx/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/inflation/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/optionlet/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/volatility/swaption/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/termstructures/yield/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/time/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/time/calendars/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/time/daycounters/all.hpp
-    ${CMAKE_BINARY_DIR}/ql/utilities/all.hpp)
+    ${PROJECT_BINARY_DIR}/ql/quantlib.hpp
+    ${PROJECT_BINARY_DIR}/ql/cashflows/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/currencies/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/amortizingbonds/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/asian/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/averageois/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/barrieroption/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/basismodels/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/callablebonds/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/catbonds/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/commodities/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/coupons/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/credit/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/exoticoptions/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/finitedifferences/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/forward/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/fx/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/inflation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/lattices/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/math/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/mcbasket/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/models/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/processes/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/risk/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/shortrate/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/swaptions/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/termstructures/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/variancegamma/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/varianceoption/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/experimental/volatility/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/indexes/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/indexes/ibor/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/indexes/inflation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/indexes/swap/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/instruments/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/instruments/bonds/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/legacy/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/legacy/libormarketmodels/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/copulas/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/distributions/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/integrals/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/interpolations/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/matrixutilities/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/ode/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/optimization/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/randomnumbers/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/solvers1d/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/math/statistics/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/meshers/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/operators/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/schemes/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/solvers/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/stepconditions/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/finitedifferences/utilities/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/lattices/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/methods/montecarlo/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/equity/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/browniangenerators/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/callability/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/correlations/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/curvestates/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/driftcomputation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/evolvers/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/evolvers/volprocesses/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/models/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/pathwisegreeks/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/products/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/products/multistep/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/products/onestep/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/marketmodels/products/pathwise/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/shortrate/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/shortrate/calibrationhelpers/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/shortrate/onefactormodels/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/shortrate/twofactormodels/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/models/volatility/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/patterns/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/asian/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/barrier/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/basket/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/bond/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/capfloor/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/cliquet/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/credit/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/forward/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/inflation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/lookback/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/quanto/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/swap/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/swaption/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/pricingengines/vanilla/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/processes/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/quotes/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/credit/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/inflation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/capfloor/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/equityfx/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/inflation/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/optionlet/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/volatility/swaption/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/termstructures/yield/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/time/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/time/calendars/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/time/daycounters/all.hpp
+    ${PROJECT_BINARY_DIR}/ql/utilities/all.hpp)
 
 add_custom_command(OUTPUT ${QL_GENERATED_HEADERS}
     COMMAND ${CMAKE_COMMAND}
-        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
-        -DBINARY_DIR=${CMAKE_BINARY_DIR}
-        -P ${CMAKE_SOURCE_DIR}/cmake/GenerateHeaders.cmake
+        -DSOURCE_DIR=${PROJECT_SOURCE_DIR}
+        -DBINARY_DIR=${PROJECT_BINARY_DIR}
+        -P ${PROJECT_SOURCE_DIR}/cmake/GenerateHeaders.cmake
     COMMENT "Generating headers..."
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 
 add_library(ql_library
     ${QL_SOURCES}
@@ -2329,8 +2329,8 @@ target_compile_options(ql_library PRIVATE
     ${OpenMP_CXX_FLAGS})
 
 target_include_directories(ql_library PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
     ${Boost_INCLUDE_DIRS}
     ${OpenMP_CXX_INCLUDE_DIRS})
@@ -2359,27 +2359,27 @@ endforeach()
 # Install generated headers from the build directory
 foreach(file ${QL_GENERATED_HEADERS})
     get_filename_component(dir ${file} DIRECTORY)
-    file(RELATIVE_PATH path ${CMAKE_BINARY_DIR} ${dir})
+    file(RELATIVE_PATH path ${PROJECT_BINARY_DIR} ${dir})
     install(FILES ${file} DESTINATION "${QL_INSTALL_INCLUDEDIR}/${path}")
 endforeach()
 
 # Install config scripts for people using `find_package(QuantLib::QuantLib CONFIG ...)`
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
     VERSION ${QL_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 export(EXPORT QuantLibTargets
-    FILE "${CMAKE_BINARY_DIR}/cmake/QuantLibTargets.cmake"
+    FILE "${PROJECT_BINARY_DIR}/cmake/QuantLibTargets.cmake"
     NAMESPACE QuantLib::
 )
 configure_file("${PROJECT_SOURCE_DIR}/cmake/QuantLibConfig.cmake.in"
-    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibConfig.cmake"
     COPYONLY
 )
 configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/QuantLibConfig.cmake.in"
-    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibConfig.cmake"
     INSTALL_DESTINATION "${QL_INSTALL_CMAKEDIR}"
 )
 install(EXPORT QuantLibTargets
@@ -2387,7 +2387,7 @@ install(EXPORT QuantLibTargets
     NAMESPACE QuantLib::
     DESTINATION "${QL_INSTALL_CMAKEDIR}"
 )
-install(FILES "${CMAKE_BINARY_DIR}/cmake/QuantLibConfig.cmake"
-    "${CMAKE_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
+install(FILES "${PROJECT_BINARY_DIR}/cmake/QuantLibConfig.cmake"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibConfigVersion.cmake"
     DESTINATION "${QL_INSTALL_CMAKEDIR}"
 )

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -386,7 +386,7 @@ if (QL_BUILD_TEST_SUITE)
     if (QL_INSTALL_TEST_SUITE)
         install(TARGETS ql_test_suite RUNTIME DESTINATION ${QL_INSTALL_BINDIR})
     endif()
-    add_test(NAME test_suite COMMAND ql_test_suite --log_level=message)
+    add_test(NAME quantlib_test_suite COMMAND ql_test_suite --log_level=message)
 endif()
 
 IF (QL_BUILD_BENCHMARK)

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -365,8 +365,8 @@ set(QL_BENCHMARK_SOURCES
 if (QL_BUILD_TEST_SUITE)
     add_library(ql_unit_test_main STATIC main.cpp)
     target_include_directories(ql_unit_test_main PRIVATE
-        ${CMAKE_BINARY_DIR}
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_BINARY_DIR}
+        ${PROJECT_SOURCE_DIR}
         ${Boost_INCLUDE_DIRS})
     add_executable(ql_test_suite ${QL_TEST_SOURCES} ${QL_TEST_HEADERS})
     set_target_properties(ql_test_suite PROPERTIES OUTPUT_NAME "quantlib-test-suite")


### PR DESCRIPTION
In ORE we build QuantLib as a cmake subproject. This is no longer possible after the overhaul of the cmake build because of wrong path references. As far as I can see this can be fixed without affecting the "normal" build by replacing

```
CMAKE_SOURCE_DIR -> PROJECT_SOURCE_DIR
CMAKE_BINARY_DIR -> PROJECT_BINARY_DIR 
```

In addition I gave the test suite a more specific name for a similar reason, i.e. to make it recognisable when running under `ctest` together with a bunch of other tests.

