### PR TITLE
Normalize equal periods to the same value.

### DIFF
--- a/ql/time/period.cpp
+++ b/ql/time/period.cpp
@@ -106,21 +106,29 @@ namespace QuantLib {
     }
 
     void Period::normalize() {
-        if (length_!=0)
+        if (length_ == 0) {
+            units_ = Days;
+        } else {
             switch (units_) {
               case Months:
-                  if ((length_ % 12) == 0) {
-                      length_ /= 12;
-                      units_ = Years;
+                if ((length_ % 12) == 0) {
+                    length_ /= 12;
+                    units_ = Years;
                 }
                 break;
               case Days:
+                if ((length_ % 7) == 0) {
+                    length_ /= 7;
+                    units_ = Weeks;
+                }
+                break;
               case Weeks:
               case Years:
                 break;
               default:
                 QL_FAIL("unknown time unit (" << Integer(units_) << ")");
             }
+        }
     }
 
     Period& Period::operator+=(const Period& p) {
@@ -205,12 +213,16 @@ namespace QuantLib {
             }
         }
 
-        //this->normalize();
         return *this;
     }
 
     Period& Period::operator-=(const Period& p) {
         return operator+=(-p);
+    }
+
+    Period& Period::operator*=(Integer n) {
+        length_ *= n;
+        return *this;
     }
 
     Period& Period::operator/=(Integer n) {
@@ -240,10 +252,6 @@ namespace QuantLib {
                        *this << " cannot be divided by " << n);
             length_ = length/n;
             units_ = units;
-            // if normalization were possible, we wouldn't be
-            // here---the "if" branch would have been executed
-            // instead.
-            // result.normalize();
         }
         return *this;
     }

--- a/ql/time/period.hpp
+++ b/ql/time/period.hpp
@@ -52,8 +52,10 @@ namespace QuantLib {
         Frequency frequency() const;
         Period& operator+=(const Period&);
         Period& operator-=(const Period&);
+        Period& operator*=(Integer);
         Period& operator/=(Integer);
         void normalize();
+        Period normalized() const;
       private:
         Integer length_ = 0;
         TimeUnit units_ = Days;
@@ -134,6 +136,12 @@ namespace QuantLib {
     }
 
     // inline definitions
+
+    inline Period Period::normalized() const {
+        Period p = *this;
+        p.normalize();
+        return p;
+    }
 
     template <typename T>
     inline Period operator*(T n, TimeUnit units) {

--- a/test-suite/period.cpp
+++ b/test-suite/period.cpp
@@ -120,10 +120,76 @@ void PeriodTest::testWeeksDaysAlgebra() {
                     " instead of " << Days);
 }
 
+void PeriodTest::testNormalization() {
+
+    BOOST_TEST_MESSAGE("Testing period normalization...");
+
+    Period test_values[] = {
+        0 * Days,
+        0 * Weeks,
+        0 * Months,
+        0 * Years,
+        3 * Days,
+        7 * Days,
+        14 * Days,
+        30 * Days,
+        60 * Days,
+        365 * Days,
+        1 * Weeks,
+        2 * Weeks,
+        4 * Weeks,
+        8 * Weeks,
+        52 * Weeks,
+        1 * Months,
+        2 * Months,
+        6 * Months,
+        12 * Months,
+        18 * Months,
+        24 * Months,
+        1 * Years,
+        2 * Years
+    };
+
+    for (Period p1 : test_values) {
+        auto n1 = p1.normalized();
+        if (n1 != p1) {
+            BOOST_ERROR("Normalizing " << p1 << " yields " << n1 << ", which compares different");
+        }
+
+        for (Period p2 : test_values) {
+            auto n2 = p2.normalized();
+            boost::optional<bool> comparison;
+            try {
+                comparison = (p1 == p2);
+            } catch (Error&) {
+                ;
+            }
+
+            if (comparison && *comparison) {
+                // periods which compare equal must normalize to exactly the same period
+                if (n1.units() != n2.units() || n1.length() != n2.length()) {
+                    BOOST_ERROR(p1 << " and " << p2 << " compare equal, but normalize to "
+                                << n1 << " and " << n2 << " respectively");
+                }
+            }
+
+            if (n1.units() == n2.units() && n1.length() == n2.length()) {
+                // periods normalizing to exactly the same period must compare equal
+                if (p1 != p2) {
+                    BOOST_ERROR(p1 << " and " << p2 << " compare different, but normalize to "
+                                << n1 << " and " << n2 << " respectively");
+                }
+            }
+        }
+    }
+
+}
+
 test_suite* PeriodTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Period tests");
     suite->add(QUANTLIB_TEST_CASE(&PeriodTest::testYearsMonthsAlgebra));
     suite->add(QUANTLIB_TEST_CASE(&PeriodTest::testWeeksDaysAlgebra));
+    suite->add(QUANTLIB_TEST_CASE(&PeriodTest::testNormalization));
     return suite;
 }
 

--- a/test-suite/period.hpp
+++ b/test-suite/period.hpp
@@ -29,6 +29,7 @@ class PeriodTest {
   public:
     static void testYearsMonthsAlgebra();
     static void testWeeksDaysAlgebra();
+    static void testNormalization();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
This is needed so that periods comparing as equal can be given (through the normalized string representation) the same hash when used as dictionary keys in languages such as Python or C#.