### PR TITLE
Replace boost/cstdint.hpp with cstdint

### DIFF
--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -27,7 +27,7 @@
 #define quantlib_sobol_ld_rsg_hpp
 
 #include <ql/methods/montecarlo/sample.hpp>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 #include <vector>
 
 namespace QuantLib {
@@ -119,11 +119,11 @@ namespace QuantLib {
                           unsigned long seed = 0,
                           DirectionIntegers directionIntegers = Jaeckel);
         /*! skip to the n-th sample in the low-discrepancy sequence */
-        void skipTo(boost::uint_least32_t n);
-        const std::vector<boost::uint_least32_t>& nextInt32Sequence() const;
+        void skipTo(std::uint_least32_t n);
+        const std::vector<std::uint_least32_t>& nextInt32Sequence() const;
 
         const SobolRsg::sample_type& nextSequence() const {
-            const std::vector<boost::uint_least32_t>& v = nextInt32Sequence();
+            const std::vector<std::uint_least32_t>& v = nextInt32Sequence();
             // normalize to get a double in (0,1)
             for (Size k=0; k<dimensionality_; ++k)
                 sequence_.value[k] = v[k] * normalizationFactor_;
@@ -135,11 +135,11 @@ namespace QuantLib {
         static const int bits_;
         static const double normalizationFactor_;
         Size dimensionality_;
-        mutable boost::uint_least32_t sequenceCounter_;
+        mutable std::uint_least32_t sequenceCounter_;
         mutable bool firstDraw_;
         mutable sample_type sequence_;
-        mutable std::vector<boost::uint_least32_t> integerSequence_;
-        std::vector<std::vector<boost::uint_least32_t> > directionIntegers_;
+        mutable std::vector<std::uint_least32_t> integerSequence_;
+        std::vector<std::vector<std::uint_least32_t>> directionIntegers_;
     };
 
 }

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -34,13 +34,13 @@
 #include <ql/time/period.hpp>
 #include <ql/time/weekday.hpp>
 #include <ql/utilities/null.hpp>
-#include <boost/cstdint.hpp>
 
 #ifdef QL_HIGH_RESOLUTION_DATE
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #endif
 
+#include <cstdint>
 #include <utility>
 #include <functional>
 #include <string>
@@ -125,7 +125,7 @@ namespace QuantLib {
     class Date {
       public:
         //! serial number type
-        typedef boost::int_fast32_t serial_type;
+        typedef std::int_fast32_t serial_type;
         //! \name constructors
         //@{
         //! Default constructor returning a null date.

--- a/test-suite/lowdiscrepancysequences.cpp
+++ b/test-suite/lowdiscrepancysequences.cpp
@@ -1054,8 +1054,8 @@ void LowDiscrepancyTest::testSobolSkipping() {
 
                 // compare next 100 samples
                 for (Size m = 0; m < 100; m++) {
-                    std::vector<boost::uint_least32_t> s1 = rsg1.nextInt32Sequence();
-                    std::vector<boost::uint_least32_t> s2 = rsg2.nextInt32Sequence();
+                    std::vector<std::uint_least32_t> s1 = rsg1.nextInt32Sequence();
+                    std::vector<std::uint_least32_t> s2 = rsg2.nextInt32Sequence();
                     for (Size n = 0; n < s1.size(); n++) {
                         if (s1[n] != s2[n]) {
                             BOOST_ERROR("Mismatch after skipping:"


### PR DESCRIPTION
From [the Boost docs](https://www.boost.org/doc/libs/1_79_0/libs/config/doc/html/boost_config/cstdint.html), apparently last updated in 2007:

> Should some future C++ standard include <stdint.h> and <cstdint>, then <boost/cstdint.hpp> will continue to function, but will become redundant and may be safely deprecated.

Indeed [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint) was introduced in C++11 so these Boost versions are no longer necessary.

Both `boost::uint_least32_t` and `std::uint_least32_t` are typedefs for `unsigned int` on my platform, and while I haven't checked other platforms, the boost docs above suggest that these should always be typedef'd to the same underlying type. So even though this affects a public interface, it should be transparent to users.