### PR TITLE
Fixed link error due to using refs to static const

### DIFF
--- a/ql/math/interpolations/mixedinterpolation.hpp
+++ b/ql/math/interpolations/mixedinterpolation.hpp
@@ -217,8 +217,8 @@ namespace QuantLib {
                                    const Interpolator2& factory2 = Interpolator2())
             : Interpolation::templateImpl<I1,I2>(
                                xBegin, xEnd, yBegin,
-                               std::max<Size>(Interpolator1::requiredPoints,
-                                              Interpolator2::requiredPoints)),
+                               std::max(Size(Interpolator1::requiredPoints),
+                                        Size(Interpolator2::requiredPoints))),
               n_(n) {
 
                 xBegin2_ = this->xBegin_ + n_;


### PR DESCRIPTION
solves the linker issue is with references to "static consts" without creating a cpp file, by creating refs locally
For detailed description, see https://stackoverflow.com/questions/16957458/static-const-in-c-class-undefined-reference for details
