### PR TITLE
extend OvernightIndexedCoupon and OvernightLeg

### DIFF
--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -33,6 +33,7 @@
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/schedule.hpp>
 
+
 namespace QuantLib {
 
     //! overnight coupon
@@ -60,7 +61,10 @@ namespace QuantLib {
                     const Date& refPeriodEnd = Date(),
                     const DayCounter& dayCounter = DayCounter(),
                     bool telescopicValueDates = false,
-                    RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                    RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                    Natural fixingDays=Null<Natural>(),
+                    bool withObservationShift=false,
+                    Natural lockoutDays=0);
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded
@@ -71,6 +75,8 @@ namespace QuantLib {
         const std::vector<Rate>& indexFixings() const;
         //! value dates for the rates to be compounded
         const std::vector<Date>& valueDates() const { return valueDates_; }
+        //! accrual dates that determines how many calendar days each rate is compounded for
+        const std::vector<Date>& accrualDates() const { return accrualDates_; }
         //@}
         //! \name FloatingRateCoupon interface
         //@{
@@ -83,7 +89,7 @@ namespace QuantLib {
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-        std::vector<Date> valueDates_, fixingDates_;
+        std::vector<Date> valueDates_, accrualDates_, fixingDates_;
         mutable std::vector<Rate> fixings_;
         Size n_;
         std::vector<Time> dt_;
@@ -101,7 +107,10 @@ namespace QuantLib {
         OvernightLeg& withPaymentDayCounter(const DayCounter&);
         OvernightLeg& withPaymentAdjustment(BusinessDayConvention);
         OvernightLeg& withPaymentCalendar(const Calendar&);
-        OvernightLeg& withPaymentLag(Natural lag);
+        OvernightLeg& withPaymentLag(Natural lag, bool lagLastPayment=true);
+        OvernightLeg& withObservationShift(bool flag=true);
+        OvernightLeg& withLockout(Natural lockoutDays, bool lockoutOnlyLastPayment=false);
+        OvernightLeg& withFixingDays(Natural fixingDays);
         OvernightLeg& withGearings(Real gearing);
         OvernightLeg& withGearings(const std::vector<Real>& gearings);
         OvernightLeg& withSpreads(Spread spread);
@@ -117,6 +126,11 @@ namespace QuantLib {
         Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_;
         Natural paymentLag_;
+        bool lagLastPayment_;
+        bool withObservationShift_;
+        Natural lockoutDays_;
+        bool lockoutOnlyLastPayment_;
+        Natural fixingDays_;
         std::vector<Real> gearings_;
         std::vector<Spread> spreads_;
         bool telescopicValueDates_;


### PR DESCRIPTION
extend OvernightIndexedCoupon and OvernightLeg with fixing days, observation shift, lockout and no payment lag on final payment

I am not a professionaly trained C++ programmer... Also, i'm not set up to compile the whole QuantLib. I've only tested this code by overriding these two files while linking to QuantLib 1.25. I've checked with Bloomberg for only the interest accrued values for a few overnight indexed bonds. 

This is more of a draft to get feedback. tries to solve #1422 

Fixing Days
- the implementation for fixing days is similar to IborIndex

Observation Shift
- observation shift is needed for most SOFR floating rate bond, this is where the daily schedule, used to calculate the number of calendar days each SOFR rate applies, is also shifted by fixing days.
-  i'm not sure whether this can be done by simply shifting valueDates_. Currently valueDates_ is used for telescopic calculations, which i don't understand enough to touch, so i created a third vector called accrualDates_. Note that this cannot be implemented by shifting the startDate and endDate used to instantiate OvernightIndexedCoupon, because that messes up accrualPeriod() and accruedPeriod(). 
- Also i fixed an inconsistency in the pricer averageRate. we should not use coupon_->accruedPeriod(date) in averageRate because accruedPeriod() uses the coupon daycounter which is used to compute interest accrued and coupon payments. However for averageRate, the day counter used should always be the index day counter because that is how dt_ is calculated. Of course, maybe the better fix is to calculate dt_ and averageRate using coupon day counter, not sure. probably doesn't matter much as most floaters would use same day counter as the index. But code change was required anyway to handle observationShift. 

Lockout 
- Currently buggy because BondFunctions::accruedAmount finds the wrong coupon. I think hasOccurred() looks at payment dates, which because is lagged, retrieves the wrong coupon in a bond's cashflow, given a settlement date
- currently incorrect for accruedAmount. in an eg 2 day lockout coupon with no fixing days lag, for any date, there will be unknown but needed index fixings. Bloomberg help page states that for bond interest accrued, when a required fixing is not yet known, the latest available fixing should be used. this needs to be handled in the pricer averageRate, based on evaluationDate. ie fixings that are not available, but not available as of evaluationDate should be masked and filled. this actually requires an extra field in OvernightIndex, to state the day lag in fixing availability, eg SOFR has a 1 day publication lag, which is conceptually different to settlements aka fixing days, and is currently unavailable in OvernightIndex class. 