### PR TITLE
Move global typedefs into namespace

### DIFF
--- a/ql/experimental/math/fireflyalgorithm.hpp
+++ b/ql/experimental/math/fireflyalgorithm.hpp
@@ -35,18 +35,18 @@ http://arxiv.org/pdf/1003.1464.pdf
 #include <ql/math/randomnumbers/seedgenerator.hpp>
 
 #include <boost/random/mersenne_twister.hpp>
-typedef boost::mt19937 base_generator_type;
-
 #include <boost/random/normal_distribution.hpp>
-typedef boost::random::normal_distribution<QuantLib::Real> BoostNormalDistribution;
 #include <boost/random/uniform_int_distribution.hpp>
-typedef boost::random::uniform_int_distribution<QuantLib::Size> uniform_integer;
 #include <boost/random/variate_generator.hpp>
-typedef boost::variate_generator<base_generator_type, uniform_integer> variate_integer;
 
 #include <cmath>
 
 namespace QuantLib {
+
+    typedef boost::mt19937 base_generator_type;
+    typedef boost::random::normal_distribution<QuantLib::Real> BoostNormalDistribution;
+    typedef boost::random::uniform_int_distribution<QuantLib::Size> uniform_integer;
+    typedef boost::variate_generator<base_generator_type, uniform_integer> variate_integer;
 
     /*! The main process is as follows:
     M individuals are used to explore the N-dimensional parameter space:

--- a/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
+++ b/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
@@ -29,22 +29,11 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/math/optimization/problem.hpp>
 
 #include <boost/random/mersenne_twister.hpp>
-typedef boost::mt19937 base_generator_type;
-
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/lognormal_distribution.hpp>
 #include <boost/random/cauchy_distribution.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
-typedef boost::random::uniform_real_distribution<double> uniform;
-typedef boost::random::normal_distribution<> normal_random;
-typedef boost::random::lognormal_distribution<> lognormal_random;
-typedef boost::random::cauchy_distribution<> cauchy_random;
-
 #include <boost/random/variate_generator.hpp>
-typedef boost::variate_generator<base_generator_type&, uniform > uniform_variate;
-typedef boost::variate_generator<base_generator_type, normal_random > normal_variate;
-typedef boost::variate_generator<base_generator_type&, lognormal_random > lognormal_variate;
-typedef boost::variate_generator<base_generator_type&, cauchy_random > cauchy_variate;
 
 #include <algorithm> //for std::max
 #include <cmath>     //for log
@@ -53,6 +42,16 @@ typedef boost::variate_generator<base_generator_type&, cauchy_random > cauchy_va
 
 namespace QuantLib
 {
+    typedef boost::mt19937 base_generator_type;
+    typedef boost::random::uniform_real_distribution<double> uniform;
+    typedef boost::random::normal_distribution<> normal_random;
+    typedef boost::random::lognormal_distribution<> lognormal_random;
+    typedef boost::random::cauchy_distribution<> cauchy_random;
+    typedef boost::variate_generator<base_generator_type&, uniform > uniform_variate;
+    typedef boost::variate_generator<base_generator_type, normal_random > normal_variate;
+    typedef boost::variate_generator<base_generator_type&, lognormal_random > lognormal_variate;
+    typedef boost::variate_generator<base_generator_type&, cauchy_random > cauchy_variate;
+
     //! Lognormal Sampler
     /*!    Sample from lognormal distribution. This means that the parameter space
     must have support on the positve side of the real line only.

--- a/ql/experimental/math/particleswarmoptimization.hpp
+++ b/ql/experimental/math/particleswarmoptimization.hpp
@@ -35,12 +35,12 @@ Computation, 6(2): 58–73.
 #include <ql/math/randomnumbers/seedgenerator.hpp>
 
 #include <boost/random/mersenne_twister.hpp>
-typedef boost::mt19937 base_generator_type;
-
 #include <boost/random/uniform_int_distribution.hpp>
-typedef boost::random::uniform_int_distribution<QuantLib::Size> uniform_integer;
 
 namespace QuantLib {
+
+    typedef boost::mt19937 base_generator_type;
+    typedef boost::random::uniform_int_distribution<QuantLib::Size> uniform_integer;
 
     /*! The process is as follows:
     M individuals are used to explore the N-dimensional parameter space:

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -50,8 +50,6 @@ using namespace boost::unit_test_framework;
 
 using std::exp;
 
-typedef PiecewiseYieldCurve<Discount,LogLinear> PiecewiseFlatForward;
-
 namespace overnight_indexed_swap_test {
 
     struct Datum {
@@ -351,8 +349,7 @@ namespace overnight_indexed_swap_test {
         eoniaHelpers.push_back(helper);
     }
 
-    ext::shared_ptr<PiecewiseFlatForward> eoniaTS(
-        new PiecewiseFlatForward (vars.today, eoniaHelpers, Actual365Fixed()));
+    auto eoniaTS = ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(vars.today, eoniaHelpers, Actual365Fixed());
 
     vars.eoniaTermStructure.linkTo(eoniaTS);
 

--- a/test-suite/riskstats.cpp
+++ b/test-suite/riskstats.cpp
@@ -29,14 +29,11 @@
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
-typedef GenericGaussianStatistics<IncrementalStatistics>
-    IncrementalGaussianStatistics;
-
 void RiskStatisticsTest::testResults() {
 
     BOOST_TEST_MESSAGE("Testing risk measures...");
 
-    IncrementalGaussianStatistics igs;
+    GenericGaussianStatistics<IncrementalStatistics> igs;
     RiskStatistics s;
 
     Real averages[] = { -100.0, -1.0, 0.0, 1.0, 100.0 };


### PR DESCRIPTION
Currently these typedefs are in the global namespace, which may conflict with other libraries, so I have either moved them into the QuantLib namespace or removed them if they were only used in one place.

Since all the modified classes are in `ql/experimental` or `test-suite`, I believe that the typedefs do not need to be deprecated before being moved.