### PR TITLE
Add C++23 CI jobs

### DIFF
--- a/.github/workflows/linux-full-tests.yml
+++ b/.github/workflows/linux-full-tests.yml
@@ -116,6 +116,12 @@ jobs:
             cc: gcc
             cxx: g++
             cxxflags: "-std=c++20"
+          - name: "C++23 mode"
+            shortname: c++23
+            tag: rolling
+            cc: gcc
+            cxx: g++
+            cxxflags: "-std=c++23"
           - name: "Unity build enabled"
             shortname: unity
             tag: rolling

--- a/.github/workflows/linux-nondefault.yml
+++ b/.github/workflows/linux-nondefault.yml
@@ -111,6 +111,12 @@ jobs:
             cc: gcc
             cxx: g++
             cxxflags: "-std=c++20"
+          - name: "C++23 mode"
+            shortname: c++23
+            tag: rolling
+            cc: gcc
+            cxx: g++
+            cxxflags: "-std=c++23"
           - name: "Unity build enabled"
             shortname: unity
             tag: rolling

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,6 +118,12 @@ jobs:
             cc: gcc
             cxx: g++
             cxxflags: "-std=c++20"
+          - name: "C++23 mode"
+            shortname: c++23
+            tag: rolling
+            cc: gcc
+            cxx: g++
+            cxxflags: "-std=c++23"
           - name: "Unity build enabled"
             shortname: unity
             tag: rolling


### PR DESCRIPTION
C++23 support is still in progress for most compilers but I figure it can't hurt to add it to the CI so that we have plenty of time to fix or report any issues before it becomes mainstream.

Also, I noticed that we don't have the full 'matrix' of CI jobs set up for Windows yet. The closest we have is the `cmake-win-with-options` CMake build job. Considering that C++20 support in MSVC is now [complete](https://devblogs.microsoft.com/cppblog/msvcs-stl-completes-stdc20/), I think it would be good to either bump `cmake-win-with-options` up to C++20 or make a new job for C++20. What do you think?