### PR TITLE
Add `remove` method to thread-local singleton

### DIFF
--- a/ql/patterns/singleton.hpp
+++ b/ql/patterns/singleton.hpp
@@ -105,7 +105,7 @@ namespace QuantLib {
 
 #ifdef QL_ENABLE_SESSIONS
         //! remove the session-local instance, return true if there was such an instance
-        bool remove() {
+        static bool remove() {
             boost::unique_lock<boost::shared_mutex> uniqueLock(m_mutex());
             return m_instances().erase(sessionId()) != 0;
         }

--- a/ql/patterns/singleton.hpp
+++ b/ql/patterns/singleton.hpp
@@ -103,6 +103,14 @@ namespace QuantLib {
         //! access to the unique instance
         static T& instance();
 
+#ifdef QL_ENABLE_SESSIONS
+        //! remove the session-local instance, return true if there was such an instance
+        bool remove() {
+            boost::unique_lock<boost::shared_mutex> uniqueLock(m_mutex());
+            return m_instances().erase(sessionId()) != 0;
+        }
+#endif
+
       protected:
         Singleton() = default;
 


### PR DESCRIPTION
We use thread-local singletons in "worker" threads whose lifetime ends before the "master" threads ends. We want to be able to remove the associated singletons before such a thread ends.