### PR TITLE
Computation of cdf in LocalVolRNDCalculator

### DIFF
--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -157,6 +157,7 @@ namespace QuantLib {
             {
                   addition=*1.1;
                   xl-=addition;
+            }
 
             return GaussLobattoIntegral(maxIter_, 0.1*localVolProbEps_)(
                 [&](Real _x){ return pdf(_x, t); }, xl, x);

--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -156,7 +156,7 @@ namespace QuantLib {
         else {
             while (pdf(xl, t) > 0.01*localVolProbEps_)
             {
-                  addition=*1.1;
+                  addition*=1.1;
                   xl-=addition;
             }
 

--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -140,7 +140,8 @@ namespace QuantLib {
         else if (x > xr)
             return 1.0;
 
-        Real addition = 1.0;
+        Real addition = 0.1*(xr-xl);
+
         // left or right hand integral
         if (x > 0.5*(xr+xl)) {
             while (pdf(xr, t) > 0.01*localVolProbEps_) 


### PR DESCRIPTION
Computing cdf boundaries was wrong. In case xl is positive, while loop lowers xl but only to 0, if it is negative xl (through while loop) rise towards 0. In case xr is positive previous code is good as it tends towards +infinity. However, if xr is negative it tends towards -infinity.

xl should always tends towards -infinity and xr towards +infinity (up to a tolerance)

Maybe this can be done in better way, however this should work