### PR TITLE
AAD-ready QuantLib

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -766,7 +766,7 @@ namespace QuantLib {
         // flows of the opposite sign have been specified (otherwise
         // IRR is nonsensical.)
 
-        Integer lastSign = sign(-npv_),
+        Integer lastSign = sign(Real(-npv_)),
                 signChanges = 0;
         for (const auto& i : leg_) {
             if (!i->hasOccurred(settlementDate_, includeSettlementDateFlows_) &&

--- a/ql/cashflows/couponpricer.cpp
+++ b/ql/cashflows/couponpricer.cpp
@@ -207,9 +207,9 @@ namespace QuantLib {
             capletVolatility()->volatilityType() == ShiftedLognormal;
 
         Spread adjustment = shiftedLn
-                                ? (fixing + shift) * (fixing + shift) *
-                                      variance * tau / (1.0 + fixing * tau)
-                                : variance * tau / (1.0 + fixing * tau);
+                                ? Real((fixing + shift) * (fixing + shift) *
+                                      variance * tau / (1.0 + fixing * tau))
+                                : Real(variance * tau / (1.0 + fixing * tau));
 
         if (timingAdjustment_ == BivariateLognormal) {
             QL_REQUIRE(!correlation_.empty(), "no correlation given");
@@ -227,11 +227,11 @@ namespace QuantLib {
                      1.0) /
                     tau2;
                 adjustment -= shiftedLn
-                                  ? correlation_->value() * tau2 * variance *
+                                  ? Real(correlation_->value() * tau2 * variance *
                                         (fixing + shift) * (fixing2 + shift) /
-                                        (1.0 + fixing2 * tau2)
-                                  : correlation_->value() * tau2 * variance /
-                                        (1.0 + fixing2 * tau2);
+                                        (1.0 + fixing2 * tau2))
+                                  : Real(correlation_->value() * tau2 * variance /
+                                        (1.0 + fixing2 * tau2));
             }
         }
         return fixing + adjustment;

--- a/ql/cashflows/floatingratecoupon.hpp
+++ b/ql/cashflows/floatingratecoupon.hpp
@@ -139,7 +139,7 @@ namespace QuantLib {
 
     inline Rate
     FloatingRateCoupon::convexityAdjustmentImpl(Rate fixing) const {
-        return (gearing() == 0.0 ? 0.0 : adjustedFixing()-fixing);
+        return (gearing() == 0.0 ? Rate(0.0) : Rate(adjustedFixing()-fixing));
     }
 
     inline void FloatingRateCoupon::accept(AcyclicVisitor& v) {

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -31,9 +31,27 @@
 
 using namespace std;
 
-#define SIGN(a,b) ((b) >= 0.0 ? fabs(a) : -fabs(a))
-#define ABS(x) (((x) < 0) ? -(x) : (x))
-#define POW(x,y) pow( (Real) (x), (Real) (y))
+namespace {
+
+    inline QuantLib::Real SIGN(const QuantLib::Real& a, const QuantLib::Real& b) 
+    {
+        if (b > 0.0) 
+            return std::fabs(a);
+        else
+            return -std::fabs(a);
+    }
+
+    inline QuantLib::Real ABS(const QuantLib::Real& a) 
+    { 
+        return std::abs(a); 
+    }
+
+    inline QuantLib::Real POW(const QuantLib::Real& a, const QuantLib::Real& b) {
+        return std::pow(a, b);
+    }
+
+}
+
 #define PI 3.14159265358979324
 
 namespace QuantLib {

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -41,11 +41,6 @@ namespace {
             return -std::fabs(a);
     }
 
-    inline QuantLib::Real ABS(const QuantLib::Real& a) 
-    { 
-        return std::abs(a); 
-    }
-
     inline QuantLib::Real POW(const QuantLib::Real& a, const QuantLib::Real& b) {
         return std::pow(a, b);
     }

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -1487,8 +1487,8 @@ namespace QuantLib {
             explicit alpha_adapter(const ext::shared_ptr<GeneralizedBlackScholesProcess>& process)
             : r(*(process->riskFreeRate())), q(*(process->dividendYield())) {}
             Real operator()(Real t) const {
-                return r->forwardRate(t,t,Continuous)
-                     - q->forwardRate(t,t,Continuous);
+                return r->forwardRate(t,t,Continuous).rate()
+                     - q->forwardRate(t,t,Continuous).rate();
             }
         };
 

--- a/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
+++ b/ql/experimental/barrieroption/perturbativebarrieroptionengine.cpp
@@ -41,10 +41,6 @@ namespace {
             return -std::fabs(a);
     }
 
-    inline QuantLib::Real POW(const QuantLib::Real& a, const QuantLib::Real& b) {
-        return std::pow(a, b);
-    }
-
 }
 
 #define PI 3.14159265358979324
@@ -151,8 +147,8 @@ namespace QuantLib {
         e3=PHID(d3);
         e4=PHID(d4);
 
-        v0=kprice*e1-kprice*POW(s0,(1.0-gm))*e2;
-        v0=v0+exp(gm*0.5*sigmat)*(-hbarr*s0*e3+hbarr*POW(s0,-gm)*e4);
+        v0=kprice*e1-kprice*std::pow(s0,(1.0-gm))*e2;
+        v0=v0+exp(gm*0.5*sigmat)*(-hbarr*s0*e3+hbarr*std::pow(s0,-gm)*e4);
         v0=v0*exp(disc);
 
         if(iord==0) return v0;
@@ -175,7 +171,7 @@ namespace QuantLib {
         x=log(s0);
         et=exp(0.5*(1.0-gm)*x);
 
-        dsqpi=POW(pi,0.5);
+        dsqpi=std::pow(pi,0.5);
 
         v1=0.0;
         for( i=1;i<=npoint;i++) {
@@ -392,9 +388,9 @@ namespace QuantLib {
         Real aa, caux;
         Real ppi= 3.14159265358979324;
 
-        aa=-(b*p-b*tt+a)/POW(2.0*(tt-p),0.5);
+        aa=-(b*p-b*tt+a)/std::pow(2.0*(tt-p),0.5);
 
-        caux=2.0*POW(ppi,0.5)*PHID(aa);
+        caux=2.0*std::pow(ppi,0.5)*PHID(aa);
         aa=b*b-(1.0-gm)*(1.0-gm);
         aa=aa/4.0;
         phid=exp(-0.5*a*b)*exp(aa*(tt-p))*caux;
@@ -412,10 +408,10 @@ namespace QuantLib {
         Real result;
         Real aa,caux;
 
-        aa=-(p*(a-b)+b*tt)/POW(2.0*p*tt*(tt-p),0.5);
+        aa=-(p*(a-b)+b*tt)/std::pow(2.0*p*tt*(tt-p),0.5);
         caux=PHID(aa);
 
-        aa=exp(POW((a-b),2)/(4.0*tt))*exp(POW((1.0-gm),2)*tt/4.0)*POW(tt,0.5);
+        aa=exp(std::pow((a-b),2)/(4.0*tt))*exp(std::pow((1.0-gm),2)*tt/4.0)*std::pow(tt,0.5);
         result=caux/aa;
 
         return(result);
@@ -432,14 +428,14 @@ namespace QuantLib {
         Real ppi= 3.14159265358979324;
         Real aa;
 
-        xx=(-a+b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=(-a+b*tt+c)/POW(2.0*tt,0.5);
-        rho=POW((tt-p)/tt,0.5);
+        xx=(-a+b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=(-a+b*tt+c)/std::pow(2.0*tt,0.5);
+        rho=std::pow((tt-p)/tt,0.5);
         aa=b*b-(1.0-gm)*(1.0-gm);
         aa=aa/4.0;
         caux=ND2(-xx,-yy,rho);
 
-        bvnd=2.0*POW(ppi,0.5)*exp(-a*b*0.5)*exp(aa*(tt-p))*caux;
+        bvnd=2.0*std::pow(ppi,0.5)*exp(-a*b*0.5)*exp(aa*(tt-p))*caux;
         return(bvnd);
     }
 
@@ -463,27 +459,27 @@ namespace QuantLib {
         Real aa,caux,caux1,caux2;
         Real xx,yy,rho;
 
-        aa=(a*p+b*(tt-p))/POW(2.0*p*tt*(tt-p),0.5);
+        aa=(a*p+b*(tt-p))/std::pow(2.0*p*tt*(tt-p),0.5);
         caux=PHID(aa);
 
-        aa=exp((a-b)*(a-b)/(4.0*tt))*exp(POW((1.0-gm),2)*tt/4.0)*POW(tt,0.5);
+        aa=exp((a-b)*(a-b)/(4.0*tt))*exp(std::pow((1.0-gm),2)*tt/4.0)*std::pow(tt,0.5);
         caux=-caux/aa;
 
-        xx=(a*p+b*(tt-p))/POW(2.0*tt*p*(tt-p),0.5);
-        yy=(a*s+b*(tt-s))/POW(2.0*tt*s*(tt-s),0.5);
-        rho=POW((s*(tt-p))/(p*(tt-s)),0.5);
+        xx=(a*p+b*(tt-p))/std::pow(2.0*tt*p*(tt-p),0.5);
+        yy=(a*s+b*(tt-s))/std::pow(2.0*tt*s*(tt-s),0.5);
+        rho=std::pow((s*(tt-p))/(p*(tt-s)),0.5);
         caux1=ND2(-xx,-yy,rho);
         caux1=caux1/aa;
 
 
-        aa=exp((a+b)*(a+b)/(4.0*tt))*exp(POW((1.0-gm),2)*tt/4.0)*POW(tt,0.5);
+        aa=exp((a+b)*(a+b)/(4.0*tt))*exp(std::pow((1.0-gm),2)*tt/4.0)*std::pow(tt,0.5);
 
-        xx=(a*p-b*(tt-p))/POW(2.0*tt*p*(tt-p),0.5);
-        yy=(a*s-b*(tt-s))/POW(2.0*tt*s*(tt-s),0.5);
-        rho=POW((s*(tt-p))/(p*(tt-s)),0.5);
+        xx=(a*p-b*(tt-p))/std::pow(2.0*tt*p*(tt-p),0.5);
+        yy=(a*s-b*(tt-s))/std::pow(2.0*tt*s*(tt-s),0.5);
+        rho=std::pow((s*(tt-p))/(p*(tt-s)),0.5);
         caux2=ND2(-xx,-yy,rho);
         caux2=caux2/aa;
-        result=(caux+caux1+caux2)/(2.0*POW(ppi,0.5));
+        result=(caux+caux1+caux2)/(2.0*std::pow(ppi,0.5));
         return(result);
     }
 
@@ -498,18 +494,18 @@ namespace QuantLib {
         Real aa,caux,caux1,caux2;
         Real xx,yy,rho;
 
-        xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
+        xx=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
         caux=-PHID(xx)*exp(-0.5*a*b);
 
-        xx=(a+b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=(a+b*(tt-s))/POW(2.0*(tt-s),0.5);
-        rho=POW((tt-p)/(tt-s),0.5);
+        xx=(a+b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=(a+b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        rho=std::pow((tt-p)/(tt-s),0.5);
         caux1=ND2(-xx,-yy,rho);
         caux1=exp(0.5*a*b)*caux1;
 
-        xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=(a-b*(tt-s))/POW(2.0*(tt-s),0.5);
-        rho=POW((tt-p)/(tt-s),0.5);
+        xx=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=(a-b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        rho=std::pow((tt-p)/(tt-s),0.5);
         caux2=ND2(-xx,-yy,rho);
         caux2=exp(-0.5*a*b)*caux2;
 
@@ -532,21 +528,21 @@ namespace QuantLib {
         Real sigmarho[4],limit[4],epsi;
 
         epsi=1.e-12;
-        limit[1]=(a+b*(tt-p))/POW(2.0*(tt-p),0.5);
-        limit[2]=(a+b*(tt-s))/POW(2.0*(tt-s),0.5);
-        limit[3]=(a+b*tt+c)/POW(2.0*tt,0.5);
-        sigmarho[1]=POW((tt-p)/(tt-s),0.5);
-        sigmarho[2]=POW((tt-p)/tt,0.5);
-        sigmarho[3]=POW((tt-s)/tt,0.5);
+        limit[1]=(a+b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        limit[2]=(a+b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        limit[3]=(a+b*tt+c)/std::pow(2.0*tt,0.5);
+        sigmarho[1]=std::pow((tt-p)/(tt-s),0.5);
+        sigmarho[2]=std::pow((tt-p)/tt,0.5);
+        sigmarho[3]=std::pow((tt-s)/tt,0.5);
 
         caux=exp(0.5*a*b)*tvtl(0,limit,sigmarho,epsi);
 
-        limit[1]=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
-        limit[2]=(-a+b*(tt-s))/POW(2.0*(tt-s),0.5);
-        limit[3]=(-a+b*tt+c)/POW(2.0*tt,0.5);
-        sigmarho[1]=-POW((tt-p)/(tt-s),0.5);
-        sigmarho[2]=-POW((tt-p)/tt,0.5);
-        sigmarho[3]=POW((tt-s)/tt,0.5);
+        limit[1]=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        limit[2]=(-a+b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        limit[3]=(-a+b*tt+c)/std::pow(2.0*tt,0.5);
+        sigmarho[1]=-std::pow((tt-p)/(tt-s),0.5);
+        sigmarho[2]=-std::pow((tt-p)/tt,0.5);
+        sigmarho[3]=std::pow((tt-s)/tt,0.5);
 
         caux1=-exp(-0.5*a*b)*tvtl(0,limit,sigmarho,epsi);
 
@@ -570,40 +566,40 @@ namespace QuantLib {
         Real result;
         double ppi= 3.14159265358979324;
 
-        xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
+        xx=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
         caux=PHID(xx)*exp(-0.5*a*b);
 
-        xx=(a+b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=(a+b*(tt-s))/POW(2.0*(tt-s),0.5);
-        rho=POW((tt-p)/(tt-s),0.5);
+        xx=(a+b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=(a+b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        rho=std::pow((tt-p)/(tt-s),0.5);
         caux1=ND2(-xx,-yy,rho);
         caux1=exp(0.5*a*b)*caux1;
 
-        xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=(a-b*(tt-s))/POW(2.0*(tt-s),0.5);
-        rho=POW((tt-p)/(tt-s),0.5);
+        xx=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=(a-b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        rho=std::pow((tt-p)/(tt-s),0.5);
         caux2=ND2(-xx,-yy,rho);
         caux2=-exp(-0.5*a*b)*caux2;
 
         caux=0.5*b*(caux+caux1+caux2);
 
-        xx=(a+b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=b*POW((p-s),0.5)/POW(2.0,0.5);
-        caux1=exp(-0.5*xx*xx)*exp(0.5*a*b)*PHID(yy)/(2.0*POW(ppi*(tt-p),0.5));
+        xx=(a+b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=b*std::pow((p-s),0.5)/std::pow(2.0,0.5);
+        caux1=exp(-0.5*xx*xx)*exp(0.5*a*b)*PHID(yy)/(2.0*std::pow(ppi*(tt-p),0.5));
 
 
-        xx=(a+b*(tt-s))/POW(2.0*(tt-s),0.5);
-        yy=a*POW((p-s),0.5)/POW(2.0*(tt-p)*(tt-s),0.5);
-        caux2=exp(-0.5*xx*xx)*exp(0.5*a*b)*PHID(yy)/(2.0*POW(ppi*(tt-s),0.5));
+        xx=(a+b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        yy=a*std::pow((p-s),0.5)/std::pow(2.0*(tt-p)*(tt-s),0.5);
+        caux2=exp(-0.5*xx*xx)*exp(0.5*a*b)*PHID(yy)/(2.0*std::pow(ppi*(tt-s),0.5));
 
-        xx=(a-b*(tt-p))/POW(2.0*(tt-p),0.5);
-        yy=b*POW((p-s),0.5)/POW(2.0,0.5);
-        caux3=-exp(-0.5*xx*xx)*exp(-0.5*a*b)*PHID(yy)/(2.0*POW(ppi*(tt-p),0.5));
+        xx=(a-b*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        yy=b*std::pow((p-s),0.5)/std::pow(2.0,0.5);
+        caux3=-exp(-0.5*xx*xx)*exp(-0.5*a*b)*PHID(yy)/(2.0*std::pow(ppi*(tt-p),0.5));
 
 
-        xx=(a-b*(tt-s))/POW(2.0*(tt-s),0.5);
-        yy=a*POW((p-s),0.5)/POW(2.0*(tt-p)*(tt-s),0.5);
-        caux4=exp(-0.5*xx*xx)*exp(-0.5*a*b)*PHID(yy)/(2.0*POW(ppi*(tt-s),0.5));
+        xx=(a-b*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        yy=a*std::pow((p-s),0.5)/std::pow(2.0*(tt-p)*(tt-s),0.5);
+        caux4=exp(-0.5*xx*xx)*exp(-0.5*a*b)*PHID(yy)/(2.0*std::pow(ppi*(tt-s),0.5));
 
 
 
@@ -628,45 +624,45 @@ namespace QuantLib {
         Real epsi;
 
         epsi=1.e-12;
-        limit[1]=(ax+bx*(tt-p))/POW(2.0*(tt-p),0.5);
-        limit[2]=(ax+bx*(tt-s))/POW(2.0*(tt-s),0.5);
-        limit[3]=(ax+bx*tt+c)/POW(2.0*tt,0.5);
-        sigmarho[1]=POW((tt-p)/(tt-s),0.5);
-        sigmarho[2]=POW((tt-p)/tt,0.5);
-        sigmarho[3]=POW((tt-s)/tt,0.5);
+        limit[1]=(ax+bx*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        limit[2]=(ax+bx*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        limit[3]=(ax+bx*tt+c)/std::pow(2.0*tt,0.5);
+        sigmarho[1]=std::pow((tt-p)/(tt-s),0.5);
+        sigmarho[2]=std::pow((tt-p)/tt,0.5);
+        sigmarho[3]=std::pow((tt-s)/tt,0.5);
 
         caux=0.5*bx*tvtl(0,limit,sigmarho,epsi);
 
 
         idx=1;
-        caux=caux+derivn3(limit,sigmarho,idx)/POW(2.0*(tt-p),0.5);
+        caux=caux+derivn3(limit,sigmarho,idx)/std::pow(2.0*(tt-p),0.5);
 
         idx=2;
-        caux=caux+derivn3(limit,sigmarho,idx)/POW(2.0*(tt-s),0.5);
+        caux=caux+derivn3(limit,sigmarho,idx)/std::pow(2.0*(tt-s),0.5);
 
         idx=3;
-        caux=caux+derivn3(limit,sigmarho,idx)/POW(2.0*tt,0.5);
+        caux=caux+derivn3(limit,sigmarho,idx)/std::pow(2.0*tt,0.5);
 
         caux=exp(0.5*ax*bx)*caux;
 
-        limit[1]=(ax-bx*(tt-p))/POW(2.0*(tt-p),0.5);
-        limit[2]=(-ax+bx*(tt-s))/POW(2.0*(tt-s),0.5);
-        limit[3]=(-ax+bx*tt+c)/POW(2.0*tt,0.5);
-        sigmarho[1]=-POW((tt-p)/(tt-s),0.5);
-        sigmarho[2]=-POW((tt-p)/tt,0.5);
-        sigmarho[3]=POW((tt-s)/tt,0.5);
+        limit[1]=(ax-bx*(tt-p))/std::pow(2.0*(tt-p),0.5);
+        limit[2]=(-ax+bx*(tt-s))/std::pow(2.0*(tt-s),0.5);
+        limit[3]=(-ax+bx*tt+c)/std::pow(2.0*tt,0.5);
+        sigmarho[1]=-std::pow((tt-p)/(tt-s),0.5);
+        sigmarho[2]=-std::pow((tt-p)/tt,0.5);
+        sigmarho[3]=std::pow((tt-s)/tt,0.5);
 
         caux1=0.5*bx*tvtl(0,limit,sigmarho,epsi);
 
         idx=1;
-        caux1=caux1-derivn3(limit,sigmarho,idx)/POW(2.0*(tt-p),0.5);
+        caux1=caux1-derivn3(limit,sigmarho,idx)/std::pow(2.0*(tt-p),0.5);
 
         idx=2;
-        caux1=caux1+derivn3(limit,sigmarho,idx)/POW(2.0*(tt-s),0.5);
+        caux1=caux1+derivn3(limit,sigmarho,idx)/std::pow(2.0*(tt-s),0.5);
 
 
         idx=3;
-        caux1=caux1+derivn3(limit,sigmarho,idx)/POW(2.0*tt,0.5);
+        caux1=caux1+derivn3(limit,sigmarho,idx)/std::pow(2.0*tt,0.5);
 
         caux1=exp(-0.5*ax*bx)*caux1;
 
@@ -690,54 +686,54 @@ namespace QuantLib {
         static Real xx,yy,rho;
         static double ppi= 3.14159265358979324;
 
-        aa=(a*p+b*(tt-p))/POW(2.0*p*tt*(tt-p),0.5);
+        aa=(a*p+b*(tt-p))/std::pow(2.0*p*tt*(tt-p),0.5);
         caux=PHID(aa);
 
         aa=exp(-(a-b)*(a-b)/(4.0*tt))/tt;
 
         caux=0.5*aa*caux*(a-b);
 
-        xx=(a*p+b*(tt-p))/POW(2.0*tt*p*(tt-p),0.5);
-        yy=(a*s+b*(tt-s))/POW(2.0*tt*s*(tt-s),0.5);
-        rho=POW((s*(tt-p))/(p*(tt-s)),0.5);
+        xx=(a*p+b*(tt-p))/std::pow(2.0*tt*p*(tt-p),0.5);
+        yy=(a*s+b*(tt-s))/std::pow(2.0*tt*s*(tt-s),0.5);
+        rho=std::pow((s*(tt-p))/(p*(tt-s)),0.5);
         caux1=ND2(-xx,-yy,rho);
         caux1=-0.5*aa*caux1*(a-b);
 
 
         aa=exp(-(a+b)*(a+b)/(4.0*tt))/tt;
 
-        xx=(a*p-b*(tt-p))/POW(2.0*tt*p*(tt-p),0.5);
-        yy=(a*s-b*(tt-s))/POW(2.0*tt*s*(tt-s),0.5);
-        rho=POW((s*(tt-p))/(p*(tt-s)),0.5);
+        xx=(a*p-b*(tt-p))/std::pow(2.0*tt*p*(tt-p),0.5);
+        yy=(a*s-b*(tt-s))/std::pow(2.0*tt*s*(tt-s),0.5);
+        rho=std::pow((s*(tt-p))/(p*(tt-s)),0.5);
         caux2=ND2(-xx,-yy,rho);
         caux2=-0.5*aa*caux2*(a+b);
 
-        aa=-b*POW((p-s)/POW(2.0*p*s,0.5),0.5);
-        aux=POW(p/(ppi*tt*(tt-p)),0.5)*PHID(aa);
+        aa=-b*std::pow((p-s)/std::pow(2.0*p*s,0.5),0.5);
+        aux=std::pow(p/(ppi*tt*(tt-p)),0.5)*PHID(aa);
 
         xx=(a+b)*(a+b)/(4.0*tt);
-        yy=POW((a*p-b*(tt-p)),2)/(4.0*p*tt*(tt-p));
+        yy=std::pow((a*p-b*(tt-p)),2)/(4.0*p*tt*(tt-p));
         caux3=aux*exp(-xx)*exp(-yy)/2.0;
 
 
         xx=(a-b)*(a-b)/(4.0*tt);
-        yy=POW((a*p+b*(tt-p)),2)/(4.0*p*tt*(tt-p));
+        yy=std::pow((a*p+b*(tt-p)),2)/(4.0*p*tt*(tt-p));
         caux4=aux*exp(-xx)*exp(-yy)/2.0;
 
-        aa=a*POW((p-s)/POW(2.0*(tt-p)*(tt-s),0.5),0.5);
-        aux=POW(s/(ppi*tt*(tt-s)),0.5)*PHID(aa);
+        aa=a*std::pow((p-s)/std::pow(2.0*(tt-p)*(tt-s),0.5),0.5);
+        aux=std::pow(s/(ppi*tt*(tt-s)),0.5)*PHID(aa);
 
         xx=(a+b)*(a+b)/(4.0*tt);
-        yy=POW((a*s-b*(tt-s)),2)/(4.0*s*tt*(tt-s));
+        yy=std::pow((a*s-b*(tt-s)),2)/(4.0*s*tt*(tt-s));
         caux5=aux*exp(-xx)*exp(-yy)/2.0;
 
         xx=(a-b)*(a-b)/(4.0*tt);
-        yy=POW((a*s+b*(tt-s)),2)/(4.0*s*tt*(tt-s));
+        yy=std::pow((a*s+b*(tt-s)),2)/(4.0*s*tt*(tt-s));
         caux6=aux*exp(-xx)*exp(-yy)/2.0;
 
-        aux=exp((1.0-gm)*(1.0-gm)*tt/4.0)*POW(tt,0.5);
+        aux=exp((1.0-gm)*(1.0-gm)*tt/4.0)*std::pow(tt,0.5);
 
-        result=(caux+caux1+caux2+caux3+caux4+caux5+caux6)/(aux*2.0*POW(ppi,0.5));
+        result=(caux+caux1+caux2+caux3+caux4+caux5+caux6)/(aux*2.0*std::pow(ppi,0.5));
         return(result);
     }
 
@@ -753,14 +749,14 @@ namespace QuantLib {
         static Real xx,yy,rho,sc;
         static double  ppi= 3.14159265358979324;
         static Real deriv;
-        sc=POW(2.0*ppi,0.5);
+        sc=std::pow(2.0*ppi,0.5);
 
         if(idx==1)
             {
-                aa=exp(-0.5*POW(limit[1],2));
-                xx=(limit[3]-sigmarho[2]*limit[1])/POW((1.0-POW(sigmarho[2],2)),0.5);
-                yy=(limit[2]-sigmarho[1]*limit[1])/POW((1.0-POW(sigmarho[1],2)),0.5);
-                rho=(sigmarho[3]-sigmarho[1]*sigmarho[2])/POW((1.0-sigmarho[1]*sigmarho[1])*(1.0-sigmarho[2]*sigmarho[2]),0.5);
+                aa=exp(-0.5*std::pow(limit[1],2));
+                xx=(limit[3]-sigmarho[2]*limit[1])/std::pow((1.0-std::pow(sigmarho[2],2)),0.5);
+                yy=(limit[2]-sigmarho[1]*limit[1])/std::pow((1.0-std::pow(sigmarho[1],2)),0.5);
+                rho=(sigmarho[3]-sigmarho[1]*sigmarho[2])/std::pow((1.0-sigmarho[1]*sigmarho[1])*(1.0-sigmarho[2]*sigmarho[2]),0.5);
                 deriv=aa*ND2(-xx,-yy,rho)/sc;
             }
         else
@@ -768,10 +764,10 @@ namespace QuantLib {
                 if(idx==2)
                     {
                         aa=exp(-0.5*limit[2]*limit[2]);
-                        xx=(limit[1]-sigmarho[1]*limit[2])/POW((1.0-POW(sigmarho[1],2)),0.5);
-                        yy=(limit[3]-sigmarho[3]*limit[2])/POW((1.0-POW(sigmarho[3],2)),0.5);
+                        xx=(limit[1]-sigmarho[1]*limit[2])/std::pow((1.0-std::pow(sigmarho[1],2)),0.5);
+                        yy=(limit[3]-sigmarho[3]*limit[2])/std::pow((1.0-std::pow(sigmarho[3],2)),0.5);
                         rho=(sigmarho[2]-sigmarho[1]*sigmarho[3])/ \
-                            POW((1.0-sigmarho[1]*sigmarho[1])*(1.0-sigmarho[3]*sigmarho[3]),0.5);
+                            std::pow((1.0-sigmarho[1]*sigmarho[1])*(1.0-sigmarho[3]*sigmarho[3]),0.5);
                         deriv=aa*ND2(-xx,-yy,rho)/sc;
                     }
                 else
@@ -779,10 +775,10 @@ namespace QuantLib {
                         //!!! idx=3
                         aa=exp(-0.5*limit[3]*limit[3]);
 
-                        xx=(limit[1]-sigmarho[2]*limit[3])/POW((1.0-POW(sigmarho[2],2)),0.5);
-                        yy=(limit[2]-sigmarho[3]*limit[3])/POW((1.0-POW(sigmarho[3],2)),0.5);
+                        xx=(limit[1]-sigmarho[2]*limit[3])/std::pow((1.0-std::pow(sigmarho[2],2)),0.5);
+                        yy=(limit[2]-sigmarho[3]*limit[3])/std::pow((1.0-std::pow(sigmarho[3],2)),0.5);
                         rho=(sigmarho[1]-sigmarho[2]*sigmarho[3])/ \
-                            POW((1.0-sigmarho[2]*sigmarho[2])*(1.0-sigmarho[3]*sigmarho[3]),0.5);
+                            std::pow((1.0-sigmarho[2]*sigmarho[2])*(1.0-sigmarho[3]*sigmarho[3]),0.5);
                         deriv=aa*ND2(-xx,-yy,rho)/sc;
                     }
 
@@ -946,7 +942,7 @@ namespace QuantLib {
         */
         static Real PT, EE;
         PT = 1.57079632679489661923132169163975;
-        EE = POW(( PT - fabs(X) ),2);
+        EE = std::pow(( PT - fabs(X) ),2);
 
         if ( EE < 5e-5 )
             {
@@ -997,7 +993,7 @@ namespace QuantLib {
                         FIN = FIN + FI[I];
                         ERR = ERR + EI[I]*EI[I];
                     }
-                ERR = POW( ERR,0.5 );
+                ERR = std::pow( ERR,0.5 );
             }
         result=FIN;
         //   ADONET = FIN
@@ -1103,7 +1099,7 @@ namespace QuantLib {
 
         if ( NU < 1 ) result= PHID( T );
         else if ( NU == 1 ) result = ( 1 + 2.0*atan(T)/PI )/2.0;
-        else if ( NU == 2 ) result = ( 1 + T/POW(( 2.0 + T*T),0.5))/2.0;
+        else if ( NU == 2 ) result = ( 1 + T/std::pow(( 2.0 + T*T),0.5))/2.0;
         else
             {
                 TT = T*T;
@@ -1116,12 +1112,12 @@ namespace QuantLib {
                 if ((NU-2*int(NU/2) ) == 1 )
                     {
                         RN = NU;
-                        TS = T/POW(RN,0.5);
+                        TS = T/std::pow(RN,0.5);
                         result = ( 1.0 + 2.0*( atan(TS) + TS*CSSTHE*POLYN )/PI )/2.0;
                     }
                 else
                     {
-                        SNTHE = T/POW(( NU + TT ),0.5);
+                        SNTHE = T/std::pow(( NU + TT ),0.5);
                         result = ( 1 + SNTHE*POLYN )/2.0;
                     }
                 result = max( ZRO, min( result, ONE ) );
@@ -1180,7 +1176,7 @@ namespace QuantLib {
             {
                 TPI = 2.0*PI;
                 SNU = (double)NU;
-                SNU = POW(SNU,0.5);
+                SNU = std::pow(SNU,0.5);
                 ORS = 1.0 - R*R;
                 HRK = DH - R*DK;
                 KRH = DK - R*DH;
@@ -1199,13 +1195,13 @@ namespace QuantLib {
                 KS =(int)SIGN( ONE, DK - R*DH );
                 if((NU-2*(int)(NU/2))==0 )
                     {
-                        BVT = atan2( POW(ORS,0.5), -R )/TPI;
-                        GMPH = DH/POW( 16*( NU + DH*DH ),0.5 );
-                        GMPK = DK/POW( 16*( NU + DK*DK),0.5);
-                        BTNCKH = 2*atan2( POW( XNKH,0.5 ), POW(( 1-XNKH),0.5) )/PI;
-                        BTPDKH = 2*POW( XNKH*( 1 - XNKH ),0.5 )/PI;
-                        BTNCHK = 2*atan2( POW( XNHK,0.5 ), POW((1 - XNHK),0.5) )/PI;
-                        BTPDHK = 2*POW( XNHK*( 1 - XNHK ),0.5 )/PI;
+                        BVT = atan2( std::pow(ORS,0.5), -R )/TPI;
+                        GMPH = DH/std::pow( 16*( NU + DH*DH ),0.5 );
+                        GMPK = DK/std::pow( 16*( NU + DK*DK),0.5);
+                        BTNCKH = 2*atan2( std::pow( XNKH,0.5 ), std::pow(( 1-XNKH),0.5) )/PI;
+                        BTPDKH = 2*std::pow( XNKH*( 1 - XNKH ),0.5 )/PI;
+                        BTNCHK = 2*atan2( std::pow( XNHK,0.5 ), std::pow((1 - XNHK),0.5) )/PI;
+                        BTPDHK = 2*std::pow( XNHK*( 1 - XNHK ),0.5 )/PI;
                         for( J = 1; J<= NU/2;J++)
                             {
                                 BVT = BVT + GMPH*( 1 + KS*BTNCKH );
@@ -1220,7 +1216,7 @@ namespace QuantLib {
                     }
                 else
                     {
-                        QHRK = POW((DH*DH + DK*DK - 2*R*DH*DK + NU*ORS),0.5 ) ;
+                        QHRK = std::pow((DH*DH + DK*DK - 2*R*DH*DK + NU*ORS),0.5 ) ;
                         HKRN = DH*DK + R*NU ;
                         HKN = DH*DK - NU;
                         HPK = DH + DK;
@@ -1228,9 +1224,9 @@ namespace QuantLib {
                         if ( BVT < -EPS ) BVT = BVT + 1;
                         GMPH = DH/( TPI*SNU*( 1 + DH*DH/NU ) );
                         GMPK = DK/( TPI*SNU*( 1 + DK*DK/NU ) );
-                        BTNCKH = POW( XNKH,0.5 );
+                        BTNCKH = std::pow( XNKH,0.5 );
                         BTPDKH = BTNCKH;
-                        BTNCHK = POW( XNHK,0.5 );
+                        BTNCHK = std::pow( XNHK,0.5 );
                         BTPDHK = BTNCHK;
                         for( J = 1;J<= ( NU - 1 )/2; J++)
                             {
@@ -1261,17 +1257,17 @@ namespace QuantLib {
           static Real DT, FT, BT,result;
 
           result = 0.0;
-          DT = RR*( RR - POW(( RA - RB ),2) - 2*RA*RB*( 1 - R ) );
+          DT = RR*( RR - std::pow(( RA - RB ),2) - 2*RA*RB*( 1 - R ) );
           if( DT > 0 ) {
-              BT = ( BC*RR + BA*( R*RB - RA ) + BB*( R*RA -RB ) )/POW(DT,0.5);
-              FT = POW(( BA - R*BB ),0.5)/RR + BB*BB;
+              BT = ( BC*RR + BA*( R*RB - RA ) + BB*( R*RA -RB ) )/std::pow(DT,0.5);
+              FT = std::pow(( BA - R*BB ),0.5)/RR + BB*BB;
               if( NUC<1 ) {
                   if ( (BT > -10) && (FT <100) ) {
                       result = exp( -FT/2 );
                       if ( BT <10 ) result= result*PHID(BT);
                   } else {
-                      FT = POW((1 + FT/NUC),0.5);
-                      result = STUDNT( NUC, BT/FT )/POW(FT,NUC);
+                      FT = std::pow((1 + FT/NUC),0.5);
+                      result = STUDNT( NUC, BT/FT )/std::pow(FT,NUC);
                   }
               }
           }
@@ -1408,22 +1404,22 @@ namespace QuantLib {
 
                 if( fabs(R) <1 ) {
                     AS = ( 1 - R )*( 1 + R );
-                    AA = POW(AS,0.5);
+                    AA = std::pow(AS,0.5);
 
-                    BS = POW(( H - K ),2);
+                    BS = std::pow(( H - K ),2);
                     C = ( 4 - HK )/8 ;
                     D = ( 12 - HK )/16;
                     ASR = -( BS/AS + HK )/2;
                     if( ASR > -100 ) BVN = AA*exp(ASR)*( 1 - C*( BS - AS )*( 1 - D*BS/5 )/3 + C*D*AS*AS/5 );
                     if( -HK<100 ){
-                        BB = POW(BS,0.5);
-                        BVN = BVN - exp( -HK/2 )*POW(TWOPI,0.5)*PHID(-BB/AA)*BB*( 1 - C*BS*( 1 - D*BS/5 )/3 );
+                        BB = std::pow(BS,0.5);
+                        BVN = BVN - exp( -HK/2 )*std::pow(TWOPI,0.5)*PHID(-BB/AA)*BB*( 1 - C*BS*( 1 - D*BS/5 )/3 );
                     }
                     AA = AA/2   ;
                     for (I = 1; I<= LG;I++){
                         for( IS = -1; IS<=1; IS=IS+2){
-                            XS =POW( ( AA*(  IS*XL[I][NG] + 1 ) ),2)  ;
-                            RS = POW( (1 - XS),2 );
+                            XS =std::pow( ( AA*(  IS*XL[I][NG] + 1 ) ),2)  ;
+                            RS = std::pow( (1 - XS),2 );
                             ASR = -( BS/XS + HK )/2;
                             if ( ASR > -100 ) {
 

--- a/ql/experimental/commodities/energybasisswap.cpp
+++ b/ql/experimental/commodities/energybasisswap.cpp
@@ -226,7 +226,7 @@ namespace QuantLib {
                 totalQuantityAmount += periodQuantityAmount;
 
                 Real avgDailyQuantityAmount =
-                    periodDayCount == 0 ? 0 :
+                    periodDayCount == 0 ? Real(0) :
                                           periodQuantityAmount / periodDayCount;
 
                 Real payLegValue = 0;

--- a/ql/experimental/commodities/energyvanillaswap.cpp
+++ b/ql/experimental/commodities/energyvanillaswap.cpp
@@ -183,7 +183,7 @@ namespace QuantLib {
                 totalQuantityAmount += periodQuantityAmount;
 
                 Real avgDailyQuantityAmount =
-                    periodDayCount == 0 ? 0 :
+                    periodDayCount == 0 ? Real(0) :
                                           periodQuantityAmount / periodDayCount;
 
                 Real payLegValue = 0;

--- a/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
+++ b/ql/experimental/coupons/lognormalcmsspreadpricer.cpp
@@ -121,7 +121,7 @@ namespace QuantLib {
                  (rho_ * gearing1_ * vol1_ + gearing2_ * vol2_) * s);
         Real f =
             close_enough(alpha_, 0.0)
-                ? std::max(beta, 0.0)
+                ? Real(std::max(beta, 0.0))
                 : psi_ * alpha_ / (M_SQRTPI * M_SQRT2) *
                           std::exp(-beta * beta / (2.0 * alpha_ * alpha_)) +
                       beta * (1.0 - (*cnd_)(-psi_ * beta / alpha_));

--- a/ql/experimental/coupons/strippedcapflooredcoupon.cpp
+++ b/ql/experimental/coupons/strippedcapflooredcoupon.cpp
@@ -54,8 +54,8 @@ namespace QuantLib {
         // collar, otherwise the value of a long floor or a long cap respectively
 
         return (underlying_->isFloored() && underlying_->isCapped())
-                   ? floorletRate - capletRate
-                   : floorletRate + capletRate;
+                   ? Real(floorletRate - capletRate)
+                   : Real(floorletRate + capletRate);
     }
 
     Rate StrippedCappedFlooredCoupon::convexityAdjustment() const {

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -177,7 +177,7 @@ namespace QuantLib {
                 copula_->conditionalDefaultProbabilityInvP(uncondDefProbInv[j],
                     j, mktFactors);
         // of full portfolio:
-        Real avgProb = avgLgd <= QL_EPSILON ? 0. : // only if all are 0
+        Real avgProb = avgLgd <= QL_EPSILON ? Real(0.) : // only if all are 0
                 std::inner_product(condDefProb.begin(), 
                     condDefProb.end(), lgdsLeft.begin(), Real(0.))
                 / (avgLgd * bsktSize);
@@ -202,7 +202,7 @@ namespace QuantLib {
         Real variance = std::inner_product(condDefProb.begin(), 
             condDefProb.end(), lgdsLeft.begin(), Real(0.));
 
-        variance = avgLgd <= QL_EPSILON ? 0. : 
+        variance = avgLgd <= QL_EPSILON ? Real(0.) : 
             variance / (bsktSize * bsktSize * avgLgd * avgLgd );
         Real sumAves = -std::pow(ceilAveProb-m, 2) 
             - (std::pow(floorAveProb-m, 2) - std::pow(ceilAveProb,2.)) 

--- a/ql/experimental/credit/binomiallossmodel.hpp
+++ b/ql/experimental/credit/binomiallossmodel.hpp
@@ -191,7 +191,7 @@ namespace QuantLib {
         std::vector<Probability> oneMinusDefProb;//: 1.-condDefProb[j]
         std::transform(condDefProb.begin(), condDefProb.end(), 
                        std::back_inserter(oneMinusDefProb), 
-                       [](Real x){ return 1.0-x; });
+                       [](Real x) -> Real { return 1.0-x; });
 
         //breaks condDefProb and lgdsLeft to spare memory
         std::transform(condDefProb.begin(), condDefProb.end(), 

--- a/ql/experimental/credit/homogeneouspooldef.hpp
+++ b/ql/experimental/credit/homogeneouspooldef.hpp
@@ -129,7 +129,7 @@ namespace QuantLib {
         std::vector<Real> recoveries = copula_->recoveries();
         std::transform(recoveries.begin(), recoveries.end(), 
                        std::back_inserter(lgd),
-                       [](Real x){ return 1.0-x; });
+                       [](Real x) -> Real { return 1.0-x; });
         std::transform(lgd.begin(), lgd.end(), notionals_.begin(), 
             lgd.begin(), std::multiplies<Real>());
         std::vector<Real> prob = basket_->remainingProbabilities(d);

--- a/ql/experimental/credit/inhomogeneouspooldef.hpp
+++ b/ql/experimental/credit/inhomogeneouspooldef.hpp
@@ -137,7 +137,7 @@ namespace QuantLib {
         std::vector<Real> recoveries = copula_->recoveries();
         std::transform(recoveries.begin(), recoveries.end(), 
                        std::back_inserter(lgd),
-                       [](Real x){ return 1.0-x; });
+                       [](Real x) -> Real { return 1.0-x; });
         std::transform(lgd.begin(), lgd.end(), notionals_.begin(), 
                        lgd.begin(), std::multiplies<Real>());
         std::vector<Real> prob = basket_->remainingProbabilities(d);

--- a/ql/experimental/credit/randomdefaultlatentmodel.hpp
+++ b/ql/experimental/credit/randomdefaultlatentmodel.hpp
@@ -624,7 +624,7 @@ namespace QuantLib {
         std::vector<Real> varLevels = splitVaRAndError(date, loss, 0.95)[0];
         // turn relative units into absolute:
         std::transform(varLevels.begin(), varLevels.end(), varLevels.begin(),
-                       [=](Real x){ return x * loss; });
+                       [=](Real x) -> Real { return x * loss; });
         return varLevels;
     }
 

--- a/ql/experimental/credit/syntheticcdo.cpp
+++ b/ql/experimental/credit/syntheticcdo.cpp
@@ -41,7 +41,7 @@ namespace QuantLib {
                                BusinessDayConvention paymentConvention,
                                boost::optional<Real> notional)
     : basket_(basket), side_(side), upfrontRate_(upfrontRate), runningRate_(runningRate),
-      leverageFactor_(notional ? notional.get() / basket->trancheNotional() : 1.), // NOLINT(readability-implicit-bool-conversion)
+      leverageFactor_(notional ? notional.get() / basket->trancheNotional() : Real(1.)), // NOLINT(readability-implicit-bool-conversion)
       dayCounter_(dayCounter), paymentConvention_(paymentConvention) {
         QL_REQUIRE(!basket->names().empty(), "basket is empty");
         // Basket inception must lie before contract protection start.

--- a/ql/experimental/exoticoptions/analyticpdfhestonengine.cpp
+++ b/ql/experimental/exoticoptions/analyticpdfhestonengine.cpp
@@ -78,7 +78,7 @@ namespace QuantLib {
         const Real s_t = std::exp(x_t);
         const Real payoff = (*arguments_.payoff)(s_t);
 
-        return (payoff != 0.0) ? payoff*Pv(x_t, t)*rD : 0.0;
+        return (payoff != 0.0) ? payoff*Pv(x_t, t)*rD : Real(0.0);
     }
 }
 

--- a/ql/experimental/exoticoptions/continuousarithmeticasianlevyengine.cpp
+++ b/ql/experimental/exoticoptions/continuousarithmeticasianlevyengine.cpp
@@ -77,8 +77,8 @@ namespace QuantLib {
         Real b = riskFreeRate - dividendYield;
 
         Real Se = (std::fabs(b) > 1000*QL_EPSILON) 
-            ? (spot/(T*b))*(exp((b-riskFreeRate)*T2)-exp(-riskFreeRate*T2))
-            : spot*T2/T * std::exp(-riskFreeRate*T2);
+            ? Real((spot/(T*b))*(exp((b-riskFreeRate)*T2)-exp(-riskFreeRate*T2)))
+            : Real(spot*T2/T * std::exp(-riskFreeRate*T2));
 
         Real X;
         if (T2 < T) {

--- a/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
+++ b/ql/experimental/finitedifferences/fdmhestonfwdop.cpp
@@ -67,8 +67,8 @@ namespace QuantLib {
         const Real lowerBoundaryFactor = mapY_->lowerBoundaryFactor(type);
         const Real upperBoundaryFactor = mapY_->upperBoundaryFactor(type);
 
-        const Real logFacLow = type == FdmSquareRootFwdOp::Log ? exp(mapY_->v(0)) : 1.0;
-        const Real logFacUpp = type == FdmSquareRootFwdOp::Log ? exp(mapY_->v(n+1)) : 1.0;
+        const Real logFacLow = type == FdmSquareRootFwdOp::Log ? Real(exp(mapY_->v(0))) : 1.0;
+        const Real logFacUpp = type == FdmSquareRootFwdOp::Log ? Real(exp(mapY_->v(n+1))) : 1.0;
 
         const Real alpha = -2*rho_/mixedSigma_*lowerBoundaryFactor*logFacLow;
         const Real beta  = -2*rho_/mixedSigma_*upperBoundaryFactor*logFacUpp;

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
             std::vector<Real> operator()(Real d, std::vector<Real> v) 
             {
                 std::transform(v.begin(), v.end(), v.begin(), 
-                               [=](Real x){ return x*d; });
+                               [=](Real x) -> Real { return x * d; });
                 return v;
             }
         };
@@ -343,7 +343,7 @@ namespace QuantLib {
                 // systemic term:
                 factorWeights_[iVar].end(), allFactors.begin(),
                 // idiosyncratic term:
-                allFactors[numFactors()+iVar] * idiosyncFctrs_[iVar]);
+                Real(allFactors[numFactors()+iVar] * idiosyncFctrs_[iVar]));
         }
         // \to do write variants of the above, although is the most common case
 

--- a/ql/experimental/math/latentmodel.hpp
+++ b/ql/experimental/math/latentmodel.hpp
@@ -569,7 +569,7 @@ namespace QuantLib {
         Real latentVariableCorrel(Size iVar1, Size iVar2) const {
             // true for any normalized combination
             Real init = (iVar1 == iVar2 ? 
-                idiosyncFctrs_[iVar1] * idiosyncFctrs_[iVar1] : 0.);
+                idiosyncFctrs_[iVar1] * idiosyncFctrs_[iVar1] : Real(0.));
             return std::inner_product(factorWeights_[iVar1].begin(), 
                 factorWeights_[iVar1].end(), factorWeights_[iVar2].begin(), 
                     init);

--- a/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
+++ b/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
@@ -167,7 +167,7 @@ namespace QuantLib {
                 this->process_->time(fixings[i]);
         }
 
-        const Size numberOfTimeSteps = timeSteps_ != Null<Size>() ? timeSteps_ : timeStepsPerYear_ * fixingTimes.back();
+        const Size numberOfTimeSteps = timeSteps_ != Null<Size>() ? timeSteps_ : static_cast<Size>(timeStepsPerYear_ * fixingTimes.back());
 
         return TimeGrid(fixingTimes.begin(), fixingTimes.end(), numberOfTimeSteps);
      }

--- a/ql/experimental/models/hestonslvfdmmodel.cpp
+++ b/ql/experimental/models/hestonslvfdmmodel.cpp
@@ -416,7 +416,7 @@ namespace QuantLib {
                 std::transform(xMesher[i]->locations().begin(),
                                xMesher[i]->locations().end(),
                                vStrikes[i]->begin(),
-                               [](Real x) { return std::exp(x); });
+                               [](Real x) -> Real { return std::exp(x); });
             }
         }
 

--- a/ql/experimental/models/hestonslvfdmmodel.cpp
+++ b/ql/experimental/models/hestonslvfdmmodel.cpp
@@ -491,7 +491,7 @@ namespace QuantLib {
                     const Volatility localVol = localVol_->localVol(t, x[j]);
 
                     const Real l = (scale >= 0.0)
-                      ? localVol*std::sqrt(scale) : 1.0;
+                      ? localVol*std::sqrt(scale) : Real(1.0);
 
                     (*L)[j][i] = std::min(50.0, std::max(0.001, l));
 

--- a/ql/experimental/models/normalclvmodel.cpp
+++ b/ql/experimental/models/normalclvmodel.cpp
@@ -45,7 +45,7 @@ namespace QuantLib {
     : x_(M_SQRT2 * GaussHermiteIntegration(lagrangeOrder).x()),
       sigma_((pMax != Null<Real>()) ?
                  x_.back() / InverseCumulativeNormal()(pMax) :
-                 (pMin != Null<Real>()) ? x_.front() / InverseCumulativeNormal()(pMin) : 1.0),
+                 (pMin != Null<Real>()) ? x_.front() / InverseCumulativeNormal()(pMin) : Real(1.0)),
       bsProcess_(bsProcess), ouProcess_(std::move(ouProcess)), maturityDates_(maturityDates),
       rndCalculator_(ext::make_shared<GBSMRNDCalculator>(bsProcess)),
       maturityTimes_(maturityDates.size()) {

--- a/ql/experimental/processes/hestonslvprocess.cpp
+++ b/ql/experimental/processes/hestonslvprocess.cpp
@@ -100,7 +100,7 @@ namespace QuantLib {
             const Real beta = (1-p)/m;
             const Real u = CumulativeNormalDistribution()(dw[1]);
 
-            retVal[1] = ((u <= p) ? 0.0 : std::log((1-p)/(1-u))/beta);
+            retVal[1] = ((u <= p) ? Real(0.0) : std::log((1-p)/(1-u))/beta);
         }
 
         const Real mu = riskFreeRate()->forwardRate(t0, t0+dt, Continuous).rate()

--- a/ql/experimental/risk/creditriskplus.cpp
+++ b/ql/experimental/risk/creditriskplus.cpp
@@ -131,7 +131,7 @@ namespace QuantLib {
                 maxNu_ = exUnit;
             pdAdj[k] = exposure_[k] > 0.0
                            ? exposure_[k] * pd_[k] / (exUnit * unit_)
-                           : 0.0; // adjusted pd
+                           : Real(0.0); // adjusted pd
             Real el = exUnit * pdAdj[k];
             if (exUnit > 0) {
                 iter = epsNuC_.find(exUnit);

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -283,8 +283,8 @@ namespace QuantLib {
                 Rate forwardRate =
                     termStructure_->forwardRate(t, t, Continuous, NoFrequency);
                 Real temp = a_ < std::sqrt(QL_EPSILON) ?
-                            sigma_*t :
-                            sigma_*(1.0 - std::exp(-a_*t))/a_;
+                            Real(sigma_*t) :
+                            Real(sigma_*(1.0 - std::exp(-a_*t))/a_);
                 return (forwardRate + 0.5*temp*temp);
             }
 

--- a/ql/experimental/volatility/noarbsabr.cpp
+++ b/ql/experimental/volatility/noarbsabr.cpp
@@ -177,7 +177,7 @@ Real NoArbSabrModel::p(const Real f) const {
         std::exp(-(xz * xz) / (2.0 * expiryTime_) +
                  (h + kappa1 * expiryTime_)) *
         modifiedBesselFunction_i_exponentiallyWeighted(gamma,
-                                                       zF * zf / expiryTime_);
+                                                       Real(zF * zf / expiryTime_));
     return res;
 }
 

--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -358,10 +358,10 @@ Real ZabrModel::y(const Real strike) const {
         return std::log(forward_ / strike) * std::pow(alpha_, gamma_ - 2.0);
     } else {
         return (strike < 0.0
-                    ? std::pow(forward_, 1.0 - beta_) +
-                          std::pow(-strike, 1.0 - beta_)
-                    : std::pow(forward_, 1.0 - beta_) -
-                          std::pow(strike, 1.0 - beta_)) *
+                    ? Real(std::pow(forward_, 1.0 - beta_) +
+                          std::pow(-strike, 1.0 - beta_))
+                    : Real(std::pow(forward_, 1.0 - beta_) -
+                          std::pow(strike, 1.0 - beta_))) *
                std::pow(alpha_, gamma_ - 2.0) / (1.0 - beta_);
     }
 }

--- a/ql/experimental/volatility/zabrinterpolation.hpp
+++ b/ql/experimental/volatility/zabrinterpolation.hpp
@@ -44,7 +44,7 @@ template <typename Evaluation> struct ZabrSpecs {
             // adapt alpha to beta level
             params[0] =
                 0.2 *
-                (params[1] < 0.9999 ? std::pow(forward, 1.0 - params[1]) : 1.0);
+                (params[1] < 0.9999 ? std::pow(forward, 1.0 - params[1]) : Real(1.0));
         if (params[2] == Null<Real>())
             params[2] = std::sqrt(0.4);
         if (params[3] == Null<Real>())
@@ -78,7 +78,7 @@ template <typename Evaluation> struct ZabrSpecs {
                   const std::vector<Real> &, const Real) {
         Array x(5);
         x[0] = y[0] < 25.0 + eps1() ? std::sqrt(y[0] - eps1())
-                                    : (y[0] - eps1() + 25.0) / 10.0;
+                                    : Real((y[0] - eps1() + 25.0) / 10.0);
         x[1] = std::sqrt(-std::log(y[1]));
         x[2] = std::tan(M_PI*(y[4]/5.0-0.5));
         x[3] = std::asin(y[3] / eps2());
@@ -88,7 +88,7 @@ template <typename Evaluation> struct ZabrSpecs {
     Array direct(const Array &x, const std::vector<bool> &,
                  const std::vector<Real> &, const Real) {
         Array y(5);
-        y[0] = std::fabs(x[0]) < 5.0 ? x[0] * x[0] + eps1()
+        y[0] = std::fabs(x[0]) < 5.0 ? Real(x[0] * x[0] + eps1())
                                      : (10.0 * std::fabs(x[0]) - 25.0) + eps1();
         y[1] = std::fabs(x[1]) < std::sqrt(-std::log(eps1()))
                    ? std::exp(-(x[1] * x[1]))
@@ -97,7 +97,7 @@ template <typename Evaluation> struct ZabrSpecs {
         y[2] = (std::atan(x[2])/M_PI + 0.5) * 5.0;
         y[3] = std::fabs(x[3]) < 2.5 * M_PI
                    ? eps2() * std::sin(x[3])
-                   : eps2() * (x[3] > 0.0 ? 1.0 : (-1.0));
+                   : Real(eps2() * (x[3] > 0.0 ? 1.0 : (-1.0)));
         // limit gamma to 1.9
         y[4] = (std::atan(x[4])/M_PI + 0.5) * 1.9;
         return y;

--- a/ql/instruments/payoffs.cpp
+++ b/ql/instruments/payoffs.cpp
@@ -178,9 +178,9 @@ namespace QuantLib {
     Real GapPayoff::operator()(Real price) const {
         switch (type_) {
           case Option::Call:
-            return (price-strike_ >= 0.0 ? price-secondStrike_ : 0.0);
+            return (price-strike_ >= 0.0 ? Real(price-secondStrike_) : 0.0);
           case Option::Put:
-            return (strike_-price >= 0.0 ? secondStrike_-price : 0.0);
+              return (strike_ - price >= 0.0 ? Real(secondStrike_ - price) : 0.0);
           default:
             QL_FAIL("unknown/illegal option type");
         }
@@ -195,7 +195,7 @@ namespace QuantLib {
     }
 
     Real SuperFundPayoff::operator()(Real price) const {
-        return (price>=strike_ && price<secondStrike_) ? price/strike_ : 0.0;
+        return (price>=strike_ && price<secondStrike_) ? Real(price/strike_) : 0.0;
     }
 
     void SuperFundPayoff::accept(AcyclicVisitor& v) {

--- a/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
+++ b/ql/legacy/libormarketmodels/lfmhullwhiteparam.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
                                      tmpSqrtCorr[i], Real(0.0)));
                 std::transform(
                     tmpSqrtCorr[i], tmpSqrtCorr[i]+factors_, sqrtCorr[i],
-                    [=](Real x){ return x/p; });
+                               [=](Real x) -> Real { return x / p; });
             }
         }
 

--- a/ql/legacy/libormarketmodels/lmlinexpvolmodel.cpp
+++ b/ql/legacy/libormarketmodels/lmlinexpvolmodel.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
 
         const Time T = fixingTimes_[i];
 
-        return (T>t) ? (a*(T-t)+d)*std::exp(-b*(T-t)) + c : 0.0;
+        return (T>t) ? (a*(T-t)+d)*std::exp(-b*(T-t)) + c : Real(0.0);
     }
 
     Real LmLinearExponentialVolatilityModel::integratedVariance(

--- a/ql/math/abcdmathfunction.hpp
+++ b/ql/math/abcdmathfunction.hpp
@@ -106,17 +106,17 @@ namespace QuantLib {
     // inline AbcdMathFunction
     inline Real AbcdMathFunction::operator()(Time t) const {
         //return (a_ + b_*t)*std::exp(-c_*t) + d_;
-        return t<0 ? 0.0 : (a_ + b_*t)*std::exp(-c_*t) + d_;
+        return t<0 ? 0.0 : Real((a_ + b_*t)*std::exp(-c_*t) + d_);
     }
 
     inline Real AbcdMathFunction::derivative(Time t) const {
         //return (da_ + db_*t)*std::exp(-c_*t);
-        return t<0 ? 0.0 : (da_ + db_*t)*std::exp(-c_*t);
+        return t<0 ? 0.0 : Real((da_ + db_*t)*std::exp(-c_*t));
     }
 
     inline Real AbcdMathFunction::primitive(Time t) const {
         //return (pa_ + pb_*t)*std::exp(-c_*t) + d_*t + K_;
-        return t<0 ? 0.0 : (pa_ + pb_*t)*std::exp(-c_*t) + d_*t + K_;
+        return t<0 ? 0.0 : Real((pa_ + pb_*t)*std::exp(-c_*t) + d_*t + K_);
     }
 
     inline Real AbcdMathFunction::maximumValue() const {

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -322,8 +322,7 @@ namespace QuantLib {
 
 
     inline const Array& Array::operator+=(Real x) {
-        std::transform(begin(), end(), begin(),
-                       [=](Real y) { return y+x; });
+        std::transform(begin(), end(), begin(), [=](Real y) -> Real { return y + x; });
         return *this;
     }
 
@@ -337,8 +336,7 @@ namespace QuantLib {
     }
 
     inline const Array& Array::operator-=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       [=](Real y) { return y-x; });
+        std::transform(begin(),end(),begin(), [=](Real y) -> Real { return y - x; });
         return *this;
     }
 
@@ -352,8 +350,7 @@ namespace QuantLib {
     }
 
     inline const Array& Array::operator*=(Real x) {
-        std::transform(begin(), end(), begin(),
-                       [=](Real y) { return y*x; });
+        std::transform(begin(), end(), begin(), [=](Real y) -> Real { return y * x; });
         return *this;
     }
 
@@ -370,8 +367,7 @@ namespace QuantLib {
         #if defined(QL_EXTRA_SAFETY_CHECKS)
         QL_REQUIRE(x != 0.0, "division by zero");
         #endif
-        std::transform(begin(), end(), begin(),
-                       [=](Real y) { return y/x; });
+        std::transform(begin(), end(), begin(), [=](Real y) -> Real { return y / x; });
         return *this;
     }
 
@@ -536,15 +532,13 @@ namespace QuantLib {
 
     inline Array operator+(const Array& v1, Real a) {
         Array result(v1.size());
-        std::transform(v1.begin(), v1.end(), result.begin(),
-                       [=](Real y) { return y+a; });
+        std::transform(v1.begin(), v1.end(), result.begin(), [=](Real y) -> Real { return y + a; });
         return result;
     }
 
     inline Array operator+(Real a, const Array& v2) {
         Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       [=](Real y) { return a+y; });
+        std::transform(v2.begin(),v2.end(),result.begin(), [=](Real y) -> Real { return a + y; });
         return result;
     }
 
@@ -560,15 +554,13 @@ namespace QuantLib {
 
     inline Array operator-(const Array& v1, Real a) {
         Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       [=](Real y) { return y-a; });
+        std::transform(v1.begin(),v1.end(),result.begin(), [=](Real y) -> Real { return y - a; });
         return result;
     }
 
     inline Array operator-(Real a, const Array& v2) {
         Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       [=](Real y) { return a-y; });
+        std::transform(v2.begin(),v2.end(),result.begin(), [=](Real y) -> Real { return a - y; });
         return result;
     }
 
@@ -584,15 +576,13 @@ namespace QuantLib {
 
     inline Array operator*(const Array& v1, Real a) {
         Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       [=](Real y) { return y*a; });
+        std::transform(v1.begin(),v1.end(),result.begin(), [=](Real y) -> Real { return y * a; });
         return result;
     }
 
     inline Array operator*(Real a, const Array& v2) {
         Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       [=](Real y) { return a*y; });
+        std::transform(v2.begin(),v2.end(),result.begin(), [=](Real y) -> Real { return a * y; });
         return result;
     }
 
@@ -608,15 +598,13 @@ namespace QuantLib {
 
     inline Array operator/(const Array& v1, Real a) {
         Array result(v1.size());
-        std::transform(v1.begin(),v1.end(),result.begin(),
-                       [=](Real y) { return y/a; });
+        std::transform(v1.begin(),v1.end(),result.begin(), [=](Real y) -> Real { return y / a; });
         return result;
     }
 
     inline Array operator/(Real a, const Array& v2) {
         Array result(v2.size());
-        std::transform(v2.begin(),v2.end(),result.begin(),
-                       [=](Real y) { return a/y; });
+        std::transform(v2.begin(),v2.end(),result.begin(), [=](Real y) -> Real { return a / y; });
         return result;
     }
 
@@ -625,28 +613,28 @@ namespace QuantLib {
     inline Array Abs(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(), v.end(), result.begin(),
-                       [](Real x) { return std::fabs(x); });
+                       [](Real x) -> Real { return std::fabs(x); });
         return result;
     }
 
     inline Array Sqrt(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
-                       [](Real x) { return std::sqrt(x); });
+                       [](Real x) -> Real { return std::sqrt(x); });
         return result;
     }
 
     inline Array Log(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(),v.end(),result.begin(),
-                       [](Real x) { return std::log(x); });
+                       [](Real x) -> Real { return std::log(x); });
         return result;
     }
 
     inline Array Exp(const Array& v) {
         Array result(v.size());
         std::transform(v.begin(), v.end(), result.begin(),
-                       [](Real x) { return std::exp(x); });
+                       [](Real x) -> Real { return std::exp(x); });
         return result;
     }
 

--- a/ql/math/autocovariance.hpp
+++ b/ql/math/autocovariance.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
             std::size_t n = 1;
             for (InputIterator it = begin; it != end; ++it, ++n)
                 mean = (mean*Real(n-1) + *it)/n;
-            std::transform(begin, end, out, [=](Real x){ return x - mean; });
+            std::transform(begin, end, out, [=](Real x) -> Real { return x - mean; });
             return mean;
         }
 

--- a/ql/math/distributions/chisquaredistribution.cpp
+++ b/ql/math/distributions/chisquaredistribution.cpp
@@ -127,7 +127,7 @@ namespace QuantLib {
         solver.setMaxEvaluations(evaluations);
         return solver.solve([&](Real y) { return nonCentralDist_(y) - x; },
                             accuracy_, 0.75*upper, 
-                            (evaluations == maxEvaluations_)? 0.0: 0.5*upper,
+                            (evaluations == maxEvaluations_)? 0.0: Real(0.5*upper),
                             upper);
     }
 }

--- a/ql/math/distributions/normaldistribution.hpp
+++ b/ql/math/distributions/normaldistribution.hpp
@@ -295,7 +295,7 @@ namespace QuantLib {
         Real exponent = -(deltax*deltax)/denominator_;
         // debian alpha had some strange problem in the very-low range
         return exponent <= -690.0 ? 0.0 :  // exp(x) < 1.0e-300 anyway
-            normalizationFactor_*std::exp(exponent);
+            Real(normalizationFactor_*std::exp(exponent));
     }
 
     inline Real NormalDistribution::derivative(Real x) const {

--- a/ql/math/generallinearleastsquares.hpp
+++ b/ql/math/generallinearleastsquares.hpp
@@ -145,7 +145,7 @@ namespace QuantLib {
             = std::inner_product(residuals_.begin(), residuals_.end(), residuals_.begin(), Real(0.0));
         const Real multiplier = std::sqrt(chiSq/(n-2));
         std::transform(err_.begin(), err_.end(), standardErrors_.begin(),
-                       [=](Real x){ return x * multiplier; });
+                       [=](Real x) -> Real { return x * multiplier; });
     }
 
 }

--- a/ql/math/integrals/exponentialintegrals.cpp
+++ b/ql/math/integrals/exponentialintegrals.cpp
@@ -78,7 +78,7 @@ namespace QuantLib {
     namespace ExponentialIntegral {
         Real Si(Real x) {
             if (x < 0)
-                return -Si(-x);
+                return -Si(Real(-x));
             else if (x <= 4.0) {
                 const Real x2 = x*x;
 

--- a/ql/math/integrals/filonintegral.cpp
+++ b/ql/math/integrals/filonintegral.cpp
@@ -60,12 +60,12 @@ namespace QuantLib {
         ext::function<Real(Real)> f1, f2;
         switch(type_) {
           case Cosine:
-            f1 = [](Real x) { return std::sin(x); };
-            f2 = [](Real x) { return std::cos(x); };
+            f1 = [](Real x) -> Real { return std::sin(x); };
+            f2 = [](Real x) -> Real { return std::cos(x); };
             break;
           case Sine:
-            f1 = [](Real x) { return std::cos(x); };
-            f2 = [](Real x) { return std::sin(x); };
+            f1 = [](Real x) -> Real { return std::cos(x); };
+            f2 = [](Real x) -> Real { return std::sin(x); };
             break;
           default:
             QL_FAIL("unknown integration type");

--- a/ql/math/integrals/gaussianorthogonalpolynomial.cpp
+++ b/ql/math/integrals/gaussianorthogonalpolynomial.cpp
@@ -82,7 +82,7 @@ namespace QuantLib {
     }
 
     Real GaussHermitePolynomial::beta(Size i) const {
-        return (i % 2) != 0U ? i / 2.0 + mu_ : i / 2.0;
+        return (i % 2) != 0U ? Real(i / 2.0 + mu_) : Real(i / 2.0);
     }
 
     Real GaussHermitePolynomial::w(Real x) const {

--- a/ql/math/interpolations/linearinterpolation.hpp
+++ b/ql/math/interpolations/linearinterpolation.hpp
@@ -80,7 +80,7 @@ namespace QuantLib {
                 primitiveConst_[0] = 0.0;
                 for (Size i=1; i<Size(this->xEnd_-this->xBegin_); ++i) {
                     Real dx = this->xBegin_[i]-this->xBegin_[i-1];
-                    s_[i-1] = (this->yBegin_[i]-this->yBegin_[i-1])/dx;
+                    s_[i-1] = (Real(this->yBegin_[i])-Real(this->yBegin_[i-1]))/dx;
                     primitiveConst_[i] = primitiveConst_[i-1]
                         + dx*(this->yBegin_[i-1] +0.5*dx*s_[i-1]);
                 }

--- a/ql/math/interpolations/sabrinterpolation.hpp
+++ b/ql/math/interpolations/sabrinterpolation.hpp
@@ -71,8 +71,8 @@ struct SABRSpecs {
         if (params[0] == Null<Real>())
             // adapt alpha to beta level
             params[0] = 0.2 * (params[1] < 0.9999 ?
-                                   std::pow(forward + (addParams.empty() ? 0.0 : addParams[0]),
-                                            1.0 - params[1]) :
+                                   Real(std::pow(forward + (addParams.empty() ? 0.0 : addParams[0]),
+                                            1.0 - params[1])) :
                                    1.0);
         if (params[2] == Null<Real>())
             params[2] = std::sqrt(0.4);
@@ -103,29 +103,29 @@ struct SABRSpecs {
     Array inverse(const Array &y, const std::vector<bool> &,
                   const std::vector<Real> &, const Real) {
         Array x(4);
-        x[0] = y[0] < 25.0 + eps1() ? std::sqrt(y[0] - eps1())
-                                    : (y[0] - eps1() + 25.0) / 10.0;
+        x[0] = y[0] < 25.0 + eps1() ? Real(std::sqrt(y[0] - eps1()))
+                                    : Real((y[0] - eps1() + 25.0) / 10.0);
         // y_[1] = std::tan(M_PI*(x[1] - 0.5))/dilationFactor();
         x[1] = std::sqrt(-std::log(y[1]));
-        x[2] = y[2] < 25.0 + eps1() ? std::sqrt(y[2] - eps1())
-                                    : (y[2] - eps1() + 25.0) / 10.0;
+        x[2] = y[2] < 25.0 + eps1() ? Real(std::sqrt(y[2] - eps1()))
+                                    : Real((y[2] - eps1() + 25.0) / 10.0);
         x[3] = std::asin(y[3] / eps2());
         return x;
     }
     Array direct(const Array &x, const std::vector<bool> &,
                  const std::vector<Real> &, const Real) {
         Array y(4);
-        y[0] = std::fabs(x[0]) < 5.0 ? x[0] * x[0] + eps1()
-                                     : (10.0 * std::fabs(x[0]) - 25.0) + eps1();
+        y[0] = std::fabs(x[0]) < 5.0 ? Real(x[0] * x[0] + eps1())
+                                     : Real((10.0 * std::fabs(x[0]) - 25.0) + eps1());
         // y_[1] = std::atan(dilationFactor_*x[1])/M_PI + 0.5;
         y[1] = std::fabs(x[1]) < std::sqrt(-std::log(eps1()))
                    ? std::exp(-(x[1] * x[1]))
                    : eps1();
-        y[2] = std::fabs(x[2]) < 5.0 ? x[2] * x[2] + eps1()
-                                     : (10.0 * std::fabs(x[2]) - 25.0) + eps1();
+        y[2] = std::fabs(x[2]) < 5.0 ? Real(x[2] * x[2] + eps1())
+                                     : Real((10.0 * std::fabs(x[2]) - 25.0) + eps1());
         y[3] = std::fabs(x[3]) < 2.5 * M_PI
-                   ? eps2() * std::sin(x[3])
-                   : eps2() * (x[3] > 0.0 ? 1.0 : (-1.0));
+                   ? Real(eps2() * std::sin(x[3]))
+                   : Real(eps2() * (x[3] > 0.0 ? 1.0 : (-1.0)));
         return y;
     }
     Real weight(const Real strike, const Real forward, const Real stdDev,

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -283,14 +283,12 @@ namespace QuantLib {
     }
 
     inline const Matrix& Matrix::operator*=(Real x) {
-        std::transform(begin(), end(), begin(),
-                       [=](Real y) { return y*x; });
+        std::transform(begin(), end(), begin(), [=](Real y) -> Real { return y * x; });
         return *this;
     }
 
     inline const Matrix& Matrix::operator/=(Real x) {
-        std::transform(begin(),end(),begin(),
-                       [=](Real y) { return y/x; });
+        std::transform(begin(),end(),begin(), [=](Real y) -> Real { return y / x; });
         return *this;
     }
 
@@ -519,22 +517,19 @@ namespace QuantLib {
 
     inline Matrix operator*(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(), m.end(), temp.begin(),
-                       [=](Real y) { return y*x; });
+        std::transform(m.begin(), m.end(), temp.begin(), [=](Real y) -> Real { return y * x; });
         return temp;
     }
 
     inline Matrix operator*(Real x, const Matrix& m) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(), m.end(), temp.begin(),
-                       [=](Real y) { return x*y; });
+        std::transform(m.begin(), m.end(), temp.begin(), [=](Real y) -> Real { return x * y; });
         return temp;
     }
 
     inline Matrix operator/(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
-        std::transform(m.begin(), m.end(), temp.begin(),
-                       [=](Real y) { return y/x; });
+        std::transform(m.begin(), m.end(), temp.begin(), [=](Real y) -> Real { return y / x; });
         return temp;
     }
 
@@ -607,7 +602,7 @@ namespace QuantLib {
 
         for (Size i=0; v1begin!=v1end; i++, v1begin++)
             std::transform(v2begin, v2end, result.row_begin(i),
-                           [=](Real y) { return y * (*v1begin); });
+                           [=](Real y) -> Real { return y * (*v1begin); });
 
         return result;
     }

--- a/ql/math/matrixutilities/choleskydecomposition.cpp
+++ b/ql/math/matrixutilities/choleskydecomposition.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
                     // In this case sum happens to be zero as well
                     result[j][i] = close_enough(result[i][i], 0.0)
                                        ? 0.0
-                                       : sum / result[i][i];
+                                       : Real(sum / result[i][i]);
                 }
             }
         }

--- a/ql/math/matrixutilities/svd.cpp
+++ b/ql/math/matrixutilities/svd.cpp
@@ -306,8 +306,8 @@ namespace QuantLib {
                     if (ks == k) {
                         break;
                     }
-                    Real t = (ks != p ? std::fabs(e[ks]) : 0.) +
-                        (ks != k+1 ? std::fabs(e[ks-1]) : 0.);
+                    Real t = (ks != p ? Real(std::fabs(e[ks])) : 0.) +
+                        (ks != k+1 ? Real(std::fabs(e[ks-1])) : 0.);
                     if (std::fabs(s_[ks]) <= eps*t)  {
                         s_[ks] = 0.0;
                         break;
@@ -449,7 +449,7 @@ namespace QuantLib {
                   // Make the singular values positive.
 
                   if (s_[k] <= 0.0) {
-                      s_[k] = (s_[k] < 0.0 ? -s_[k] : 0.0);
+                      s_[k] = (s_[k] < 0.0 ? Real(-s_[k]) : 0.0);
                       for (i = 0; i <= pp; i++) {
                           V_[i][k] = -V_[i][k];
                       }

--- a/ql/math/matrixutilities/tqreigendecomposition.cpp
+++ b/ql/math/matrixutilities/tqreigendecomposition.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
                     const Real lambda =
                         (std::fabs(t2+t1 - d_[k]) < std::fabs(t2-t1 - d_[k]))?
-                        t2+t1 : t2-t1;
+                        Real(t2+t1) : Real(t2-t1);
 
                     if (strategy == CloseEigenValue) {
                         q-=lambda;

--- a/ql/math/optimization/costfunction.hpp
+++ b/ql/math/optimization/costfunction.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
         //! method to overload to compute the cost function value in x
         virtual Real value(const Array& x) const {
             Array v = values(x);
-            std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
+            std::transform(v.begin(), v.end(), v.begin(), [](Real x) -> Real { return x*x; });
             return std::sqrt(std::accumulate(v.begin(), v.end(), Real(0.0)) /
                              static_cast<Real>(v.size()));
         }

--- a/ql/math/optimization/spherecylinder.cpp
+++ b/ql/math/optimization/spherecylinder.cpp
@@ -133,7 +133,7 @@ namespace QuantLib {
 
         Real x2sq = s_*s_ - (x1-alpha_)*(x1-alpha_);
          // a negative number will be minuscule and a result of rounding error
-        Real x2 = x2sq >= 0.0 ? std::sqrt(x2sq) : 0.0;
+        Real x2 = x2sq >= 0.0 ? Real(std::sqrt(x2sq)) : 0.0;
         Real x3= std::sqrt(r_*r_ - x1*x1-x2*x2);
 
         Real err=0.0;

--- a/ql/math/randomnumbers/stochasticcollocationinvcdf.cpp
+++ b/ql/math/randomnumbers/stochasticcollocationinvcdf.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
       sigma_( (pMax != Null<Real>())
               ? x_.back() / InverseCumulativeNormal()(pMax)
               : (pMin != Null<Real>())
-                  ? x_.front() / InverseCumulativeNormal()(pMin)
+                  ? Real(x_.front() / InverseCumulativeNormal()(pMin))
                   : 1.0),
       y_(g(sigma_, x_, invCDF)),
       interpl_(x_.begin(), x_.end(), y_.begin()) {

--- a/ql/math/rounding.cpp
+++ b/ql/math/rounding.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
           default:
             QL_FAIL("unknown rounding method");
         }
-        return (neg) ? -(lvalue/mult) : lvalue/mult;
+        return (neg) ? Real(-(lvalue / mult)) : Real(lvalue / mult);
     }
 
 }

--- a/ql/math/sampledcurve.hpp
+++ b/ql/math/sampledcurve.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
         }
         void regridLogGrid(Real min, Real max) {
             regrid(BoundedLogGrid(min, max, size() - 1),
-                   [](Real x) { return std::log(x); });
+                   [](Real x) -> Real { return std::log(x); });
         }
         void shiftGrid(Real s) {
             grid_ += s;

--- a/ql/math/solvers1d/brent.hpp
+++ b/ql/math/solvers1d/brent.hpp
@@ -133,7 +133,7 @@ namespace QuantLib {
         }
       private:
         Real sign(Real a, Real b) const {
-            return b >= 0.0 ? std::fabs(a) : -std::fabs(a);
+            return b >= 0.0 ? Real(std::fabs(a)) : Real(-std::fabs(a));
         }
     };
 

--- a/ql/math/solvers1d/ridder.hpp
+++ b/ql/math/solvers1d/ridder.hpp
@@ -111,7 +111,7 @@ namespace QuantLib {
         }
       private:
         Real sign(Real a, Real b) const {
-            return b >= 0.0 ? std::fabs(a) : -std::fabs(a);
+            return b >= 0.0 ? std::fabs(a) : Real(-std::fabs(a));
         }
     };
 

--- a/ql/math/statistics/generalstatistics.cpp
+++ b/ql/math/statistics/generalstatistics.cpp
@@ -44,7 +44,10 @@ namespace QuantLib {
         // Subtract the mean and square. Repeat on the whole range.
         // Hopefully, the whole thing will be inlined in a single loop.
         Real m = mean();
-        Real s2 = expectationValue([=](Real x) { Real d = x - m; return d * d; }).first;
+        Real s2 = expectationValue([=](Real x) -> Real {
+                      Real d = x - m;
+                      return d * d;
+                  }).first;
         return s2*N/(N-1.0);
     }
 
@@ -54,7 +57,10 @@ namespace QuantLib {
                    "sample number <=2, unsufficient");
 
         Real m = mean();
-        Real X = expectationValue([=](Real x) { Real d = x - m; return d * d * d; }).first;
+        Real X = expectationValue([=](Real x) -> Real {
+                     Real d = x - m;
+                     return d * d * d;
+                 }).first;
         Real sigma = standardDeviation();
 
         return (X/(sigma*sigma*sigma))*(N/(N-1.0))*(N/(N-2.0));
@@ -66,7 +72,11 @@ namespace QuantLib {
                    "sample number <=3, unsufficient");
 
         Real m = mean();
-        Real X = expectationValue([=](Real x) { Real d = x - m; Real d2 = d * d ; return d2 * d2; }).first;
+        Real X = expectationValue([=](Real x) -> Real {
+                     Real d = x - m;
+                     Real d2 = d * d;
+                     return d2 * d2;
+                 }).first;
         Real sigma2 = variance();
 
         Real c1 = (N/(N-1.0)) * (N/(N-2.0)) * ((N+1.0)/(N-3.0));

--- a/ql/math/statistics/riskstatistics.hpp
+++ b/ql/math/statistics/riskstatistics.hpp
@@ -151,9 +151,12 @@ namespace QuantLib {
     template <class S>
     Real GenericRiskStatistics<S>::regret(Real target) const {
         // average over the range below the target
-        std::pair<Real,Size> result =
-            this->expectationValue([=](Real xi) { Real d = (xi-target); return d * d; },
-                                   [=](Real xi) { return xi < target; });
+        std::pair<Real,Size> result = this->expectationValue(
+            [=](Real xi) -> Real {
+                Real d = (xi - target);
+                return d * d;
+            },
+            [=](Real xi) -> Real { return xi < target; });
         Real x = result.first;
         Size N = result.second;
         QL_REQUIRE(N > 1,
@@ -204,14 +207,14 @@ namespace QuantLib {
     template <class S>
     Real GenericRiskStatistics<S>::shortfall(Real target) const {
         QL_ENSURE(this->samples() != 0, "empty sample set");
-        return this->expectationValue([=](Real x) { return x < target ? 1.0 : 0.0; }).first;
+        return this->expectationValue([=](Real x) -> Real { return x < target ? 1.0 : 0.0; }).first;
     }
 
     template <class S>
     Real GenericRiskStatistics<S>::averageShortfall(Real target)
         const {
-        std::pair<Real,Size> result =
-            this->expectationValue([=](Real xi) { return target - xi; },
+        std::pair<Real,Size> result = this->expectationValue(
+            [=](Real xi) -> Real { return target - xi; },
                                    [=](Real xi) { return xi < target; });
         Real x = result.first;
         Size N = result.second;

--- a/ql/math/transformedgrid.hpp
+++ b/ql/math/transformedgrid.hpp
@@ -96,7 +96,7 @@ namespace QuantLib {
     class LogGrid : public TransformedGrid {
     public:
         LogGrid(const Array &grid) :
-            TransformedGrid(grid, [](Real x) { return std::log(x); }){};
+            TransformedGrid(grid, [](Real x) -> Real { return std::log(x); }){};
         const Array & logGridArray() const { return transformedGridArray();}
         Real logGrid(Size i) const { return transformedGrid(i);}
     };

--- a/ql/methods/finitedifferences/meshers/fdmcev1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmcev1dmesher.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
         const Real lowerBound = (massAtZero > eps)
             ? ((beta < 0)? QL_EPSILON : 0.0)
-            : rndCalculator.invcdf(eps, maturity)/scaleFactor;
+            : Real(rndCalculator.invcdf(eps, maturity)/scaleFactor);
 
 
         ext::shared_ptr<Fdm1dMesher> helper;

--- a/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.cpp
@@ -120,7 +120,7 @@ namespace QuantLib {
         }
 
         Real skewHint = ((process->kappa() != 0.0) 
-                ? std::max(1.0, mixedSigma/process->kappa()) : 1.0);
+                ? Real(std::max(1.0, mixedSigma/process->kappa())) : 1.0);
 
         std::sort(pGrid.begin(), pGrid.end());
         volaEstimate_ = GaussLobattoIntegral(100000, 1e-4)(

--- a/ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmsimpleprocess1dmesher.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
             locations_.back() += qMax;
         }
         std::transform(locations_.begin(), locations_.end(), locations_.begin(),
-                       [=](Real x){ return x / tAvgSteps; });
+                       [=](Real x) -> Real { return x / tAvgSteps; });
         for (Size i=0; i < size-1; ++i) {
             dminus_[i+1] = dplus_[i] = locations_[i+1] - locations_[i];
         }

--- a/ql/methods/finitedifferences/operators/numericaldifferentiation.cpp
+++ b/ql/methods/finitedifferences/operators/numericaldifferentiation.cpp
@@ -78,12 +78,12 @@ namespace QuantLib {
 
                     for (Size m=0; m <= std::min(n, M); ++m) {
                         d[m][n][nu] = (x[n]*d[m][n-1][nu]
-                             - ((m > 0)? m*d[m-1][n-1][nu] : 0.0))/c3;
+                             - ((m > 0)? Real(m*d[m-1][n-1][nu]) : 0.0))/c3;
                     }
                 }
 
                 for (Size m=0; m <= M; ++m) {
-                    d[m][n][n] = c1/c2*( ((m > 0)? m*d[m-1][n-1][n-1] : 0.0) -
+                    d[m][n][n] = c1/c2*( ((m > 0)? Real(m*d[m-1][n-1][n-1]) : 0.0) -
                         x[n-1]*d[m][n-1][n-1] );
                 }
                 c1=c2;

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -126,7 +126,7 @@ namespace QuantLib {
             for (const auto& i : swap_->leg(j)) {
                 npv +=
                     ext::dynamic_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
-                        i->amount() * disTs_->discount(i->date()) :
+                        Real(i->amount() * disTs_->discount(i->date())) :
                         0.0;
             }
             if (j == 0)

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -97,7 +97,7 @@ namespace QuantLib {
         Real retVal;
         try {
             const Real acc
-                = ((f(a) != 0.0 || f(b) != 0.0) ? (f(a)+f(b))*5e-5 : 1e-4);
+                = ((f(a) != 0.0 || f(b) != 0.0) ? Real((f(a)+f(b))*5e-5) : 1e-4);
             retVal = SimpsonIntegral(acc, 8)(f, a, b)/(b-a);
         }
         catch (Error&) {

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         Size direction)
     : FdmCellAveragingInnerValue(
         payoff, mesher, direction,
-        [](Real x) { return std::exp(x); }) {}
+        [](Real x) -> Real { return std::exp(x); }) {}
 
 
     FdmLogBasketInnerValue::FdmLogBasketInnerValue(ext::shared_ptr<BasketPayoff> payoff,

--- a/ql/models/marketmodels/marketmodeldifferences.cpp
+++ b/ql/models/marketmodels/marketmodeldifferences.cpp
@@ -106,7 +106,7 @@ namespace QuantLib {
                     std::transform(correlations.row_begin(j),
                                    correlations.row_end(j),
                                    pseudoRoot.row_begin(j),
-                                   [=](Real x){ return x * volatility; });
+                                   [=](Real x) -> Real { return x * volatility; });
                 }
                 pseudoRoots.push_back(pseudoRoot);
             }

--- a/ql/models/marketmodels/models/capletcoterminalmaxhomogeneity.cpp
+++ b/ql/models/marketmodels/models/capletcoterminalmaxhomogeneity.cpp
@@ -162,7 +162,7 @@ namespace QuantLib {
             Real S2 = capletVariance/theta - constQuadraticTerm;
 
             // if S2 < 0, there are no solutions so we take the best we can. 
-            Real S = S2 > 0 ? std::sqrt(S2) : 0;
+            Real S = S2 > 0 ? Real(std::sqrt(S2)) : 0;
 
             Real R = std::sqrt(thisSwapVariance);
 

--- a/ql/models/shortrate/onefactormodels/hullwhite.hpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.hpp
@@ -140,8 +140,8 @@ namespace QuantLib {
                 Rate forwardRate =
                     termStructure_->forwardRate(t, t, Continuous, NoFrequency);
                 Real temp = a_ < std::sqrt(QL_EPSILON) ?
-                            sigma_*t :
-                            sigma_*(1.0 - std::exp(-a_*t))/a_;
+                            Real(sigma_*t) :
+                            Real(sigma_*(1.0 - std::exp(-a_*t))/a_);
                 return (forwardRate + 0.5*temp*temp);
             }
 

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -662,7 +662,7 @@ namespace QuantLib {
                     modelPut, marketVega, marketRawCall, marketRawPut;
                 for (Size j = 0; j < money.size(); j++) {
                     strikes.push_back(sec->volatilityType() == Normal ?
-                                          calibrationPoint.second.atm_ + money[j] :
+                                          Real(calibrationPoint.second.atm_ + money[j]) :
                                           money[j] * (calibrationPoint.second.atm_ + shift) -
                                               shift);
                     try {
@@ -796,7 +796,7 @@ namespace QuantLib {
 
         Array ya(1, y);
         return numeraireArray(t, ya)[0] *
-               (yts.empty() ? 1.0
+               (yts.empty() ? Real(1.0)
                             : (yts->discount(numeraireTime()) /
                                yts->discount(t) * termStructure()->discount(t) /
                                termStructure()->discount(numeraireTime())));
@@ -811,7 +811,7 @@ namespace QuantLib {
                                : yts->discount(T, true);
         Array ya(1, y);
         return zerobondArray(T, t, ya)[0] *
-               (yts.empty() ? 1.0 : (yts->discount(T) / yts->discount(t) *
+               (yts.empty() ? Real(1.0) : (yts->discount(T) / yts->discount(t) *
                                      termStructure()->discount(t) /
                                      termStructure()->discount(T)));
     }

--- a/ql/models/shortrate/twofactormodels/g2.cpp
+++ b/ql/models/shortrate/twofactormodels/g2.cpp
@@ -160,7 +160,7 @@ namespace QuantLib {
             Size i;
             for (i=0; i<size_; i++) {
                 Real tau = (i==0 ? t_[0] - T_ : t_[i] - t_[i-1]);
-                Real c = (i==size_-1 ? (1.0+rate_*tau) : rate_*tau);
+                Real c = (i==size_-1 ? Real(1.0+rate_*tau) : rate_*tau);
                 lambda[i] = c*A_[i]*std::exp(-Ba_[i]*x);
             }
 

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
                 sigma2prev = sigma2;
             }
             std::transform(grad.begin(), grad.end(), grad.begin(),
-                           [=](Real x){ return x/norm; });
+                           [=](Real x) -> Real { return x / norm; });
         }
 
         Real Garch11CostFunction::valueAndGradient(Array& grad,
@@ -135,7 +135,7 @@ namespace QuantLib {
                 sigma2prev = sigma2;
             }
             std::transform(grad.begin(), grad.end(), grad.begin(),
-                           [=](Real x){ return x/norm; });
+                           [=](Real x) -> Real { return x / norm; });
             return retval / norm;
         }
 
@@ -418,7 +418,7 @@ namespace QuantLib {
         Array acf(maxLag+1);
         std::vector<Volatility> tmp(r2.size());
         std::transform (r2.begin(), r2.end(), tmp.begin(),
-                        [=](Real x){ return x - mean_r2; });
+                       [=](Real x) -> Real { return x - mean_r2; });
         autocovariances (tmp.begin(), tmp.end(), acf.begin(), maxLag);
         QL_REQUIRE (acf[0] > 0, "Data series is constant");
 
@@ -518,7 +518,7 @@ namespace QuantLib {
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
         std::transform(r2.begin(), r2.end(), tmp.begin(),
-                       [=](Real x){ return x - mean_r2; });
+                       [=](Real x) -> Real { return x - mean_r2; });
         return calibrate_r2(tmp, method, endCriteria, initGuess,
                             alpha, beta, omega);
     }
@@ -551,7 +551,7 @@ namespace QuantLib {
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         std::vector<Volatility> tmp(r2.size());
         std::transform(r2.begin(), r2.end(), tmp.begin(),
-                       [=](Real x){ return x - mean_r2; });
+                       [=](Real x) -> Real { return x - mean_r2; });
         return calibrate_r2(tmp, method, constraints, endCriteria,
                             initGuess, alpha, beta, omega);
     }

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -236,7 +236,7 @@ namespace QuantLib {
             Real A = mean_r2*mean_r2/A4; // 1/sigma^2
             Real B = A21 / A4; // rho(1)
 
-            Real gammaLower = A <= 1./3. - tol_level ? std::sqrt((1 - 3*A)/(3 - 3*A)) + tol_level : tol_level;
+            Real gammaLower = A <= 1./3. - tol_level ? std::sqrt((1 - 3*A)/(3 - 3*A)) + tol_level : Real(tol_level);
             Garch11Constraint constraints(gammaLower, 1.0 - tol_level);
 
             Real gamma = gammaLower + (1 - gammaLower) * 0.5;
@@ -322,7 +322,7 @@ namespace QuantLib {
             Real A4 = acf[0] + mean_r2*mean_r2;
             Real A = mean_r2*mean_r2/A4; // 1/sigma^2
             Real B = A21 / A4; // rho(1)
-            Real gammaLower = A <= 1./3. - tol_level ? std::sqrt((1 - 3*A)/(3 - 3*A)) + tol_level : tol_level;
+            Real gammaLower = A <= 1./3. - tol_level ? std::sqrt((1 - 3*A)/(3 - 3*A)) + tol_level : Real(tol_level);
             Garch11Constraint constraints(gammaLower, 1.0 - tol_level);
 
             // ACF

--- a/ql/models/volatility/garch.hpp
+++ b/ql/models/volatility/garch.hpp
@@ -244,7 +244,7 @@ namespace QuantLib {
                 u2 = *begin; u2 *= u2;
                 retval += std::log(sigma2) + u2 / sigma2;
             }
-            return N > 0 ? retval / (2*N) : 0.0;
+            return N > 0 ? Real(retval / (2*N)) : 0.0;
         }
         //@}
       private:

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -79,7 +79,7 @@ namespace QuantLib {
         // since displacement is non-negative strike==0 iff displacement==0
         // so returning forward*discount is OK
         if (strike==0.0)
-            return (optionType==Option::Call ? forward*discount : 0.0);
+            return (optionType==Option::Call ? Real(forward*discount) : 0.0);
 
         Real d1 = std::log(forward/strike)/stdDev + 0.5*stdDev;
         Real d2 = d1 - stdDev;
@@ -281,7 +281,7 @@ namespace QuantLib {
         const Real ey2 = ey*ey;
         const Real y = std::log(ey);
         const Real alpha = marketValue/(K*df);
-        const Real R = 2*alpha + ((type == Option::Call) ? -ey+1.0 : ey-1.0);
+        const Real R = 2 * alpha + ((type == Option::Call) ? Real(-ey + 1.0) : ey - 1.0);
         const Real R2 = R*R;
 
         const Real a = std::exp((1.0-M_2_PI)*y);
@@ -296,7 +296,7 @@ namespace QuantLib {
 
         if (y >= 0.0) {
             const Real M0 = K*df*(
-                (type == Option::Call) ? ey*Af(std::sqrt(2*y)) - 0.5
+                (type == Option::Call) ? Real(ey*Af(std::sqrt(2*y)) - 0.5)
                                        : 0.5-ey*Af(-std::sqrt(2*y)));
 
             if (marketValue <= M0)
@@ -306,7 +306,7 @@ namespace QuantLib {
         }
         else {
             const Real M0 = K*df*(
-                (type == Option::Call) ? 0.5*ey - Af(-std::sqrt(-2*y))
+                (type == Option::Call) ? Real(0.5*ey - Af(-std::sqrt(-2*y)))
                                        : Af(std::sqrt(-2*y)) - 0.5*ey);
 
             if (marketValue <= M0)
@@ -512,7 +512,7 @@ namespace QuantLib {
 
         Real x = std::log(forward/strike);
         Real cs = (optionType == Option::Call)
-            ? blackPrice / (forward*discount)
+            ? Real(blackPrice / (forward*discount))
             : (blackPrice/ (forward*discount) + 1.0 - strike/forward);
 
         QL_REQUIRE(cs >= 0.0, "normalized call price (" << cs
@@ -824,7 +824,7 @@ namespace QuantLib {
         nu = std::max(-1.0 + QL_EPSILON, std::min(nu,1.0 - QL_EPSILON));
 
         // nu / arctanh(nu) -> 1 as nu -> 0
-        Real eta = (std::fabs(nu) < SQRT_QL_EPSILON) ? 1.0 : nu / boost::math::atanh(nu);
+        Real eta = (std::fabs(nu) < SQRT_QL_EPSILON) ? 1.0 : Real(nu / boost::math::atanh(nu));
 
         Real heta = h(eta);
 

--- a/ql/pricingengines/mcsimulation.hpp
+++ b/ql/pricingengines/mcsimulation.hpp
@@ -123,7 +123,7 @@ namespace QuantLib {
                        << ") is still above tolerance (" << tolerance << ")");
 
             // conservative estimate of how many samples are needed
-            order = maxError(error*error)/tolerance/tolerance;
+            order = maxError(Real(error*error))/tolerance/tolerance;
             nextBatch =
                 Size(std::max<Real>(static_cast<Real>(sampleNumber)*order*0.8 - static_cast<Real>(sampleNumber),
                                     static_cast<Real>(minSamples)));

--- a/ql/pricingengines/swaption/basketgeneratingengine.cpp
+++ b/ql/pricingengines/swaption/basketgeneratingengine.cpp
@@ -111,7 +111,7 @@ namespace QuantLib {
                 const Real h = 0.0001; // finite difference step in $y$, make
                                        // this a parameter of the engine ?
                 Real zSpreadDsc =
-                    oas_.empty() ? 1.0
+                    oas_.empty() ? Real(1.0)
                                  : exp(-oas_->value() *
                                        onefactormodel_->termStructure()
                                            ->dayCounter()

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -227,7 +227,7 @@ namespace QuantLib {
                 Real price = 0.0, pricea = 0.0;
                 if (event1Time != Null<Real>()) {
                     Real zSpreadDf = oas_.empty()
-                                         ? 1.0
+                                         ? Real(1.0)
                                          : std::exp(-oas_->value() *
                                                     (event1Time - event0Time));
                     Array yg =
@@ -342,7 +342,7 @@ namespace QuantLib {
                         if (event1Time != Null<Real>()) {
                             Real zSpreadDf =
                                 oas_.empty()
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : std::exp(-oas_->value() *
                                                (event1Time - event0Time));
                             Array yg = model_->yGrid(
@@ -437,7 +437,7 @@ namespace QuantLib {
                                  arguments_.leg1FixingDates.begin();
                         Real zSpreadDf =
                             oas_.empty()
-                                ? 1.0
+                                ? Real(1.0)
                                 : std::exp(
                                       -oas_->value() *
                                       (model_->termStructure()
@@ -521,7 +521,7 @@ namespace QuantLib {
                                  arguments_.leg2FixingDates.begin();
                         Real zSpreadDf =
                             oas_.empty()
-                                ? 1.0
+                                ? Real(1.0)
                                 : std::exp(
                                       -oas_->value() *
                                       (model_->termStructure()
@@ -601,7 +601,7 @@ namespace QuantLib {
                             rebateDate = rebatedExercise_->rebatePaymentDate(j);
                             zSpreadDf =
                                 oas_.empty()
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : std::exp(-oas_->value() *
                                                (model_->termStructure()
                                                     ->dayCounter()
@@ -621,7 +621,7 @@ namespace QuantLib {
                                 // the no call probability
                                 npvp0.back()[k] =
                                     probabilities_ == Naive
-                                        ? 1.0
+                                        ? Real(1.0)
                                         : 1.0 / (model_->zerobond(
                                                      event0Time, 0.0, 0.0,
                                                      discountCurve_) *
@@ -632,7 +632,7 @@ namespace QuantLib {
                             if (exerciseValue >= npv0[k]) {
                                 npvp0[exIdx-1][k] =
                                     probabilities_ == Naive
-                                        ? 1.0
+                                        ? Real(1.0)
                                         : 1.0 / (model_->zerobond(
                                                      event0Time, 0.0, 0.0,
                                                      discountCurve_) *

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
                 model_->zerobond(arguments_.fixedPayDates[i], expiry, y,
                                  discountCurve_) *
                 (oas_.empty()
-                     ? 1.0
+                     ? Real(1.0)
                      : exp(-oas_->value() *
                            model_->termStructure()->dayCounter().yearFraction(
                                expiry, arguments_.fixedPayDates[i])));
@@ -78,7 +78,7 @@ namespace QuantLib {
                 amount * model_->zerobond(arguments_.floatingPayDates[i],
                                           expiry, y, discountCurve_) *
                 (oas_.empty()
-                     ? 1.0
+                     ? Real(1.0)
                      : exp(-oas_->value() *
                            model_->termStructure()->dayCounter().yearFraction(
                                expiry, arguments_.floatingPayDates[i])));
@@ -206,7 +206,7 @@ namespace QuantLib {
                 Real price = 0.0;
                 if (expiry1Time != Null<Real>()) {
                     Real zSpreadDf =
-                        oas_.empty() ? 1.0
+                        oas_.empty() ? Real(1.0)
                                      : std::exp(-oas_->value() *
                                                 (expiry1Time - expiry0Time));
                     Array yg = model_->yGrid(stddevs_, integrationPoints_,
@@ -276,7 +276,7 @@ namespace QuantLib {
                         if (expiry1Time != Null<Real>()) {
                             Real zSpreadDf =
                                 oas_.empty()
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : std::exp(-oas_->value() *
                                                (expiry1Time - expiry0Time));
                             Array yg = model_->yGrid(
@@ -361,7 +361,7 @@ namespace QuantLib {
                          l++) {
                         Real zSpreadDf =
                             oas_.empty()
-                                ? 1.0
+                                ? Real(1.0)
                                 : std::exp(
                                       -oas_->value() *
                                       (model_->termStructure()
@@ -392,7 +392,7 @@ namespace QuantLib {
                     for (Size l = j1; l < arguments_.fixedCoupons.size(); l++) {
                         Real zSpreadDf =
                             oas_.empty()
-                                ? 1.0
+                                ? Real(1.0)
                                 : std::exp(
                                       -oas_->value() *
                                       (model_->termStructure()
@@ -414,7 +414,7 @@ namespace QuantLib {
                         rebateDate = rebatedExercise->rebatePaymentDate(idx);
                         zSpreadDf =
                             oas_.empty()
-                                ? 1.0
+                                ? Real(1.0)
                                 : std::exp(
                                       -oas_->value() *
                                       (model_->termStructure()
@@ -438,7 +438,7 @@ namespace QuantLib {
                                           // the no call probability
                             npvp0.back()[k] =
                                 probabilities_ == Naive
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : 1.0 / (model_->zerobond(expiry0Time, 0.0,
                                                               0.0,
                                                               discountCurve_) *
@@ -447,7 +447,7 @@ namespace QuantLib {
                         if (exerciseValue >= npv0[k]) {
                             npvp0[idx - minIdxAlive][k] =
                                 probabilities_ == Naive
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : 1.0 /
                                           (model_->zerobond(expiry0Time, 0.0,
                                                             0.0,

--- a/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
@@ -284,7 +284,7 @@ namespace QuantLib {
                                           // the no call probability
                             npvp0.back()[k] =
                                 probabilities_ == Naive
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : 1.0 / (model_->zerobond(expiry0Time, 0.0,
                                                               0.0,
                                                               discountCurve_) *
@@ -293,7 +293,7 @@ namespace QuantLib {
                         if (exerciseValue >= npv0[k]) {
                             npvp0[idx - minIdxAlive][k] =
                                 probabilities_ == Naive
-                                    ? 1.0
+                                    ? Real(1.0)
                                     : 1.0 /
                                           (model_->zerobond(expiry0Time, 0.0,
                                                             0.0,

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -196,7 +196,7 @@ namespace QuantLib {
         dd_(x_-std::log(ratio)),
         sigma2_(sigma_*sigma_),
         rsigma_(model->rho()*sigma_),
-        t0_(kappa_ - ((j_== 1)? model->rho()*sigma_ : 0)),
+        t0_(kappa_ - ((j_== 1)? model->rho()*sigma_ : Real(0))),
         b_(0), g_km1_(0),
         engine_(engine)
     {
@@ -223,7 +223,7 @@ namespace QuantLib {
         dd_(x_-std::log(ratio)),
         sigma2_(sigma_*sigma_),
         rsigma_(rho*sigma_),
-        t0_(kappa - ((j== 1)? rho*sigma : 0)),
+        t0_(kappa - ((j== 1)? rho*sigma : Real(0))),
         b_(0),
         g_km1_(0),
         engine_(engine)
@@ -243,7 +243,7 @@ namespace QuantLib {
                                                Size j)
     : j_(j), kappa_(kappa), theta_(theta), sigma_(sigma), v0_(v0), cpxLog_(cpxLog), term_(term),
       x_(std::log(s0)), sx_(std::log(strike)), dd_(x_ - std::log(ratio)), sigma2_(sigma_ * sigma_),
-      rsigma_(rho * sigma_), t0_(kappa - ((j == 1) ? rho * sigma : 0)), b_(0), g_km1_(0),
+      rsigma_(rho * sigma_), t0_(kappa - ((j == 1) ? rho * sigma : Real(0))), b_(0), g_km1_(0),
       engine_(nullptr) {}
 
 

--- a/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticptdhestonengine.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
                 const Real theta = model_->theta(t);
 
                 const Real sigma2 = sigma*sigma;
-                const Real t0 = kappa - ((j_== 1)? rho*sigma : 0);
+                const Real t0 = kappa - ((j_== 1)? Real(rho*sigma) : 0);
                 const Real rpsig = rho*sigma*phi;
 
                 const std::complex<Real> t1 = t0+std::complex<Real>(0, -rpsig);

--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -76,8 +76,8 @@ namespace QuantLib {
             std::sqrt(variance);
         CumulativeNormalDistribution cumNormalDist;
         Real K = (!close(riskFreeDiscount, 1.0, 1000))
-                ? -2.0*std::log(riskFreeDiscount)
-                   / (variance*(1.0-riskFreeDiscount))
+                ? Real(-2.0*std::log(riskFreeDiscount)
+                   / (variance*(1.0-riskFreeDiscount)))
                  : 2.0/variance;
         Real temp = blackFormula(payoff->optionType(), payoff->strike(),
                 forwardSi, std::sqrt(variance))*riskFreeDiscount;
@@ -198,8 +198,8 @@ namespace QuantLib {
                 /std::sqrt(variance);
             Real n = 2.0*std::log(dividendDiscount/riskFreeDiscount)/variance;
             Real K = (!close(riskFreeDiscount, 1.0, 1000))
-                    ? -2.0*std::log(riskFreeDiscount)
-                       / (variance*(1.0-riskFreeDiscount))
+                    ? Real(-2.0*std::log(riskFreeDiscount)
+                       / (variance*(1.0-riskFreeDiscount)))
                      : 2.0/variance;
             Real Q, a;
             switch (payoff->optionType()) {

--- a/ql/pricingengines/vanilla/exponentialfittinghestonengine.cpp
+++ b/ql/pricingengines/vanilla/exponentialfittinghestonengine.cpp
@@ -252,7 +252,7 @@ namespace QuantLib {
         const Real scalingFactor = (scaling_ == Null<Real>())
             ? (analyticCV != AnalyticHestonEngine::AsymptoticChF)
                     ? std::max(0.01, std::min(10.0, 0.25/std::sqrt(0.5*vAvg*t)))
-                    : 1.0
+                    : Real(1.0)
             : scaling_;
 
         Size n;

--- a/ql/processes/coxingersollrossprocess.hpp
+++ b/ql/processes/coxingersollrossprocess.hpp
@@ -131,7 +131,7 @@ namespace QuantLib {
 
             const Real u = CumulativeNormalDistribution()(dw);
 
-            result = ((u <= p) ? 0.0 : std::log((1-p)/(1-u))/beta);
+            result = ((u <= p) ? 0.0 : Real(std::log((1-p)/(1-u))/beta));
         }
 
         return result;

--- a/ql/processes/gjrgarchprocess.cpp
+++ b/ql/processes/gjrgarchprocess.cpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         const Real q2 = 1.0 + lambda_*lambda_;
         const Real q3 = lambda_*n + N + lambda_*lambda_*N;
         const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
-                         : (discretization_ == Reflection) ? - std::sqrt(-x[1])
+                         : (discretization_ == Reflection) ? Real(-std::sqrt(-x[1]))
                          : 0.0;
 
         return {
@@ -94,7 +94,7 @@ namespace QuantLib {
         const Real sigma13 = -2.0*n - 2*lambda_*N;
         const Real sigma23 = 2.0*N + sigma12*sigma13;
         const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
-                         : (discretization_ == Reflection) ? - std::sqrt(-x[1])
+                         : (discretization_ == Reflection) ? Real(- std::sqrt(-x[1]))
                          : 1e-8; // set vol to (almost) zero but still
                                  // expose some correlation information
         const Real rho1 = std::sqrt(daysPerYear_)*(alpha_*sigma12 

--- a/ql/processes/gsrprocesscore.cpp
+++ b/ql/processes/gsrprocesscore.cpp
@@ -102,7 +102,7 @@ Real GsrProcessCore::expectation_rn_part(const Time w,
         for (int l = 0; l <= k - 1; l++) {
             Real res2 = 1.0;
             // alpha_l
-            res2 *= revZero(l) ? vol(l) * vol(l) * (time2(l + 1) - time2(l))
+            res2 *= revZero(l) ? Real(vol(l) * vol(l) * (time2(l + 1) - time2(l)))
                                : vol(l) * vol(l) / (2.0 * rev(l)) *
                                      (1.0 - exp(-2.0 * rev(l) *
                                                 (time2(l + 1) - time2(l))));
@@ -115,13 +115,13 @@ Real GsrProcessCore::expectation_rn_part(const Time w,
             // zeta_k beta_k
             res2 *=
                 revZero(k)
-                    ? 2.0 * time2(k) - flooredTime(k, w) -
+                    ? Real(2.0 * time2(k) - flooredTime(k, w) -
                           cappedTime(k + 1, t) -
-                          2.0 * (time2(k) - cappedTime(k + 1, t))
-                    : (exp(rev(k) * (2.0 * time2(k) - flooredTime(k, w) -
+                          2.0 * (time2(k) - cappedTime(k + 1, t)))
+                    : Real((exp(rev(k) * (2.0 * time2(k) - flooredTime(k, w) -
                                      cappedTime(k + 1, t))) -
                        exp(2.0 * rev(k) * (time2(k) - cappedTime(k + 1, t)))) /
-                          rev(k);
+                          rev(k));
             // add to sum
             res += res2;
         }
@@ -130,19 +130,19 @@ Real GsrProcessCore::expectation_rn_part(const Time w,
         // alpha_k zeta_k
         res2 *=
             revZero(k)
-                ? vol(k) * vol(k) / 4.0 *
+                ? Real(vol(k) * vol(k) / 4.0 *
                       (4.0 * pow(cappedTime(k + 1, t) - time2(k), 2.0) -
                        (pow(flooredTime(k, w) - 2.0 * time2(k) +
                                 cappedTime(k + 1, t),
                             2.0) +
-                        pow(cappedTime(k + 1, t) - flooredTime(k, w), 2.0)))
-                : vol(k) * vol(k) / (2.0 * rev(k) * rev(k)) *
+                        pow(cappedTime(k + 1, t) - flooredTime(k, w), 2.0))))
+                : Real(vol(k) * vol(k) / (2.0 * rev(k) * rev(k)) *
                       (exp(-2.0 * rev(k) * (cappedTime(k + 1, t) - time2(k))) +
                        1.0 -
                        (exp(-rev(k) * (flooredTime(k, w) - 2.0 * time2(k) +
                                        cappedTime(k + 1, t))) +
                         exp(-rev(k) *
-                            (cappedTime(k + 1, t) - flooredTime(k, w)))));
+                            (cappedTime(k + 1, t) - flooredTime(k, w))))));
         // zeta_i (i>k)
         for (int i = k + 1; i <= upperIndex(t) - 1; i++)
             res2 *= exp(-rev(i) * (cappedTime(i + 1, t) - time2(i)));
@@ -176,7 +176,7 @@ Real GsrProcessCore::expectation_tf_part(const Time w,
             Real res3 = 1.0;
             // eta_l
             res3 *= revZero(l)
-                        ? cappedTime(l + 1, T_) - time2(l)
+                        ? Real(cappedTime(l + 1, T_) - time2(l))
                         : (1.0 -
                            exp(-rev(l) * (cappedTime(l + 1, T_) - time2(l)))) /
                               rev(l);
@@ -189,14 +189,14 @@ Real GsrProcessCore::expectation_tf_part(const Time w,
             // zeta_k gamma_k
             res3 *=
                 revZero(k)
-                    ? (cappedTime(k + 1, t) - time2(k + 1) -
+                    ? Real((cappedTime(k + 1, t) - time2(k + 1) -
                        (2.0 * flooredTime(k, w) - cappedTime(k + 1, t) -
                         time2(k + 1))) /
-                          2.0
-                    : (exp(rev(k) * (cappedTime(k + 1, t) - time2(k + 1))) -
+                          2.0)
+                    : Real((exp(rev(k) * (cappedTime(k + 1, t) - time2(k + 1))) -
                        exp(rev(k) * (2.0 * flooredTime(k, w) -
                                      cappedTime(k + 1, t) - time2(k + 1)))) /
-                          (2.0 * rev(k));
+                          (2.0 * rev(k)));
             // add to sum
             res2 += res3;
         }
@@ -205,20 +205,20 @@ Real GsrProcessCore::expectation_tf_part(const Time w,
         // eta_k zeta_k
         res3 *=
             revZero(k)
-                ? (-pow(cappedTime(k + 1, t) - cappedTime(k + 1, T_), 2.0) -
+                ? Real((-pow(cappedTime(k + 1, t) - cappedTime(k + 1, T_), 2.0) -
                    2.0 * pow(cappedTime(k + 1, t) - flooredTime(k, w), 2.0) +
                    pow(2.0 * flooredTime(k, w) - cappedTime(k + 1, T_) -
                            cappedTime(k + 1, t),
                        2.0)) /
-                      4.0
-                : (2.0 - exp(rev(k) *
+                      4.0)
+                : Real((2.0 - exp(rev(k) *
                              (cappedTime(k + 1, t) - cappedTime(k + 1, T_))) -
                    (2.0 * exp(-rev(k) *
                               (cappedTime(k + 1, t) - flooredTime(k, w))) -
                     exp(rev(k) *
                         (2.0 * flooredTime(k, w) - cappedTime(k + 1, T_) -
                          cappedTime(k + 1, t))))) /
-                      (2.0 * rev(k) * rev(k));
+                      (2.0 * rev(k) * rev(k)));
         // zeta_i (i>k)
         for (int i = k + 1; i <= upperIndex(t) - 1; i++)
             res3 *= exp(-rev(i) * (cappedTime(i + 1, t) - time2(i)));
@@ -248,7 +248,7 @@ Real GsrProcessCore::variance(const Time w, const Time dt) const {
         Real res2 = vol(k) * vol(k);
         // zeta_k^2
         res2 *= revZero(k)
-                    ? -(flooredTime(k, w) - cappedTime(k + 1, t))
+                    ? Real(-(flooredTime(k, w) - cappedTime(k + 1, t)))
                     : (1.0 - exp(2.0 * rev(k) *
                                  (flooredTime(k, w) - cappedTime(k + 1, t)))) /
                           (2.0 * rev(k));
@@ -276,7 +276,7 @@ Real GsrProcessCore::y(const Time t) const {
         for (int j = i + 1; j <= upperIndex(t) - 1; j++) {
             res2 *= exp(-2.0 * rev(j) * (cappedTime(j + 1, t) - time2(j)));
         }
-        res2 *= revZero(i) ? vol(i) * vol(i) * (cappedTime(i + 1, t) - time2(i))
+        res2 *= revZero(i) ? Real(vol(i) * vol(i) * (cappedTime(i + 1, t) - time2(i)))
                            : (vol(i) * vol(i) / (2.0 * rev(i)) *
                               (1.0 - exp(-2.0 * rev(i) *
                                          (cappedTime(i + 1, t) - time2(i)))));
@@ -300,7 +300,7 @@ Real GsrProcessCore::G(const Time t, const Time w) const {
         for (int j = lowerIndex(t); j <= i - 1; j++) {
             res2 *= exp(-rev(j) * (time2(j + 1) - flooredTime(j, t)));
         }
-        res2 *= revZero(i) ? cappedTime(i + 1, w) - flooredTime(i, t)
+        res2 *= revZero(i) ? Real(cappedTime(i + 1, w) - flooredTime(i, t))
                            : (1.0 - exp(-rev(i) * (cappedTime(i + 1, w) -
                                                    flooredTime(i, t)))) /
                                  rev(i);

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
 
     Array HestonProcess::drift(Time t, const Array& x) const {
         const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
-                         : (discretization_ == Reflection) ? - std::sqrt(-x[1])
+                         : (discretization_ == Reflection) ? Real(- std::sqrt(-x[1]))
                          : 0.0;
 
         return {
@@ -90,7 +90,7 @@ namespace QuantLib {
         */
         Matrix tmp(2,2);
         const Real vol = (x[1] > 0.0) ? std::sqrt(x[1])
-                         : (discretization_ == Reflection) ? -std::sqrt(-x[1])
+                         : (discretization_ == Reflection) ? Real(-std::sqrt(-x[1]))
                          : 1e-8; // set vol to (almost) zero but still
                                  // expose some correlation information
         const Real sigma2 = sigma_ * vol;
@@ -307,7 +307,7 @@ namespace QuantLib {
                     ? std::max(0.0, std::min(1.0,
                         gaussLaguerreIntegration(
                             [&](Real u){ return ch(process, x, u, nu_0, nu_t, dt); })))
-                    : 1.0;
+                    : Real(1.0);
               }
               case HestonProcess::BroadieKayaExactSchemeLobatto:
               {
@@ -321,7 +321,7 @@ namespace QuantLib {
                         GaussLobattoIntegral(Null<Size>(), eps)(
                             [&](Real xi){ return ch(process, x, xi, nu_0, nu_t, dt); },
                             QL_EPSILON, upper)))
-                    : 1.0;
+                    : Real(1.0);
               }
               case HestonProcess::BroadieKayaExactSchemeTrapezoidal:
               {
@@ -408,7 +408,7 @@ namespace QuantLib {
           //  stochastic volatility models",
           // Working Paper, Tinbergen Institute
           case PartialTruncation:
-            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : Real(0.0);
             vol2 = sigma_ * vol;
             mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous).rate()
                   - dividendYield_->forwardRate(t0, t0+dt, Continuous).rate()
@@ -419,7 +419,7 @@ namespace QuantLib {
             retVal[1] = x0[1] + nu*dt + vol2*sdt*(rho_*dw[0] + sqrhov*dw[1]);
             break;
           case FullTruncation:
-            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : Real(0.0);
             vol2 = sigma_ * vol;
             mu =    riskFreeRate_->forwardRate(t0, t0+dt, Continuous).rate()
                   - dividendYield_->forwardRate(t0, t0+dt, Continuous).rate()
@@ -447,7 +447,7 @@ namespace QuantLib {
             // and Ito's Lemma. Then use exact sampling for the variance
             // process. For further details please read the Wilmott thread
             // "QuantLib code is very high quality"
-            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+            vol = (x0[1] > 0.0) ? std::sqrt(x0[1]) : Real(0.0);
             mu =   riskFreeRate_->forwardRate(t0, t0+dt, Continuous).rate()
                  - dividendYield_->forwardRate(t0, t0+dt, Continuous).rate()
                    - 0.5 * vol*vol;
@@ -504,7 +504,7 @@ namespace QuantLib {
                     QL_REQUIRE(A < beta, "illegal value");
                     k0 = -std::log(p+beta*(1-p)/(beta-A))-(k1+0.5*k3)*x0[1];
                 }
-                retVal[1] = ((u <= p) ? 0.0 : std::log((1-p)/(1-u))/beta);
+                retVal[1] = ((u <= p) ? Real(0.0) : std::log((1-p)/(1-u))/beta);
             }
 
             mu =   riskFreeRate_->forwardRate(t0, t0+dt, Continuous).rate()

--- a/ql/processes/hullwhiteprocess.cpp
+++ b/ql/processes/hullwhiteprocess.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
     Real HullWhiteProcess::alpha(Time t) const {
         Real alfa = a_ > QL_EPSILON ?
-                    (sigma_/a_)*(1 - std::exp(-a_*t)) :
+                    Real((sigma_/a_)*(1 - std::exp(-a_*t))) :
                     sigma_*t;
         alfa *= 0.5*alfa;
         alfa += h_->forwardRate(t, t, Continuous, NoFrequency);
@@ -123,7 +123,7 @@ namespace QuantLib {
 
     Real HullWhiteForwardProcess::alpha(Time t) const {
         Real alfa = a_ > QL_EPSILON ?
-                    (sigma_/a_)*(1 - std::exp(-a_*t)) :
+                    Real((sigma_/a_)*(1 - std::exp(-a_*t))) :
                     sigma_*t;
         alfa *= 0.5*alfa;
         alfa += h_->forwardRate(t, t, Continuous, NoFrequency);
@@ -147,7 +147,7 @@ namespace QuantLib {
 
     Real HullWhiteForwardProcess::B(Time t, Time T) const {
         return a_ > QL_EPSILON ?
-               1/a_ * (1-std::exp(-a_*(T-t))) :
+               Real(1/a_ * (1-std::exp(-a_*(T-t)))) :
                T-t;
     }
 

--- a/ql/processes/hybridhestonhullwhiteprocess.cpp
+++ b/ql/processes/hybridhestonhullwhiteprocess.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
         const Real sigma     = hullWhiteProcess_->sigma();
         const Real rho       = corrEquityShortRate_;
         const Real xi        = hestonProcess_->rho();
-        const Volatility eta = (x0[1] > 0.0) ? std::sqrt(x0[1]) : 0.0;
+        const Volatility eta = (x0[1] > 0.0) ? Real(std::sqrt(x0[1])) : 0.0;
         const Time s = t0;
         const Time t = t0 + dt;
         const Time T = T_;

--- a/ql/processes/jointstochasticprocess.cpp
+++ b/ql/processes/jointstochasticprocess.cpp
@@ -195,7 +195,7 @@ namespace QuantLib {
                 for (Size j=i; j < cov.columns(); ++j) {
                     const Real div = sqrtDiag[i]*sqrtDiag[j];
 
-                    cov[i][j] = cov[j][i] = ( div > 0) ? cov[i][j]/div : 0.0;
+                    cov[i][j] = cov[j][i] = ( div > 0) ? Real(cov[i][j]/div) : 0.0;
                 }
             }
 

--- a/ql/processes/jointstochasticprocess.cpp
+++ b/ql/processes/jointstochasticprocess.cpp
@@ -215,7 +215,7 @@ namespace QuantLib {
                     if (vol > 0.0) {
                         std::transform(stdDev.row_begin(i), stdDev.row_end(i),
                                        stdDev.row_begin(i),
-                                       [=](Real x){ return x/vol; });
+                                       [=](Real x) -> Real { return x / vol; });
                     }
                     else {
                         // keep the svd happy

--- a/ql/processes/stochasticprocessarray.cpp
+++ b/ql/processes/stochasticprocessarray.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
             Real sigma = processes_[i]->diffusion(t, x[i]);
             std::transform(tmp.row_begin(i), tmp.row_end(i),
                            tmp.row_begin(i),
-                           [=](Real x){ return x * sigma; });
+                           [=](Real x) -> Real { return x * sigma; });
         }
         return tmp;
     }
@@ -87,7 +87,7 @@ namespace QuantLib {
             Real sigma = processes_[i]->stdDeviation(t0, x0[i], dt);
             std::transform(tmp.row_begin(i), tmp.row_end(i),
                            tmp.row_begin(i),
-                           [=](Real x){ return x * sigma; });
+                           [=](Real x) -> Real { return x * sigma; });
         }
         return tmp;
     }

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -58,21 +58,6 @@
 #undef INCLUDE_FILE_
 #undef INCLUDE_FILE
 
-/* Eventually these might go into userconfig.hpp.
-   For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler.
-*/
-#ifndef QL_INTEGER
-#    define QL_INTEGER int
-#endif
-
-#ifndef QL_BIG_INTEGER
-#    define QL_BIG_INTEGER long
-#endif
-
-#ifndef QL_REAL
-#   define QL_REAL double
-#endif
 
 
 /*! \defgroup macros QuantLib macros
@@ -102,6 +87,22 @@
    #include <ql/config.ansi.hpp>
 #endif
 
+/* Eventually these might go into userconfig.hpp.
+   For the time being, we hard code them here.
+   They can be overridden by passing the #define to the compiler
+   or by defining them in config.hpp.
+*/
+#ifndef QL_INTEGER
+#    define QL_INTEGER int
+#endif
+
+#ifndef QL_BIG_INTEGER
+#    define QL_BIG_INTEGER long
+#endif
+
+#ifndef QL_REAL
+#   define QL_REAL double
+#endif
 
 // extra debug checks
 #ifdef QL_DEBUG

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -60,8 +60,7 @@
 
 /* Eventually these might go into userconfig.hpp.
    For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler
-   or by defining them in config.hpp.
+   They can be overridden by passing the #define to the compiler.
 */
 #ifndef QL_INTEGER
 #    define QL_INTEGER int

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -50,7 +50,7 @@
    The idea is to provide a hook for defining QL_REAL and at the
    same time including any necessary headers for the new type.
 */
-#define INCLUDE_FILE(F) INCLUDE_FILE__(F)
+#define INCLUDE_FILE(F) INCLUDE_FILE_(F)
 #define INCLUDE_FILE_(F) #F
 #ifdef QL_INCLUDE_FIRST
 #    include INCLUDE_FILE(QL_INCLUDE_FIRST)

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -58,6 +58,22 @@
 #undef INCLUDE_FILE_
 #undef INCLUDE_FILE
 
+/* Eventually these might go into userconfig.hpp.
+   For the time being, we hard code them here.
+   They can be overridden by passing the #define to the compiler
+   or by defining them in config.hpp.
+*/
+#ifndef QL_INTEGER
+#    define QL_INTEGER int
+#endif
+
+#ifndef QL_BIG_INTEGER
+#    define QL_BIG_INTEGER long
+#endif
+
+#ifndef QL_REAL
+#   define QL_REAL double
+#endif
 
 
 /*! \defgroup macros QuantLib macros
@@ -87,22 +103,6 @@
    #include <ql/config.ansi.hpp>
 #endif
 
-/* Eventually these might go into userconfig.hpp.
-   For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler
-   or by defining them in config.hpp.
-*/
-#ifndef QL_INTEGER
-#    define QL_INTEGER int
-#endif
-
-#ifndef QL_BIG_INTEGER
-#    define QL_BIG_INTEGER long
-#endif
-
-#ifndef QL_REAL
-#   define QL_REAL double
-#endif
 
 // extra debug checks
 #ifdef QL_DEBUG

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -61,8 +61,7 @@
 
 /* Eventually these might go into userconfig.hpp.
    For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler
-   or by defining them in config.hpp.
+   They can be overridden by passing the #define to the compiler.
 */
 #ifndef QL_INTEGER
 #    define QL_INTEGER int

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -59,21 +59,6 @@
 #undef INCLUDE_FILE_
 #undef INCLUDE_FILE
 
-/* Eventually these might go into userconfig.hpp.
-   For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler.
-*/
-#ifndef QL_INTEGER
-#    define QL_INTEGER int
-#endif
-
-#ifndef QL_BIG_INTEGER
-#    define QL_BIG_INTEGER long
-#endif
-
-#ifndef QL_REAL
-#   define QL_REAL double
-#endif
 
 
 /*! \defgroup macros QuantLib macros
@@ -101,6 +86,23 @@
    #include <ql/config.sun.hpp>
 #else                           // We hope that the compiler follows ANSI
    #include <ql/config.ansi.hpp>
+#endif
+
+/* Eventually these might go into userconfig.hpp.
+   For the time being, we hard code them here.
+   They can be overridden by passing the #define to the compiler
+   or by defining them in config.hpp.
+*/
+#ifndef QL_INTEGER
+#    define QL_INTEGER int
+#endif
+
+#ifndef QL_BIG_INTEGER
+#    define QL_BIG_INTEGER long
+#endif
+
+#ifndef QL_REAL
+#   define QL_REAL double
 #endif
 
 
@@ -169,7 +171,7 @@
 /*! \def QL_EPSILON
     Defines the machine precision for operations over doubles
 */
-#include <boost/limits.hpp>
+#include <limits>
 // limits used as such
 #define QL_MIN_INTEGER         ((std::numeric_limits<QL_INTEGER>::min)())
 #define QL_MAX_INTEGER         ((std::numeric_limits<QL_INTEGER>::max)())

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -51,7 +51,7 @@
    The idea is to provide a hook for defining QL_REAL and at the
    same time including any necessary headers for the new type.
 */
-#define INCLUDE_FILE(F) INCLUDE_FILE__(F)
+#define INCLUDE_FILE(F) INCLUDE_FILE_(F)
 #define INCLUDE_FILE_(F) #F
 #ifdef QL_INCLUDE_FIRST
 #    include INCLUDE_FILE(QL_INCLUDE_FIRST)

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -59,6 +59,22 @@
 #undef INCLUDE_FILE_
 #undef INCLUDE_FILE
 
+/* Eventually these might go into userconfig.hpp.
+   For the time being, we hard code them here.
+   They can be overridden by passing the #define to the compiler
+   or by defining them in config.hpp.
+*/
+#ifndef QL_INTEGER
+#    define QL_INTEGER int
+#endif
+
+#ifndef QL_BIG_INTEGER
+#    define QL_BIG_INTEGER long
+#endif
+
+#ifndef QL_REAL
+#   define QL_REAL double
+#endif
 
 
 /*! \defgroup macros QuantLib macros
@@ -86,23 +102,6 @@
    #include <ql/config.sun.hpp>
 #else                           // We hope that the compiler follows ANSI
    #include <ql/config.ansi.hpp>
-#endif
-
-/* Eventually these might go into userconfig.hpp.
-   For the time being, we hard code them here.
-   They can be overridden by passing the #define to the compiler
-   or by defining them in config.hpp.
-*/
-#ifndef QL_INTEGER
-#    define QL_INTEGER int
-#endif
-
-#ifndef QL_BIG_INTEGER
-#    define QL_BIG_INTEGER long
-#endif
-
-#ifndef QL_REAL
-#   define QL_REAL double
 #endif
 
 

--- a/ql/termstructures/defaulttermstructure.hpp
+++ b/ql/termstructures/defaulttermstructure.hpp
@@ -215,7 +215,7 @@ namespace QuantLib {
     Rate DefaultProbabilityTermStructure::hazardRate(Time t,
                                                      bool extrapolate) const {
         Probability S = survivalProbability(t, extrapolate);
-        return S == 0.0 ? 0.0 : defaultDensity(t, extrapolate)/S;
+        return S == 0.0 ? 0.0 : Real(defaultDensity(t, extrapolate)/S);
     }
 
     inline

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -262,7 +262,7 @@ template <class Curve> void GlobalBootstrap<Curve>::calculate() const {
 
         Real value(const Array& x) const override {
             Array v = values(x);
-            std::transform(v.begin(), v.end(), v.begin(), [](Real x){ return x*x; });
+            std::transform(v.begin(), v.end(), v.begin(), [](Real x) -> Real { return x*x; });
             return std::sqrt(std::accumulate(v.begin(), v.end(), Real(0.0)) / static_cast<Real>(v.size()));
         }
 

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Rate r = *(std::min_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r*2.0 : r/2.0;
+                return r<0.0 ? Real(r*2.0) : r/2.0;
             }
             return -detail::maxInflation;
         }
@@ -89,7 +89,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Rate r = *(std::max_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r/2.0 : r*2.0;
+                return r<0.0 ? Real(r/2.0) : r*2.0;
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
@@ -153,7 +153,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Rate r = *(std::min_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r*2.0 : r/2.0;
+                return r<0.0 ? Real(r*2.0) : r/2.0;
             }
             return -detail::maxInflation;
         }
@@ -165,7 +165,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Rate r = *(std::max_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r/2.0 : r*2.0;
+                return r<0.0 ? Real(r/2.0) : r*2.0;
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -285,9 +285,9 @@ namespace detail {
                 } else {
                     // Extending a previous attempt.  A negative min
                     // is enlarged; a positive one is shrunk towards 0.
-                    min = (min < 0.0 ? min * minFactor_ : min / minFactor_);
+                    min = (min < 0.0 ? Real(min * minFactor_) : Real(min / minFactor_));
                     // The opposite holds for the max.
-                    max = (max > 0.0 ? max * maxFactor_ : max / maxFactor_);
+                    max = (max > 0.0 ? Real(max * maxFactor_) : Real(max / maxFactor_));
                 }
                 Real guess = Traits::guess(i, ts_, validData, firstAliveHelper_);
 

--- a/ql/termstructures/volatility/equityfx/localvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.cpp
@@ -91,7 +91,7 @@ namespace QuantLib {
         Real w, wp, wm, dwdy, d2wdy2;
         strike = underlyingLevel;
         y = std::log(strike/forwardValue);
-        dy = ((std::fabs(y) > 0.001) ? y*0.0001 : 0.000001);
+        dy = ((std::fabs(y) > 0.001) ? Real(y*0.0001) : 0.000001);
         strikep=strike*std::exp(dy);
         strikem=strike/std::exp(dy);
         w  = blackTS_->blackVariance(t, strike,  true);

--- a/ql/termstructures/volatility/smilesection.cpp
+++ b/ql/termstructures/volatility/smilesection.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
         // minstrike, maxstrike interval
         if (volatilityType() == ShiftedLognormal)
             return blackFormula(type,strike,atm, std::fabs(strike+shift()) < QL_EPSILON ?
-                            0.2 : sqrt(variance(strike)),discount,shift());
+                            0.2 : Real(sqrt(variance(strike))),discount,shift());
         else
             return bachelierBlackFormula(type,strike,atm,sqrt(variance(strike)),discount);
     }
@@ -89,7 +89,7 @@ namespace QuantLib {
                                           Option::Type type,
                                           Real discount,
                                           Real gap) const {
-        Real m = volatilityType() == ShiftedLognormal ? -shift() : -QL_MAX_REAL;
+        Real m = volatilityType() == ShiftedLognormal ? Real(-shift()) : -QL_MAX_REAL;
         Real kl = std::max(strike-gap/2.0,m);
         Real kr = kl+gap;
         return (type==Option::Call ? 1.0 : -1.0) *
@@ -97,7 +97,7 @@ namespace QuantLib {
     }
 
     Real SmileSection::density(Rate strike, Real discount, Real gap) const {
-        Real m = volatilityType() == ShiftedLognormal ? -shift() : -QL_MAX_REAL;
+        Real m = volatilityType() == ShiftedLognormal ? Real(-shift()) : -QL_MAX_REAL;
         Real kl = std::max(strike-gap/2.0,m);
         Real kr = kl+gap;
         return (digitalOptionPrice(kl,Option::Call,discount,gap) -

--- a/ql/termstructures/volatility/smilesectionutils.cpp
+++ b/ql/termstructures/volatility/smilesectionutils.cpp
@@ -96,15 +96,15 @@ namespace QuantLib {
                      // in order to not loose too much information
                 if (k < section.minStrike() && !minStrikeAdded) {
                     m_.push_back(section.volatilityType() == Normal
-                                     ? section.minStrike() - f_
-                                     : (section.minStrike() + shift) / f_);
+                                     ? Real(section.minStrike() - f_)
+                                     : Real((section.minStrike() + shift) / f_));
                     k_.push_back(section.minStrike());
                     minStrikeAdded = true;
                 }
                 if (k > section.maxStrike() && !maxStrikeAdded) {
                     m_.push_back(section.volatilityType() == Normal
-                                     ? section.maxStrike() - f_
-                                     : (section.maxStrike() + shift) / f_);
+                                     ? Real(section.maxStrike() - f_)
+                                     : Real((section.maxStrike() + shift) / f_));
                     k_.push_back(section.maxStrike());
                     maxStrikeAdded = true;
                 }

--- a/ql/termstructures/volatility/swaption/cmsmarketcalibration.hpp
+++ b/ql/termstructures/volatility/swaption/cmsmarketcalibration.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
         }
         static Real betaTransformDirect(Real y) {
             return std::max(
-                std::min(std::fabs(y) < 10.0 ? std::exp(-(y * y)) : 0.0,
+                std::min(std::fabs(y) < 10.0 ? Real(std::exp(-(y * y))) : 0.0,
                          0.999999),
                 0.000001);
         }

--- a/ql/termstructures/yield/bootstraptraits.hpp
+++ b/ql/termstructures/yield/bootstraptraits.hpp
@@ -159,7 +159,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::min_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r*2.0 : r/2.0;
+                return r<0.0 ? Real(r*2.0) : Real(r/2.0);
             }
             // no constraints.
             // We choose as min a value very unlikely to be exceeded.
@@ -173,7 +173,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::max_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r/2.0 : r*2.0;
+                return r<0.0 ? Real(r/2.0) : Real(r*2.0);
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
@@ -240,7 +240,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::min_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r*2.0 : r/2.0;
+                return r<0.0 ? Real(r*2.0) : Real(r/2.0);
             }
             // no constraints.
             // We choose as min a value very unlikely to be exceeded.
@@ -254,7 +254,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::max_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r/2.0 : r*2.0;
+                return r<0.0 ? Real(r/2.0) : Real(r*2.0);
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
@@ -321,7 +321,7 @@ namespace QuantLib {
             Real result;
             if (validData) {
                 Real r = *(std::min_element(c->data().begin(), c->data().end()));
-                result = r<0.0 ? r*2.0 : r/2.0;
+                result = r<0.0 ? Real(r*2.0) : r/2.0;
             } else {
                 // no constraints.
                 // We choose as min a value very unlikely to be exceeded.
@@ -338,7 +338,7 @@ namespace QuantLib {
         {
             if (validData) {
                 Real r = *(std::max_element(c->data().begin(), c->data().end()));
-                return r<0.0 ? r/2.0 : r*2.0;
+                return r<0.0 ? Real(r/2.0) : r*2.0;
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -155,19 +155,19 @@ void ArrayTest::testArrayResize() {
     Array a(10,1.0,1.0);
 
     for (Size i=0; i < 10; ++i)
-        BOOST_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
+        QL_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
 
     a.resize(5);
     BOOST_CHECK(a.size() == 5);
 
     for (Size i=0; i < 5; ++i)
-        BOOST_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
+        QL_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
 
     a.resize(15);
     BOOST_CHECK(a.size() == 15);
 
     for (Size i=0; i < 5; ++i)
-        BOOST_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
+        QL_CHECK_CLOSE(a[i], Real(1+i), 10*QL_EPSILON);
 
     const Array::const_iterator iter = a.begin();
     a.resize(a.size());

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -166,24 +166,24 @@ void CatBondTest::testBetaRisk() {
         poissonSumSquares+=path.size()*path.size();
     }
     Real poissonMean = poissonSum/PATHS;
-    BOOST_CHECK_CLOSE(Real(3.0/100.0), poissonMean, 2);
+    QL_CHECK_CLOSE(Real(3.0/100.0), poissonMean, 2);
     Real poissonVar = poissonSumSquares/PATHS - poissonMean*poissonMean;
-    BOOST_CHECK_CLOSE(Real(3.0/100.0), poissonVar, 5);
+    QL_CHECK_CLOSE(Real(3.0/100.0), poissonVar, 5);
     
     Real expectedMean = 3.0*10.0/100.0;
     Real actualMean = sum/PATHS;
     #ifdef _LIBCPP_VERSION
-    BOOST_CHECK_CLOSE(expectedMean, actualMean, 5);
+    QL_CHECK_CLOSE(expectedMean, actualMean, 5);
     #else
-    BOOST_CHECK_CLOSE(expectedMean, actualMean, 1);
+    QL_CHECK_CLOSE(expectedMean, actualMean, 1);
     #endif
     
     Real expectedVar = 3.0*(15.0*15.0+10*10)/100.0;
     Real actualVar = sumSquares/PATHS - actualMean*actualMean;
     #ifdef _LIBCPP_VERSION
-    BOOST_CHECK_CLOSE(expectedVar, actualVar, 10);
+    QL_CHECK_CLOSE(expectedVar, actualVar, 10);
     #else
-    BOOST_CHECK_CLOSE(expectedVar, actualVar, 1);
+    QL_CHECK_CLOSE(expectedVar, actualVar, 1);
     #endif
 }
 
@@ -437,9 +437,9 @@ void CatBondTest::testCatBondInDoomScenario() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(Real(1.0), lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(1.0), exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(1.0), expectedLoss, tolerance);
+    QL_CHECK_CLOSE(Real(1.0), lossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(1.0), exhaustionProbability, tolerance);
+    QL_CHECK_CLOSE(Real(1.0), expectedLoss, tolerance);
 }
 
 
@@ -505,9 +505,9 @@ void CatBondTest::testCatBondWithDoomOnceInTenYears() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(0.1), exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(0.1), expectedLoss, tolerance);
+    QL_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.1), exhaustionProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.1), expectedLoss, tolerance);
 
     ext::shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
     catBond.setPricingEngine(catBondEngineRF);
@@ -518,11 +518,11 @@ void CatBondTest::testCatBondWithDoomOnceInTenYears() {
     Real riskFreeExhaustionProbability = catBond.exhaustionProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(0.0), riskFreeExhaustionProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.0), riskFreeExhaustionProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
-    BOOST_CHECK_CLOSE(riskFreePrice*0.9, price, tolerance);
+    QL_CHECK_CLOSE(riskFreePrice*0.9, price, tolerance);
     BOOST_CHECK_LT(riskFreeYield, yield);
 }
 
@@ -588,9 +588,9 @@ void CatBondTest::testCatBondWithDoomOnceInTenYearsProportional() {
     Real exhaustionProbability = catBond.exhaustionProbability();
     Real expectedLoss = catBond.expectedLoss();
 
-    BOOST_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(0.0), exhaustionProbability, tolerance);
-    BOOST_CHECK_CLOSE(Real(0.05), expectedLoss, tolerance);
+    QL_CHECK_CLOSE(Real(0.1), lossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.0), exhaustionProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.05), expectedLoss, tolerance);
 
     ext::shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
     catBond.setPricingEngine(catBondEngineRF);
@@ -600,10 +600,10 @@ void CatBondTest::testCatBondWithDoomOnceInTenYearsProportional() {
     Real riskFreeLossProbability = catBond.lossProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
-    BOOST_CHECK_CLOSE(riskFreePrice*0.95, price, tolerance);
+    QL_CHECK_CLOSE(riskFreePrice*0.95, price, tolerance);
     BOOST_CHECK_LT(riskFreeYield, yield);
 }
 
@@ -678,7 +678,7 @@ void CatBondTest::testCatBondWithGeneratedEventsProportional() {
     Real riskFreeLossProbability = catBond.lossProbability();
     Real riskFreeExpectedLoss = catBond.expectedLoss();
     
-    BOOST_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
+    QL_CHECK_CLOSE(Real(0.0), riskFreeLossProbability, tolerance);
     BOOST_CHECK(std::abs(riskFreeExpectedLoss) < tolerance);
     
     BOOST_CHECK_GT(riskFreePrice, price);

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -223,11 +223,11 @@ void CmsSpreadTest::testCouponPricing() {
 #else
     constexpr double eqTol = 1e-13;
 #endif
-    BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
+    QL_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms10y->addFixing(d.refDate, 0.05);
-    BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
+    QL_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     cms2y->addFixing(d.refDate, 0.03);
-    BOOST_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
+    QL_CHECK_CLOSE(cpn1->rate(), cpn1a->rate() - cpn1b->rate(), eqTol);
     IndexManager::instance().clearHistories();
 
     ext::shared_ptr<CmsCoupon> cpn2a = ext::shared_ptr<CmsCoupon>(
@@ -271,23 +271,23 @@ void CmsSpreadTest::testCouponPricing() {
     flooredCpn->setPricer(d.cmsspPricerLn);
     collaredCpn->setPricer(d.cmsspPricerLn);
 
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(plainCpn->rate() - mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL,
                                                      -QL_MAX_REAL, d.swLn,
                                                      d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(cappedCpn->rate() - mcReferenceValue(cpn2a, cpn2b, 0.03,
                                                       -QL_MAX_REAL, d.swLn,
                                                       d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(flooredCpn->rate() -
                  mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL, 0.01, d.swLn,
                                   d.correlation->value())),
 
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(collaredCpn->rate() -
                  mcReferenceValue(cpn2a, cpn2b, 0.03, 0.01, d.swLn,
                                   d.correlation->value())),
@@ -300,23 +300,23 @@ void CmsSpreadTest::testCouponPricing() {
     flooredCpn->setPricer(d.cmsspPricerSln);
     collaredCpn->setPricer(d.cmsspPricerSln);
 
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(plainCpn->rate() - mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL,
                                                      -QL_MAX_REAL, d.swSln,
                                                      d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(cappedCpn->rate() - mcReferenceValue(cpn2a, cpn2b, 0.03,
                                                       -QL_MAX_REAL, d.swSln,
                                                       d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(flooredCpn->rate() -
                  mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL, 0.01, d.swSln,
                                   d.correlation->value())),
 
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(collaredCpn->rate() -
                  mcReferenceValue(cpn2a, cpn2b, 0.03, 0.01, d.swSln,
                                   d.correlation->value())),
@@ -329,22 +329,22 @@ void CmsSpreadTest::testCouponPricing() {
     flooredCpn->setPricer(d.cmsspPricerN);
     collaredCpn->setPricer(d.cmsspPricerN);
 
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(plainCpn->rate() - mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL,
                                                      -QL_MAX_REAL, d.swN,
                                                      d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(
+    QL_CHECK_SMALL(
         std::abs(cappedCpn->rate() - mcReferenceValue(cpn2a, cpn2b, 0.03,
                                                       -QL_MAX_REAL, d.swN,
                                                       d.correlation->value())),
         tol);
-    BOOST_CHECK_SMALL(std::abs(flooredCpn->rate() -
+    QL_CHECK_SMALL(std::abs(flooredCpn->rate() -
                                mcReferenceValue(cpn2a, cpn2b, QL_MAX_REAL, 0.01,
                                                 d.swN, d.correlation->value())),
 
                       tol);
-    BOOST_CHECK_SMALL(std::abs(collaredCpn->rate() -
+    QL_CHECK_SMALL(std::abs(collaredCpn->rate() -
                                mcReferenceValue(cpn2a, cpn2b, 0.03, 0.01, d.swN,
                                                 d.correlation->value())),
                       tol);

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -696,7 +696,7 @@ void CreditDefaultSwapTest::testIsdaEngine() {
                         .withNominal(10000000.)
                         .withPricingEngine(engine);
 
-                BOOST_CHECK_CLOSE(conventionalTrade->notional() * conventionalTrade->fairUpfront(),
+                QL_CHECK_CLOSE(conventionalTrade->notional() * conventionalTrade->fairUpfront(),
                                   markitValues[l], tolerance);
 
                 l++;
@@ -738,7 +738,7 @@ void CreditDefaultSwapTest::testAccrualRebateAmounts() {
         Settings::instance().evaluationDate() = input.first;
         CreditDefaultSwap cds = MakeCreditDefaultSwap(maturity, spread)
             .withNominal(notional);
-        BOOST_CHECK_SMALL(input.second - cds.accrualRebate()->amount(), 0.01);
+        QL_CHECK_SMALL(input.second - cds.accrualRebate()->amount(), 0.01);
     }
 }
 

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -157,8 +157,8 @@ namespace crosscurrencyratehelpers_test {
             const Real baseCcyLegNotional = 1.0;
             Real quoteCcyLegNotional = baseCcyLegNotional * fxSpot;
 
-            Spread baseCcyLegBasis = isBasisOnFxBaseCurrencyLeg ? q.basis * basisPoint : 0.0;
-            Spread quoteCcyLegBasis = isBasisOnFxBaseCurrencyLeg ? 0.0 : q.basis * basisPoint;
+            Spread baseCcyLegBasis = isBasisOnFxBaseCurrencyLeg ? Real(q.basis * basisPoint) : 0.0;
+            Spread quoteCcyLegBasis = isBasisOnFxBaseCurrencyLeg ? 0.0 : Real(q.basis * basisPoint);
 
             std::vector<ext::shared_ptr<Swap> > legs;
             bool payer = true;

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -125,7 +125,7 @@ namespace {
 
         Real operator()(Real s) const override {
             return  ((s >= 100.0) ? 108.0 : 100.0)
-                  - ((s <= 75.0) ? 100.0 - s : 0.0);
+                  - ((s <= 75.0) ? Real(100.0 - s) : 0.0);
         }
     };
 

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -1452,11 +1452,11 @@ void FdmLinearOpTest::testSpareMatrixReference() {
 
     for (Size i=0; i < rows; ++i) {
         for (Size j=0; j < columns; ++j) {
-            if (std::fabs(calculated(i,j) - expected(i,j)) > 100*QL_EPSILON) {
+            if (std::fabs(Real(calculated(i,j)) - Real(expected(i,j))) > 100*QL_EPSILON) {
                 BOOST_FAIL("Error using sparse matrix references in " <<
                            "Element (" << i << ", " << j << ")" <<
-                        "\n expected  : " << expected(i, j) <<
-                        "\n calculated: " << calculated(i, j));
+                        "\n expected  : " << Real(expected(i, j)) <<
+                        "\n calculated: " << Real(calculated(i, j)));
             }
         }
     }

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -190,7 +190,7 @@ void FittedBondDiscountCurveTest::testFlatExtrapolation() {
         // Real curveYield1 = curve1->zeroRate(t, Continuous).rate();
         Real curveYield2 = curve2->zeroRate(t, Continuous).rate();
 
-        BOOST_CHECK_CLOSE(modelYield2, curveYield2, 1.0); // 1.0 percent relative tolerance
+        QL_CHECK_CLOSE(modelYield2, curveYield2, 1.0); // 1.0 percent relative tolerance
     }
     
 }

--- a/test-suite/gaussianquadratures.cpp
+++ b/test-suite/gaussianquadratures.cpp
@@ -97,15 +97,15 @@ namespace gaussian_quadratures_test {
     template <class T>
     void testSingleJacobi(const T& I) {
         testSingle(I, "f(x) = 1",
-                   [](Real x){ return 1.0; },   2.0);
+                   [](Real x) -> Real { return 1.0; }, 2.0);
         testSingle(I, "f(x) = x",
-                   [](Real x){ return x; },     0.0);
+                   [](Real x) -> Real { return x; }, 0.0);
         testSingle(I, "f(x) = x^2",
-                   [](Real x){ return x * x; }, 2/3.);
+                   [](Real x) -> Real{ return x * x; }, 2/3.);
         testSingle(I, "f(x) = sin(x)",
-                   [](Real x) { return std::sin(x); }, 0.0);
+                   [](Real x) -> Real { return std::sin(x); }, 0.0);
         testSingle(I, "f(x) = cos(x)",
-                   [](Real x) { return std::cos(x); },
+                   [](Real x) -> Real { return std::cos(x); },
                    std::sin(1.0)-std::sin(-1.0));
         testSingle(I, "f(x) = Gaussian(x)",
                    NormalDistribution(),
@@ -197,15 +197,15 @@ void GaussianQuadraturesTest::testTabulated() {
 
      using namespace gaussian_quadratures_test;
 
-     testSingleTabulated([](Real x){ return 1.0; }, "f(x) = 1",
+     testSingleTabulated([](Real x) -> Real { return 1.0; }, "f(x) = 1",
                          2.0,       1.0e-13);
-     testSingleTabulated([](Real x){ return x; }, "f(x) = x",
+     testSingleTabulated([](Real x) -> Real { return x; }, "f(x) = x",
                          0.0,       1.0e-13);
-     testSingleTabulated([](Real x){ return x * x; }, "f(x) = x^2",
+     testSingleTabulated([](Real x) -> Real { return x * x; }, "f(x) = x^2",
                          (2.0/3.0), 1.0e-13);
-     testSingleTabulated([](Real x){ return x * x * x; }, "f(x) = x^3",
+     testSingleTabulated([](Real x) -> Real { return x * x * x; }, "f(x) = x^3",
                          0.0,       1.0e-13);
-     testSingleTabulated([](Real x){ return x * x * x * x; }, "f(x) = x^4",
+     testSingleTabulated([](Real x) -> Real { return x * x * x * x; }, "f(x) = x^4",
                          (2.0/5.0), 1.0e-13);
 }
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3078,7 +3078,7 @@ namespace {
 void HestonModelTest::testHestonEngineIntegration() {
     BOOST_TEST_MESSAGE("Testing Heston engine integration signature...");
 
-    auto square = [](Real x){ return x*x; };
+    auto square = [](Real x) -> Real { return x * x; };
 
     const AnalyticHestonEngine::Integration integration =
         AnalyticHestonEngine::Integration::gaussLobatto(1e-12, 1e-12);

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -57,18 +57,16 @@ namespace integrals_test {
 
     template <class T>
     void testSeveral(const T& I) {
-        testSingle(I, "f(x) = 0",
-                   [](Real x){ return 0.0; },   0.0, 1.0, 0.0);
-        testSingle(I, "f(x) = 1",
-                   [](Real x){ return 1.0; },   0.0, 1.0, 1.0);
-        testSingle(I, "f(x) = x",
-                   [](Real x){ return x; },     0.0, 1.0, 0.5);
+        testSingle(I, "f(x) = 0", [](Real x) -> Real { return 0.0; }, 0.0, 1.0, 0.0);
+        testSingle(I, "f(x) = 1", [](Real x) -> Real { return 1.0; }, 0.0, 1.0, 1.0);
+        testSingle(I, "f(x) = x", [](Real x) -> Real { return x; }, 0.0, 1.0, 0.5);
         testSingle(I, "f(x) = x^2",
-                   [](Real x){ return x * x; }, 0.0, 1.0, 1.0/3.0);
+                   [](Real x) -> Real { return x * x; }, 0.0, 1.0, 1.0/3.0);
         testSingle(I, "f(x) = sin(x)",
-                   [](Real x) { return std::sin(x); }, 0.0, M_PI, 2.0);
+                   [](Real x) -> Real { return std::sin(x); }, 0.0, M_PI, 2.0);
         testSingle(I, "f(x) = cos(x)",
-                   [](Real x) { return std::cos(x); }, 0.0, M_PI, 0.0);
+                   [](Real x) -> Real { return std::cos(x); }, 0.0, M_PI, 0.0);
+
         testSingle(I, "f(x) = Gaussian(x)",
                    NormalDistribution(), -10.0, 10.0, 1.0);
         testSingle(I, "f(x) = Abcd2(x)",
@@ -78,8 +76,8 @@ namespace integrals_test {
 
     template <class T>
     void testDegeneratedDomain(const T& I) {
-        testSingle(I, "f(x) = 0 over [1, 1 + macheps]",
-                   [](Real x){ return 0.0; }, 1.0, 1.0 + QL_EPSILON, 0.0);
+        testSingle(I, "f(x) = 0 over [1, 1 + macheps]", [](Real x) -> Real { return 0.0; }, 1.0,
+            1.0 + QL_EPSILON, 0.0);
     }
 
 }
@@ -558,7 +556,7 @@ void IntegralTest::testRealSiCiIntegrals() {
         si = Si(x);
         diff = std::fabs(si + i[1]);
         if (diff > tol) {
-            integrals_test::reportSiCiFail("SineIntegral", x, si, -i[1], diff, tol);
+            integrals_test::reportSiCiFail("SineIntegral", x, si, Real(-i[1]), diff, tol);
         }
     }
 }

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -40,10 +40,10 @@ void LinearLeastSquaresRegressionTest::testRegression() {
     PseudoRandom::rng_type rng(PseudoRandom::urng_type(1234U));
 
     std::vector<ext::function<Real(Real)>> v = {
-        [](Real x){ return 1.0; },
-        [](Real x){ return x; },
-        [](Real x){ return x*x; },
-        [](Real x){ return std::sin(x); }
+        [](Real x) -> Real { return 1.0; },
+        [](Real x) -> Real { return x; },
+        [](Real x) -> Real { return x*x; },
+        [](Real x) -> Real { return std::sin(x); }
     };
 
     std::vector<ext::function<Real(Real)>> w(v);

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -852,7 +852,7 @@ void NthOrderDerivativeOpTest::testCompareFirstDerivativeOp2dUniformGrid() {
         const Size idx = k*n;
         for (Size i=1; i < n-1; ++i)
             for (Size j=0; j < n*m; ++j)
-                BOOST_CHECK(std::fabs(fm(idx + i, j) - dm(idx + i, j)) < 1e-12);
+                BOOST_CHECK(std::fabs(Real(fm(idx + i, j)) - Real(dm(idx + i, j))) < 1e-12);
     }
 
     fm = FirstDerivativeOp(1, mc).toMatrix();
@@ -860,7 +860,7 @@ void NthOrderDerivativeOpTest::testCompareFirstDerivativeOp2dUniformGrid() {
 
     for (Size i=n; i < n*(m-1); ++i)
         for (Size j=0; j < n*m; ++j)
-            BOOST_CHECK(std::fabs(fm(i, j) - dm(i, j)) < 1e-12);
+            BOOST_CHECK(std::fabs(Real(fm(i, j)) - Real(dm(i, j))) < 1e-12);
 }
 
 void NthOrderDerivativeOpTest::testMixedSecondOrder9PointsOnUniformGrid() {

--- a/test-suite/numericaldifferentiation.cpp
+++ b/test-suite/numericaldifferentiation.cpp
@@ -193,7 +193,7 @@ void NumericalDifferentiationTest::testDerivativesOfSineFunction() {
     BOOST_TEST_MESSAGE("Testing numerical differentiation"
                        " of sin function...");
 
-    const ext::function<Real(Real)> f = [](Real x) { return std::sin(x); };
+    const ext::function<Real(Real)> f = [](Real x) -> Real { return std::sin(x); };
 
     const ext::function<Real(Real)> df_central
         = NumericalDifferentiation(f, 1, std::sqrt(QL_EPSILON), 3,

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -298,10 +298,10 @@ void ObservableTest::testDeepUpdate() {
     vol->deepUpdate();
     Real v4 = vol->volatility(refDate + 100, 0.01);
 
-    BOOST_CHECK_CLOSE(v1, 0.2, 1E-10);
-    BOOST_CHECK_CLOSE(v2, 0.2, 1E-10);
-    BOOST_CHECK_CLOSE(v3, 0.2, 1E-10);
-    BOOST_CHECK_CLOSE(v4, 0.21, 1E-10);
+    QL_CHECK_CLOSE(v1, 0.2, 1E-10);
+    QL_CHECK_CLOSE(v2, 0.2, 1E-10);
+    QL_CHECK_CLOSE(v3, 0.2, 1E-10);
+    QL_CHECK_CLOSE(v4, 0.21, 1E-10);
 }
 
 namespace {

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1317,7 +1317,7 @@ void PiecewiseYieldCurveTest::testGlobalBootstrap() {
     // check expected zero rates
     for (Size i = 0; i < LENGTH(refZeroRate); ++i) {
         // 0.01 basis points tolerance
-        BOOST_CHECK_SMALL(std::fabs(refZeroRate[i] - curve->zeroRate(refDate[i], Actual360(), Continuous).rate()),
+        QL_CHECK_SMALL(std::fabs(refZeroRate[i] - curve->zeroRate(refDate[i], Actual360(), Continuous).rate()),
                           1E-6);
     }
 }
@@ -1428,7 +1428,7 @@ void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
     DiscountFactor oneYearDfArs = arsYts->discount(oneYearFwdDate);
     Real calcFwd = (spotDfArs * arsSpot->value() / oneYearDfArs) / (spotDfUsd / oneYearDfUsd);
     Real expFwd = arsSpot->value() + arsFwdPoints.at(1 * Years);
-    BOOST_CHECK_SMALL(calcFwd - expFwd, 1e-10);
+    QL_CHECK_SMALL(calcFwd - expFwd, 1e-10);
 }
 
 test_suite* PiecewiseYieldCurveTest::suite() {

--- a/test-suite/riskstats.cpp
+++ b/test-suite/riskstats.cpp
@@ -141,7 +141,7 @@ void RiskStatisticsTest::testResults() {
 
             // mean
             expected = averages[i];
-            tolerance = (expected == 0.0 ? 1.0e-13 :
+            tolerance = (expected == 0.0 ? Real(1.0e-13) :
                                            std::fabs(expected)*1.0e-13);
             calculated = igs.mean();
             if (std::fabs(calculated-expected) > tolerance)
@@ -264,7 +264,7 @@ void RiskStatisticsTest::testResults() {
 
             // percentile
             expected = averages[i];
-            tolerance = (expected == 0.0 ? 1.0e-3 :
+            tolerance = (expected == 0.0 ? Real(1.0e-3) :
                                            std::fabs(expected*1.0e-3));
             calculated = igs.gaussianPercentile(0.5);
             if (std::fabs(calculated-expected) > tolerance)
@@ -303,7 +303,7 @@ void RiskStatisticsTest::testResults() {
             Real twoSigma = cumulative(upper_tail);
 
             expected = std::max<Real>(upper_tail,0.0);
-            tolerance = (expected == 0.0 ? 1.0e-3 :
+            tolerance = (expected == 0.0 ? Real(1.0e-3) :
                                            std::fabs(expected*1.0e-3));
             calculated = igs.gaussianPotentialUpside(twoSigma);
             if (std::fabs(calculated-expected) > tolerance)
@@ -348,7 +348,7 @@ void RiskStatisticsTest::testResults() {
 
             // value-at-risk
             expected = -std::min<Real>(lower_tail,0.0);
-            tolerance = (expected == 0.0 ? 1.0e-3 :
+            tolerance = (expected == 0.0 ? Real(1.0e-3) :
                                            std::fabs(expected*1.0e-3));
             calculated = igs.gaussianValueAtRisk(twoSigma);
             if (std::fabs(calculated-expected) > tolerance)
@@ -393,7 +393,7 @@ void RiskStatisticsTest::testResults() {
                                        - sigmas[j]*sigmas[j]
                                        * normal(lower_tail)/(1.0-twoSigma),
                                        0.0);
-            tolerance = (expected == 0.0 ? 1.0e-4
+            tolerance = (expected == 0.0 ? Real(1.0e-4)
                                          : std::fabs(expected)*1.0e-2);
             calculated = igs.gaussianExpectedShortfall(twoSigma);
             if (std::fabs(calculated-expected) > tolerance)
@@ -427,7 +427,7 @@ void RiskStatisticsTest::testResults() {
 
             // shortfall
             expected = 0.5;
-            tolerance = (expected == 0.0 ? 1.0e-3 :
+            tolerance = (expected == 0.0 ? Real(1.0e-3) :
                                            std::fabs(expected*1.0e-3));
             calculated = igs.gaussianShortfall(averages[i]);
             if (std::fabs(calculated-expected) > tolerance)
@@ -529,7 +529,7 @@ void RiskStatisticsTest::testResults() {
 
             // downsideVariance
             expected = s.downsideVariance();
-            tolerance = (expected == 0.0 ? 1.0e-3 :
+            tolerance = (expected == 0.0 ? Real(1.0e-3) :
                                            std::fabs(expected*1.0e-3));
             calculated = igs.downsideVariance();
             if (std::fabs(calculated-expected) > tolerance)

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -364,8 +364,8 @@ namespace square_root_clv_model {
                         const Real strike = strikes_[k];
 
                         const Real payoff = (strike < 1.0)
-                            ?  s1 * std::max(0.0, strike - s2/s1)
-                            :  s1 * std::max(0.0, s2/s1 - strike);
+                            ?  Real(s1 * std::max(0.0, strike - s2/s1))
+                            :  Real(s1 * std::max(0.0, s2/s1 - strike));
 
                         stats[k].add(payoff);
                     }
@@ -616,8 +616,8 @@ void SquareRootCLVModelTest::testForwardSkew() {
             for (Size j=0; j < LENGTH(strikes); ++j) {
                 const Real strike = strikes[j];
                     slvStats[i][j].add((strike < 1.0)
-                        ? S_t1 * std::max(0.0, strike - S_T1/S_t1)
-                        : S_t1 * std::max(0.0, S_T1/S_t1 - strike));
+                        ? Real(S_t1 * std::max(0.0, strike - S_T1/S_t1))
+                        : Real(S_t1 * std::max(0.0, S_T1/S_t1 - strike)));
             }
 
         }

--- a/test-suite/svivolatility.cpp
+++ b/test-suite/svivolatility.cpp
@@ -49,7 +49,7 @@ void SviVolatilityTest::testSviSmileSection() {
     BOOST_CHECK_NO_THROW(time_section =
                              ext::make_shared<SviSmileSection>(tte, forward, sviParameters));
     BOOST_CHECK_EQUAL(time_section->atmLevel(), forward);
-    BOOST_CHECK_CLOSE(time_section->variance(strike), a + b * sigma, 1E-10);
+    QL_CHECK_CLOSE(time_section->variance(strike), a + b * sigma, 1E-10);
 
     // Test date based constructor
     Date date = today + Period(11, Days);
@@ -59,7 +59,7 @@ void SviVolatilityTest::testSviSmileSection() {
                              ext::make_shared<SviSmileSection>(date, forward, sviParameters));
 
     BOOST_CHECK_EQUAL(date_section->atmLevel(), forward);
-    BOOST_CHECK_CLOSE(date_section->variance(strike), a + b * sigma, 1E-10);
+    QL_CHECK_CLOSE(date_section->variance(strike), a + b * sigma, 1E-10);
 }
 
 test_suite* SviVolatilityTest::experimental() {

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -89,9 +89,9 @@ void SwingOptionTest::testExtendedOrnsteinUhlenbeckProcess() {
         ExtendedOrnsteinUhlenbeckProcess::GaussLobatto};
 
     ext::function<Real (Real)> f[] 
-        = { [=](Real x){ return level; },
-            [ ](Real x){ return x + 1.0; },
-            [ ](Real x) { return std::sin(x); }}; 
+        = { [=](Real x) -> Real { return level; },
+            [ ](Real x) -> Real { return x + 1.0; },
+            [ ](Real x) -> Real { return std::sin(x); }}; 
 
     for (Size n=0; n < LENGTH(f); ++n) {
         ExtendedOrnsteinUhlenbeckProcess refProcess(

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -41,16 +41,16 @@
 #include <utility>
 #include <vector>
 
-// this adapts the BOOST_CHECK_SMALL and BOOST_CHECK_CLOSE macro and friends to
+// This adapts the BOOST_CHECK_SMALL and BOOST_CHECK_CLOSE macros to
 // support a struct as Real for arguments, while fully transparant to regular doubles.
-// The macro definitions are taken from the boost test framework - unfortnuately boost
-// does not provide a different way to customize these macro's behaviour.
+// Unfortunately boost does not provide a portable way to customize these macros' behaviour,
+// so we need to define wrapper macros QL_CHECK_SMALL etc.
 //
-// It is required to have a function value defined that returns the double-value
-// of the Real type (or a value function in the real type's namespace).
+// It is required to have a function `value` defined that returns the double-value
+// of the Real type (or a value function in the Real type's namespace for ADT).
 
 namespace QuantLib {
-    // specialize this function in case Real is something different - it should alway return double
+    // overload this function in case Real is something different - it should alway return double
     inline double value(double x) {
         return x;
     }
@@ -58,34 +58,8 @@ namespace QuantLib {
 
 using QuantLib::value;
 
-#undef BOOST_WARN_SMALL
-#undef BOOST_CHECK_SMALL
-#undef BOOST_REQUIRE_SMALL
-#define BOOST_WARN_SMALL(FPV, T)                                                            \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", WARN, CHECK_SMALL, \
-                         (value(FPV))(value(T)))
-#define BOOST_CHECK_SMALL(FPV, T)                                                            \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", CHECK, CHECK_SMALL, \
-                         (value(FPV))(value(T)))
-#define BOOST_REQUIRE_SMALL(FPV, T)                                                            \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", REQUIRE, CHECK_SMALL, \
-                         (value(FPV))(                                                         \
-                             : value(T)))
-
-#undef BOOST_WARN_CLOSE
-#undef BOOST_CHECK_CLOSE
-#undef BOOST_REQUIRE_CLOSE
-#define BOOST_WARN_CLOSE(L, R, T)                                                           \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", WARN, CHECK_CLOSE, \
-                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
-
-#define BOOST_CHECK_CLOSE(L, R, T)                                                           \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", CHECK, CHECK_CLOSE, \
-                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
-
-#define BOOST_REQUIRE_CLOSE(L, R, T)                                                           \
-    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", REQUIRE, CHECK_CLOSE, \
-                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
+#define QL_CHECK_SMALL(FPV, T)  BOOST_CHECK_SMALL(value(FPV), value(T))
+#define QL_CHECK_CLOSE(L, R, T) BOOST_CHECK_CLOSE(value(L), value(R), value(T))
 
 
 // This makes it easier to use array literals (for new code, use std::vector though)

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -41,6 +41,53 @@
 #include <utility>
 #include <vector>
 
+// this adapts the BOOST_CHECK_SMALL and BOOST_CHECK_CLOSE macro and friends to
+// support a struct as Real for arguments, while fully transparant to regular doubles.
+// The macro definitions are taken from the boost test framework - unfortnuately boost
+// does not provide a different way to customize these macro's behaviour.
+//
+// It is required to have a function value defined that returns the double-value
+// of the Real type (or a value function in the real type's namespace).
+
+namespace QuantLib {
+    // specialize this function in case Real is something different - it should alway return double
+    inline double value(double x) {
+        return x;
+    }
+}
+
+using QuantLib::value;
+
+#undef BOOST_WARN_SMALL
+#undef BOOST_CHECK_SMALL
+#undef BOOST_REQUIRE_SMALL
+#define BOOST_WARN_SMALL(FPV, T)                                                            \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", WARN, CHECK_SMALL, \
+                         (value(FPV))(value(T)))
+#define BOOST_CHECK_SMALL(FPV, T)                                                            \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", CHECK, CHECK_SMALL, \
+                         (value(FPV))(value(T)))
+#define BOOST_REQUIRE_SMALL(FPV, T)                                                            \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_small_t(), "", REQUIRE, CHECK_SMALL, \
+                         (value(FPV))(                                                         \
+                             : value(T)))
+
+#undef BOOST_WARN_CLOSE
+#undef BOOST_CHECK_CLOSE
+#undef BOOST_REQUIRE_CLOSE
+#define BOOST_WARN_CLOSE(L, R, T)                                                           \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", WARN, CHECK_CLOSE, \
+                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
+
+#define BOOST_CHECK_CLOSE(L, R, T)                                                           \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", CHECK, CHECK_CLOSE, \
+                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
+
+#define BOOST_REQUIRE_CLOSE(L, R, T)                                                           \
+    BOOST_TEST_TOOL_IMPL(0, ::boost::test_tools::check_is_close_t(), "", REQUIRE, CHECK_CLOSE, \
+                         (value(L))(value(R))(::boost::math::fpc::percent_tolerance(value(T))))
+
+
 // This makes it easier to use array literals (for new code, use std::vector though)
 #define LENGTH(a) (sizeof(a)/sizeof(a[0]))
 

--- a/test-suite/zerocouponswap.cpp
+++ b/test-suite/zerocouponswap.cpp
@@ -132,7 +132,7 @@ namespace zerocouponswap_test {
 
         auto subPeriodCpn = vars.createSubPeriodsCoupon(start, end);
         Real expectedFloatLegNPV =
-            paymentDate < vars.settlement ? 0.0 : Integer(type) * discountAtPayment * subPeriodCpn->amount();
+            paymentDate < vars.settlement ? 0.0 : Real(Integer(type) * discountAtPayment * subPeriodCpn->amount());
 
         Real expectedNPV = expectedFloatLegNPV + expectedFixedLegNPV;
 


### PR DESCRIPTION
These changes enable AAD in QuantLib with operator-overloading tools. These tools use a class or struct for `Real` and overload all operators and math functions to track values and derivatives. The following changes have been applied:

- explicit return type specification for lambdas (the type of an expression may not be Real with AAD tools)
- explicit ternary operator type conversions (types on the left and right of the `:` need to be convertible to each other)
- conversions to `Real` before calling template functions
- proxy objects returned e.g. by uBlas accessors need to be converted to `Real` before use
- boost unit test macro adaptation to convert to double before comparisons
