### PR TITLE
Replace gcc and clang diagnostics with system headers

### DIFF
--- a/.github/workflows/macos-nondefault.yml
+++ b/.github/workflows/macos-nondefault.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-shared --enable-error-lines --enable-error-functions --enable-tracing --enable-indexed-coupons --enable-extra-safety-checks --enable-sessions --enable-thread-safe-observer-pattern --enable-intraday --with-boost-include=/usr/local/include --with-boost-lib=/usr/local/lib ${{ matrix.configureflags }}  CC="ccache $(brew --prefix llvm)/bin/clang" CXX="ccache $(brew --prefix llvm)/bin/clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
+        ./configure --disable-shared --enable-error-lines --enable-error-functions --enable-tracing --enable-indexed-coupons --enable-extra-safety-checks --enable-sessions --enable-thread-safe-observer-pattern --enable-intraday ${{ matrix.configureflags }}  CC="ccache clang" CXX="ccache clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
         make -j 2
     - name: Run tests
       run: |

--- a/.github/workflows/macos-nondefault.yml
+++ b/.github/workflows/macos-nondefault.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-shared --enable-error-lines --enable-error-functions --enable-tracing --enable-indexed-coupons --enable-extra-safety-checks --enable-sessions --enable-thread-safe-observer-pattern --enable-intraday ${{ matrix.configureflags }}  CC="ccache clang" CXX="ccache clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
+        ./configure --disable-shared --enable-error-lines --enable-error-functions --enable-tracing --enable-indexed-coupons --enable-extra-safety-checks --enable-sessions --enable-thread-safe-observer-pattern --enable-intraday --with-boost-include=/usr/local/include --with-boost-lib=/usr/local/lib ${{ matrix.configureflags }}  CC="ccache $(brew --prefix llvm)/bin/clang" CXX="ccache $(brew --prefix llvm)/bin/clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
         make -j 2
     - name: Run tests
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-shared --with-boost-include=/usr/local/include ${{ matrix.configureflags }} CC="ccache $(brew --prefix llvm)/bin/clang" CXX="ccache $(brew --prefix llvm)/bin/clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
+        ./configure --disable-shared ${{ matrix.configureflags }} CC="ccache clang" CXX="ccache clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
         make -j 2
     - name: Run tests
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-shared ${{ matrix.configureflags }} CC="ccache clang" CXX="ccache clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
+        ./configure --disable-shared --with-boost-include=/usr/local/include ${{ matrix.configureflags }} CC="ccache $(brew --prefix llvm)/bin/clang" CXX="ccache $(brew --prefix llvm)/bin/clang++" CXXFLAGS="-O2 -g0 -Wall -Werror -stdlib=libc++ -mmacosx-version-min=10.9 ${{ matrix.cxxflags }}" LDFLAGS="-stdlib=libc++ -mmacosx-version-min=10.9"
         make -j 2
     - name: Run tests
       run: |

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -28,6 +28,25 @@ AC_DEFUN([QL_CHECK_CPP11],
     ])
 ])
 
+# QL_CHECK_SYSTEM_HEADER_PREFIX
+# -----------------------------
+# Check whether the compiler supports the --system-header-prefix flag
+AC_DEFUN([QL_CHECK_SYSTEM_HEADER_PREFIX],
+[AC_MSG_CHECKING([if ${CXX} supports --system-header-prefix])
+ AC_REQUIRE([AC_PROG_CC])
+ ql_original_CXXFLAGS=$CXXFLAGS
+ CXXFLAGS="$ql_original_CXXFLAGS --system-header-prefix=boost/"
+ AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[int foo() { return 0; }]],
+        [[]])],
+    [AC_MSG_RESULT([yes])
+     AC_SUBST([SYSTEM_HEADER_CXXFLAGS],["--system-header-prefix=boost/"])
+    ],
+    [AC_MSG_RESULT([no])])
+ CXXFLAGS="$ql_original_CXXFLAGS ${SYSTEM_HEADER_CXXFLAGS}"
+])
+
 # QL_CHECK_BOOST_DEVEL
 # --------------------
 # Check whether the Boost headers are available

--- a/configure.ac
+++ b/configure.ac
@@ -38,8 +38,8 @@ AC_ARG_WITH([boost-include],
             [ql_boost_include_path="`cd ${withval} 2>/dev/null && pwd`"],
             [ql_boost_include_path=""])
 if test [ -n "$ql_boost_include_path" ] ; then
-   AC_SUBST([BOOST_INCLUDE],["-I${ql_boost_include_path}"])
-   AC_SUBST([CPPFLAGS],["${CPPFLAGS} -I${ql_boost_include_path}"])
+   AC_SUBST([BOOST_INCLUDE],["-isystem ${ql_boost_include_path}"])
+   AC_SUBST([CPPFLAGS],["${CPPFLAGS} -isystem ${ql_boost_include_path}"])
 fi
 AC_ARG_WITH([boost-lib],
             AS_HELP_STRING([--with-boost-lib=LIB_PATH],

--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,9 @@ fi
 # Check for C++11 support
 QL_CHECK_CPP11
 
+# Check for other compiler flags
+QL_CHECK_SYSTEM_HEADER_PREFIX
+
 # Check for Boost components
 QL_CHECK_BOOST
 AM_CONDITIONAL(BOOST_UNIT_TEST_FOUND, test "x${HAVE_BOOST_TEST}" != "x")

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2335,7 +2335,9 @@ target_compile_options(ql_library PRIVATE
 target_include_directories(ql_library PUBLIC
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>)
+
+target_include_directories(ql_library SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${OpenMP_CXX_INCLUDE_DIRS})
 

--- a/ql/experimental/finitedifferences/fdmextoujumpop.cpp
+++ b/ql/experimental/finitedifferences/fdmextoujumpop.cpp
@@ -37,20 +37,11 @@
 #pragma warning(disable:4180)
 #endif
 
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/operation.hpp>
 
 #if defined(QL_PATCH_MSVC)
 #pragma warning(pop)
-#endif
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
 #endif
 
 namespace QuantLib {

--- a/ql/experimental/math/convolvedstudentt.cpp
+++ b/ql/experimental/math/convolvedstudentt.cpp
@@ -23,15 +23,7 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/math/functional.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/math/distributions/students_t.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 namespace QuantLib {
 

--- a/ql/experimental/models/hestonslvmcmodel.cpp
+++ b/ql/experimental/models/hestonslvmcmodel.cpp
@@ -25,16 +25,8 @@
 #include <ql/termstructures/volatility/equityfx/fixedlocalvolsurface.hpp>
 #include <ql/experimental/models/hestonslvmcmodel.hpp>
 #include <ql/experimental/processes/hestonslvprocess.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/multi_array.hpp>
 #include <utility>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#    pragma GCC diagnostic pop
-#endif
 
 namespace QuantLib {
     HestonSLVMCModel::HestonSLVMCModel(

--- a/ql/functional.hpp
+++ b/ql/functional.hpp
@@ -29,16 +29,9 @@
 #if defined(QL_USE_STD_FUNCTION)
 #include <functional>
 #else
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/function.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/ref.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #endif
 
 namespace QuantLib {

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -18,14 +18,7 @@
 */
 
 #include <ql/indexes/indexmanager.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string/case_conv.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#    pragma GCC diagnostic pop
-#endif
 
 using boost::algorithm::to_upper_copy;
 using std::string;

--- a/ql/math/distributions/normaldistribution.cpp
+++ b/ql/math/distributions/normaldistribution.cpp
@@ -23,16 +23,7 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/comparison.hpp>
 
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
 #include <boost/math/distributions/normal.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 namespace QuantLib {
 

--- a/ql/math/matrix.cpp
+++ b/ql/math/matrix.cpp
@@ -28,16 +28,6 @@
 #pragma warning(disable:4127)
 #endif
 
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
-
 #if BOOST_VERSION == 106400
 #include <boost/serialization/array_wrapper.hpp>
 #endif
@@ -48,15 +38,6 @@
 #if defined(QL_PATCH_MSVC)
 #pragma warning(pop)
 #endif
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
 
 namespace QuantLib {
 

--- a/ql/math/matrixutilities/sparsematrix.hpp
+++ b/ql/math/matrixutilities/sparsematrix.hpp
@@ -33,16 +33,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #pragma warning(disable:4127)
 #endif
 
-#if defined(__clang__) && BOOST_VERSION > 105300
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#endif
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
 #if BOOST_VERSION == 106400
 #include <boost/serialization/array_wrapper.hpp>
 #endif
@@ -51,14 +41,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 #if defined(QL_PATCH_MSVC)
 #pragma warning(pop)
-#endif
-
-#if defined(__clang__) && BOOST_VERSION > 105300
-#pragma clang diagnostic pop
-#endif
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
 #endif
 
 namespace QuantLib {

--- a/ql/methods/finitedifferences/operators/numericaldifferentiation.cpp
+++ b/ql/methods/finitedifferences/operators/numericaldifferentiation.cpp
@@ -24,15 +24,8 @@
 #ifndef QL_EXTRA_SAFETY_CHECKS
 #define BOOST_DISABLE_ASSERTS 1
 #endif
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/multi_array.hpp>
 #include <utility>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#    pragma GCC diagnostic pop
-#endif
 
 namespace QuantLib {
 

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -43,16 +43,7 @@
 #include <boost/math/bindings/rr.hpp>
 #endif
 
-#if defined(__GNUC__) &&                                                       \
-    (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/math/special_functions/erf.hpp>
-#if defined(__GNUC__) &&                                                       \
-    (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 #include <unordered_map>
 

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -22,23 +22,7 @@
 #include <ql/currencies/exchangeratemanager.hpp>
 #include <ql/math/comparison.hpp>
 
-#if defined(__clang__) && (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsuggest-override"
-#endif
-#if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsuggest-override"
-#endif
-
 #include <boost/format.hpp>
-
-#if defined(__clang__) && (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
-#pragma clang diagnostic pop
-#endif
-#if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
-#pragma GCC diagnostic pop
-#endif
 
 namespace QuantLib {
 

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -32,15 +32,7 @@
 #include <ql/math/solvers1d/newtonsafe.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/math/special_functions/atanh.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
-
 #include <boost/math/special_functions/sign.hpp>
 
 namespace {

--- a/ql/termstructures/volatility/kahalesmilesection.hpp
+++ b/ql/termstructures/volatility/kahalesmilesection.hpp
@@ -38,14 +38,7 @@
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/termstructures/volatility/smilesectionutils.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/math/distributions/normal.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #include <vector>
 #include <utility>
 

--- a/ql/time/asx.cpp
+++ b/ql/time/asx.cpp
@@ -24,14 +24,7 @@
 #include <ql/time/asx.hpp>
 #include <ql/settings.hpp>
 #include <ql/utilities/dataparsers.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string/case_conv.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #include <string>
 
 using boost::algorithm::to_upper_copy;

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -27,16 +27,9 @@
 #include <ql/time/date.hpp>
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/errors.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/functional/hash.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #include <iomanip>
 #include <ctime>
 

--- a/ql/time/ecb.cpp
+++ b/ql/time/ecb.cpp
@@ -21,14 +21,7 @@
 #include <ql/time/ecb.hpp>
 #include <ql/settings.hpp>
 #include <ql/utilities/dataparsers.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string/case_conv.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #include <algorithm>
 #include <string>
 

--- a/ql/time/imm.cpp
+++ b/ql/time/imm.cpp
@@ -23,14 +23,7 @@
 #include <ql/time/imm.hpp>
 #include <ql/settings.hpp>
 #include <ql/utilities/dataparsers.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/algorithm/string/case_conv.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 #include <string>
 
 using boost::algorithm::to_upper_copy;

--- a/ql/utilities/dataparsers.cpp
+++ b/ql/utilities/dataparsers.cpp
@@ -24,16 +24,9 @@
 #include <ql/utilities/null.hpp>
 #include <ql/time/period.hpp>
 #include <ql/errors.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #ifndef QL_PATCH_SOLARIS
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
-#endif
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
 #endif
 #include <string>
 #include <locale>

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -369,7 +369,8 @@ if (QL_BUILD_TEST_SUITE OR QL_BUILD_BENCHMARK)
     add_library(ql_unit_test_main STATIC main.cpp)
     target_include_directories(ql_unit_test_main PRIVATE
         ${PROJECT_BINARY_DIR}
-        ${PROJECT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR})
+    target_include_directories(ql_unit_test_main SYSTEM PRIVATE
         ${Boost_INCLUDE_DIRS})
     if (NOT Boost_USE_STATIC_LIBS)
         target_compile_definitions(ql_unit_test_main PRIVATE BOOST_TEST_DYN_LINK)

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -31,15 +31,7 @@
 #include <ql/math/distributions/poissondistribution.hpp>
 #include <ql/math/randomnumbers/stochasticcollocationinvcdf.hpp>
 #include <ql/math/comparison.hpp>
-
-#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 #include <boost/math/distributions/non_central_chi_squared.hpp>
-#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
-#pragma GCC diagnostic pop
-#endif
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -72,15 +72,8 @@
 #include <ql/math/matrixutilities/sparseilupreconditioner.hpp>
 #include <ql/functional.hpp>
 
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/operation.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 #include <numeric>
 #include <utility>

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -86,17 +86,8 @@
 #include <ql/experimental/barrieroption/doublebarrieroption.hpp>
 #include <ql/experimental/barrieroption/analyticdoublebarrierbinaryengine.hpp>
 #include <boost/math/special_functions/gamma.hpp>
-#include <iomanip>
-
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/multi_array.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
+#include <iomanip>
 
 using namespace QuantLib;
 using boost::unit_test_framework::test_suite;

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -23,15 +23,7 @@
 #include <ql/math/randomnumbers/rngtraits.hpp>
 #include <ql/math/linearleastsquaresregression.hpp>
 #include <ql/functional.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
 #include <boost/circular_buffer.hpp>
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -43,27 +43,15 @@
 #include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
 #include <ql/pricingengines/vanilla/analytichestonengine.hpp>
 
+#include <boost/numeric/ublas/banded.hpp>
+#include <boost/numeric/ublas/operation_sparse.hpp>
+#include <boost/numeric/ublas/matrix_proxy.hpp>
 
 #include <numeric>
 #include <utility>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
-
-#include <boost/numeric/ublas/banded.hpp>
-
-#if defined(__clang__) || defined(__GNUC__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
-#endif
-
-#include <boost/numeric/ublas/operation_sparse.hpp>
-
-#if defined(__clang__) || defined(__GNUC__)
-#pragma clang diagnostic pop
-#endif
-
-#include <boost/numeric/ublas/matrix_proxy.hpp>
 
 void NthOrderDerivativeOpTest::testSparseMatrixApply() {
     BOOST_TEST_MESSAGE("Testing sparse matrix apply...");

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -48,14 +48,7 @@
 #include <ql/experimental/barrieroption/analyticdoublebarrierbinaryengine.hpp>
 #include <ql/experimental/volatility/sabrvoltermstructure.hpp>
 
-#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 #include <boost/math/distributions/non_central_chi_squared.hpp>
-#if defined(__GNUC__) && !defined(__clang__) && BOOST_VERSION > 106300
-#pragma GCC diagnostic pop
-#endif
 
 #include <set>
 #include <utility>

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -23,17 +23,7 @@
 #include <ql/timeseries.hpp>
 #include <ql/prices.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-#endif
-
 #include <boost/unordered_map.hpp>
-
-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)) || (__GNUC__ > 4))
-#pragma GCC diagnostic pop
-#endif
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;


### PR DESCRIPTION
Currently the CMake and autoconf builds include boost headers as non-system headers, which can result in unwanted compiler warnings.

Including them instead as system headers allows us to remove all the compiler diagnostics from the source code.

As a minor note, it should be possible to remove the `--system-header-prefix` from the macos builds but so far I haven't been able to figure out how to pass the `-isystem` flag on macos using autoconf. If anyone knows where this would go, that would be a big help.