### PR TITLE
 allow to specify endOfMonth for OISRateHelper

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -40,14 +40,15 @@ namespace QuantLib {
                                  const Spread overnightSpread,
                                  Pillar::Choice pillar,
                                  Date customPillarDate,
-                                 RateAveraging::Type averagingMethod)
+                                 RateAveraging::Type averagingMethod,
+                                 bool endOfMonth)
     : RelativeDateRateHelper(fixedRate), pillarChoice_(pillar), settlementDays_(settlementDays),
       tenor_(tenor), overnightIndex_(std::move(overnightIndex)),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
       paymentLag_(paymentLag), paymentConvention_(paymentConvention),
       paymentFrequency_(paymentFrequency), paymentCalendar_(std::move(paymentCalendar)),
       forwardStart_(forwardStart), overnightSpread_(overnightSpread),
-      averagingMethod_(averagingMethod) {
+      averagingMethod_(averagingMethod), endOfMonth_(endOfMonth) {
         registerWith(overnightIndex_);
         registerWith(discountHandle_);
 
@@ -75,7 +76,8 @@ namespace QuantLib {
             .withPaymentFrequency(paymentFrequency_)
             .withPaymentCalendar(paymentCalendar_)
             .withOvernightLegSpread(overnightSpread_)
-            .withAveragingMethod(averagingMethod_);
+            .withAveragingMethod(averagingMethod_)
+            .withEndOfMonth(endOfMonth_);
 
         earliestDate_ = swap_->startDate();
         maturityDate_ = swap_->maturityDate();

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -47,9 +47,9 @@ namespace QuantLib {
                       const Period& forwardStart = 0 * Days,
                       Spread overnightSpread = 0.0,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date(), 
+                      Date customPillarDate = Date(),
                       RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                      bool endOfMonth = true);
+                      boost::optional<bool> endOfMonth = boost::none);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -85,7 +85,7 @@ namespace QuantLib {
       Period forwardStart_;
       Spread overnightSpread_;
       RateAveraging::Type averagingMethod_;
-      bool endOfMonth_;
+      boost::optional<bool> endOfMonth_;
     };
 
     //! Rate helper for bootstrapping over Overnight Indexed Swap rates

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -48,7 +48,8 @@ namespace QuantLib {
                       Spread overnightSpread = 0.0,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(), 
-                      RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                      RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                      bool endOfMonth = true);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -84,6 +85,7 @@ namespace QuantLib {
       Period forwardStart_;
       Spread overnightSpread_;
       RateAveraging::Type averagingMethod_;
+      bool endOfMonth_;
     };
 
     //! Rate helper for bootstrapping over Overnight Indexed Swap rates


### PR DESCRIPTION
The ISDA curves published by Markit published by Markit do not use end of month=true (see parameters [here](https://rfr.ihsmarkit.com/isda/document/RFR%20Interest%20Rate%20Curve%20Specification%20-%206%20Currencies%20(April%207,%202021).pdf).) Therefore we can't match CDS upfront calculations unless we can override the default.