### PR TITLE
Consistently use Real datatype

### DIFF
--- a/Examples/BasketLosses/BasketLosses.cpp
+++ b/Examples/BasketLosses/BasketLosses.cpp
@@ -70,7 +70,7 @@ int main(int, char* []) {
         for(Size i=0; i<hazardRates.size(); i++)
             names.push_back(std::string("Acme") + std::to_string(i));
         std::vector<Handle<DefaultProbabilityTermStructure> > defTS;
-        for (double& hazardRate : hazardRates) {
+        for (Real& hazardRate : hazardRates) {
             defTS.emplace_back(
                 ext::make_shared<FlatHazardRate>(0, TARGET(), hazardRate, Actual365Fixed()));
             defTS.back()->enableExtrapolation();

--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -163,7 +163,7 @@ int main(int, char* []) {
         };
 
         std::vector< ext::shared_ptr<SimpleQuote> > quote;
-        for (double marketQuote : marketQuotes) {
+        for (Real marketQuote : marketQuotes) {
             ext::shared_ptr<SimpleQuote> cp(new SimpleQuote(marketQuote));
             quote.push_back(cp);
         }

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -89,12 +89,12 @@ int main(int, char* []) {
         const Size numberOfBonds = 15;
         Real cleanPrice[numberOfBonds];
 
-        for (double& i : cleanPrice) {
+        for (Real& i : cleanPrice) {
             i = 100.0;
         }
 
         std::vector< ext::shared_ptr<SimpleQuote> > quote;
-        for (double i : cleanPrice) {
+        for (Real i : cleanPrice) {
             ext::shared_ptr<SimpleQuote> cp(new SimpleQuote(i));
             quote.push_back(cp);
         }
@@ -227,7 +227,7 @@ int main(int, char* []) {
                            20.0,  25.0, 30.0, 40.0, 50.0 };
 
         std::vector<Time> knotVector;
-        for (double& knot : knots) {
+        for (Real& knot : knots) {
             knotVector.push_back(knot);
         }
 

--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -56,7 +56,7 @@ Real ackley(const Array& x) {
     //Minimum is found at 0
     Real p1 = 0.0, p2 = 0.0;
 
-    for (double i : x) {
+    for (Real i : x) {
         p1 += i * i;
         p2 += std::cos(M_TWOPI * i);
     }
@@ -103,7 +103,7 @@ Real rosenbrock(const Array& x) {
 Real easom(const Array& x) {
     //Minimum is found at f(\pi, \pi, ...)
     Real p1 = 1.0, p2 = 0.0;
-    for (double i : x) {
+    for (Real i : x) {
         p1 *= std::cos(i);
         p2 += (i - M_PI) * (i - M_PI);
     }

--- a/Examples/LatentModel/LatentModel.cpp
+++ b/Examples/LatentModel/LatentModel.cpp
@@ -71,7 +71,7 @@ int main(int, char* []) {
             names.push_back(std::string("Acme") + std::to_string(i));
         std::vector<Handle<DefaultProbabilityTermStructure> > defTS;
         defTS.reserve(hazardRates.size());
-        for (double& hazardRate : hazardRates)
+        for (Real& hazardRate : hazardRates)
             defTS.emplace_back(
                 ext::make_shared<FlatHazardRate>(0, TARGET(), hazardRate, Actual365Fixed()));
         std::vector<Issuer> issuers;

--- a/Examples/MarketModels/MarketModels.cpp
+++ b/Examples/MarketModels/MarketModels.cpp
@@ -322,7 +322,7 @@ int Bermudan()
 
     std::vector<Real> means(stats.mean());
 
-    for (double mean : means)
+    for (Real mean : means)
         std::cout << mean << "\n";
 
     std::cout << " time to build strategy, " << (t2-t1)/static_cast<Real>(CLOCKS_PER_SEC)<< ", seconds.\n";
@@ -655,7 +655,7 @@ int InverseFloater(Real rateLevel)
 
     std::vector<Real> means(stats.mean());
 
-    for (double mean : means)
+    for (Real mean : means)
         std::cout << mean << "\n";
 
     std::cout << " time to build strategy, " << (t2-t1)/static_cast<Real>(CLOCKS_PER_SEC)<< ", seconds.\n";

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 struct integrand {
     Real operator()(const std::vector<Real>& arg) const {
         Real sum = 1.;
-        for (double i : arg)
+        for (Real i : arg)
             sum *= std::exp(-i * i) * std::cos(i);
         return sum;
     }

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -601,7 +601,7 @@ namespace QuantLib {
 
     Real GFunctionFactory::GFunctionExactYield::operator()(Real x) {
         Real product = 1.;
-        for (double accrual : accruals_) {
+        for (Real accrual : accruals_) {
             product *= 1. / (1. + accrual * x);
         }
         return x*std::pow(1.+ accruals_[0]*x,-delta_)*(1./(1.-product));
@@ -612,7 +612,7 @@ namespace QuantLib {
         Real derC = 0.;
         std::vector<Real> b;
         b.reserve(accruals_.size());
-        for (double accrual : accruals_) {
+        for (Real accrual : accruals_) {
             Real temp = 1.0 / (1.0 + accrual * x);
             b.push_back(temp);
             c *= temp;
@@ -634,7 +634,7 @@ namespace QuantLib {
         Real sumOfSquare = 0.;
         std::vector<Real> b;
         b.reserve(accruals_.size());
-        for (double accrual : accruals_) {
+        for (Real accrual : accruals_) {
             Real temp = 1.0 / (1.0 + accrual * x);
             b.push_back(temp);
             c *= temp;
@@ -699,7 +699,7 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
             const Date paymentDate(cpn->date());
-            const double swapPaymentTime(dc.yearFraction(rateCurve->referenceDate(), paymentDate));
+            const Real swapPaymentTime(dc.yearFraction(rateCurve->referenceDate(), paymentDate));
             shapedSwapPaymentTimes_.push_back(shapeOfShift(swapPaymentTime));
             swapPaymentDiscounts_.push_back(rateCurve->discount(paymentDate));
         }

--- a/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_cont_geom_av_price_heston.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                   Real xiRightLimit) : t_(0.0), T_(T), K_(K), logK_(std::log(K)), cutoff_(cutoff),
                                        parent_(parent), xiRightLimit_(xiRightLimit), i_(std::complex<Real>(0.0, 1.0)) {}
 
-        double operator()(double xi) const {
-            double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
+        Real operator()(Real xi) const {
+            Real xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
 
             std::complex<Real> inner1 = parent_->Phi(1.0 + xiDash*i_, 0, T_, t_, cutoff_);
             std::complex<Real> inner2 = - K_*parent_->Phi(xiDash*i_, 0, T_, t_, cutoff_);
@@ -63,8 +63,8 @@ namespace QuantLib {
             denominator_ = std::log(riskFreeRate_->discount(t_)) - std::log(dividendYield_->discount(t_));
         }
 
-        double operator()(double u) const {
-            double uDash = (0.5+1e-8+0.5*u) * (T_ - t_) + t_; // Map u to full range
+        Real operator()(Real u) const {
+            Real uDash = (0.5+1e-8+0.5*u) * (T_ - t_) + t_; // Map u to full range
             return 0.5*(T_ - t_)*(-std::log(riskFreeRate_->discount(uDash))
                                + std::log(dividendYield_->discount(uDash)) + denominator_);
         }
@@ -172,7 +172,7 @@ namespace QuantLib {
         for (Size i=0; i<cutoff; i++) {
             temp = f(z1, z2, z3, z4, i, tau);
             runningSum1 += temp;
-            runningSum2 += temp*double(i)/tau;
+            runningSum2 += temp*Real(i)/tau;
         }
 
         std::pair<std::complex<Real>, std::complex<Real> > result(runningSum1, runningSum2);

--- a/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
+++ b/ql/experimental/asian/analytic_discr_geom_av_price_heston.cpp
@@ -45,8 +45,8 @@ namespace QuantLib {
           tauK_(std::move(tauK)), parent_(parent), xiRightLimit_(xiRightLimit),
           i_(std::complex<Real>(0.0, 1.0)) {}
 
-        double operator()(double xi) const {
-            double xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
+        Real operator()(Real xi) const {
+            Real xiDash = (0.5+1e-8+0.5*xi) * xiRightLimit_; // Map xi to full range
 
             std::complex<Real> inner1 = parent_->Phi(1.0 + xiDash*i_, 0, t_, T_, kStar_, t_n_, tauK_);
             std::complex<Real> inner2 = -K_*parent_->Phi(xiDash*i_, 0, t_, T_, kStar_, t_n_, tauK_);
@@ -96,8 +96,8 @@ namespace QuantLib {
 
     std::complex<Real> AnalyticDiscreteGeometricAveragePriceAsianHestonEngine::z(
             const std::complex<Real>& s, const std::complex<Real>& w, Size k, Size n) const {
-        auto k_ = double(k);
-        auto n_ = double(n);
+        auto k_ = Real(k);
+        auto n_ = Real(n);
         std::complex<Real> term1 = (2*rho_*kappa_ - sigma_)*((n_-k_+1)*s + n_*w)/(2*sigma_*n_);
         std::complex<Real> term2 = (1-rho_*rho_)*pow(((n_-k_+1)*s + n_*w), 2)/(2*n_*n_);
 
@@ -120,8 +120,8 @@ namespace QuantLib {
             const std::complex<Real>& w,
             Time t, Time T, Size kStar,
             const std::vector<Time>& t_n) const {
-        auto kStar_ = double(kStar);
-        auto n_ = double(t_n.size());
+        auto kStar_ = Real(kStar);
+        auto n_ = Real(t_n.size());
         Real temp = -rho_*kappa_*theta_/sigma_;
 
         Time summation = 0.0;
@@ -262,7 +262,7 @@ namespace QuantLib {
         tkr_tk_ = std::vector<Real>();
         tr_t_ = -std::log(riskFreeRate_->discount(startTime) / dividendYield_->discount(startTime));
         Tr_T_ = -std::log(riskFreeRate_->discount(expiryTime) / dividendYield_->discount(expiryTime));
-        for (double fixingTime : fixingTimes) {
+        for (Real fixingTime : fixingTimes) {
             if (fixingTime < 0) {
                 tkr_tk_.push_back(1.0);
             } else {

--- a/ql/experimental/barrieroption/discretizeddoublebarrieroption.cpp
+++ b/ql/experimental/barrieroption/discretizeddoublebarrieroption.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
                 stoppingTime = true;
             break;
           case Exercise::Bermudan:
-              for (double i : stoppingTimes_) {
+              for (Real i : stoppingTimes_) {
                   if (isOnTime(i)) {
                       stoppingTime = true;
                       break;

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1457,8 +1457,8 @@ namespace QuantLib {
                 const ext::shared_ptr<GeneralizedBlackScholesProcess>& process)
             : r(*(process->riskFreeRate())), q(*(process->dividendYield())) {}
             Real operator()(Real t1,Real t2) const {
-                Real alpha = r->forwardRate(t1,t2,Continuous)
-                           - q->forwardRate(t1,t2,Continuous);
+                Real alpha = r->forwardRate(t1,t2,Continuous).rate()
+                           - q->forwardRate(t1,t2,Continuous).rate();
                 return alpha * (t2-t1);
             }
         };

--- a/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
+++ b/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
@@ -317,7 +317,7 @@ namespace QuantLib {
 
             //touch probability
             CumulativeNormalDistribution cnd;
-            Real mu = domesticTS_->zeroRate(T_, Continuous) - foreignTS_->zeroRate(T_, Continuous) - pow(atmVol_->value(), 2.0)/2.0;
+            Real mu = domesticTS_->zeroRate(T_, Continuous).rate() - foreignTS_->zeroRate(T_, Continuous).rate() - pow(atmVol_->value(), 2.0)/2.0;
             Real h2 = (log(arguments_.barrier/x0Quote->value()) + mu*T_)/(atmVol_->value()*sqrt(T_));
             Real h2Prime = (log(x0Quote->value()/arguments_.barrier) + mu*T_)/(atmVol_->value()*sqrt(T_));
             Real probTouch = 0.0;

--- a/ql/experimental/barrieroption/vannavolgadoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/vannavolgadoublebarrierengine.hpp
@@ -348,8 +348,8 @@ namespace QuantLib {
 
                      Real H = arguments_.barrier_hi;
                      Real L = arguments_.barrier_lo;
-                     Real theta_tilt_minus = ((domesticTS_->zeroRate(T_, Continuous) -
-                                               foreignTS_->zeroRate(T_, Continuous)) /
+                     Real theta_tilt_minus = ((domesticTS_->zeroRate(T_, Continuous).rate() -
+                                               foreignTS_->zeroRate(T_, Continuous).rate()) /
                                                   atmVol_->value() -
                                               atmVol_->value() / 2.0) *
                                              std::sqrt(T_);

--- a/ql/experimental/basismodels/tenoroptionletvts.cpp
+++ b/ql/experimental/basismodels/tenoroptionletvts.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
 
     Volatility TenorOptionletVTS::TenorOptionletSmileSection::volatilityImpl(Rate strike) const {
         Real sum_v = 0.0;
-        for (double k : v_)
+        for (Real k : v_)
             sum_v += k;
         std::vector<Real> volBase(v_.size());
         for (Size k = 0; k < fraRateBase_.size(); ++k) {

--- a/ql/experimental/basismodels/tenorswaptionvts.cpp
+++ b/ql/experimental/basismodels/tenorswaptionvts.cpp
@@ -91,7 +91,7 @@ namespace QuantLib {
         // calculate affine TSR model u and v
         // Sum tau_j   (fixed leg)
         Real sumTauj = 0.0;
-        for (double k : cfs.annuityWeights())
+        for (Real k : cfs.annuityWeights())
             sumTauj += k;
         // Sum tau_j (T_M - T_j)   (fixed leg)
         Real sumTaujDeltaT = 0.0;
@@ -100,7 +100,7 @@ namespace QuantLib {
                 cfs.annuityWeights()[k] * (cfs.fixedTimes().back() - cfs.fixedTimes()[k]);
         // Sum w_i   (float leg)
         Real sumWi = 0.0;
-        for (double k : cfs.floatWeights())
+        for (Real k : cfs.floatWeights())
             sumWi += k;
         // Sum w_i (T_N - T_i)    (float leg)
         Real sumWiDeltaT = 0.0;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -154,10 +154,10 @@ namespace QuantLib {
                           Compounding compounding,
                           Frequency frequency)
     {
-        double zz=yts->zeroRate(b.maturityDate(),
-                                dayCounter,
-                                Continuous,
-                                NoFrequency);
+        Real zz=yts->zeroRate(b.maturityDate(),
+                              dayCounter,
+                              Continuous,
+                              NoFrequency);
         InterestRate baseRate(zz,
                               dayCounter,
                               Continuous,
@@ -166,16 +166,16 @@ namespace QuantLib {
                                   dayCounter,
                                   Continuous,
                                   NoFrequency);
-        double br=baseRate.equivalentRate(dayCounter,
-                                          compounding,
-                                          frequency,
-                                          yts->referenceDate(),
-                                          b.maturityDate()).rate();
-        double sr=spreadedRate.equivalentRate(dayCounter,
-                                              compounding,
-                                              frequency,
-                                              yts->referenceDate(),
-                                              b.maturityDate()).rate();
+        Real br=baseRate.equivalentRate(dayCounter,
+                                        compounding,
+                                        frequency,
+                                        yts->referenceDate(),
+                                        b.maturityDate()).rate();
+        Real sr=spreadedRate.equivalentRate(dayCounter,
+                                            compounding,
+                                            frequency,
+                                            yts->referenceDate(),
+                                            b.maturityDate()).rate();
         // Return the spread
         return sr-br;
     }
@@ -190,10 +190,10 @@ namespace QuantLib {
                           Compounding compounding,
                           Frequency frequency)
     {
-        double zz=yts->zeroRate(b.maturityDate(),
-                                dayCounter,
-                                compounding,
-                                frequency);
+        Real zz=yts->zeroRate(b.maturityDate(),
+                              dayCounter,
+                              compounding,
+                              frequency);
         InterestRate baseRate(zz,
                               dayCounter,
                               compounding,
@@ -203,16 +203,16 @@ namespace QuantLib {
                                   dayCounter,
                                   compounding,
                                   frequency);
-        double br=baseRate.equivalentRate(dayCounter,
-                                          Continuous,
-                                          NoFrequency,
-                                          yts->referenceDate(),
-                                          b.maturityDate()).rate();
-        double sr=spreadedRate.equivalentRate(dayCounter,
-                                              Continuous,
-                                              NoFrequency,
-                                              yts->referenceDate(),
-                                              b.maturityDate()).rate();
+        Real br=baseRate.equivalentRate(dayCounter,
+                                        Continuous,
+                                        NoFrequency,
+                                        yts->referenceDate(),
+                                        b.maturityDate()).rate();
+        Real sr=spreadedRate.equivalentRate(dayCounter,
+                                            Continuous,
+                                            NoFrequency,
+                                            yts->referenceDate(),
+                                            b.maturityDate()).rate();
         // Return the spread
         return sr-br;
     }

--- a/ql/experimental/credit/basket.cpp
+++ b/ql/experimental/credit/basket.cpp
@@ -59,7 +59,7 @@ namespace QuantLib {
         //   probability term structures for the defultKeys(eventType+
         //   currency+seniority) entering in this basket. This is not
         //   necessarily a problem.
-        for (double notional : notionals_) {
+        for (Real notional : notionals_) {
             basketNotional_ += notional;
             attachmentAmount_ += notional * attachmentRatio_;
             detachmentAmount_ += notional * detachmentRatio_;
@@ -103,7 +103,7 @@ namespace QuantLib {
     }
 
     Real Basket::notional() const {
-        return std::accumulate(notionals_.begin(), notionals_.end(), 0.0);
+        return std::accumulate(notionals_.begin(), notionals_.end(), Real(0.0));
     }
 
     vector<Real> Basket::probabilities(const Date& d) const {

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -179,7 +179,7 @@ namespace QuantLib {
         // of full portfolio:
         Real avgProb = avgLgd <= QL_EPSILON ? 0. : // only if all are 0
                 std::inner_product(condDefProb.begin(), 
-                    condDefProb.end(), lgdsLeft.begin(), 0.)
+                    condDefProb.end(), lgdsLeft.begin(), Real(0.))
                 / (avgLgd * bsktSize);
         // model parameters:
         Real m = avgProb * bsktSize;
@@ -200,7 +200,7 @@ namespace QuantLib {
         std::transform(lgdsLeft.begin(), lgdsLeft.end(), 
             lgdsLeft.begin(), lgdsLeft.begin(), std::multiplies<Real>());
         Real variance = std::inner_product(condDefProb.begin(), 
-            condDefProb.end(), lgdsLeft.begin(), 0.);
+            condDefProb.end(), lgdsLeft.begin(), Real(0.));
 
         variance = avgLgd <= QL_EPSILON ? 0. : 
             variance / (bsktSize * bsktSize * avgLgd * avgLgd );

--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -153,7 +153,7 @@ namespace QuantLib {
             const std::vector<Real>& m) const {
             Real sumMs = 
                 std::inner_product(factorWeights_[iName].begin(), 
-                    factorWeights_[iName].end(), m.begin(), 0.);
+                    factorWeights_[iName].end(), m.begin(), Real(0.));
             Real res = cumulativeZ((invCumYProb - sumMs) / 
                     idiosyncFctrs_[iName] );
             #if defined(QL_EXTRA_SAFETY_CHECKS)

--- a/ql/experimental/credit/distribution.cpp
+++ b/ql/experimental/credit/distribution.cpp
@@ -266,7 +266,7 @@ namespace QuantLib {
         dx_.erase(dx_.begin() + size_, dx_.end());
 
         // truncate
-        for (double& i : x_) {
+        for (Real& i : x_) {
             i = std::min(std::max(i - attachmentPoint, 0.), detachmentPoint - attachmentPoint);
         }
 

--- a/ql/experimental/credit/gaussianlhplossmodel.cpp
+++ b/ql/experimental/credit/gaussianlhplossmodel.cpp
@@ -60,7 +60,7 @@ namespace QuantLib {
           beta_(sqrt(correlation)),
           biphi_(-sqrt(correlation))
         {
-        for (double recoverie : recoveries)
+        for (Real recoverie : recoveries)
             rrQuotes_.emplace_back(ext::make_shared<RecoveryRateQuote>(recoverie));
         }
 
@@ -77,7 +77,7 @@ namespace QuantLib {
           biphi_(-sqrt(correlQuote->value()))
         {
             registerWith(correl_);
-            for (double recoverie : recoveries)
+            for (Real recoverie : recoveries)
                 rrQuotes_.emplace_back(ext::make_shared<RecoveryRateQuote>(recoverie));
         }
 

--- a/ql/experimental/credit/gaussianlhplossmodel.hpp
+++ b/ql/experimental/credit/gaussianlhplossmodel.hpp
@@ -157,7 +157,7 @@ namespace QuantLib {
             const std::vector<Real> remainingNots = 
                 basket_->remainingNotionals(d);
             return std::inner_product(probs.begin(), probs.end(), 
-                remainingNots.begin(), 0.) / basket_->remainingNotional(d);
+                remainingNots.begin(), Real(0.)) / basket_->remainingNotional(d);
         }
 
         /* One could define the average recovery without the probability
@@ -178,14 +178,14 @@ namespace QuantLib {
                 recoveries.push_back(rrQuotes_[i]->value());
             std::vector<Real> notionals = basket_->remainingNotionals(d);
             Real denominator = std::inner_product(notionals.begin(), 
-                notionals.end(), probs.begin(), 0.);
+                notionals.end(), probs.begin(), Real(0.));
             if(denominator == 0.) return 0.;
 
             std::transform(notionals.begin(), notionals.end(), probs.begin(),
                 notionals.begin(), std::multiplies<Real>());
 
             return std::inner_product(recoveries.begin(), recoveries.end(), 
-                notionals.begin(), 0.) / denominator;
+                notionals.begin(), Real(0.)) / denominator;
         }
 
     private:

--- a/ql/experimental/credit/saddlepointlossmodel.hpp
+++ b/ql/experimental/credit/saddlepointlossmodel.hpp
@@ -895,7 +895,7 @@ namespace QuantLib {
     template<class CP>
     std::map<Real, Probability> SaddlePointLossModel<CP>::lossDistribution(const Date& d) const {
         std::map<Real, Probability> distrib;
-        static const Real numPts = 500.;
+        static constexpr double numPts = 500.;
         for(Real lossFraction=1./numPts; lossFraction<0.45; 
             lossFraction+= 1./numPts)
             distrib.insert(std::make_pair<Real, Probability>(

--- a/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
         //calculate payoff discount factor assuming continuous compounding
         DiscountFactor discount = riskFreeDiscount(t1);
         Real result = 0;
-        constexpr Real minusInf = -std::numeric_limits<Real>::infinity();
+        const Real minusInf = -std::numeric_limits<Real>::infinity();
 
         Real y1 = this->y1(payoff->optionType()),
              y2 = this->y2(payoff->optionType());

--- a/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticholderextensibleoptionengine.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
         //calculate payoff discount factor assuming continuous compounding
         DiscountFactor discount = riskFreeDiscount(t1);
         Real result = 0;
-        const Real minusInf = -std::numeric_limits<Real>::infinity();
+        constexpr double minusInf = -std::numeric_limits<double>::infinity();
 
         Real y1 = this->y1(payoff->optionType()),
              y2 = this->y2(payoff->optionType());

--- a/ql/experimental/forward/analytichestonforwardeuropeanengine.cpp
+++ b/ql/experimental/forward/analytichestonforwardeuropeanengine.cpp
@@ -46,8 +46,8 @@ namespace QuantLib {
         }
 
         // QL Gaussian Quadrature - map phi from [-1 to 1] to {0, phiRightLimit] 
-        double operator()(double phi) const {
-            double phiDash = (0.5+1e-8+0.5*phi) * phiRightLimit_; // Map phi to full range
+        Real operator()(Real phi) const {
+            Real phiDash = (0.5+1e-8+0.5*phi) * phiRightLimit_; // Map phi to full range
             return 0.5*phiRightLimit_*std::real((std::exp(-phiDash*logK_*i_) / (phiDash*i_)) * engine_->chF(phiDash+adj_, tenor_));
         }
     };
@@ -72,7 +72,7 @@ namespace QuantLib {
                         Real nuRightLimit) : tenor_(tenor), resetTime_(resetTime),
             s0_(s0), P1_(P1), logK_(logK), phiRightLimit_(phiRightLimit),
             nuRightLimit_(nuRightLimit), parent_(parent), innerIntegrator_(128) {}
-        double operator()(double nu) const {
+        Real operator()(Real nu) const {
 
             // Rescale nu to [-1, 1]
             Real nuDash = nuRightLimit_ * (0.5 * nu + 0.5 + 1e-8);
@@ -224,7 +224,7 @@ namespace QuantLib {
         // Now construct equation (18) from the paper term-by-term
         term1 = std::exp(-0.5*(B * varReset + Lambda)) * B / 2;
         term2 = std::pow(B * varReset / Lambda, 0.5*(R_/2 - 1));
-        term3 = modifiedBesselFunction_i(R_/2 - 1,std::sqrt(Lambda * B * varReset));
+        term3 = modifiedBesselFunction_i(Real(R_/2 - 1),Real(std::sqrt(Lambda * B * varReset)));
 
         return term1 * term2 * term3;
     }

--- a/ql/experimental/math/convolvedstudentt.cpp
+++ b/ql/experimental/math/convolvedstudentt.cpp
@@ -150,7 +150,7 @@ namespace QuantLib {
         const std::vector<Real>& factors,
         Real accuracy)
     : normSqr_(std::inner_product(factors.begin(), factors.end(),
-        factors.begin(), 0.)),
+        factors.begin(), Real(0.))),
       accuracy_(accuracy), distrib_(degreesFreedom, factors) { }
 
     Real InverseCumulativeBehrensFisher::operator()(const Probability q) const {

--- a/ql/experimental/math/expm.cpp
+++ b/ql/experimental/math/expm.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
                 std::vector<Real> result(m_.rows());
                 for (Size i=0; i < result.size(); i++) {
                     result[i] = std::inner_product(y.begin(), y.end(),
-                                                   m_.row_begin(i), 0.0);
+                                                   m_.row_begin(i), Real(0.0));
                 }
                 return result;
             }

--- a/ql/experimental/math/gaussiancopulapolicy.hpp
+++ b/ql/experimental/math/gaussiancopulapolicy.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
             /* check factors in LM are normalized. */
             for (const auto& factorWeight : factorWeights) {
                 Real factorsNorm = std::inner_product(factorWeight.begin(), factorWeight.end(),
-                                                      factorWeight.begin(), 0.);
+                                                      factorWeight.begin(), Real(0.));
                 QL_REQUIRE(factorsNorm < 1., 
                     "Non normal random factor combination.");
             }

--- a/ql/experimental/math/gaussiannoncentralchisquaredpolynomial.cpp
+++ b/ql/experimental/math/gaussiannoncentralchisquaredpolynomial.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
 
         #define NM 28
 
-        #define moment_(n, x) Real f_##n(double _nu, double _lambda) \
+        #define moment_(n, x) Real f_##n(Real _nu, Real _lambda) \
           {                                                          \
              const Real lambda(_lambda);                             \
              const Real nu(_nu);                                     \

--- a/ql/experimental/math/hybridsimulatedannealing.hpp
+++ b/ql/experimental/math/hybridsimulatedannealing.hpp
@@ -179,7 +179,7 @@ namespace QuantLib {
             //Increase steps
             k++;
             kStationary++;
-            for (double& i : annealStep)
+            for (Real& i : annealStep)
                 i++;
 
             //Reanneal if necessary

--- a/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
+++ b/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
@@ -244,7 +244,7 @@ namespace QuantLib
         inline bool operator()(Real currentValue, Real newValue, const Array &temp) {
             if (newValue < currentValue)
                 return true;
-            double mTemperature = *std::max_element(temp.begin(), temp.end());
+            Real mTemperature = *std::max_element(temp.begin(), temp.end());
             return (1.0 / (1.0 + exp((newValue - currentValue) / mTemperature))) > distribution_(generator_);
         }
     private:
@@ -383,7 +383,7 @@ namespace QuantLib
             QL_REQUIRE(steps.size() == N_, "Incompatible input");
 
             Array finiteDiffs(N_, 0.0);
-            double finiteDiffMax = 0.0;
+            Real finiteDiffMax = 0.0;
             Array ofssetPoint(currentPoint);
             for (Size i = 0; i < N_; i++) {
                 ofssetPoint[i] += stepSize_;

--- a/ql/experimental/math/tcopulapolicy.cpp
+++ b/ql/experimental/math/tcopulapolicy.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
                        "Incompatible number of T functions and number of factors.");
 
             Real factorsNorm = std::inner_product(factorWeight.begin(), factorWeight.end(),
-                                                  factorWeight.begin(), 0.);
+                                                  factorWeight.begin(), Real(0.));
             QL_REQUIRE(factorsNorm < 1., 
                 "Non normal random factor combination.");
             Real idiosyncFctr = std::sqrt(1.-factorsNorm);

--- a/ql/experimental/math/tcopulapolicy.hpp
+++ b/ql/experimental/math/tcopulapolicy.hpp
@@ -146,7 +146,7 @@ namespace QuantLib {
         //to use this (by default) version, the generator must be a uniform one.
         std::vector<Real> allFactorCumulInverter(const std::vector<Real>& probs) const;
     private:
-        mutable std::vector<boost::math::students_t_distribution<> > distributions_;
+        mutable std::vector<boost::math::students_t_distribution<Real> > distributions_;
         mutable std::vector<Real> varianceFactors_;
         mutable std::vector<CumulativeBehrensFisher> latentVarsCumul_;
         mutable std::vector<InverseCumulativeBehrensFisher> latentVarsInverters_;

--- a/ql/experimental/models/squarerootclvmodel.cpp
+++ b/ql/experimental/models/squarerootclvmodel.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
         const Real b = xMin - x.front();
         const Real a = (xMax - xMin)/(x.back() - x.front());
 
-        for (double& i : x) {
+        for (Real& i : x) {
             i = a * i + b;
         }
 

--- a/ql/experimental/processes/extendedblackscholesprocess.cpp
+++ b/ql/experimental/processes/extendedblackscholesprocess.cpp
@@ -36,8 +36,8 @@ namespace QuantLib {
         // we could be more anticipatory if we know the right dt
         // for which the drift will be used
         Time t1 = t + 0.0001;
-        return riskFreeRate()->forwardRate(t,t1,Continuous,NoFrequency,true)
-             - dividendYield()->forwardRate(t,t1,Continuous,NoFrequency,true)
+        return riskFreeRate()->forwardRate(t,t1,Continuous,NoFrequency,true).rate()
+             - dividendYield()->forwardRate(t,t1,Continuous,NoFrequency,true).rate()
              - 0.5 * sigma * sigma;
     }
 

--- a/ql/experimental/processes/hestonslvprocess.cpp
+++ b/ql/experimental/processes/hestonslvprocess.cpp
@@ -53,8 +53,8 @@ namespace QuantLib {
         const Volatility vol =
            std::max(1e-8, std::sqrt(x[1])*leverageFct_->localVol(t, x[0], true));
 
-        tmp[0] = riskFreeRate()->forwardRate(t, t, Continuous)
-               - dividendYield()->forwardRate(t, t, Continuous)
+        tmp[0] = riskFreeRate()->forwardRate(t, t, Continuous).rate()
+               - dividendYield()->forwardRate(t, t, Continuous).rate()
                - 0.5*vol*vol;
 
         tmp[1] = kappa_*(theta_ - x[1]);

--- a/ql/experimental/volatility/zabrsmilesection.hpp
+++ b/ql/experimental/volatility/zabrsmilesection.hpp
@@ -176,7 +176,7 @@ void ZabrSmileSection<Evaluation>::init(const std::vector<Real> &moneyness,
     strikes_.clear(); // should not be necessary, anyway
     Real lastF = 0.0;
     bool firstStrike = true;
-    for (double i : tmp) {
+    for (Real i : tmp) {
         Real f = i * forward_;
         if (f > 0.0) {
             if (!firstStrike) {

--- a/ql/instruments/basketoption.hpp
+++ b/ql/instruments/basketoption.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
         Real accumulate(const Array& a) const override {
             return std::inner_product(weights_.begin(),
                                       weights_.end(),
-                                      a.begin(), 0.0);
+                                      a.begin(), Real(0.0));
         }
 
       private:

--- a/ql/instruments/bonds/btp.cpp
+++ b/ql/instruments/bonds/btp.cpp
@@ -172,7 +172,7 @@ namespace QuantLib {
         }
         duration_ = std::inner_product(basket_->weights().begin(),
                                        basket_->weights().end(),
-                                       durations_.begin(), 0.0);
+                                       durations_.begin(), Real(0.0));
 
         Natural settlDays = 2;
         DayCounter fixedDayCount = swaps_[0]->fixedDayCount();

--- a/ql/instruments/bonds/btp.hpp
+++ b/ql/instruments/bonds/btp.hpp
@@ -213,7 +213,7 @@ namespace QuantLib {
     inline Rate RendistatoCalculator::yield() const {
         return std::inner_product(basket_->weights().begin(),
                                   basket_->weights().end(),
-                                  yields().begin(), 0.0);
+                                  yields().begin(), Real(0.0));
     }
 
     inline Time RendistatoCalculator::duration() const {

--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -217,10 +217,10 @@ namespace QuantLib {
         // if the gearing is zero then the ibor / cms leg will be set up with
         // fixed coupons which makes trouble here in this context. We therefore
         // use a dirty trick and enforce the gearing to be non zero.
-        for (double& i : gearing1_)
+        for (Real& i : gearing1_)
             if (close(i, 0.0))
                 i = QL_EPSILON;
-        for (double& i : gearing2_)
+        for (Real& i : gearing2_)
             if (close(i, 0.0))
                 i = QL_EPSILON;
 

--- a/ql/instruments/nonstandardswap.cpp
+++ b/ql/instruments/nonstandardswap.cpp
@@ -148,7 +148,7 @@ namespace QuantLib {
         // if the gearing is zero then the ibor leg will be set up with fixed
         // coupons which makes trouble here in this context. We therefore use
         // a dirty trick and enforce the gearing to be non zero.
-        for (double& i : gearing_) {
+        for (Real& i : gearing_) {
             if (close(i, 0.0))
                 i = QL_EPSILON;
         }

--- a/ql/interestrate.hpp
+++ b/ql/interestrate.hpp
@@ -185,6 +185,15 @@ namespace QuantLib {
         Real freq_;
     };
 
+    // helper to avoid relying on implicit conversion to Rate
+    inline Rate operator-(const InterestRate& a, const InterestRate& b) {
+        return a.rate() - b.rate();
+    }
+
+    inline Rate operator+(const InterestRate& a, const InterestRate& b) {
+        return a.rate() + b.rate();
+    }
+
     /*! \relates InterestRate */
     std::ostream& operator<<(std::ostream&,
                              const InterestRate&);

--- a/ql/interestrate.hpp
+++ b/ql/interestrate.hpp
@@ -185,15 +185,6 @@ namespace QuantLib {
         Real freq_;
     };
 
-    // helper to avoid relying on implicit conversion to Rate
-    inline Rate operator-(const InterestRate& a, const InterestRate& b) {
-        return a.rate() - b.rate();
-    }
-
-    inline Rate operator+(const InterestRate& a, const InterestRate& b) {
-        return a.rate() + b.rate();
-    }
-
     /*! \relates InterestRate */
     std::ostream& operator<<(std::ostream&,
                              const InterestRate&);

--- a/ql/legacy/libormarketmodels/lfmcovarparam.cpp
+++ b/ql/legacy/libormarketmodels/lfmcovarparam.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
         const Matrix m = param_->diffusion(t);
 
         return std::inner_product(m.row_begin(i_), m.row_end(i_),
-                                  m.row_begin(j_), 0.0);
+                                  m.row_begin(j_), Real(0.0));
     }
 
     Matrix LfmCovarianceParameterization::covariance(Time t, const Array& x) const {

--- a/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
+++ b/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
             for (Size i=0; i < size_-1; ++i) {
                 Real p = std::sqrt(std::inner_product(
                                      tmpSqrtCorr[i],tmpSqrtCorr[i]+factors_,
-                                     tmpSqrtCorr[i], 0.0));
+                                     tmpSqrtCorr[i], Real(0.0)));
                 std::transform(
                     tmpSqrtCorr[i], tmpSqrtCorr[i]+factors_, sqrtCorr[i],
                     [=](Real x){ return x/p; });

--- a/ql/legacy/libormarketmodels/lfmprocess.cpp
+++ b/ql/legacy/libormarketmodels/lfmprocess.cpp
@@ -75,7 +75,7 @@ namespace QuantLib {
         for (Size k=m; k<size_; ++k) {
             m1[k] = accrualPeriod_[k]*x[k]/(1+accrualPeriod_[k]*x[k]);
             f[k]  = std::inner_product(m1.begin()+m, m1.begin()+k+1,
-                                       covariance.column_begin(k)+m,0.0)
+                                       covariance.column_begin(k)+m,Real(0.0))
                     - 0.5*covariance[k][k];
         }
 
@@ -127,17 +127,17 @@ namespace QuantLib {
             m1[k] = y/(1+y);
             const Real d = (
                 std::inner_product(m1.begin()+m, m1.begin()+k+1,
-                                   covariance.column_begin(k)+m,0.0)
+                                   covariance.column_begin(k)+m,Real(0.0))
                 -0.5*covariance[k][k]) * dt;
 
             const Real r = std::inner_product(
-                diff.row_begin(k), diff.row_end(k), dw.begin(), 0.0)*sdt;
+                diff.row_begin(k), diff.row_end(k), dw.begin(), Real(0.0))*sdt;
 
             const Real x = y*std::exp(d + r);
             m2[k] = x/(1+x);
             f[k] = x0[k] * std::exp(0.5*(d+
                  (std::inner_product(m2.begin()+m, m2.begin()+k+1,
-                                     covariance.column_begin(k)+m,0.0)
+                                     covariance.column_begin(k)+m,Real(0.0))
                   -0.5*covariance[k][k])*dt)+ r);
         }
 

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -498,7 +498,7 @@ namespace QuantLib {
         QL_REQUIRE(v1.size() == v2.size(),
                    "arrays with different sizes (" << v1.size() << ", "
                    << v2.size() << ") cannot be multiplied");
-        return std::inner_product(v1.begin(),v1.end(),v2.begin(),0.0);
+        return std::inner_product(v1.begin(),v1.end(),v2.begin(),Real(0.0));
     }
 
     inline Real Norm2(const Array& v) {

--- a/ql/math/generallinearleastsquares.hpp
+++ b/ql/math/generallinearleastsquares.hpp
@@ -128,7 +128,7 @@ namespace QuantLib {
             if (w[i] > threshold) {
                 const Real u = std::inner_product(U.column_begin(i),
                     U.column_end(i),
-                    yBegin, 0.0)/w[i];
+                    yBegin, Real(0.0))/w[i];
 
                 for (Size j=0; j<m; ++j) {
                     a_[j]  +=u*V[j][i];
@@ -142,7 +142,7 @@ namespace QuantLib {
                        yBegin, residuals_.begin(), std::minus<Real>());
 
         const Real chiSq
-            = std::inner_product(residuals_.begin(), residuals_.end(), residuals_.begin(), 0.0);
+            = std::inner_product(residuals_.begin(), residuals_.end(), residuals_.begin(), Real(0.0));
         const Real multiplier = std::sqrt(chiSq/(n-2));
         std::transform(err_.begin(), err_.end(), standardErrors_.begin(),
                        [=](Real x){ return x * multiplier; });

--- a/ql/math/interpolations/kernelinterpolation.hpp
+++ b/ql/math/interpolations/kernelinterpolation.hpp
@@ -116,7 +116,7 @@ namespace QuantLib {
 
                 Array diffVec=Abs(M_*alphaVec_ - yVec_);
 
-                for (double i : diffVec) {
+                for (Real i : diffVec) {
                     QL_REQUIRE(i < invPrec_, "Inversion failed in 1d kernel interpolation");
                 }
             }

--- a/ql/math/interpolations/kernelinterpolation2d.hpp
+++ b/ql/math/interpolations/kernelinterpolation2d.hpp
@@ -166,7 +166,7 @@ namespace QuantLib {
                 // I've chosen not to check determinant(M_)!=0 before solving
 
                 Array diffVec=Abs(M_*alphaVec_ - yVec_);
-                for (double i : diffVec) {
+                for (Real i : diffVec) {
                     QL_REQUIRE(i < invPrec_, "inversion failed in 2d kernel interpolation");
                 }
             }

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -547,7 +547,7 @@ namespace QuantLib {
         for (Size i=0; i<result.size(); i++)
             result[i] =
                 std::inner_product(v.begin(),v.end(),
-                                   m.column_begin(i),0.0);
+                                   m.column_begin(i),Real(0.0));
         return result;
     }
 
@@ -559,7 +559,7 @@ namespace QuantLib {
         Array result(m.rows());
         for (Size i=0; i<result.size(); i++)
             result[i] =
-                std::inner_product(v.begin(),v.end(),m.row_begin(i),0.0);
+                std::inner_product(v.begin(),v.end(),m.row_begin(i),Real(0.0));
         return result;
     }
 

--- a/ql/math/matrixutilities/basisincompleteordered.cpp
+++ b/ql/math/matrixutilities/basisincompleteordered.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
         for (auto& currentBasi : currentBasis_) {
             Real innerProd =
-                std::inner_product(newVector_.begin(), newVector_.end(), currentBasi.begin(), 0.0);
+                std::inner_product(newVector_.begin(), newVector_.end(), currentBasi.begin(), Real(0.0));
 
             for (Size k=0; k<euclideanDimension_; ++k)
                 newVector_[k] -= innerProd * currentBasi[k];
@@ -46,7 +46,7 @@ namespace QuantLib {
 
         Real norm = std::sqrt(std::inner_product(newVector_.begin(),
             newVector_.end(),
-            newVector_.begin(), 0.0));
+            newVector_.begin(), Real(0.0)));
 
         if (norm<1e-12) // maybe this should be a tolerance
             return false;

--- a/ql/math/matrixutilities/gmres.cpp
+++ b/ql/math/matrixutilities/gmres.cpp
@@ -132,11 +132,11 @@ namespace QuantLib {
 
         for (Integer i=k-2; i >= 0; --i) {
             y[i] = (z[i] - std::inner_product(
-                 h[i].begin()+i+1, h[i].begin()+k, y.begin()+i+1, 0.0))/h[i][i];
+                 h[i].begin()+i+1, h[i].begin()+k, y.begin()+i+1, Real(0.0)))/h[i][i];
         }
 
         Array xm = std::inner_product(
-            v.begin(), v.begin()+k, y.begin(), Array(x.size(), 0.0));
+            v.begin(), v.begin()+k, y.begin(), Array(x.size(), Real(0.0)));
 
         xm = x + (M_ == QL_NULL_FUNCTION ? xm : M_(xm));
 

--- a/ql/math/matrixutilities/qrdecomposition.cpp
+++ b/ql/math/matrixutilities/qrdecomposition.cpp
@@ -77,7 +77,7 @@ namespace QuantLib {
                     Array w(n, 0.0);
                     for (Size l=0; l < n; ++l)
                         w[l] += std::inner_product(
-                            v.begin()+i, v.end(), q.column_begin(l)+i, 0.0);
+                            v.begin()+i, v.end(), q.column_begin(l)+i, Real(0.0));
 
                     for (Size k=i; k < m; ++k) {
                         const Real a = tau*v[k];
@@ -98,7 +98,7 @@ namespace QuantLib {
                     if (t3 != 0.0) {
                         const Real t
                             = std::inner_product(mT.row_begin(j)+j, mT.row_end(j),
-                                                 w.begin()+j, 0.0)/t3;
+                                                 w.begin()+j, Real(0.0))/t3;
                         for (Size i=j; i<m; ++i) {
                             w[i]-=mT[j][i]*t;
                         }

--- a/ql/math/optimization/costfunction.hpp
+++ b/ql/math/optimization/costfunction.hpp
@@ -38,7 +38,7 @@ namespace QuantLib {
         virtual Real value(const Array& x) const {
             Array v = values(x);
             std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
-            return std::sqrt(std::accumulate(v.begin(), v.end(), 0.0) /
+            return std::sqrt(std::accumulate(v.begin(), v.end(), Real(0.0)) /
                              static_cast<Real>(v.size()));
         }
         //! method to overload to compute the cost function values in x

--- a/ql/math/optimization/differentialevolution.cpp
+++ b/ql/math/optimization/differentialevolution.cpp
@@ -138,7 +138,7 @@ namespace QuantLib {
               Array jitter(population[0].values.size(), 0.0);
 
               for (Size popIter = 0; popIter < population.size(); popIter++) {
-                  for (double& jitterIter : jitter) {
+                  for (Real& jitterIter : jitter) {
                       jitterIter = rng_.nextReal();
                   }
                   population[popIter].values = bestMemberEver_.values
@@ -174,7 +174,7 @@ namespace QuantLib {
               randomize(population.begin(), population.end(), rng_);
               mirrorPopulation = shuffledPop1;
               Array FWeight = Array(population.front().values.size(), 0.0);
-              for (double& fwIter : FWeight)
+              for (Real& fwIter : FWeight)
                   fwIter = (1.0 - configuration().stepsizeWeight) * rng_.nextReal() +
                            configuration().stepsizeWeight;
               for (Size popIter = 0; popIter < population.size(); popIter++) {
@@ -361,7 +361,7 @@ namespace QuantLib {
          // [=tau1] A Comparative Study on Numerical Benchmark
          // Problems." page 649 for reference
         Real sizeWeightChangeProb = 0.1;
-        for (double& currGenSizeWeight : currGenSizeWeights_) {
+        for (Real& currGenSizeWeight : currGenSizeWeights_) {
             if (rng_.nextReal() < sizeWeightChangeProb)
                 currGenSizeWeight = sizeWeightLowerBound + rng_.nextReal() * sizeWeightUpperBound;
         }
@@ -369,7 +369,7 @@ namespace QuantLib {
 
     void DifferentialEvolution::adaptCrossover() const {
         Real crossoverChangeProb = 0.1; // [=tau2]
-        for (double& coIter : currGenCrossover_) {
+        for (Real& coIter : currGenCrossover_) {
             if (rng_.nextReal() < crossoverChangeProb)
                 coIter = rng_.nextReal();
         }

--- a/ql/math/sampledcurve.hpp
+++ b/ql/math/sampledcurve.hpp
@@ -122,7 +122,7 @@ namespace QuantLib {
             Array newValues = new_grid;
             std::transform(newValues.begin(), newValues.end(),
                            newValues.begin(), func);
-            for (double& newValue : newValues) {
+            for (Real& newValue : newValues) {
                 newValue = priceSpline(newValue, true);
             }
             values_.swap(newValues);

--- a/ql/math/statistics/histogram.cpp
+++ b/ql/math/statistics/histogram.cpp
@@ -157,7 +157,7 @@ namespace QuantLib {
         counts_.resize(bins_);
         std::fill(counts_.begin(), counts_.end(), 0);
 
-        for (double p : data_) {
+        for (Real p : data_) {
             bool processed = false;
             for (Size i=0; i<breaks_.size(); ++i) {
                 if (p < breaks_[i]) {

--- a/ql/models/marketmodels/accountingengine.cpp
+++ b/ql/models/marketmodels/accountingengine.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             product_->possibleCashFlowTimes();
         const std::vector<Rate>& rateTimes = product_->evolution().rateTimes();
         discounters_.reserve(cashFlowTimes.size());
-        for (double cashFlowTime : cashFlowTimes)
+        for (Real cashFlowTime : cashFlowTimes)
             discounters_.emplace_back(cashFlowTime, rateTimes);
     }
 

--- a/ql/models/marketmodels/driftcomputation/lmmdriftcalculator.cpp
+++ b/ql/models/marketmodels/driftcomputation/lmmdriftcalculator.cpp
@@ -103,7 +103,7 @@ namespace QuantLib {
         for (i=alive_; i<numberOfRates_; ++i) {
             drifts[i] = std::inner_product(tmp_.begin()+downs_[i],
                                            tmp_.begin()+ups_[i],
-                                           C_.row_begin(i)+downs_[i], 0.0);
+                                           C_.row_begin(i)+downs_[i], Real(0.0));
             if (numeraire_>i+1)
                 drifts[i] = -drifts[i];
         }

--- a/ql/models/marketmodels/driftcomputation/lmmnormaldriftcalculator.cpp
+++ b/ql/models/marketmodels/driftcomputation/lmmnormaldriftcalculator.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
         for (i=alive_; i<numberOfRates_; ++i) {
             drifts[i] = std::inner_product(tmp_.begin()+downs_[i],
                                            tmp_.begin()+ups_[i],
-                                           C_.row_begin(i)+downs_[i], 0.0);
+                                           C_.row_begin(i)+downs_[i], Real(0.0));
             if (numeraire_>i+1)
                 drifts[i] = -drifts[i];
         }

--- a/ql/models/marketmodels/evolvers/lognormalcmswapratepc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalcmswapratepc.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
             for (Size k=0; k<numberOfRates_; ++k) {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                                       A.row_begin(k), 0.0);
+                                       A.row_begin(k), Real(0.0));
                 fixed[k] = -0.5*variance;
             }
             fixedDrifts_.push_back(fixed);
@@ -123,7 +123,7 @@ namespace QuantLib {
             logSwapRates_[i] += drifts1_[i] + fixedDrift[i];
             logSwapRates_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             swapRates_[i] = std::exp(logSwapRates_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/evolvers/lognormalcotswapratepc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalcotswapratepc.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
             for (Size k=0; k<numberOfRates_; ++k) {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                                       A.row_begin(k), 0.0);
+                                       A.row_begin(k), Real(0.0));
                 fixed[k] = -0.5*variance;
             }
             fixedDrifts_.push_back(fixed);
@@ -122,7 +122,7 @@ namespace QuantLib {
             logSwapRates_[i] += drifts1_[i] + fixedDrift[i];
             logSwapRates_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             swapRates_[i] = std::exp(logSwapRates_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/evolvers/lognormalfwdrateballand.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdrateballand.cpp
@@ -118,7 +118,7 @@ namespace QuantLib {
         {
             logForwards_[i] += drifts1_[i] + fixedDrift[i];
             logForwards_[i] += std::inner_product(A.row_begin(i), A.row_end(i),
-                                                  brownians_.begin(), 0.0);
+                                                  brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/evolvers/lognormalfwdrateeuler.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdrateeuler.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
             for (Size k=0; k<numberOfRates_; ++k) {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                                       A.row_begin(k), 0.0);
+                                       A.row_begin(k), Real(0.0));
                 fixed[k] = -0.5*variance;
             }
             fixedDrifts_.push_back(fixed);
@@ -118,7 +118,7 @@ namespace QuantLib {
             logForwards_[i] += drifts1_[i] + fixedDrift[i];
             logForwards_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/evolvers/lognormalfwdrateeulerconstrained.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdrateeulerconstrained.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
             for (Size k=0; k<numberOfRates_; ++k) {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                    A.row_begin(k), 0.0);
+                    A.row_begin(k), Real(0.0));
                 variances[k] = variance;
                 fixed[k] = -0.5*variance;
             }
@@ -176,7 +176,7 @@ namespace QuantLib {
             logForwards_[i] += drifts1_[i] + fixedDrift[i];
             logForwards_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                brownians_.begin(), 0.0);
+                brownians_.begin(), Real(0.0));
         }
 
         // check constraint active

--- a/ql/models/marketmodels/evolvers/lognormalfwdrateiballand.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdrateiballand.cpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         {
             logForwards_[i] += fixedDrift[i];
             logForwards_[i] += std::inner_product( A.row_begin(i), A.row_end(i),
-                                                   brownians_.begin(), 0.0 );
+                                                   brownians_.begin(), Real(0.0) );
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
             blFwd = std::sqrt( marketModel_->initialRates()[i]*forwards_[i] );
             g_[i] = rateTaus_[i]*( blFwd+displacements_[i] )/
@@ -129,7 +129,7 @@ namespace QuantLib {
                 drifts2 -= g_[j]*C[i][j];
             logForwards_[i] += drifts2 + fixedDrift[i];
             logForwards_[i] += std::inner_product( A.row_begin(i), A.row_end(i),
-                                                   brownians_.begin(), 0.0);
+                                                   brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
 
             blFwd = std::sqrt( marketModel_->initialRates()[i]*forwards_[i] );

--- a/ql/models/marketmodels/evolvers/lognormalfwdrateipc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdrateipc.cpp
@@ -126,7 +126,7 @@ namespace QuantLib {
             logForwards_[i] += 0.5*(drifts1_[i]+drifts2) + fixedDrift[i];
             logForwards_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
             g_[i] = rateTaus_[i]*(forwards_[i]+displacements_[i])/
                 (1.0+rateTaus_[i]*forwards_[i]);

--- a/ql/models/marketmodels/evolvers/lognormalfwdratepc.cpp
+++ b/ql/models/marketmodels/evolvers/lognormalfwdratepc.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
             for (Size k=0; k<numberOfRates_; ++k) {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                                       A.row_begin(k), 0.0);
+                                       A.row_begin(k), Real(0.0));
                 fixed[k] = -0.5*variance;
             }
             fixedDrifts_.push_back(fixed);
@@ -119,7 +119,7 @@ namespace QuantLib {
             logForwards_[i] += drifts1_[i] + fixedDrift[i];
             logForwards_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/evolvers/normalfwdratepc.cpp
+++ b/ql/models/marketmodels/evolvers/normalfwdratepc.cpp
@@ -113,7 +113,7 @@ namespace QuantLib {
             forwards_[i] += drifts1_[i] ;
             forwards_[i] +=
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
         }
 
         // c) recompute drifts D2 using the predicted forwards;

--- a/ql/models/marketmodels/evolvers/svddfwdratepc.cpp
+++ b/ql/models/marketmodels/evolvers/svddfwdratepc.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
             {
                 Real variance =
                     std::inner_product(A.row_begin(k), A.row_end(k),
-                                       A.row_begin(k), 0.0);
+                                       A.row_begin(k), Real(0.0));
                 fixed[k] = -0.5*variance;
             }
             fixedDrifts_.push_back(fixed);
@@ -167,7 +167,7 @@ namespace QuantLib {
             logForwards_[i] += varianceMultiplier*(drifts1_[i] + fixedDrift[i]);
             logForwards_[i] += sdMultiplier*
                 std::inner_product(A.row_begin(i), A.row_end(i),
-                                   brownians_.begin(), 0.0);
+                                   brownians_.begin(), Real(0.0));
             forwards_[i] = std::exp(logForwards_[i]) - displacements_[i];
         }
 

--- a/ql/models/marketmodels/pathwiseaccountingengine.cpp
+++ b/ql/models/marketmodels/pathwiseaccountingengine.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
         const std::vector<Time>& evolutionTimes = product_->evolution().evolutionTimes();
         discounters_.reserve(cashFlowTimes.size());
 
-        for (double cashFlowTime : cashFlowTimes)
+        for (Real cashFlowTime : cashFlowTimes)
             discounters_.emplace_back(cashFlowTime, rateTimes);
 
 
@@ -416,7 +416,7 @@ namespace QuantLib {
         const std::vector<Time>& evolutionTimes = product_->evolution().evolutionTimes();
         discounters_.reserve(cashFlowTimes.size());
 
-        for (double cashFlowTime : cashFlowTimes)
+        for (Real cashFlowTime : cashFlowTimes)
             discounters_.emplace_back(cashFlowTime, rateTimes);
 
 
@@ -808,7 +808,7 @@ namespace QuantLib {
         const std::vector<Time>& evolutionTimes = product_->evolution().evolutionTimes();
         discounters_.reserve(cashFlowTimes.size());
 
-        for (double cashFlowTime : cashFlowTimes)
+        for (Real cashFlowTime : cashFlowTimes)
             discounters_.emplace_back(cashFlowTime, rateTimes);
 
 

--- a/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
                                                      std::vector<Real> fixedAccruals,
                                                      std::vector<Real> floatingAccruals,
                                                      const std::vector<Time>& paymentTimes,
-                                                     double fixedRate)
+                                                     Real fixedRate)
     : MultiProductMultiStep(rateTimes), fixedAccruals_(std::move(fixedAccruals)),
       floatingAccruals_(std::move(floatingAccruals)), paymentTimes_(paymentTimes),
       fixedRate_(fixedRate) {

--- a/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.hpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
                                 std::vector<Real> fixedAccruals,
                                 std::vector<Real> floatingAccruals,
                                 const std::vector<Time>& paymentTimes,
-                                double fixedRate);
+                                Real fixedRate);
         //! \name MarketModelMultiProduct interface
         //@{
         std::vector<Time> possibleCashFlowTimes() const override;
@@ -46,7 +46,7 @@ namespace QuantLib {
       private:
         std::vector<Real> fixedAccruals_, floatingAccruals_;
         std::vector<Time> paymentTimes_;
-        double fixedRate_;
+        Real fixedRate_;
         Size lastIndex_;
         // things that vary in a path
         Size currentIndex_;

--- a/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
 
         checkIncreasingTimes(forwardOptionPaymentTimes);
         checkIncreasingTimes(swaptionPaymentTimes);
-        for (double& swaptionPaymentTime : swaptionPaymentTimes_)
+        for (Real& swaptionPaymentTime : swaptionPaymentTimes_)
             paymentTimes_.push_back(swaptionPaymentTime);
         lastIndex_ = rateTimes.size()-1;
         numberFRAs_ = rateTimes.size()-1;

--- a/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
                                                  std::vector<Real> fixedAccruals,
                                                  std::vector<Real> floatingAccruals,
                                                  const std::vector<Time>& paymentTimes,
-                                                 double fixedRate)
+                                                 Real fixedRate)
     : MultiProductOneStep(rateTimes), fixedAccruals_(std::move(fixedAccruals)),
       floatingAccruals_(std::move(floatingAccruals)), paymentTimes_(paymentTimes),
       fixedRate_(fixedRate) {

--- a/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.hpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.hpp
@@ -30,7 +30,7 @@ namespace QuantLib {
                               std::vector<Real> fixedAccruals,
                               std::vector<Real> floatingAccruals,
                               const std::vector<Time>& paymentTimes,
-                              double fixedRate);
+                              Real fixedRate);
         //! \name MarketModelMultiProduct interface
         //@{
         std::vector<Time> possibleCashFlowTimes() const override;
@@ -45,7 +45,7 @@ namespace QuantLib {
       private:
         std::vector<Real> fixedAccruals_, floatingAccruals_;
         std::vector<Time> paymentTimes_;
-        double fixedRate_;
+        Real fixedRate_;
         Size lastIndex_;
     };
 

--- a/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
                                                    std::vector<Real> fixedAccruals,
                                                    std::vector<Real> floatingAccruals,
                                                    const std::vector<Time>& paymentTimes,
-                                                   double fixedRate)
+                                                   Real fixedRate)
     : MultiProductOneStep(rateTimes), fixedAccruals_(std::move(fixedAccruals)),
       floatingAccruals_(std::move(floatingAccruals)), paymentTimes_(paymentTimes),
       fixedRate_(fixedRate) {

--- a/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.hpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
                                std::vector<Real> fixedAccruals,
                                std::vector<Real> floatingAccruals,
                                const std::vector<Time>& paymentTimes,
-                               double fixedRate);
+                               Real fixedRate);
         //! \name MarketModelMultiProduct interface
         //@{
         std::vector<Time> possibleCashFlowTimes() const override;
@@ -46,7 +46,7 @@ namespace QuantLib {
       private:
         std::vector<Real> fixedAccruals_, floatingAccruals_;
         std::vector<Time> paymentTimes_;
-        double fixedRate_;
+        Real fixedRate_;
         Size lastIndex_;
     };
 

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -382,7 +382,7 @@ namespace QuantLib {
                             << k.size() << ")");
                     std::vector<Real> v;
                     v.reserve(k.size());
-                    for (double j : k) {
+                    for (Real j : k) {
                         v.push_back(i->second.rawSmileSection_->volatility(j));
                     }
 

--- a/ql/pricingengines/asian/analytic_cont_geom_av_price.cpp
+++ b/ql/pricingengines/asian/analytic_cont_geom_av_price.cpp
@@ -60,9 +60,9 @@ namespace QuantLib {
 
         Spread dividendYield = 0.5 * (
             process_->riskFreeRate()->zeroRate(exercise, rfdc,
-                                               Continuous, NoFrequency) +
+                                               Continuous, NoFrequency).rate() +
             process_->dividendYield()->zeroRate(exercise, divdc,
-                                                Continuous, NoFrequency) +
+                                                Continuous, NoFrequency).rate() +
             volatility*volatility/6.0);
 
         Time t_q = divdc.yearFraction(

--- a/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
@@ -162,7 +162,7 @@ namespace QuantLib {
         std::vector<Time> fixingTimes = timeGrid.mandatoryTimes();
         std::vector<Size> fixingIndexes;
         fixingIndexes.reserve(fixingTimes.size());
-        for (double fixingTime : fixingTimes) {
+        for (Real fixingTime : fixingTimes) {
             fixingIndexes.push_back(timeGrid.closestIndex(fixingTime));
         }
 
@@ -201,7 +201,7 @@ namespace QuantLib {
         std::vector<Time> fixingTimes = timeGrid.mandatoryTimes();
         std::vector<Size> fixingIndexes;
         fixingIndexes.reserve(fixingTimes.size());
-        for (double fixingTime : fixingTimes) {
+        for (Real fixingTime : fixingTimes) {
             fixingIndexes.push_back(timeGrid.closestIndex(fixingTime));
         }
 

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             product *= path.front();
         }
         // care must be taken not to overflow product
-        const Real maxValue = QL_MAX_REAL;
+        constexpr double maxValue = QL_MAX_REAL;
         averagePrice = 1.0;
         for (Size i=1; i<n+1; i++) {
             Real price = path[i];

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             product *= path.front();
         }
         // care must be taken not to overflow product
-        constexpr Real maxValue = QL_MAX_REAL;
+        const Real maxValue = QL_MAX_REAL;
         averagePrice = 1.0;
         for (Size i=1; i<n+1; i++) {
             Real price = path[i];

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         Size fixings = pastFixings_ + fixingIndices_.size();
 
         // care must be taken not to overflow product
-        const Real maxValue = QL_MAX_REAL;
+        constexpr double maxValue = QL_MAX_REAL;
         for (unsigned long fixingIndice : fixingIndices_) {
             Real price = path[fixingIndice];
             if (product < maxValue/price) {

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         Size fixings = pastFixings_ + fixingIndices_.size();
 
         // care must be taken not to overflow product
-        constexpr Real maxValue = QL_MAX_REAL;
+        const Real maxValue = QL_MAX_REAL;
         for (unsigned long fixingIndice : fixingIndices_) {
             Real price = path[fixingIndice];
             if (product < maxValue/price) {

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
@@ -144,7 +144,7 @@ namespace QuantLib {
         std::vector<Time> fixingTimes = timeGrid.mandatoryTimes();
         std::vector<Size> fixingIndexes;
         fixingIndexes.reserve(fixingTimes.size());
-        for (double fixingTime : fixingTimes) {
+        for (Real fixingTime : fixingTimes) {
             fixingIndexes.push_back(timeGrid.closestIndex(fixingTime));
         }
 

--- a/ql/pricingengines/barrier/discretizedbarrieroption.cpp
+++ b/ql/pricingengines/barrier/discretizedbarrieroption.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
                 stoppingTime = true;
             break;
           case Exercise::Bermudan:
-              for (double i : stoppingTimes_) {
+              for (Real i : stoppingTimes_) {
                   if (isOnTime(i)) {
                       stoppingTime = true;
                       break;

--- a/ql/pricingengines/bond/discretizedconvertible.cpp
+++ b/ql/pricingengines/bond/discretizedconvertible.cpp
@@ -86,13 +86,13 @@ namespace QuantLib {
 
         if (!grid.empty()) {
             // adjust times to grid
-            for (double& stoppingTime : stoppingTimes_)
+            for (Real& stoppingTime : stoppingTimes_)
                 stoppingTime = grid.closestTime(stoppingTime);
-            for (double& couponTime : couponTimes_)
+            for (Real& couponTime : couponTimes_)
                 couponTime = grid.closestTime(couponTime);
-            for (double& callabilityTime : callabilityTimes_)
+            for (Real& callabilityTime : callabilityTimes_)
                 callabilityTime = grid.closestTime(callabilityTime);
-            for (double& dividendTime : dividendTimes_)
+            for (Real& dividendTime : dividendTimes_)
                 dividendTime = grid.closestTime(dividendTime);
         }
     }
@@ -142,7 +142,7 @@ namespace QuantLib {
                 convertible = true;
             break;
           case Exercise::Bermudan:
-              for (double stoppingTime : stoppingTimes_) {
+              for (Real stoppingTime : stoppingTimes_) {
                   if (isOnTime(stoppingTime))
                       convertible = true;
               }
@@ -238,7 +238,7 @@ namespace QuantLib {
                 DiscountFactor dividendDiscount =
                     process_->riskFreeRate()->discount(dividendTime) /
                     process_->riskFreeRate()->discount(t);
-                for (double& j : grid)
+                for (Real& j : grid)
                     j += d->amount(j) * dividendDiscount;
             }
         }

--- a/ql/pricingengines/capfloor/gaussian1dcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/gaussian1dcapfloorengine.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     void Gaussian1dCapFloorEngine::calculate() const {
 
-        for (double spread : arguments_.spreads)
+        for (Real spread : arguments_.spreads)
             QL_REQUIRE(spread == 0.0, "Non zero spreads (" << spread << ") are not allowed.");
 
         Size optionlets = arguments_.startDates.size();

--- a/ql/pricingengines/swap/discretizedswap.cpp
+++ b/ql/pricingengines/swap/discretizedswap.cpp
@@ -101,19 +101,19 @@ namespace QuantLib {
 
     std::vector<Time> DiscretizedSwap::mandatoryTimes() const {
         std::vector<Time> times;
-        for (double t : fixedResetTimes_) {
+        for (Real t : fixedResetTimes_) {
             if (t >= 0.0)
                 times.push_back(t);
         }
-        for (double t : fixedPayTimes_) {
+        for (Real t : fixedPayTimes_) {
             if (t >= 0.0)
                 times.push_back(t);
         }
-        for (double t : floatingResetTimes_) {
+        for (Real t : floatingResetTimes_) {
             if (t >= 0.0)
                 times.push_back(t);
         }
-        for (double t : floatingPayTimes_) {
+        for (Real t : floatingPayTimes_) {
             if (t >= 0.0)
                 times.push_back(t);
         }

--- a/ql/pricingengines/swaption/basketgeneratingengine.hpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.hpp
@@ -144,7 +144,7 @@ namespace QuantLib {
             Real value(const Array& v) const override {
                 Array vals = values(v);
                 Real res = 0.0;
-                for (double val : vals) {
+                for (Real val : vals) {
                     res += val * val;
                 }
                 return std::sqrt(res / vals.size());

--- a/ql/pricingengines/vanilla/analyticdividendeuropeanengine.cpp
+++ b/ql/pricingengines/vanilla/analyticdividendeuropeanengine.cpp
@@ -93,8 +93,8 @@ namespace QuantLib {
                 && d <= arguments_.exercise->lastDate()) {
 
                 delta_theta -= arguments_.cashFlow[i]->amount() *
-                  (  process_->riskFreeRate()->zeroRate(d,rfdc,Continuous,Annual)
-                   - process_->dividendYield()->zeroRate(d,dydc,Continuous,Annual)) *
+                  (  process_->riskFreeRate()->zeroRate(d,rfdc,Continuous,Annual).rate()
+                   - process_->dividendYield()->zeroRate(d,dydc,Continuous,Annual).rate()) *
                   process_->riskFreeRate()->discount(d) /
                   process_->dividendYield()->discount(d);
 

--- a/ql/pricingengines/vanilla/discretizedvanillaoption.cpp
+++ b/ql/pricingengines/vanilla/discretizedvanillaoption.cpp
@@ -58,7 +58,7 @@ namespace QuantLib {
                 applySpecificCondition();
             break;
           case Exercise::Bermudan:
-              for (double stoppingTime : stoppingTimes_) {
+              for (Real stoppingTime : stoppingTimes_) {
                   if (isOnTime(stoppingTime))
                       applySpecificCondition();
               }

--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -76,8 +76,8 @@ namespace QuantLib {
         // we could be more anticipatory if we know the right dt
         // for which the drift will be used
         Time t1 = t + 0.0001;
-        return riskFreeRate_->forwardRate(t,t1,Continuous,NoFrequency,true)
-             - dividendYield_->forwardRate(t,t1,Continuous,NoFrequency,true)
+        return riskFreeRate_->forwardRate(t,t1,Continuous,NoFrequency,true).rate()
+             - dividendYield_->forwardRate(t,t1,Continuous,NoFrequency,true).rate()
              - 0.5 * sigma * sigma;
     }
 

--- a/ql/processes/gjrgarchprocess.cpp
+++ b/ql/processes/gjrgarchprocess.cpp
@@ -64,8 +64,8 @@ namespace QuantLib {
                          : 0.0;
 
         return {
-            riskFreeRate_->forwardRate(t, t, Continuous)
-               - dividendYield_->forwardRate(t, t, Continuous)
+            riskFreeRate_->forwardRate(t, t, Continuous).rate()
+               - dividendYield_->forwardRate(t, t, Continuous).rate()
                - 0.5 * vol * vol,
             daysPerYear_*daysPerYear_*omega_ + daysPerYear_*(beta_ 
                                              + alpha_*q2 + gamma_*q3 - 1.0) *

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -73,8 +73,8 @@ namespace QuantLib {
                          : 0.0;
 
         return {
-            riskFreeRate_->forwardRate(t, t, Continuous)
-               - dividendYield_->forwardRate(t, t, Continuous)
+            riskFreeRate_->forwardRate(t, t, Continuous).rate()
+               - dividendYield_->forwardRate(t, t, Continuous).rate()
                - 0.5 * vol * vol,
             kappa_* (theta_-((discretization_==PartialTruncation) ? x[1] : vol*vol))
         };

--- a/ql/processes/jointstochasticprocess.cpp
+++ b/ql/processes/jointstochasticprocess.cpp
@@ -211,7 +211,7 @@ namespace QuantLib {
                     const Volatility vol = std::sqrt(
                         std::inner_product(stdDev.row_begin(i),
                                            stdDev.row_end(i),
-                                           stdDev.row_begin(i), 0.0));
+                                           stdDev.row_begin(i), Real(0.0)));
                     if (vol > 0.0) {
                         std::transform(stdDev.row_begin(i), stdDev.row_end(i),
                                        stdDev.row_begin(i),

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -263,7 +263,7 @@ template <class Curve> void GlobalBootstrap<Curve>::calculate() const {
         Real value(const Array& x) const override {
             Array v = values(x);
             std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
-            return std::sqrt(std::accumulate(v.begin(), v.end(), 0.0) / static_cast<Real>(v.size()));
+            return std::sqrt(std::accumulate(v.begin(), v.end(), Real(0.0)) / static_cast<Real>(v.size()));
         }
 
         Array values(const Array& x) const override {

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -435,7 +435,7 @@ namespace QuantLib {
             }
 
             avgError_ +=
-                std::accumulate(vegaDiffs.begin(), vegaDiffs.end(), 0.0);
+                std::accumulate(vegaDiffs.begin(), vegaDiffs.end(), Real(0.0));
             minError_ = std::min(minError_,
                 *std::min_element(vegaDiffs.begin(), vegaDiffs.end()));
             maxError_ = std::max(maxError_,

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
         Brent solver;
         solver.setMaxEvaluations(10000);
         const Volatility guess = std::sqrt(theta);
-        const Real accuracy = std::numeric_limits<Real>::epsilon();
+        constexpr double accuracy = std::numeric_limits<double>::epsilon();
 
         return solver.solve([&](Volatility _v) { return blackValue(payoff.optionType(), strike, fwd,
                                                                    t, _v, df, npv); },

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
         Brent solver;
         solver.setMaxEvaluations(10000);
         const Volatility guess = std::sqrt(theta);
-        constexpr Real accuracy = std::numeric_limits<Real>::epsilon();
+        const Real accuracy = std::numeric_limits<Real>::epsilon();
 
         return solver.solve([&](Volatility _v) { return blackValue(payoff.optionType(), strike, fwd,
                                                                    t, _v, df, npv); },

--- a/ql/termstructures/volatility/kahalesmilesection.cpp
+++ b/ql/termstructures/volatility/kahalesmilesection.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         // for shifted smile sections we shift the forward and the strikes
         // and do as if we were in a lognormal setting
 
-        for (double& i : k_) {
+        for (Real& i : k_) {
             i += shift();
         }
 

--- a/ql/termstructures/volatility/kahalesmilesection.hpp
+++ b/ql/termstructures/volatility/kahalesmilesection.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
                     return std::exp(-a_ * k + b_);
                 if (s_ < QL_EPSILON)
                     return std::max(f_ - k, 0.0) + a_ * k + b_;
-                boost::math::normal normal;
+                boost::math::normal_distribution<Real> normal;
                 Real d1 = std::log(f_ / k) / s_ + s_ / 2.0;
                 Real d2 = d1 - s_;
                 return f_ * boost::math::cdf(normal, d1) -
@@ -78,7 +78,7 @@ namespace QuantLib {
             aHelper(Real k0, Real k1, Real c0, Real c1, Real c0p, Real c1p)
                 : k0_(k0), k1_(k1), c0_(c0), c1_(c1), c0p_(c0p), c1p_(c1p) {}
             Real operator()(Real a) const {
-                boost::math::normal normal;
+                boost::math::normal_distribution<Real> normal;
                 Real d20 = boost::math::quantile(normal, -c0p_ + a);
                 Real d21 = boost::math::quantile(normal, -c1p_ + a);
                 Real alpha = (d20 - d21) / (std::log(k0_) - std::log(k1_));
@@ -99,7 +99,7 @@ namespace QuantLib {
             sHelper(Real k0, Real c0, Real c0p) : k0_(k0), c0_(c0), c0p_(c0p) {}
             Real operator()(Real s) const {
                 s = std::max(s, 0.0);
-                boost::math::normal normal;
+                boost::math::normal_distribution<Real> normal;
                 Real d20 = boost::math::quantile(normal, -c0p_);
                 f_ = k0_ * std::exp(s * d20 + s * s / 2.0);
                 QL_REQUIRE(f_ < QL_KAHALE_FMAX, "dummy"); // this is caught
@@ -115,7 +115,7 @@ namespace QuantLib {
                 : k1_(k1), c0_(c0), c1_(c1), c1p_(c1p) {}
             Real operator()(Real s) const {
                 s = std::max(s, 0.0);
-                boost::math::normal normal;
+                boost::math::normal_distribution<Real> normal;
                 Real d21 = boost::math::quantile(normal, -c1p_);
                 f_ = k1_ * std::exp(s * d21 + s * s / 2.0);
                 QL_REQUIRE(f_ < QL_KAHALE_FMAX, "dummy"); // this is caught

--- a/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
+++ b/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
                 0); // strikes are the same for all times ?!
         std::vector< Real > stddevs;
         stddevs.reserve(optionletStrikes.size());
-        for (double optionletStrike : optionletStrikes) {
+        for (Real optionletStrike : optionletStrikes) {
             stddevs.push_back(volatilityImpl(t, optionletStrike) * std::sqrt(t));
         }
         // Extrapolation may be a problem with splines, but since minStrike()

--- a/ql/termstructures/volatility/smilesectionutils.cpp
+++ b/ql/termstructures/volatility/smilesectionutils.cpp
@@ -81,8 +81,8 @@ namespace QuantLib {
         }
 
         bool minStrikeAdded = false, maxStrikeAdded = false;
-        for (double& i : tmp) {
-            Real k = section.volatilityType() == Normal ? f_ + i : i * (f_ + shift) - shift;
+        for (Real& i : tmp) {
+            Real k = section.volatilityType() == Normal ? Real(f_ + i) : Real(i * (f_ + shift) - shift);
             if ((section.volatilityType() == ShiftedLognormal && i <= QL_EPSILON) ||
                 (k >= section.minStrike() && k <= section.maxStrike())) {
                 if (!minStrikeAdded || !close(k, section.minStrike())) {

--- a/ql/termstructures/volatility/swaption/cmsmarketcalibration.cpp
+++ b/ql/termstructures/volatility/swaption/cmsmarketcalibration.cpp
@@ -202,7 +202,7 @@ namespace {
         for (Size i = 0; i < nSwapTenors; ++i) {
             std::vector<Real> beta(x.begin() + (i * nSwapLengths),
                                    x.begin() + ((i + 1) * nSwapLengths));
-            for (double& j : beta)
+            for (Real& j : beta)
                 j = CmsMarketCalibration::betaTransformDirect(j);
             volCubeBySabr->recalibration(swapLengths, beta, swapTenors[i]);
         }
@@ -229,7 +229,7 @@ namespace {
         for (Size i = 0; i < nSwapTenors; ++i) {
             std::vector<Real> beta(x.begin() + (i * nSwapLengths),
                                    x.begin() + ((i + 1) * nSwapLengths));
-            for (double& j : beta)
+            for (Real& j : beta)
                 j = CmsMarketCalibration::betaTransformDirect(j);
             volCubeBySabr->recalibration(swapLengths, beta, swapTenors[i]);
         }

--- a/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube1.hpp
@@ -632,7 +632,7 @@ namespace QuantLib {
         std::vector<Time> swapLengths(sparseParameters_.swapLengths());
         sparseSmiles_.clear();
 
-        for (double& optionTime : optionTimes) {
+        for (Real& optionTime : optionTimes) {
             std::vector<ext::shared_ptr<SmileSection> > tmp;
             Size n = swapLengths.size();
             tmp.reserve(n);

--- a/ql/termstructures/yield/drifttermstructure.hpp
+++ b/ql/termstructures/yield/drifttermstructure.hpp
@@ -100,8 +100,8 @@ namespace QuantLib {
         //          a) all TS have the same daycount.
         //          b) all TS have the same referenceDate
         //          It should be QL_REQUIREd
-        return riskFreeTS_->zeroRate(t, Continuous, NoFrequency, true)
-             - dividendTS_->zeroRate(t, Continuous, NoFrequency, true)
+        return riskFreeTS_->zeroRate(t, Continuous, NoFrequency, true).rate()
+             - dividendTS_->zeroRate(t, Continuous, NoFrequency, true).rate()
              - 0.5 * blackVolTS_->blackVol(t, underlyingLevel_, true)
                    * blackVolTS_->blackVol(t, underlyingLevel_, true);
     }

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -242,7 +242,7 @@ namespace QuantLib {
                                                        const Array& x) const {
         Real squaredError = 0.0;
         Array vals = values(x);
-        for (double val : vals) {
+        for (Real val : vals) {
             squaredError += val;
         }
         return squaredError;

--- a/ql/termstructures/yield/quantotermstructure.hpp
+++ b/ql/termstructures/yield/quantotermstructure.hpp
@@ -123,9 +123,9 @@ namespace QuantLib {
     inline Rate QuantoTermStructure::zeroYieldImpl(Time t) const {
         // warning: here it is assumed that all TS have the same daycount.
         //          It should be QL_REQUIREd
-        return underlyingDividendTS_->zeroRate(t, Continuous, NoFrequency, true)
-            +            riskFreeTS_->zeroRate(t, Continuous, NoFrequency, true)
-            -     foreignRiskFreeTS_->zeroRate(t, Continuous, NoFrequency, true)
+        return underlyingDividendTS_->zeroRate(t, Continuous, NoFrequency, true).rate()
+            +            riskFreeTS_->zeroRate(t, Continuous, NoFrequency, true).rate()
+            -     foreignRiskFreeTS_->zeroRate(t, Continuous, NoFrequency, true).rate()
             + underlyingExchRateCorrelation_
             * underlyingBlackVolTS_->blackVol(t, strike_, true)
             *   exchRateBlackVolTS_->blackVol(t, exchRateATMlevel_, true);

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -459,7 +459,7 @@ namespace {
         ext::shared_ptr<StrikedTypePayoff> payoff;
 
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 for (int year : years) {
                     Date exDate = today + year * Years;
                     ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
@@ -472,10 +472,10 @@ namespace {
                     VanillaOption option(payoff, exercise);
                     option.setPricingEngine(engine);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
                                     Rate q = m, r = n;
                                     spot->setValue(u);
                                     qRate->setValue(q);

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -285,7 +285,7 @@ namespace andreasen_huge_volatility_interpl_test {
 
         AndreasenHugeVolatilityInterpl::CalibrationSet calibrationSet;
 
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (unsigned long maturityMonth : maturityMonths) {
                 const Date maturityDate = today + Period(maturityMonth, Months);
                 const Time t = dc.yearFraction(today, maturityDate);
@@ -713,7 +713,7 @@ void AndreasenHugeVolatilityInterplTest::testBarrierOptionPricing() {
 
     AndreasenHugeVolatilityInterpl::CalibrationSet calibrationSet;
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         for (unsigned long maturityMonth : maturityMonths) {
             const Date maturityDate = today + Period(maturityMonth, Months);
             const Time t = dc.yearFraction(today, maturityDate);
@@ -806,7 +806,7 @@ namespace andreasen_huge_volatility_interpl_test {
 
         const Real strikes[] = { 0.02, 0.025, 0.03, 0.035, 0.04, 0.05, 0.06 };
 
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             const Volatility vol = sabrVolatility(strike, forward, maturity, alpha, beta, nu, rho);
 
             calibrationSet.push_back(std::make_pair(
@@ -1024,7 +1024,7 @@ void AndreasenHugeVolatilityInterplTest::testFlatVolCalibration() {
         const Time t = rTS->timeFromReference(expiry);
         const Real fwd = spot->value() / rTS->discount(t) * qTS->discount(t);
 
-        for (double m : moneyness) {
+        for (Real m : moneyness) {
             const Real strike = fwd * m;
             const Real mn = std::log(fwd/strike)/std::sqrt(t);
 

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -126,13 +126,13 @@ void ArrayTest::testArrayFunctions() {
         a[i] = std::sin(Real(i))+1.1;
     }
 
-    constexpr Real exponential = -2.3;
+    const Real exponential = -2.3;
     const Array p = Pow(a, exponential);
     const Array e = Exp(a);
     const Array l = Log(a);
     const Array s = Sqrt(a);
 
-    constexpr Real tol = 10*QL_EPSILON;
+    const Real tol = 10*QL_EPSILON;
     for (Size i=0; i < a.size(); ++i) {
         if (std::fabs(p[i]-std::pow(a[i], exponential)) > tol) {
             BOOST_FAIL("Array function test Pow failed");

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -126,13 +126,13 @@ void ArrayTest::testArrayFunctions() {
         a[i] = std::sin(Real(i))+1.1;
     }
 
-    const Real exponential = -2.3;
+    constexpr double exponential = -2.3;
     const Array p = Pow(a, exponential);
     const Array e = Exp(a);
     const Array l = Log(a);
     const Array s = Sqrt(a);
 
-    const Real tol = 10*QL_EPSILON;
+    constexpr double tol = 10*QL_EPSILON;
     for (Size i=0; i < a.size(); ++i) {
         if (std::fabs(p[i]-std::pow(a[i], exponential)) > tol) {
             BOOST_FAIL("Array function test Pow failed");

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -212,7 +212,7 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks() {
          new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
 
                 ext::shared_ptr<EuropeanExercise> maturity(
@@ -229,10 +229,10 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks() {
                 Size pastFixings = Null<Size>();
                 Real runningAverage = Null<Real>();
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
 
                                 Rate q = m, r = n;
                                 spot->setValue(u);
@@ -1357,7 +1357,7 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks() {
          new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
 
                 ext::shared_ptr<EuropeanExercise> maturity(
@@ -1380,10 +1380,10 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks() {
                                                     fixingDates, payoff, maturity);
                 option.setPricingEngine(engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
 
                                 Rate q = m, r = n;
                                 spot->setValue(u);

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -70,7 +70,7 @@ namespace {
         for (auto term : terms)
             dates.push_back(NullCalendar().advance(today, term, Unadjusted));
         std::vector<Real> ratesPlusSpread(rates);
-        for (double& k : ratesPlusSpread)
+        for (Real& k : ratesPlusSpread)
             k += spread;
         ext::shared_ptr<YieldTermStructure> ts =
             ext::shared_ptr<YieldTermStructure>(new InterpolatedZeroCurve<Cubic>(
@@ -113,7 +113,7 @@ namespace {
         for (auto& capletVol : capletVols) {
             std::vector<Handle<Quote> > row;
             row.reserve(capletVol.size());
-            for (double j : capletVol)
+            for (Real j : capletVol)
                 row.push_back(RelinkableHandle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(j))));
             capletVolQuotes.push_back(row);
         }
@@ -144,7 +144,7 @@ namespace {
         for (auto& swaptionVol : swaptionVols) {
             std::vector<Handle<Quote> > row;
             row.reserve(swaptionVol.size());
-            for (double j : swaptionVol)
+            for (Real j : swaptionVol)
                 row.push_back(RelinkableHandle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(j))));
             swaptionVolQuotes.push_back(row);
         }
@@ -265,7 +265,7 @@ void BasismodelsTest::testTenoroptionletvts() {
         ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m(
             new TenorOptionletVTS(optionletVTS3m, euribor3m, euribor6m, corr));
         for (auto& capletTerm : capletTerms) {
-            for (double& capletStrike : capletStrikes) {
+            for (Real& capletStrike : capletStrikes) {
                 Real vol3m = optionletVTS3m->volatility(capletTerm, capletStrike, true);
                 Real vol6m = optionletVTS6m->volatility(capletTerm, capletStrike, true);
                 Real vol6mShifted =
@@ -300,7 +300,7 @@ void BasismodelsTest::testTenoroptionletvts() {
         ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m(
             new TenorOptionletVTS(optionletVTS3m, euribor3m, euribor6m, corr));
         for (Size i = 0; i < capletTerms.size(); ++i) {
-            for (double& capletStrike : capletStrikes) {
+            for (Real& capletStrike : capletStrikes) {
                 Real vol3m = optionletVTS3m->volatility(capletTerms[i], capletStrike, true);
                 Real vol6m = optionletVTS6m->volatility(capletTerms[i], capletStrike, true);
                 Real vol6mShifted =

--- a/test-suite/blackformula.cpp
+++ b/test-suite/blackformula.cpp
@@ -43,7 +43,7 @@ void BlackFormulaTest::testBachelierImpliedVol(){
     Real discount = 0.95;
 
     Real d[] = {-3.0, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 3.0};
-    for (double i : d) {
+    for (Real i : d) {
 
 
         Real strike = forward - i * bpvol * std::sqrt(tte);
@@ -74,11 +74,11 @@ void BlackFormulaTest::testChambersImpliedVol() {
     Real tol = 5.0E-4;
 
     for (auto& type : types) {
-        for (double& displacement : displacements) {
-            for (double& forward : forwards) {
-                for (double& strike : strikes) {
-                    for (double& stdDev : stdDevs) {
-                        for (double& discount : discounts) {
+        for (Real& displacement : displacements) {
+            for (Real& forward : forwards) {
+                for (Real& strike : strikes) {
+                    for (Real& stdDev : stdDevs) {
+                        for (Real& discount : discounts) {
                             if (forward + displacement > 0.0 && strike + displacement > 0.0) {
                                 Real premium = blackFormula(type, strike, forward, stdDev, discount,
                                                             displacement);
@@ -127,7 +127,7 @@ void BlackFormulaTest::testRadoicicStefanicaImpliedVol() {
 
     const Real tol = 0.02;
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         for (auto type : types) {
             const ext::shared_ptr<PlainVanillaPayoff> payoff(
                 ext::make_shared<PlainVanillaPayoff>(type, strike));
@@ -225,12 +225,12 @@ void BlackFormulaTest::testImpliedVolAdaptiveSuccessiveOverRelaxation() {
 
     const Real tol = 1e-8;
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         for (auto type : types) {
             const ext::shared_ptr<PlainVanillaPayoff> payoff(
                 ext::make_shared<PlainVanillaPayoff>(type, strike));
 
-            for (double displacement : displacements) {
+            for (Real displacement : displacements) {
 
                 const Real marketValue = blackFormula(payoff, forward, stdDev, df, displacement);
 
@@ -269,7 +269,7 @@ void assertBlackFormulaForwardDerivative(
     Real epsilon = 1.e-10;
     std::string type = optionType == Option::Call ? "Call" : "Put";
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         Real delta = blackFormulaForwardDerivative(optionType, strike, forward, stdDev, discount,
                                                    displacement);
         Real bumpedDelta = blackFormulaForwardDerivative(
@@ -360,7 +360,7 @@ void assertBachelierBlackFormulaForwardDerivative(
     Real epsilon = 1.e-10;
     std::string type = optionType == Option::Call ? "Call" : "Put";
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         Real delta =
             bachelierBlackFormulaForwardDerivative(optionType, strike, forward, stdDev, discount);
         Real bumpedDelta = bachelierBlackFormulaForwardDerivative(

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -120,7 +120,7 @@ void BondTest::testYield() {
 
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
-            for (double& coupon : coupons) {
+            for (Real& coupon : coupons) {
                 for (auto& frequencie : frequencies) {
                     for (auto& n : compounding) {
 
@@ -136,7 +136,7 @@ void BondTest::testYield() {
                                            std::vector<Rate>(1, coupon), bondDayCount,
                                            paymentConvention, redemption, issue);
 
-                        for (double m : yields) {
+                        for (Real m : yields) {
 
                             Real price =
                                 BondFunctions::cleanPrice(bond, m, bondDayCount, n, frequencie);
@@ -218,7 +218,7 @@ void BondTest::testAtmRate() {
 
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
-            for (double& coupon : coupons) {
+            for (Real& coupon : coupons) {
                 for (auto& frequencie : frequencies) {
                     Date dated = vars.calendar.advance(vars.today, issueMonth, Months);
                     Date issue = dated;
@@ -283,7 +283,7 @@ void BondTest::testZspread() {
 
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
-            for (double& coupon : coupons) {
+            for (Real& coupon : coupons) {
                 for (auto& frequencie : frequencies) {
                     for (auto& n : compounding) {
 
@@ -299,7 +299,7 @@ void BondTest::testZspread() {
                                            std::vector<Rate>(1, coupon), bondDayCount,
                                            paymentConvention, redemption, issue);
 
-                        for (double spread : spreads) {
+                        for (Real spread : spreads) {
 
                             Real price = BondFunctions::cleanPrice(bond, *discountCurve, spread,
                                                                    bondDayCount, n, frequencie);
@@ -358,7 +358,7 @@ void BondTest::testTheoretical() {
     Rate yields[] = { 0.03, 0.04, 0.05, 0.06, 0.07 };
 
     for (unsigned long length : lengths) {
-        for (double& coupon : coupons) {
+        for (Real& coupon : coupons) {
             for (auto& frequencie : frequencies) {
 
                 Date dated = vars.today;
@@ -378,7 +378,7 @@ void BondTest::testTheoretical() {
                 ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(discountCurve));
                 bond.setPricingEngine(bondEngine);
 
-                for (double m : yields) {
+                for (Real m : yields) {
 
                     rate->setValue(m);
 

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -133,7 +133,7 @@ void CallableBondTest::testInterplay() {
                                 vars.issueDate(), callabilities);
     bond.setPricingEngine(engine);
 
-    double expected = callabilities[0]->price().amount() *
+    Real expected = callabilities[0]->price().amount() *
                       vars.termStructure->discount(callabilities[0]->date()) /
                       vars.termStructure->discount(bond.settlementDate());
 
@@ -348,7 +348,7 @@ void CallableBondTest::testObservability() {
 
     bond.setPricingEngine(engine);
 
-    double originalValue = bond.NPV();
+    Real originalValue = bond.NPV();
 
     observable->setValue(0.04);
 
@@ -637,9 +637,9 @@ void CallableBondTest::testSnappingExerciseDate2ClosestCouponDate() {
     };
 
     auto initialCallDate = Date(14, Feb, 2022);
-    auto tolerance = 1e-10;
-    auto prevOAS = 0.0266;
-    auto expectedOasStep = 0.00005;
+    Real tolerance = 1e-10;
+    Real prevOAS = 0.0266;
+    Real expectedOasStep = 0.00005;
 
     ext::shared_ptr<CallableFixedRateBond> callableBond;
     ext::shared_ptr<FixedRateBond> fixedRateBond;

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -169,8 +169,8 @@ void CapFloorTest::testVega() {
     static const Real tolerance = 0.005;
 
     for (int length : lengths) {
-        for (double vol : vols) {
-            for (double strike : strikes) {
+        for (Real vol : vols) {
+            for (Real strike : strikes) {
                 for (auto& type : types) {
                     Leg leg = vars.makeLeg(startDate, length);
                     ext::shared_ptr<CapFloor> capFloor = vars.makeCapFloor(type, leg, strike, vol);
@@ -217,10 +217,10 @@ void CapFloorTest::testStrikeDependency() {
     Date startDate = vars.termStructure->referenceDate();
 
     for (int& length : lengths) {
-        for (double vol : vols) {
+        for (Real vol : vols) {
             // store the results for different strikes...
             std::vector<Real> cap_values, floor_values;
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 Leg leg = vars.makeLeg(startDate, length);
                 ext::shared_ptr<Instrument> cap =
                     vars.makeCapFloor(CapFloor::Cap, leg, strike, vol);
@@ -274,9 +274,9 @@ void CapFloorTest::testConsistency() {
     Date startDate = vars.termStructure->referenceDate();
 
     for (int& length : lengths) {
-        for (double& cap_rate : cap_rates) {
-            for (double& floor_rate : floor_rates) {
-                for (double vol : vols) {
+        for (Real& cap_rate : cap_rates) {
+            for (Real& floor_rate : floor_rates) {
+                for (Real vol : vols) {
 
                     Leg leg = vars.makeLeg(startDate, length);
                     ext::shared_ptr<CapFloor> cap =
@@ -380,8 +380,8 @@ void CapFloorTest::testParity() {
     Date startDate = vars.termStructure->referenceDate();
 
     for (int& length : lengths) {
-        for (double strike : strikes) {
-            for (double vol : vols) {
+        for (Real strike : strikes) {
+            for (Real vol : vols) {
 
                 Leg leg = vars.makeLeg(startDate, length);
                 ext::shared_ptr<Instrument> cap =
@@ -433,8 +433,8 @@ void CapFloorTest::testATMRate() {
                           vars.convention,vars.convention,
                           DateGeneration::Forward,false);
 
-        for (double strike : strikes) {
-            for (double vol : vols) {
+        for (Real strike : strikes) {
+            for (Real vol : vols) {
                 ext::shared_ptr<CapFloor> cap = vars.makeCapFloor(CapFloor::Cap, leg, strike, vol);
                 ext::shared_ptr<CapFloor> floor =
                     vars.makeCapFloor(CapFloor::Floor, leg, strike, vol);
@@ -493,12 +493,12 @@ void CapFloorTest::testImpliedVolatility() {
         Leg leg = vars.makeLeg(vars.settlement, length);
 
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
 
                 ext::shared_ptr<CapFloor> capfloor = vars.makeCapFloor(type, leg, strike, 0.0);
 
-                for (double r : rRates) {
-                    for (double v : vols) {
+                for (Real r : rRates) {
+                    for (Real v : vols) {
 
                         vars.termStructure.linkTo(flatRate(vars.settlement, r, Actual360()));
                         capfloor->setPricingEngine(vars.makeEngine(v));
@@ -647,11 +647,11 @@ void CapFloorTest::testCachedValueFromOptionLets() {
             << "    calculated: " << capletPrices.size() << " caplet prices\n"
             << "    expected:   " << 40);
 
-    for (double capletPrice : capletPrices) {
+    for (Real capletPrice : capletPrices) {
         calculatedCapletsNPV += capletPrice;
     }
 
-    for (double floorletPrice : floorletPrices) {
+    for (Real floorletPrice : floorletPrices) {
         calculatedFloorletsNPV += floorletPrice;
     }
 

--- a/test-suite/cliquetoption.cpp
+++ b/test-suite/cliquetoption.cpp
@@ -142,7 +142,7 @@ namespace {
                                                           qTS, rTS, volTS));
 
         for (auto& type : types) {
-            for (double moneynes : moneyness) {
+            for (Real moneynes : moneyness) {
                 for (int length : lengths) {
                     for (auto& frequencie : frequencies) {
 
@@ -162,10 +162,10 @@ namespace {
                         CliquetOption option(payoff, maturity, reset);
                         option.setPricingEngine(engine);
 
-                        for (double u : underlyings) {
-                            for (double m : qRates) {
-                                for (double n : rRates) {
-                                    for (double v : vols) {
+                        for (Real u : underlyings) {
+                            for (Real m : qRates) {
+                                for (Real n : rRates) {
+                                    for (Real v : vols) {
 
                                         Rate q = m, r = n;
                                         spot->setValue(u);
@@ -300,7 +300,7 @@ void CliquetOptionTest::testMcPerformance() {
                                                           qTS, rTS, volTS));
 
     for (auto& type : types) {
-        for (double moneynes : moneyness) {
+        for (Real moneynes : moneyness) {
             for (int length : lengths) {
                 for (auto& frequencie : frequencies) {
 
@@ -326,10 +326,10 @@ void CliquetOptionTest::testMcPerformance() {
                             .withAbsoluteTolerance(5.0e-3)
                             .withSeed(42);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
 
                                     Rate q = m, r = n;
                                     spot->setValue(u);

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -140,7 +140,7 @@ Real mcReferenceValue(const ext::shared_ptr<CmsCoupon>& cpn1,
                       const Handle<SwaptionVolatilityStructure>& vol,
                       const Real correlation) {
     Size samples = 1000000;
-    accumulator_set<double, stats<tag::mean> > acc;
+    accumulator_set<Real, stats<tag::mean> > acc;
     Matrix Cov(2, 2);
     Cov(0, 0) = vol->blackVariance(cpn1->fixingDate(), cpn1->index()->tenor(),
                                    cpn1->indexFixing());
@@ -219,9 +219,9 @@ void CmsSpreadTest::testCouponPricing() {
     cpn1->setPricer(d.cmsspPricerLn);
 
 #ifndef __FAST_MATH__
-    constexpr Real eqTol = 100*QL_EPSILON;
+    const Real eqTol = 100*QL_EPSILON;
 #else
-    constexpr Real eqTol = 1e-13;
+    const Real eqTol = 1e-13;
 #endif
     BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms10y->addFixing(d.refDate, 0.05);

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -219,9 +219,9 @@ void CmsSpreadTest::testCouponPricing() {
     cpn1->setPricer(d.cmsspPricerLn);
 
 #ifndef __FAST_MATH__
-    const Real eqTol = 100*QL_EPSILON;
+    constexpr double eqTol = 100*QL_EPSILON;
 #else
-    const Real eqTol = 1e-13;
+    constexpr double eqTol = 1e-13;
 #endif
     BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms10y->addFixing(d.refDate, 0.05);

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -675,8 +675,8 @@ void CreditDefaultSwapTest::testIsdaEngine() {
     size_t l = 0;
 
     for (auto termDate : termDates) {
-        for (double spread : spreads) {
-            for (double& recoverie : recoveries) {
+        for (Real spread : spreads) {
+            for (Real& recoverie : recoveries) {
 
                 ext::shared_ptr<CreditDefaultSwap> quotedTrade =
                     MakeCreditDefaultSwap(termDate, spread).withNominal(10000000.);

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -242,7 +242,7 @@ void DayCounterTest::testActualActualIsma()
 
     DayCounter dayCounter = ActualActual(ActualActual::ISMA, schedule);
 
-    double calculated(dayCounter.yearFraction(d1, d2));
+    Real calculated(dayCounter.yearFraction(d1, d2));
 
     if (std::fabs(calculated - expected) > 1.0e-10) {
         std::ostringstream period;

--- a/test-suite/digitalcoupon.cpp
+++ b/test-suite/digitalcoupon.cpp
@@ -95,11 +95,11 @@ void DigitalCouponTest::testAssetOrNothing() {
                         with black formula result */
     ext::shared_ptr<DigitalReplication>
         replication(new DigitalReplication(Replication::Central, gap));
-    for (double capletVol : vols) {
+    for (Real capletVol : vols) {
         RelinkableHandle<OptionletVolatilityStructure> vol;
         vol.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
             vars.today, vars.calendar, Following, capletVol, Actual360())));
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (Size k = 9; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
                 Date endDate = vars.calendar.advance(vars.settlement,(k+2)*Years);
@@ -510,11 +510,11 @@ void DigitalCouponTest::testCashOrNothing() {
     ext::shared_ptr<DigitalReplication> replication(new
         DigitalReplication(Replication::Central, gap));
 
-    for (double capletVol : vols) {
+    for (Real capletVol : vols) {
         RelinkableHandle<OptionletVolatilityStructure> vol;
         vol.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
             vars.today, vars.calendar, Following, capletVol, Actual360())));
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
                 Date endDate = vars.calendar.advance(vars.settlement,(k+2)*Years);
@@ -880,12 +880,12 @@ void DigitalCouponTest::testCallPutParity() {
     ext::shared_ptr<DigitalReplication> replication(new
         DigitalReplication(Replication::Central, gap));
 
-    for (double capletVolatility : vols) {
+    for (Real capletVolatility : vols) {
         RelinkableHandle<OptionletVolatilityStructure> volatility;
         volatility.linkTo(
             ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
                 vars.today, vars.calendar, Following, capletVolatility, Actual360())));
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
                 Date endDate = vars.calendar.advance(vars.settlement,(k+2)*Years);
@@ -987,12 +987,12 @@ void DigitalCouponTest::testReplicationType() {
     ext::shared_ptr<DigitalReplication> superReplication(new
         DigitalReplication(Replication::Super, gap));
 
-    for (double capletVolatility : vols) {
+    for (Real capletVolatility : vols) {
         RelinkableHandle<OptionletVolatilityStructure> volatility;
         volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
         ConstantOptionletVolatility(vars.today, vars.calendar, Following,
                                     capletVolatility, Actual360())));
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
                 Date endDate = vars.calendar.advance(vars.settlement,(k+2)*Years);

--- a/test-suite/digitaloption.cpp
+++ b/test-suite/digitaloption.cpp
@@ -564,17 +564,17 @@ void DigitalOptionTest::testCashAtHitOrNothingAmericanGreeks() {
     bool knockin=true;
     for (Size j=0; j<LENGTH(engines); j++) {
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 ext::shared_ptr<StrikedTypePayoff> payoff(
                     new CashOrNothingPayoff(type, strike, cashPayoff));
 
                 VanillaOption opt(payoff, exercises[j]);
                 opt.setPricingEngine(engines[j]);
 
-                for (double u : underlyings) {
-                    for (double q : qRates) {
-                        for (double r : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real q : qRates) {
+                        for (Real r : rRates) {
+                            for (Real v : vols) {
                                 // test data
                                 spot->setValue(u);
                                 qRate->setValue(q);

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -155,7 +155,7 @@ namespace distributions_test {
         const Real x(0.0);
         const Real y(0.0);
 
-        for (double i : rho) {
+        for (Real i : rho) {
             for (Integer sgn=-1; sgn < 2; sgn+=2) {
                 Bivariate bvn(sgn * i);
                 Real expected = 0.25 + std::asin(sgn * i) / (2 * M_PI);
@@ -720,8 +720,8 @@ void DistributionTest::testSankaranApproximation() {
     const Real ncps[] = {1,2,3,1,2,3};
 
     const Real tol = 0.01;
-    for (double df : dfs) {
-        for (double ncp : ncps) {
+    for (Real df : dfs) {
+        for (Real ncp : ncps) {
             const NonCentralCumulativeChiSquareDistribution d(df, ncp);
             const NonCentralCumulativeChiSquareSankaranApprox sankaran(df, ncp);
 

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -87,7 +87,7 @@ void DividendOptionTest::testEuropeanValues() {
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -115,10 +115,10 @@ void DividendOptionTest::testEuropeanValues() {
                 VanillaOption ref_option(payoff, exercise);
                 ref_option.setPricingEngine(ref_engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -237,7 +237,7 @@ void DividendOptionTest::testEuropeanStartLimit() {
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -261,10 +261,10 @@ void DividendOptionTest::testEuropeanStartLimit() {
                 VanillaOption ref_option(payoff, exercise);
                 ref_option.setPricingEngine(ref_engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -319,7 +319,7 @@ void DividendOptionTest::testEuropeanEndLimit() {
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -347,10 +347,10 @@ void DividendOptionTest::testEuropeanEndLimit() {
                 VanillaOption ref_option(refPayoff, exercise);
                 ref_option.setPricingEngine(ref_engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -408,7 +408,7 @@ void DividendOptionTest::testEuropeanGreeks() {
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -431,10 +431,10 @@ void DividendOptionTest::testEuropeanGreeks() {
                 DividendVanillaOption option(payoff, exercise, dividendDates, dividends);
                 option.setPricingEngine(engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -541,7 +541,7 @@ void DividendOptionTest::testFdEuropeanValues() {
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -573,10 +573,10 @@ void DividendOptionTest::testFdEuropeanValues() {
                 DividendVanillaOption ref_option(payoff, exercise, dividendDates, dividends);
                 ref_option.setPricingEngine(ref_engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -631,7 +631,7 @@ namespace {
         Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
 
                 std::vector<Date> dividendDates;
                 std::vector<Real> dividends;
@@ -656,10 +656,10 @@ namespace {
                                              dividendDates, dividends);
                 option.setPricingEngine(engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -637,8 +637,8 @@ void EuropeanOptionTest::testGreeks() {
     ext::shared_ptr<StrikedTypePayoff> payoff;
 
     for (auto& type : types) {
-        for (double strike : strikes) {
-            for (double residualTime : residualTimes) {
+        for (Real strike : strikes) {
+            for (Real residualTime : residualTimes) {
                 Date exDate = today + timeToDays(residualTime);
                 ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
                 for (Size kk = 0; kk < 4; kk++) {
@@ -663,10 +663,10 @@ void EuropeanOptionTest::testGreeks() {
                     EuropeanOption option(payoff, exercise);
                     option.setPricingEngine(engine);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
                                     Rate q = m, r = n;
                                     spot->setValue(u);
                                     qRate->setValue(q);
@@ -785,7 +785,7 @@ void EuropeanOptionTest::testImpliedVol() {
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     for (auto& type : types) {
-        for (double& strike : strikes) {
+        for (Real& strike : strikes) {
             for (int length : lengths) {
                 // option to check
                 Date exDate = today + length;
@@ -797,10 +797,10 @@ void EuropeanOptionTest::testImpliedVol() {
                 ext::shared_ptr<GeneralizedBlackScholesProcess> process =
                     makeProcess(spot, qTS, rTS, volTS);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
                                 Rate q = m, r = n;
                                 spot->setValue(u);
                                 qRate->setValue(q);
@@ -982,7 +982,7 @@ namespace {
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today,rRate,dc);
 
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 for (int length : lengths) {
                     Date exDate = today + length * 360;
                     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -995,10 +995,10 @@ namespace {
                     ext::shared_ptr<VanillaOption> option = makeOption(
                         payoff, exercise, spot, qTS, rTS, volTS, engine, binomialSteps, samples);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
                                     Rate q = m, r = n;
                                     spot->setValue(u);
                                     qRate->setValue(q);
@@ -1577,7 +1577,7 @@ void EuropeanOptionTest::testPDESchemes() {
     }
 
     const Real expectedDiv = std::accumulate(
-        dividendPrices.begin(), dividendPrices.end(), 0.0)/nEngines;
+        dividendPrices.begin(), dividendPrices.end(), Real(0.0))/nEngines;
 
     for (Size i=0; i < nEngines; ++i) {
         const Real calculated = dividendPrices[i];

--- a/test-suite/extendedtrees.cpp
+++ b/test-suite/extendedtrees.cpp
@@ -172,7 +172,7 @@ namespace {
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today,rRate,dc);
 
         for (auto& type : types) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 for (int length : lengths) {
                     Date exDate = today + length * 360;
                     ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
@@ -184,10 +184,10 @@ namespace {
                     ext::shared_ptr<VanillaOption> option =
                         makeOption(payoff, exercise, spot, qTS, rTS, volTS, engine, binomialSteps);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
                                     Rate q = m, r = n;
                                     spot->setValue(u);
                                     qRate->setValue(q);

--- a/test-suite/fdcev.cpp
+++ b/test-suite/fdcev.cpp
@@ -57,7 +57,7 @@ void FdCevTest::testLocalMartingale() {
     const Real alpha = 1.75;
     const Real betas[] = {-2.4, 0.23, 0.9, 1.1, 1.5};
 
-    for (double beta : betas) {
+    for (Real beta : betas) {
         const CEVRNDCalculator rndCalculator(f0, alpha, beta);
 
         const Real eps = 1e-10;
@@ -154,7 +154,7 @@ void FdCevTest::testFdmCevOp() {
         const Real alpha = 0.75;
 
         const Real betas[] = { -2.0, -0.5, 0.45, 0.6, 0.9, 1.45 };
-        for (double beta : betas) {
+        for (Real beta : betas) {
 
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(ext::make_shared<AnalyticCEVEngine>(

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -522,7 +522,7 @@ void FdHestonTest::testFdmHestonBlackScholes() {
     Real strikes[]  = { 8, 9, 10, 11, 12 };
     const Real tol = 0.0001;
 
-    for (double& strike : strikes) {
+    for (Real& strike : strikes) {
         Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(strike)));
 
         ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
@@ -676,7 +676,7 @@ void FdHestonTest::testFdmHestonConvergence() {
     for (const auto& scheme : schemes) {
         for (auto& value : values) {
             for (unsigned long j : tn) {
-                for (double k : v0) {
+                for (Real k : v0) {
                     Handle<YieldTermStructure> rTS(flatRate(value.r, Actual365Fixed()));
                     Handle<YieldTermStructure> qTS(flatRate(value.q, Actual365Fixed()));
 

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -223,7 +223,7 @@ void FdmLinearOpTest::testUniformGridMesher() {
     const Real dx2 = 95.0/(dim[1]-1);
     const Real dx3 = 10.0/(dim[2]-1);
 
-    constexpr Real tol = 100*QL_EPSILON;
+    const Real tol = 100*QL_EPSILON;
     if (   std::fabs(dx1-mesher.dminus(layout->begin(),0)) > tol
         || std::fabs(dx1-mesher.dplus(layout->begin(),0)) > tol
         || std::fabs(dx2-mesher.dminus(layout->begin(),1)) > tol
@@ -1252,7 +1252,7 @@ void FdmLinearOpTest::testBiCGstab() {
 
     Array b(n*m);
     MersenneTwisterUniformRng rng(1234);
-    for (double& i : b) {
+    for (Real& i : b) {
         i = rng.next().value;
     }
 
@@ -1288,7 +1288,7 @@ void FdmLinearOpTest::testGMRES() {
     
     Array b(n*m);
     MersenneTwisterUniformRng rng(1234);
-    for (double& i : b) {
+    for (Real& i : b) {
         i = rng.next().value;
     }
 
@@ -1671,7 +1671,7 @@ void FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher() 
     const Real calculatedMin = std::exp(loc.front());
 
 
-    constexpr Real relTol = 1e5*QL_EPSILON;
+    const Real relTol = 1e5*QL_EPSILON;
 
     const Real maxDiff = std::fabs(calculatedMax - maximum);
     if (maxDiff > relTol*maximum) {

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -223,7 +223,7 @@ void FdmLinearOpTest::testUniformGridMesher() {
     const Real dx2 = 95.0/(dim[1]-1);
     const Real dx3 = 10.0/(dim[2]-1);
 
-    const Real tol = 100*QL_EPSILON;
+    constexpr double tol = 100*QL_EPSILON;
     if (   std::fabs(dx1-mesher.dminus(layout->begin(),0)) > tol
         || std::fabs(dx1-mesher.dplus(layout->begin(),0)) > tol
         || std::fabs(dx2-mesher.dminus(layout->begin(),1)) > tol
@@ -1671,7 +1671,7 @@ void FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher() 
     const Real calculatedMin = std::exp(loc.front());
 
 
-    const Real relTol = 1e5*QL_EPSILON;
+    constexpr double relTol = 1e5*QL_EPSILON;
 
     const Real maxDiff = std::fabs(calculatedMax - maximum);
     if (maxDiff > relTol*maximum) {

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -144,7 +144,7 @@ void FdSabrTest::testFdmSabrOp() {
             Handle<Quote>(ext::make_shared<SimpleQuote>(f0)),
             rTS, rTS, Handle<BlackVolTermStructure>(flatVol(0.2, dc)));
 
-    for (double beta : betas) {
+    for (Real beta : betas) {
 
         const ext::shared_ptr<PricingEngine> pdeEngine =
             ext::make_shared<FdSabrVanillaEngine>(f0, alpha, beta, nu, rho, rTS, 100, 400, 100);
@@ -230,13 +230,13 @@ void FdSabrTest::testFdmSabrCevPricing() {
     const Real tol = 5e-5;
 
     for (auto optionType : optionTypes) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             const ext::shared_ptr<PlainVanillaPayoff> payoff =
                 ext::make_shared<PlainVanillaPayoff>(optionType, strike);
 
             VanillaOption option(payoff, exercise);
 
-            for (double beta : betas) {
+            for (Real beta : betas) {
                 option.setPricingEngine(ext::make_shared<FdSabrVanillaEngine>(
                     f0, alpha, beta, nu, rho, rTS, 100, 400, 3));
 
@@ -297,7 +297,7 @@ void FdSabrTest::testFdmSabrVsVolApproximation() {
 
     const Real tol = 2.5e-3;
     for (auto optionType : optionTypes) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             VanillaOption option(ext::make_shared<PlainVanillaPayoff>(optionType, strike),
                                  ext::make_shared<EuropeanExercise>(maturityDate));
 

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -240,7 +240,7 @@ namespace {
                             new Engine<AnalyticEuropeanEngine>(stochProcess));
 
         for (auto& type : types) {
-            for (double& moneynes : moneyness) {
+            for (Real& moneynes : moneyness) {
                 for (int length : lengths) {
                     for (int startMonth : startMonths) {
 
@@ -255,10 +255,10 @@ namespace {
                         ForwardVanillaOption option(moneynes, reset, payoff, exercise);
                         option.setPricingEngine(engine);
 
-                        for (double u : underlyings) {
-                            for (double m : qRates) {
-                                for (double n : rRates) {
-                                    for (double v : vols) {
+                        for (Real u : underlyings) {
+                            for (Real m : qRates) {
+                                for (Real n : rRates) {
+                                    for (Real v : vols) {
 
                                         Rate q = m, r = n;
                                         spot->setValue(u);

--- a/test-suite/forwardrateagreement.cpp
+++ b/test-suite/forwardrateagreement.cpp
@@ -90,7 +90,7 @@ void ForwardRateAgreementTest::testConstructionWithoutACurve() {
         quotes[1]->setValue(0.02);
         quotes[2]->setValue(0.03);
 
-        double rate = fra.forwardRate();
+        Real rate = fra.forwardRate();
         if (std::fabs(rate - 0.01) > 1e-6) {
             BOOST_ERROR("grid creation failed, got rate " << rate << " expected " << 0.01);
         }

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -258,7 +258,7 @@ void GaussianQuadraturesTest::testNonCentralChiSquaredSumOfNodes() {
 
 	 for (Size n = 4; n < 10; ++n) {
 		 const Array x = GaussianQuadrature(n, orthPoly).x();
-         const Real calculated = std::accumulate(x.begin(), x.end(), 0.0);
+         const Real calculated = std::accumulate(x.begin(), x.end(), Real(0.0));
 
 
          if (std::fabs(calculated - expected[n-4]) > tol) {

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -2048,7 +2048,7 @@ void HestonModelTest::testCharacteristicFct() {
     const COSHestonEngine cosEngine(model);
     const AnalyticHestonEngine analyticEngine(model);
 
-    const Real tol = 100*QL_EPSILON;
+    constexpr double tol = 100*QL_EPSILON;
     for (Real i : u) {
         for (Real j : t) {
             const std::complex<Real> c = cosEngine.chF(i, j);
@@ -2423,7 +2423,7 @@ void HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF() {
                 TimeGrid(dayCounter.yearFraction(settlementDate, maturityDate),
                          10))));
 
-    const Real tol = 100 * QL_EPSILON;
+    constexpr double tol = 100 * QL_EPSILON;
     for (Real r = 0.1; r < 4; r+=0.25) {
         for (Real phi = 0; phi < 360; phi+=60) {
             for (Time t=0.1; t <= 1.0; t+=0.3) {

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -940,7 +940,7 @@ void HestonModelTest::testDifferentIntegrals() {
             ext::shared_ptr<Exercise> exercise(
                 ext::make_shared<EuropeanExercise>(settlementDate + Period(maturitie, Months)));
 
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 for (auto type : types) {
 
                     ext::shared_ptr<StrikedTypePayoff> payoff(
@@ -1026,7 +1026,7 @@ void HestonModelTest::testMultipleStrikesEngine() {
     multiStrikeEngine->enableMultipleStrikesCaching(strikes);
 
     Real relTol = 5e-3;
-    for (double& strike : strikes) {
+    for (Real& strike : strikes) {
         ext::shared_ptr<StrikedTypePayoff> payoff(
             ext::make_shared<PlainVanillaPayoff>(Option::Put, strike));
 
@@ -2048,9 +2048,9 @@ void HestonModelTest::testCharacteristicFct() {
     const COSHestonEngine cosEngine(model);
     const AnalyticHestonEngine analyticEngine(model);
 
-    constexpr Real tol = 100*QL_EPSILON;
-    for (double i : u) {
-        for (double j : t) {
+    const Real tol = 100*QL_EPSILON;
+    for (Real i : u) {
+        for (Real j : t) {
             const std::complex<Real> c = cosEngine.chF(i, j);
             const std::complex<Real> a = analyticEngine.chF(i, j);
 
@@ -2169,7 +2169,7 @@ void HestonModelTest::testAndersenPiterbargPricing() {
         const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
 
         for (auto optionType : optionTypes) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 VanillaOption option(ext::make_shared<PlainVanillaPayoff>(optionType, strike),
                                      exercise);
 
@@ -2423,7 +2423,7 @@ void HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF() {
                 TimeGrid(dayCounter.yearFraction(settlementDate, maturityDate),
                          10))));
 
-    constexpr Real tol = 100*QL_EPSILON;
+    const Real tol = 100 * QL_EPSILON;
     for (Real r = 0.1; r < 4; r+=0.25) {
         for (Real phi = 0; phi < 360; phi+=60) {
             for (Time t=0.1; t <= 1.0; t+=0.3) {
@@ -2868,9 +2868,9 @@ void HestonModelTest::testSmallSigmaExpansion4ExpFitting() {
 
         Option::Type optionType = Option::Call;
 
-        for (double kappa : kappas) {
-            for (double theta : thetas) {
-                for (double v0 : v0s) {
+        for (Real kappa : kappas) {
+            for (Real theta : thetas) {
+                for (Real v0 : v0s) {
                     const ext::shared_ptr<PricingEngine> engine =
                         ext::make_shared<ExponentialFittingHestonEngine>(
                             ext::make_shared<HestonModel>(ext::make_shared<HestonProcess>(

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -212,7 +212,7 @@ void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation() {
 		ext::make_shared<EuropeanExercise>(maturityDate));
     const Real strikes[] = { 50, 80, 100, 130, 150 };
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         const ext::shared_ptr<StrikedTypePayoff> payoff(
             ext::make_shared<PlainVanillaPayoff>(Option::Call, strike));
 
@@ -828,7 +828,7 @@ namespace {
             }
 
             Real avg=0, min=QL_MAX_REAL, max=0;
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 const ext::shared_ptr<StrikedTypePayoff> payoff(
                     ext::make_shared<PlainVanillaPayoff>((strike > s0) ? Option::Call : Option::Put,
                                                          strike));
@@ -1433,7 +1433,7 @@ namespace {
                         hestonModel.currentLink(), Size(std::max(51.0, 51 * time / 12.0)), 201, 101,
                         0, FdmSchemeDesc::ModifiedCraigSneyd(), l));
 
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 const ext::shared_ptr<StrikedTypePayoff> payoff(
                     ext::make_shared<PlainVanillaPayoff>((strike > s0) ? Option::Call : Option::Put,
                                                          strike));
@@ -1659,7 +1659,7 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
     const ext::shared_ptr<PricingEngine> hestonEngine(
 		ext::make_shared<AnalyticHestonEngine>(hestonModel.currentLink(), 164));
 
-    for (double strike : strikeValues) {
+    for (Real strike : strikeValues) {
         for (auto maturitie : maturities) {
             const Date exerciseDate = todaysDate + maturitie;
             const Time t = dc.yearFraction(todaysDate, exerciseDate);
@@ -1905,7 +1905,7 @@ void HestonSLVModelTest::testMonteCarloVsFdmPricing() {
             FdmSchemeDesc::ModifiedCraigSneyd(), leverageFct, 0.1);
 
     const Real strikes[] = { s0, 1.1*s0 };
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::make_shared<PlainVanillaPayoff>(Option::Call, strike);
 
@@ -2025,7 +2025,7 @@ void HestonSLVModelTest::testMonteCarloCalibration() {
             const ext::shared_ptr<Exercise> exercise
                 = ext::make_shared<EuropeanExercise>(maturity);
 
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 const ext::shared_ptr<StrikedTypePayoff> payoff =
                     ext::make_shared<PlainVanillaPayoff>(strike < s0 ? Option::Put : Option::Call,
                                                          strike);
@@ -2654,7 +2654,7 @@ void HestonSLVModelTest::testBarrierPricingMixedModelsMonteCarloVsFdmPricing() {
         ext::make_shared<SobolBrownianGeneratorFactory>(SobolBrownianGenerator::Diagonal, 1234UL,
                                                         SobolRsg::JoeKuoD7));
 
-    for (double mixingFactor : mixingFactors) {
+    for (Real mixingFactor : mixingFactors) {
 
         // Finite Difference calibration
         const HestonSLVFokkerPlanckFdmParams logParams = {

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -213,7 +213,7 @@ void HybridHestonHullWhiteProcessTest::testCompareBsmHWandHestonHW() {
     const Option::Type types[] = { Option::Put, Option::Call };
 
     for (auto type : types) {
-        for (double j : strike) {
+        for (Real j : strike) {
             for (unsigned long l : maturity) {
                 const Date maturityDate = today + Period(l, Years);
 
@@ -409,8 +409,8 @@ void HybridHestonHullWhiteProcessTest::testMcVanillaPricing() {
     const Real corr[] = {-0.9, -0.5, 0.0, 0.5, 0.9 };
     const Real strike[] = { 100 };
 
-    for (double i : corr) {
-        for (double j : strike) {
+    for (Real i : corr) {
+        for (Real j : strike) {
             ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
                 new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, i));
 
@@ -496,8 +496,8 @@ void HybridHestonHullWhiteProcessTest::testMcPureHestonPricing() {
     const Real corr[] = { -0.45, 0.45, 0.25 };
     const Real strike[] = { 100, 75, 50, 150 };
 
-    for (double i : corr) {
-        for (double j : strike) {
+    for (Real i : corr) {
+        for (Real j : strike) {
             ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
                 new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, i,
                                                  HybridHestonHullWhiteProcess::Euler));
@@ -586,7 +586,7 @@ void HybridHestonHullWhiteProcessTest::testAnalyticHestonHullWhitePricing() {
     const Option::Type types[] = { Option::Put, Option::Call };
 
     for (auto type : types) {
-        for (double j : strike) {
+        for (Real j : strike) {
             ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
                 new HybridHestonHullWhiteProcess(
                         hestonProcess, hwFwdProcess, 0.0,
@@ -789,8 +789,8 @@ void HybridHestonHullWhiteProcessTest::testDiscretizationError() {
     const Real corr[] = {-0.85, 0.5 };
     const Real strike[] = { 50, 100, 125 };
 
-    for (double i : corr) {
-        for (double j : strike) {
+    for (Real i : corr) {
+        for (Real j : strike) {
             ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Put, j));
             ext::shared_ptr<Exercise> exercise(
                                new EuropeanExercise(maturity));
@@ -861,8 +861,8 @@ void HybridHestonHullWhiteProcessTest::testFdmHestonHullWhiteEngine() {
     const Real corr[] = {-0.85, 0.5 };
     const Real strike[] = { 75, 120, 160 };
 
-    for (double i : corr) {
-        for (double j : strike) {
+    for (Real i : corr) {
+        for (Real j : strike) {
             ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Call, j));
             VanillaOption option(payoff, exercise);
 
@@ -1054,7 +1054,7 @@ void HybridHestonHullWhiteProcessTest::testBsmHullWhitePricing() {
                 fdEngine->enableMultipleStrikesCaching(strikes);
 
                 Real avgPriceDiff = 0.0;
-                for (double& strike : strikes) {
+                for (Real& strike : strikes) {
                     VanillaOptionData optionData = {strike, maturity, Option::Call};
                     ext::shared_ptr<VanillaOption> option
                                         = makeVanillaOption(optionData);
@@ -1119,7 +1119,7 @@ void HybridHestonHullWhiteProcessTest::testSpatialDiscretizatinError() {
                         schemes[i].schemeDesc));
                 fdEngine->enableMultipleStrikesCaching(strikes);
 
-                for (double& strike : strikes) {
+                for (Real& strike : strikes) {
                     VanillaOptionData optionData = {strike, maturity, Option::Call};
                     ext::shared_ptr<VanillaOption> option
                                         = makeVanillaOption(optionData);

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -291,9 +291,9 @@ void InflationCapFloorTest::testConsistency() {
 
     for (Size whichPricer = 0; whichPricer < 3; whichPricer++) {
         for (int& length : lengths) {
-            for (double& cap_rate : cap_rates) {
-                for (double& floor_rate : floor_rates) {
-                    for (double vol : vols) {
+            for (Real& cap_rate : cap_rates) {
+                for (Real& floor_rate : floor_rates) {
+                    for (Real vol : vols) {
 
                         Leg leg = vars.makeYoYLeg(vars.evaluationDate, length);
 
@@ -413,8 +413,8 @@ void InflationCapFloorTest::testParity() {
     // cap-floor-swap parity is model-independent
     for (Size whichPricer = 0; whichPricer < 3; whichPricer++) {
         for (int& length : lengths) {
-            for (double strike : strikes) {
-                for (double vol : vols) {
+            for (Real strike : strikes) {
+                for (Real vol : vols) {
 
                     Leg leg = vars.makeYoYLeg(vars.evaluationDate, length);
 

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -712,8 +712,8 @@ void InflationCapFlooredCouponTest::testInstrumentEquality() {
     // floored coupon = fwd + floor
     for (Size whichPricer = 0; whichPricer < 3; whichPricer++) {
         for (int& length : lengths) {
-            for (double& strike : strikes) {
-                for (double vol : vols) {
+            for (Real& strike : strikes) {
+                for (Real vol : vols) {
 
                     Leg leg = vars.makeYoYLeg(vars.evaluationDate, length);
 

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -222,9 +222,9 @@ namespace inflation_volatility_test {
         cStrikesEU.clear();
         fStrikesEU.clear();
         cfMaturitiesEU.clear();
-        for (double& i : capStrikesEU)
+        for (Real& i : capStrikesEU)
             cStrikesEU.push_back(i);
-        for (double& i : floorStrikesEU)
+        for (Real& i : floorStrikesEU)
             fStrikesEU.push_back(i);
         for (auto& i : capMaturitiesEU)
             cfMaturitiesEU.push_back(i);

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1406,7 +1406,7 @@ void InterpolationTest::testKernelInterpolation() {
 
     // Check that y-values at knots are exactly the feeded y-values,
     // irrespective of kernel parameters
-    for (double i : lambdaVec) {
+    for (Real i : lambdaVec) {
         GaussianKernel myKernel(0, i);
 
         for (auto currY : yd) {
@@ -2191,7 +2191,7 @@ void InterpolationTest::testLagrangeInterpolation() {
         0.5130076920869246
     };
 
-    constexpr Real tol = 50*QL_EPSILON;
+    const Real tol = 50*QL_EPSILON;
     for (Size i=0; i < 79; ++i) {
         const Real xx = -1.0 + i*0.025;
         const Real calculated = interpl(xx);
@@ -2373,7 +2373,7 @@ void InterpolationTest::testBackwardFlatOnSinglePoint() {
 
     const Real x[] = { -1.0, 1.0, 2.0, 3.0 };
 
-    for (double i : x) {
+    for (Real i : x) {
         const Real calculated = impl(i, true);
         const Real expected = values[0];
 

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2191,7 +2191,7 @@ void InterpolationTest::testLagrangeInterpolation() {
         0.5130076920869246
     };
 
-    const Real tol = 50*QL_EPSILON;
+    constexpr double tol = 50*QL_EPSILON;
     for (Size i=0; i < 79; ++i) {
         const Real xx = -1.0 + i*0.025;
         const Real calculated = interpl(xx);

--- a/test-suite/jumpdiffusion.cpp
+++ b/test-suite/jumpdiffusion.cpp
@@ -400,14 +400,14 @@ void JumpDiffusionTest::testGreeks() {
                                  new JumpDiffusionEngine(stochProcess,1e-08));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
-            for (double& jj1 : jInt) {
+        for (Real strike : strikes) {
+            for (Real& jj1 : jInt) {
                 jumpIntensity->setValue(jj1);
-                for (double& jj2 : mLJ) {
+                for (Real& jj2 : mLJ) {
                     meanLogJump->setValue(jj2);
-                    for (double& jj3 : jV) {
+                    for (Real& jj3 : jV) {
                         jumpVol->setValue(jj3);
-                        for (double residualTime : residualTimes) {
+                        for (Real residualTime : residualTimes) {
                             Date exDate = today + timeToDays(residualTime);
                             ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
                             for (Size kk = 0; kk < 1; kk++) {
@@ -422,10 +422,10 @@ void JumpDiffusionTest::testGreeks() {
                                 EuropeanOption option(payoff, exercise);
                                 option.setPricingEngine(engine);
 
-                                for (double u : underlyings) {
-                                    for (double q : qRates) {
-                                        for (double r : rRates) {
-                                            for (double v : vols) {
+                                for (Real u : underlyings) {
+                                    for (Real q : qRates) {
+                                        for (Real r : rRates) {
+                                            for (Real v : vols) {
                                                 spot->setValue(u);
                                                 qRate->setValue(q);
                                                 rRate->setValue(r);

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -178,7 +178,7 @@ void LiborMarketModelProcessTest::testLambdaBootstrapping() {
     std::vector<Time> tmp = process->fixingTimes();
     TimeGrid grid(tmp.begin(), tmp.end(), 14);
 
-    for (double t : grid) {
+    for (Real t : grid) {
         Matrix diff = (param->integratedCovariance(t) -
                        param->LfmCovarianceParameterization::integratedCovariance(t));
 

--- a/test-suite/margrabeoption.cpp
+++ b/test-suite/margrabeoption.cpp
@@ -327,7 +327,7 @@ void MargrabeOptionTest::testGreeks() {
     ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(vol2, dc);
 
-    for (double residualTime : residualTimes) {
+    for (Real residualTime : residualTimes) {
         Date exDate = today + timeToDays(residualTime);
         ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
 
@@ -359,7 +359,7 @@ void MargrabeOptionTest::testGreeks() {
 
             for (Size l = 0; l < LENGTH(underlyings1); l++) {
                 for (Size m=0; m<LENGTH(qRates1); m++) {
-                    for (double n : rRates) {
+                    for (Real n : rRates) {
                         for (Size p = 0; p < LENGTH(vols1); p++) {
                             Real u1 = underlyings1[l], u2 = underlyings2[l], u;
                             Rate q1 = qRates1[m], q2 = qRates2[m], r = n;

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -487,7 +487,7 @@ namespace market_model_test {
                     Real minError = QL_MAX_REAL;
                     Real maxError = QL_MIN_REAL;
                     Real errorThreshold = subProductExpectedValue->errorThreshold;
-                    for (double value : subProductExpectedValue->values) {
+                    for (Real value : subProductExpectedValue->values) {
                         Real stdDev =
                             (results[currentResultIndex] - value) / errors[currentResultIndex];
                         stdDevs.push_back(stdDev);

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -241,7 +241,7 @@ namespace {
         };
 
         q6m.reserve(10 + 15 + 35);
-        for (double i : q6mh) {
+        for (Real i : q6mh) {
             q6m.push_back(ext::shared_ptr<Quote>(new SimpleQuote(i)));
         }
 
@@ -650,7 +650,7 @@ void MarkovFunctionalTest::testKahaleSmileSection() {
     std::vector<Real> money;
     std::vector<Real> calls0;
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         money.push_back(strike / atm);
         calls0.push_back(blackFormula(Option::Call, strike, atm, 0.50 * std::sqrt(t), 1.0, 0.0));
     }

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -304,7 +304,7 @@ void MatricesTest::testQRSolve() {
         Array b(A.rows());
 
         for (Size k=0; k < 10; ++k) {
-            for (double& iter : b) {
+            for (Real& iter : b) {
                 iter = rng.next().value;
             }
             const Array x = qrSolve(A, b, true);
@@ -329,7 +329,7 @@ void MatricesTest::testQRSolve() {
                     if (w[i] > threshold) {
                         const Real u = std::inner_product(U.column_begin(i),
                                                           U.column_end(i),
-                                                          b.begin(), 0.0)/w[i];
+                                                          b.begin(), Real(0.0))/w[i];
 
                         for (Size j=0; j<n; ++j) {
                             xr[j]  +=u*V[j][i];
@@ -402,7 +402,7 @@ void MatricesTest::testDeterminant() {
     MersenneTwisterUniformRng rng(1234);
     for (Size j=0; j<100; ++j) {
         Matrix m(3, 3, 0.0);
-        for (double& iter : m)
+        for (Real& iter : m)
             iter = rng.next().value;
 
         if ((j % 3) == 0U) {
@@ -592,7 +592,7 @@ void MatricesTest::testMoorePenroseInverse() {
 
     Real cached[6] = {1.153846153846152, 1.461538461538463, 1.384615384615384,
                       1.384615384615385, 1.461538461538462, 1.153846153846152};
-    constexpr Real tol = 500.0 * QL_EPSILON;
+    const Real tol = 500.0 * QL_EPSILON;
 
     for (Size i = 0; i < 6; ++i) {
         if (std::abs(x[i] - cached[i]) > tol) {
@@ -605,7 +605,7 @@ void MatricesTest::testMoorePenroseInverse() {
     }
 
     Array y = A*x;
-    constexpr Real tol2 = 2000.0 * QL_EPSILON;
+    const Real tol2 = 2000.0 * QL_EPSILON;
     for (Size i = 0; i < 6; ++i) {
         if (std::abs(y[i] - 260.0) > tol2) {
             BOOST_FAIL(
@@ -646,7 +646,7 @@ void MatricesTest::testIterativeSolvers() {
     Array b(3);
     b[0] = 1.0; b[1] = 0.5; b[2] = 3.0;
 
-    constexpr Real relTol = 1e4*QL_EPSILON;
+    const Real relTol = 1e4 * QL_EPSILON;
 
     const Array x = BiCGstab(MatrixMult(M1), 3, relTol).solve(b).x;
     if (norm2(M1*x-b)/norm2(b) > relTol) {
@@ -662,7 +662,7 @@ void MatricesTest::testIterativeSolvers() {
                 << "\n  rel tolerance : " << relTol);
     }
     const Array errors = Array(u.errors.begin(), u.errors.end());
-    for (double error : errors) {
+    for (Real error : errors) {
         const Array x = GMRES(MatrixMult(M1), 10, 1.01 * error).solve(b, b).x;
 
         const Real calculated = norm2(M1*x-b)/norm2(b);

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -592,7 +592,7 @@ void MatricesTest::testMoorePenroseInverse() {
 
     Real cached[6] = {1.153846153846152, 1.461538461538463, 1.384615384615384,
                       1.384615384615385, 1.461538461538462, 1.153846153846152};
-    const Real tol = 500.0 * QL_EPSILON;
+    constexpr double tol = 500.0 * QL_EPSILON;
 
     for (Size i = 0; i < 6; ++i) {
         if (std::abs(x[i] - cached[i]) > tol) {
@@ -605,7 +605,7 @@ void MatricesTest::testMoorePenroseInverse() {
     }
 
     Array y = A*x;
-    const Real tol2 = 2000.0 * QL_EPSILON;
+    constexpr double tol2 = 2000.0 * QL_EPSILON;
     for (Size i = 0; i < 6; ++i) {
         if (std::abs(y[i] - 260.0) > tol2) {
             BOOST_FAIL(
@@ -646,7 +646,7 @@ void MatricesTest::testIterativeSolvers() {
     Array b(3);
     b[0] = 1.0; b[1] = 0.5; b[2] = 3.0;
 
-    const Real relTol = 1e4 * QL_EPSILON;
+    constexpr double relTol = 1e4 * QL_EPSILON;
 
     const Array x = BiCGstab(MatrixMult(M1), 3, relTol).solve(b).x;
     if (norm2(M1*x-b)/norm2(b) > relTol) {

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -81,7 +81,7 @@ void NormalCLVModelTest::testBSCumlativeDistributionFunction() {
     const BSMRNDCalculator rndCalculator(bsProcess);
 
 
-    constexpr Real tol = 1e5*QL_EPSILON;
+    const Real tol = 1e5 * QL_EPSILON;
     const Time t = dc.yearFraction(today, maturity);
     for (Real x=10; x < 400; x+=10) {
         const Real calculated = m.cdf(maturity, x);

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -81,7 +81,7 @@ void NormalCLVModelTest::testBSCumlativeDistributionFunction() {
     const BSMRNDCalculator rndCalculator(bsProcess);
 
 
-    const Real tol = 1e5 * QL_EPSILON;
+    constexpr double tol = 1e5 * QL_EPSILON;
     const Time t = dc.yearFraction(today, maturity);
     for (Real x=10; x < 400; x+=10) {
         const Real calculated = m.cdf(maturity, x);

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -590,7 +590,7 @@ namespace {
 
                     const Real offset = (specialPoint - 0.5*d) - loc[i];
 
-                    for (double& l : loc)
+                    for (Real& l : loc)
                         l += offset;
 
                     break;

--- a/test-suite/nthtodefault.cpp
+++ b/test-suite/nthtodefault.cpp
@@ -148,7 +148,7 @@ void NthToDefaultTest::testGauss() {
 
     vector<Handle<DefaultProbabilityTermStructure> > probabilities;
     Period maxTerm (10, Years);
-    for (double i : lambda) {
+    for (Real i : lambda) {
         Handle<Quote> h(ext::shared_ptr<Quote>(new SimpleQuote(i)));
         ext::shared_ptr<DefaultProbabilityTermStructure> ptr (
                                          new FlatHazardRate(asofDate, h, dc));
@@ -294,7 +294,7 @@ void NthToDefaultTest::testStudent() {
 
     vector<Handle<DefaultProbabilityTermStructure> > probabilities;
     Period maxTerm (10, Years);
-    for (double i : lambda) {
+    for (Real i : lambda) {
         Handle<Quote> h(ext::shared_ptr<Quote>(new SimpleQuote(i)));
         ext::shared_ptr<DefaultProbabilityTermStructure> ptr (
                                          new FlatHazardRate(asofDate, h, dc));

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -31,7 +31,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
     bool isTheSame(Real a, Real b) {
-        constexpr Real eps = 500*QL_EPSILON;
+        const Real eps = 500 * QL_EPSILON;
 
         if (std::fabs(b) < QL_EPSILON)
             return std::fabs(a) < eps;

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -31,7 +31,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
     bool isTheSame(Real a, Real b) {
-        const Real eps = 500 * QL_EPSILON;
+        constexpr double eps = 500 * QL_EPSILON;
 
         if (std::fabs(b) < QL_EPSILON)
             return std::fabs(a) < eps;

--- a/test-suite/ode.cpp
+++ b/test-suite/ode.cpp
@@ -197,8 +197,8 @@ void OdeTest::testMatrixExponentialOfZero() {
 
     Matrix m(3, 3, 0.0);
 
-    const Real tol = 100*QL_EPSILON;
-    const Real t=1.0;
+    constexpr double tol = 100*QL_EPSILON;
+    constexpr double t=1.0;
     const Matrix calculated = Expm(m, t);
 
     for (Size i=0; i < calculated.rows(); ++i) {

--- a/test-suite/ode.cpp
+++ b/test-suite/ode.cpp
@@ -24,6 +24,7 @@
 #include <ql/math/ode/adaptiverungekutta.hpp>
 #include <complex>
 
+
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
@@ -196,8 +197,8 @@ void OdeTest::testMatrixExponentialOfZero() {
 
     Matrix m(3, 3, 0.0);
 
-    constexpr Real tol = 100*QL_EPSILON;
-    constexpr Time t=1.0;
+    const Real tol = 100*QL_EPSILON;
+    const Real t=1.0;
     const Matrix calculated = Expm(m, t);
 
     for (Size i=0; i < calculated.rows(); ++i) {

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -205,7 +205,7 @@ namespace {
     Real maxDifference(const Array& a, const Array& b) {
         Array diff = a-b;
         Real maxDiff = 0.0;
-        for (double i : diff)
+        for (Real i : diff)
             maxDiff = std::max(maxDiff, std::fabs(i));
         return maxDiff;
     }
@@ -390,7 +390,7 @@ namespace {
         }
         Real value(const Array& x) const override {
             Real fx = 0.0;
-            for (double i : x) {
+            for (Real i : x) {
                 fx += std::floor(i) * std::floor(i);
             }
             return fx;
@@ -422,7 +422,7 @@ namespace {
         }
         Real value(const Array& x) const override {
             Real fx = 0.0;
-            for (double i : x) {
+            for (Real i : x) {
                 fx += i * i / 4000.0;
             }
             Real p = 1.0;

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -189,7 +189,7 @@ void OvernightIndexedSwapTest::testFairRate() {
     Spread spreads[] = { -0.001, -0.01, 0.0, 0.01, 0.001 };
 
     for (auto& length : lengths) {
-        for (double spread : spreads) {
+        for (Real spread : spreads) {
 
             ext::shared_ptr<OvernightIndexedSwap> swap = vars.makeSwap(length, 0.0, spread, false);
             ext::shared_ptr<OvernightIndexedSwap> swap2 = vars.makeSwap(length, 0.0, spread, true);
@@ -234,7 +234,7 @@ void OvernightIndexedSwapTest::testFairSpread() {
     Rate rates[] = { 0.04, 0.05, 0.06, 0.07 };
 
     for (auto& length : lengths) {
-        for (double j : rates) {
+        for (Real j : rates) {
 
             ext::shared_ptr<OvernightIndexedSwap> swap = vars.makeSwap(length, j, 0.0, false);
             ext::shared_ptr<OvernightIndexedSwap> swap2 = vars.makeSwap(length, j, 0.0, true);
@@ -418,7 +418,7 @@ void OvernightIndexedSwapTest::testSeasonedSwaps() {
     vars.eoniaIndex->addFixing(Date(5,February,2009), 0.0013);
 
     for (auto& length : lengths) {
-        for (double spread : spreads) {
+        for (Real spread : spreads) {
 
             ext::shared_ptr<OvernightIndexedSwap> swap =
                 vars.makeSwap(length, 0.0, spread, false, effectiveDate);

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -346,7 +346,7 @@ void QuantoOptionTest::testGreeks() {
                                                   Handle<Quote>(correlation)));
 
     for (auto& type : types) {
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             for (int length : lengths) {
 
                 Date exDate = today + length * Years;
@@ -357,13 +357,13 @@ void QuantoOptionTest::testGreeks() {
                 QuantoVanillaOption option(payoff, exercise);
                 option.setPricingEngine(engine);
 
-                for (double u : underlyings) {
-                    for (double m : qRates) {
-                        for (double n : rRates) {
-                            for (double v : vols) {
-                                for (double fxr : rRates) {
-                                    for (double fxv : vols) {
-                                        for (double corr : correlations) {
+                for (Real u : underlyings) {
+                    for (Real m : qRates) {
+                        for (Real n : rRates) {
+                            for (Real v : vols) {
+                                for (Real fxr : rRates) {
+                                    for (Real fxv : vols) {
+                                        for (Real corr : correlations) {
 
                                             Rate q = m, r = n;
                                             spot->setValue(u);
@@ -624,7 +624,7 @@ void QuantoOptionTest::testForwardGreeks() {
                                                  Handle<Quote>(correlation)));
 
     for (auto& type : types) {
-        for (double moneynes : moneyness) {
+        for (Real moneynes : moneyness) {
             for (int length : lengths) {
                 for (int startMonth : startMonths) {
 
@@ -638,13 +638,13 @@ void QuantoOptionTest::testForwardGreeks() {
                     QuantoForwardVanillaOption option(moneynes, reset, payoff, exercise);
                     option.setPricingEngine(engine);
 
-                    for (double u : underlyings) {
-                        for (double m : qRates) {
-                            for (double n : rRates) {
-                                for (double v : vols) {
-                                    for (double fxr : rRates) {
-                                        for (double fxv : vols) {
-                                            for (double corr : correlations) {
+                    for (Real u : underlyings) {
+                        for (Real m : qRates) {
+                            for (Real n : rRates) {
+                                for (Real v : vols) {
+                                    for (Real fxr : rRates) {
+                                        for (Real fxv : vols) {
+                                            for (Real corr : correlations) {
 
                                                 Rate q = m, r = n;
                                                 spot->setValue(u);

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -75,12 +75,12 @@ void RiskNeutralDensityCalculatorTest::testDensityAgainstOptionPrices() {
     const Time times[] = { 0.5, 1.0, 2.0 };
     const Real strikes[] = { 75.0, 100.0, 150.0 };
 
-    for (double t : times) {
+    for (Real t : times) {
         const Volatility stdDev = v * std::sqrt(t);
         const DiscountFactor df = rTS->discount(t);
         const Real fwd = s0*qTS->discount(t)/df;
 
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             const Real xs = std::log(strike);
             const BlackCalculator blackCalc(
                 Option::Put, strike, fwd, stdDev, df);
@@ -159,8 +159,8 @@ void RiskNeutralDensityCalculatorTest::testBSMagainstHestonRND() {
     const Real strikes[] = { 7.5, 10, 15 };
     const Real probs[] = { 1e-6, 0.01, 0.5, 0.99, 1.0-1e-6 };
 
-    for (double t : times) {
-        for (double strike : strikes) {
+    for (Real t : times) {
+        for (Real strike : strikes) {
             const Real xs = std::log(strike);
 
             const Real expectedPDF = bsm.pdf(xs, t);
@@ -189,7 +189,7 @@ void RiskNeutralDensityCalculatorTest::testBSMagainstHestonRND() {
             }
         }
 
-        for (double prob : probs) {
+        for (Real prob : probs) {
             const Real expectedInvCDF = bsm.invcdf(prob, t);
             const Real calculatedInvCDF = heston.invcdf(prob, t);
 
@@ -432,7 +432,7 @@ void RiskNeutralDensityCalculatorTest::testLocalVolatilityRND() {
 
         const ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
 
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             const ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(
                 (strike > spot->value()) ? Option::Call : Option::Put, strike));
 
@@ -613,7 +613,7 @@ void RiskNeutralDensityCalculatorTest::testBlackScholesWithSkew() {
 
     const Real strikes[] = { 85, 75, 90, 110, 125, 150 };
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         const Real logStrike = std::log(strike);
 
         const Real expected = hestonCalc.cdf(logStrike, maturity);
@@ -645,7 +645,7 @@ void RiskNeutralDensityCalculatorTest::testBlackScholesWithSkew() {
         }
     }
 
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         const Real logStrike = std::log(strike);
 
         const Real expected = hestonCalc.pdf(logStrike, maturity)/strike;
@@ -679,7 +679,7 @@ void RiskNeutralDensityCalculatorTest::testBlackScholesWithSkew() {
     }
 
     const Real quantiles[] = { 0.05, 0.25, 0.5, 0.75, 0.95 };
-    for (double quantile : quantiles) {
+    for (Real quantile : quantiles) {
         const Real expected = std::exp(hestonCalc.invcdf(quantile, maturity));
         const Real calculatedGBSM = gbsmCalc.invcdf(quantile, maturity);
 

--- a/test-suite/rngtraits.cpp
+++ b/test-suite/rngtraits.cpp
@@ -36,7 +36,7 @@ void RngTraitsTest::testGaussian() {
 
     const std::vector<Real>& values = rsg.nextSequence().value;
     Real sum = 0.0;
-    for (double value : values)
+    for (Real value : values)
         sum += value;
 
     Real stored = 4.09916;
@@ -59,7 +59,7 @@ void RngTraitsTest::testDefaultPoisson() {
 
     const std::vector<Real>& values = rsg.nextSequence().value;
     Real sum = 0.0;
-    for (double value : values)
+    for (Real value : values)
         sum += value;
 
     Real stored = 108.0;
@@ -82,7 +82,7 @@ void RngTraitsTest::testCustomPoisson() {
 
     const std::vector<Real>& values = rsg.nextSequence().value;
     Real sum = 0.0;
-    for (double value : values)
+    for (Real value : values)
         sum += value;
 
     Real stored = 409.0;

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -376,7 +376,7 @@ void ShortRateModelTest::testSwaps() {
             Schedule floatSchedule(startDate, maturity, Period(Semiannual),
                                    calendar, Following, Following,
                                    DateGeneration::Forward, false);
-            for (double rate : rates) {
+            for (Real rate : rates) {
 
                 VanillaSwap swap(Swap::Payer, 1000000.0, fixedSchedule, rate,
                                  Thirty360(Thirty360::BondBasis),

--- a/test-suite/solvers.cpp
+++ b/test-suite/solvers.cpp
@@ -57,7 +57,7 @@ namespace {
                             const F& f, Real guess) {
         Real accuracy[] = { 1.0e-4, 1.0e-6, 1.0e-8 };
         Real expected = 1.0;
-        for (double& i : accuracy) {
+        for (Real& i : accuracy) {
             Real root = solver.solve(f, i, guess, 0.1);
             if (std::fabs(root - expected) > i) {
                 BOOST_FAIL(name << " solver (not bracketed):\n"
@@ -73,7 +73,7 @@ namespace {
                         const F& f, Real guess) {
         Real accuracy[] = { 1.0e-4, 1.0e-6, 1.0e-8 };
         Real expected = 1.0;
-        for (double& i : accuracy) {
+        for (Real& i : accuracy) {
             // guess on the left side of the root, increasing function
             Real root = solver.solve(f, i, guess, 0.0, 2.0);
             if (std::fabs(root - expected) > i) {

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -130,7 +130,7 @@ void SquareRootCLVModelTest::testSquareRootCLVVanillaPricing() {
     const chi_squared_type dist(df, ncp);
         
     const Real strikes[] = { 50, 75, 100, 125, 150, 200 };
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         const Option::Type optionType = (strike > fwd) ? Option::Call : Option::Put;
 
         const Real expected = BlackCalculator(
@@ -228,7 +228,7 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
 
         const Real fwd = s0*qTS->discount(m)/rTS->discount(m);
 
-        for (double strike : strikes) {
+        for (Real strike : strikes) {
             const Option::Type optionType = (strike > fwd) ? Option::Call : Option::Put;
 
             const Real expected = BlackCalculator(
@@ -281,7 +281,7 @@ namespace square_root_clv_model {
             const Array diff = values(params);
 
             Real retVal = 0.0;
-            for (double i : diff)
+            for (Real i : diff)
                 retVal += i * i;
 
             return retVal;

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -111,7 +111,7 @@ void SwapTest::testFairRate() {
     Spread spreads[] = { -0.001, -0.01, 0.0, 0.01, 0.001 };
 
     for (int& length : lengths) {
-        for (double spread : spreads) {
+        for (Real spread : spreads) {
 
             ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(length, 0.0, spread);
             swap = vars.makeSwap(length, swap->fairRate(), spread);
@@ -138,7 +138,7 @@ void SwapTest::testFairSpread() {
     Rate rates[] = { 0.04, 0.05, 0.06, 0.07 };
 
     for (int& length : lengths) {
-        for (double j : rates) {
+        for (Real j : rates) {
 
             ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(length, j, 0.0);
             swap = vars.makeSwap(length, j, swap->fairSpread());
@@ -165,10 +165,10 @@ void SwapTest::testRateDependency() {
     Rate rates[] = { 0.03, 0.04, 0.05, 0.06, 0.07 };
 
     for (int& length : lengths) {
-        for (double spread : spreads) {
+        for (Real spread : spreads) {
             // store the results for different rates...
             std::vector<Real> swap_values;
-            for (double rate : rates) {
+            for (Real rate : rates) {
                 ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(length, rate, spread);
                 swap_values.push_back(swap->NPV());
             }
@@ -200,10 +200,10 @@ void SwapTest::testSpreadDependency() {
     Spread spreads[] = { -0.01, -0.002, -0.001, 0.0, 0.001, 0.002, 0.01 };
 
     for (int& length : lengths) {
-        for (double j : rates) {
+        for (Real j : rates) {
             // store the results for different spreads...
             std::vector<Real> swap_values;
-            for (double spread : spreads) {
+            for (Real spread : spreads) {
                 ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(length, j, spread);
                 swap_values.push_back(swap->NPV());
             }

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -141,7 +141,7 @@ void SwaptionTest::testStrikeDependency() {
                 std::vector<Real> values;
                 std::vector<Real> values_cash;
                 Volatility vol = 0.20;
-                for (double strike : strikes) {
+                for (Real strike : strikes) {
                     ext::shared_ptr<VanillaSwap> swap =
                         MakeVanillaSwap(length, vars.index, strike)
                             .withEffectiveDate(startDate)
@@ -238,7 +238,7 @@ void SwaptionTest::testSpreadDependency() {
                 // store the results for different rates...
                 std::vector<Real> values;
                 std::vector<Real> values_cash;
-                for (double spread : spreads) {
+                for (Real spread : spreads) {
                     ext::shared_ptr<VanillaSwap> swap =
                         MakeVanillaSwap(length, vars.index, 0.06)
                             .withFixedLegTenor(1 * Years)
@@ -326,7 +326,7 @@ void SwaptionTest::testSpreadTreatment() {
                 Date startDate =
                     vars.calendar.advance(exerciseDate,
                                           vars.settlementDays,Days);
-                for (double spread : spreads) {
+                for (Real spread : spreads) {
                     ext::shared_ptr<VanillaSwap> swap =
                         MakeVanillaSwap(length, vars.index, 0.06)
                             .withFixedLegTenor(1 * Years)
@@ -427,7 +427,7 @@ void SwaptionTest::testVega() {
         Date startDate = vars.calendar.advance(exerciseDate,
                                            vars.settlementDays*Days);
         for (auto& length : lengths) {
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 for (Size h=0; h<LENGTH(type); h++) {
                     ext::shared_ptr<VanillaSwap> swap =
                         MakeVanillaSwap(length, vars.index, strike)
@@ -436,7 +436,7 @@ void SwaptionTest::testVega() {
                             .withFixedLegDayCount(vars.fixedDayCount)
                             .withFloatingLegSpread(0.0)
                             .withType(type[h]);
-                    for (double vol : vols) {
+                    for (Real vol : vols) {
                         ext::shared_ptr<Swaption> swaption =
                             vars.makeSwaption(swap, exerciseDate, vol, types[h], methods[h]);
                         // FLOATING_POINT_EXCEPTION
@@ -805,7 +805,7 @@ void SwaptionTest::testImpliedVolatility() {
             Date startDate = vars.calendar.advance(exerciseDate,
                                                    vars.settlementDays, Days);
 
-            for (double& strike : strikes) {
+            for (Real& strike : strikes) {
                 for (auto& k : type) {
                     ext::shared_ptr<VanillaSwap> swap =
                         MakeVanillaSwap(length, vars.index, strike)
@@ -815,7 +815,7 @@ void SwaptionTest::testImpliedVolatility() {
                             .withFloatingLegSpread(0.0)
                             .withType(k);
                     for (Size h=0; h<LENGTH(types); h++) {
-                        for (double vol : vols) {
+                        for (Real vol : vols) {
                             ext::shared_ptr<Swaption> swaption =
                                 vars.makeSwaption(swap, exerciseDate, vol, types[h], methods[h],
                                                   BlackSwaptionEngine::DiscountCurve);
@@ -920,10 +920,10 @@ void checkSwaptionDelta(bool useBachelierVol)
     Rate strikes[] = { 0.03, 0.04, 0.05, 0.06, 0.07 };
     Volatility vols[] = { 0.0, 0.10, 0.20, 0.30, 0.70, 0.90 };
 
-    for (double vol : vols) {
+    for (Real vol : vols) {
         for (auto exercise : exercises) {
             for (auto& length : lengths) {
-                for (double& strike : strikes) {
+                for (Real& strike : strikes) {
                     for (Size h=0; h<LENGTH(type); h++) {
                         Volatility volatility = useBachelierVol ? vol / 100.0 : vol;
                         ext::shared_ptr<Engine> swaptionEngine = makeConstVolEngine<Engine>(

--- a/test-suite/swaptionvolatilitycube.cpp
+++ b/test-suite/swaptionvolatilitycube.cpp
@@ -307,7 +307,7 @@ void SwaptionVolatilityCubeTest::testSpreadedCube() {
                 volCube->smileSection(vars.cube.tenors.options[i], vars.cube.tenors.swaps[j]);
             ext::shared_ptr<SmileSection> smileSectionBySpreadedCube =
                 spreadedVolCube->smileSection(vars.cube.tenors.options[i], vars.cube.tenors.swaps[j]);
-            for (double strike : strikes) {
+            for (Real strike : strikes) {
                 Real diff = spreadedVolCube->volatility(vars.cube.tenors.options[i],
                                                         vars.cube.tenors.swaps[j], strike) -
                             volCube->volatility(vars.cube.tenors.options[i],

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -921,7 +921,7 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
     Array x(mesher->layout()->size());
 
     PseudoRandom::rng_type rng(PseudoRandom::urng_type(12345UL));
-    for (double& i : x) {
+    for (Real& i : x) {
         i = rng.next().value;
     }
 


### PR DESCRIPTION
This replaces many stray uses of the `double` datatype with `QuantLib::Real`, to ensure it is used consistently throughout the library and test suite. 

In particular:
- it replaces `double` with `Real`
- it initialises accumulators in `std::inner_product` and `std::accumulate` with `Real` literals, to ensure the values are aggregated with the correct data type internally
- it avoids `constexpr Real x = ...` statements, as with the global typedef we cannot generally assume that Real can in fact be initialised in a `constexpr`