### PR TITLE
Add some null-pointer checks

### DIFF
--- a/ql/cashflows/cmscoupon.cpp
+++ b/ql/cashflows/cmscoupon.cpp
@@ -56,7 +56,9 @@ namespace QuantLib {
 
     CmsLeg::CmsLeg(Schedule schedule, ext::shared_ptr<SwapIndex> swapIndex)
     : schedule_(std::move(schedule)), swapIndex_(std::move(swapIndex)),
-      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false) {}
+      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false) {
+        QL_REQUIRE(swapIndex_, "no index provided");
+    }
 
     CmsLeg& CmsLeg::withNotionals(Real notional) {
         notionals_ = std::vector<Real>(1, notional);

--- a/ql/cashflows/floatingratecoupon.cpp
+++ b/ql/cashflows/floatingratecoupon.cpp
@@ -45,8 +45,9 @@ namespace QuantLib {
                                            const Date& exCouponDate)
     : Coupon(paymentDate, nominal, startDate, endDate, refPeriodStart, refPeriodEnd, exCouponDate),
       index_(index), dayCounter_(std::move(dayCounter)),
-      fixingDays_(fixingDays == Null<Natural>() ? index->fixingDays() : fixingDays),
+      fixingDays_(fixingDays == Null<Natural>() ? (index ? index->fixingDays() : 0) : fixingDays),
       gearing_(gearing), spread_(spread), isInArrears_(isInArrears) {
+        QL_REQUIRE(index_, "no index provided");
         QL_REQUIRE(gearing_!=0, "Null gearing not allowed");
 
         if (dayCounter_.empty())

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -165,7 +165,9 @@ namespace QuantLib {
     : schedule_(std::move(schedule)), index_(std::move(index)), paymentAdjustment_(Following),
       paymentLag_(0), paymentCalendar_(Calendar()), inArrears_(false), zeroPayments_(false),
       exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), exCouponAdjustment_(Unadjusted),
-      exCouponEndOfMonth_(false) {}
+      exCouponEndOfMonth_(false) {
+        QL_REQUIRE(index_, "no index provided");
+    }
 
     IborLeg& IborLeg::withNotionals(Real notional) {
         notionals_ = std::vector<Real>(1,notional);

--- a/ql/cashflows/indexedcashflow.cpp
+++ b/ql/cashflows/indexedcashflow.cpp
@@ -19,17 +19,17 @@
 
 #include <ql/cashflows/indexedcashflow.hpp>
 #include <ql/index.hpp>
+#include <utility>
 
 namespace QuantLib {
 
     IndexedCashFlow::IndexedCashFlow(Real notional,
-                                     const ext::shared_ptr<Index> &index,
+                                     ext::shared_ptr<Index> index,
                                      const Date& baseDate,
                                      const Date& fixingDate,
                                      const Date& paymentDate,
                                      bool growthOnly)
-    : notional_(notional), index_(index),
-      baseDate_(baseDate), fixingDate_(fixingDate),
+    : notional_(notional), index_(std::move(index)), baseDate_(baseDate), fixingDate_(fixingDate),
       paymentDate_(paymentDate), growthOnly_(growthOnly) {
         QL_REQUIRE(index_, "no index provided");
         registerWith(index_);

--- a/ql/cashflows/indexedcashflow.cpp
+++ b/ql/cashflows/indexedcashflow.cpp
@@ -22,6 +22,19 @@
 
 namespace QuantLib {
 
+    IndexedCashFlow::IndexedCashFlow(Real notional,
+                                     const ext::shared_ptr<Index> &index,
+                                     const Date& baseDate,
+                                     const Date& fixingDate,
+                                     const Date& paymentDate,
+                                     bool growthOnly)
+    : notional_(notional), index_(index),
+      baseDate_(baseDate), fixingDate_(fixingDate),
+      paymentDate_(paymentDate), growthOnly_(growthOnly) {
+        QL_REQUIRE(index_, "no index provided");
+        registerWith(index_);
+    }
+
     Real IndexedCashFlow::amount() const {
         Real I0 = index_->fixing(baseDate_);
         Real I1 = index_->fixing(fixingDate_);

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -49,12 +49,7 @@ namespace QuantLib {
                         const Date& baseDate,
                         const Date& fixingDate,
                         const Date& paymentDate,
-                        bool growthOnly = false)
-        : notional_(notional), index_(index),
-          baseDate_(baseDate), fixingDate_(fixingDate),
-          paymentDate_(paymentDate), growthOnly_(growthOnly) {
-            registerWith(index);
-        }
+                        bool growthOnly = false);
         //! \name Event interface
         //@{
         Date date() const override { return paymentDate_; }

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
                             public Observer {
       public:
         IndexedCashFlow(Real notional,
-                        const ext::shared_ptr<Index> &index,
+                        ext::shared_ptr<Index> index,
                         const Date& baseDate,
                         const Date& fixingDate,
                         const Date& paymentDate,

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -149,7 +149,8 @@ namespace QuantLib {
                     bool telescopicValueDates, 
                     RateAveraging::Type averagingMethod)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
-                         overnightIndex->fixingDays(), overnightIndex,
+                         overnightIndex ? overnightIndex->fixingDays() : 0,
+                         overnightIndex,
                          gearing, spread,
                          refPeriodStart, refPeriodEnd,
                          dayCounter, false) {
@@ -271,7 +272,9 @@ namespace QuantLib {
     OvernightLeg::OvernightLeg(const Schedule& schedule, ext::shared_ptr<OvernightIndex> i)
     : schedule_(schedule), overnightIndex_(std::move(i)), paymentCalendar_(schedule.calendar()),
       paymentAdjustment_(Following), paymentLag_(0), telescopicValueDates_(false),
-      averagingMethod_(RateAveraging::Compound) {}
+      averagingMethod_(RateAveraging::Compound) {
+        QL_REQUIRE(overnightIndex_, "no index provided");
+    }
 
     OvernightLeg& OvernightLeg::withNotionals(Real notional) {
         notionals_ = vector<Real>(1, notional);

--- a/ql/cashflows/subperiodcoupon.cpp
+++ b/ql/cashflows/subperiodcoupon.cpp
@@ -159,7 +159,9 @@ namespace QuantLib {
     : schedule_(schedule), index_(std::move(i)), paymentCalendar_(schedule.calendar()),
       paymentAdjustment_(Following), paymentLag_(0), averagingMethod_(RateAveraging::Compound), 
       exCouponPeriod_(Period()), exCouponCalendar_(Calendar()), 
-      exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {}
+      exCouponAdjustment_(Unadjusted), exCouponEndOfMonth_(false) {
+        QL_REQUIRE(index_, "no index provided");
+    }
 
     SubPeriodsLeg& SubPeriodsLeg::withNotionals(Real notional) {
         notionals_ = std::vector<Real>(1, notional);

--- a/ql/experimental/coupons/cmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.cpp
@@ -46,7 +46,9 @@ namespace QuantLib {
 
     CmsSpreadLeg::CmsSpreadLeg(Schedule schedule, ext::shared_ptr<SwapSpreadIndex> index)
     : schedule_(std::move(schedule)), swapSpreadIndex_(std::move(index)),
-      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false) {}
+      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false) {
+        QL_REQUIRE(swapSpreadIndex_, "no index provided");
+    }
 
     CmsSpreadLeg &CmsSpreadLeg::withNotionals(Real notional) {
         notionals_ = std::vector<Real>(1, notional);

--- a/ql/experimental/processes/extouwithjumpsprocess.cpp
+++ b/ql/experimental/processes/extouwithjumpsprocess.cpp
@@ -34,7 +34,9 @@ namespace QuantLib {
         Real jumpIntensity,
         Real eta)
     : Y0_(Y0), beta_(beta), jumpIntensity_(jumpIntensity), eta_(eta),
-      ouProcess_(std::move(process)) {}
+      ouProcess_(std::move(process)) {
+        QL_REQUIRE(ouProcess_, "null Ornstein/Uhlenbeck process");
+    }
 
     Size ExtOUWithJumpsProcess::size() const {
         return 2;

--- a/ql/experimental/processes/klugeextouprocess.cpp
+++ b/ql/experimental/processes/klugeextouprocess.cpp
@@ -30,7 +30,10 @@ namespace QuantLib {
         ext::shared_ptr<ExtOUWithJumpsProcess> klugeProcess,
         ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess)
     : rho_(rho), sqrtMRho_(std::sqrt(1 - rho * rho)), klugeProcess_(std::move(klugeProcess)),
-      ouProcess_(std::move(ouProcess)) {}
+      ouProcess_(std::move(ouProcess)) {
+        QL_REQUIRE(klugeProcess_, "null Kluge process");
+        QL_REQUIRE(ouProcess_, "null Ornstein-Uhlenbeck process");
+    }
 
     Size KlugeExtOUProcess::size() const {
         return klugeProcess_->size() + 1;

--- a/ql/instruments/compositeinstrument.cpp
+++ b/ql/instruments/compositeinstrument.cpp
@@ -21,8 +21,8 @@
 
 namespace QuantLib {
 
-    void CompositeInstrument::add(
-           const ext::shared_ptr<Instrument>& instrument, Real multiplier) {
+    void CompositeInstrument::add(const ext::shared_ptr<Instrument>& instrument, Real multiplier) {
+        QL_REQUIRE(instrument, "null instrument provided");
         components_.emplace_back(instrument, multiplier);
         registerWith(instrument);
         update();

--- a/ql/pricingengines/swaption/fdg2swaptionengine.cpp
+++ b/ql/pricingengines/swaption/fdg2swaptionengine.cpp
@@ -46,6 +46,7 @@ namespace QuantLib {
     }
 
     void FdG2SwaptionEngine::calculate() const {
+        QL_REQUIRE(!model_.empty(), "no model specified");
 
         // 1. Term structure
         const Handle<YieldTermStructure> ts = model_->termStructure();

--- a/ql/pricingengines/swaption/g2swaptionengine.hpp
+++ b/ql/pricingengines/swaption/g2swaptionengine.hpp
@@ -50,13 +50,13 @@ namespace QuantLib {
         void calculate() const override {
             QL_REQUIRE(arguments_.settlementType == Settlement::Physical,
                        "cash-settled swaptions not priced with G2 engine");
+            QL_REQUIRE(!model_.empty(), "no model specified");
 
             // adjust the fixed rate of the swap for the spread on the
             // floating leg (which is not taken into account by the
             // model)
             VanillaSwap swap = *arguments_.swap;
-            swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                  new DiscountingSwapEngine(model_->termStructure(), false)));
+            swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(model_->termStructure(), false));
             Spread correction = swap.spread() *
                 std::fabs(swap.floatingLegBPS() / swap.fixedLegBPS());
             Rate fixedRate = swap.fixedRate() - correction;

--- a/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -64,7 +64,9 @@ namespace QuantLib {
                    "cannot use the Jamshidian decomposition "
                    "on exotic swaptions");
 
-        QL_REQUIRE(arguments_.swap->spread() == 0.0, "non zero spread (" << arguments_.swap->spread() << ") not allowed"); // PC
+        QL_REQUIRE(arguments_.swap->spread() == 0.0, "non zero spread (" << arguments_.swap->spread() << ") not allowed");
+
+        QL_REQUIRE(!model_.empty(), "no model specified");
 
         Date referenceDate;
         DayCounter dayCounter;

--- a/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
+++ b/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
@@ -68,6 +68,8 @@ namespace QuantLib {
         const ext::shared_ptr<HullWhite>& model)
     : GenericModelEngine<HullWhite, VanillaOption::arguments, VanillaOption::results>(model),
       rho_(equityShortRateCorrelation), process_(std::move(process)) {
+        QL_REQUIRE(process_, "no Black-Scholes process specified");
+        QL_REQUIRE(!model_.empty(), "no Hull-White model specified");
         registerWith(process_);
     }
 

--- a/ql/processes/stochasticprocessarray.cpp
+++ b/ql/processes/stochasticprocessarray.cpp
@@ -34,8 +34,10 @@ namespace QuantLib {
         QL_REQUIRE(correlation.rows() == processes.size(),
                    "mismatch between number of processes "
                    "and size of correlation matrix");
-        for (auto& processe : processes_)
-            registerWith(processe);
+        for (auto& process : processes_) {
+            QL_REQUIRE(process, "null 1-D stochastic process");
+            registerWith(process);
+        }
     }
 
     Size StochasticProcessArray::size() const {


### PR DESCRIPTION
This allows to return error messages a bit more useful than "assertion failed: px != 0".  When using `std::shared_ptr`, it avoids null-pointer access.

Many more are needed.