### PR TITLE
Correct New Year's Day holiday for Australia

### DIFF
--- a/ql/time/calendars/australia.cpp
+++ b/ql/time/calendars/australia.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
         Day em = easterMonday(y);
         if (isWeekend(w)
             // New Year's Day (possibly moved to Monday)
-            || ((d == 1 || d == 2)  && m == January)
+            || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == January)
             // Australia Day, January 26th (possibly moved to Monday)
             || ((d == 26 || ((d == 27 || d == 28) && w == Monday)) &&
                 m == January)

--- a/ql/time/calendars/australia.hpp
+++ b/ql/time/calendars/australia.hpp
@@ -33,7 +33,7 @@ namespace QuantLib {
         <ul>
         <li>Saturdays</li>
         <li>Sundays</li>
-        <li>New Year's Day, January 1st</li>
+        <li>New Year's Day, January 1st (possibly moved to Monday)</li>
         <li>Australia Day, January 26th (possibly moved to Monday)</li>
         <li>Good Friday</li>
         <li>Easter Monday</li>


### PR DESCRIPTION
Hi,
This was mentioned as an issue in #1374 and #1365. See the comments there for references on the change.

Best,
Fredrik