### PR TITLE
Allow more generic Real->integer casts

### DIFF
--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -177,9 +177,9 @@ int test(OptimizationMethod& method, CostFunction& f, const EndCriteria& endCrit
         std::cout << "Global optimum: ";
         Real optimVal = printFunction(p, optimum);
         if(std::abs(optimVal) < 1e-13)
-            return static_cast<int>(std::abs(val - optimVal) < 1e-6);
+            return ql_cast<int>(std::abs(val - optimVal) < 1e-6);
         else
-            return static_cast<int>(std::abs((val - optimVal) / optimVal) < 1e-6);
+            return ql_cast<int>(std::abs((val - optimVal) / optimVal) < 1e-6);
     }
     return 1;
 }

--- a/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
+++ b/ql/experimental/amortizingbonds/amortizingfixedratebond.cpp
@@ -85,8 +85,8 @@ namespace QuantLib {
                 ((Real)superDays.first)/((Real)subDays.second);
             Real maxPeriodRatio =
                 ((Real)superDays.second)/((Real)subDays.first);
-            auto lowRatio = static_cast<Integer>(std::floor(minPeriodRatio));
-            auto highRatio = static_cast<Integer>(std::ceil(maxPeriodRatio));
+            auto lowRatio = ql_cast<Integer>(std::floor(minPeriodRatio));
+            auto highRatio = ql_cast<Integer>(std::ceil(maxPeriodRatio));
 
             try {
                 for(Integer i=lowRatio; i <= highRatio; ++i) {

--- a/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
@@ -168,7 +168,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(residualTime, timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*residualTime);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*residualTime);
             return TimeGrid(residualTime, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1182,8 +1182,8 @@ namespace QuantLib {
                         XNKH = 0.0;
                     }
 
-                HS =(int)SIGN( ONE, DH - R*DK );
-                KS =(int)SIGN( ONE, DK - R*DH );
+                HS = QuantLib::ql_cast<int>(SIGN(ONE, DH - R * DK));
+                KS = QuantLib::ql_cast<int>(SIGN(ONE, DK - R * DH));
                 if((NU-2*(int)(NU/2))==0 )
                     {
                         BVT = atan2( POW(ORS,0.5), -R )/TPI;

--- a/ql/experimental/basismodels/tenoroptionletvts.cpp
+++ b/ql/experimental/basismodels/tenoroptionletvts.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         Real oneDayAsYear =
             volTS.dayCounter().yearFraction(volTS.referenceDate(), volTS.referenceDate() + 1);
         Date exerciseDate =
-            volTS.referenceDate() + ((BigInteger)ClosestRounding(0)(optionTime / oneDayAsYear));
+            volTS.referenceDate() + (ql_cast<BigInteger>(ClosestRounding(0)(optionTime / oneDayAsYear)));
         Date effectiveDate = volTS.baseIndex_->fixingCalendar().advance(
             exerciseDate, volTS.baseIndex_->fixingDays() * Days);
         Date maturityDate = volTS.baseIndex_->fixingCalendar().advance(

--- a/ql/experimental/basismodels/tenorswaptionvts.cpp
+++ b/ql/experimental/basismodels/tenorswaptionvts.cpp
@@ -41,11 +41,11 @@ namespace QuantLib {
         Real oneDayAsYear =
             volTS.dayCounter().yearFraction(volTS.referenceDate(), volTS.referenceDate() + 1);
         Date exerciseDate =
-            volTS.referenceDate() + ((BigInteger)ClosestRounding(0)(optionTime / oneDayAsYear));
+            volTS.referenceDate() + (ql_cast<BigInteger>(ClosestRounding(0)(optionTime / oneDayAsYear)));
         Date effectiveDate = volTS.baseIndex_->fixingCalendar().advance(
             exerciseDate, volTS.baseIndex_->fixingDays() * Days);
         Date maturityDate = volTS.baseIndex_->fixingCalendar().advance(
-            effectiveDate, ((BigInteger)swapLength * 12.0) * Months, Unadjusted, false);
+            effectiveDate, (ql_cast<BigInteger>(swapLength) * 12.0) * Months, Unadjusted, false);
         // now we can set up the schedules
         Schedule baseFixedSchedule(effectiveDate, maturityDate, volTS.baseFixedFreq_,
                                    volTS.baseIndex_->fixingCalendar(), ModifiedFollowing,

--- a/ql/experimental/catbonds/catrisk.cpp
+++ b/ql/experimental/catbonds/catrisk.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
 
     namespace {
         Integer round(Real r) {
-            return (r > 0.0) ? Integer(std::floor(r + 0.5)) : Integer(std::ceil(r - 0.5));
+            return (r > 0.0) ? ql_cast<Integer>(std::floor(r + 0.5)) : ql_cast<Integer>(std::ceil(r - 0.5));
         }
     }
 

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -235,8 +235,8 @@ namespace QuantLib {
             // adjust average
             Real epsilon = (1.-alpha)*(ceilAveProb-m);
             Real epsilonPlus = 1.-alpha-epsilon;
-            lossProbDensity[static_cast<Size>(floorAveProb)] += epsilon;
-            lossProbDensity[static_cast<Size>(ceilAveProb)]  += epsilonPlus;
+            lossProbDensity[ql_cast<Size>(floorAveProb)] += epsilon;
+            lossProbDensity[ql_cast<Size>(ceilAveProb)] += epsilonPlus;
         }
         return lossProbDensity;
     }

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -480,7 +480,7 @@ namespace QuantLib {
         std::sort(losses.begin(), losses.end());
         Real posit = std::ceil(percent * nSims_);
         posit = posit >= 0. ? posit : 0.;
-        Size position = static_cast<Size>(posit);
+        Size position = ql_cast<Size>(posit);
         Real perctlInf = losses[position];//q_{\alpha}
 
         // the prob of values strictly larger than the quantile value.
@@ -570,7 +570,7 @@ namespace QuantLib {
         }
 
         std::sort(rankLosses.begin(), rankLosses.end());
-        Size quantilePosition = static_cast<Size>(floor(nSims_*percentile));
+        Size quantilePosition = ql_cast<Size>(floor(nSims_ * percentile));
         Real quantileValue = rankLosses[quantilePosition];
 
         // compute confidence interval:
@@ -765,7 +765,7 @@ namespace QuantLib {
                 read only)
                 */
                 return dts_->defaultProbability(curveRef_ +
-                    Period(static_cast<Integer>(t), Days), true) - pd_;
+                    Period(ql_cast<Integer>(t), Days), true) - pd_;
             }
           private:
             const Handle<DefaultProbabilityTermStructure> dts_;
@@ -937,7 +937,7 @@ namespace QuantLib {
                 // compute and store default time with respect to the
                 //  curve ref date:
                 Size dateSTride =
-                    static_cast<Size>(Brent().solve(// casted from Real:
+                    ql_cast<Size>(Brent().solve( // casted from Real:
                         detail::Root(dfts, simDefaultProb),
                             accuracy_,0.,1.));
                    /*
@@ -946,7 +946,7 @@ namespace QuantLib {
                    // \todo: see how to include this 'polymorphically'.
                    // While not the case in pricing in risk metrics/real
                    //   probabilities the curves are often flat
-                    static_cast<Size>(ceil(maxHorizon_ *
+                    ql_cast<Size>(ceil(maxHorizon_ *
                                         std::log(1.-simDefaultProb)
                     /std::log(1.-data_.horizonDefaultPs_[iName])));
                    */

--- a/ql/experimental/credit/randomlosslatentmodel.hpp
+++ b/ql/experimental/credit/randomlosslatentmodel.hpp
@@ -182,7 +182,7 @@ namespace QuantLib {
                 // compute and store default time with respect to the 
                 //  curve ref date:
                 Size dateSTride =
-                    static_cast<Size>(Brent().solve(// casted from Real:
+                    ql_cast<Size>(Brent().solve( // casted from Real:
                     detail::Root(dfts, simDefaultProb), accuracy_, 0., 1.));
                 /*
                 // value if one approximates to a flat HR; 
@@ -190,7 +190,7 @@ namespace QuantLib {
                 // \todo: see how to include this 'polymorphically'. While
                 //   not the case in pricing in risk metrics/real  
                 //   probabilities the curves are often flat
-                static_cast<Size>(ceil(maxHorizon_ * 
+                ql_cast<Size>(ceil(maxHorizon_ * 
                                     std::log(1.-simDefaultProb)
                 /std::log(1.-data_.horizonDefaultPs_[iName])));
                 */
@@ -203,7 +203,7 @@ namespace QuantLib {
                 Unless the gap is ridiculous this has no practical effect for 
                 the RR value*/
                 Date today = Settings::instance().evaluationDate();
-                Date eventDate = today+Period(static_cast<Integer>(dateSTride), 
+                Date eventDate = today+Period(ql_cast<Integer>(dateSTride), 
                     Days);
                 if(eventDate<dfts->referenceDate()) 
                     eventDate = dfts->referenceDate();

--- a/ql/experimental/exoticoptions/continuousarithmeticasianvecerengine.cpp
+++ b/ql/experimental/exoticoptions/continuousarithmeticasianvecerengine.cpp
@@ -183,7 +183,7 @@ namespace QuantLib {
             } // End Time Loop
 
             DownRounding Rounding(0);
-            auto lowerI = Integer(Rounding((Z_0 - z_min_) / h));
+            auto lowerI = ql_cast<Integer>(Rounding((Z_0 - z_min_) / h));
             // Interpolate solution
             Real pv;
 

--- a/ql/experimental/exoticoptions/mceverestengine.hpp
+++ b/ql/experimental/exoticoptions/mceverestengine.hpp
@@ -176,7 +176,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(residualTime, timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*residualTime);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*residualTime);
             return TimeGrid(residualTime, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/experimental/finitedifferences/dynprogvppintrinsicvalueengine.cpp
+++ b/ql/experimental/finitedifferences/dynprogvppintrinsicvalueengine.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
               powerPrices_(powerPrices) {}
 
             Real innerValue(const FdmLinearOpIterator&, Time t) override {
-                Size i = (Size) t;
+                Size i = ql_cast<Size>(t);
                 QL_REQUIRE(i < powerPrices_.size(), "invalid time");
                 return powerPrices_[i] - heatRate_*fuelPrices_[i];
             }
@@ -63,9 +63,9 @@ namespace QuantLib {
             : fuelPrices_(fuelPrices) {}
 
             Real innerValue(const FdmLinearOpIterator&, Time t) override {
-                Size i = (Size) t;
+                Size i = ql_cast<Size>(t);
                 QL_REQUIRE(i < fuelPrices_.size(), "invalid time");
-                return fuelPrices_[(Size) t];
+                return fuelPrices_[ql_cast<Size>(t)];
             }
             Real avgInnerValue(const FdmLinearOpIterator& iter, Time t) override {
                 return innerValue(iter, t);

--- a/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
+++ b/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
             //elevator mesher
             std::vector<Real> storageValues(1, arguments_.capacity);
             storageValues.reserve(
-                Size(arguments_.capacity/arguments_.changeRate)+1);
+                ql_cast<Size>(arguments_.capacity/arguments_.changeRate)+1);
 
             for (Real level=0; level <= arguments_.capacity;
                     level+=arguments_.changeRate) {

--- a/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
+++ b/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
@@ -113,7 +113,7 @@ namespace QuantLib {
         lag_ = surf_->observationLag();
         capfloor_ =
             MakeYoYInflationCapFloor(type, anIndex,
-                                     (Size)std::floor(0.5+surf->timeFromReference(surf->minMaturity())),
+                                     ql_cast<Size>(std::floor(0.5+surf->timeFromReference(surf->minMaturity()))),
                                      surf->calendar(), lag)
             .withNominal(10000.0)
             .withStrike(K);
@@ -127,7 +127,7 @@ namespace QuantLib {
         tvec_[1] = surf_->dayCounter().yearFraction(surf_->referenceDate(),
                                                     dvec_[1]);
 
-        Size n = (Size)std::floor(0.5 + surf->timeFromReference(surf_->minMaturity()));
+        Size n = ql_cast<Size>(std::floor(0.5 + surf->timeFromReference(surf_->minMaturity())));
         QL_REQUIRE( n > 0,
                     "first maturity in price surface not > 0: "
                     << n);
@@ -232,7 +232,7 @@ namespace QuantLib {
                                                new SimpleQuote( nextPrice )));
                 // helper should be an integer number of periods away,
                 // this is enforced by rounding
-                Size nT = (Size)floor(s->timeFromReference(s->yoyOptionDateFromTenor(Tp))+0.5);
+                Size nT = ql_cast<Size>(floor(s->timeFromReference(s->yoyOptionDateFromTenor(Tp))+0.5));
                 helpers.push_back(ext::shared_ptr<YoYOptionletHelper>(
                           new YoYOptionletHelper(quote1, notional, useType,
                                                  lag_,

--- a/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
+++ b/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
@@ -179,8 +179,8 @@ namespace QuantLib {
     Volatility KInterpolatedYoYOptionletVolatilitySurface<Interpolator1D>::
     volatilityImpl(Time length,  Rate strike) const {
 
-        auto years = (Natural)floor(length);
-        auto days = (Natural)floor((length - years) * 365.0);
+        auto years = ql_cast<Natural>(floor(length));
+        auto days = ql_cast<Natural>(floor((length - years) * 365.0));
         Date d = referenceDate() + Period(years, Years) + Period(days, Days);
 
         return this->volatilityImpl(d, strike);

--- a/ql/experimental/inflation/yoyinflationoptionletvolatilitystructure2.hpp
+++ b/ql/experimental/inflation/yoyinflationoptionletvolatilitystructure2.hpp
@@ -72,7 +72,7 @@ namespace QuantLib {
         Real maxStrike() const override { return maxStrike_; }
         Date maxDate() const override {
             //FIXME approx
-            return optionDateFromTenor(Period((int)ceil(this->interpolation_.xMax()),Years));
+            return optionDateFromTenor(Period(ql_cast<int>(ceil(this->interpolation_.xMax())),Years));
         }
         //@}
 

--- a/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
+++ b/ql/experimental/math/hybridsimulatedannealingfunctors.hpp
@@ -191,7 +191,7 @@ namespace QuantLib
                 newPoint[i] = lower_[i] - 1.0;
                 while (newPoint[i] < lower_[i] || newPoint[i] > upper_[i]) {
                     Real draw = distribution_(generator_);
-                    Real sign = static_cast<int>(0.5 < draw) - static_cast<int>(draw < 0.5);
+                    Real sign = ql_cast<int>(0.5 < draw) - ql_cast<int>(draw < 0.5);
                     Real y = sign*temp[i] * (std::pow(1.0 + 1.0 / temp[i],
                                                       std::abs(2 * draw - 1.0)) - 1.0);
                     newPoint[i] = currentPoint[i] + y*(upper_[i] - lower_[i]);

--- a/ql/experimental/models/hestonslvfdmmodel.cpp
+++ b/ql/experimental/models/hestonslvfdmmodel.cpp
@@ -329,7 +329,7 @@ namespace QuantLib {
 
         Time tIdx=0.0;
         std::vector<Time> times(1, tIdx);
-        times.reserve(Size(T*params_.tMinStepsPerYear));
+        times.reserve(ql_cast<Size>(T * params_.tMinStepsPerYear));
         while (tIdx < T) {
             const Real decayFactor = std::exp(-params_.tStepNumberDecay*tIdx);
             const Time dt = maxDt*decayFactor + minDt*(1.0-decayFactor);

--- a/ql/experimental/models/hestonslvmcmodel.cpp
+++ b/ql/experimental/models/hestonslvmcmodel.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         gridTimes.push_back(dc.yearFraction(refDate, endDate));
 
         timeGrid_ = ext::make_shared<TimeGrid>(gridTimes.begin(), gridTimes.end(),
-                std::max(Size(2), Size(gridTimes.back()*timeStepsPerYear)));
+            std::max(Size(2), ql_cast<Size>(gridTimes.back() * timeStepsPerYear)));
     }
 
     ext::shared_ptr<HestonProcess> HestonSLVMCModel::hestonProcess() const {

--- a/ql/experimental/processes/gemanroncoroniprocess.cpp
+++ b/ql/experimental/processes/gemanroncoroniprocess.cpp
@@ -77,7 +77,8 @@ namespace QuantLib {
         // random number generator for the jump part 
         if (!urng_) {
             typedef PseudoRandom::urng_type urng_type;
-            urng_ = ext::make_shared<urng_type>((unsigned long)(1234UL * dw + 56789UL));
+            urng_ =
+                ext::make_shared<urng_type>(ql_cast<unsigned long>(1234UL * dw + 56789UL));
         }
         Array du(3); 
         du[0] = urng_->next().value; 

--- a/ql/experimental/risk/creditriskplus.cpp
+++ b/ql/experimental/risk/creditriskplus.cpp
@@ -124,7 +124,8 @@ namespace QuantLib {
         std::map<unsigned long, Real, std::less<unsigned long> >::iterator iter;
 
         for (Size k = 0; k < m_; ++k) {
-            auto exUnit = (unsigned long)(std::floor(0.5 + exposure_[k] / unit_)); // round
+            auto exUnit =
+                ql_cast<unsigned long>(std::floor(0.5 + exposure_[k] / unit_)); // round
             if (exposure_[k] > 0 && exUnit == 0)
                 exUnit = 1; // but avoid zero exposure
             if (exUnit > maxNu_)

--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -130,7 +130,7 @@ namespace QuantLib {
         Real lnEt = integrateMeanReversion(speed_,0,t);
         Real Et = exp(lnEt);
         Real B = 0;
-        Size N = std::min<Size>(Size((T-t)*365), 2000);
+        Size N = std::min<Size>(ql_cast<Size>((T-t)*365), 2000);
         if (N==0) N=1;
         Real dt = 0.5*(T-t)/N;
         Real a,b,c,_t,total=0;
@@ -153,7 +153,7 @@ namespace QuantLib {
         // Gurrieri et al, equation (37)
         Real lnEt = integrateMeanReversion(speed_,0,t);
         Real V = 0,Eu;
-        Size N = std::min<Size>(Size((T-t)*365), 2000);
+        Size N = std::min<Size>(ql_cast<Size>((T-t)*365), 2000);
         if (N==0) N=1;
         Real dt = 0.5*(T-t)/N;
         Real a,b,c,_t,lnE=lnEt;

--- a/ql/experimental/variancegamma/fftengine.cpp
+++ b/ql/experimental/variancegamma/fftengine.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
                     maxStrike = payoff->strike();
             }
             Real nR = 2.0 * (std::log(maxStrike) + lambda_) / lambda_;
-      Size log2_n = (static_cast<Size>((std::log(nR) / std::log(2.0))) + 1);
+            Size log2_n = (ql_cast<Size>((std::log(nR) / std::log(2.0))) + 1);
             Size n = static_cast<std::size_t>(1) << log2_n;
 
             // Strike range (equation 19,20)

--- a/ql/experimental/volatility/sabrvolsurface.cpp
+++ b/ql/experimental/volatility/sabrvolsurface.cpp
@@ -117,7 +117,7 @@ namespace QuantLib {
     ext::shared_ptr<SmileSection>
     SabrVolSurface::smileSectionImpl(Time t) const {
 
-        auto n = BigInteger(t * 365.0);
+        auto n = ql_cast<BigInteger>(t * 365.0);
         Date d = referenceDate()+n*Days;
         // interpolating on ref smile sections
         std::vector<Volatility> volSpreads = volatilitySpreads(d);

--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -127,7 +127,7 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
     const Size size = 500;                    // grid points
     const Real density = 0.1; // density for concentrating mesher
     const Size steps =
-        (Size)std::ceil(expiryTime_ * 24); // number of steps in dimension t
+        ql_cast<Size>(std::ceil(expiryTime_ * 24)); // number of steps in dimension t
     const Size dampingSteps = 5;           // thereof damping steps
 
     // Layout
@@ -210,7 +210,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
 
     const Size sizef = 100;
     const Size sizev = 100;
-    const Size steps = Size(24 * expiryTime_ + 1);
+    const Size steps = ql_cast<Size>(24 * expiryTime_ + 1);
     const Size dampingSteps = 5;
     const Real densityf = 0.1;
     const Real densityv = 0.1;
@@ -231,7 +231,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     const Real x0 = std::min(forward_, strike);
     const Real x1 = std::max(forward_, strike);
     const Size sizefa = std::max<Size>(
-        4, (Size)std::ceil(((x0 + x1) / 2.0 - f0) / (f1 - f0) * (Real)sizef));
+        4, ql_cast<Size>(std::ceil(((x0 + x1) / 2.0 - f0) / (f1 - f0) * (Real)sizef)));
     const Size sizefb = sizef - sizefa + 1; // common point, so we can spend
     // one more here
     const ext::shared_ptr<Fdm1dMesher> mfa(

--- a/ql/interestrate.hpp
+++ b/ql/interestrate.hpp
@@ -56,7 +56,7 @@ namespace QuantLib {
         const DayCounter& dayCounter() const { return dc_; }
         Compounding compounding() const { return comp_; }
         Frequency frequency() const {
-            return freqMakesSense_ ? Frequency(Integer(freq_)) : NoFrequency;
+            return freqMakesSense_ ? Frequency(ql_cast<Integer>(freq_)) : NoFrequency;
         }
         //@}
 

--- a/ql/math/fastfouriertransform.hpp
+++ b/ql/math/fastfouriertransform.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
 
         //! the minimum order required for the given input size
         static std::size_t min_order(std::size_t inputSize) {
-            return static_cast<std::size_t>(
+            return ql_cast<std::size_t>(
                 std::ceil(std::log(static_cast<Real>(inputSize)) / M_LN2));
         }
 

--- a/ql/math/primenumbers.cpp
+++ b/ql/math/primenumbers.cpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         do {
             // skip the even numbers
             m += 2;
-            n = static_cast<BigNatural>(std::sqrt(Real(m)));
+            n = ql_cast<BigNatural>(std::sqrt(Real(m)));
             // i=1 since the even numbers have already been skipped
             Size i = 1;
             do {

--- a/ql/math/randomnumbers/haltonrsg.cpp
+++ b/ql/math/randomnumbers/haltonrsg.cpp
@@ -67,7 +67,7 @@ namespace QuantLib {
                 k /= b;
             }
             sequence_.value[i] = h+randomShift_[i];
-            sequence_.value[i] -= long(sequence_.value[i]);
+            sequence_.value[i] -= ql_cast<long>(sequence_.value[i]);
         }
         return sequence_;
     }

--- a/ql/math/statistics/histogram.cpp
+++ b/ql/math/statistics/histogram.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
                 return *std::max_element(samples.begin(), samples.end());
 
             // general situation: middle region and nsample >= 2
-            Size index = static_cast<Size>(std::floor((nsample+a)*prob+a));
+            Size index = ql_cast<Size>(std::floor((nsample + a) * prob + a));
             std::vector<Real> sorted(index+1);
             std::partial_sort_copy(samples.begin(), samples.end(),
                                    sorted.begin(), sorted.end());
@@ -106,7 +106,7 @@ namespace QuantLib {
         if (bins_ == Null<Size>()) {
             switch (algorithm_) {
               case Sturges: {
-                  bins_ = static_cast<Size>(
+                  bins_ = ql_cast<Size>(
                            std::ceil(std::log(static_cast<Real>(data_.size()))
                                      /std::log(2.0) + 1));
                   break;
@@ -115,7 +115,7 @@ namespace QuantLib {
                   Real r1 = quantile(data_, 0.25);
                   Real r2 = quantile(data_, 0.75);
                   Real h = 2.0 * (r2-r1) * std::pow(static_cast<Real>(data_.size()), -1.0/3.0);
-                  bins_ = static_cast<Size>(std::ceil((max-min)/h));
+                  bins_ = ql_cast<Size>(std::ceil((max-min)/h));
                   break;
               }
               case Scott: {
@@ -124,7 +124,7 @@ namespace QuantLib {
                   Real variance = summary.variance();
                   Real h = 3.5 * std::sqrt(variance)
                          * std::pow(static_cast<Real>(data_.size()), -1.0/3.0);
-                  bins_ = static_cast<Size>(std::ceil((max-min)/h));
+                  bins_ = ql_cast<Size>(std::ceil((max-min)/h));
                   break;
               }
               case None:

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
@@ -55,7 +55,8 @@ namespace QuantLib {
                 intermediateSteps.emplace_back(process->time(i->date()), i->amount());
         }
 
-        const Size intermediateTimeSteps = std::max<Size>(2, Size(24.0*maturity));
+        const Size intermediateTimeSteps =
+            std::max<Size>(2, ql_cast<Size>(24.0 * maturity));
         for (Size i=0; i < intermediateTimeSteps; ++i)
             intermediateSteps.emplace_back((i + 1) * (maturity / intermediateTimeSteps), 0.0);
 

--- a/ql/methods/lattices/trinomialtree.cpp
+++ b/ql/methods/lattices/trinomialtree.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             for (Integer j=jMin; j<=jMax; j++) {
                 Real x = x0_ + j*dx_[i];
                 Real m = process->expectation(t, x, dt);
-                auto temp = Integer(std::floor((m - x0_) / dx_[i + 1] + 0.5));
+                auto temp = ql_cast<Integer>(std::floor((m - x0_) / dx_[i + 1] + 0.5));
 
                 if (isPositive) {
                     while (x0_+(temp-1)*dx_[i+1]<=0) {

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -197,7 +197,7 @@ namespace QuantLib {
                             makeSwaptionCalibrationPoint(
                                 *j,
                                 Period(
-                                    static_cast<Integer>(rounder(
+                                    ql_cast<Integer>(rounder(
                                         (swapIndexBase_->dayCounter()
                                              .yearFraction(*j, numeraireKnown) -
                                          0.5 / 365) *

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -414,7 +414,7 @@ namespace QuantLib {
         omega = mean_r2 * dataSize / (dataSize - 1);
 
         // ACF
-        Size maxLag = (Size)std::sqrt(dataSize);
+        Size maxLag = ql_cast<Size>(std::sqrt(dataSize));
         Array acf(maxLag+1);
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),

--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -172,7 +172,7 @@ namespace QuantLib {
             return TimeGrid(fixingTimes.begin(), fixingTimes.end(), timeSteps_);
         } else if (this->timeStepsPerYear_ != Null<Size>()) {
             return TimeGrid(fixingTimes.begin(), fixingTimes.end(),
-                static_cast<Size>(this->timeStepsPerYear_*t));
+                ql_cast<Size>(this->timeStepsPerYear_*t));
         }
 
         return TimeGrid(fixingTimes.begin(), fixingTimes.end());

--- a/ql/pricingengines/barrier/binomialbarrierengine.hpp
+++ b/ql/pricingengines/barrier/binomialbarrierengine.hpp
@@ -139,7 +139,7 @@ namespace QuantLib {
                divisor = std::pow(std::log(arguments_.barrier / s0), 2);
             if (!close(divisor,0)) {
                 for (Size i=1; i < timeSteps_ ; ++i) {
-                    Size optimum = Size(( i*i * v*v * maturity) / divisor);
+                    Size optimum = ql_cast<Size>(( i*i * v*v * maturity) / divisor);
                     if (timeSteps_ < optimum) {
                         optimum_steps = optimum;
                         break; // found first minimum with iterations>=timesteps

--- a/ql/pricingengines/barrier/mcbarrierengine.hpp
+++ b/ql/pricingengines/barrier/mcbarrierengine.hpp
@@ -220,7 +220,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(residualTime, timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*residualTime);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*residualTime);
             return TimeGrid(residualTime, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/pricingengines/basket/mceuropeanbasketengine.hpp
+++ b/ql/pricingengines/basket/mceuropeanbasketengine.hpp
@@ -178,7 +178,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(residualTime, timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*residualTime);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*residualTime);
             return TimeGrid(residualTime, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -130,7 +130,7 @@ namespace QuantLib {
         if (this->timeSteps_ != Null<Size>()) {
             totalSteps = timeSteps_;
         } else if (this->timeStepsPerYear_ != Null<Size>()) {
-            totalSteps = static_cast<Size>(this->timeStepsPerYear_*t2);
+            totalSteps = ql_cast<Size>(this->timeStepsPerYear_*t2);
         }
 
         std::vector<Time> fixingTimes;

--- a/ql/pricingengines/forward/mcvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/mcvarianceswapengine.hpp
@@ -201,7 +201,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(t, this->timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*t);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*t);
             return TimeGrid(t, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");
@@ -317,7 +317,7 @@ namespace QuantLib {
             Integrand(Path path, ext::shared_ptr<GeneralizedBlackScholesProcess> process)
             : path_(std::move(path)), process_(std::move(process)) {}
             Real operator()(Time t) const {
-                Size i =  static_cast<Size>(t/path_.timeGrid().dt(0));
+                Size i =  ql_cast<Size>(t/path_.timeGrid().dt(0));
                 Real sigma = process_->diffusion(t,path_[i]);
                 return sigma*sigma;
             }
@@ -334,7 +334,7 @@ namespace QuantLib {
         Time t0 = path.timeGrid().front();
         Time t = path.timeGrid().back();
         Time dt = path.timeGrid().dt(0);
-        SegmentIntegral integrator(static_cast<Size>(t/dt));
+        SegmentIntegral integrator(ql_cast<Size>(t/dt));
         detail::Integrand f(path, process_);
         return integrator(f,t0,t)/t;
     }

--- a/ql/pricingengines/lookback/mclookbackengine.hpp
+++ b/ql/pricingengines/lookback/mclookbackengine.hpp
@@ -151,7 +151,7 @@ namespace QuantLib {
         if (timeSteps_ != Null<Size>()) {
             return TimeGrid(residualTime, timeSteps_);
         } else if (timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(timeStepsPerYear_*residualTime);
+            Size steps = ql_cast<Size>(timeStepsPerYear_*residualTime);
             return TimeGrid(residualTime, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -230,7 +230,7 @@ namespace QuantLib {
             return TimeGrid(requiredTimes.begin(), requiredTimes.end(),
                             this->timeSteps_);
         } else if (this->timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(this->timeStepsPerYear_ *
+            Size steps = ql_cast<Size>(this->timeStepsPerYear_ *
                                            requiredTimes.back());
             return TimeGrid(requiredTimes.begin(), requiredTimes.end(),
                             std::max<Size>(steps, 1));

--- a/ql/pricingengines/mcsimulation.hpp
+++ b/ql/pricingengines/mcsimulation.hpp
@@ -125,8 +125,8 @@ namespace QuantLib {
             // conservative estimate of how many samples are needed
             order = maxError(error*error)/tolerance/tolerance;
             nextBatch =
-                Size(std::max<Real>(static_cast<Real>(sampleNumber)*order*0.8 - static_cast<Real>(sampleNumber),
-                                    static_cast<Real>(minSamples)));
+                ql_cast<Size>(std::max<Real>(static_cast<Real>(sampleNumber)*order*0.8 - static_cast<Real>(sampleNumber),
+                                             static_cast<Real>(minSamples)));
 
             // do not exceed maxSamples
             nextBatch = std::min(nextBatch, maxSamples-sampleNumber);

--- a/ql/pricingengines/swaption/basketgeneratingengine.cpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.cpp
@@ -188,10 +188,10 @@ namespace QuantLib {
 
                 Real maturity = fabs(solution[1]);
 
-                Size years = (Size)std::floor(maturity);
+                Size years = ql_cast<Size>(std::floor(maturity));
                 maturity -= (Real)years;
                 maturity *= 12.0;
-                Size months = (Size)std::floor(maturity + 0.5);
+                Size months = ql_cast<Size>(std::floor(maturity + 0.5));
                 if (years == 0 && months == 0)
                     months = 1; // ensure a maturity of at least one months
                 // maturity -= (Real)months; maturity *= 365.25;

--- a/ql/pricingengines/swaption/basketgeneratingengine.hpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.hpp
@@ -162,10 +162,10 @@ namespace QuantLib {
                 Real fixedRate = v[2]; // allow for negative rates explicitly
                 // (though it might not be reasonable for calibration depending
                 // on the model to calibrate and the market instrument quotation)
-                Size years = (Size)std::floor(maturity);
+                Size years = ql_cast<Size>(std::floor(maturity));
                 maturity -= (Real)years;
                 maturity *= 12.0;
-                Size months = (Size)std::floor(maturity);
+                Size months = ql_cast<Size>(std::floor(maturity));
                 Real alpha = 1.0 - (maturity - (Real)months);
                 if (years == 0 && months == 0) {
                     months = 1;  // ensure a maturity of at least one month ...

--- a/ql/pricingengines/vanilla/fdvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdvanillaengine.cpp
@@ -133,7 +133,7 @@ namespace QuantLib {
         static const Size minGridPointsPerYear = 2;
         return std::max(gridPoints,
                         residualTime > 1.0 ?
-                            static_cast<Size>((minGridPoints +
+                            ql_cast<Size>((minGridPoints +
                                                (residualTime-1.0) *
                                                 minGridPointsPerYear))
                             : minGridPoints);

--- a/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
+++ b/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
@@ -105,7 +105,7 @@ namespace QuantLib {
         // Haug arbitrary criterium is:
         //for (i=0; i<11; i++) {
         for (i=0;  (lastContribution>relativeAccuracy_ && i<maxIterations_) 
-                 || i < Size(lambda*t); i++) {
+                 || i < ql_cast<Size>(lambda*t); i++) {
 
             // constant vol/rate assumption. It should be relaxed
             v = std::sqrt((variance + i*jumpSquareVol)/t);

--- a/ql/pricingengines/vanilla/mcvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/mcvanillaengine.hpp
@@ -156,7 +156,7 @@ namespace QuantLib {
         if (this->timeSteps_ != Null<Size>()) {
             return TimeGrid(t, this->timeSteps_);
         } else if (this->timeStepsPerYear_ != Null<Size>()) {
-            Size steps = static_cast<Size>(this->timeStepsPerYear_*t);
+            Size steps = ql_cast<Size>(this->timeStepsPerYear_*t);
             return TimeGrid(t, std::max<Size>(steps, 1));
         } else {
             QL_FAIL("time steps not specified");

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.cpp
@@ -47,12 +47,12 @@ Gaussian1dSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                Time swapLength) const {
     DateHelper hlp(*this, optionTime);
     NewtonSafe newton;
-    Date d(static_cast<Date::serial_type>(newton.solve(
+    Date d(ql_cast<Date::serial_type>(newton.solve(
         hlp, 0.1,
         365.25 * optionTime + static_cast<Real>(referenceDate().serialNumber()),
         1.0)));
     Period tenor(
-        static_cast<Integer>(Rounding(0)(swapLength * 12.0)),
+        ql_cast<Integer>(Rounding(0)(swapLength * 12.0)),
         Months);
     d = indexBase_->fixingCalendar().adjust(d);
     return smileSectionImpl(d, tenor);

--- a/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
+++ b/ql/termstructures/volatility/swaption/gaussian1dswaptionvolatility.hpp
@@ -73,11 +73,11 @@ class Gaussian1dSwaptionVolatility : public SwaptionVolatilityStructure {
       public:
         DateHelper(const TermStructure &ts, const Time t) : ts_(ts), t_(t) {}
         Real operator()(Real date) const {
-            Date d1(static_cast<Date::serial_type>(date));
-            Date d2(static_cast<Date::serial_type>(date) + 1);
+            Date d1(ql_cast<Date::serial_type>(date));
+            Date d2(ql_cast<Date::serial_type>(date) + 1);
             Real t1 = ts_.timeFromReference(d1) - t_;
             Real t2 = ts_.timeFromReference(d2) - t_;
-            Real h = date - static_cast<Date::serial_type>(date);
+            Real h = date - ql_cast<Date::serial_type>(date);
             return h * t2 + (1.0 - h) * t1;
         }
         Real derivative(Real date) const {

--- a/ql/termstructures/volatility/swaption/swaptionvolcube2.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube2.cpp
@@ -71,7 +71,7 @@ namespace QuantLib {
         calculate();
         Date optionDate = optionDateFromTime(optionTime);
         Rounding rounder(0);
-        Period swapTenor(static_cast<Integer>(rounder(swapLength*12.0)), Months);
+        Period swapTenor(ql_cast<Integer>(rounder(swapLength*12.0)), Months);
         // ensure that option date is valid fixing date
         optionDate =
             swapTenor > shortSwapIndexBase_->tenor()

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
     }
 
     inline Date SwaptionVolatilityDiscrete::optionDateFromTime(Time optionTime) const {
-        return Date(static_cast<Date::serial_type>(optionInterpolator_(optionTime)));
+        return Date(ql_cast<Date::serial_type>(optionInterpolator_(optionTime)));
     }
 }
 

--- a/ql/time/calendars/japan.cpp
+++ b/ql/time/calendars/japan.cpp
@@ -45,10 +45,10 @@ namespace QuantLib {
         const Time moving_amount = (y-2000)*diff_per_year;
         Integer number_of_leap_years = (y-2000)/4+(y-2000)/100-(y-2000)/400;
         Day ve =    // vernal equinox day
-            Day(exact_vernal_equinox_time
+            ql_cast<Day>(exact_vernal_equinox_time
                 + moving_amount - number_of_leap_years);
         Day ae =    // autumnal equinox day
-            Day(exact_autumnal_equinox_time
+            ql_cast<Day>(exact_autumnal_equinox_time
                 + moving_amount - number_of_leap_years);
         // checks
         if (isWeekend(w)

--- a/ql/time/period.hpp
+++ b/ql/time/period.hpp
@@ -145,12 +145,12 @@ namespace QuantLib {
 
     template <typename T>
     inline Period operator*(T n, TimeUnit units) {
-        return {Integer(n), units};
+        return {ql_cast<Integer>(n), units};
     }
 
     template <typename T>
     inline Period operator*(TimeUnit units, T n) {
-        return {Integer(n), units};
+        return {ql_cast<Integer>(n), units};
     }
 
     inline Period operator-(const Period& p) { return {-p.length(), p.units()}; }

--- a/ql/types.hpp
+++ b/ql/types.hpp
@@ -81,6 +81,12 @@ namespace QuantLib {
     /*! \ingroup types */
     typedef Real Probability;
 
+    //! type conversions wrapper Real -> T, to allow specialisations for custom Real types
+    /*! \ingroup types */
+    template <class T>
+    T ql_cast(const Real& x) {
+        return static_cast<T>(x);
+    };
 }
 
 

--- a/ql/types.hpp
+++ b/ql/types.hpp
@@ -83,8 +83,8 @@ namespace QuantLib {
 
     //! type conversions wrapper Real -> T, to allow specialisations for custom Real types
     /*! \ingroup types */
-    template <class T>
-    T ql_cast(const Real& x) {
+    template <class T, class F>
+    T ql_cast(const F& x) {
         return static_cast<T>(x);
     };
 }

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -126,8 +126,8 @@ namespace andreasen_huge_volatility_interpl_test {
 
             for (Size j=1; j < LENGTH(i); ++j) {
                 if (i[j] > QL_EPSILON) {
-                    const Date maturity
-                        = today + Period(Size(365*maturityTimes[j-1]), Days);
+                    const Date maturity =
+                        today + Period(ql_cast<Size>(365 * maturityTimes[j - 1]), Days);
 
                     const Volatility impliedVol = i[j];
 
@@ -230,7 +230,7 @@ namespace andreasen_huge_volatility_interpl_test {
 
             const ext::shared_ptr<PricingEngine> fdEngine(
                 ext::make_shared<FdBlackScholesVanillaEngine>(
-                    localVolProcess, std::max<Size>(30, Size(100*t)),
+                    localVolProcess, std::max<Size>(30, ql_cast<Size>(100 * t)),
                     200, 0, FdmSchemeDesc::Douglas(), true));
 
             option->setPricingEngine(fdEngine);

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -1037,10 +1037,10 @@ void AsianOptionTest::testMCDiscreteArithmeticAveragePriceHeston() {
         std::vector<Time> timeIncrements(l.fixings);
         std::vector<Date> fixingDates(l.fixings);
         timeIncrements[0] = l.first;
-        fixingDates[0] = today + Integer(timeIncrements[0]*365.25);
+        fixingDates[0] = today + ql_cast<Integer>(timeIncrements[0] * 365.25);
         for (Size i = 1; i < l.fixings; i++) {
             timeIncrements[i] = i * dt + l.first;
-            fixingDates[i] = today + Integer(timeIncrements[i]*365.25);
+            fixingDates[i] = today + ql_cast<Integer>(timeIncrements[i] * 365.25);
         }
         ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[l.fixings - 1]));
 

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -488,7 +488,7 @@ void BasketOptionTest::testBarraquandThreeValues() {
         ext::shared_ptr<PlainVanillaPayoff> payoff(
             new PlainVanillaPayoff(value.type, value.strike));
 
-        Date exDate = today + Integer(value.t) * 30;
+        Date exDate = today + ql_cast<Integer>(value.t) * 30;
         ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
         ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
                                                                     exDate));

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -684,7 +684,7 @@ void FdHestonTest::testFdmHestonConvergence() {
                         rTS, qTS, s0, k, value.kappa, value.theta, value.sigma, value.rho));
 
                     Date exerciseDate =
-                        todaysDate + Period(static_cast<Integer>(value.T * 365), Days);
+                        todaysDate + Period(ql_cast<Integer>(value.T * 365), Days);
                     ext::shared_ptr<Exercise> exercise(
                                           new EuropeanExercise(exerciseDate));
 

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -1436,8 +1436,8 @@ void FdmLinearOpTest::testSpareMatrixReference() {
     for (auto& i : v) {
         SparseMatrixReference m(i);
         for (Size j=0; j < nElements; ++j) {
-            const Size row    = Size(rng.next().value*rows);
-            const Size column = Size(rng.next().value*columns);
+            const Size row    = ql_cast<Size>(rng.next().value*rows);
+            const Size column = ql_cast<Size>(rng.next().value*columns);
 
             const Real value = rng.next().value;
             m(row, column)        += value;

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -55,7 +55,7 @@ namespace {
             const Size nSims = 64*1024;
 
             const Real timeStepsPerYear = 1./dt;
-            const Size timeSteps = Size(maturity_*timeStepsPerYear+1e-8);
+            const Size timeSteps = ql_cast<Size>(maturity_*timeStepsPerYear+1e-8);
 
             const Real sqrtDt = std::sqrt(dt);
             const Real w = std::sqrt(1.0-rho_*rho_);
@@ -393,7 +393,7 @@ void FdSabrTest::testOosterleeTestCaseIV() {
         const Date maturityDate = today + maturities[i];
         const Time maturityTime = dc.yearFraction(today, maturityDate);
 
-        const Size timeSteps = Size(5*maturityTime);
+        const Size timeSteps = ql_cast<Size>(5*maturityTime);
 
         const ext::shared_ptr<PricingEngine> engine =
             ext::make_shared<FdSabrVanillaEngine>(
@@ -497,9 +497,9 @@ void FdSabrTest::testBenchOpSabrCase() {
 
             option.setPricingEngine(ext::make_shared<FdSabrVanillaEngine>(
                     f0, alpha, beta, nu, rho, rTS,
-                    Size(gridT*factor),
-                    Size(gridX*factor),
-                    Size(gridY*std::sqrt(factor))));
+                    ql_cast<Size>(gridT*factor),
+                    ql_cast<Size>(gridX*factor),
+                    ql_cast<Size>(gridY*std::sqrt(factor))));
 
             const Real calculated = option.NPV();
             const Real diff = std::fabs(calculated - expected[i][j]);

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -2018,7 +2018,7 @@ void HestonSLVModelTest::testMonteCarloCalibration() {
 
             const ext::shared_ptr<PricingEngine> fdEngine
                 = ext::make_shared<FdHestonVanillaEngine>(
-                    hestonModel, std::max(Size(26), Size(maturityTime*51)),
+                    hestonModel, std::max(Size(26), ql_cast<Size>(maturityTime*51)),
                     201, 51, 0,
                     FdmSchemeDesc::ModifiedCraigSneyd(), leverageFct);
 

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -987,7 +987,7 @@ namespace hybrid_heston_hullwhite_process_test {
                                             const VanillaOptionData& params) {
 
         Date maturity = Date(Settings::instance().evaluationDate())
-                                          + Period(Size(params.maturity*365), Days);
+                                          + Period(ql_cast<Size>(params.maturity*365), Days);
         ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
         ext::shared_ptr<StrikedTypePayoff> payoff(
                     new PlainVanillaPayoff(params.optionType, params.strike));
@@ -1046,7 +1046,7 @@ void HybridHestonHullWhiteProcessTest::testBsmHullWhitePricing() {
         SchemeData scheme = schemes[l];
         for (bool i : controlVariate) {
             for (unsigned long u : listOfTimeStepsPerYear) {
-                Size tSteps = Size(maturity * u);
+                Size tSteps = ql_cast<Size>(maturity * u);
 
                 ext::shared_ptr<FdHestonHullWhiteVanillaEngine> fdEngine(
                     new FdHestonHullWhiteVanillaEngine(hestonModel, hwProcess, equityIrCorr, tSteps,
@@ -1111,7 +1111,7 @@ void HybridHestonHullWhiteProcessTest::testSpatialDiscretizatinError() {
                 ext::shared_ptr<PricingEngine> analyticEngine(
                                new AnalyticHestonEngine(hestonModel, 172));
 
-                Size tSteps = Size(maturity * u);
+                Size tSteps = ql_cast<Size>(maturity * u);
 
                 ext::shared_ptr<FdHestonVanillaEngine> fdEngine(
                     new FdHestonVanillaEngine(
@@ -1302,7 +1302,7 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
     fdmHestonModel->setParams(analyticHestonModel->params());
 
     for (Size i=0; i < maturities.size(); ++i) {
-        const Size tGrid = static_cast<Size>(std::max(5.0, maturities[i]*5.0));
+        const Size tGrid = ql_cast<Size>(std::max(5.0, maturities[i]*5.0));
         ext::shared_ptr<FdHestonHullWhiteVanillaEngine> engine(
             new FdHestonHullWhiteVanillaEngine(fdmHestonModel, hwProcess,
                                                equityShortRateCorr,

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -135,8 +135,8 @@ namespace inflation_volatility_test {
         Size nTimesGBP = LENGTH(timesGBP);
         for (Size i = 0; i < nTimesEUR; i++) {
             r.push_back(ratesEUR[i]);
-            Size ys = (Size)floor(timesEUR[i]);
-            Size ds = (Size)((timesEUR[i]-(Real)ys)*365);
+            Size ys = ql_cast<Size>(floor(timesEUR[i]));
+            Size ds = ql_cast<Size>((timesEUR[i]-(Real)ys)*365);
             Date dd = eval + Period(ys,Years) + Period(ds,Days);
             d.push_back( dd );
         }
@@ -150,8 +150,8 @@ namespace inflation_volatility_test {
         r.clear();
         for (Size i = 0; i < nTimesGBP; i++) {
             r.push_back(ratesGBP[i]);
-            Size ys = (Size)floor(timesGBP[i]);
-            Size ds = (Size)((timesGBP[i]-(Real)ys)*365);
+            Size ys = ql_cast<Size>(floor(timesGBP[i]));
+            Size ds = ql_cast<Size>((timesGBP[i]-(Real)ys)*365);
             Date dd = eval + Period(ys,Years) + Period(ds,Days);
             d.push_back( dd );
         }

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -407,7 +407,7 @@ void MatricesTest::testDeterminant() {
 
         if ((j % 3) == 0U) {
             // every third matrix is a singular matrix
-            Size row = Size(3*rng.next().value);
+            Size row = ql_cast<Size>(3*rng.next().value);
             std::fill(m.row_begin(row), m.row_end(row), 0.0);
         }
 

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -768,7 +768,7 @@ namespace {
 
         const Array strikes = {100};
 
-        const Size yGrid = Size(1/h);
+        const Size yGrid = ql_cast<Size>(1/h);
         const GridSetup setup = {
               5.50966, 0.0130581,
              true, false,

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -1177,7 +1177,7 @@ void QuantoOptionTest::testPDEOptionValues()  {
 
         const ext::shared_ptr<PricingEngine> pdeEngine =
             ext::make_shared<FdBlackScholesVanillaEngine>(bsmProcess, quantoHelper,
-                                                          Size(value.t * 200), 500, 1);
+                                                          ql_cast<Size>(value.t * 200), 500, 1);
 
         option.setPricingEngine(pdeEngine);
 

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -427,7 +427,7 @@ void RiskNeutralDensityCalculatorTest::testLocalVolatilityRND() {
 
         const ext::shared_ptr<PricingEngine> engine(
             new FdBlackScholesVanillaEngine(
-                bsmProcess, std::max(Size(51), Size(expiry*101)),
+                bsmProcess, std::max(Size(51), ql_cast<Size>(expiry*101)),
                 201, 0, FdmSchemeDesc::Douglas(), true, b1));
 
         const ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -196,7 +196,7 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
             spot, qTS, rTS, sabrVol));
 
     std::vector<Date> calibrationDates(1, todaysDate + Period(3, Months));
-    calibrationDates.reserve(Size(daysBetween(todaysDate, maturityDate)/7 + 1));
+    calibrationDates.reserve(ql_cast<Size>(daysBetween(todaysDate, maturityDate)/7 + 1));
     while (calibrationDates.back() < maturityDate)
         calibrationDates.push_back(calibrationDates.back() + Period(1, Weeks));
 

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -468,7 +468,7 @@ namespace swing_option_test {
             option_->setPricingEngine(
                 ext::make_shared<FdExtOUJumpVanillaEngine>(
                     process_, rTS,
-                    Size(gridT/x), Size(gridX/x), Size(gridY/x), shape_));
+                    ql_cast<Size>(gridT/x), ql_cast<Size>(gridX/x), ql_cast<Size>(gridY/x), shape_));
 
             return option_->NPV();
         }

--- a/test-suite/varianceoption.cpp
+++ b/test-suite/varianceoption.cpp
@@ -54,7 +54,7 @@ void VarianceOptionTest::testIntegralHeston() {
     Real strike = 0.05;
     Real nominal = 1.0;
     Time T = 1.5;
-    Date exDate = today + int(360*T);
+    Date exDate = today + ql_cast<int>(360*T);
 
     ext::shared_ptr<Payoff> payoff(new PlainVanillaPayoff(Option::Call,
                                                             strike));
@@ -88,7 +88,7 @@ void VarianceOptionTest::testIntegralHeston() {
     strike = 0.7;
     nominal = 1.0;
     T = 1.0;
-    exDate = today + int(360*T);
+    exDate = today + ql_cast<int>(360*T);
 
     payoff = ext::shared_ptr<Payoff>(new PlainVanillaPayoff(Option::Put,
                                                               strike));

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -160,7 +160,7 @@ void VPPTest::testGemanRoncoroniProcess() {
 
     const Time T = 10.0;
     const Size stepsPerYear = 250;
-    const Size steps = Size(T*Real(stepsPerYear));
+    const Size steps = ql_cast<Size>(T*Real(stepsPerYear));
 
     TimeGrid grid(T, steps);
 
@@ -470,7 +470,7 @@ namespace vpp_test {
             QL_REQUIRE(t-std::sqrt(QL_EPSILON) <=  shape_->back().first,
                         "invalid time");
 
-            const Size i = Size(t * 365U * 24U);
+            const Size i = ql_cast<Size>(t * 365U * 24U);
             const Real f = std::lower_bound(shape_->begin(), shape_->end(),
                 std::pair<Time, Real>(t-std::sqrt(QL_EPSILON), 0.0))->second;
 
@@ -500,7 +500,7 @@ namespace vpp_test {
             QL_REQUIRE(t-std::sqrt(QL_EPSILON) <=  powerShape_->back().first,
                         "invalid time");
 
-            const Size i = Size(t * 365U * 24U);
+            const Size i = ql_cast<Size>(t * 365U * 24U);
             const Real f = std::lower_bound(
                 powerShape_->begin(), powerShape_->end(),
                 std::pair<Time, Real>(t-std::sqrt(QL_EPSILON), 0.0))->second;


### PR DESCRIPTION
This replaces all casts from `Real` to integers (both explicit and implicit) with a call to a template function `ql_cast<T>`. This cast works exactly the same way as `static_cast` but allows for customisation of these conversions and is therefore more generic.

Such customisations would be required in case the `Real` data type is not implicitly convertible to integers. An example for such a type could be a high precision floating point type. 