### PR TITLE
Use ql/shared_ptr.hpp header

### DIFF
--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -33,7 +33,7 @@
 #include <ql/time/schedule.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
-#include <boost/make_shared.hpp>
+#include <ql/shared_ptr.hpp>
 #include <iomanip>
 
 using namespace QuantLib;

--- a/test-suite/fdcev.cpp
+++ b/test-suite/fdcev.cpp
@@ -24,10 +24,8 @@
 #include <ql/math/statistics/generalstatistics.hpp>
 #include <ql/pricingengines/vanilla/analyticcevengine.hpp>
 #include <ql/pricingengines/vanilla/fdcevvanillaengine.hpp>
-
 #include <ql/methods/finitedifferences/utilities/cevrndcalculator.hpp>
-
-#include <boost/make_shared.hpp>
+#include <ql/shared_ptr.hpp>
 
 using namespace QuantLib;
 using boost::unit_test_framework::test_suite;

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -32,7 +32,7 @@
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/termstructures/volatility/sabr.hpp>
-#include <boost/make_shared.hpp>
+#include <ql/shared_ptr.hpp>
 #include <utility>
 
 using namespace QuantLib;


### PR DESCRIPTION
`<boost/make_shared.hpp>` should not be included directly, but rather through `<ql/shared_ptr.hpp>`.