### PR TITLE
Use std `<thread>` for parallel test runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,9 +142,25 @@ if (QL_ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)
 endif()
 
-# Parallel test runner needs library rt on *nix for shm_open, etc.
-if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER AND UNIX AND NOT APPLE)
-    find_library(RT_LIBRARY rt REQUIRED)
+# Prefer pthread flag as per https://cmake.org/cmake/help/latest/module/FindThreads.html
+if (NOT DEFINED THREADS_PREFER_PTHREAD_FLAG)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+endif()
+
+set(QL_THREAD_LIBRARIES)
+
+if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER)
+    find_package(Threads REQUIRED)
+    set(QL_THREAD_LIBRARIES Threads::Threads ${QL_THREAD_LIBRARIES})
+    # Parallel test runner needs library rt on *nix for shm_open, etc.
+    if (UNIX AND NOT APPLE)
+        find_library(RT_LIBRARY rt REQUIRED)
+        set(QL_THREAD_LIBRARIES ${RT_LIBRARY} ${QL_THREAD_LIBRARIES})
+    endif()
+endif()
+
+if (QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
+    set(QL_THREAD_LIBRARIES Boost::thread ${QL_THREAD_LIBRARIES})
 endif()
 
 # If available, use PIC for shared libs and PIE for executables

--- a/Examples/BasketLosses/CMakeLists.txt
+++ b/Examples/BasketLosses/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(BasketLosses BasketLosses.cpp)
-target_link_libraries(BasketLosses ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(BasketLosses ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS BasketLosses RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/BermudanSwaption/CMakeLists.txt
+++ b/Examples/BermudanSwaption/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(BermudanSwaption BermudanSwaption.cpp)
-target_link_libraries(BermudanSwaption ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(BermudanSwaption ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS BermudanSwaption RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/Bonds/CMakeLists.txt
+++ b/Examples/Bonds/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(Bonds Bonds.cpp)
-target_link_libraries(Bonds ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(Bonds ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS Bonds RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/CDS/CMakeLists.txt
+++ b/Examples/CDS/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(CDS CDS.cpp)
-target_link_libraries(CDS ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(CDS ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS CDS RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,8 +1,3 @@
-if (QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR
-        QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
-    set(QL_EXAMPLES_LIBRARIES Boost::thread ${RT_LIBRARY})
-endif()
-
 add_subdirectory(BasketLosses)
 add_subdirectory(BermudanSwaption)
 add_subdirectory(Bonds)

--- a/Examples/CVAIRS/CMakeLists.txt
+++ b/Examples/CVAIRS/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(CVAIRS CVAIRS.cpp)
-target_link_libraries(CVAIRS ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(CVAIRS ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS CVAIRS RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/CallableBonds/CMakeLists.txt
+++ b/Examples/CallableBonds/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(CallableBonds CallableBonds.cpp)
-target_link_libraries(CallableBonds ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(CallableBonds ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS CallableBonds RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/ConvertibleBonds/CMakeLists.txt
+++ b/Examples/ConvertibleBonds/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(ConvertibleBonds ConvertibleBonds.cpp)
-target_link_libraries(ConvertibleBonds ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(ConvertibleBonds ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS ConvertibleBonds RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/DiscreteHedging/CMakeLists.txt
+++ b/Examples/DiscreteHedging/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(DiscreteHedging DiscreteHedging.cpp)
-target_link_libraries(DiscreteHedging ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(DiscreteHedging ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS DiscreteHedging RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/EquityOption/CMakeLists.txt
+++ b/Examples/EquityOption/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(EquityOption EquityOption.cpp)
-target_link_libraries(EquityOption ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(EquityOption ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS EquityOption RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/FRA/CMakeLists.txt
+++ b/Examples/FRA/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(FRA FRA.cpp)
-target_link_libraries(FRA ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(FRA ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS FRA RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/FittedBondCurve/CMakeLists.txt
+++ b/Examples/FittedBondCurve/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(FittedBondCurve FittedBondCurve.cpp)
-target_link_libraries(FittedBondCurve ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(FittedBondCurve ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS FittedBondCurve RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/Gaussian1dModels/CMakeLists.txt
+++ b/Examples/Gaussian1dModels/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(Gaussian1dModels Gaussian1dModels.cpp)
-target_link_libraries(Gaussian1dModels ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(Gaussian1dModels ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS Gaussian1dModels RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/GlobalOptimizer/CMakeLists.txt
+++ b/Examples/GlobalOptimizer/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(GlobalOptimizer GlobalOptimizer.cpp)
-target_link_libraries(GlobalOptimizer ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(GlobalOptimizer ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS GlobalOptimizer RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/LatentModel/CMakeLists.txt
+++ b/Examples/LatentModel/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(LatentModel LatentModel.cpp)
-target_link_libraries(LatentModel ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(LatentModel ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS LatentModel RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/MarketModels/CMakeLists.txt
+++ b/Examples/MarketModels/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(MarketModels MarketModels.cpp)
-target_link_libraries(MarketModels ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(MarketModels ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS MarketModels RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/MulticurveBootstrapping/CMakeLists.txt
+++ b/Examples/MulticurveBootstrapping/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(MulticurveBootstrapping MulticurveBootstrapping.cpp)
-target_link_libraries(MulticurveBootstrapping ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(MulticurveBootstrapping ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS MulticurveBootstrapping RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/MultidimIntegral/CMakeLists.txt
+++ b/Examples/MultidimIntegral/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(MultidimIntegral MultidimIntegral.cpp)
-target_link_libraries(MultidimIntegral ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(MultidimIntegral ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS MultidimIntegral RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/Replication/CMakeLists.txt
+++ b/Examples/Replication/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(Replication Replication.cpp)
-target_link_libraries(Replication ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(Replication ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS Replication RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/Examples/Repo/CMakeLists.txt
+++ b/Examples/Repo/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(Repo Repo.cpp)
-target_link_libraries(Repo ql_library ${QL_EXAMPLES_LIBRARIES})
+target_link_libraries(Repo ql_library ${QL_THREAD_LIBRARIES})
 if (QL_INSTALL_EXAMPLES)
     install(TARGETS Repo RUNTIME DESTINATION ${QL_INSTALL_EXAMPLESDIR})
 endif()

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -208,10 +208,9 @@ AC_DEFUN([QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM],
 AC_DEFUN([QL_CHECK_BOOST_TEST_INTERPROCESS],
 [AC_MSG_CHECKING([whether Boost interprocess is available])
  AC_REQUIRE([AC_PROG_CC])
- AC_REQUIRE([QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM])
  ql_original_LIBS=$LIBS
- for boost_interprocess_lib in "" "-lrt"; do 
-     LIBS="$ql_original_LIBS $boost_thread_lib $boost_interprocess_lib"
+ for boost_interprocess_lib in "-pthread" "-pthread -lrt"; do
+     LIBS="$ql_original_LIBS $boost_interprocess_lib"
      boost_interprocess_found=no
         
 	 AC_LINK_IFELSE([AC_LANG_SOURCE(
@@ -239,6 +238,8 @@ AC_DEFUN([QL_CHECK_BOOST_TEST_INTERPROCESS],
  else
      AC_MSG_RESULT([yes])
      AC_SUBST([BOOST_INTERPROCESS_LIB],[$boost_interprocess_lib])
+     AC_SUBST([PTHREAD_CXXFLAGS],["-pthread"])
+     AC_SUBST([CXXFLAGS],["${CXXFLAGS} -pthread"])
  fi
 ])
      

--- a/configure.ac
+++ b/configure.ac
@@ -292,9 +292,6 @@ if test "$ql_use_parallel_test" = "yes" ; then
              [Define this if you want to enable 
               the parallel unit test runner.])
    QL_CHECK_BOOST_VERSION_1_59_OR_HIGHER
-   if test "$ql_use_tsop" != "yes" ; then
-      QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM
-   fi
    QL_CHECK_BOOST_TEST_INTERPROCESS
 else
    AC_SUBST([BOOST_INTERPROCESS_LIB],[""])

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -380,14 +380,10 @@ if (QL_BUILD_TEST_SUITE)
     if (NOT Boost_USE_STATIC_LIBS)
         target_compile_definitions(ql_test_suite PRIVATE BOOST_ALL_DYN_LINK BOOST_TEST_DYN_LINK)
     endif()
-    if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER OR QL_ENABLE_SESSIONS OR
-            QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
-        set(QL_TEST_SUITE_LIBRARIES Boost::thread ${RT_LIBRARY})
-    endif()
     target_link_libraries(ql_test_suite PRIVATE
         ql_library
         ql_unit_test_main
-        ${QL_TEST_SUITE_LIBRARIES})
+        ${QL_THREAD_LIBRARIES})
     if (QL_INSTALL_TEST_SUITE)
         install(TARGETS ql_test_suite RUNTIME DESTINATION ${QL_INSTALL_BINDIR})
     endif()
@@ -400,14 +396,10 @@ IF (QL_BUILD_BENCHMARK)
     if (NOT Boost_USE_STATIC_LIBS)
         target_compile_definitions(ql_benchmark PRIVATE BOOST_ALL_DYN_LINK BOOST_TEST_DYN_LINK)
     endif()
-    if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER OR QL_ENABLE_SESSIONS OR
-            QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
-        set(QL_BENCHMARK_LIBRARIES Boost::thread ${RT_LIBRARY})
-    endif()
     target_link_libraries(ql_benchmark PRIVATE
         ql_library
         ql_unit_test_main
-        ${QL_BENCHMARK_LIBRARIES})
+        ${QL_THREAD_LIBRARIES})
     if (QL_INSTALL_BENCHMARK)
         install(TARGETS ql_benchmark RUNTIME DESTINATION ${QL_INSTALL_BINDIR})
     endif()


### PR DESCRIPTION
- Use `std::thread` instead of `boost::thread` in `paralleltestrunner.hpp`.
- Replace `QL_EXAMPLES_LIBRARIES`, `QL_BENCHMARK_LIBRARIES`, and `QL_TEST_SUITE_LIBRARIES` with `QL_THREAD_LIBRARIES` and remove some redundant CMake option checks.
- Add direct dependency on underlying threading library (`pthread` on Linux and `Threads` with CMake) instead of inheriting it through Boost.Thread.

One thing I'm not sure about is whether the parallel test runner was used on Windows outside of CMake. If so, that will need to be updated as well, but I'm not sure how.

Also I plan to migrate the rest of Boost.Thread to std `<thread>` in a future pull request.