### PR TITLE
add ConstParam to speed up MC

### DIFF
--- a/ql/experimental/processes/constparamprocess.cpp
+++ b/ql/experimental/processes/constparamprocess.cpp
@@ -1,0 +1,169 @@
+﻿/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Ruilong Xu
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/experimental/processes/constparamprocess.hpp>
+
+namespace QuantLib {
+    void ConstParam<VegaStressedBlackScholesProcess>::fetchValue() const {
+        if (fetched_ == false) {
+            ext::shared_ptr<FlatForward> flatDividendTS =
+                ext::dynamic_pointer_cast<FlatForward>(dividendYield_.currentLink());
+            QL_REQUIRE(flatDividendTS != nullptr,
+                       "flat dividend yield term structure is required in ConstParam");
+            QL_REQUIRE(flatDividendTS->compounding() != SimpleThenCompounded &&
+                           flatDividendTS->compounding() != CompoundedThenSimple,
+                       "dividend yield term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<FlatForward> flatRiskFreeTS =
+                ext::dynamic_pointer_cast<FlatForward>(riskFreeRate_.currentLink());
+            QL_REQUIRE(flatRiskFreeTS != nullptr,
+                       "flat risk free rate term structure is required in ConstParam");
+            QL_REQUIRE(flatRiskFreeTS->compounding() != SimpleThenCompounded &&
+                           flatRiskFreeTS->compounding() != CompoundedThenSimple,
+                       "risk free rate term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<BlackConstantVol> flatBlackVol =
+                ext::dynamic_pointer_cast<BlackConstantVol>(blackVolatility_.currentLink());
+            QL_REQUIRE(flatBlackVol != nullptr,
+                       "flat volatility term structure is required in ConstParam");
+
+            x0Value_ = x0_->value();
+
+            static Real t1 = 0.0, t2 = 1.0;
+            dividendYieldValue_ =
+                flatDividendTS->forwardRate(t1, t2, Continuous, NoFrequency, true);
+            riskFreeRateValue_ = flatRiskFreeTS->forwardRate(t1, t2, Continuous, NoFrequency, true);
+            blackVolatilityValue_ = flatBlackVol->blackVol(0.0, x0_->value());
+
+            carryCost_ = riskFreeRateValue_ - dividendYieldValue_;
+            fetched_ = true;
+        } else {
+            return;
+        }
+    }
+
+    Real ConstParam<VegaStressedBlackScholesProcess>::diffusion(Time t, Real x) const {
+        fetchValue();
+        if (lowerTimeBorderForStressTest_ <= t && t <= upperTimeBorderForStressTest_ &&
+            lowerAssetBorderForStressTest_ <= x && x <= upperAssetBorderForStressTest_) {
+            return blackVolatilityValue_ + stressLevel_;
+        } else {
+            return blackVolatilityValue_;
+        }
+    }
+}
+
+namespace QuantLib {
+    void ConstParam<HestonProcess>::fetchValue() const {
+        if (fetched_ == false) {
+            ext::shared_ptr<FlatForward> flatDividendTS =
+                ext::dynamic_pointer_cast<FlatForward>(dividendYield_.currentLink());
+            QL_REQUIRE(flatDividendTS != nullptr,
+                       "flat dividend yield term structure is required in ConstParam");
+            QL_REQUIRE(flatDividendTS->compounding() != SimpleThenCompounded &&
+                           flatDividendTS->compounding() != CompoundedThenSimple,
+                       "dividend yield term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<FlatForward> flatRiskFreeTS =
+                ext::dynamic_pointer_cast<FlatForward>(riskFreeRate_.currentLink());
+            QL_REQUIRE(flatRiskFreeTS != nullptr,
+                       "flat risk free rate term structure is required in ConstParam");
+            QL_REQUIRE(flatRiskFreeTS->compounding() != SimpleThenCompounded &&
+                           flatRiskFreeTS->compounding() != CompoundedThenSimple,
+                       "risk free rate term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            static Real t1 = 0.0, t2 = 1.0;
+            dividendYieldValue_ = flatDividendTS->forwardRate(t1, t2, Continuous);
+            riskFreeRateValue_ = flatRiskFreeTS->forwardRate(t1, t2, Continuous);
+
+            carryCost_ = riskFreeRateValue_ - dividendYieldValue_;
+            fetched_ = true;
+        } else {
+            return;
+        }
+    }
+
+    void ConstParam<BatesProcess>::fetchValue() const {
+        if (fetched_ == false) {
+            ext::shared_ptr<FlatForward> flatDividendTS =
+                ext::dynamic_pointer_cast<FlatForward>(dividendYield_.currentLink());
+            QL_REQUIRE(flatDividendTS != nullptr,
+                       "flat dividend yield term structure is required in ConstParam");
+            QL_REQUIRE(flatDividendTS->compounding() != SimpleThenCompounded &&
+                           flatDividendTS->compounding() != CompoundedThenSimple,
+                       "dividend yield term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<FlatForward> flatRiskFreeTS =
+                ext::dynamic_pointer_cast<FlatForward>(riskFreeRate_.currentLink());
+            QL_REQUIRE(flatRiskFreeTS != nullptr,
+                       "flat risk free rate term structure is required in ConstParam");
+            QL_REQUIRE(flatRiskFreeTS->compounding() != SimpleThenCompounded &&
+                           flatRiskFreeTS->compounding() != CompoundedThenSimple,
+                       "risk free rate term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            static Real t1 = 0.0, t2 = 1.0;
+            dividendYieldValue_ = flatDividendTS->forwardRate(t1, t2, Continuous);
+            riskFreeRateValue_ = flatRiskFreeTS->forwardRate(t1, t2, Continuous);
+
+            carryCost_ = riskFreeRateValue_ - dividendYieldValue_;
+            fetched_ = true;
+        } else {
+            return;
+        }
+    }
+}
+
+namespace QuantLib {
+    void ConstParam<GJRGARCHProcess>::fetchValue() const {
+        if (fetched_ == false) {
+            ext::shared_ptr<FlatForward> flatDividendTS =
+                ext::dynamic_pointer_cast<FlatForward>(dividendYield_.currentLink());
+            QL_REQUIRE(flatDividendTS != nullptr,
+                       "flat dividend yield term structure is required in ConstParam");
+            QL_REQUIRE(flatDividendTS->compounding() != SimpleThenCompounded &&
+                           flatDividendTS->compounding() != CompoundedThenSimple,
+                       "dividend yield term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<FlatForward> flatRiskFreeTS =
+                ext::dynamic_pointer_cast<FlatForward>(riskFreeRate_.currentLink());
+            QL_REQUIRE(flatRiskFreeTS != nullptr,
+                       "flat risk free rate term structure is required in ConstParam");
+            QL_REQUIRE(flatRiskFreeTS->compounding() != SimpleThenCompounded &&
+                           flatRiskFreeTS->compounding() != CompoundedThenSimple,
+                       "risk free rate term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            static Real t1 = 0.0, t2 = 1.0;
+            dividendYieldValue_ = flatDividendTS->forwardRate(t1, t2, Continuous);
+            riskFreeRateValue_ = flatRiskFreeTS->forwardRate(t1, t2, Continuous);
+
+            carryCost_ = riskFreeRateValue_ - dividendYieldValue_;
+            fetched_ = true;
+        } else {
+            return;
+        }
+    }
+}

--- a/ql/experimental/processes/constparamprocess.hpp
+++ b/ql/experimental/processes/constparamprocess.hpp
@@ -1,0 +1,327 @@
+﻿/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Ruilong Xu
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file constparamprocess.hpp
+    \brief constant parameter stochastic process for speeding up MC
+*/
+
+#ifndef quantlib_constant_parameter_process_hpp
+#define quantlib_constant_parameter_process_hpp
+
+#include <ql/experimental/processes/vegastressedblackscholesprocess.hpp>
+#include <ql/processes/batesprocess.hpp>
+#include <ql/processes/gjrgarchprocess.hpp>
+#include <ql/processes/hestonprocess.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/volatility/equityfx/localconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/types.hpp>
+
+namespace QuantLib {
+    template <class BSM>
+    class ConstParam : public BSM {
+      public:
+        template <class... ARGS>
+        ConstParam(ARGS... args) : BSM(args...), fetched_(false) {
+            isStrikeIndependent_ = true;
+            forceDiscretization_ = false;
+        }
+
+        Real x0() const override;
+        Real drift(Time t, Real x) const override;
+        Real diffusion(Time t, Real x) const override;
+        Real expectation(Time t0, Real x0, Time dt) const override;
+        Real stdDeviation(Time t0, Real x0, Time dt) const override;
+        Real variance(Time t0, Real x0, Time dt) const override;
+        Real evolve(Time t0, Real x0, Time dt, Real dw) const override;
+        void update() override;
+
+      private:
+        mutable Real x0Value_;
+        mutable Rate dividendYieldValue_, riskFreeRateValue_;
+        mutable Spread carryCost_;
+        mutable Volatility blackVolatilityValue_;
+        mutable bool fetched_;
+
+        void fetchValue() const;
+    };
+
+    template <class BSM>
+    void ConstParam<BSM>::fetchValue() const {
+        if (fetched_ == false) {
+            ext::shared_ptr<FlatForward> flatDividendTS =
+                ext::dynamic_pointer_cast<FlatForward>(dividendYield_.currentLink());
+            QL_REQUIRE(flatDividendTS != nullptr,
+                       "flat dividend yield term structure is required in ConstParam");
+            QL_REQUIRE(flatDividendTS->compounding() != SimpleThenCompounded &&
+                           flatDividendTS->compounding() != CompoundedThenSimple,
+                       "dividend yield term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<FlatForward> flatRiskFreeTS =
+                ext::dynamic_pointer_cast<FlatForward>(riskFreeRate_.currentLink());
+            QL_REQUIRE(flatRiskFreeTS != nullptr,
+                       "flat risk free rate term structure is required in ConstParam");
+            QL_REQUIRE(flatRiskFreeTS->compounding() != SimpleThenCompounded &&
+                           flatRiskFreeTS->compounding() != CompoundedThenSimple,
+                       "risk free rate term structure without SimpleThenCompounded or "
+                       "CompoundedThenSimple is required in ConstParam");
+
+            ext::shared_ptr<BlackConstantVol> flatBlackVol =
+                ext::dynamic_pointer_cast<BlackConstantVol>(blackVolatility_.currentLink());
+            QL_REQUIRE(flatBlackVol != nullptr,
+                       "flat volatility term structure is required in ConstParam");
+
+            x0Value_ = x0_->value();
+
+            static Real t1 = 0.0, t2 = 1.0;
+            dividendYieldValue_ =
+                flatDividendTS->forwardRate(t1, t2, Continuous, NoFrequency, true);
+            riskFreeRateValue_ = flatRiskFreeTS->forwardRate(t1, t2, Continuous, NoFrequency, true);
+            blackVolatilityValue_ = flatBlackVol->blackVol(0.0, x0_->value());
+
+            carryCost_ = riskFreeRateValue_ - dividendYieldValue_;
+            fetched_ = true;
+        } else {
+            return;
+        }
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::x0() const {
+        fetchValue();
+        return x0Value_;
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::drift(Time t, Real x) const {
+        fetchValue();
+        return carryCost_ - 0.5 * blackVolatilityValue_ * blackVolatilityValue_;
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::diffusion(Time t, Real x) const {
+        fetchValue();
+        return blackVolatilityValue_;
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::expectation(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        return x0 * std::exp(dt * carryCost_);
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::stdDeviation(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        return blackVolatilityValue_ * std::sqrt(dt);
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::variance(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        return blackVolatilityValue_ * blackVolatilityValue_ * dt;
+    }
+
+    template <class BSM>
+    inline Real ConstParam<BSM>::evolve(Time t0, Real x0, Time dt, Real dw) const {
+        fetchValue();
+        Real var = blackVolatilityValue_ * blackVolatilityValue_ * dt;
+        Real drift = carryCost_ * dt - 0.5 * var;
+        return x0 * std::exp(std::sqrt(var) * dw + drift);
+    }
+
+    template <class BSM>
+    inline void ConstParam<BSM>::update() {
+        fetched_ = false;
+        // update x0, dividendYield, riskFreeRate and blackVol
+        fetchValue();
+        BSM::update();
+    }
+}
+
+namespace QuantLib {
+    template <>
+    class ConstParam<VegaStressedBlackScholesProcess> : public VegaStressedBlackScholesProcess {
+      public:
+        template <class... ARGS>
+        ConstParam(ARGS... args) : VegaStressedBlackScholesProcess(args...), fetched_(false) {
+            isStrikeIndependent_ = true;
+            forceDiscretization_ = false;
+        }
+
+        Real x0() const override;
+        Real drift(Time t, Real x) const override;
+        Real diffusion(Time t, Real x) const override;
+        Real expectation(Time t0, Real x0, Time dt) const override;
+        Real stdDeviation(Time t0, Real x0, Time dt) const override;
+        Real variance(Time t0, Real x0, Time dt) const override;
+        Real evolve(Time t0, Real x0, Time dt, Real dw) const override;
+        void update() override;
+
+      private:
+        mutable Real x0Value_;
+        mutable Rate dividendYieldValue_, riskFreeRateValue_;
+        mutable Spread carryCost_;
+        mutable Volatility blackVolatilityValue_;
+        mutable bool fetched_;
+
+        void fetchValue() const;
+    };
+
+    inline Real ConstParam<VegaStressedBlackScholesProcess>::x0() const {
+        fetchValue();
+        return x0Value_;
+    }
+
+    inline Real ConstParam<VegaStressedBlackScholesProcess>::drift(Time t, Real x) const {
+        fetchValue();
+        Real sigma = diffusion(t, x);
+        return carryCost_ - 0.5 * sigma * sigma;
+    }
+
+    inline Real
+    ConstParam<VegaStressedBlackScholesProcess>::expectation(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        return x0 * std::exp(dt * carryCost_);
+    }
+
+    inline Real
+    ConstParam<VegaStressedBlackScholesProcess>::stdDeviation(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        return std::sqrt(variance(t0, x0, dt));
+    }
+
+    inline Real
+    ConstParam<VegaStressedBlackScholesProcess>::variance(Time t0, Real x0, Time dt) const {
+        fetchValue();
+        Real sigma = blackVolatilityValue_;
+        return sigma * sigma * dt;
+    }
+
+    inline Real
+    ConstParam<VegaStressedBlackScholesProcess>::evolve(Time t0, Real x0, Time dt, Real dw) const {
+        fetchValue();
+        Real var = variance(t0, x0, dt);
+        Real drift = carryCost_ * dt - 0.5 * var;
+        return x0 * std::exp(std::sqrt(var) * dw + drift);
+    }
+
+    inline void ConstParam<VegaStressedBlackScholesProcess>::update() {
+        fetched_ = false;
+        // update x0, dividendYield, riskFreeRate and blackVol
+        fetchValue();
+        VegaStressedBlackScholesProcess::update();
+    }
+}
+
+namespace QuantLib {
+    template <>
+    class ConstParam<HestonProcess> : public HestonProcess {
+      public:
+        template <class... ARGS>
+        ConstParam(ARGS... args) : HestonProcess(args...), fetched_(false) {}
+
+        void update() override {
+            fetched_ = false;
+            // update dividendYield, riskFreeRate and carryCost
+            fetchValue();
+            HestonProcess::update();
+        }
+
+        Spread forwardCarryCost(Time t1,
+                                Time t2,
+                                Compounding comp,
+                                Frequency freq = Annual,
+                                bool extrapolate = false) const override {
+            fetchValue();
+            return carryCost_;
+        }
+
+      private:
+        mutable Rate dividendYieldValue_, riskFreeRateValue_;
+        mutable Spread carryCost_;
+        mutable bool fetched_;
+
+        void fetchValue() const;
+    };
+
+    template <>
+    class ConstParam<BatesProcess> : public BatesProcess {
+      public:
+        template <class... ARGS>
+        ConstParam(ARGS... args) : BatesProcess(args...), fetched_(false) {}
+
+        void update() override {
+            fetched_ = false;
+            // update dividendYield, riskFreeRate and carryCost
+            fetchValue();
+            BatesProcess::update();
+        }
+
+        Spread forwardCarryCost(Time t1,
+                                Time t2,
+                                Compounding comp,
+                                Frequency freq = Annual,
+                                bool extrapolate = false) const override {
+            fetchValue();
+            return carryCost_;
+        }
+
+      private:
+        mutable Rate dividendYieldValue_, riskFreeRateValue_;
+        mutable Spread carryCost_;
+        mutable bool fetched_;
+
+        void fetchValue() const;
+    };
+}
+
+namespace QuantLib {
+    template <>
+    class ConstParam<GJRGARCHProcess> : public GJRGARCHProcess {
+      public:
+        template <class... ARGS>
+        ConstParam(ARGS... args) : GJRGARCHProcess(args...), fetched_(false) {}
+
+        void update() override {
+            fetched_ = false;
+            // update dividendYield, riskFreeRate and carryCost
+            fetchValue();
+            GJRGARCHProcess::update();
+        }
+
+        Spread forwardCarryCost(Time t1,
+                                Time t2,
+                                Compounding comp,
+                                Frequency freq = Annual,
+                                bool extrapolate = false) const override {
+            fetchValue();
+            return carryCost_;
+        }
+
+      private:
+        mutable Rate dividendYieldValue_, riskFreeRateValue_;
+        mutable Spread carryCost_;
+        mutable bool fetched_;
+
+        void fetchValue() const;
+    };
+}
+#endif

--- a/ql/experimental/processes/hestonslvprocess.cpp
+++ b/ql/experimental/processes/hestonslvprocess.cpp
@@ -3,16 +3,13 @@
 /*
  Copyright (C) 2015 Johannes Göttker-Schnetmann
  Copyright (C) 2015 Klaus Spanderen
-
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
-
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
-
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -54,9 +51,7 @@ namespace QuantLib {
         const Volatility vol =
            std::max(1e-8, std::sqrt(x[1])*leverageFct_->localVol(t, x[0], true));
 
-        tmp[0] = riskFreeRate()->forwardRate(t, t, Continuous)
-               - dividendYield()->forwardRate(t, t, Continuous)
-               - 0.5*vol*vol;
+        tmp[0] = hestonProcess_->forwardCarryCost(t, t, Continuous) - 0.5*vol*vol;
 
         tmp[1] = kappa_*(theta_ - x[1]);
 
@@ -105,8 +100,7 @@ namespace QuantLib {
             retVal[1] = ((u <= p) ? 0.0 : std::log((1-p)/(1-u))/beta);
         }
 
-        const Real mu = riskFreeRate()->forwardRate(t0, t0+dt, Continuous)
-             - dividendYield()->forwardRate(t0, t0+dt, Continuous);
+        const Real mu = hestonProcess_->forwardCarryCost(t0, t0 + dt, Continuous);
 
         const Real rho1 = std::sqrt(1-rho_*rho_);
 

--- a/ql/experimental/processes/vegastressedblackscholesprocess.hpp
+++ b/ql/experimental/processes/vegastressedblackscholesprocess.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             Real upperAssetBorderForStressTest = 1000000,
             Real stressLevel = 0,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization));
+                ext::shared_ptr<discretization>(new EulerDiscretization));
         //! \name StochasticProcess1D interface
         //@{
         Real diffusion(Time t, Real x) const override;
@@ -71,15 +71,13 @@ namespace QuantLib {
         // set stress level
         void setStressLevel(Real SL);
         //@}
-      private:
+      protected:
         Real lowerTimeBorderForStressTest_;
         Real upperTimeBorderForStressTest_;
         Real lowerAssetBorderForStressTest_;
         Real upperAssetBorderForStressTest_;
         Real stressLevel_;
     };
-
 }
-
 
 #endif

--- a/ql/processes/blackscholesprocess.hpp
+++ b/ql/processes/blackscholesprocess.hpp
@@ -97,7 +97,7 @@ namespace QuantLib {
         const Handle<BlackVolTermStructure>& blackVolatility() const;
         const Handle<LocalVolTermStructure>& localVolatility() const;
         //@}
-      private:
+      protected:
         Handle<Quote> x0_;
         Handle<YieldTermStructure> riskFreeRate_, dividendYield_;
         Handle<BlackVolTermStructure> blackVolatility_;

--- a/ql/processes/gjrgarchprocess.cpp
+++ b/ql/processes/gjrgarchprocess.cpp
@@ -2,16 +2,13 @@
 
 /*
  Copyright (C) 2008 Yee Man Chan
-
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
-
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
-
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -155,9 +152,7 @@ namespace QuantLib {
           // Working Paper, Tinbergen Institute
           case PartialTruncation:
             vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol * vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = daysPerYear_*daysPerYear_*omega_ 
                 + daysPerYear_*(beta_ + alpha_*q2 + gamma_*q3 - 1.0) * x0[1];
 
@@ -166,9 +161,7 @@ namespace QuantLib {
             break;
           case FullTruncation:
             vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol * vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = daysPerYear_*daysPerYear_*omega_ 
                 + daysPerYear_*(beta_ + alpha_*q2 + gamma_*q3 - 1.0) * vol *vol;
 
@@ -177,9 +170,7 @@ namespace QuantLib {
             break;
           case Reflection:
             vol = std::sqrt(std::fabs(x0[1]));
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol*vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = daysPerYear_*daysPerYear_*omega_ 
                 + daysPerYear_*(beta_ + alpha_*q2 + gamma_*q3 - 1.0) * vol * vol;
 

--- a/ql/processes/gjrgarchprocess.hpp
+++ b/ql/processes/gjrgarchprocess.hpp
@@ -24,12 +24,11 @@
 #ifndef quantlib_gjrgarch_process_hpp
 #define quantlib_gjrgarch_process_hpp
 
+#include <ql/quote.hpp>
 #include <ql/stochasticprocess.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/quote.hpp>
 
 namespace QuantLib {
-
     //! Stochastic-volatility GJR-GARCH(1,1) process
     // parameters supplied should be daily constants
     // they are annualized by setting the parameter daysPerYear
@@ -38,20 +37,20 @@ namespace QuantLib {
         \f[
         \begin{array}{rcl}
         dS(t, S)  &=& \mu S dt + \sqrt{v} S dW_1 \\
-        dv(t, S)  &=& (\omega + (\beta + \alpha * q_{2} 
-        + \gamma * q_{3} - 1) v) dt + (\alpha \sigma_{12} 
-        + \gamma \sigma_{13}) v dW_1 
-        + \sqrt{\alpha^{2} (\sigma^{2}_{2} - \sigma^{2}_{12}) 
-        + \gamma^{2} (\sigma^{2}_{3} - \sigma^{2}_{13}) 
+        dv(t, S)  &=& (\omega + (\beta + \alpha * q_{2}
+        + \gamma * q_{3} - 1) v) dt + (\alpha \sigma_{12}
+        + \gamma \sigma_{13}) v dW_1
+        + \sqrt{\alpha^{2} (\sigma^{2}_{2} - \sigma^{2}_{12})
+        + \gamma^{2} (\sigma^{2}_{3} - \sigma^{2}_{13})
         + 2 \alpha \gamma (\sigma_{23} - \sigma_{12} \sigma_{13})} v dW_2 \ \
         N = normalCDF(\lambda) \\
         n &=& \exp{-\lambda^{2}/2} / \sqrt{2 \pi} \\
         q_{2} &=& 1 + \lambda^{2} \\
         q_{3} &=& \lambda n + N + \lambda^2 N \\
         \sigma^{2}_{2} = 2 + 4 \lambda^{4} \\
-        \sigma^{2}_{3} = \lambda^{3} n + 5 \lambda n + 3N 
-        + \lambda^{4} N + 6 \lambda^{2} N -\\lambda^{2} n^{2} - N^{2} 
-        - \lambda^{4} N^{2} - 2 \lambda n N - 2 \lambda^{3} nN 
+        \sigma^{2}_{3} = \lambda^{3} n + 5 \lambda n + 3N
+        + \lambda^{4} N + 6 \lambda^{2} N -\\lambda^{2} n^{2} - N^{2}
+        - \lambda^{4} N^{2} - 2 \lambda n N - 2 \lambda^{3} nN
         - 2 \lambda^{2} N^{2} \                 \
         \sigma_{12} = -2 \lambda \\
         \sigma_{13} = -2 n - 2 \lambda N \\
@@ -99,14 +98,23 @@ namespace QuantLib {
 
         Time time(const Date&) const override;
 
-      private:
+        // forward cost of carry = forward risk free rate - forward dividend yield
+        virtual Spread forwardCarryCost(Time t1,
+                                        Time t2,
+                                        Compounding comp,
+                                        Frequency freq = Annual,
+                                        bool extrapolate = false) const {
+            Real spread = riskFreeRate_->forwardRate(t1, t2, comp, freq, extrapolate) -
+                          dividendYield_->forwardRate(t1, t2, comp, freq, extrapolate);
+            return spread;
+        }
+
+      protected:
         Handle<YieldTermStructure> riskFreeRate_, dividendYield_;
         Handle<Quote> s0_;
         Real v0_, omega_, alpha_, beta_, gamma_, lambda_, daysPerYear_;
         Discretization discretization_;
     };
-
 }
-
 
 #endif

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -2,16 +2,13 @@
 
 /*
  Copyright (C) 2005, 2007, 2009, 2014 Klaus Spanderen
-
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
-
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
-
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -76,9 +73,7 @@ namespace QuantLib {
                          : (discretization_ == Reflection) ? - std::sqrt(-x[1])
                          : 0.0;
 
-        tmp[0] = riskFreeRate_->forwardRate(t, t, Continuous)
-               - dividendYield_->forwardRate(t, t, Continuous)
-               - 0.5 * vol * vol;
+        tmp[0] = forwardCarryCost(t, t, Continuous) - 0.5 * vol * vol;
 
         tmp[1] = kappa_*
            (theta_-((discretization_==PartialTruncation) ? x[1] : vol*vol));
@@ -416,9 +411,7 @@ namespace QuantLib {
           case PartialTruncation:
             vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
             vol2 = sigma_ * vol;
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol * vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = kappa_*(theta_ - x0[1]);
 
             retVal[0] = x0[0] * std::exp(mu*dt+vol*dw[0]*sdt);
@@ -427,9 +420,7 @@ namespace QuantLib {
           case FullTruncation:
             vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
             vol2 = sigma_ * vol;
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol * vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = kappa_*(theta_ - vol*vol);
 
             retVal[0] = x0[0] * std::exp(mu*dt+vol*dw[0]*sdt);
@@ -438,9 +429,7 @@ namespace QuantLib {
           case Reflection:
             vol = std::sqrt(std::fabs(x0[1]));
             vol2 = sigma_ * vol;
-            mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                    - 0.5 * vol*vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
             nu = kappa_*(theta_ - vol*vol);
 
             retVal[0] = x0[0]*std::exp(mu*dt+vol*dw[0]*sdt);
@@ -454,9 +443,7 @@ namespace QuantLib {
             // process. For further details please read the Wilmott thread
             // "QuantLib code is very high quality"
             vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
-            mu =   riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                 - dividendYield_->forwardRate(t0, t0+dt, Continuous)
-                   - 0.5 * vol*vol;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) - 0.5 * vol * vol;
 
             retVal[1] = varianceDistribution(x0[1], dw[1], dt);
             dy = (mu - rho_/sigma_*kappa_
@@ -513,9 +500,8 @@ namespace QuantLib {
                 retVal[1] = ((u <= p) ? 0.0 : std::log((1-p)/(1-u))/beta);
             }
 
-            mu =   riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                 - dividendYield_->forwardRate(t0, t0+dt, Continuous);
-
+            mu = forwardCarryCost(t0, t0 + dt, Continuous);
+            
             retVal[0] = x0[0]*std::exp(mu*dt + k0 + k1*x0[1] + k2*retVal[1]
                                        +std::sqrt(k3*x0[1]+k4*retVal[1])*dw[0]);
           }
@@ -537,9 +523,7 @@ namespace QuantLib {
             const Real vdw
                 = (nu_t - nu_0 - kappa_*theta_*dt + kappa_*vds)/sigma_;
 
-            mu = ( riskFreeRate_->forwardRate(t0, t0+dt, Continuous)
-                  -dividendYield_->forwardRate(t0, t0+dt, Continuous))*dt
-                - 0.5*vds + rho_*vdw;
+            mu = forwardCarryCost(t0, t0 + dt, Continuous) * dt - 0.5*vds + rho_*vdw;
 
             const Volatility sig = std::sqrt((1-rho_*rho_)*vds);
             const Real s = x0[0]*std::exp(mu + sig*dw[0]);

--- a/ql/processes/hestonprocess.hpp
+++ b/ql/processes/hestonprocess.hpp
@@ -24,12 +24,11 @@
 #ifndef quantlib_heston_process_hpp
 #define quantlib_heston_process_hpp
 
+#include <ql/quote.hpp>
 #include <ql/stochasticprocess.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
-#include <ql/quote.hpp>
 
 namespace QuantLib {
-
     //! Square-root stochastic-volatility Heston process
     /*! This class describes the square root stochastic volatility
         process governed by
@@ -90,7 +89,18 @@ namespace QuantLib {
         // semi-analytical solution of the Fokker-Planck equation in x=ln(s)
         Real pdf(Real x, Real v, Time t, Real eps=1e-3) const;
 
-      private:
+        // forward cost of carry = forward risk free rate - forward dividend yield
+        virtual Spread forwardCarryCost(Time t1,
+                                        Time t2,
+                                        Compounding comp,
+                                        Frequency freq = Annual,
+                                        bool extrapolate = false) const {
+            Real spread = riskFreeRate_->forwardRate(t1, t2, comp, freq, extrapolate) -
+                          dividendYield_->forwardRate(t1, t2, comp, freq, extrapolate);
+            return spread;
+        }
+
+      protected:
         Real varianceDistribution(Real v, Real dw, Time dt) const;
 
         Handle<YieldTermStructure> riskFreeRate_, dividendYield_;

--- a/test-suite/constparamprocess.cpp
+++ b/test-suite/constparamprocess.cpp
@@ -1,0 +1,1018 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Ruilong Xu
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "constparamprocess.hpp"
+#include "utilities.hpp"
+#include <ql/experimental/processes/constparamprocess.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/math/randomnumbers/rngtraits.hpp>
+#include <ql/pricingengines/asian/mc_discr_arith_av_price.hpp>
+#include <ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+#include <ql/processes/gjrgarchprocess.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actualactual.hpp>
+#include <chrono>
+#include <utility>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace {
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeGBSprocess(const ext::shared_ptr<Quote>& u,
+                   const ext::shared_ptr<YieldTermStructure>& q,
+                   const ext::shared_ptr<YieldTermStructure>& r,
+                   const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<GeneralizedBlackScholesProcess>(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPGBSprocess(const ext::shared_ptr<Quote>& u,
+                     const ext::shared_ptr<YieldTermStructure>& q,
+                     const ext::shared_ptr<YieldTermStructure>& r,
+                     const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<ConstParam<GeneralizedBlackScholesProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeBSMprocess(const ext::shared_ptr<Quote>& u,
+                   const ext::shared_ptr<YieldTermStructure>& q,
+                   const ext::shared_ptr<YieldTermStructure>& r,
+                   const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<BlackScholesMertonProcess>(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPBSMprocess(const ext::shared_ptr<Quote>& u,
+                     const ext::shared_ptr<YieldTermStructure>& q,
+                     const ext::shared_ptr<YieldTermStructure>& r,
+                     const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<ConstParam<BlackScholesMertonProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeBSprocess(const ext::shared_ptr<Quote>& u,
+                  const ext::shared_ptr<YieldTermStructure>& r,
+                  const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<BlackScholesProcess>(
+            Handle<Quote>(u), Handle<YieldTermStructure>(r), Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPBSprocess(const ext::shared_ptr<Quote>& u,
+                    const ext::shared_ptr<YieldTermStructure>& r,
+                    const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<ConstParam<BlackScholesProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(r), Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeBprocess(const ext::shared_ptr<Quote>& u,
+                 const ext::shared_ptr<YieldTermStructure>& r,
+                 const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<BlackProcess>(Handle<Quote>(u), Handle<YieldTermStructure>(r),
+                                              Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPBprocess(const ext::shared_ptr<Quote>& u,
+                   const ext::shared_ptr<YieldTermStructure>& r,
+                   const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<ConstParam<BlackProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(r), Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeGKSprocess(const ext::shared_ptr<Quote>& u,
+                   const ext::shared_ptr<YieldTermStructure>& f,
+                   const ext::shared_ptr<YieldTermStructure>& d,
+                   const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<GarmanKohlagenProcess>(
+            Handle<Quote>(u), Handle<YieldTermStructure>(f), Handle<YieldTermStructure>(d),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPGKSprocess(const ext::shared_ptr<Quote>& u,
+                     const ext::shared_ptr<YieldTermStructure>& f,
+                     const ext::shared_ptr<YieldTermStructure>& d,
+                     const ext::shared_ptr<BlackVolTermStructure>& vol) {
+        return ext::make_shared<ConstParam<GarmanKohlagenProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(f), Handle<YieldTermStructure>(d),
+            Handle<BlackVolTermStructure>(vol));
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeVSBSMprocess(const ext::shared_ptr<Quote>& u,
+                     const ext::shared_ptr<YieldTermStructure>& q,
+                     const ext::shared_ptr<YieldTermStructure>& r,
+                     const ext::shared_ptr<BlackVolTermStructure>& vol,
+                     Real lt,
+                     Real ut,
+                     Real la,
+                     Real ua,
+                     Real stress) {
+        return ext::make_shared<VegaStressedBlackScholesProcess>(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol), lt, ut, la, ua, stress);
+    }
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
+    makeCPVSBSMprocess(const ext::shared_ptr<Quote>& u,
+                       const ext::shared_ptr<YieldTermStructure>& q,
+                       const ext::shared_ptr<YieldTermStructure>& r,
+                       const ext::shared_ptr<BlackVolTermStructure>& vol,
+                       Real lt,
+                       Real ut,
+                       Real la,
+                       Real ua,
+                       Real stress) {
+        return ext::make_shared<ConstParam<VegaStressedBlackScholesProcess> >(
+            Handle<Quote>(u), Handle<YieldTermStructure>(q), Handle<YieldTermStructure>(r),
+            Handle<BlackVolTermStructure>(vol), lt, ut, la, ua, stress);
+    }
+}
+
+void ConstParamProcessTest::testConstParamGeneralizedBlackScholesProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter generalized Black-Scholes-Merton process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    q,    r,    t,  vol
+    100.00, 0.05, 0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess =
+        makeGBSprocess(spot, qTS, rTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+        makeCPGBSprocess(spot, qTS, rTS, volTS);
+
+    const Time T = 10.0;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = u;
+    Real p = u;
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamBlackScholesMertonProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Black-Scholes-Merton process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    q,    r,    t,  vol
+    100.00, 0.05, 0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess =
+        makeBSMprocess(spot, qTS, rTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+        makeCPBSMprocess(spot, qTS, rTS, volTS);
+
+    const Time T = 10.0;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = u;
+    Real p = u;
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamBlackScholesProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Black-Scholes process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    r,    t,  vol
+    100.00, 0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess = makeBSprocess(spot, rTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process = makeCPBSprocess(spot, rTS, volTS);
+
+    const Time T = 10.0;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = u;
+    Real p = u;
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamBlackProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Black process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    r,    t,  vol
+    100.00, 0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess = makeBprocess(spot, rTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process = makeCPBprocess(spot, rTS, volTS);
+
+    const Time T = 10.0;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = u;
+    Real p = u;
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamGarmanKohlagenProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Garman-Kohlagen process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    foreign,    domestic,    t,  vol
+    100.00,       0.05,        0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> fRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> fTS = flatRate(today, fRate, dc);
+    ext::shared_ptr<SimpleQuote> dRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> dTS = flatRate(today, dRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess =
+        makeGKSprocess(spot, fTS, dTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+        makeCPGKSprocess(spot, fTS, dTS, volTS);
+
+    const Time T = 10.0;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = u;
+    Real p = u;
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+namespace {
+    struct DiscreteAverageData {
+        Option::Type type;
+        Real underlying;
+        Real strike;
+        Rate dividendYield;
+        Rate riskFreeRate;
+        Time first;
+        Time length;
+        Size fixings;
+        Volatility volatility;
+        bool controlVariate;
+        Real result;
+    };
+}
+
+void ConstParamProcessTest::speedUpBSMProcess() {
+    BOOST_TEST_MESSAGE(
+        "Speeding up BSM process in discrete arithmetic average-price Asians option MC pricing...");
+    // data from "Asian Option", Levy, 1997
+    // in "Exotic Options: The State of the Art",
+    // edited by Clewlow, Strickland
+    DiscreteAverageData asian{Option::Put, 90.0, 87.0, 0.06,  0.025,       1.0 / 12.0,
+                              11.0 / 12.0, 12,   0.13, false, 2.1105094397};
+
+    DayCounter dc = Actual360();
+    Date today = Settings::instance().evaluationDate();
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    spot->setValue(asian.underlying);
+    qRate->setValue(asian.dividendYield);
+    rRate->setValue(asian.riskFreeRate);
+    vol->setValue(asian.volatility);
+
+    Average::Type averageType = Average::Arithmetic;
+    Real runningSum = 0.0;
+    Size pastFixings = 0;
+    ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(asian.type, asian.strike));
+
+    Time dt = asian.length / (asian.fixings - 1);
+    std::vector<Time> timeIncrements(asian.fixings);
+    std::vector<Date> fixingDates(asian.fixings);
+    timeIncrements[0] = asian.first;
+    fixingDates[0] = today + timeToDays(timeIncrements[0]);
+    for (Size i = 1; i < asian.fixings; i++) {
+        timeIncrements[i] = i * dt + asian.first;
+        fixingDates[i] = today + timeToDays(timeIncrements[i]);
+    }
+    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[asian.fixings - 1]));
+    DiscreteAveragingAsianOption option(averageType, runningSum, pastFixings, fixingDates, payoff,
+                                        exercise);
+
+    Size samples = 100000;
+
+    decltype(std::chrono::steady_clock::now()) t0, t1, t2;
+
+    t0 = std::chrono::steady_clock::now();
+    {
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+            Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
+            Handle<BlackVolTermStructure>(volTS)));
+
+        ext::shared_ptr<PricingEngine> engineSlow =
+            MakeMCDiscreteArithmeticAPEngine<LowDiscrepancy>(stochProcess)
+                .withSamples(samples)
+                .withControlVariate(asian.controlVariate);
+
+        option.setPricingEngine(engineSlow);
+        Real calculated = option.NPV();
+    }
+    t1 = std::chrono::steady_clock::now();
+    {
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
+            new ConstParam<BlackScholesMertonProcess>(
+                Handle<Quote>(spot), Handle<YieldTermStructure>(qTS),
+                Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS)));
+
+        ext::shared_ptr<PricingEngine> engineFast =
+            MakeMCDiscreteArithmeticAPEngine<LowDiscrepancy>(stochProcess)
+                .withSamples(samples)
+                .withControlVariate(asian.controlVariate);
+
+        option.setPricingEngine(engineFast);
+        Real calculated = option.NPV();
+    }
+    t2 = std::chrono::steady_clock::now();
+
+    Real running1 =
+        static_cast<Real>(std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count());
+    Real running2 =
+        static_cast<Real>(std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count());
+
+    std::cout << "speed up BSM process simulation " << running1 / running2 << " times" << std::endl;
+}
+
+void ConstParamProcessTest::speedUpHestonProcess() {
+
+    BOOST_TEST_MESSAGE("Speeding up Heston process in discrete arithmetic average-price Asians "
+                       "option MC pricing...");
+
+    // data from "A numerical method to price exotic path-dependent
+    // options on an underlying described by the Heston stochastic
+    // volatility model", Ballestra, Pacelli and Zirilli, Journal
+    // of Banking & Finance, 2007 (section 4 - Numerical Results)
+
+    // nb. for Heston, the volatility param below is ignored
+    DiscreteAverageData asian{Option::Call, 120.0, 100.0, 0.0,   0.05, 1.0 / 12.0,
+                              11.0 / 12.0,  12,    0.1,   false, 22.50};
+
+    Real vol = 0.3;
+    Real v0 = vol * vol;
+    Real kappa = 11.35;
+    Real theta = 0.022;
+    Real sigma = 0.618;
+    Real rho = -0.5;
+
+    DayCounter dc = Actual360();
+    Date today = Settings::instance().evaluationDate();
+
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+
+    Average::Type averageType = Average::Arithmetic;
+    Real runningSum = 0.0;
+    Size pastFixings = 0;
+
+    ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(asian.type, asian.strike));
+
+    Time dt = asian.length / (asian.fixings - 1);
+    std::vector<Time> timeIncrements(asian.fixings);
+    std::vector<Date> fixingDates(asian.fixings);
+    timeIncrements[0] = asian.first;
+    fixingDates[0] = today + Integer(timeIncrements[0] * 365.25);
+    for (Size i = 1; i < asian.fixings; i++) {
+        timeIncrements[i] = i * dt + asian.first;
+        fixingDates[i] = today + Integer(timeIncrements[i] * 365.25);
+    }
+    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[asian.fixings - 1]));
+
+    spot->setValue(asian.underlying);
+    qRate->setValue(asian.dividendYield);
+    rRate->setValue(asian.riskFreeRate);
+
+    Size samples = 100000;
+    decltype(std::chrono::steady_clock::now()) t0, t1, t2;
+
+    t0 = std::chrono::steady_clock::now();
+    {
+        ext::shared_ptr<HestonProcess> hestonProcess(
+            new HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                              Handle<Quote>(spot), v0, kappa, theta, sigma, rho));
+
+        ext::shared_ptr<PricingEngine> engineSlow =
+            MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSeed(42)
+                .withSamples(samples);
+
+        DiscreteAveragingAsianOption option(averageType, runningSum, pastFixings, fixingDates,
+                                            payoff, exercise);
+        option.setPricingEngine(engineSlow);
+
+        Real calculated = option.NPV();
+    }
+
+    t1 = std::chrono::steady_clock::now();
+    {
+        ext::shared_ptr<HestonProcess> hestonProcess(new ConstParam<HestonProcess>(
+            Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS), Handle<Quote>(spot),
+            v0, kappa, theta, sigma, rho));
+
+        ext::shared_ptr<PricingEngine> engineSlow =
+            MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
+                .withSeed(42)
+                .withSamples(samples);
+
+        DiscreteAveragingAsianOption option(averageType, runningSum, pastFixings, fixingDates,
+                                            payoff, exercise);
+        option.setPricingEngine(engineSlow);
+
+        Real calculated = option.NPV();
+    }
+    t2 = std::chrono::steady_clock::now();
+
+    Real running1 =
+        static_cast<Real>(std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count());
+    Real running2 =
+        static_cast<Real>(std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count());
+
+    std::cout << "speed up Heston process simulation " << running1 / running2 << " times"
+              << std::endl;
+}
+
+void ConstParamProcessTest::testFetchValue() {
+    BOOST_TEST_MESSAGE("Testing fetchValue method of constant parameter process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    q,    r,    t,  vol
+    100.00, 0.05, 0.10, 10.0, 0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess =
+        makeGBSprocess(spot, qTS, rTS, volTS);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+        makeCPGBSprocess(spot, qTS, rTS, volTS);
+
+    const Time T = 10;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = spot->value();
+    Real p = spot->value();
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+
+    /*
+      spot,    q,    r,    t,  vol
+    110.00, 0.06, 0.11, 10.0, 0.30
+    */
+
+    spot->setValue(110.0);
+    qRate->setValue(0.06);
+    rRate->setValue(0.11);
+    vol->setValue(0.30);
+
+    t = 0.0;
+    q = spot->value();
+    p = spot->value();
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamVegaStressedBlackScholesProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Vega stressed Black-Scholes-Merton process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    /*
+      spot,    q,    r,    t,  vol lt, ut, la,  ua, stress
+    100.00, 0.05, 0.10, 10.0, 0.20  3,  7, 95, 105,   0.20
+    */
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.05));
+    ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.10));
+    ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
+    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
+
+    Real lt = 3.0, ut = 7.0, la = 95.0, ua = 105.0, stress = 0.2;
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess> refProcess =
+        makeVSBSMprocess(spot, qTS, rTS, volTS, lt, ut, la, ua, stress);
+    ext::shared_ptr<GeneralizedBlackScholesProcess> process =
+        makeCPVSBSMprocess(spot, qTS, rTS, volTS, lt, ut, la, ua, stress);
+
+    const Time T = 10;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Real q = spot->value();
+    Real p = spot->value();
+
+    PseudoRandom::rng_type rng(PseudoRandom::urng_type(42U));
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+
+    /*
+      spot,    q,    r,    t,  vol lt, ut,  la,  ua, stress
+    110.00, 0.06, 0.11, 10.0, 0.30  2,  6, 100, 120,   0.10
+    */
+
+    spot->setValue(110.0);
+    qRate->setValue(0.06);
+    rRate->setValue(0.11);
+    vol->setValue(0.30);
+
+    lt = 2.0, ut = 6.0, la = 100.0, ua = 120.0, stress = 0.1;
+
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(process)
+        ->setLowerTimeBorderForStressTest(lt);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(process)
+        ->setUpperTimeBorderForStressTest(ut);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(process)
+        ->setLowerAssetBorderForStressTest(la);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(process)
+        ->setUpperAssetBorderForStressTest(ua);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(process)->setStressLevel(stress);
+
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(refProcess)
+        ->setLowerTimeBorderForStressTest(lt);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(refProcess)
+        ->setUpperTimeBorderForStressTest(ut);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(refProcess)
+        ->setLowerAssetBorderForStressTest(la);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(refProcess)
+        ->setUpperAssetBorderForStressTest(ua);
+    ext::dynamic_pointer_cast<VegaStressedBlackScholesProcess>(refProcess)->setStressLevel(stress);
+
+    t = 0.0;
+    q = spot->value();
+    p = spot->value();
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        const Real dw = rng.next().value;
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (std::fabs(q / p - 1.0) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamHestonProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Heston process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.08));
+
+    Handle<Quote> s0(spot);
+    Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
+    Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
+
+    ext::shared_ptr<HestonProcess> process(ext::make_shared<ConstParam<HestonProcess> >(
+        rTS, qTS, s0, 0.25 * 0.25, 1.0, 0.25 * 0.25, 0.001, 0.0));
+    ext::shared_ptr<HestonProcess> refProcess(
+        ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.25 * 0.25, 1.0, 0.25 * 0.25, 0.001, 0.0));
+
+    const Time T = 10;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Array p(2), q(2);
+    q[0] = s0->value(), q[1] = refProcess->v0();
+    p[0] = s0->value(), p[1] = refProcess->v0();
+
+    PseudoRandom::rsg_type rsg = PseudoRandom::make_sequence_generator(refProcess->factors(), 42U);
+    Array dw(refProcess->factors());
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+
+    /* update */
+
+    spot->setValue(110.0);
+    rRate->setValue(0.09);
+    qRate->setValue(0.05);
+
+    t = 0.0;
+    q[0] = s0->value(), q[1] = refProcess->v0();
+    p[0] = s0->value(), p[1] = refProcess->v0();
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamBatesProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter Bates process...");
+
+    SavedSettings backup;
+
+    DayCounter dc = Actual360();
+    Date today = Date::todaysDate();
+
+    Real u = 100.0;
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.08));
+
+    Handle<Quote> s0(spot);
+    Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
+    Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
+
+    ext::shared_ptr<BatesProcess> process(
+        new ConstParam<BatesProcess>(rTS, qTS, s0, 0.07, 2.0, 0.04, 0.55, -0.8, 2.0, -0.2, 0.1));
+    ext::shared_ptr<BatesProcess> refProcess(
+        new BatesProcess(rTS, qTS, s0, 0.07, 2.0, 0.04, 0.55, -0.8, 2.0, -0.2, 0.1));
+
+    const Time T = 10;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Array p(2), q(2);
+    q[0] = s0->value(), q[1] = refProcess->v0();
+    p[0] = s0->value(), p[1] = refProcess->v0();
+
+    PseudoRandom::rsg_type rsg = PseudoRandom::make_sequence_generator(refProcess->factors(), 42U);
+    Array dw(refProcess->factors());
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+
+    /* update */
+
+    spot->setValue(110.0);
+    rRate->setValue(0.09);
+    qRate->setValue(0.05);
+
+    t = 0.0;
+    q[0] = s0->value(), q[1] = refProcess->v0();
+    p[0] = s0->value(), p[1] = refProcess->v0();
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+void ConstParamProcessTest::testConstParamGJRGARCHProcess() {
+    BOOST_TEST_MESSAGE("Testing constant parameter GJRGARCH process...");
+
+    SavedSettings backup;
+
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
+
+    const Date today = Date::todaysDate();
+
+    const Real u = 50.0;
+    const Real omega = 2.0e-6;
+    const Real alpha = 0.024;
+    const Real beta = 0.93;
+    const Real gamma = 0.059;
+    const Real daysPerYear = 365.0; // number of trading days per year
+    const Size maturity = 180;
+    const Real strike = 45;
+    const Real lambda = 0.1;
+
+    Real m1 = beta +
+              (alpha + gamma * CumulativeNormalDistribution()(lambda)) * (1.0 + lambda * lambda) +
+              gamma * lambda * std::exp(-lambda * lambda / 2.0) / std::sqrt(2.0 * M_PI);
+    Real v0 = omega / (1.0 - m1);
+
+    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+
+    Handle<Quote> s0(spot);
+    Handle<YieldTermStructure> riskFreeTS(flatRate(today, rRate, dayCounter));
+    Handle<YieldTermStructure> dividendTS(flatRate(today, qRate, dayCounter));
+
+    ext::shared_ptr<GJRGARCHProcess> process(new ConstParam<GJRGARCHProcess>(
+        riskFreeTS, dividendTS, s0, v0, omega, alpha, beta, gamma, lambda, daysPerYear));
+    ext::shared_ptr<GJRGARCHProcess> refProcess(new GJRGARCHProcess(
+        riskFreeTS, dividendTS, s0, v0, omega, alpha, beta, gamma, lambda, daysPerYear));
+
+    const Time T = 10;
+    const Size nTimeSteps = 10000;
+
+    const Time dt = T / nTimeSteps;
+    Time t = 0.0;
+    Array p(2), q(2);
+    q[0] = spot->value(), q[1] = refProcess->v0();
+    p[0] = spot->value(), p[1] = refProcess->v0();
+
+    PseudoRandom::rsg_type rsg = PseudoRandom::make_sequence_generator(refProcess->factors(), 42U);
+    Array dw(refProcess->factors());
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+
+    /* update */
+
+    spot->setValue(60.0);
+    rRate->setValue(0.09);
+    qRate->setValue(0.05);
+
+    t = 0.0;
+    q[0] = spot->value(), q[1] = refProcess->v0();
+    p[0] = spot->value(), p[1] = refProcess->v0();
+
+    for (Size j = 0; j < nTimeSteps; ++j) {
+        for (Size i = 0; i < refProcess->factors(); ++i) {
+            dw[i] = rsg.nextSequence().value[i];
+        }
+
+        q = process->evolve(t, q, dt, dw);
+        p = refProcess->evolve(t, p, dt, dw);
+
+        if (Norm2(q - p) / Norm2(p) > 1.0e-10) {
+            BOOST_FAIL("invalid process evaluation at " << j << " " << q - p);
+        }
+        t += dt;
+    }
+}
+
+test_suite* ConstParamProcessTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("Constant parameter BSM process Test");
+
+    suite->add(
+        QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamGeneralizedBlackScholesProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamBlackScholesMertonProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamBlackScholesProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamBlackProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamGarmanKohlagenProcess));
+    suite->add(
+        QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamVegaStressedBlackScholesProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamHestonProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamBatesProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testConstParamGJRGARCHProcess));
+    //suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::speedUpBSMProcess));
+    //suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::speedUpHestonProcess));
+    suite->add(QUANTLIB_TEST_CASE(&ConstParamProcessTest::testFetchValue));
+    return suite;
+}

--- a/test-suite/constparamprocess.hpp
+++ b/test-suite/constparamprocess.hpp
@@ -1,0 +1,46 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Ruilong Xu
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_const_param_process_hpp
+#define quantlib_test_const_param_process_hpp
+
+#include "speedlevel.hpp"
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class ConstParamProcessTest {
+  public:
+    static void testConstParamGeneralizedBlackScholesProcess();
+    static void testConstParamBlackScholesMertonProcess();
+    static void testConstParamBlackScholesProcess();
+    static void testConstParamBlackProcess();
+    static void testConstParamGarmanKohlagenProcess();
+    static void testConstParamVegaStressedBlackScholesProcess();
+    static void testConstParamHestonProcess();
+    static void testConstParamBatesProcess();
+    static void testConstParamGJRGARCHProcess();
+    static void speedUpBSMProcess();
+    static void speedUpHestonProcess();
+    static void testFetchValue();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -79,6 +79,7 @@
 #include "commodityunitofmeasure.hpp"
 #include "compiledboostversion.hpp"
 #include "compoundoption.hpp"
+#include "constparamprocess.hpp"
 #include "convertiblebonds.hpp"
 #include "covariance.hpp"
 #include "creditdefaultswap.hpp"
@@ -384,6 +385,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(CashFlowsTest::suite());
     test->add(CliquetOptionTest::suite());
     test->add(CmsTest::suite());
+    test->add(ConstParamProcessTest::suite());
     test->add(ConvertibleBondTest::suite());
     test->add(CovarianceTest::suite());
     test->add(CPISwapTest::suite());


### PR DESCRIPTION
In fact, most MC simulations in test suites use constant parameter stochastic processes, while term structures are main bottleneck of performance. 

For constant parameter BSM process, we can speed up it by avoid using term structure and overriding all associated member functions. That is how class template `ConstParam` works.

For constant parameter Heston, Bates and GJRGARCH process, I add a new member function `forwardCarryCost`, we can avoid using term structure by overriding it.

On my laptop, `ConstParam` can speed up BSM process about 8 times, and Heston process 2 times. See `speedUpBSMProcess` and `speedUpHestonProcess`.
