### PR TITLE
Make minimum language version C++14

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ Checks: >
           -misc-non-private-member-variables-in-classes,
           -misc-unused-parameters,
         modernize-*,
+          -modernize-avoid-bind,
           -modernize-avoid-c-arrays,
           -modernize-make-shared,
           -modernize-use-trailing-return-type,

--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -92,12 +92,6 @@ jobs:
             tag: jammy
             cc: clang
             cxx: clang++
-          - name: "C++11 mode"
-            shortname: c++11
-            tag: rolling
-            cc: gcc
-            cxx: g++
-            cxxflags: "-std=c++11"
           - name: "C++14 mode"
             shortname: c++14
             tag: rolling
@@ -134,7 +128,7 @@ jobs:
             cc: gcc
             cxx: g++
             configureflags: --enable-indexed-coupons
-          - name: "C++11 classes enabled"
+          - name: "Standard Library classes enabled"
             shortname: stdclasses
             tag: rolling
             cc: gcc

--- a/.github/workflows/linux-nondefault.yml
+++ b/.github/workflows/linux-nondefault.yml
@@ -87,12 +87,6 @@ jobs:
             tag: jammy
             cc: clang
             cxx: clang++
-          - name: "C++11 mode"
-            shortname: c++11
-            tag: rolling
-            cc: gcc
-            cxx: g++
-            cxxflags: "-std=c++11"
           - name: "C++14 mode"
             shortname: c++14
             tag: rolling
@@ -117,7 +111,7 @@ jobs:
             cc: gcc
             cxx: g++
             configureflags: --enable-unity-build
-          - name: "C++11 classes enabled"
+          - name: "Standard Library classes enabled"
             shortname: stdclasses
             tag: rolling
             cc: gcc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,11 +7,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "gcc 4.8 (Boost 1.48)"
-            shortname: gcc4
-            tag: trusty
-            cc: gcc
-            cxx: g++
           - name: "gcc 5.4 (Boost 1.66)"
             shortname: gcc5
             tag: xenial
@@ -94,12 +89,6 @@ jobs:
             cc: clang
             cxx: clang++
             tests: true
-          - name: "C++11 mode"
-            shortname: c++11
-            tag: rolling
-            cc: gcc
-            cxx: g++
-            cxxflags: "-std=c++11"
           - name: "C++14 mode"
             shortname: c++14
             tag: rolling
@@ -138,7 +127,7 @@ jobs:
             cxx: g++
             configureflags: --enable-indexed-coupons
             tests: true
-          - name: "C++11 classes enabled"
+          - name: "Standard Library classes enabled"
             shortname: stdclasses
             tag: rolling
             cc: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,16 +99,16 @@ if (NOT DEFINED Boost_USE_STATIC_RUNTIME)
     set(Boost_USE_STATIC_RUNTIME ${MSVC})
 endif()
 
-# Require C++11 or higher
+# Require C++14 or higher
 if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-elseif(CMAKE_CXX_STANDARD LESS 11)
-    message(FATAL_ERROR "Please specify CMAKE_CXX_STANDARD of 11 or higher")
+    set(CMAKE_CXX_STANDARD 14)
+elseif(CMAKE_CXX_STANDARD LESS 14)
+    message(FATAL_ERROR "Please specify CMAKE_CXX_STANDARD of 14 or higher")
 endif()
 if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
-# Avoid use of compiler language extensions, i.e. -std=c++11 not -std=gnu++11
+# Avoid use of compiler language extensions, i.e. -std=c++14 not -std=gnu++14
 if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
     set(CMAKE_CXX_EXTENSIONS FALSE)
 endif()

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,30 +1,24 @@
 
-# QL_CHECK_CPP11
+# QL_CHECK_CPP14
 # --------------------
-# Check whether C++11 features are supported by default.
-# If not (e.g., with Clang on Mac OS) add -std=c++11
-AC_DEFUN([QL_CHECK_CPP11],
-[AC_MSG_CHECKING([for C++11 support])
+# Check whether C++14 features are supported by default.
+# If not (e.g., with Clang on Mac OS) add -std=c++14
+AC_DEFUN([QL_CHECK_CPP14],
+[AC_MSG_CHECKING([for C++14 support])
  AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
-        [[@%:@include <initializer_list>
-          struct S {
-            int i = 3;
-            double x = 3.5;
-          };
-
+        [[@%:@include <memory>
           class C {
             public:
               C(int) noexcept;
-              C(std::initializer_list<int>);
-              S f() { return { 2, 1.5 }; }
+              auto f() { return std::make_unique<C>(1); }
           };
           ]],
         [[]])],
     [AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no: adding -std=c++11 to CXXFLAGS])
-     AC_SUBST([CPP11_CXXFLAGS],["-std=c++11"])
-     AC_SUBST([CXXFLAGS],["${CXXFLAGS} -std=c++11"])
+    [AC_MSG_RESULT([no: adding -std=c++14 to CXXFLAGS])
+     AC_SUBST([CPP14_CXXFLAGS],["-std=c++14"])
+     AC_SUBST([CXXFLAGS],["${CXXFLAGS} -std=c++14"])
     ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -74,8 +74,8 @@ if test "$ql_openmp" = "yes" ; then
    AC_SUBST([CXXFLAGS],["${CXXFLAGS} ${OPENMP_CXXFLAGS}"])
 fi
 
-# Check for C++11 support
-QL_CHECK_CPP11
+# Check for C++14 support
+QL_CHECK_CPP14
 
 # Check for other compiler flags
 QL_CHECK_SYSTEM_HEADER_PREFIX

--- a/quantlib-config.in
+++ b/quantlib-config.in
@@ -39,7 +39,7 @@ while test $# -gt 0; do
       echo @PACKAGE_VERSION@
       ;;
     --cflags)
-      echo -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP11_CXXFLAGS@
+      echo -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP14_CXXFLAGS@
       ;;
     --libs)
       echo -L@libdir@ @BOOST_LIB@ -lQuantLib @OPENMP_CXXFLAGS@ @BOOST_THREAD_LIB@

--- a/quantlib.pc.in
+++ b/quantlib.pc.in
@@ -6,5 +6,5 @@ includedir=@includedir@
 Name: QuantLib
 Description: The free/open-source library for quantitative finance.
 Version: @PACKAGE_VERSION@
-Cflags: -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP11_CXXFLAGS@
+Cflags: -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP14_CXXFLAGS@
 Libs: -L@libdir@ @BOOST_LIB@ -lQuantLib @OPENMP_CXXFLAGS@ @BOOST_THREAD_LIB@


### PR DESCRIPTION
Closes #1306 

- Removed C++11 builds
- Removed GCC 4.8 that predates C++14
- Added `-modernize-avoid-bind` to .clang-tidy to prevent compilation error after automatic fix was applied (this can be removed from .clang-tidy once the code in question is refactored in a more C++14 friendly way)

Note that I did not yet update the minimum Visual Studio version from 2013 to 2015. I can do that as part of this pull request, or as a separate one.

I may have missed a few places that are still implicitly relying on C++11, so a full review would be most welcome.