### PR TITLE
Split `.clang-tidy` into one for fixes and one for checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,32 @@ Checks: >
           -bugprone-branch-clone,
           -bugprone-macro-parentheses,
           -bugprone-narrowing-conversions,
+        clang-analyzer-*,
+          -clang-analyzer-core.UndefinedBinaryOperatorResult,
+          -clang-analyzer-core.uninitialized.Assign,
+          -clang-analyzer-deadcode.DeadStores,
+          -clang-analyzer-optin.cplusplus.UninitializedObject,
+          -clang-analyzer-optin.cplusplus.VirtualCall,
+          -clang-analyzer-optin.performance.Padding,
+          -clang-analyzer-security.FloatLoopCounter,
+        cppcoreguidelines-*,
+          -cppcoreguidelines-avoid-c-arrays,
+          -cppcoreguidelines-avoid-goto,
+          -cppcoreguidelines-avoid-magic-numbers,
+          -cppcoreguidelines-avoid-non-const-global-variables,
+          -cppcoreguidelines-init-variables,
+          -cppcoreguidelines-macro-usage,
+          -cppcoreguidelines-narrowing-conversions,
+          -cppcoreguidelines-non-private-member-variables-in-classes,
+          -cppcoreguidelines-owning-memory,
+          -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+          -cppcoreguidelines-pro-bounds-constant-array-index,
+          -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+          -cppcoreguidelines-pro-type-const-cast,
+          -cppcoreguidelines-pro-type-member-init,
+          -cppcoreguidelines-pro-type-vararg,
+          -cppcoreguidelines-slicing,
+          -cppcoreguidelines-special-member-functions,
         misc-*,
           -misc-no-recursion,
           -misc-non-private-member-variables-in-classes,
@@ -20,22 +46,16 @@ Checks: >
           -readability-convert-member-functions-to-static,
           -readability-else-after-return,
           -readability-function-cognitive-complexity,
+          -readability-identifier-length,
           -readability-inconsistent-declaration-parameter-name,
           -readability-isolate-declaration,
           -readability-magic-numbers,
           -readability-named-parameter,
           -readability-simplify-boolean-expr,
           -readability-use-anyofallof,
-WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:
   - key:   modernize-use-default-member-init.UseAssignment
-    value: 1
-  - key:   readability-identifier-length.MinimumParameterNameLength
-    value: 1
-  - key:   readability-identifier-length.MinimumVariableNameLength
-    value: 1
-  - key:   readability-identifier-length.MinimumLoopCounterNameLength
     value: 1
 ...

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,6 +73,17 @@
       }
     },
     {
+      "name": "linux-gcc-debug-with-clang-tidy",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_COMPILER": "g++",
+        "QL_CLANG_TIDY_OPTIONS": "-warnings-as-errors=*",
+        "QL_USE_CLANG_TIDY": "ON"
+      }
+    },
+    {
       "name": "linux-ci-build-with-clang-tidy",
       "binaryDir": "${sourceDir}/build",
       "generator": "Unix Makefiles",
@@ -144,6 +155,10 @@
     {
       "name": "linux-gcc-release",
       "configurePreset": "linux-gcc-release"
+    },
+    {
+      "name": "linux-gcc-debug-with-clang-tidy",
+      "configurePreset": "linux-gcc-debug-with-clang-tidy"
     },
     {
       "name": "windows-clang-x64-debug",

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -210,7 +210,7 @@ namespace QuantLib {
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wsuggest-override"
         #endif
-        Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override)
+        Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override, cppcoreguidelines-explicit-virtual-functions)
                                          // (sometimes this method is not virtual,
                                          //  depending on the base class)
         #if defined(__clang__)

--- a/tools/run_tidy.sh
+++ b/tools/run_tidy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo Checking $1
-clang-tidy-10 -quiet -fix $1 -- -std=c++11 -I$PWD -DQL_USE_STD_SHARED_PTR=1 -DQL_USE_STD_FUNCTION=1 -DQL_USE_STD_TUPLE=1
-


### PR DESCRIPTION
Continuation of #1338 

- Move checks with fixes to new `.clang-tidy-fixes` file and use that file in the CI job.
- Add new `linux-gcc-debug-with-clang-tidy` to illustrate how to develop with all clang-tidy checks enabled.
- Add new checks from `clang-analyzer` and `cppcoreguidelines` and disable ones that currently fail - most of these can and should be addressed in a separate merge request.
- Remove unused `run_tidy.sh` script.