### PR TITLE
Using lambdas instead of function pointers

### DIFF
--- a/ql/experimental/models/hestonslvfdmmodel.cpp
+++ b/ql/experimental/models/hestonslvfdmmodel.cpp
@@ -416,7 +416,7 @@ namespace QuantLib {
                 std::transform(xMesher[i]->locations().begin(),
                                xMesher[i]->locations().end(),
                                vStrikes[i]->begin(),
-                               static_cast<Real(*)(Real)>(std::exp));
+                               [](Real x) { return std::exp(x); });
             }
         }
 

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -624,29 +624,29 @@ namespace QuantLib {
 
     inline Array Abs(const Array& v) {
         Array result(v.size());
-        std::transform(v.begin(),v.end(),result.begin(),
-                       static_cast<Real(*)(Real)>(std::fabs));
+        std::transform(v.begin(), v.end(), result.begin(),
+                       [](Real x) { return std::fabs(x); });
         return result;
     }
 
     inline Array Sqrt(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
-                       static_cast<Real(*)(Real)>(std::sqrt));
+                       [](Real x) { return std::sqrt(x); });
         return result;
     }
 
     inline Array Log(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
-                       static_cast<Real(*)(Real)>(std::log));
+                       [](Real x) { return std::log(x); });
         return result;
     }
 
     inline Array Exp(const Array& v) {
         Array result(v.size());
-        std::transform(v.begin(),v.end(),result.begin(),
-                       static_cast<Real(*)(Real)>(std::exp));
+        std::transform(v.begin(), v.end(), result.begin(),
+                       [](Real x) { return std::exp(x); });
         return result;
     }
 

--- a/ql/math/integrals/filonintegral.cpp
+++ b/ql/math/integrals/filonintegral.cpp
@@ -60,12 +60,12 @@ namespace QuantLib {
         ext::function<Real(Real)> f1, f2;
         switch(type_) {
           case Cosine:
-            f1 = static_cast<Real(*)(Real)>(std::sin);
-            f2 = static_cast<Real(*)(Real)>(std::cos);
+            f1 = [](Real x) { return std::sin(x); };
+            f2 = [](Real x) { return std::cos(x); };
             break;
           case Sine:
-            f1 = static_cast<Real(*)(Real)>(std::cos);
-            f2 = static_cast<Real(*)(Real)>(std::sin);
+            f1 = [](Real x) { return std::cos(x); };
+            f2 = [](Real x) { return std::sin(x); };
             break;
           default:
             QL_FAIL("unknown integration type");

--- a/ql/math/sampledcurve.hpp
+++ b/ql/math/sampledcurve.hpp
@@ -87,8 +87,8 @@ namespace QuantLib {
             setGrid(BoundedLogGrid(min, max, size()-1));
         }
         void regridLogGrid(Real min, Real max) {
-            regrid(BoundedLogGrid(min, max, size()-1),
-                   static_cast<Real(*)(Real)>(std::log));
+            regrid(BoundedLogGrid(min, max, size() - 1),
+                   [](Real x) { return std::log(x); });
         }
         void shiftGrid(Real s) {
             grid_ += s;

--- a/ql/math/transformedgrid.hpp
+++ b/ql/math/transformedgrid.hpp
@@ -96,7 +96,7 @@ namespace QuantLib {
     class LogGrid : public TransformedGrid {
     public:
         LogGrid(const Array &grid) :
-            TransformedGrid(grid, static_cast<Real(*)(Real)>(std::log)) {};
+            TransformedGrid(grid, [](Real x) { return std::log(x); }){};
         const Array & logGridArray() const { return transformedGridArray();}
         Real logGrid(Size i) const { return transformedGrid(i);}
     };

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -108,17 +108,13 @@ namespace QuantLib {
         return retVal;
     }
 
-    namespace {
-        typedef Real (*Real2RealFct)(Real);
-    }
-
     FdmLogInnerValue::FdmLogInnerValue(
         const ext::shared_ptr<Payoff>& payoff,
         const ext::shared_ptr<FdmMesher>& mesher,
         Size direction)
     : FdmCellAveragingInnerValue(
         payoff, mesher, direction,
-        ext::function<Real(Real)>([](Real x) { return std::exp(x); })) {}
+        [](Real x) { return std::exp(x); }) {}
 
 
     FdmLogBasketInnerValue::FdmLogBasketInnerValue(ext::shared_ptr<BasketPayoff> payoff,

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -118,8 +118,7 @@ namespace QuantLib {
         Size direction)
     : FdmCellAveragingInnerValue(
         payoff, mesher, direction,
-        ext::function<Real(Real)>(static_cast<Real2RealFct>(std::exp))) {
-    }
+        ext::function<Real(Real)>([](Real x) { return std::exp(x); })) {}
 
 
     FdmLogBasketInnerValue::FdmLogBasketInnerValue(ext::shared_ptr<BasketPayoff> payoff,

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -103,9 +103,9 @@ namespace gaussian_quadratures_test {
         testSingle(I, "f(x) = x^2",
                    [](Real x){ return x * x; }, 2/3.);
         testSingle(I, "f(x) = sin(x)",
-                   static_cast<Real(*)(Real)>(std::sin), 0.0);
+                   [](Real x) { return std::sin(x); }, 0.0);
         testSingle(I, "f(x) = cos(x)",
-                   static_cast<Real(*)(Real)>(std::cos),
+                   [](Real x) { return std::cos(x); },
                    std::sin(1.0)-std::sin(-1.0));
         testSingle(I, "f(x) = Gaussian(x)",
                    NormalDistribution(),

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -66,9 +66,9 @@ namespace integrals_test {
         testSingle(I, "f(x) = x^2",
                    [](Real x){ return x * x; }, 0.0, 1.0, 1.0/3.0);
         testSingle(I, "f(x) = sin(x)",
-                   static_cast<Real(*)(Real)>(std::sin), 0.0, M_PI, 2.0);
+                   [](Real x) { return std::sin(x); }, 0.0, M_PI, 2.0);
         testSingle(I, "f(x) = cos(x)",
-                   static_cast<Real(*)(Real)>(std::cos), 0.0, M_PI, 0.0);
+                   [](Real x) { return std::cos(x); }, 0.0, M_PI, 0.0);
         testSingle(I, "f(x) = Gaussian(x)",
                    NormalDistribution(), -10.0, 10.0, 1.0);
         testSingle(I, "f(x) = Abcd2(x)",

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -193,7 +193,7 @@ void NumericalDifferentiationTest::testDerivativesOfSineFunction() {
     BOOST_TEST_MESSAGE("Testing numerical differentiation"
                        " of sin function...");
 
-    const ext::function<Real(Real)> f = static_cast<Real(*)(Real)>(std::sin);
+    const ext::function<Real(Real)> f = [](Real x) { return std::sin(x); };
 
     const ext::function<Real(Real)> df_central
         = NumericalDifferentiation(f, 1, std::sqrt(QL_EPSILON), 3,

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -91,7 +91,7 @@ void SwingOptionTest::testExtendedOrnsteinUhlenbeckProcess() {
     ext::function<Real (Real)> f[] 
         = { [=](Real x){ return level; },
             [ ](Real x){ return x + 1.0; },
-            static_cast<Real(*)(Real)>(std::sin) }; 
+            [ ](Real x) { return std::sin(x); }}; 
 
     for (Size n=0; n < LENGTH(f); ++n) {
         ExtendedOrnsteinUhlenbeckProcess refProcess(


### PR DESCRIPTION
Various places in the code use `static_cast<Real(*)(Real)>(std::exp)` and similar code to create a function object. This PR replaces this with lambdas, which has the following advantages:

- more readable / natural / modern
- more generic, as overload resolution and template / inline functions can be captured as well