### PR TITLE
Correct SVI parameter check to account for expiry

### DIFF
--- a/ql/experimental/volatility/sviinterpolation.hpp
+++ b/ql/experimental/volatility/sviinterpolation.hpp
@@ -33,7 +33,7 @@ namespace QuantLib {
 namespace detail {
 
 inline void checkSviParameters(const Real a, const Real b, const Real sigma,
-                               const Real rho, const Real m) {
+                               const Real rho, const Real m, const Time tte) {
     QL_REQUIRE(b >= 0.0, "b (" << b << ") must be non negative");
     QL_REQUIRE(std::fabs(rho) < 1.0, "rho (" << rho << ") must be in (-1,1)");
     QL_REQUIRE(sigma > 0.0, "sigma (" << sigma << ") must be positive");
@@ -41,8 +41,8 @@ inline void checkSviParameters(const Real a, const Real b, const Real sigma,
                "a + b sigma sqrt(1-rho^2) (a=" << a << ", b=" << b << ", sigma="
                                                << sigma << ", rho=" << rho
                                                << ") must be non negative");
-    QL_REQUIRE(b * (1.0 + std::fabs(rho)) < 4.0,
-               "b(1+|rho|) must be less than 4");
+    QL_REQUIRE(b * (1.0 + std::fabs(rho)) <= 4.0 / tte,
+               "b(1+|rho|) must be less than or equal to 4/T");
 }
 
 inline Real sviTotalVariance(const Real a, const Real b, const Real sigma,

--- a/ql/experimental/volatility/sviinterpolation.hpp
+++ b/ql/experimental/volatility/sviinterpolation.hpp
@@ -41,8 +41,10 @@ inline void checkSviParameters(const Real a, const Real b, const Real sigma,
                "a + b sigma sqrt(1-rho^2) (a=" << a << ", b=" << b << ", sigma="
                                                << sigma << ", rho=" << rho
                                                << ") must be non negative");
-    QL_REQUIRE(b * (1.0 + std::fabs(rho)) <= 4.0 / tte,
-               "b(1+|rho|) must be less than or equal to 4/T");
+    if (tte != 0.0) {
+        QL_REQUIRE(b * (1.0 + std::fabs(rho)) <= 4.0 / tte,
+                   "b(1+|rho|) must be less than or equal to 4/T");
+    }
 }
 
 inline Real sviTotalVariance(const Real a, const Real b, const Real sigma,

--- a/ql/experimental/volatility/svismilesection.cpp
+++ b/ql/experimental/volatility/svismilesection.cpp
@@ -37,6 +37,7 @@ namespace QuantLib {
     }
 
 void SviSmileSection::init() {
+    QL_REQUIRE(exerciseTime() > 0.0, "svi expects a strictly positive expiry time");
     QL_REQUIRE(params_.size() == 5,
                "svi expects 5 parameters (a,b,sigma,rho,m) but ("
                    << params_.size() << ") given");

--- a/ql/experimental/volatility/svismilesection.cpp
+++ b/ql/experimental/volatility/svismilesection.cpp
@@ -40,8 +40,8 @@ void SviSmileSection::init() {
     QL_REQUIRE(params_.size() == 5,
                "svi expects 5 parameters (a,b,sigma,rho,m) but ("
                    << params_.size() << ") given");
-    detail::checkSviParameters(params_[0], params_[1], params_[2], params_[3],
-                               params_[4]);
+    detail::checkSviParameters(params_[0], params_[1], params_[2], params_[3], params_[4],
+                               exerciseTime());
 }
 
 Volatility SviSmileSection::volatilityImpl(Rate strike) const {

--- a/ql/experimental/volatility/svismilesection.hpp
+++ b/ql/experimental/volatility/svismilesection.hpp
@@ -30,6 +30,10 @@
 
 namespace QuantLib {
 
+//! Stochastic Volatility Inspired Smile Section
+/*! \test the correctness of the result is tested by checking it
+          against known good values.
+*/
 class SviSmileSection : public SmileSection {
 
   public:

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -141,6 +141,7 @@ set(QL_TEST_SOURCES
     squarerootclvmodel.cpp
     stats.cpp
     subperiodcoupons.cpp
+    svivolatility.cpp
     swap.cpp
     swapforwardmappings.cpp
     swaption.cpp
@@ -310,6 +311,7 @@ set(QL_TEST_HEADERS
     squarerootclvmodel.hpp
     stats.hpp
     subperiodcoupons.hpp
+    svivolatility.hpp
     swap.hpp
     swapforwardmappings.hpp
     swaption.hpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -142,6 +142,7 @@ QL_TEST_SRCS = \
 	squarerootclvmodel.cpp \
 	stats.cpp \
 	subperiodcoupons.cpp \
+	svivolatility.cpp \
 	swap.cpp \
 	swapforwardmappings.cpp \
 	swaption.cpp \
@@ -309,6 +310,7 @@ QL_TEST_HDRS = \
 	squarerootclvmodel.hpp \
 	stats.hpp \
 	subperiodcoupons.hpp \
+	svivolatility.hpp \
 	swap.hpp \
 	swapforwardmappings.hpp \
 	swaption.hpp \

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -181,6 +181,7 @@
 #include "swingoption.hpp"
 #include "stats.hpp"
 #include "subperiodcoupons.hpp"
+#include "svivolatility.hpp"
 #include "swap.hpp"
 #include "swapforwardmappings.hpp"
 #include "swaption.hpp"
@@ -520,6 +521,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(RiskNeutralDensityCalculatorTest::experimental(speed));
     test->add(SpreadOptionTest::suite());
     test->add(SquareRootCLVModelTest::experimental());
+    test->add(SviVolatilityTest::experimental());
     test->add(SwingOptionTest::suite(speed));
     test->add(TwoAssetBarrierOptionTest::suite());
     test->add(TwoAssetCorrelationOptionTest::suite());

--- a/test-suite/svivolatility.cpp
+++ b/test-suite/svivolatility.cpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "svivolatility.hpp"
+#include "utilities.hpp"
+#include <ql/experimental/volatility/svismilesection.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+
+void SviVolatilityTest::testSviSmileSection() {
+
+    BOOST_TEST_MESSAGE("Testing SviSmileSection construction...");
+
+    Date today = Settings::instance().evaluationDate();
+
+    // Test time based constructor
+    Time tte = 11.0 / 365;
+    Real forward = 123.45;
+    Real a = -2.21;
+    Real b = 7.61;
+    Real sigma = 0.337;
+    Real rho = 0.439;
+    Real m = 0.193;
+    std::vector<Real> sviParameters = {a, b, sigma, rho, m};
+    // Compute the strike that yields x (log-moneyness) equal to m,
+    // this simplifies the variance expression to a+b*sigma so we can test the correctness
+    // against the input parameters
+    Real strike = forward * std::exp(m);
+    ext::shared_ptr<SviSmileSection> time_section;
+
+    BOOST_CHECK_NO_THROW(time_section =
+                             ext::make_shared<SviSmileSection>(tte, forward, sviParameters));
+    BOOST_CHECK_EQUAL(time_section->atmLevel(), forward);
+    BOOST_CHECK_CLOSE(time_section->variance(strike), a + b * sigma, 1E-10);
+
+    // Test date based constructor
+    Date date = today + Period(11, Days);
+    ext::shared_ptr<SviSmileSection> date_section;
+
+    BOOST_CHECK_NO_THROW(date_section =
+                             ext::make_shared<SviSmileSection>(date, forward, sviParameters));
+
+    BOOST_CHECK_EQUAL(date_section->atmLevel(), forward);
+    BOOST_CHECK_CLOSE(date_section->variance(strike), a + b * sigma, 1E-10);
+}
+
+test_suite* SviVolatilityTest::experimental() {
+    auto* suite = BOOST_TEST_SUITE("SVI volatility tests");
+    suite->add(QUANTLIB_TEST_CASE(&SviVolatilityTest::testSviSmileSection));
+    return suite;
+}

--- a/test-suite/svivolatility.hpp
+++ b/test-suite/svivolatility.hpp
@@ -1,0 +1,35 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_svi_volatility_hpp
+#define quantlib_test_svi_volatility_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class SviVolatilityTest {
+  public:
+    static void testSviSmileSection();
+    static boost::unit_test_framework::test_suite* experimental();
+};
+
+
+#endif

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -777,6 +777,7 @@
     <ClCompile Include="squarerootclvmodel.cpp" />
     <ClCompile Include="stats.cpp" />
     <ClCompile Include="subperiodcoupons.cpp" />
+    <ClCompile Include="svivolatility.cpp" />
     <ClCompile Include="swap.cpp" />
     <ClCompile Include="swapforwardmappings.cpp" />
     <ClCompile Include="swaption.cpp" />
@@ -946,6 +947,7 @@
     <ClInclude Include="squarerootclvmodel.hpp" />
     <ClInclude Include="stats.hpp" />
     <ClInclude Include="subperiodcoupons.hpp" />
+    <ClInclude Include="svivolatility.hpp" />
     <ClInclude Include="swap.hpp" />
     <ClInclude Include="swapforwardmappings.hpp" />
     <ClInclude Include="swaption.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -504,6 +504,9 @@
     <ClCompile Include="bondforward.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="svivolatility.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="americanoption.hpp">
@@ -1005,6 +1008,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="bondforward.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="svivolatility.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Hi all,
When running SVI data through the `SviSmileSection` class, I came across an issue with the last condition in `checkSviParameters()`. Looking at the original reference, [Gatheral (2004)](http://faculty.baruch.cuny.edu/jgatheral/madrid2004.pdf), I believe the condition should indeed be `b* (1 + |rho|) <= 4.0 / T`, not `... < 4.0`. 

I added an initial test case for the construction of the class using a set of simplified parameters. This to help ensure that the variance returned is as expected and that the parameter check doesn't incorrectly fail "legal" parameters.

Best,
Fredrik 