### PR TITLE
Add UndefinedBehaviorSanitizer to Linux CI

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 jobs:
-  build:
+  sanitize:
     runs-on: ubuntu-latest
     container: ghcr.io/lballabio/quantlib-devenv:rolling
     steps:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build
       run: |
         ./autogen.sh
-        ./configure --disable-static CC="ccache gcc" CXX="ccache g++" CXXFLAGS="-O2 -g0 -fsanitize=address -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror"
+        ./configure --disable-static CC="ccache gcc" CXX="ccache g++" CXXFLAGS="-O2 -g0 -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror"
         make -j 2
     - name: Run tests
       run: |

--- a/ql/cashflows/cmscoupon.cpp
+++ b/ql/cashflows/cmscoupon.cpp
@@ -56,7 +56,8 @@ namespace QuantLib {
 
     CmsLeg::CmsLeg(Schedule schedule, ext::shared_ptr<SwapIndex> swapIndex)
     : schedule_(std::move(schedule)), swapIndex_(std::move(swapIndex)),
-      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false) {
+      paymentAdjustment_(Following), inArrears_(false), zeroPayments_(false),
+      exCouponAdjustment_(Following), exCouponEndOfMonth_(false) {
         QL_REQUIRE(swapIndex_, "no index provided");
     }
 

--- a/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
+++ b/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
@@ -28,8 +28,8 @@ namespace QuantLib {
         const Clone<MarketModelMultiProduct>& underlying,
         const Clone<ExerciseStrategy<CurveState> >& strategy,
         Clone<MarketModelMultiProduct> rebate)
-    : underlying_(underlying), strategy_(strategy), rebate_(std::move(rebate)), callable_(true) {
-
+    : underlying_(underlying), strategy_(strategy), rebate_(std::move(rebate)),
+      rebateOffset_(0UL), wasCalled_(false), currentIndex_(0UL), callable_(true) {
         Size products = underlying_->numberOfProducts();
         EvolutionDescription d1 = underlying->evolution();
         const std::vector<Time>& rateTimes1 = d1.rateTimes();

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
         const Clone<ExerciseStrategy<CurveState> >& strategy,
         Clone<MarketModelPathwiseMultiProduct> rebate)
     : underlying_(underlying), strategy_(strategy), rebate_(std::move(rebate)),
-      rebateOffset_(0UL), wasCalled_(0UL), currentIndex_(0UL), callable_(true) {
+      rebateOffset_(0UL), wasCalled_(false), currentIndex_(0UL), callable_(true) {
         Size products = underlying_->numberOfProducts();
         EvolutionDescription d1 = underlying->evolution();
         const std::vector<Time>& rateTimes1 = d1.rateTimes();

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
@@ -29,8 +29,8 @@ namespace QuantLib {
         const Clone<MarketModelPathwiseMultiProduct>& underlying,
         const Clone<ExerciseStrategy<CurveState> >& strategy,
         Clone<MarketModelPathwiseMultiProduct> rebate)
-    : underlying_(underlying), strategy_(strategy), rebate_(std::move(rebate)), callable_(true) {
-
+    : underlying_(underlying), strategy_(strategy), rebate_(std::move(rebate)),
+      rebateOffset_(0UL), wasCalled_(0UL), currentIndex_(0UL), callable_(true) {
         Size products = underlying_->numberOfProducts();
         EvolutionDescription d1 = underlying->evolution();
         const std::vector<Time>& rateTimes1 = d1.rateTimes();


### PR DESCRIPTION
Add [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) (a.k.a. UBSan) to the Linux CI job in addition to AddressSanitizer, which has already been added.

Also fix a couple uninitialized member variables that UBSan flagged. I am not sure if these are the correct default values to use, but they are at least better than uninitialized values. Even better would be if the classes could be refactored to always take in the value to initialize the variables with, but I will leave that to a future refactoring.

In case you're curious, `-fno-sanitize-recover=all` is required because some UBSan checks are recoverable and do not terminate the process, but we want any violations to result in the CI failing.