### PR TITLE
Deprecate function objects

### DIFF
--- a/Examples/MarketModels/MarketModels.cpp
+++ b/Examples/MarketModels/MarketModels.cpp
@@ -61,7 +61,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/math/statistics/convergencestatistics.hpp>
 #include <ql/termstructures/volatility/abcd.hpp>
 #include <ql/termstructures/volatility/abcdcalibration.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/optimization/simplex.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <sstream>

--- a/ql/discretizedasset.hpp
+++ b/ql/discretizedasset.hpp
@@ -27,7 +27,6 @@
 
 #include <ql/exercise.hpp>
 #include <ql/math/comparison.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/numericalmethod.hpp>
 #include <utility>
 
@@ -231,7 +230,7 @@ namespace QuantLib {
         std::vector<Time> times = underlying_->mandatoryTimes();
         // discard negative times...
         auto i = std::find_if(exerciseTimes_.begin(), exerciseTimes_.end(),
-                              greater_or_equal_to<Time>(0.0));
+                              [](Time t){ return t >= 0.0; });
         // and add the positive ones
         times.insert(times.end(), i, exerciseTimes_.end());
         return times;

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -23,7 +23,6 @@
 #include <ql/experimental/credit/basket.hpp>
 #include <ql/experimental/credit/constantlosslatentmodel.hpp>
 #include <ql/experimental/credit/defaultlossmodel.hpp>
-#include <ql/functional.hpp>
 #include <ql/handle.hpp>
 #include <algorithm>
 #include <numeric>
@@ -192,7 +191,7 @@ namespace QuantLib {
         std::vector<Probability> oneMinusDefProb;//: 1.-condDefProb[j]
         std::transform(condDefProb.begin(), condDefProb.end(), 
                        std::back_inserter(oneMinusDefProb), 
-                       subtract_from<Real>(1.0));
+                       [](Real x){ return 1.0-x; });
 
         //breaks condDefProb and lgdsLeft to spare memory
         std::transform(condDefProb.begin(), condDefProb.end(), 

--- a/ql/experimental/credit/distribution.cpp
+++ b/ql/experimental/credit/distribution.cpp
@@ -19,11 +19,10 @@
 
 /*! \file distribution.cpp
     \brief Discretized probability density and cumulative probability
- */
+*/
 
 #include <ql/experimental/credit/distribution.hpp>
 #include <ql/math/comparison.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/errors.hpp>
 #include <algorithm>
 #include <functional>
@@ -255,7 +254,7 @@ namespace QuantLib {
         }
 
         // remove losses over detachment point:
-        auto detachPosit = std::find_if(x_.begin(), x_.end(), greater_than<Real>(detachmentPoint));
+        auto detachPosit = std::find_if(x_.begin(), x_.end(), [=](Real x){ return x > detachmentPoint; });
         if(detachPosit != x_.end())
             x_.erase(detachPosit + 1, x_.end());
 

--- a/ql/experimental/credit/homogeneouspooldef.hpp
+++ b/ql/experimental/credit/homogeneouspooldef.hpp
@@ -25,7 +25,6 @@
 #include <ql/experimental/credit/basket.hpp>
 #include <ql/experimental/credit/constantlosslatentmodel.hpp>
 #include <ql/experimental/credit/defaultlossmodel.hpp>
-#include <ql/math/functional.hpp>
 
 // Intended to replace HomogeneousPoolCDOEngine in syntheticcdoengines.hpp
 
@@ -130,7 +129,7 @@ namespace QuantLib {
         std::vector<Real> recoveries = copula_->recoveries();
         std::transform(recoveries.begin(), recoveries.end(), 
                        std::back_inserter(lgd),
-                       subtract_from<Real>(1.0));
+                       [](Real x){ return 1.0-x; });
         std::transform(lgd.begin(), lgd.end(), notionals_.begin(), 
             lgd.begin(), std::multiplies<Real>());
         std::vector<Real> prob = basket_->remainingProbabilities(d);

--- a/ql/experimental/credit/inhomogeneouspooldef.hpp
+++ b/ql/experimental/credit/inhomogeneouspooldef.hpp
@@ -25,7 +25,6 @@
 #include <ql/experimental/credit/basket.hpp>
 #include <ql/experimental/credit/constantlosslatentmodel.hpp>
 #include <ql/experimental/credit/defaultlossmodel.hpp>
-#include <ql/math/functional.hpp>
 
 // Intended to replace InhomogeneousPoolCDOEngine in syntheticcdoengines.hpp
 
@@ -138,7 +137,7 @@ namespace QuantLib {
         std::vector<Real> recoveries = copula_->recoveries();
         std::transform(recoveries.begin(), recoveries.end(), 
                        std::back_inserter(lgd),
-                       subtract_from<Real>(1.0));
+                       [](Real x){ return 1.0-x; });
         std::transform(lgd.begin(), lgd.end(), notionals_.begin(), 
                        lgd.begin(), std::multiplies<Real>());
         std::vector<Real> prob = basket_->remainingProbabilities(d);

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -28,7 +28,6 @@
 #include <ql/experimental/math/latentmodel.hpp>
 #include <ql/experimental/math/tcopulapolicy.hpp>
 #include <ql/math/beta.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/randomnumbers/mt19937uniformrng.hpp>
 #include <ql/math/randomnumbers/sobolrsg.hpp>
 #include <ql/math/solvers1d/brent.hpp>
@@ -288,7 +287,7 @@ namespace QuantLib {
         }
         std::transform(hitsByDate.begin(), hitsByDate.end(),
                        hitsByDate.begin(),
-                       divide_by<Real>(Real(nSims_)));
+                       [this](Real x){ return x/nSims_; });
         return hitsByDate;
         // \todo Provide confidence interval
     }
@@ -503,7 +502,7 @@ namespace QuantLib {
         /*
         std::vector<Real>::iterator itPastPerc =
             std::find_if(losses.begin() + position, losses.end(),
-                         greater_or_equal_to<Real>(perctlInf));
+                         [=](Real x){ return x >= perctlInf; });
         // notice if the sample is flat at the end this might be zero
         Size pointsOverVal = nSims_ - std::distance(itPastPerc, losses.end());
         return pointsOverVal == 0 ? 0. :
@@ -625,7 +624,7 @@ namespace QuantLib {
         std::vector<Real> varLevels = splitVaRAndError(date, loss, 0.95)[0];
         // turn relative units into absolute:
         std::transform(varLevels.begin(), varLevels.end(), varLevels.begin(),
-                       multiply_by<Real>(loss));
+                       [=](Real x){ return x * loss; });
         return varLevels;
     }
 

--- a/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmblackscholesfwdop.cpp
@@ -62,15 +62,13 @@ namespace QuantLib {
                 const Size i = iter.index();
 
                 if (illegalLocalVolOverwrite_ < 0.0) {
-                    v[i] = square<Real>()(
-                        localVol_->localVol(0.5*(t1+t2), x_[i], true));
+                    v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));
                 }
                 else {
                     try {
-                        v[i] = square<Real>()(
-                            localVol_->localVol(0.5*(t1+t2), x_[i], true));
+                        v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));
                     } catch (Error&) {
-                        v[i] = square<Real>()(illegalLocalVolOverwrite_);
+                        v[i] = squared(illegalLocalVolOverwrite_);
                     }
                 }
             }

--- a/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
+++ b/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
     : mesher_(mesher), process_(std::move(process)), rTS_(std::move(rTS)), bcSet_(std::move(bcSet)),
       direction_(direction), x_(mesher->locations(direction)), dxMap_(direction, mesher),
       dxxMap_(SecondDerivativeOp(direction, mesher)
-                  .mult(0.5 * square<Real>()(process_->volatility()) *
+                  .mult(0.5 * squared(process_->volatility()) *
                         Array(mesher->layout()->size(), 1.))),
       mapX_(direction, mesher) {}
 

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -23,7 +23,6 @@
 
 #include <ql/experimental/finitedifferences/fdmhestonfwdop.hpp>
 #include <ql/experimental/finitedifferences/modtriplebandlinearop.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
 #include <ql/methods/finitedifferences/operators/firstderivativeop.hpp>

--- a/ql/experimental/finitedifferences/fdmhestongreensfct.cpp
+++ b/ql/experimental/finitedifferences/fdmhestongreensfct.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
               {
                 const Real sd_x = l0_*std::sqrt(v0*t);
                   const Real p_x = M_1_SQRTPI*M_SQRT1_2/sd_x
-                          * std::exp(-0.5*square<Real>()((x - x0)/sd_x));
+                          * std::exp(-0.5*squared((x - x0)/sd_x));
                   const Real p_v = SquareRootProcessRNDCalculator(
                       v0, kappa, theta, sigma).pdf(v, t);
 
@@ -85,8 +85,8 @@ namespace QuantLib {
                 const Real sd_v = sigma*std::sqrt(v0*t);
                 const Real z0 = v0 + kappa*(theta - v0)*t;
                 retVal = 1.0/(M_TWOPI*sd_x*sd_v*std::sqrt(1-rho*rho))
-                    *std::exp(-(  square<Real>()((x-x0)/sd_x)
-                                + square<Real>()((v-z0)/sd_v)
+                    *std::exp(-(  squared((x-x0)/sd_x)
+                                + squared((v-z0)/sd_v)
                                 - 2*rho*(x-x0)*(v-z0)/(sd_x*sd_v))
                               /(2*(1-rho*rho)) );
               }

--- a/ql/experimental/finitedifferences/fdmsquarerootfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmsquarerootfwdop.cpp
@@ -23,15 +23,12 @@
     \brief Fokker-Planck forward operator for an square root process
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
 #include <ql/methods/finitedifferences/operators/firstderivativeop.hpp>
 #include <ql/methods/finitedifferences/operators/secondderivativeop.hpp>
-
 #include <ql/experimental/finitedifferences/fdmsquarerootfwdop.hpp>
 #include <ql/experimental/finitedifferences/modtriplebandlinearop.hpp>
-
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/distributions/non_central_chi_squared.hpp>
 

--- a/ql/experimental/finitedifferences/fdmvppstartlimitstepcondition.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstartlimitstepcondition.cpp
@@ -21,7 +21,6 @@
 */
 
 #include <ql/math/array.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>
 #include <ql/experimental/finitedifferences/fdmvppstartlimitstepcondition.hpp>

--- a/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
@@ -22,7 +22,6 @@
 
 #include <ql/experimental/finitedifferences/fdmvppstepcondition.hpp>
 #include <ql/math/array.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -28,7 +28,6 @@
 #include <ql/experimental/math/gaussiancopulapolicy.hpp>
 #include <ql/experimental/math/tcopulapolicy.hpp>
 #include <ql/math/randomnumbers/boxmullergaussianrng.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/experimental/math/polarstudenttrng.hpp>
 #include <ql/handle.hpp>
 #include <ql/quote.hpp>
@@ -47,7 +46,7 @@ namespace QuantLib {
             std::vector<Real> operator()(Real d, std::vector<Real> v) 
             {
                 std::transform(v.begin(), v.end(), v.begin(), 
-                               multiply_by<Real>(d));
+                               [=](Real x){ return x*d; });
                 return v;
             }
         };

--- a/ql/experimental/math/multidimquadrature.hpp
+++ b/ql/experimental/math/multidimquadrature.hpp
@@ -30,7 +30,6 @@
 #ifndef QL_PATCH_SOLARIS
 
 #include <ql/math/integrals/gaussianquadratures.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/functional.hpp>
 
 namespace QuantLib {
@@ -60,8 +59,8 @@ namespace QuantLib {
                 //first one, we do not know the size of the vector returned by f
                 Integer i = order()-1;
                 std::vector<Real> term = f(x_[i]);// potential copy! @#$%^!!!
-                std::for_each(term.begin(), term.end(), 
-                              multiply_by<Real>(w_[i]));
+                std::for_each(term.begin(), term.end(),
+                              [&](Real x){ return x * w_[i]; });
                 std::vector<Real> sum = term;
            
                 for (i--; i >= 0; --i) {

--- a/ql/experimental/mcbasket/longstaffschwartzmultipathpricer.hpp
+++ b/ql/experimental/mcbasket/longstaffschwartzmultipathpricer.hpp
@@ -21,7 +21,6 @@
 #define quantlib_longstaff_schwartz_multi_path_pricer_hpp
 
 #include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/methods/montecarlo/pathpricer.hpp>
 #include <ql/methods/montecarlo/multipath.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>

--- a/ql/experimental/models/hestonslvmcmodel.cpp
+++ b/ql/experimental/models/hestonslvmcmodel.cpp
@@ -177,8 +177,7 @@ namespace QuantLib {
                 sum/=inc;
 
                 vStrikes[n]->at(i) = 0.5*(pairs[e-1].first + pairs[s].first);
-                (*L)[i][n] = std::sqrt(square<Real>()(
-                     localVol_->localVol(t, vStrikes[n]->at(i), true))/sum);
+                (*L)[i][n] = std::sqrt(squared(localVol_->localVol(t, vStrikes[n]->at(i), true))/sum);
 
                 s = e;
             }

--- a/ql/experimental/models/normalclvmodel.cpp
+++ b/ql/experimental/models/normalclvmodel.cpp
@@ -24,7 +24,6 @@
 #include <ql/experimental/models/normalclvmodel.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/math/solvers1d/brent.hpp>

--- a/ql/experimental/processes/gemanroncoroniprocess.cpp
+++ b/ql/experimental/processes/gemanroncoroniprocess.cpp
@@ -63,11 +63,11 @@ namespace QuantLib {
     }
     
     Real GemanRoncoroniProcess::diffusion(Time t, Real /*x*/) const {
-        return std::sqrt(sig2_ + a_*square<Real>()(std::cos(M_PI*t+b_)));
+        return std::sqrt(sig2_ + a_*squared(std::cos(M_PI*t+b_)));
     }
 
     Real GemanRoncoroniProcess::stdDeviation(Time t0, Real /*x0*/, Time dt) const {
-        const Volatility sig2t = sig2_+a_*square<Real>()(std::cos(M_PI*t0+b_));
+        const Volatility sig2t = sig2_+a_*squared(std::cos(M_PI*t0+b_));
         
         return std::sqrt(sig2t/(2*theta1_)*(1.0-std::exp(-2*theta1_*dt)));
     }

--- a/ql/experimental/processes/hestonslvprocess.cpp
+++ b/ql/experimental/processes/hestonslvprocess.cpp
@@ -24,7 +24,6 @@
 
 #include <ql/experimental/processes/hestonslvprocess.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/utilities/squarerootprocessrndcalculator.hpp>
 #include <utility>
 

--- a/ql/legacy/libormarketmodels/lfmcovarproxy.cpp
+++ b/ql/legacy/libormarketmodels/lfmcovarproxy.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <ql/legacy/libormarketmodels/lfmcovarproxy.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/kronrodintegral.hpp>
 #include <utility>
 
@@ -52,7 +51,7 @@ namespace QuantLib {
         for (Size i=0; i<size_; ++i) {
             std::transform(pca.row_begin(i), pca.row_end(i),
                            pca.row_begin(i),
-                           multiply_by<Real>(vol[i]));
+                           [&](Real x){ return x * vol[i]; });
         }
 
         return pca;

--- a/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
+++ b/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
@@ -19,7 +19,6 @@
 
 #include <ql/math/matrixutilities/pseudosqrt.hpp>
 #include <ql/legacy/libormarketmodels/lfmhullwhiteparam.hpp>
-#include <ql/math/functional.hpp>
 
 namespace QuantLib {
 
@@ -51,11 +50,12 @@ namespace QuantLib {
             // "Reconstructing a valid correlation matrix from invalid data"
             // (<http://www.quarchome.org/correlationmatrix.pdf>)
             for (Size i=0; i < size_-1; ++i) {
+                Real p = std::sqrt(std::inner_product(
+                                     tmpSqrtCorr[i],tmpSqrtCorr[i]+factors_,
+                                     tmpSqrtCorr[i], 0.0));
                 std::transform(
                     tmpSqrtCorr[i], tmpSqrtCorr[i]+factors_, sqrtCorr[i],
-                    divide_by<Real>(std::sqrt(std::inner_product(
-                                     tmpSqrtCorr[i],tmpSqrtCorr[i]+factors_,
-                                     tmpSqrtCorr[i], 0.0))));
+                    [=](Real x){ return x/p; });
             }
         }
 

--- a/ql/legacy/libormarketmodels/lfmprocess.cpp
+++ b/ql/legacy/libormarketmodels/lfmprocess.cpp
@@ -23,7 +23,6 @@
 #include <ql/cashflows/floatingratecoupon.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/legacy/libormarketmodels/lfmprocess.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/processes/eulerdiscretization.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/time/schedule.hpp>

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -28,7 +28,6 @@
 
 #include <ql/types.hpp>
 #include <ql/errors.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/utilities/null.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/type_traits.hpp>
@@ -323,8 +322,8 @@ namespace QuantLib {
 
 
     inline const Array& Array::operator+=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       add<Real>(x));
+        std::transform(begin(), end(), begin(),
+                       [=](Real y) { return y+x; });
         return *this;
     }
 
@@ -339,7 +338,7 @@ namespace QuantLib {
 
     inline const Array& Array::operator-=(Real x) {
         std::transform(begin(),end(),begin(),
-                       subtract<Real>(x));
+                       [=](Real y) { return y-x; });
         return *this;
     }
 
@@ -353,8 +352,8 @@ namespace QuantLib {
     }
 
     inline const Array& Array::operator*=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       multiply_by<Real>(x));
+        std::transform(begin(), end(), begin(),
+                       [=](Real y) { return y*x; });
         return *this;
     }
 
@@ -368,8 +367,11 @@ namespace QuantLib {
     }
 
     inline const Array& Array::operator/=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       divide_by<Real>(x));
+        #if defined(QL_EXTRA_SAFETY_CHECKS)
+        QL_REQUIRE(x != 0.0, "division by zero");
+        #endif
+        std::transform(begin(), end(), begin(),
+                       [=](Real y) { return y/x; });
         return *this;
     }
 
@@ -534,15 +536,15 @@ namespace QuantLib {
 
     inline Array operator+(const Array& v1, Real a) {
         Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       add<Real>(a));
+        std::transform(v1.begin(), v1.end(), result.begin(),
+                       [=](Real y) { return y+a; });
         return result;
     }
 
     inline Array operator+(Real a, const Array& v2) {
         Array result(v2.size());
         std::transform(v2.begin(),v2.end(),result.begin(),
-                       add<Real>(a));
+                       [=](Real y) { return a+y; });
         return result;
     }
 
@@ -559,14 +561,14 @@ namespace QuantLib {
     inline Array operator-(const Array& v1, Real a) {
         Array result(v1.size());
         std::transform(v1.begin(),v1.end(),result.begin(),
-                       subtract<Real>(a));
+                       [=](Real y) { return y-a; });
         return result;
     }
 
     inline Array operator-(Real a, const Array& v2) {
         Array result(v2.size());
         std::transform(v2.begin(),v2.end(),result.begin(),
-                       subtract_from<Real>(a));
+                       [=](Real y) { return a-y; });
         return result;
     }
 
@@ -583,14 +585,14 @@ namespace QuantLib {
     inline Array operator*(const Array& v1, Real a) {
         Array result(v1.size());
         std::transform(v1.begin(),v1.end(),result.begin(),
-                       multiply_by<Real>(a));
+                       [=](Real y) { return y*a; });
         return result;
     }
 
     inline Array operator*(Real a, const Array& v2) {
         Array result(v2.size());
         std::transform(v2.begin(),v2.end(),result.begin(),
-                       multiply_by<Real>(a));
+                       [=](Real y) { return a*y; });
         return result;
     }
 
@@ -607,14 +609,14 @@ namespace QuantLib {
     inline Array operator/(const Array& v1, Real a) {
         Array result(v1.size());
         std::transform(v1.begin(),v1.end(),result.begin(),
-                       divide_by<Real>(a));
+                       [=](Real y) { return y/a; });
         return result;
     }
 
     inline Array operator/(Real a, const Array& v2) {
         Array result(v2.size());
         std::transform(v2.begin(),v2.end(),result.begin(),
-                       divide<Real>(a));
+                       [=](Real y) { return a/y; });
         return result;
     }
 

--- a/ql/math/autocovariance.hpp
+++ b/ql/math/autocovariance.hpp
@@ -26,7 +26,6 @@
 
 #include <ql/math/fastfouriertransform.hpp>
 #include <ql/math/array.hpp>
-#include <ql/math/functional.hpp>
 #include <complex>
 #include <vector>
 #include <algorithm>
@@ -65,8 +64,7 @@ namespace QuantLib {
             std::size_t n = 1;
             for (InputIterator it = begin; it != end; ++it, ++n)
                 mean = (mean*Real(n-1) + *it)/n;
-            std::transform(begin, end, out,
-                           subtract<Real>(mean));
+            std::transform(begin, end, out, [=](Real x){ return x - mean; });
             return mean;
         }
 

--- a/ql/math/distributions/chisquaredistribution.cpp
+++ b/ql/math/distributions/chisquaredistribution.cpp
@@ -92,8 +92,8 @@ namespace QuantLib {
 
     Real NonCentralCumulativeChiSquareSankaranApprox::operator()(Real x) const {
 
-        const Real h = 1-2*(df_+ncp_)*(df_+3*ncp_)/(3*square<Real>()(df_+2*ncp_));
-        const Real p = (df_+2*ncp_)/square<Real>()(df_+ncp_);
+        const Real h = 1-2*(df_+ncp_)*(df_+3*ncp_)/(3*squared(df_+2*ncp_));
+        const Real p = (df_+2*ncp_)/squared(df_+ncp_);
         const Real m = (h-1)*(1-3*h);
 
         const Real u= (std::pow(x/(df_+ncp_), h) - (1 + h*p*(h-1-0.5*(2-h)*m*p)))/
@@ -125,8 +125,7 @@ namespace QuantLib {
         // use a Brent solver for the rest
         Brent solver;
         solver.setMaxEvaluations(evaluations);
-        return solver.solve(compose(subtract<Real>(x),
-                                    nonCentralDist_),
+        return solver.solve([&](Real y) { return nonCentralDist_(y) - x; },
                             accuracy_, 0.75*upper, 
                             (evaluations == maxEvaluations_)? 0.0: 0.5*upper,
                             upper);

--- a/ql/math/functional.hpp
+++ b/ql/math/functional.hpp
@@ -36,7 +36,9 @@ namespace QuantLib {
     template <class T, class U>
     class constant {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef U result_type;
         explicit constant(const U& u) : u_(u) {}
         U operator()(const T&) const { return u_; }
@@ -47,7 +49,9 @@ namespace QuantLib {
     template <class T>
     class identity {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t; }
     };
@@ -55,7 +59,9 @@ namespace QuantLib {
     template <class T>
     class square {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t*t; }
     };
@@ -63,7 +69,9 @@ namespace QuantLib {
     template <class T>
     class cube {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t*t*t; }
     };
@@ -71,7 +79,9 @@ namespace QuantLib {
     template <class T>
     class fourth_power {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { T t2 = t*t; return t2*t2; }
     };
@@ -82,9 +92,10 @@ namespace QuantLib {
     class add {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit add(Real y) : y(y) {}
         Real operator()(T x) const { return x + y; }
     };
@@ -93,9 +104,10 @@ namespace QuantLib {
     class subtract {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit subtract(Real y) : y(y) {}
         Real operator()(T x) const { return x - y; }
     };
@@ -104,9 +116,10 @@ namespace QuantLib {
     class subtract_from {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit subtract_from(Real y) : y(y) {}
         Real operator()(T x) const { return y - x; }
     };
@@ -115,9 +128,10 @@ namespace QuantLib {
     class multiply_by {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit multiply_by(Real y) : y(y) {}
         Real operator()(T x) const { return x * y; }
     };
@@ -126,9 +140,10 @@ namespace QuantLib {
     class divide {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit divide(Real y) : y(y) {}
         Real operator()(T x) const { return y / x; }
     };
@@ -137,9 +152,10 @@ namespace QuantLib {
     class divide_by {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef Real result_type;
-
         explicit divide_by(Real y) : y(y) {}
         Real operator()(T x) const { return x / y; }
     };
@@ -148,9 +164,10 @@ namespace QuantLib {
     class less_than {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
-
         explicit less_than(Real y) : y(y) {}
         bool operator()(T x) const { return x < y; }
     };
@@ -159,9 +176,10 @@ namespace QuantLib {
     class greater_than {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
-
         explicit greater_than(Real y) : y(y) {}
         bool operator()(T x) const { return x > y; }
     };
@@ -170,9 +188,10 @@ namespace QuantLib {
     class greater_or_equal_to {
         T y;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
-
         explicit greater_or_equal_to(Real y) : y(y) {}
         bool operator()(T x) const { return x >= y; }
     };
@@ -180,7 +199,9 @@ namespace QuantLib {
     template <class T>
     class not_zero {
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
         bool operator()(T x) const { return x != T(); }
     };
@@ -189,9 +210,10 @@ namespace QuantLib {
     class not_null {
         T null;
       public:
+        QL_DEPRECATED
         typedef T argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
-
         not_null() : null(Null<T>()) {}
         bool operator()(T x) const { return x != null; }
     };
@@ -211,10 +233,12 @@ namespace QuantLib {
     template <class T>
     class equal_within {
       public:
+        QL_DEPRECATED
         typedef T first_argument_type;
+        QL_DEPRECATED
         typedef T second_argument_type;
+        QL_DEPRECATED
         typedef bool result_type;
-
         explicit equal_within(const T& eps) : eps_(eps) {}
         bool operator()(const T& a, const T& b) const {
             return std::fabs(a-b) <= eps_;
@@ -227,12 +251,17 @@ namespace QuantLib {
     template <class F, class R>
     class clipped_function {
       public:
+        QL_DEPRECATED
         typedef typename F::argument_type argument_type;
+        QL_DEPRECATED
         typedef typename F::result_type result_type;
+        QL_DEPRECATED
         clipped_function(const F& f, const R& r) : f_(f), r_(r) {}
+        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const argument_type& x) const {
             return r_(x) ? f_(x) : result_type();
         }
+        QL_DEPRECATED_ENABLE_WARNING
       private:
         F f_;
         R r_;
@@ -244,21 +273,28 @@ namespace QuantLib {
         return [f_ = std::forward<F>(f), r_ = std::forward<R>(r)](const auto& x) { return r_(x) ? f_(x) : decltype(f_(x)){}; };
     }
 #else
+    QL_DEPRECATED_DISABLE_WARNING
     template <class F, class R>
     clipped_function<F,R> clip(const F& f, const R& r) {
         return clipped_function<F,R>(f,r);
     }
+    QL_DEPRECATED_ENABLE_WARNING
 #endif
 
     template <class F, class G>
     class composed_function {
       public:
+        QL_DEPRECATED
         typedef typename G::argument_type argument_type;
+        QL_DEPRECATED
         typedef typename F::result_type result_type;
+        QL_DEPRECATED
         composed_function(const F& f, G g) : f_(f), g_(std::move(g)) {}
+        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const argument_type& x) const {
             return f_(g_(x));
         }
+        QL_DEPRECATED_ENABLE_WARNING
       private:
         F f_;
         G g_;
@@ -270,26 +306,32 @@ namespace QuantLib {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g)](const auto& x) { return f_(g_(x)); };
     }
 #else
+    QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G>
     composed_function<F,G> compose(const F& f, const G& g) {
         return composed_function<F,G>(f,g);
     }
+    QL_DEPRECATED_ENABLE_WARNING
 #endif
 
     template <class F, class G, class H>
     class binary_compose3_function {
       public:
+        QL_DEPRECATED
         typedef typename G::argument_type first_argument_type;
+        QL_DEPRECATED
         typedef typename H::argument_type second_argument_type;
+        QL_DEPRECATED
         typedef typename F::result_type result_type;
-
+        QL_DEPRECATED
         binary_compose3_function(const F& f, const G& g, const H& h)
         : f_(f), g_(g), h_(h) {}
-
+        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const first_argument_type&  x,
                                const second_argument_type& y) const {
             return f_(g_(x), h_(y));
         }
+        QL_DEPRECATED_ENABLE_WARNING
 
       private:
         F f_;
@@ -303,10 +345,12 @@ namespace QuantLib {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g), h_ = std::forward<H>(h)](const auto& x, const auto& y) { return f_(g_(x), h_(y)); };
     }
 #else
+    QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G, class H> binary_compose3_function<F, G, H>
     compose3(const F& f, const G& g, const H& h) {
         return binary_compose3_function<F, G, H>(f, g, h);
     }
+    QL_DEPRECATED_ENABLE_WARNING
 #endif
 }
 

--- a/ql/math/functional.hpp
+++ b/ql/math/functional.hpp
@@ -33,12 +33,13 @@ namespace QuantLib {
 
     // functions
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T, class U>
-    class constant {
+    class QL_DEPRECATED constant {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef U result_type;
         explicit constant(const U& u) : u_(u) {}
         U operator()(const T&) const { return u_; }
@@ -46,173 +47,191 @@ namespace QuantLib {
         U u_;
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class identity {
+    class QL_DEPRECATED identity {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t; }
     };
 
     template <class T>
-    class square {
+    inline T squared(T x) { return x * x; }
+
+    /*! \deprecated Use squared or a lambda instead.
+                    Deprecated in version 1.27.
+    */
+    template <class T>
+    class QL_DEPRECATED square {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t*t; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class cube {
+    class QL_DEPRECATED cube {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { return t*t*t; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class fourth_power {
+    class QL_DEPRECATED fourth_power {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef T result_type;
         T operator()(const T& t) const { T t2 = t*t; return t2*t2; }
     };
 
     // a few shortcuts for common binders
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class add {
+    class QL_DEPRECATED add {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit add(Real y) : y(y) {}
         Real operator()(T x) const { return x + y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class subtract {
+    class QL_DEPRECATED subtract {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit subtract(Real y) : y(y) {}
         Real operator()(T x) const { return x - y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class subtract_from {
+    class QL_DEPRECATED subtract_from {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit subtract_from(Real y) : y(y) {}
         Real operator()(T x) const { return y - x; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class multiply_by {
+    class QL_DEPRECATED multiply_by {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit multiply_by(Real y) : y(y) {}
         Real operator()(T x) const { return x * y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class divide {
+    class QL_DEPRECATED divide {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit divide(Real y) : y(y) {}
         Real operator()(T x) const { return y / x; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class divide_by {
+    class QL_DEPRECATED divide_by {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef Real result_type;
         explicit divide_by(Real y) : y(y) {}
         Real operator()(T x) const { return x / y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class less_than {
+    class QL_DEPRECATED less_than {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         explicit less_than(Real y) : y(y) {}
         bool operator()(T x) const { return x < y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class greater_than {
+    class QL_DEPRECATED greater_than {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         explicit greater_than(Real y) : y(y) {}
         bool operator()(T x) const { return x > y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class greater_or_equal_to {
+    class QL_DEPRECATED greater_or_equal_to {
         T y;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         explicit greater_or_equal_to(Real y) : y(y) {}
         bool operator()(T x) const { return x >= y; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class not_zero {
+    class QL_DEPRECATED not_zero {
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         bool operator()(T x) const { return x != T(); }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class not_null {
+    class QL_DEPRECATED not_null {
         T null;
       public:
-        QL_DEPRECATED
         typedef T argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         not_null() : null(Null<T>()) {}
         bool operator()(T x) const { return x != null; }
@@ -220,24 +239,34 @@ namespace QuantLib {
     
     // predicates
 
-    class everywhere : public constant<Real,bool> {
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
+    class QL_DEPRECATED everywhere {
       public:
-        everywhere() : constant<Real,bool>(true) {}
+        typedef Real argument_type;
+        typedef bool result_type;
+        bool operator()(Real) const { return true; }
     };
 
-    class nowhere : public constant<Real,bool> {
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
+    class QL_DEPRECATED nowhere {
       public:
-        nowhere() : constant<Real,bool>(false) {}
+        typedef Real argument_type;
+        typedef bool result_type;
+        bool operator()(Real) const { return false; }
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class T>
-    class equal_within {
+    class QL_DEPRECATED equal_within {
       public:
-        QL_DEPRECATED
         typedef T first_argument_type;
-        QL_DEPRECATED
         typedef T second_argument_type;
-        QL_DEPRECATED
         typedef bool result_type;
         explicit equal_within(const T& eps) : eps_(eps) {}
         bool operator()(const T& a, const T& b) const {
@@ -248,105 +277,113 @@ namespace QuantLib {
     };
 
     // combinators
+
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class F, class R>
-    class clipped_function {
+    class QL_DEPRECATED clipped_function {
       public:
-        QL_DEPRECATED
         typedef typename F::argument_type argument_type;
-        QL_DEPRECATED
         typedef typename F::result_type result_type;
-        QL_DEPRECATED
         clipped_function(const F& f, const R& r) : f_(f), r_(r) {}
-        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const argument_type& x) const {
             return r_(x) ? f_(x) : result_type();
         }
-        QL_DEPRECATED_ENABLE_WARNING
       private:
         F f_;
         R r_;
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class R>
+    QL_DEPRECATED
     auto clip(F&& f, R&& r) {
         return [f_ = std::forward<F>(f), r_ = std::forward<R>(r)](const auto& x) { return r_(x) ? f_(x) : decltype(f_(x)){}; };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class R>
+    QL_DEPRECATED
     clipped_function<F,R> clip(const F& f, const R& r) {
         return clipped_function<F,R>(f,r);
     }
     QL_DEPRECATED_ENABLE_WARNING
 #endif
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class F, class G>
-    class composed_function {
+    class QL_DEPRECATED composed_function {
       public:
-        QL_DEPRECATED
         typedef typename G::argument_type argument_type;
-        QL_DEPRECATED
         typedef typename F::result_type result_type;
-        QL_DEPRECATED
         composed_function(const F& f, G g) : f_(f), g_(std::move(g)) {}
-        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const argument_type& x) const {
             return f_(g_(x));
         }
-        QL_DEPRECATED_ENABLE_WARNING
       private:
         F f_;
         G g_;
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class G>
+    QL_DEPRECATED
     auto compose(F&& f, G&& g) {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g)](const auto& x) { return f_(g_(x)); };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G>
+    QL_DEPRECATED
     composed_function<F,G> compose(const F& f, const G& g) {
         return composed_function<F,G>(f,g);
     }
     QL_DEPRECATED_ENABLE_WARNING
 #endif
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
     template <class F, class G, class H>
-    class binary_compose3_function {
+    class QL_DEPRECATED binary_compose3_function {
       public:
-        QL_DEPRECATED
         typedef typename G::argument_type first_argument_type;
-        QL_DEPRECATED
         typedef typename H::argument_type second_argument_type;
-        QL_DEPRECATED
         typedef typename F::result_type result_type;
-        QL_DEPRECATED
         binary_compose3_function(const F& f, const G& g, const H& h)
         : f_(f), g_(g), h_(h) {}
-        QL_DEPRECATED_DISABLE_WARNING
         result_type operator()(const first_argument_type&  x,
                                const second_argument_type& y) const {
             return f_(g_(x), h_(y));
         }
-        QL_DEPRECATED_ENABLE_WARNING
-
       private:
         F f_;
         G g_;
         H h_;
     };
 
+    /*! \deprecated Use a lambda instead.
+                    Deprecated in version 1.27.
+    */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class G, class H>
+    QL_DEPRECATED
     auto compose3(F&& f, G&& g, H&& h) {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g), h_ = std::forward<H>(h)](const auto& x, const auto& y) { return f_(g_(x), h_(y)); };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G, class H> binary_compose3_function<F, G, H>
+    QL_DEPRECATED
     compose3(const F& f, const G& g, const H& h) {
         return binary_compose3_function<F, G, H>(f, g, h);
     }

--- a/ql/math/generallinearleastsquares.hpp
+++ b/ql/math/generallinearleastsquares.hpp
@@ -30,7 +30,6 @@
 #include <ql/qldefines.hpp>
 #include <ql/math/matrixutilities/svd.hpp>
 #include <ql/math/array.hpp>
-#include <ql/math/functional.hpp>
 #include <boost/type_traits.hpp>
 #include <vector>
 
@@ -143,10 +142,10 @@ namespace QuantLib {
                        yBegin, residuals_.begin(), std::minus<Real>());
 
         const Real chiSq
-            = std::inner_product(residuals_.begin(), residuals_.end(),
-            residuals_.begin(), 0.0);
+            = std::inner_product(residuals_.begin(), residuals_.end(), residuals_.begin(), 0.0);
+        const Real multiplier = std::sqrt(chiSq/(n-2));
         std::transform(err_.begin(), err_.end(), standardErrors_.begin(),
-                       multiply_by<Real>(std::sqrt(chiSq/(n-2))));
+                       [=](Real x){ return x * multiplier; });
     }
 
 }

--- a/ql/math/integrals/filonintegral.cpp
+++ b/ql/math/integrals/filonintegral.cpp
@@ -49,8 +49,8 @@ namespace QuantLib {
         const Real theta3 = theta2*theta;
 
         const Real alpha = 1/theta + std::sin(2*theta)/(2*theta2)
-            - 2*square<Real>()(std::sin(theta))/theta3;
-        const Real beta = 2*( (1+square<Real>()(std::cos(theta)))/theta2
+            - 2*squared(std::sin(theta))/theta3;
+        const Real beta = 2*( (1+squared(std::cos(theta)))/theta2
             - std::sin(2*theta)/theta3);
         const Real gamma = 4*(std::sin(theta)/theta3 - std::cos(theta)/theta2);
 

--- a/ql/math/integrals/gausslaguerrecosinepolynomial.hpp
+++ b/ql/math/integrals/gausslaguerrecosinepolynomial.hpp
@@ -101,8 +101,7 @@ namespace QuantLib {
       protected:
         mp_real m0() const override { return 1 / (1 + this->u_ * this->u_); }
         mp_real m1() const override {
-            return (1 - this->u_*this->u_)
-                    /square<mp_real>()(1 + this->u_*this->u_);
+            return (1 - this->u_*this->u_) / squared(1 + this->u_*this->u_);
         }
 
       private:
@@ -134,7 +133,7 @@ namespace QuantLib {
       protected:
         mp_real m0() const override { return this->u_ / (1 + this->u_ * this->u_); }
         mp_real m1() const override {
-            return 2*this->u_/square<mp_real>()(1 + this->u_*this->u_);
+            return 2*this->u_ / squared(1 + this->u_*this->u_);
         }
 
       private:

--- a/ql/math/linearleastsquaresregression.hpp
+++ b/ql/math/linearleastsquaresregression.hpp
@@ -56,8 +56,8 @@ namespace QuantLib {
             typedef typename xContainer::value_type ArgumentType;
             LinearFcts (const xContainer &x, Real intercept) {
                 if (intercept != 0.0)
-                    v.push_back(constant<ArgumentType, Real>(intercept));
-                v.push_back(identity<ArgumentType>());
+                    v.push_back([=](ArgumentType x){ return intercept; });
+                v.push_back([](ArgumentType x){ return x; });
             }
 
             const std::vector< ext::function<Real(ArgumentType)> > & fcts() {
@@ -75,7 +75,7 @@ namespace QuantLib {
             typedef typename xContainer::value_type ArgumentType;
             LinearFcts (const xContainer &x, Real intercept) {
                 if (intercept != 0.0)
-                    v.push_back(constant<ArgumentType, Real>(intercept));
+                    v.push_back([=](ArgumentType x){ return intercept; });
                 Size m = x.begin()->size();
                 for (Size i = 0; i < m; ++i)
                     v.push_back(LinearFct<ArgumentType>(i));

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -283,14 +283,14 @@ namespace QuantLib {
     }
 
     inline const Matrix& Matrix::operator*=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       multiply_by<Real>(x));
+        std::transform(begin(), end(), begin(),
+                       [=](Real y) { return y*x; });
         return *this;
     }
 
     inline const Matrix& Matrix::operator/=(Real x) {
         std::transform(begin(),end(),begin(),
-                       divide_by<Real>(x));
+                       [=](Real y) { return y/x; });
         return *this;
     }
 
@@ -519,22 +519,22 @@ namespace QuantLib {
 
     inline Matrix operator*(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
-                       multiply_by<Real>(x));
+        std::transform(m.begin(), m.end(), temp.begin(),
+                       [=](Real y) { return y*x; });
         return temp;
     }
 
     inline Matrix operator*(Real x, const Matrix& m) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
-                       multiply_by<Real>(x));
+        std::transform(m.begin(), m.end(), temp.begin(),
+                       [=](Real y) { return x*y; });
         return temp;
     }
 
     inline Matrix operator/(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(),m.end(),temp.begin(),
-                       divide_by<Real>(x));
+        std::transform(m.begin(), m.end(), temp.begin(),
+                       [=](Real y) { return y/x; });
         return temp;
     }
 
@@ -607,7 +607,7 @@ namespace QuantLib {
 
         for (Size i=0; v1begin!=v1end; i++, v1begin++)
             std::transform(v2begin, v2end, result.row_begin(i),
-                           multiply_by<Real>(*v1begin));
+                           [=](Real y) { return y * (*v1begin); });
 
         return result;
     }

--- a/ql/math/matrixutilities/gmres.cpp
+++ b/ql/math/matrixutilities/gmres.cpp
@@ -111,8 +111,7 @@ namespace QuantLib {
                 h[i+1][j] = h1;
             }
 
-            const Real nu = std::sqrt(  square<Real>()(h[j][j])
-                                      + square<Real>()(h[j+1][j]));
+            const Real nu = std::sqrt(squared(h[j][j]) + squared(h[j+1][j]));
 
             c[j] = h[j][j]/nu;
             s[j] = h[j+1][j]/nu;

--- a/ql/math/optimization/costfunction.hpp
+++ b/ql/math/optimization/costfunction.hpp
@@ -27,7 +27,6 @@
 
 #include <ql/math/array.hpp>
 #include <ql/math/matrix.hpp>
-#include <ql/math/functional.hpp>
 
 namespace QuantLib {
 
@@ -38,7 +37,7 @@ namespace QuantLib {
         //! method to overload to compute the cost function value in x
         virtual Real value(const Array& x) const {
             Array v = values(x);
-            std::transform(v.begin(), v.end(), v.begin(), square<Real>());
+            std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
             return std::sqrt(std::accumulate(v.begin(), v.end(), 0.0) /
                              static_cast<Real>(v.size()));
         }

--- a/ql/math/statistics/generalstatistics.hpp
+++ b/ql/math/statistics/generalstatistics.hpp
@@ -132,6 +132,15 @@ namespace QuantLib {
                 return std::make_pair(num/den,N);
         }
 
+        /*! Expectation value of a function \f$ f \f$ over the whole
+            set of samples; equivalent to passing the other overload
+            a range function always returning <tt>true</tt>.
+        */
+        template <class Func>
+        std::pair<Real,Size> expectationValue(const Func& f) const {
+            return expectationValue(f, [](Real x) { return true; });
+        }
+        
         /*! \f$ y \f$-th percentile, defined as the value \f$ \bar{x} \f$
             such that
             \f[ y = \frac{\sum_{x_i < \bar{x}} w_i}{

--- a/ql/math/statistics/riskstatistics.hpp
+++ b/ql/math/statistics/riskstatistics.hpp
@@ -24,7 +24,6 @@
 #ifndef quantlib_risk_statistics_h
 #define quantlib_risk_statistics_h
 
-#include <ql/math/functional.hpp>
 #include <ql/math/statistics/gaussianstatistics.hpp>
 
 namespace QuantLib {
@@ -153,9 +152,8 @@ namespace QuantLib {
     Real GenericRiskStatistics<S>::regret(Real target) const {
         // average over the range below the target
         std::pair<Real,Size> result =
-            this->expectationValue(compose(square<Real>(),
-                                           subtract<Real>(target)),
-                                   less_than<Real>(target));
+            this->expectationValue([=](Real xi) { Real d = (xi-target); return d * d; },
+                                   [=](Real xi) { return xi < target; });
         Real x = result.first;
         Size N = result.second;
         QL_REQUIRE(N > 1,
@@ -194,8 +192,8 @@ namespace QuantLib {
         QL_ENSURE(this->samples() != 0, "empty sample set");
         Real target = -valueAtRisk(centile);
         std::pair<Real,Size> result =
-            this->expectationValue(identity<Real>(),
-                                   less_than<Real>(target));
+            this->expectationValue([ ](Real xi) { return xi; },
+                                   [=](Real xi) { return xi < target; });
         Real x = result.first;
         Size N = result.second;
         QL_ENSURE(N != 0, "no data below the target");
@@ -206,17 +204,15 @@ namespace QuantLib {
     template <class S>
     Real GenericRiskStatistics<S>::shortfall(Real target) const {
         QL_ENSURE(this->samples() != 0, "empty sample set");
-        return this->expectationValue(clip(constant<Real,Real>(1.0),
-                                           less_than<Real>(target)),
-                                      everywhere()).first;
+        return this->expectationValue([=](Real x) { return x < target ? 1.0 : 0.0; }).first;
     }
 
     template <class S>
     Real GenericRiskStatistics<S>::averageShortfall(Real target)
         const {
         std::pair<Real,Size> result =
-            this->expectationValue(subtract_from<Real>(target),
-                                   less_than<Real>(target));
+            this->expectationValue([=](Real xi) { return target - xi; },
+                                   [=](Real xi) { return xi < target; });
         Real x = result.first;
         Size N = result.second;
         QL_ENSURE(N != 0, "no data below the target");

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -122,7 +122,7 @@ namespace QuantLib {
             Real jac(Real a, Real, Real y) const {
                 Real s=0.0;
                 for (Size i=0; i < points_.size(); ++i) {
-                    s+=1.0/(betas_[i] + square<Real>()(y - points_[i]));
+                    s+=1.0/(betas_[i] + squared(y - points_[i]));
                 }
                 return a/std::sqrt(s);
             }
@@ -149,7 +149,7 @@ namespace QuantLib {
         std::vector<Real> points, betas;
         for (const auto& cPoint : cPoints) {
             points.push_back(ext::get<0>(cPoint));
-            betas.push_back(square<Real>()(ext::get<1>(cPoint) * (end - start)));
+            betas.push_back(squared(ext::get<1>(cPoint) * (end - start)));
         }
 
         // get scaling factor a so that y(1) = end

--- a/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
@@ -55,17 +55,15 @@ namespace QuantLib {
 
         std::vector<Real> vGrid(size, 0.0), pGrid(size, 0.0);
         const Real mixedSigma = process->sigma()*mixingFactor;
-        const Real df  = 4*process->theta()*process->kappa()/
-                            square<Real>()(mixedSigma);
+        const Real df  = 4*process->theta()*process->kappa()/squared(mixedSigma);
         try {
             std::multiset<std::pair<Real, Real> > grid;
             
             for (Size l=1; l<=tAvgSteps; ++l) {
                 const Real t = (maturity*l)/tAvgSteps;
-                const Real ncp = 4*process->kappa()*std::exp(-process->kappa()*t)
-                    /(square<Real>()(mixedSigma)
+                const Real ncp = 4*process->kappa()*std::exp(-process->kappa()*t)/(squared(mixedSigma)
                     *(1-std::exp(-process->kappa()*t)))*process->v0();
-                const Real k = square<Real>()(mixedSigma)
+                const Real k = squared(mixedSigma)
                     *(1-std::exp(-process->kappa()*t))/(4*process->kappa());
 
                 const Real qMin = 0.0; // v_min = 0.0;
@@ -199,7 +197,7 @@ namespace QuantLib {
                     const Real gf = x*vol*std::sqrt(t);
                     const Real f = fwd*std::exp(gf);
 
-                    sig[i] = square<Real>()(leverageFct->localVol(t, f, true));
+                    sig[i] = squared(leverageFct->localVol(t, f, true));
                 }
 
                 const Real leverageAvg =

--- a/ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.cpp
@@ -17,7 +17,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/stochasticprocess.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.hpp>
@@ -56,7 +55,7 @@ namespace QuantLib {
             locations_.back() += qMax;
         }
         std::transform(locations_.begin(), locations_.end(), locations_.begin(),
-                       divide_by<Real>(Real(tAvgSteps)));
+                       [=](Real x){ return x / tAvgSteps; });
         for (Size i=0; i < size-1; ++i) {
             dminus_[i+1] = dplus_[i] = locations_[i+1] - locations_[i];
         }

--- a/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
@@ -62,17 +62,14 @@ namespace QuantLib {
                 const Size i = iter.index();
 
                 if (illegalLocalVolOverwrite_ < 0.0) {
-                    v[i] = square<Real>()(
-                        localVol_->localVol(0.5*(t1+t2), x_[i], true));
+                    v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));
                 }
                 else {
                     try {
-                        v[i] = square<Real>()(
-                            localVol_->localVol(0.5*(t1+t2), x_[i], true));
+                        v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));
                     } catch (Error&) {
-                        v[i] = square<Real>()(illegalLocalVolOverwrite_);
+                        v[i] = squared(illegalLocalVolOverwrite_);
                     }
-
                 }
             }
 

--- a/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
@@ -50,8 +50,7 @@ namespace QuantLib {
             iter != endIter; ++iter) {
             const Size i = iter.index();
 
-            v[i] = square<Real>()(
-                localVol_->localVol(0.5*(t1+t2), x_[i], true));
+            v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));
         }
         mapT_.axpyb(Array(1, 1.0), dxMap_.multR(- r + q + 0.5*v),
                     dxxMap_.multR(0.5*v), Array(1, 0.0));

--- a/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
         m_.axpyb(drift, FirstDerivativeOp(direction, mesher),
             SecondDerivativeOp(direction, mesher)
-                .mult(0.5*square<Real>()(process_->volatility())
+                .mult(0.5*squared(process_->volatility())
                       *Array(mesher->layout()->size(), 1.0)), Array());
     }
 

--- a/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
+++ b/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
@@ -116,7 +116,7 @@ namespace QuantLib {
         bcSet_.applyBeforeSolving(*map_, fn);
 
         const array_type f =
-            (1/alpha_*fStar - square<Real>()(1-alpha_)/alpha_*fn)/(2-alpha_);
+            (1/alpha_*fStar - squared(1-alpha_)/alpha_*fn)/(2-alpha_);
 
         if (map_->size() == 1) {
             fn = map_->solve_splitting(0, f, -beta_);

--- a/ql/methods/finitedifferences/utilities/cevrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/cevrndcalculator.cpp
@@ -23,9 +23,7 @@
 #include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-
 #include <ql/methods/finitedifferences/utilities/cevrndcalculator.hpp>
-
 #include <boost/math/special_functions/gamma.hpp>
 #include <boost/math/distributions/non_central_chi_squared.hpp>
 
@@ -48,11 +46,11 @@ namespace QuantLib {
     }
 
     Real CEVRNDCalculator::X(Real f) const {
-        return std::pow(f, 2.0*(1.0-beta_))/square<Real>()(alpha_*(1.0-beta_));
+        return std::pow(f, 2.0*(1.0-beta_))/squared(alpha_*(1.0-beta_));
     }
 
     Real CEVRNDCalculator::invX(Real x) const {
-        return std::pow(x*square<Real>()(alpha_*(1.0-beta_)),
+        return std::pow(x*squared(alpha_*(1.0-beta_)),
                         1.0/(2.0*(1.0-beta_)));
     }
 
@@ -90,8 +88,8 @@ namespace QuantLib {
 
         c = std::max(c, -0.45*b);
 
-        const Real h = 1 - 2*(b+c)*(b+3*c)/(3*square<Real>()(b+2*c));
-        const Real p = (b+2*c)/square<Real>()(b+c);
+        const Real h = 1 - 2*(b+c)*(b+3*c)/(3*squared(b+2*c));
+        const Real p = (b+2*c)/squared(b+c);
         const Real m = (h-1)*(1-3*h);
 
         const Real u = (std::pow(a/(b+c), h) - (1 + h*p*(h-1-0.5*(2-h)*m*p)))/

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -24,7 +24,6 @@
 */
 
 #include <ql/instruments/basketoption.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/simpsonintegral.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp>

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.hpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.hpp
@@ -28,7 +28,6 @@
 
 #include <ql/types.hpp>
 #include <ql/shared_ptr.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/functional.hpp>
 #include <vector>
 
@@ -55,7 +54,7 @@ namespace QuantLib {
         FdmCellAveragingInnerValue(ext::shared_ptr<Payoff> payoff,
                                    ext::shared_ptr<FdmMesher> mesher,
                                    Size direction,
-                                   ext::function<Real(Real)> gridMapping = identity<Real>());
+                                   ext::function<Real(Real)> gridMapping = [](Real x){ return x; });
 
         Real innerValue(const FdmLinearOpIterator& iter, Time) override;
         Real avgInnerValue(const FdmLinearOpIterator& iter, Time t) override;

--- a/ql/methods/finitedifferences/utilities/gbsmrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/gbsmrndcalculator.cpp
@@ -23,7 +23,6 @@
 */
 
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/methods/finitedifferences/utilities/gbsmrndcalculator.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>

--- a/ql/methods/finitedifferences/utilities/hestonrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/hestonrndcalculator.cpp
@@ -59,7 +59,7 @@ namespace {
             CpxPv_Helper(const HestonParams& p, Real x, Time t)
               : p_(p), t_(t), x_(x),
                 c_inf_(std::min(10.0, std::max(0.0001,
-                      std::sqrt(1.0-square<Real>()(p_.rho))/p_.sigma))
+                      std::sqrt(1.0-squared(p_.rho))/p_.sigma))
                       *(p_.v0 + p_.kappa*p_.theta*t))  {}
 
             Real operator()(Real x) const {

--- a/ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.cpp
@@ -18,7 +18,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.hpp>
 

--- a/ql/methods/montecarlo/longstaffschwartzpathpricer.hpp
+++ b/ql/methods/montecarlo/longstaffschwartzpathpricer.hpp
@@ -27,7 +27,6 @@
 #define quantlib_longstaff_schwartz_path_pricer_hpp
 
 #include <ql/functional.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/generallinearleastsquares.hpp>
 #include <ql/math/statistics/incrementalstatistics.hpp>
 #include <ql/methods/montecarlo/earlyexercisepathpricer.hpp>

--- a/ql/models/marketmodels/marketmodeldifferences.cpp
+++ b/ql/models/marketmodels/marketmodeldifferences.cpp
@@ -21,7 +21,6 @@
 #include <ql/models/marketmodels/evolutiondescription.hpp>
 #include <ql/models/marketmodels/piecewiseconstantcorrelation.hpp>
 #include <ql/models/marketmodels/models/piecewiseconstantvariance.hpp>
-#include <ql/math/functional.hpp>
 
 namespace QuantLib {
 
@@ -93,7 +92,7 @@ namespace QuantLib {
             QL_ENSURE(piecewiseConstantCorrelation.times()
                 == piecewiseConstantVariances.front()->rateTimes(),
                 "correlations and volatilities intertave");
-            std::vector<Matrix> peudoRoots;
+            std::vector<Matrix> pseudoRoots;
             const std::vector<Time>& rateTimes
                 = piecewiseConstantVariances.front()->rateTimes();
             for (Size i=1; i<rateTimes.size(); ++i) {
@@ -107,11 +106,11 @@ namespace QuantLib {
                     std::transform(correlations.row_begin(j),
                                    correlations.row_end(j),
                                    pseudoRoot.row_begin(j),
-                                   multiply_by<Real>(volatility));
+                                   [=](Real x){ return x * volatility; });
                 }
-                peudoRoots.push_back(pseudoRoot);
+                pseudoRoots.push_back(pseudoRoot);
             }
-            return peudoRoots;
+            return pseudoRoots;
     }
 
 }

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -19,7 +19,6 @@
 */
 
 #include <ql/math/autocovariance.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/optimization/leastsquare.hpp>
 #include <ql/math/optimization/simplex.hpp>
 #include <ql/models/volatility/garch.hpp>
@@ -112,7 +111,7 @@ namespace QuantLib {
                 sigma2prev = sigma2;
             }
             std::transform(grad.begin(), grad.end(), grad.begin(),
-                           divide_by<Real>(norm));
+                           [=](Real x){ return x/norm; });
         }
 
         Real Garch11CostFunction::valueAndGradient(Array& grad,
@@ -136,7 +135,7 @@ namespace QuantLib {
                 sigma2prev = sigma2;
             }
             std::transform(grad.begin(), grad.end(), grad.begin(),
-                           divide_by<Real>(norm));
+                           [=](Real x){ return x/norm; });
             return retval / norm;
         }
 
@@ -419,7 +418,7 @@ namespace QuantLib {
         Array acf(maxLag+1);
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        subtract<Real>(mean_r2));
+                        [=](Real x){ return x - mean_r2; });
         autocovariances (tmp.begin(), tmp.end(), acf.begin(), maxLag);
         QL_REQUIRE (acf[0] > 0, "Data series is constant");
 
@@ -518,8 +517,8 @@ namespace QuantLib {
                const EndCriteria &endCriteria,
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
-        std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        subtract<Real>(mean_r2));
+        std::transform(r2.begin(), r2.end(), tmp.begin(),
+                       [=](Real x){ return x - mean_r2; });
         return calibrate_r2(tmp, method, endCriteria, initGuess,
                             alpha, beta, omega);
     }
@@ -551,8 +550,8 @@ namespace QuantLib {
                const EndCriteria &endCriteria,
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
-        std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        subtract<Real>(mean_r2));
+        std::transform(r2.begin(), r2.end(), tmp.begin(),
+                       [=](Real x){ return x - mean_r2; });
         return calibrate_r2(tmp, method, constraints, endCriteria,
                             initGuess, alpha, beta, omega);
     }

--- a/ql/pricingengines/basket/kirkengine.cpp
+++ b/ql/pricingengines/basket/kirkengine.cpp
@@ -68,7 +68,7 @@ namespace QuantLib {
         const Real f = f1/(f2 + strike);
         const Real v 
             = std::sqrt(variance1 
-                        + variance2*square<Real>()(f2/(f2+strike))
+                        + variance2*squared(f2/(f2+strike))
                         - 2*rho_*std::sqrt(variance1*variance2)
                             *(f2/(f2+strike)));
         

--- a/ql/pricingengines/basket/mcamericanbasketengine.cpp
+++ b/ql/pricingengines/basket/mcamericanbasketengine.cpp
@@ -18,7 +18,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
 #include <ql/pricingengines/basket/mcamericanbasketengine.hpp>
 #include <utility>

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -293,11 +293,11 @@ namespace QuantLib {
         const Real R2 = R*R;
 
         const Real a = std::exp((1.0-M_2_PI)*y);
-        const Real A = square<Real>()(a - 1.0/a);
+        const Real A = squared(a - 1.0/a);
         const Real b = std::exp(M_2_PI*y);
         const Real B = 4.0*(b + 1/b)
             - 2*K/F*(a + 1.0/a)*(ey2 + 1 - R2);
-        const Real C = (R2-square<Real>()(ey-1))*(square<Real>()(ey+1)-R2)/ey2;
+        const Real C = (R2-squared(ey-1))*(squared(ey+1)-R2)/ey2;
 
         const Real beta = 2*C/(B+std::sqrt(B*B+4*A*C));
         const Real gamma = -M_PI_2*std::log(beta);

--- a/ql/pricingengines/swaption/treeswaptionengine.cpp
+++ b/ql/pricingengines/swaption/treeswaptionengine.cpp
@@ -18,7 +18,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/pricingengines/swaption/discretizedswaption.hpp>
 #include <ql/pricingengines/swaption/treeswaptionengine.hpp>
 #include <utility>
@@ -89,9 +88,8 @@ namespace QuantLib {
         swaption.initialize(lattice, stoppingTimes.back());
 
         Time nextExercise =
-            *std::find_if(stoppingTimes.begin(),
-                          stoppingTimes.end(),
-                          greater_or_equal_to<Time>(0.0));
+            *std::find_if(stoppingTimes.begin(), stoppingTimes.end(),
+                          [](Time t){ return t >= 0.0; });
         swaption.rollback(nextExercise);
 
         results_.value = swaption.presentValue();

--- a/ql/pricingengines/vanilla/analyticcevengine.cpp
+++ b/ql/pricingengines/vanilla/analyticcevengine.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
       x0_(X(f0)) { }
 
     Real CEVCalculator::X(Real f) const {
-        return std::pow(f, 2.0*(1.0-beta_))/square<Real>()(alpha_*(1.0-beta_));
+        return std::pow(f, 2.0*(1.0-beta_))/squared(alpha_*(1.0-beta_));
     }
 
     Real CEVCalculator::value(

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -32,6 +32,7 @@
 #include <ql/math/integrals/simpsonintegral.hpp>
 #include <ql/math/integrals/trapezoidintegral.hpp>
 #include <ql/math/solvers1d/brent.hpp>
+#include <ql/math/functional.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/analytichestonengine.hpp>
 #include <utility>
@@ -495,14 +496,14 @@ namespace QuantLib {
                     /(2.*kappa*kappa)*sigma
                    + (std::exp(-2*kt - ((theta - v0 + ekt
                 *((-1 + kt)*theta + v0))*z*zpi)/(2.*ekt*kappa))*z*z*zpi
-                *(-2*rho2*square<Real>()(2*theta + kt*theta - v0 -
+                *(-2*rho2*squared(2*theta + kt*theta - v0 -
                     kt*v0 + ekt*((-2 + kt)*theta + v0))
                   *z*z*zpi + 2*kappa*v0*(-zpi
                     + e2kt*(zpi + 4*rho2*z) - 2*ekt*(2*rho2*z
                     + kt*(zpi + rho2*(2 + kt)*z))) + kappa*theta*(zpi + e2kt
                 *(-5.0*zpi - 24*rho2*z+ 2*kt*(zpi + 4*rho2*z)) +
                 4*ekt*(zpi + 6*rho2*z + kt*(zpi + rho2*(4 + kt)*z)))))
-                /(16.*square<Real>()(square<Real>()(kappa)))*sigma2;
+                /(16.*squared(squared(kappa)))*sigma2;
         }
     }
 

--- a/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
@@ -300,7 +300,7 @@ namespace QuantLib {
         switch(cpxLog_) {
           case Gatheral: {
             const Real c_inf = std::min(0.2, std::max(0.0001,
-                std::sqrt(1.0-square<Real>()(rhoAvg))/sigmaAvg))
+                std::sqrt(1.0-squared(rhoAvg))/sigmaAvg))
                 *(v0 + kappaAvg*thetaAvg*term);
 
             const Real p1 = integration_->calculate(c_inf,
@@ -335,7 +335,7 @@ namespace QuantLib {
 
               const std::complex<Real> D_u_inf =
                   -std::complex<Real>(
-                      std::sqrt(1-square<Real>()(model_->rho(t05))),
+                      std::sqrt(1-squared(model_->rho(t05))),
                       model_->rho(t05)) / model_->sigma(t05);
 
               const Size lastI = std::distance(timeGrid.begin(),

--- a/ql/pricingengines/vanilla/coshestonengine.cpp
+++ b/ql/pricingengines/vanilla/coshestonengine.cpp
@@ -119,8 +119,7 @@ namespace QuantLib {
         const Real sigma2 = sigma_*sigma_;
 
         const std::complex<Real> D = std::sqrt(
-            square<std::complex<Real> >()(
-                std::complex<Real>(kappa_, -rho_*sigma_*u))
+            squared(std::complex<Real>(kappa_, -rho_*sigma_*u))
             + std::complex<Real>(u*u, u)*sigma2);
 
         const std::complex<Real> g(kappa_, -rho_*sigma_*u);
@@ -281,9 +280,8 @@ namespace QuantLib {
        return c3(t)/std::pow(c2(t), 1.5);
    }
    Real COSHestonEngine::kurtosis(Time t) const {
-       return c4(t)/square<Real>()(c2(t));
+       return c4(t)/squared(c2(t));
    }
+
 }
-
-
 

--- a/ql/pricingengines/vanilla/hestonexpansionengine.cpp
+++ b/ql/pricingengines/vanilla/hestonexpansionengine.cpp
@@ -21,9 +21,7 @@
     \brief analytic Heston expansion engine
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/pricingengines/blackformula.hpp>
-
 #include <ql/instruments/payoffs.hpp>
 #include <ql/pricingengines/vanilla/hestonexpansionengine.hpp>
 

--- a/ql/pricingengines/vanilla/mcamericanengine.cpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.cpp
@@ -23,7 +23,6 @@
 
 #include <ql/errors.hpp>
 #include <ql/instruments/payoffs.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/pricingengines/vanilla/mcamericanengine.hpp>
 #include <utility>
 

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -181,8 +181,7 @@ namespace QuantLib {
             return gaussLaguerreIntegration(
                 [&](Real u){ return ph(process, y, u, nu_0, nu_t, t); })
                 / std::sqrt(2*M_PI*(1-rho*rho)*y)
-                * std::exp(-0.5*square<Real>()(  x - x0 - a
-                                               + y*(0.5-rho*kappa/sigma))
+                * std::exp(-0.5*squared(x - x0 - a + y*(0.5-rho*kappa/sigma))
                            /(y*(1-rho*rho)));
         }
 

--- a/ql/processes/jointstochasticprocess.cpp
+++ b/ql/processes/jointstochasticprocess.cpp
@@ -21,7 +21,6 @@
     \brief multi model process for hybrid products
 */
 
-#include <ql/math/functional.hpp>
 #include <ql/math/matrixutilities/pseudosqrt.hpp>
 #include <ql/math/matrixutilities/svd.hpp>
 #include <ql/processes/jointstochasticprocess.hpp>
@@ -216,7 +215,7 @@ namespace QuantLib {
                     if (vol > 0.0) {
                         std::transform(stdDev.row_begin(i), stdDev.row_end(i),
                                        stdDev.row_begin(i),
-                                       divide_by<Real>(vol));
+                                       [=](Real x){ return x/vol; });
                     }
                     else {
                         // keep the svd happy

--- a/ql/processes/stochasticprocessarray.cpp
+++ b/ql/processes/stochasticprocessarray.cpp
@@ -20,7 +20,6 @@
 
 #include <ql/processes/stochasticprocessarray.hpp>
 #include <ql/math/matrixutilities/pseudosqrt.hpp>
-#include <ql/math/functional.hpp>
 
 namespace QuantLib {
 
@@ -66,7 +65,7 @@ namespace QuantLib {
             Real sigma = processes_[i]->diffusion(t, x[i]);
             std::transform(tmp.row_begin(i), tmp.row_end(i),
                            tmp.row_begin(i),
-                           multiply_by<Real>(sigma));
+                           [=](Real x){ return x * sigma; });
         }
         return tmp;
     }
@@ -88,7 +87,7 @@ namespace QuantLib {
             Real sigma = processes_[i]->stdDeviation(t0, x0[i], dt);
             std::transform(tmp.row_begin(i), tmp.row_end(i),
                            tmp.row_begin(i),
-                           multiply_by<Real>(sigma));
+                           [=](Real x){ return x * sigma; });
         }
         return tmp;
     }

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -26,7 +26,6 @@
 #define quantlib_global_bootstrap_hpp
 
 #include <ql/functional.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/termstructures/bootstraperror.hpp>
@@ -263,7 +262,7 @@ template <class Curve> void GlobalBootstrap<Curve>::calculate() const {
 
         Real value(const Array& x) const override {
             Array v = values(x);
-            std::transform(v.begin(), v.end(), v.begin(), square<Real>());
+            std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
             return std::sqrt(std::accumulate(v.begin(), v.end(), 0.0) / static_cast<Real>(v.size()));
         }
 

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
         const Real npv = volInterpl_->optionPrice(t, strike, optionType);
 
-        return square<Real>()(blackFormulaImpliedStdDevLiRS(
+        return squared(blackFormulaImpliedStdDevLiRS(
             optionType, strike, fwd, npv,
             volInterpl_->riskFreeRate()->discount(t),
             0.0, Null<Real>(), 1.0, eps_, 1000));

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -21,7 +21,6 @@
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/array.hpp>
 #include <ql/math/comparison.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/interpolations/backwardflatinterpolation.hpp>
 #include <ql/math/interpolations/cubicinterpolation.hpp>
 #include <ql/methods/finitedifferences/meshers/concentrating1dmesher.hpp>
@@ -305,10 +304,11 @@ namespace QuantLib {
         const DiscountFactor discount = rTS_->discount(expiryTime);
         const Real fwd = spot_->value()*qTS_->discount(expiryTime)/discount;
 
+        Size null = Null<Size>();
         const Size nOptions = std::count_if(
             calibrationMatrix_[iExpiry].begin(),
             calibrationMatrix_[iExpiry].end(),
-            not_null<Size>());
+            [=](Size n){ return n != null; });
 
         Array lnMarketStrikes(nOptions),
             marketNPVs(nOptions), marketVegas(nOptions);
@@ -317,7 +317,7 @@ namespace QuantLib {
         for (Size j=0, k=0; j < strikes_.size(); ++j) {
             const Size idx = calibrationMatrix_[iExpiry][j];
 
-            if (idx != Null<Size>()) {
+            if (idx != null) {
 
                 const Volatility vol = calibrationSet_[idx].second->value();
                 const Real stdDev = vol*std::sqrt(expiryTime);

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
     }
 
     Real HestonBlackVolSurface::blackVarianceImpl(Time t, Real strike) const {
-        return square<Real>()(blackVolImpl(t, strike))*t;
+        return squared(blackVolImpl(t, strike))*t;
     }
 
     Volatility HestonBlackVolSurface::blackVolImpl(Time t, Real strike) const {

--- a/ql/termstructures/volatility/sabr.cpp
+++ b/ql/termstructures/volatility/sabr.cpp
@@ -205,13 +205,13 @@ namespace QuantLib {
 
             Real Dint(Real k) const {
                 return 1/nu*std::log( ( std::sqrt(1+2*rho*nu/alpha*y(k)
-                    + square<Real>()(nu/alpha*y(k)) )
+                    + squared(nu/alpha*y(k)) )
                     - rho - nu/alpha*y(k) ) / (1-rho) );
             }
 
             Real D(Real k) const {
                 return std::sqrt(alpha*alpha+2*alpha*rho*nu*y(k)
-                    + square<Real>()(nu*y(k)))*std::pow(k,beta);
+                    + squared(nu*y(k)))*std::pow(k,beta);
             }
 
             Real omega0(Real k) const {
@@ -223,7 +223,7 @@ namespace QuantLib {
                 if (m > 1.0025 || m < 0.9975) {
                     return omega0(k)*(1+0.25*rho*nu*alpha*
                        (std::pow(k,beta)-std::pow(F,beta))/(k-F)*t)
-                       -omega0(k)/square<Real>()(Dint(k))*(std::log(
+                       -omega0(k)/squared(Dint(k))*(std::log(
                            omega0(k)) + 0.5*std::log((F*k/(D(F)*D(k))) ))*t;
                 }
                 else {
@@ -236,7 +236,7 @@ namespace QuantLib {
                 const Real alpha2 = alpha*alpha;
                 const Real rho2 = rho*rho;
                 return
-                    (alpha*std::pow(F,-3 + beta)*(alpha2*square<Real>()(-1 + beta)*std::pow(F,2*beta)*t + 6*alpha*beta*nu*std::pow(F,1 + beta)*rho*t +
+                    (alpha*std::pow(F,-3 + beta)*(alpha2*squared(-1 + beta)*std::pow(F,2*beta)*t + 6*alpha*beta*nu*std::pow(F,1 + beta)*rho*t +
                         F2*(24 + nu*nu*(2 - 3*rho2)*t)))/24.0 +
                      (3*alpha2*alpha*std::pow(-1 + beta,3)*std::pow(F,3*beta)*t +
                         3*alpha2*(-1 + beta)*(-1 + 5*beta)*nu*std::pow(F,1 + 2*beta)*rho*t + nu*F2*F*rho*(24 + nu*nu*(-4 + 3*rho2)*t) +

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -119,7 +119,7 @@ namespace andreasen_huge_volatility_interpl_test {
 
         calibrationSet.reserve(std::count_if(
             &raw[0][0], &raw[nStrikes-1][nMaturities]+1,
-            not_zero<Real>()) - nStrikes);
+            [](Real x) { return x != 0.0; }) - nStrikes);
 
         for (const auto & i : raw) {
             const Real strike = spot->value()*i[0];
@@ -647,7 +647,7 @@ void AndreasenHugeVolatilityInterplTest::testArbitrageFree() {
                 const Real w1 = (w_p - w_m)/(2*eps);
                 const Real w2 = (w_p + w_m - 2*w)/(eps*eps);
 
-                const Real g_k = square<Real>()(1-m*w1/(2*w))
+                const Real g_k = squared(1-m*w1/(2*w))
                     - w1*w1/4*(1/w + 0.25) + 0.5*w2;
 
                 if (g_k < 0) {

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -31,7 +31,6 @@
 #include <ql/math/distributions/poissondistribution.hpp>
 #include <ql/math/randomnumbers/stochasticcollocationinvcdf.hpp>
 #include <ql/math/comparison.hpp>
-#include <ql/math/functional.hpp>
 
 #if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
 #pragma GCC diagnostic push
@@ -273,9 +272,10 @@ void DistributionTest::testNormal() {
     }
 
     MaddockInverseCumulativeNormal mInvCum(average, sigma);
-    std::transform(x.begin(),x.end(), x.begin(), diff.begin(),
-    			   compose3(std::minus<Real>(),
-    				  identity<Real>(), compose(mInvCum, cum)));
+    std::transform(x.begin(), x.end(), diff.begin(),
+                   [&](Real x) {
+                       return x - mInvCum(cum(x));
+                   });
 
     e = norm(diff.begin(), diff.end(), h);
     if (e > 1.0e-7) {

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -365,8 +365,8 @@ void DoubleBarrierOptionTest::testEuropeanHaugValues() {
                         Handle<YieldTermStructure>(rTS),
                         Handle<YieldTermStructure>(qTS),
                         Handle<Quote>(spot),
-                        square<Real>()(vol->value()), 1.0,
-                        square<Real>()(vol->value()), 0.001, 0.0)), 251, 76, 3);
+                        squared(vol->value()), 1.0,
+                        squared(vol->value()), 0.001, 0.0)), 251, 76, 3);
 
             opt.setPricingEngine(engine);
             calculated = opt.NPV();

--- a/test-suite/fdcev.cpp
+++ b/test-suite/fdcev.cpp
@@ -19,8 +19,6 @@
 
 #include "fdcev.hpp"
 #include "utilities.hpp"
-
-#include <ql/math/functional.hpp>
 #include <ql/math/randomnumbers/rngtraits.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/math/statistics/generalstatistics.hpp>

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -21,7 +21,6 @@
 #include "fdheston.hpp"
 #include "utilities.hpp"
 #include <ql/instruments/barrieroption.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/models/equity/hestonmodel.hpp>
 #include <ql/pricingengines/barrier/fdhestonbarrierengine.hpp>
 #include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -80,7 +80,7 @@ namespace fd_heston_test {
 
       protected:
         Volatility localVolImpl(Time t, Real s) const override {
-            return alpha_*(square<Real>()(s0_ - s) + 25.0);
+            return alpha_*(squared(s0_ - s) + 25.0);
         }
 
       private:

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -22,7 +22,6 @@
 
 #include <ql/types.hpp>
 #include <ql/math/matrix.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/integrals/momentbasedgaussianpolynomial.hpp>
@@ -98,11 +97,11 @@ namespace gaussian_quadratures_test {
     template <class T>
     void testSingleJacobi(const T& I) {
         testSingle(I, "f(x) = 1",
-                   constant<Real,Real>(1.0), 2.0);
+                   [](Real x){ return 1.0; },   2.0);
         testSingle(I, "f(x) = x",
-                   identity<Real>(),         0.0);
+                   [](Real x){ return x; },     0.0);
         testSingle(I, "f(x) = x^2",
-                   square<Real>(),           2/3.);
+                   [](Real x){ return x * x; }, 2/3.);
         testSingle(I, "f(x) = sin(x)",
                    static_cast<Real(*)(Real)>(std::sin), 0.0);
         testSingle(I, "f(x) = cos(x)",
@@ -198,15 +197,15 @@ void GaussianQuadraturesTest::testTabulated() {
 
      using namespace gaussian_quadratures_test;
 
-     testSingleTabulated(constant<Real,Real>(1.0), "f(x) = 1",
+     testSingleTabulated([](Real x){ return 1.0; }, "f(x) = 1",
                          2.0,       1.0e-13);
-     testSingleTabulated(identity<Real>(), "f(x) = x",
+     testSingleTabulated([](Real x){ return x; }, "f(x) = x",
                          0.0,       1.0e-13);
-     testSingleTabulated(square<Real>(), "f(x) = x^2",
+     testSingleTabulated([](Real x){ return x * x; }, "f(x) = x^2",
                          (2.0/3.0), 1.0e-13);
-     testSingleTabulated(cube<Real>(), "f(x) = x^3",
+     testSingleTabulated([](Real x){ return x * x * x; }, "f(x) = x^3",
                          0.0,       1.0e-13);
-     testSingleTabulated(fourth_power<Real>(), "f(x) = x^4",
+     testSingleTabulated([](Real x){ return x * x * x * x; }, "f(x) = x^4",
                          (2.0/5.0), 1.0e-13);
 }
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -26,6 +26,7 @@
 #include <ql/math/optimization/differentialevolution.hpp>
 #include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/math/randomnumbers/rngtraits.hpp>
+#include <ql/math/functional.hpp>
 #include <ql/methods/finitedifferences/operators/numericaldifferentiation.hpp>
 #include <ql/methods/montecarlo/pathgenerator.hpp>
 #include <ql/models/equity/hestonmodel.hpp>
@@ -2282,18 +2283,18 @@ void HestonModelTest::testAndersenPiterbargControlVariateIntegrand() {
         // Corrado C. and T. Su, (1996-b),
         // “Skewness and Kurtosis in S&P 500 IndexReturns Implied by Option Prices”,
         // Journal of Financial Research 19 (2), 175-192.
-        square<Real>()(blackFormulaImpliedStdDev(
+        squared(blackFormulaImpliedStdDev(
             Option::Call, strike, fwd, bsNPV + skew*q3, df)),
-        square<Real>()(blackFormulaImpliedStdDev(
+        squared(blackFormulaImpliedStdDev(
             Option::Call, strike, fwd, bsNPV + skew*q3 + kurt*q4, df)),
         // Moment matching based on
         // Rubinstein M., (1998), “Edgeworth Binomial Trees”,
         // Journal of Derivatives 5 (3), 20-27.
-        square<Real>()(blackFormulaImpliedStdDev(
+        squared(blackFormulaImpliedStdDev(
             Option::Call, strike, fwd,
             bsNPV + skew*q3 + kurt*q4 + skew*skew*q5, df)),
         // implied vol as control variate
-        square<Real>()(implStdDev),
+        squared(implStdDev),
         // remaining function becomes zero for u -> 0
         -8.0*std::log(engine->chF(std::complex<Real>(0, -0.5), maturity).real())
     };
@@ -3077,13 +3078,15 @@ namespace {
 void HestonModelTest::testHestonEngineIntegration() {
     BOOST_TEST_MESSAGE("Testing Heston engine integration signature...");
 
+    auto square = [](Real x){ return x*x; };
+
     const AnalyticHestonEngine::Integration integration =
         AnalyticHestonEngine::Integration::gaussLobatto(1e-12, 1e-12);
 
-    const Real c1 = integration.calculate(1.0, square<Real>(), 1.0);
+    const Real c1 = integration.calculate(1.0, square, 1.0);
 
     HestonIntegrationMaxBoundTestFct testFct(1.0);
-    const Real c2 = integration.calculate(1.0, square<Real>(), testFct);
+    const Real c2 = integration.calculate(1.0, square, testFct);
 
     if (testFct.getCallCounter() == 0 ||
             std::fabs(c1 - 1/3.) > 1e-10 || std::fabs(c2 - 1/3.) > 1e-10) {

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -396,8 +396,8 @@ void HestonSLVModelTest::testTransformedZeroFlowBC() {
         const Real hp = v[i+2] - v[i+1];
 
         const Real eta=1.0/(hm*(hm+hp)*hp);
-        const Real a = -eta*(square<Real>()(hm+hp) - hm*hm);
-        const Real b  = eta*square<Real>()(hm+hp);
+        const Real a = -eta*(squared(hm+hp) - hm*hm);
+        const Real b  = eta*squared(hm+hp);
         const Real c = -eta*hm*hm;
 
         const Real df = a*q[i] + b*q[i+1] + c*q[i+2];
@@ -1131,8 +1131,7 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
 
     Real v=-Null<Real>(), p_v(0.0);
     Array p(mesher->layout()->size(), 0.0);
-    const Real bsV0 = square<Real>()(
-        lvProcess->blackVolatility()->blackVol(0.0, s0, true));
+    const Real bsV0 = squared(lvProcess->blackVolatility()->blackVol(0.0, s0, true));
 
     SquareRootProcessRNDCalculator rndCalculator(v0, kappa, theta, sigma);
     const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
@@ -1150,7 +1149,7 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
                 p_v = 0.0;
         }
         const Real p_x = 1.0/(std::sqrt(M_TWOPI*bsV0*eT))
-            * std::exp(-0.5*square<Real>()(x - x0)/(bsV0*eT));
+            * std::exp(-0.5*squared(x - x0)/(bsV0*eT));
         p[iter.index()] = p_v*p_x;
     }
     const Time dt = (maturity-eT)/tGrid;

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -27,6 +27,7 @@
 #include <ql/instruments/impliedvolatility.hpp>
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/processes/hybridhestonhullwhiteprocess.hpp>
+#include <ql/math/functional.hpp>
 #include <ql/math/randomnumbers/rngtraits.hpp>
 #include <ql/math/randomnumbers/sobolbrownianbridgersg.hpp>
 #include <ql/math/optimization/simplex.hpp>
@@ -1157,8 +1158,7 @@ namespace hybrid_heston_hullwhite_process_test {
             bool test(const Array& params) const override {
                 const Real rho = params[3];
 
-                return (  square<Real>()(rho)
-                        + square<Real>()(equityShortRateCorr_) <= 1.0);
+                return (squared(rho) + squared(equityShortRateCorr_) <= 1.0);
             }
 
           private:

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -20,7 +20,6 @@
 
 #include "integrals.hpp"
 #include "utilities.hpp"
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/exponentialintegrals.hpp>
 #include <ql/math/integrals/filonintegral.hpp>
 #include <ql/math/integrals/segmentintegral.hpp>
@@ -59,13 +58,13 @@ namespace integrals_test {
     template <class T>
     void testSeveral(const T& I) {
         testSingle(I, "f(x) = 0",
-                   constant<Real,Real>(0.0), 0.0, 1.0, 0.0);
+                   [](Real x){ return 0.0; },   0.0, 1.0, 0.0);
         testSingle(I, "f(x) = 1",
-                   constant<Real,Real>(1.0), 0.0, 1.0, 1.0);
+                   [](Real x){ return 1.0; },   0.0, 1.0, 1.0);
         testSingle(I, "f(x) = x",
-                   identity<Real>(),           0.0, 1.0, 0.5);
+                   [](Real x){ return x; },     0.0, 1.0, 0.5);
         testSingle(I, "f(x) = x^2",
-                   square<Real>(),             0.0, 1.0, 1.0/3.0);
+                   [](Real x){ return x * x; }, 0.0, 1.0, 1.0/3.0);
         testSingle(I, "f(x) = sin(x)",
                    static_cast<Real(*)(Real)>(std::sin), 0.0, M_PI, 2.0);
         testSingle(I, "f(x) = cos(x)",
@@ -80,7 +79,7 @@ namespace integrals_test {
     template <class T>
     void testDegeneratedDomain(const T& I) {
         testSingle(I, "f(x) = 0 over [1, 1 + macheps]",
-                   constant<Real, Real>(0.0), 1.0, 1.0 + QL_EPSILON, 0.0);
+                   [](Real x){ return 0.0; }, 1.0, 1.0 + QL_EPSILON, 0.0);
     }
 
 }

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2303,8 +2303,7 @@ void InterpolationTest::testLagrangeInterpolationOnChebyshevPoints() {
         }
 
         const Real calculatedDeriv = interpl.derivative(x, true);
-        const Real expectedDeriv = std::exp(x)*(std::cos(x) + std::sin(x))
-                / square<Real>()(std::cos(x));
+        const Real expectedDeriv = std::exp(x)*(std::cos(x) + std::sin(x)) / squared(std::cos(x));
 
         const Real diffDeriv = std::fabs(expectedDeriv - calculatedDeriv);
         if (std::isnan(calculated) || diffDeriv > tolDeriv) {

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -20,7 +20,6 @@
 
 #include "linearleastsquaresregression.hpp"
 #include "utilities.hpp"
-#include <ql/math/functional.hpp>
 #include <ql/math/randomnumbers/rngtraits.hpp>
 #include <ql/math/linearleastsquaresregression.hpp>
 #include <ql/functional.hpp>
@@ -140,7 +139,7 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
     PseudoRandom::rng_type rng(PseudoRandom::urng_type(1234U));
 
     std::vector<ext::function<Real(Array)> > v;
-    v.emplace_back(constant<Array, Real>(1.0));
+    v.emplace_back([](Array x){ return 1.0; });
     for (Size i=0; i < dims; ++i) {
         v.emplace_back(get_item(i));
     }

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -81,7 +81,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/math/statistics/convergencestatistics.hpp>
 #include <ql/termstructures/volatility/abcd.hpp>
 #include <ql/termstructures/volatility/abcdcalibration.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/optimization/simplex.hpp>
 #include <ql/quotes/simplequote.hpp>
 
@@ -311,17 +310,17 @@ namespace market_model_test {
             std::vector<Rate> bumpedForwards(todaysForwards.size());
             std::transform(todaysForwards.begin(), todaysForwards.end(),
                            bumpedForwards.begin(),
-                           add<Rate>(forwardBump));
+                           [=](Rate r){ return r + forwardBump; });
 
             std::vector<Volatility> bumpedVols(volatilities.size());
             if (logNormal)
                 std::transform(volatilities.begin(), volatilities.end(),
                                bumpedVols.begin(),
-                               add<Volatility>(volBump));
+                               [=](Volatility v){ return v + volBump; });
             else
                 std::transform(normalVols.begin(), normalVols.end(),
                                bumpedVols.begin(),
-                               add<Volatility>(volBump));
+                               [=](Volatility v){ return v + volBump; });
 
             Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                 longTermCorrelation,

--- a/test-suite/marketmodel_cms.cpp
+++ b/test-suite/marketmodel_cms.cpp
@@ -45,7 +45,6 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/math/statistics/sequencestatistics.hpp>
 #include <ql/math/statistics/convergencestatistics.hpp>
-#include <ql/math/functional.hpp>
 #include <iostream>
 #include <sstream>
 
@@ -213,12 +212,12 @@ namespace market_model_cms_test {
             curveState_lmm.cmSwapRates(spanningForwards);
         std::transform(usedRates.begin(), usedRates.end(),
                        bumpedRates.begin(),
-                       add<Rate>(rateBump));
+                       [=](Rate r){ return r + rateBump; });
 
         std::vector<Volatility> bumpedVols(volatilities.size());
         std::transform(volatilities.begin(), volatilities.end(),
                        bumpedVols.begin(),
-                       add<Volatility>(volBump));
+                       [=](Volatility v){ return v + volBump; });
         Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                       longTermCorrelation,
                                                       beta);

--- a/test-suite/marketmodel_smm.cpp
+++ b/test-suite/marketmodel_smm.cpp
@@ -47,7 +47,6 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/math/integrals/segmentintegral.hpp>
 #include <ql/math/statistics/convergencestatistics.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/statistics/sequencestatistics.hpp>
 #include <sstream>
 
@@ -211,12 +210,12 @@ namespace market_model_smm_test {
         std::vector<Rate> usedRates = curveState_lmm.coterminalSwapRates();
         std::transform(usedRates.begin(), usedRates.end(),
                        bumpedRates.begin(),
-                       add<Rate>(rateBump));
+                       [=](Rate r){ return r + rateBump; });
 
         std::vector<Volatility> bumpedVols(volatilities.size());
         std::transform(volatilities.begin(), volatilities.end(),
                        bumpedVols.begin(),
-                       add<Volatility>(volBump));
+                       [=](Volatility v){ return v + volBump; });
         Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                       longTermCorrelation,
                                                       beta);

--- a/test-suite/marketmodel_smmcapletalphacalibration.cpp
+++ b/test-suite/marketmodel_smmcapletalphacalibration.cpp
@@ -55,7 +55,6 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/math/integrals/segmentintegral.hpp>
 #include <ql/math/statistics/convergencestatistics.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/optimization/simplex.hpp>
 #include <ql/math/statistics/sequencestatistics.hpp>
 #include <sstream>

--- a/test-suite/marketmodel_smmcapletcalibration.cpp
+++ b/test-suite/marketmodel_smmcapletcalibration.cpp
@@ -54,7 +54,6 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/math/integrals/segmentintegral.hpp>
 #include <ql/math/statistics/convergencestatistics.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/statistics/sequencestatistics.hpp>
 #include <sstream>
 

--- a/test-suite/marketmodel_smmcaplethomocalibration.cpp
+++ b/test-suite/marketmodel_smmcaplethomocalibration.cpp
@@ -60,12 +60,11 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/math/integrals/segmentintegral.hpp>
 #include <ql/math/statistics/convergencestatistics.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/optimization/simplex.hpp>
 #include <ql/math/statistics/sequencestatistics.hpp>
-#include <sstream>
 #include <ql/models/marketmodels/models/capletcoterminalperiodic.hpp>
 #include <ql/models/marketmodels/models/volatilityinterpolationspecifierabcd.hpp>
+#include <sstream>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -22,7 +22,6 @@
 #include "utilities.hpp"
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #include <ql/methods/finitedifferences/utilities/bsmrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/cevrndcalculator.hpp>

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -50,6 +50,11 @@ using namespace boost::unit_test_framework;
 
 
 namespace swing_option_test {
+
+    ext::function<Real(Real)> constant_b(Real b) {
+        return [=](Real x){ return b; };
+    }
+
     ext::shared_ptr<ExtOUWithJumpsProcess> createKlugeProcess() {
         Array x0(2);
         x0[0] = 3.0; x0[1] = 0.0;
@@ -62,7 +67,7 @@ namespace swing_option_test {
 
         ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
             new ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0[0],
-                                                 constant<Real, Real>(x0[0])));
+                                                 constant_b(x0[0])));
         return ext::make_shared<ExtOUWithJumpsProcess>(
             ouProcess, x0[1], beta, jumpIntensity, eta);
     }
@@ -84,8 +89,8 @@ void SwingOptionTest::testExtendedOrnsteinUhlenbeckProcess() {
         ExtendedOrnsteinUhlenbeckProcess::GaussLobatto};
 
     ext::function<Real (Real)> f[] 
-        = { constant<Real, Real>(level),
-            add<Real>(1.0),
+        = { [=](Real x){ return level; },
+            [ ](Real x){ return x + 1.0; },
             static_cast<Real(*)(Real)>(std::sin) }; 
 
     for (Size n=0; n < LENGTH(f); ++n) {
@@ -128,6 +133,8 @@ void SwingOptionTest::testFdmExponentialJump1dMesher() {
 
     BOOST_TEST_MESSAGE("Testing finite difference mesher for the Kluge model...");
 
+    using namespace swing_option_test;
+
     SavedSettings backup;
 
     Array x(2, 1.0);
@@ -140,7 +147,7 @@ void SwingOptionTest::testFdmExponentialJump1dMesher() {
 
     ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
         new ExtendedOrnsteinUhlenbeckProcess(1.0, 1.0, x[0],
-                                             constant<Real, Real>(1.0)));
+                                             constant_b(1.0)));
     ext::shared_ptr<ExtOUWithJumpsProcess> jumpProcess(
         new ExtOUWithJumpsProcess(ouProcess, x[1], beta, jumpIntensity, eta));
 
@@ -501,7 +508,7 @@ void SwingOptionTest::testKlugeChFVanillaPricing() {
     const ext::shared_ptr<ExtOUWithJumpsProcess> klugeProcess =
         ext::make_shared<ExtOUWithJumpsProcess>(
             ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(
-                    alpha, sig, x0, constant<Real, Real>(0.0)),
+                    alpha, sig, x0, constant_b(0.0)),
             y0, beta, lambda, eta);
 
     const Real strike = f0;
@@ -533,7 +540,7 @@ void SwingOptionTest::testKlugeChFVanillaPricing() {
         / (stdDev*stdDev*stdDev);
 
     const Real g2 = 3*(std::exp((alpha + beta)*t)
-        *  square<Real>()(2*alpha*std::exp(2*alpha*t)*(-1 + std::exp(2*beta*t))
+        *  squared(2*alpha*std::exp(2*alpha*t)*(-1 + std::exp(2*beta*t))
                   *lambda + beta*std::exp(2*beta*t)*(-1 + std::exp(2*alpha*t))
                   *eta*eta*sig*sig)
             + 16*alpha*alpha*beta*std::exp((5*alpha + 3*beta)*t)*lambda


### PR DESCRIPTION
Closes #1339.

Deprecated public typedefs in `ql/math/functional.hpp`.

This header can be cleaned up further once #1324 is merged.