### PR TITLE
move `HazardRateStructure::hazardRateImpl()` to base class

### DIFF
--- a/ql/termstructures/credit/hazardratestructure.cpp
+++ b/ql/termstructures/credit/hazardratestructure.cpp
@@ -70,6 +70,10 @@ namespace QuantLib {
                                     const std::vector<Date>& jumpDates)
     : DefaultProbabilityTermStructure(settlDays, cal, dc, jumps, jumpDates) {}
 
+    Real HazardRateStructure::hazardRateImpl(Time) const {
+        QL_FAIL("hazardRateImpl() must be implemented by a class derived from HazardRateStructure");
+    }
+
     Probability HazardRateStructure::survivalProbabilityImpl(Time t) const {
         static GaussChebyshevIntegration integral(48);
         // the Gauss-Chebyshev quadratures integrate over [-1,1],

--- a/ql/termstructures/credit/hazardratestructure.hpp
+++ b/ql/termstructures/credit/hazardratestructure.hpp
@@ -79,7 +79,7 @@ namespace QuantLib {
         */
         //@{
         //! hazard rate calculation
-        virtual Real hazardRateImpl(Time) const = 0;
+        Real hazardRateImpl(Time) const override;
         //@}
 
         //! \name DefaultProbabilityTermStructure implementation

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -199,26 +199,7 @@ namespace QuantLib {
         // methods
         Probability survivalProbabilityImpl(Time) const override;
         Real defaultDensityImpl(Time) const override;
-        #if defined(__clang__)
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Winconsistent-missing-override"
-        #if (defined(__APPLE__) && __clang_major__ > 12) || (!defined(__APPLE__) && __clang_major__ > 10)
-        #pragma clang diagnostic ignored "-Wsuggest-override"
-        #endif
-        #endif
-        #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wsuggest-override"
-        #endif
-        Real hazardRateImpl(Time) const; // NOLINT(modernize-use-override, cppcoreguidelines-explicit-virtual-functions)
-                                         // (sometimes this method is not virtual,
-                                         //  depending on the base class)
-        #if defined(__clang__)
-        #pragma clang diagnostic pop
-        #endif
-        #if defined(__GNUC__) && (((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)) || (__GNUC__ > 5))
-        #pragma GCC diagnostic pop
-        #endif
+        Real hazardRateImpl(Time) const override;
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;
         Real accuracy_;

--- a/ql/termstructures/defaulttermstructure.hpp
+++ b/ql/termstructures/defaulttermstructure.hpp
@@ -145,16 +145,21 @@ namespace QuantLib {
         //@}
       protected:
         /*! \name Calculations
-            These methods must be implemented in derived classes to
+            The first two methods must be implemented in derived classes to
             perform the actual calculations. When they are called,
             range check has already been performed; therefore, they
             must assume that extrapolation is required.
+            The third method has a default implementation which can be
+            overriden with a more efficient implementation in derived
+            classes.
         */
         //@{
         //! survival probability calculation
         virtual Probability survivalProbabilityImpl(Time) const = 0;
         //! default density calculation
         virtual Real defaultDensityImpl(Time) const = 0;
+        //! hazard rate calculation
+        virtual Real hazardRateImpl(Time) const;
         //@}
       private:
         // methods
@@ -211,11 +216,16 @@ namespace QuantLib {
         return hazardRate(timeFromReference(d), extrapolate);
     }
 
-    inline
-    Rate DefaultProbabilityTermStructure::hazardRate(Time t,
-                                                     bool extrapolate) const {
-        Probability S = survivalProbability(t, extrapolate);
-        return S == 0.0 ? 0.0 : Real(defaultDensity(t, extrapolate)/S);
+   inline
+    Rate DefaultProbabilityTermStructure::hazardRateImpl(Time t) const {
+        Probability S = survivalProbability(t, true);
+        return S == 0.0 ? 0.0 : defaultDensity(t, true)/S;
+    }
+
+    inline Rate DefaultProbabilityTermStructure::hazardRate(Time t,
+                                                            bool extrapolate) const {
+        checkRange(t, extrapolate);
+        return hazardRateImpl(t);
     }
 
     inline


### PR DESCRIPTION
There is this awkward situation that `PiecewiseDefaultCurve::hazardRateImpl()` only makes sense when `base_curve` derives from `HazardRateStructure`. This is cleaned up here by moving this method to the base class `DefaultTermStructure`. Everything should be backwards compatible.

This way we can get rid of the messy diagnostic pragmas in `PiecewiseDefaultCurve` too - which more or less already indicated that the design was skewed here.