### PR TITLE
Remove suppression for modernize-avoid-bind

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,6 @@ Checks: >
           -misc-non-private-member-variables-in-classes,
           -misc-unused-parameters,
         modernize-*,
-          -modernize-avoid-bind,
           -modernize-avoid-c-arrays,
           -modernize-make-shared,
           -modernize-use-trailing-return-type,

--- a/ql/experimental/math/multidimintegrator.hpp
+++ b/ql/experimental/math/multidimintegrator.hpp
@@ -125,9 +125,9 @@ namespace QuantLib {
 
     template<>
     void inline MultidimIntegral::spawnFcts<1>() const {
-        integrationLevelEntries_[0] = 
-            ext::bind(&MultidimIntegral::integrate<0>, this,
-                      ext::placeholders::_1, ext::placeholders::_2, ext::placeholders::_3);
+        integrationLevelEntries_[0] = [this](const auto& f, const auto& a, const auto& b) {
+            return this->integrate<0>(f, a, b);
+        };
     }
 
     template<int nT>
@@ -137,9 +137,9 @@ namespace QuantLib {
         const std::vector<Real>& b) const 
     {
         return 
-            (*integrators_[nT])(
-                ext::bind(&MultidimIntegral::vectorBinder<nT>, this, f, 
-                    ext::placeholders::_1, ext::cref(a), ext::cref(b)), a[nT], b[nT]);
+            (*integrators_[nT])([this, &f, &a, &b](auto z) {
+                return this->vectorBinder<nT>(f, z, a, b);
+            }, a[nT], b[nT]);
     }
 
     template<int T_N> 
@@ -155,9 +155,9 @@ namespace QuantLib {
 
     template<Size depth>
     void MultidimIntegral::spawnFcts() const {
-        integrationLevelEntries_[depth-1] =
-          ext::bind(&MultidimIntegral::integrate<depth-1>, this, 
-            ext::placeholders::_1, ext::placeholders::_2, ext::placeholders::_3);
+        integrationLevelEntries_[depth-1] = [this](const auto& f, const auto& a, const auto& b) {
+            return this->integrate<depth-1>(f, a, b);
+        };
         spawnFcts<depth-1>();
     }
 

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -39,8 +39,6 @@ namespace QuantLib {
 
     EndCriteria::Type LevenbergMarquardt::minimize(Problem& P,
                                                    const EndCriteria& endCriteria) {
-        using namespace ext::placeholders;
-
         EndCriteria::Type ecType = EndCriteria::None;
         P.reset();
         Array x_ = P.currentValue();
@@ -84,10 +82,14 @@ namespace QuantLib {
         // call lmdif to minimize the sum of the squares of m functions
         // in n variables by the Levenberg-Marquardt algorithm.
         MINPACK::LmdifCostFunction lmdifCostFunction =
-            ext::bind(&LevenbergMarquardt::fcn, this, _1, _2, _3, _4, _5);
+            [this](const auto m, const auto n, const auto x, const auto fvec, const auto iflag) {
+                this->fcn(m, n, x, fvec, iflag);
+            };
         MINPACK::LmdifCostFunction lmdifJacFunction =
             useCostFunctionsJacobian_
-                ? ext::bind(&LevenbergMarquardt::jacFcn, this, _1, _2, _3, _4, _5)
+                ? [this](const auto m, const auto n, const auto x, const auto fjac, const auto iflag) {
+                    this->jacFcn(m, n, x, fjac, iflag);
+                }
                 : MINPACK::LmdifCostFunction();
         MINPACK::lmdif(m, n, xx.get(), fvec.get(),
                        endCriteria.functionEpsilon(),

--- a/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
@@ -83,7 +83,6 @@ namespace QuantLib {
     }
 
     void GridModelLocalVolSurface::generateArguments() {
-        using namespace ext::placeholders;
         const ext::shared_ptr<Matrix> localVolMatrix(
             new Matrix(strikes_.front()->size(), times_.size()));
 

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -120,7 +120,6 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
     BOOST_TEST_MESSAGE(
         "Testing multi-dimensional linear least-squares regression...");
 
-    using namespace ext::placeholders;
     using namespace linear_least_square_regression_test;
 
     SavedSettings backup;


### PR DESCRIPTION
This suppression was temporarily added back in #1324 and is now being removed.

A few things to note:

* I have also removed `ext::cref` from a few places because capturing the variables by reference into the lambda should be sufficient. These can be added back if I'm missing some subtle reason why they need to be there.
* I have removed `ext::bind` and `ext::placeholders` instead of deprecating them because they were not part of any public interface.
* I needed to add `this->` inside the lambdas because GCC 5 and 6 complained without it.