### PR TITLE
Adding ACT/366 & ACT/365.25

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -135,7 +135,7 @@
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release (static runtime)|x64'">QuantLib-x64-mt-s</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">QuantLib-mt</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">QuantLib-x64-mt</TargetName>
-  </PropertyGroup>
+  </PropertyGroup>  
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
@@ -1808,6 +1808,8 @@
     <ClInclude Include="ql\time\daycounter.hpp" />
     <ClInclude Include="ql\time\daycounters\actual360.hpp" />
     <ClInclude Include="ql\time\daycounters\actual364.hpp" />
+    <ClInclude Include="ql\time\daycounters\actual366.hpp" />
+    <ClInclude Include="ql\time\daycounters\actual36525.hpp" />
     <ClInclude Include="ql\time\daycounters\actual365fixed.hpp" />
     <ClInclude Include="ql\time\daycounters\actualactual.hpp" />
     <ClInclude Include="ql\time\daycounters\all.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2868,6 +2868,12 @@
     <ClInclude Include="ql\time\daycounters\actual364.hpp">
       <Filter>time\daycounters</Filter>
     </ClInclude>
+    <ClInclude Include="ql\time\daycounters\actual366.hpp">
+      <Filter>time\daycounters</Filter>
+    </ClInclude>
+    <ClInclude Include="ql\time\daycounters\actual36525.hpp">
+      <Filter>time\daycounters</Filter>
+    </ClInclude>
     <ClInclude Include="ql\time\daycounters\actual365fixed.hpp">
       <Filter>time\daycounters</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2155,6 +2155,8 @@ set(QL_HEADERS
     time/daycounters/actual360.hpp
     time/daycounters/actual364.hpp
     time/daycounters/actual365fixed.hpp
+    time/daycounters/actual366.hpp
+    time/daycounters/actual36525.hpp
     time/daycounters/actualactual.hpp
     time/daycounters/business252.hpp
     time/daycounters/one.hpp

--- a/ql/time/daycounters/Makefile.am
+++ b/ql/time/daycounters/Makefile.am
@@ -6,6 +6,8 @@ this_include_HEADERS = \
 	all.hpp \
 	actual360.hpp \
 	actual364.hpp \
+	actual366.hpp \
+	actual36525.hpp \
 	actual365fixed.hpp \
 	actualactual.hpp \
 	business252.hpp \

--- a/ql/time/daycounters/actual36525.hpp
+++ b/ql/time/daycounters/actual36525.hpp
@@ -1,14 +1,17 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2022 Ignacio Anguita
+ 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
+ 
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
+ 
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -48,8 +51,7 @@ namespace QuantLib {
             }
             Time
             yearFraction(const Date& d1, const Date& d2, const Date&, const Date&) const override {
-                return (daysBetween(d1,d2)
-                        + (includeLastDay_ ? 1.0 : 0.0))/365.25;
+                return dayCount(d1,d2)/365.25;
             }
         };
       public:

--- a/ql/time/daycounters/actual36525.hpp
+++ b/ql/time/daycounters/actual36525.hpp
@@ -14,7 +14,7 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-/*! \file actual365.25.hpp
+/*! \file actual36525.hpp
     \brief act/365.25 day counter
 */
 

--- a/ql/time/daycounters/actual36525.hpp
+++ b/ql/time/daycounters/actual36525.hpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file actual365.25.hpp
+    \brief act/365.25 day counter
+*/
+
+#ifndef quantlib_actual365_25_day_counter_h
+#define quantlib_actual365_25_day_counter_h
+
+#include <ql/time/daycounter.hpp>
+
+namespace QuantLib {
+
+    //! Actual/365.25 day count convention
+
+    /*! Actual/365.25 day count convention, also known as "Act/365.25", or "A/365.25".
+        \ingroup daycounters
+    */
+    class Actual36525 : public DayCounter {
+      private:
+        class Impl : public DayCounter::Impl {
+          private:
+              bool includeLastDay_;
+          public:
+            explicit Impl(const bool includeLastDay)
+            : includeLastDay_(includeLastDay) {}
+            std::string name() const override {
+                return includeLastDay_ ?
+                    std::string("Actual/365.25 (inc)")
+                    : std::string("Actual/365.25");
+            }
+            Date::serial_type dayCount(const Date& d1, const Date& d2) const override {
+                return (d2-d1) + (includeLastDay_ ? 1 : 0);
+            }
+            Time
+            yearFraction(const Date& d1, const Date& d2, const Date&, const Date&) const override {
+                return (daysBetween(d1,d2)
+                        + (includeLastDay_ ? 1.0 : 0.0))/365.25;
+            }
+        };
+      public:
+        explicit Actual36525(const bool includeLastDay = false)
+        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
+            new Actual36525::Impl(includeLastDay))) {}
+    };
+
+}
+
+#endif

--- a/ql/time/daycounters/actual366.hpp
+++ b/ql/time/daycounters/actual366.hpp
@@ -1,14 +1,17 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2022 Ignacio Anguita
+ 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
+ 
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
+ 
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -48,8 +51,7 @@ namespace QuantLib {
             }
             Time
             yearFraction(const Date& d1, const Date& d2, const Date&, const Date&) const override {
-                return (daysBetween(d1,d2)
-                        + (includeLastDay_ ? 1.0 : 0.0))/366.0;
+                return dayCount(d1,d2)/366.0;
             }
         };
       public:

--- a/ql/time/daycounters/actual366.hpp
+++ b/ql/time/daycounters/actual366.hpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file actual366.hpp
+    \brief act/366 day counter
+*/
+
+#ifndef quantlib_actual366_day_counter_h
+#define quantlib_actual366_day_counter_h
+
+#include <ql/time/daycounter.hpp>
+
+namespace QuantLib {
+
+    //! Actual/366 day count convention
+
+    /*! Actual/366 day count convention, also known as "Act/366".
+        \ingroup daycounters
+    */
+    class Actual366 : public DayCounter {
+      private:
+        class Impl : public DayCounter::Impl {
+          private:
+              bool includeLastDay_;
+          public:
+            explicit Impl(const bool includeLastDay)
+            : includeLastDay_(includeLastDay) {}
+            std::string name() const override {
+                return includeLastDay_ ?
+                    std::string("Actual/366 (inc)")
+                    : std::string("Actual/366");
+            }
+            Date::serial_type dayCount(const Date& d1, const Date& d2) const override {
+                return (d2-d1) + (includeLastDay_ ? 1 : 0);
+            }
+            Time
+            yearFraction(const Date& d1, const Date& d2, const Date&, const Date&) const override {
+                return (daysBetween(d1,d2)
+                        + (includeLastDay_ ? 1.0 : 0.0))/366.0;
+            }
+        };
+      public:
+        explicit Actual366(const bool includeLastDay = false)
+        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
+            new Actual366::Impl(includeLastDay))) {}
+    };
+
+}
+
+#endif

--- a/ql/time/daycounters/all.hpp
+++ b/ql/time/daycounters/all.hpp
@@ -4,6 +4,8 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/actual364.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/time/daycounters/actual36525.hpp>
+#include <ql/time/daycounters/actual366.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/time/daycounters/business252.hpp>
 #include <ql/time/daycounters/one.hpp>

--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -26,6 +26,8 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/time/daycounters/actual36525.hpp>
+#include <ql/time/daycounters/actual366.hpp>
 #include <ql/time/daycounters/one.hpp>
 #include <ql/time/daycounters/simpledaycounter.hpp>
 #include <ql/time/daycounters/business252.hpp>
@@ -1084,6 +1086,119 @@ void DayCounterTest::testActualActualOutOfScheduleRange() {
     Settings::instance().evaluationDate() = temp;
 }
 
+
+void DayCounterTest::testAct366() {
+
+    BOOST_TEST_MESSAGE("Testing Act/366 day counter...");
+
+    std::vector<Date> testDates = {
+        Date(1, February, 2002),
+        Date(4, February, 2002),
+        Date(16, May, 2003),
+        Date(17, December, 2003),
+        Date(17, December, 2004),
+        Date(19, December, 2005),
+        Date(2, January, 2006),
+        Date(13, March, 2006),
+        Date(15, May, 2006),
+        Date(17, March, 2006),
+        Date(15, May, 2006),
+        Date(26, July, 2006),
+        Date(28, June, 2007),
+        Date(16, September, 2009),
+        Date(26, July, 2016)
+    };
+
+    Time expected[] = {
+        0.00819672131147541,
+        1.27322404371585,
+        0.587431693989071,
+        1.0000000000000,
+        1.00273224043716,
+        0.0382513661202186,
+        0.191256830601093,
+        0.172131147540984,
+        -0.16120218579235,
+        0.16120218579235,
+        0.19672131147541,
+        0.920765027322404,
+        2.21584699453552,
+        6.84426229508197
+        };
+
+    DayCounter dayCounter = Actual366();
+
+    Time calculated;
+
+    for (Size i=1; i<testDates.size(); i++) {
+        calculated = dayCounter.yearFraction(testDates[i-1],testDates[i]);
+        if (std::fabs(calculated-expected[i-1]) > 1.0e-12) {
+                BOOST_ERROR("from " << testDates[i-1]
+                            << " to " << testDates[i] << ":\n"
+                            << std::setprecision(14)
+                            << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << expected[i-1]);
+        }
+    }
+}
+
+void DayCounterTest::testAct36525() {
+
+    BOOST_TEST_MESSAGE("Testing Act/365.25 day counter...");
+
+    std::vector<Date> testDates = {
+        Date(1, February, 2002),
+        Date(4, February, 2002),
+        Date(16, May, 2003),
+        Date(17, December, 2003),
+        Date(17, December, 2004),
+        Date(19, December, 2005),
+        Date(2, January, 2006),
+        Date(13, March, 2006),
+        Date(15, May, 2006),
+        Date(17, March, 2006),
+        Date(15, May, 2006),
+        Date(26, July, 2006),
+        Date(28, June, 2007),
+        Date(16, September, 2009),
+        Date(26, July, 2016)
+    };
+
+    Time expected[] = {
+        0.0082135523613963,
+        1.27583846680356,
+        0.588637919233402,
+        1.00205338809035,
+        1.00479123887748,
+        0.0383299110198494,
+        0.191649555099247,
+        0.172484599589322,
+        -0.161533196440794,
+        0.161533196440794,
+        0.197125256673511,
+        0.922655715263518,
+        2.22039698836413,
+        6.85831622176591
+        };
+
+    DayCounter dayCounter = Actual36525();
+
+    Time calculated;
+
+    for (Size i=1; i<testDates.size(); i++) {
+        calculated = dayCounter.yearFraction(testDates[i-1],testDates[i]);
+        if (std::fabs(calculated-expected[i-1]) > 1.0e-12) {
+                BOOST_ERROR("from " << testDates[i-1]
+                            << " to " << testDates[i] << ":\n"
+                            << std::setprecision(14)
+                            << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << expected[i-1]);
+        }
+    }
+}
+
+
+
 test_suite* DayCounterTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Day counter tests");
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActual));
@@ -1103,6 +1218,8 @@ test_suite* DayCounterTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testThirty360_ISDA));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActual365_Canadian));
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testActualActualOutOfScheduleRange));
+    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testAct366));
+    suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testAct36525));
 
 #ifdef QL_HIGH_RESOLUTION_DATE
     suite->add(QUANTLIB_TEST_CASE(&DayCounterTest::testIntraday));

--- a/test-suite/daycounters.hpp
+++ b/test-suite/daycounters.hpp
@@ -42,6 +42,8 @@ class DayCounterTest {
     static void testActual365_Canadian();
     static void testIntraday();
     static void testActualActualOutOfScheduleRange();
+    static void testAct366();
+    static void testAct36525();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Hi, 

This is my first contribution to QuantLib . I have been seeing recently some products with some day count convention that QuantLib does not currently have. I need to be able to price these products so I thought it would be also useful for other users of this library to have these day counters available. 

These conventions are ACT/366 and ACT/365.25, since they are very similar to the already existing ACT/364 I have used that  implementation as a base for these two new day counters.

I have added tests as well to the test suite for these two new day counters, compile it and test it without any issues.

