### PR TITLE
Remove suppression for clang-analyzer-deadcode.DeadStores

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,6 @@ Checks: >
         clang-analyzer-*,
           -clang-analyzer-core.UndefinedBinaryOperatorResult,
           -clang-analyzer-core.uninitialized.Assign,
-          -clang-analyzer-deadcode.DeadStores,
           -clang-analyzer-optin.cplusplus.UninitializedObject,
           -clang-analyzer-optin.cplusplus.VirtualCall,
           -clang-analyzer-optin.performance.Padding,

--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -199,9 +199,11 @@ namespace QuantLib {
         if (optionType == Option::Call) {
             a = swapRateValue_;
             min = referenceStrike;
+            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             b = max = k =
                 std::min(smileSection_->maxStrike(), adjustedUpperBound_);
         } else {
+            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             a = min = k =
                 std::max(smileSection_->minStrike(), adjustedLowerBound_);
             b = swapRateValue_;
@@ -229,9 +231,11 @@ namespace QuantLib {
         if (optionType == Option::Call) {
             a = swapRateValue_;
             min = referenceStrike;
+            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             b = max = k =
                 std::min(smileSection_->maxStrike(), adjustedUpperBound_);
         } else {
+            // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             a = min = k =
                 std::max(smileSection_->minStrike(), adjustedLowerBound_);
             b = swapRateValue_;

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
         for (Size i = idx1; i < arguments_.leg1ResetDates.size(); i++) {
             nominalSum1 += arguments_.nominal1[i];
         }
-        Real nominalAvg1 = nominalSum1 /=
+        Real nominalAvg1 = nominalSum1 /
             (arguments_.leg1ResetDates.size() - idx1);
         Real weightedMaturity1 = 0.0;
         for (Size i = idx1; i < arguments_.leg1ResetDates.size(); i++) {

--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.hpp
@@ -79,7 +79,7 @@ namespace QuantLib {
         CapFloorTermVolCurve& operator=(CapFloorTermVolCurve&&) = delete;
         CapFloorTermVolCurve& operator=(const CapFloorTermVolCurve&) = delete;
 
-        ~CapFloorTermVolCurve() = default;
+        ~CapFloorTermVolCurve() override = default;
 
         //! \name TermStructure interface
         //@{

--- a/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp
@@ -112,7 +112,7 @@ namespace QuantLib {
         SwaptionVolatilityMatrix& operator=(SwaptionVolatilityMatrix&&) = delete;
         SwaptionVolatilityMatrix& operator=(const SwaptionVolatilityMatrix&) = delete;
 
-        ~SwaptionVolatilityMatrix() = default;
+        ~SwaptionVolatilityMatrix() override = default;
 
         //! \name LazyObject interface
         //@{

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -537,7 +537,6 @@ void InflationTest::testZeroTermStructure() {
 
     // For interpolated fixings, the zero rates on the curve no longer match the data.
     // The helpers still give the correct implied rates, of course.
-    forceLinearInterpolation = false;   // still
     for (Size i=0; i<zcData.size(); i++) {
         BOOST_CHECK_MESSAGE(std::fabs(helpersyes[i]->impliedQuote()
                         - zcData[i].rate/100.0) < eps,


### PR DESCRIPTION
The suppression comments can be removed once https://github.com/llvm/llvm-project/issues/55621 is resolved.