### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,8 @@
 name: CMake build
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   cmake-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,15 @@ name: "CodeQL"
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: CodeQL analysis
     runs-on: ubuntu-latest
 

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -3,8 +3,14 @@ on:
   push:
     branches:
       - '**'
+permissions:
+  contents: read
+
 jobs:
   copyrights:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,7 +1,13 @@
 name: Coverage report
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   coverage:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,5 +1,8 @@
 name: Check doc generation
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: macos-latest

--- a/.github/workflows/filelists.yml
+++ b/.github/workflows/filelists.yml
@@ -1,5 +1,8 @@
 name: Check CMake file list and VC++ projects
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   filelists:
     runs-on: ubuntu-latest

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,5 +1,8 @@
 name: Compile single headers
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   headers:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -1,5 +1,8 @@
 name: Linux build with full test matrix
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux-nondefault.yml
+++ b/.github/workflows/linux-nondefault.yml
@@ -1,5 +1,8 @@
 name: Linux build with non-default configuration
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,8 @@
 name: Linux build
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-nondefault.yml
+++ b/.github/workflows/macos-nondefault.yml
@@ -1,5 +1,8 @@
 name: Mac OS build with non-default configuration
 on: workflow_dispatch
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,8 @@
 name: Mac OS build
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/msvc-analysis.yml
+++ b/.github/workflows/msvc-analysis.yml
@@ -6,8 +6,14 @@ env:
   # Path to the CMake build directory.
   build: '${{ github.workspace }}/build'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: Analyze
     runs-on: windows-2022
 

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,5 +1,8 @@
 name: Linux build with address sanitizer enabled
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,14 @@ name: Close stale issues and PR
 on:
   schedule:
     - cron: '30 1 * * *'
+permissions:
+  contents: read
+
 jobs:
   staleness-check:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/test-times.yml
+++ b/.github/workflows/test-times.yml
@@ -1,5 +1,8 @@
 name: Check test times
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   check-test-times:
     runs-on: ubuntu-latest

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -2,8 +2,14 @@ name: Apply clang-tidy fixes
 on:
   schedule:
     - cron: '0 0 * * 0'
+permissions:
+  contents: read
+
 jobs:
   check:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
