### PR TITLE
Add deprecated annotation to Disposable

### DIFF
--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -147,6 +147,7 @@ jobs:
             tag: rolling
             cc: gcc
             cxx: g++
+            cxxflags: "-Wno-deprecated-declarations"
             configureflags: --enable-disposable
           - name: "Thread-safe observer enabled"
             shortname: threadsafe

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -153,6 +153,7 @@ jobs:
             tag: rolling
             cc: gcc
             cxx: g++
+            cxxflags: "-Wno-deprecated-declarations"
             configureflags: --enable-disposable
             tests: true
           - name: "Thread-safe observer enabled"

--- a/ql/utilities/disposable.hpp
+++ b/ql/utilities/disposable.hpp
@@ -71,12 +71,18 @@ namespace QuantLib {
             return temp;
         }
         \endcode
+
+        \deprecated This class is no longer required after C++11.
+                    Deprecated in version 1.26.
     */
     template <class T>
     class Disposable : public T {
       public:
+        QL_DEPRECATED
         Disposable(T& t);
+        QL_DEPRECATED
         Disposable(const Disposable<T>& t);
+        QL_DEPRECATED
         Disposable<T>& operator=(const Disposable<T>& t);
     };
 


### PR DESCRIPTION
Adding deprecated annotation to Disposable so that it can be removed in a future release.