### PR TITLE
Add more validations to barrier options

### DIFF
--- a/ql/experimental/barrieroption/analyticdoublebarrierengine.cpp
+++ b/ql/experimental/barrieroption/analyticdoublebarrierengine.cpp
@@ -44,7 +44,7 @@ namespace QuantLib {
                    "strike must be positive");
 
         Real spot = underlying();
-        QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot > 0.0, "negative or null underlying given");
         QL_REQUIRE(!triggered(spot), "barrier(s) already touched");
 
         DoubleBarrier::Type barrierType = arguments_.barrierType;

--- a/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
@@ -52,7 +52,7 @@ namespace QuantLib {
                               BigNatural seed);
         void calculate() const override {
             Real spot = process_->x0();
-            QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+            QL_REQUIRE(spot > 0.0, "negative or null underlying given");
             QL_REQUIRE(!triggered(spot), "barrier touched");
             McSimulation<SingleVariate,RNG,S>::calculate(requiredTolerance_,
                                                          requiredSamples_,

--- a/ql/experimental/barrieroption/suowangdoublebarrierengine.cpp
+++ b/ql/experimental/barrieroption/suowangdoublebarrierengine.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
 
         Real K = payoff->strike();
         Real S = process_->x0();
-        QL_REQUIRE(S >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(S > 0.0, "negative or null underlying given");
         QL_REQUIRE(!triggered(S), "barrier touched");
 
         DoubleBarrier::Type barrierType = arguments_.barrierType;

--- a/ql/experimental/exoticoptions/analyticcompoundoptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticcompoundoptionengine.cpp
@@ -67,7 +67,7 @@ namespace QuantLib {
         QL_REQUIRE(strikeMother()>0.0,
                    "Mother strike must be positive");
 
-        QL_REQUIRE(spot() >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot() > 0.0, "negative or null underlying given");
 
         /* Solver Setup ***************************************************/
         Date helpDate(process_->riskFreeRate()->referenceDate());

--- a/ql/experimental/exoticoptions/analyticpartialtimebarrieroptionengine.cpp
+++ b/ql/experimental/exoticoptions/analyticpartialtimebarrieroptionengine.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
                    "strike must be positive");
 
         Real spot = process_->x0();
-        QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot > 0.0, "negative or null underlying given");
 
         PartialBarrier::Type barrierType = arguments_.barrierType;
         PartialBarrier::Range barrierRange = arguments_.barrierRange;

--- a/ql/experimental/exoticoptions/analytictwoassetbarrierengine.cpp
+++ b/ql/experimental/exoticoptions/analytictwoassetbarrierengine.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
 
         Real spot2 = process2_->x0();
         // option is triggered by S2
-        QL_REQUIRE(spot2 >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot2 > 0.0, "negative or null underlying given");
         QL_REQUIRE(!triggered(spot2), "barrier touched");
 
         Barrier::Type barrierType = arguments_.barrierType;

--- a/ql/experimental/exoticoptions/analytictwoassetcorrelationengine.cpp
+++ b/ql/experimental/exoticoptions/analytictwoassetcorrelationengine.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
         ext::shared_ptr<Exercise> exercise = arguments_.exercise;
         Real strike = payoff->strike();//X1
         Real spot = p1_->x0();
-        QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot > 0.0, "negative or null underlying given");
 
         Volatility sigma1 =
             p1_->blackVolatility()->blackVol(p1_->time(exercise->lastDate()),

--- a/ql/instruments/dividendbarrieroption.cpp
+++ b/ql/instruments/dividendbarrieroption.cpp
@@ -62,5 +62,17 @@ namespace QuantLib {
         }
     }
 
-}
+    bool DividendBarrierOption::engine::triggered(Real underlying) const {
+        switch (arguments_.barrierType) {
+          case Barrier::DownIn:
+          case Barrier::DownOut:
+            return underlying < arguments_.barrier;
+          case Barrier::UpIn:
+          case Barrier::UpOut:
+            return underlying > arguments_.barrier;
+          default:
+            QL_FAIL("unknown type");
+        }
+    }
 
+}

--- a/ql/instruments/dividendbarrieroption.hpp
+++ b/ql/instruments/dividendbarrieroption.hpp
@@ -65,7 +65,10 @@ namespace QuantLib {
     //! %Dividend-barrier-option %engine base class
     class DividendBarrierOption::engine
         : public GenericEngine<DividendBarrierOption::arguments,
-                               DividendBarrierOption::results> {};
+                               DividendBarrierOption::results> {
+      protected:
+        bool triggered(Real underlying) const;
+    };
 
 }
 

--- a/ql/pricingengines/barrier/analyticbarrierengine.cpp
+++ b/ql/pricingengines/barrier/analyticbarrierengine.cpp
@@ -41,9 +41,12 @@ namespace QuantLib {
         QL_REQUIRE(payoff->strike()>0.0,
                    "strike must be positive");
 
+        QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
+                   "only european style option are supported");
+
         Real strike = payoff->strike();
         Real spot = process_->x0();
-        QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+        QL_REQUIRE(spot > 0.0, "negative or null underlying given");
         QL_REQUIRE(!triggered(spot), "barrier touched");
 
         Barrier::Type barrierType = arguments_.barrierType;

--- a/ql/pricingengines/barrier/mcbarrierengine.hpp
+++ b/ql/pricingengines/barrier/mcbarrierengine.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
                         BigNatural seed);
         void calculate() const override {
             Real spot = process_->x0();
-            QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+            QL_REQUIRE(spot > 0.0, "negative or null underlying given");
             QL_REQUIRE(!triggered(spot), "barrier touched");
             McSimulation<SingleVariate,RNG,S>::calculate(requiredTolerance_,
                                                          requiredSamples_,

--- a/ql/pricingengines/forward/forwardengine.hpp
+++ b/ql/pricingengines/forward/forwardengine.hpp
@@ -90,7 +90,7 @@ namespace QuantLib {
         // the right level is needed in order to interpolate
         // the vol
         Handle<Quote> spot = process_->stateVariable();
-        QL_REQUIRE(spot->value() >= 0.0, "negative or null underlting given");
+        QL_REQUIRE(spot->value() > 0.0, "negative or null underlying given");
         Handle<YieldTermStructure> dividendYield(
             ext::shared_ptr<YieldTermStructure>(
                new ImpliedTermStructure(process_->dividendYield(),

--- a/ql/pricingengines/lookback/mclookbackengine.hpp
+++ b/ql/pricingengines/lookback/mclookbackengine.hpp
@@ -53,7 +53,7 @@ namespace QuantLib {
                          BigNatural seed);
         void calculate() const override {
             Real spot = process_->x0();
-            QL_REQUIRE(spot >= 0.0, "negative or null underlying given");
+            QL_REQUIRE(spot > 0.0, "negative or null underlying given");
             McSimulation<SingleVariate,RNG,S>::calculate(requiredTolerance_,
                                                          requiredSamples_,
                                                          maxSamples_);


### PR DESCRIPTION
Closes #1411 

- Validate that the barrier option is not already triggered at the start of calculating in `BinomialBarrierEngine` and `FdBlackScholesBarrierEngine`.
- Add missing validation for European exercise in `AnalyticBarrierEngine` (I confirmed that the unit test fails with American exercise as mentioned in the comments).
- Make validation on spot level consistently greater than zero across all pricing engines (it was already the case for most pricing engines).
- Add test cases for zero spot price and already triggered barriers to the barrier option unit test suite.

While making this change I noticed that the `triggered` function is copy-and-pasted in a few different places, and should probably be centralized in one place in a future pull request.