### PR TITLE
allow to build with -Wsuggest-override (clang, gcc)

### DIFF
--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -25,7 +25,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#if (__clang_major__ > 11)
+#if (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
 #endif

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -31,7 +31,6 @@
 #endif
 #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -22,10 +22,8 @@
 #include <ql/currencies/exchangeratemanager.hpp>
 #include <ql/math/comparison.hpp>
 
-#if defined(__clang__)
+#if defined(__clang__) && (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#if (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
 #endif
@@ -36,7 +34,7 @@
 
 #include <boost/format.hpp>
 
-#if defined(__clang__)
+#if defined(__clang__) && (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
 #pragma clang diagnostic pop
 #endif
 #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -26,7 +26,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
-#endif
 #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -25,16 +25,14 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#if (__clang_major__ > 10)
+#if (__clang_major__ > 11)
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
 #endif
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
-#if (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic ignored "-Wsuggest-override"
-#endif
 #endif
 
 #include <boost/format.hpp>
@@ -42,7 +40,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic pop
 #endif
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -21,7 +21,22 @@
 #include <ql/money.hpp>
 #include <ql/currencies/exchangeratemanager.hpp>
 #include <ql/math/comparison.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsuggest-override"
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 #include <boost/format.hpp>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace QuantLib {
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -24,17 +24,25 @@
 
 #if defined(__clang__)
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#if (__clang_major__ > 10)
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
+#endif
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#if (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
+#endif
+
 #include <boost/format.hpp>
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -26,7 +26,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsuggest-override"
 #endif
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
@@ -34,7 +34,7 @@
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
-#if defined(__GNUC__)
+#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
 #pragma GCC diagnostic pop
 #endif
 

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -202,12 +202,16 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+        #if (__clang_major__ > 10)
         #pragma clang diagnostic ignored "-Wsuggest-override"
         #endif
-        #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
+        #endif
+        #if defined(__GNUC__)
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+        #if (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
         #pragma GCC diagnostic ignored "-Wsuggest-override"
+        #endif
         #endif
         Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override)
                                          // (sometimes this method is not virtual,
@@ -215,7 +219,7 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic pop
         #endif
-        #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
+        #if defined(__GNUC__)
         #pragma GCC diagnostic pop
         #endif
         // data members

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -208,7 +208,6 @@ namespace QuantLib {
         #endif
         #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
         #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
         #pragma GCC diagnostic ignored "-Wsuggest-override"
         #endif
         Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override)

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -204,7 +204,7 @@ namespace QuantLib {
         #pragma clang diagnostic ignored "-Winconsistent-missing-override"
         #pragma clang diagnostic ignored "-Wsuggest-override"
         #endif
-        #if defined(__GNUC__)
+        #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
         #pragma GCC diagnostic ignored "-Wsuggest-override"
@@ -215,7 +215,7 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic pop
         #endif
-        #if defined(__GNUC__)
+        #if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
         #pragma GCC diagnostic pop
         #endif
         // data members

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -202,16 +202,14 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-        #if (__clang_major__ > 10)
+        #if (__clang_major__ > 11)
         #pragma clang diagnostic ignored "-Wsuggest-override"
         #endif
         #endif
-        #if defined(__GNUC__)
+        #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
-        #if (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
         #pragma GCC diagnostic ignored "-Wsuggest-override"
-        #endif
         #endif
         Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override)
                                          // (sometimes this method is not virtual,
@@ -219,7 +217,7 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic pop
         #endif
-        #if defined(__GNUC__)
+        #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
         #pragma GCC diagnostic pop
         #endif
         // data members

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -202,7 +202,7 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-        #if (__clang_major__ > 11)
+        #if (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
         #pragma clang diagnostic ignored "-Wsuggest-override"
         #endif
         #endif

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -202,12 +202,21 @@ namespace QuantLib {
         #if defined(__clang__)
         #pragma clang diagnostic push
         #pragma clang diagnostic ignored "-Winconsistent-missing-override"
+        #pragma clang diagnostic ignored "-Wsuggest-override"
+        #endif
+        #if defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+        #pragma GCC diagnostic ignored "-Wsuggest-override"
         #endif
         Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override)
                                          // (sometimes this method is not virtual,
                                          //  depending on the base class)
         #if defined(__clang__)
         #pragma clang diagnostic pop
+        #endif
+        #if defined(__GNUC__)
+        #pragma GCC diagnostic pop
         #endif
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;


### PR DESCRIPTION
we are using `-Werror=suggest-override` which fails with current QuantLib because

- boost/format.hpp seems to be incorrectly implemented (this is with boost 1.76)
- we need to suppress this warning in piecewisedefaultcurve.hpp for clang and gcc (already done for "inconsistent override" and clang)