### PR TITLE
Refactored Null<T> class to a template function

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -53,8 +53,10 @@ namespace QuantLib {
       public:
         //! \name Constructors, destructor, and assignment
         //@{
+        //! creates the array with size 0
+        Array() : Array(static_cast<Size>(0)) {}
         //! creates the array with the given dimension
-        explicit Array(Size size = 0);
+        explicit Array(Size size);
         //! creates the array and fills it with <tt>value</tt>
         Array(Size size, Real value);
         /*! \brief creates the array and fills it according to
@@ -146,7 +148,7 @@ namespace QuantLib {
     //! specialization of null template for this class
     template <>
     inline Array Null<Array>() {
-        return Array();
+        return {};
     }
 
 

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -145,11 +145,9 @@ namespace QuantLib {
 
     //! specialization of null template for this class
     template <>
-    class Null<Array> {
-      public:
-        Null() = default;
-        operator Array() const { return Array(); }
-    };
+    inline Array Null<Array>() {
+        return Array();
+    }
 
 
 

--- a/ql/prices.hpp
+++ b/ql/prices.hpp
@@ -102,11 +102,8 @@ namespace QuantLib {
 
     
     template <>
-    class Null<IntervalPrice> 
-    {
-      public:
-        Null() = default;
-        operator IntervalPrice() const { return {}; }
+    inline IntervalPrice Null<IntervalPrice>() {
+        return IntervalPrice();
     };
 
 }

--- a/ql/prices.hpp
+++ b/ql/prices.hpp
@@ -103,7 +103,7 @@ namespace QuantLib {
     
     template <>
     inline IntervalPrice Null<IntervalPrice>() {
-        return IntervalPrice();
+        return {};
     };
 
 }

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -373,7 +373,7 @@ namespace QuantLib {
     //! specialization of Null template for the Date class
     template <>
     inline Date Null<Date>() {
-        return Date();
+        return {};
     }
 
 

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -372,11 +372,9 @@ namespace QuantLib {
 
     //! specialization of Null template for the Date class
     template <>
-    class Null<Date> {
-      public:
-        Null() = default;
-        operator Date() const { return {}; }
-    };
+    inline Date Null<Date>() {
+        return Date();
+    }
 
 
 #ifndef QL_HIGH_RESOLUTION_DATE

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -61,7 +61,7 @@ namespace QuantLib {
 
     //! template function providing a null value for a given type.
     template <typename T>
-    constexpr T Null() {
+    T Null() {
         return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
     }
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -32,9 +32,9 @@
 
 namespace QuantLib {
 
-    //! template class providing a null value for a given type.
+    //! template function providing a null value for a given type.
     template <class Type>
-    class Null;
+    Type Null();
 
 
     namespace detail {
@@ -64,13 +64,9 @@ namespace QuantLib {
 
     // default implementation for built-in types
     template <typename T>
-    class Null {
-      public:
-        constexpr Null() = default;
-        constexpr operator T() const {
-            return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
-        }
-    };
+    T Null() {
+        return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
+    }
 
 }
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
 
     //! template function providing a null value for a given type.
     template <class Type>
-    Type Null();
+    constexpr Type Null();
 
 
     namespace detail {
@@ -64,7 +64,7 @@ namespace QuantLib {
 
     // default implementation for built-in types
     template <typename T>
-    T Null() {
+    constexpr T Null() {
         return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
     }
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -32,11 +32,8 @@
 
 namespace QuantLib {
 
-    //! template function providing a null value for a given type.
-    template <class Type>
-    constexpr Type Null();
-
-
+    
+   
     namespace detail {
 
         template <bool>
@@ -62,7 +59,7 @@ namespace QuantLib {
 
     }
 
-    // default implementation for built-in types
+    //! template function providing a null value for a given type.
     template <typename T>
     constexpr T Null() {
         return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());


### PR DESCRIPTION
The approach of using a `Null<T>` class relies on implicit conversion operators to make expressions work as 

```c++
Real x = Null<Real>();
```
It creates a an object of class `Null<Real>` and immediately converts it back to `Real` using the implicit conversion operator. Relying on implicit conversions is not considered good practice, and it creates problems if `Real` itself is a class with its own implicit conversion operators, as double-implicit conversions are not allowed. 

This PR uses a different approach which is more generic and does not have the above problems. A template function is used instead (with the same name as the previous class to ensure no change for the user):

```c++
template <class T>
T Null() { ...}

Real x = Null<Real>();
```

This function template can be specialised just the same way as the original class, but is much more direct and no implicit conversions are involved.