### PR TITLE
Replace boost::noncopyable with deleted special member functions

### DIFF
--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
@@ -32,7 +32,6 @@
 #include <ql/quote.hpp>
 #include <ql/patterns/lazyobject.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
-#include <boost/noncopyable.hpp>
 #include <vector>
 
 namespace QuantLib {
@@ -43,8 +42,7 @@ namespace QuantLib {
         volatilities of a set of caps/floors with given length.
     */
     class CapFloorTermVolCurve : public LazyObject,
-                                 public CapFloorTermVolatilityStructure,
-                                 private boost::noncopyable {
+                                 public CapFloorTermVolatilityStructure {
       public:
         //! floating reference date, floating market data
         CapFloorTermVolCurve(Natural settlementDays,
@@ -74,6 +72,15 @@ namespace QuantLib {
                              const std::vector<Period>& optionTenors,
                              const std::vector<Volatility>& vols,
                              const DayCounter& dc = Actual365Fixed());
+
+        // make class non-copyable and non-movable
+        CapFloorTermVolCurve(CapFloorTermVolCurve&&) = delete;
+        CapFloorTermVolCurve(const CapFloorTermVolCurve&) = delete;
+        CapFloorTermVolCurve& operator=(CapFloorTermVolCurve&&) = delete;
+        CapFloorTermVolCurve& operator=(const CapFloorTermVolCurve&) = delete;
+
+        ~CapFloorTermVolCurve() = default;
+
         //! \name TermStructure interface
         //@{
         Date maxDate() const override;

--- a/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
@@ -30,7 +30,6 @@
 #include <ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp>
 #include <ql/math/interpolations/interpolation2d.hpp>
 #include <ql/math/matrix.hpp>
-#include <boost/noncopyable.hpp>
 #include <vector>
 
 namespace QuantLib {
@@ -49,8 +48,7 @@ namespace QuantLib {
         - <tt>M[i][j]</tt> contains the volatility corresponding
           to the <tt>i</tt>-th option and <tt>j</tt>-th tenor.
     */
-    class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete,
-                                     private boost::noncopyable {
+    class SwaptionVolatilityMatrix : public SwaptionVolatilityDiscrete {
       public:
         //! floating reference date, floating market data
         SwaptionVolatilityMatrix(
@@ -107,6 +105,14 @@ namespace QuantLib {
                                  bool flatExtrapolation = false,
                                  VolatilityType type = ShiftedLognormal,
                                  const Matrix& shifts = Matrix());
+
+        // make class non-copyable and non-movable
+        SwaptionVolatilityMatrix(SwaptionVolatilityMatrix&&) = delete;
+        SwaptionVolatilityMatrix(const SwaptionVolatilityMatrix&) = delete;
+        SwaptionVolatilityMatrix& operator=(SwaptionVolatilityMatrix&&) = delete;
+        SwaptionVolatilityMatrix& operator=(const SwaptionVolatilityMatrix&) = delete;
+
+        ~SwaptionVolatilityMatrix() = default;
 
         //! \name LazyObject interface
         //@{


### PR DESCRIPTION
This code appears to predate C++11 and so can be modernized using the `delete` keyword.

Types inheriting from `boost::noncopyable` are also non-movable so the move operators should be deleted as well, and the default destructor should be added to conform with the Rule of Five.