### PR TITLE
Deprecate unneeded typedefs

### DIFF
--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -73,8 +73,22 @@ namespace QuantLib {
 
     template <>
     struct earlier_than<CashFlow> {
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef CashFlow first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef CashFlow second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef bool result_type;
 
         bool operator()(const CashFlow& c1,

--- a/ql/cashflows/conundrumpricer.hpp
+++ b/ql/cashflows/conundrumpricer.hpp
@@ -259,7 +259,16 @@ namespace QuantLib {
         // private:
         class Function {
           public:
+            /*! \deprecated Use `auto` or `decltype` instead.
+                            Deprecated in version 1.29.
+            */
+            QL_DEPRECATED
             typedef Real argument_type;
+
+            /*! \deprecated Use `auto` or `decltype` instead.
+                            Deprecated in version 1.29.
+            */
+            QL_DEPRECATED
             typedef Real result_type;
             virtual ~Function() = default;
             virtual Real operator()(Real x) const = 0;

--- a/ql/experimental/math/convolvedstudentt.hpp
+++ b/ql/experimental/math/convolvedstudentt.hpp
@@ -59,7 +59,16 @@ namespace QuantLib {
     */
     class CumulativeBehrensFisher { // ODD orders only by now, rename?
     public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Probability result_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
         /*!
             @param degreesFreedom Degrees of freedom of the Ts convolved. The
@@ -162,7 +171,16 @@ namespace QuantLib {
      */
     class InverseCumulativeBehrensFisher {
     public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Probability argument_type;
         /*!
             @param degreesFreedom Degrees of freedom of the Ts convolved. The

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -42,7 +42,12 @@ namespace QuantLib {
     namespace detail {
         // havent figured out how to do this in-place
         struct multiplyV {
+            /*! \deprecated Use `auto` or `decltype` instead.
+                            Deprecated in version 1.29.
+            */
+            QL_DEPRECATED
             typedef std::vector<Real> result_type;
+
             std::vector<Real> operator()(Real d, std::vector<Real> v) 
             {
                 std::transform(v.begin(), v.end(), v.begin(), 

--- a/ql/math/abcdmathfunction.hpp
+++ b/ql/math/abcdmathfunction.hpp
@@ -35,7 +35,16 @@ namespace QuantLib {
     class AbcdMathFunction {
 
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Time argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         AbcdMathFunction(Real a = 0.002,

--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -133,8 +133,22 @@ namespace QuantLib {
        pointees. */
     template <class T>
     struct earlier_than<ext::shared_ptr<T> > {
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef ext::shared_ptr<T> first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef ext::shared_ptr<T> second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef bool result_type;
 
         bool operator()(const ext::shared_ptr<T>& x,

--- a/ql/math/copulas/alimikhailhaqcopula.hpp
+++ b/ql/math/copulas/alimikhailhaqcopula.hpp
@@ -33,8 +33,22 @@ namespace QuantLib {
     //! Ali-Mikhail-Haq copula
     class AliMikhailHaqCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         AliMikhailHaqCopula(Real theta);

--- a/ql/math/copulas/claytoncopula.hpp
+++ b/ql/math/copulas/claytoncopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Clayton copula
     class ClaytonCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         ClaytonCopula(Real theta);

--- a/ql/math/copulas/farliegumbelmorgensterncopula.hpp
+++ b/ql/math/copulas/farliegumbelmorgensterncopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Farlie-Gumbel-Morgenstern copula
     class FarlieGumbelMorgensternCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         FarlieGumbelMorgensternCopula(Real theta);

--- a/ql/math/copulas/frankcopula.hpp
+++ b/ql/math/copulas/frankcopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Frank copula
     class FrankCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         FrankCopula(Real theta);

--- a/ql/math/copulas/galamboscopula.hpp
+++ b/ql/math/copulas/galamboscopula.hpp
@@ -33,8 +33,22 @@ namespace QuantLib {
     //! Galambos copula
     class GalambosCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         GalambosCopula(Real theta);

--- a/ql/math/copulas/gaussiancopula.hpp
+++ b/ql/math/copulas/gaussiancopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Gaussian copula
     class GaussianCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         GaussianCopula(Real rho);

--- a/ql/math/copulas/gumbelcopula.hpp
+++ b/ql/math/copulas/gumbelcopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Gumbel copula
     class GumbelCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         GumbelCopula(Real theta);

--- a/ql/math/copulas/huslerreisscopula.hpp
+++ b/ql/math/copulas/huslerreisscopula.hpp
@@ -33,8 +33,22 @@ namespace QuantLib {
     //! Husler-Reiss copula
     class HuslerReissCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         HuslerReissCopula(Real theta_);

--- a/ql/math/copulas/independentcopula.hpp
+++ b/ql/math/copulas/independentcopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! independent copula
     class IndependentCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         Real operator()(Real x, Real y) const;

--- a/ql/math/copulas/marshallolkincopula.hpp
+++ b/ql/math/copulas/marshallolkincopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! Marshall-Olkin copula
     class MarshallOlkinCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         MarshallOlkinCopula(Real a1, Real a2);

--- a/ql/math/copulas/maxcopula.hpp
+++ b/ql/math/copulas/maxcopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! max copula
     class MaxCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         Real operator()(Real x, Real y) const;

--- a/ql/math/copulas/mincopula.hpp
+++ b/ql/math/copulas/mincopula.hpp
@@ -32,8 +32,22 @@ namespace QuantLib {
     //! min copula
     class MinCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         Real operator()(Real x, Real y) const;

--- a/ql/math/copulas/plackettcopula.hpp
+++ b/ql/math/copulas/plackettcopula.hpp
@@ -33,8 +33,22 @@ namespace QuantLib {
     //! Plackett copula
     class PlackettCopula {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         PlackettCopula(Real theta);

--- a/ql/math/distributions/binomialdistribution.hpp
+++ b/ql/math/distributions/binomialdistribution.hpp
@@ -50,7 +50,16 @@ namespace QuantLib {
     */
     class BinomialDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         BinomialDistribution(Real p, BigNatural n);
@@ -69,7 +78,16 @@ namespace QuantLib {
     */
     class CumulativeBinomialDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         CumulativeBinomialDistribution(Real p, BigNatural n);

--- a/ql/math/distributions/chisquaredistribution.hpp
+++ b/ql/math/distributions/chisquaredistribution.hpp
@@ -32,7 +32,16 @@ namespace QuantLib {
 
     class CumulativeChiSquareDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         explicit CumulativeChiSquareDistribution(Real df) : df_(df) {}
@@ -43,7 +52,16 @@ namespace QuantLib {
 
     class NonCentralCumulativeChiSquareDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         NonCentralCumulativeChiSquareDistribution(Real df, Real ncp)
@@ -55,7 +73,16 @@ namespace QuantLib {
 
     class NonCentralCumulativeChiSquareSankaranApprox {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         NonCentralCumulativeChiSquareSankaranApprox(Real df, Real ncp)
@@ -67,7 +94,16 @@ namespace QuantLib {
 
     class InverseNonCentralCumulativeChiSquareDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         InverseNonCentralCumulativeChiSquareDistribution(Real df, Real ncp,

--- a/ql/math/distributions/gammadistribution.hpp
+++ b/ql/math/distributions/gammadistribution.hpp
@@ -32,7 +32,16 @@ namespace QuantLib {
 
     class CumulativeGammaDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         CumulativeGammaDistribution(Real a) : a_(a) {
@@ -58,7 +67,16 @@ namespace QuantLib {
     */
     class GammaFunction {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         Real value(Real x) const;

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -43,7 +43,16 @@ namespace QuantLib {
     */
     class NormalDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         NormalDistribution(Real average = 0.0,
@@ -70,7 +79,16 @@ namespace QuantLib {
     */
     class CumulativeNormalDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         CumulativeNormalDistribution(Real average = 0.0,
@@ -105,7 +123,16 @@ namespace QuantLib {
     */
     class InverseCumulativeNormal {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         InverseCumulativeNormal(Real average = 0.0,
@@ -206,7 +233,16 @@ namespace QuantLib {
     */
     class MoroInverseCumulativeNormal {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         MoroInverseCumulativeNormal(Real average = 0.0,
@@ -249,7 +285,16 @@ namespace QuantLib {
     */
     class MaddockInverseCumulativeNormal {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         MaddockInverseCumulativeNormal(Real average = 0.0,
@@ -263,7 +308,16 @@ namespace QuantLib {
     //! Maddock's cumulative normal distribution class
     class MaddockCumulativeNormal {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         MaddockCumulativeNormal(Real average = 0.0,

--- a/ql/math/distributions/poissondistribution.hpp
+++ b/ql/math/distributions/poissondistribution.hpp
@@ -39,7 +39,16 @@ namespace QuantLib {
     */
     class PoissonDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         PoissonDistribution(Real mu);
@@ -63,7 +72,16 @@ namespace QuantLib {
     */
     class CumulativePoissonDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         CumulativePoissonDistribution(Real mu) : mu_(mu) {}
@@ -81,7 +99,16 @@ namespace QuantLib {
     */
     class InverseCumulativePoisson {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         InverseCumulativePoisson(Real lambda = 1.0);

--- a/ql/math/distributions/studenttdistribution.hpp
+++ b/ql/math/distributions/studenttdistribution.hpp
@@ -41,7 +41,16 @@ namespace QuantLib {
     */
     class StudentDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         StudentDistribution(Integer n) : n_(n) {
@@ -66,7 +75,16 @@ namespace QuantLib {
     */
     class CumulativeStudentDistribution {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         CumulativeStudentDistribution(Integer n) : n_(n) {
@@ -84,7 +102,16 @@ namespace QuantLib {
     */
     class InverseCumulativeStudent {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         InverseCumulativeStudent(Integer n,

--- a/ql/math/errorfunction.hpp
+++ b/ql/math/errorfunction.hpp
@@ -35,7 +35,16 @@ namespace QuantLib {
     */
     class ErrorFunction {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         ErrorFunction() = default;

--- a/ql/math/interpolation.hpp
+++ b/ql/math/interpolation.hpp
@@ -71,8 +71,18 @@ namespace QuantLib {
         };
         ext::shared_ptr<Impl> impl_;
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
+
         //! basic template implementation
         template <class I1, class I2>
         class templateImpl : public Impl {

--- a/ql/math/interpolations/interpolation2d.hpp
+++ b/ql/math/interpolations/interpolation2d.hpp
@@ -65,8 +65,22 @@ namespace QuantLib {
         };
         ext::shared_ptr<Impl> impl_;
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real first_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real second_argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
         //! basic template implementation
         template <class I1, class I2, class M>

--- a/ql/math/linearleastsquaresregression.hpp
+++ b/ql/math/linearleastsquaresregression.hpp
@@ -37,7 +37,16 @@ namespace QuantLib {
         template <class Container>
         class LinearFct {
           public:
+            /*! \deprecated Use `auto` or `decltype` instead.
+                            Deprecated in version 1.29.
+            */
+            QL_DEPRECATED
             typedef Container argument_type;
+
+            /*! \deprecated Use `auto` or `decltype` instead.
+                            Deprecated in version 1.29.
+            */
+            QL_DEPRECATED
             typedef Real result_type;
             explicit LinearFct(Size i) : i_(i) {}
 

--- a/ql/math/polynomialmathfunction.hpp
+++ b/ql/math/polynomialmathfunction.hpp
@@ -32,7 +32,16 @@ namespace QuantLib {
     class PolynomialFunction {
 
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Time argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         PolynomialFunction(const std::vector<Real>& coeff);

--- a/ql/math/randomnumbers/stochasticcollocationinvcdf.hpp
+++ b/ql/math/randomnumbers/stochasticcollocationinvcdf.hpp
@@ -41,7 +41,16 @@ namespace QuantLib {
 
     class StochasticCollocationInvCDF {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         StochasticCollocationInvCDF(

--- a/ql/methods/finitedifferences/operators/numericaldifferentiation.hpp
+++ b/ql/methods/finitedifferences/operators/numericaldifferentiation.hpp
@@ -40,7 +40,16 @@ namespace QuantLib {
     */
     class NumericalDifferentiation {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         enum Scheme { Central, Backward, Forward };

--- a/ql/methods/montecarlo/pathpricer.hpp
+++ b/ql/methods/montecarlo/pathpricer.hpp
@@ -39,6 +39,10 @@ namespace QuantLib {
     template<class PathType, class ValueType=Real>
     class PathPricer {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef PathType argument_type;
         typedef ValueType result_type;
 

--- a/ql/payoff.hpp
+++ b/ql/payoff.hpp
@@ -35,7 +35,16 @@ namespace QuantLib {
     //! Abstract base class for option payoffs
     class Payoff {
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         virtual ~Payoff() = default;

--- a/ql/termstructures/volatility/abcd.hpp
+++ b/ql/termstructures/volatility/abcd.hpp
@@ -93,7 +93,16 @@ namespace QuantLib {
     class AbcdSquared {
       
       public:
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real argument_type;
+
+        /*! \deprecated Use `auto` or `decltype` instead.
+                        Deprecated in version 1.29.
+        */
+        QL_DEPRECATED
         typedef Real result_type;
 
         AbcdSquared(Real a, Real b, Real c, Real d, Time T, Time S);


### PR DESCRIPTION
Continuation of #1339 

These public typedefs are no longer needed (and indeed are not referenced anywhere in the project as far as I can tell).