### PR TITLE
Add `constexpr` constructor and conversion operator for nulls

### DIFF
--- a/ql/experimental/credit/integralntdengine.cpp
+++ b/ql/experimental/credit/integralntdengine.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
         results_.upfrontPremiumValue = 0.;
         Real accrualValue = 0.0;
         Real claimValue = 0.0;
-        Date d, d0;
+        Date d0;
         /* Given the expense of probsBeingNthEvent both in integrable and 
         monte carlo algorithms this engine tests who to call.
         Warning: This is not entirely a basket property but of the model too.

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -168,7 +168,7 @@
 /*! \def QL_EPSILON
     Defines the machine precision for operations over doubles
 */
-#include <boost/limits.hpp>
+#include <limits>
 // limits used as such
 #define QL_MIN_INTEGER         ((std::numeric_limits<QL_INTEGER>::min)())
 #define QL_MAX_INTEGER         ((std::numeric_limits<QL_INTEGER>::max)())
@@ -176,8 +176,15 @@
 #define QL_MAX_REAL            ((std::numeric_limits<QL_REAL>::max)())
 #define QL_MIN_POSITIVE_REAL   ((std::numeric_limits<QL_REAL>::min)())
 #define QL_EPSILON             ((std::numeric_limits<QL_REAL>::epsilon)())
-// specific values---these should fit into any Integer or Real
+/*! \def QL_NULL_INTEGER
+    \deprecated Don't use this macro.
+                Deprecated in version 1.27.
+*/
 #define QL_NULL_INTEGER        ((std::numeric_limits<int>::max)())
+/*! \def QL_NULL_REAL
+    \deprecated Don't use this macro.
+                Deprecated in version 1.27.
+*/
 #define QL_NULL_REAL           ((std::numeric_limits<float>::max)())
 /*! @} */
 

--- a/ql/timeseries.hpp
+++ b/ql/timeseries.hpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <map>
 #include <vector>
+#include <type_traits>
 
 namespace QuantLib {
 
@@ -147,10 +148,8 @@ namespace QuantLib {
         // bidirectional_iterator_tag category.
         typedef typename boost::mpl::if_ <
             boost::mpl::or_ <
-                boost::is_same<iterator_category,
-                               std::bidirectional_iterator_tag>,
-                boost::is_base_of<std::bidirectional_iterator_tag,
-                                  iterator_category> >,
+                std::is_same<iterator_category, std::bidirectional_iterator_tag>,
+                std::is_base_of<std::bidirectional_iterator_tag, iterator_category> >,
             std::bidirectional_iterator_tag, 
             std::input_iterator_tag>::type enable_reverse;
 

--- a/ql/utilities/dataformatters.hpp
+++ b/ql/utilities/dataformatters.hpp
@@ -25,7 +25,7 @@
 #define quantlib_data_formatters_hpp
 
 #include <ql/utilities/null.hpp>
-#include <iosfwd>
+#include <ostream>
 
 namespace QuantLib {
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -27,17 +27,8 @@
 #define quantlib_null_hpp
 
 #include <ql/types.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
-#include <boost/type_traits.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
+#include <type_traits>
+#include <limits>
 
 namespace QuantLib {
 
@@ -55,7 +46,8 @@ namespace QuantLib {
         template <>
         struct FloatingPointNull<true> {
             constexpr static float nullValue() {
-                return QL_NULL_REAL;
+                // a specific values that should fit into any Real
+                return (std::numeric_limits<float>::max)();
             }
         };
 
@@ -63,7 +55,8 @@ namespace QuantLib {
         template <>
         struct FloatingPointNull<false> {
             constexpr static int nullValue() {
-                return QL_NULL_INTEGER;
+                // a specific values that should fit into any Integer
+                return (std::numeric_limits<int>::max)();
             }
         };
 
@@ -75,8 +68,7 @@ namespace QuantLib {
       public:
         constexpr Null() = default;
         constexpr operator T() const {
-            return T(detail::FloatingPointNull<
-                         boost::is_floating_point<T>::value>::nullValue());
+            return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
         }
     };
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         // null value for floating-point types
         template <>
         struct FloatingPointNull<true> {
-            static float nullValue() {
+            constexpr static float nullValue() {
                 return QL_NULL_REAL;
             }
         };
@@ -62,7 +62,7 @@ namespace QuantLib {
         // null value for integer types
         template <>
         struct FloatingPointNull<false> {
-            static int nullValue() {
+            constexpr static int nullValue() {
                 return QL_NULL_INTEGER;
             }
         };
@@ -73,8 +73,8 @@ namespace QuantLib {
     template <typename T>
     class Null {
       public:
-        Null() = default;
-        operator T() const {
+        constexpr Null() = default;
+        constexpr operator T() const {
             return T(detail::FloatingPointNull<
                          boost::is_floating_point<T>::value>::nullValue());
         }


### PR DESCRIPTION
Also, use a couple of C++11 std headers instead of Boost and deprecate a couple of unnecessary macros.