### PR TITLE
Replace QL_DEPRECATED with [[deprecated]]

### DIFF
--- a/ql/cashflows/couponpricer.hpp
+++ b/ql/cashflows/couponpricer.hpp
@@ -146,7 +146,7 @@ namespace QuantLib {
                         probably won't.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Real spreadLegValue_;
 
       private:

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -71,7 +71,7 @@ namespace QuantLib {
         /*! \deprecated Use the other constructor instead.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         CPICoupon(Real baseCPI,
                   const Date& paymentDate,
                   Real nominal,
@@ -114,13 +114,13 @@ namespace QuantLib {
         /*! \deprecated Use CPI::laggedFixing instead.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Rate indexObservation(const Date& onDate) const;
 
         /*! \deprecated Renamed to adjustedIndexGrowth.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Rate adjustedFixing() const;
 
         //! index used
@@ -142,7 +142,7 @@ namespace QuantLib {
         /*! \deprecated Use CPI::laggedFixing instead.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Rate indexFixing(const Date &) const;
     };
 
@@ -164,7 +164,7 @@ namespace QuantLib {
         /*! \deprecated Use the other constructor.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         CPICashFlow(Real notional,
                     const ext::shared_ptr<ZeroInflationIndex>& index,
                     const Date& baseDate,
@@ -227,12 +227,12 @@ namespace QuantLib {
         /*! \deprecated No-op; do not use.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         CPILeg& withFixingDays(Natural fixingDays);
         /*! \deprecated No-op; do not use.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         CPILeg& withFixingDays(const std::vector<Natural>& fixingDays);
         CPILeg& withObservationInterpolation(CPI::InterpolationType);
         CPILeg& withSubtractInflationNominal(bool);

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -102,15 +102,15 @@ namespace QuantLib {
         /*! \deprecated Use IborCouponSettings::Settings::instance().createAtParCoupons() instead
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED static void createAtParCoupons();
+        [[deprecated]] static void createAtParCoupons();
         /*! \deprecated Use IborCouponSettings::Settings::instance().createIndexedCoupons() instead
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED static void createIndexedCoupons();
+        [[deprecated]] static void createIndexedCoupons();
         /*! \deprecated Use IborCouponSettings::Settings::instance().usingAtParCoupons() instead
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED static bool usingAtParCoupons();
+        [[deprecated]] static bool usingAtParCoupons();
     };
 
 

--- a/ql/cashflows/zeroinflationcashflow.hpp
+++ b/ql/cashflows/zeroinflationcashflow.hpp
@@ -52,7 +52,7 @@ namespace QuantLib {
         /*! \deprecated Use the other constructor.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         ZeroInflationCashFlow(Real notional,
                               const ext::shared_ptr<ZeroInflationIndex>& index,
                               CPI::InterpolationType observationInterpolation,

--- a/ql/experimental/barrieroption/suowangdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/suowangdoublebarrierengine.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
     /*! \deprecated Use SuoWangDoubleBarrierEngine instead.
                     Deprecated in version 1.25.
     */
-    QL_DEPRECATED
+    [[deprecated]]
     typedef SuoWangDoubleBarrierEngine WulinYongDoubleBarrierEngine;
 
 }

--- a/ql/experimental/credit/riskybond.hpp
+++ b/ql/experimental/credit/riskybond.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         \deprecated Use RiskyBondEngine with regular bonds instead.
                     Deprecated in version 1.24.
     */
-    class QL_DEPRECATED RiskyBond : public Instrument {
+    class [[deprecated]] RiskyBond : public Instrument {
     public:
         /*! The value is contingent to survival, i.e., the knockout
             probability is considered.  To compute the npv given that
@@ -147,7 +147,7 @@ namespace QuantLib {
         \deprecated Use RiskyBondEngine with regular bonds instead.
                     Deprecated in version 1.24.
     */
-    class QL_DEPRECATED RiskyFixedBond : public RiskyBond {
+    class [[deprecated]] RiskyFixedBond : public RiskyBond {
     public:
       RiskyFixedBond(const std::string& name,
                      const Currency& ccy,
@@ -185,7 +185,7 @@ namespace QuantLib {
         \deprecated Use RiskyBondEngine with regular bonds instead.
                     Deprecated in version 1.24.
     */
-    class QL_DEPRECATED RiskyFloatingBond : public RiskyBond {
+    class [[deprecated]] RiskyFloatingBond : public RiskyBond {
     public:
       RiskyFloatingBond(const std::string& name,
                         const Currency& ccy,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -120,7 +120,7 @@ namespace QuantLib {
     /*! \deprecated Use ConstNotionalCrossCurrencyBasisSwapRateHelper instead.
                     Deprecated in version 1.24.
     */
-    QL_DEPRECATED
+    [[deprecated]]
     typedef ConstNotionalCrossCurrencyBasisSwapRateHelper CrossCurrencyBasisSwapRateHelper;
 
 

--- a/ql/experimental/termstructures/multicurvesensitivities.hpp
+++ b/ql/experimental/termstructures/multicurvesensitivities.hpp
@@ -61,7 +61,7 @@ quoted par rates.
                 Deprecated in version 1.27.
 
 */
-class QL_DEPRECATED MultiCurveSensitivities : public LazyObject {
+class [[deprecated]] MultiCurveSensitivities : public LazyObject {
 private:
   typedef std::map< std::string, Handle< YieldTermStructure > > curvespec;
 

--- a/ql/instruments/fixedratebondforward.hpp
+++ b/ql/instruments/fixedratebondforward.hpp
@@ -32,7 +32,7 @@ namespace QuantLib {
 
     //! %Forward contract on a fixed-rate bond
     /*! \deprecated Use BondForward instead. */
-    class QL_DEPRECATED FixedRateBondForward : public BondForward {
+    class [[deprecated]] FixedRateBondForward : public BondForward {
       public:
         FixedRateBondForward(
             const Date& valueDate,

--- a/ql/instruments/forwardrateagreement.hpp
+++ b/ql/instruments/forwardrateagreement.hpp
@@ -93,7 +93,7 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it's not correct for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Date settlementDate() const;
 
         const Calendar& calendar() const;
@@ -105,7 +105,7 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Handle<YieldTermStructure> incomeDiscountCurve() const;
 
         Date fixingDate() const;
@@ -113,12 +113,12 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Real spotIncome(const Handle<YieldTermStructure>& incomeDiscountCurve) const;
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Real spotValue() const;
 
         //! Returns the relevant forward rate associated with the FRA term
@@ -127,7 +127,7 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InterestRate impliedYield(Real underlyingSpotValue,
                                   Real forwardValue,
                                   Date settlementDate,
@@ -137,7 +137,7 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         virtual Real forwardValue() const;
         //@}
 
@@ -156,12 +156,12 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         mutable Real underlyingIncome_;
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         mutable Real underlyingSpotValue_;
 
         DayCounter dayCounter_;
@@ -171,13 +171,13 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Natural settlementDays_;
 
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         ext::shared_ptr<Payoff> payoff_;
 
         //! the valueDate is the date the underlying index starts accruing and the FRA is settled.
@@ -189,7 +189,7 @@ namespace QuantLib {
         /*! \deprecated This used to be inherited from Forward, but it doesn't make sense for FRAs.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Handle<YieldTermStructure> incomeDiscountCurve_;
 
       private:

--- a/ql/math/curve.hpp
+++ b/ql/math/curve.hpp
@@ -33,7 +33,7 @@ namespace QuantLib {
                     Copy it in your codebase if you need it.
                     Deprecated in version 1.26.
     */
-    class QL_DEPRECATED Curve {
+    class [[deprecated]] Curve {
       public:
         typedef Real argument_type;
         typedef Real result_type;

--- a/ql/math/functional.hpp
+++ b/ql/math/functional.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T, class U>
-    class QL_DEPRECATED constant {
+    class [[deprecated]] constant {
       public:
         typedef T argument_type;
         typedef U result_type;
@@ -51,7 +51,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED identity {
+    class [[deprecated]] identity {
       public:
         typedef T argument_type;
         typedef T result_type;
@@ -65,7 +65,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED square {
+    class [[deprecated]] square {
       public:
         typedef T argument_type;
         typedef T result_type;
@@ -76,7 +76,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED cube {
+    class [[deprecated]] cube {
       public:
         typedef T argument_type;
         typedef T result_type;
@@ -87,7 +87,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED fourth_power {
+    class [[deprecated]] fourth_power {
       public:
         typedef T argument_type;
         typedef T result_type;
@@ -100,7 +100,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED add {
+    class [[deprecated]] add {
         T y;
       public:
         typedef T argument_type;
@@ -113,7 +113,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED subtract {
+    class [[deprecated]] subtract {
         T y;
       public:
         typedef T argument_type;
@@ -126,7 +126,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED subtract_from {
+    class [[deprecated]] subtract_from {
         T y;
       public:
         typedef T argument_type;
@@ -139,7 +139,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED multiply_by {
+    class [[deprecated]] multiply_by {
         T y;
       public:
         typedef T argument_type;
@@ -152,7 +152,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED divide {
+    class [[deprecated]] divide {
         T y;
       public:
         typedef T argument_type;
@@ -165,7 +165,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED divide_by {
+    class [[deprecated]] divide_by {
         T y;
       public:
         typedef T argument_type;
@@ -178,7 +178,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED less_than {
+    class [[deprecated]] less_than {
         T y;
       public:
         typedef T argument_type;
@@ -191,7 +191,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED greater_than {
+    class [[deprecated]] greater_than {
         T y;
       public:
         typedef T argument_type;
@@ -204,7 +204,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED greater_or_equal_to {
+    class [[deprecated]] greater_or_equal_to {
         T y;
       public:
         typedef T argument_type;
@@ -217,7 +217,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED not_zero {
+    class [[deprecated]] not_zero {
       public:
         typedef T argument_type;
         typedef bool result_type;
@@ -228,7 +228,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED not_null {
+    class [[deprecated]] not_null {
         T null;
       public:
         typedef T argument_type;
@@ -242,7 +242,7 @@ namespace QuantLib {
     /*! \deprecated Use a lambda instead.
                     Deprecated in version 1.27.
     */
-    class QL_DEPRECATED everywhere {
+    class [[deprecated]] everywhere {
       public:
         typedef Real argument_type;
         typedef bool result_type;
@@ -252,7 +252,7 @@ namespace QuantLib {
     /*! \deprecated Use a lambda instead.
                     Deprecated in version 1.27.
     */
-    class QL_DEPRECATED nowhere {
+    class [[deprecated]] nowhere {
       public:
         typedef Real argument_type;
         typedef bool result_type;
@@ -263,7 +263,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class T>
-    class QL_DEPRECATED equal_within {
+    class [[deprecated]] equal_within {
       public:
         typedef T first_argument_type;
         typedef T second_argument_type;
@@ -282,7 +282,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class F, class R>
-    class QL_DEPRECATED clipped_function {
+    class [[deprecated]] clipped_function {
       public:
         typedef typename F::argument_type argument_type;
         typedef typename F::result_type result_type;
@@ -300,14 +300,14 @@ namespace QuantLib {
     */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class R>
-    QL_DEPRECATED
+    [[deprecated]]
     auto clip(F&& f, R&& r) {
         return [f_ = std::forward<F>(f), r_ = std::forward<R>(r)](const auto& x) { return r_(x) ? f_(x) : decltype(f_(x)){}; };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class R>
-    QL_DEPRECATED
+    [[deprecated]]
     clipped_function<F,R> clip(const F& f, const R& r) {
         return clipped_function<F,R>(f,r);
     }
@@ -318,7 +318,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class F, class G>
-    class QL_DEPRECATED composed_function {
+    class [[deprecated]] composed_function {
       public:
         typedef typename G::argument_type argument_type;
         typedef typename F::result_type result_type;
@@ -336,14 +336,14 @@ namespace QuantLib {
     */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class G>
-    QL_DEPRECATED
+    [[deprecated]]
     auto compose(F&& f, G&& g) {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g)](const auto& x) { return f_(g_(x)); };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G>
-    QL_DEPRECATED
+    [[deprecated]]
     composed_function<F,G> compose(const F& f, const G& g) {
         return composed_function<F,G>(f,g);
     }
@@ -354,7 +354,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <class F, class G, class H>
-    class QL_DEPRECATED binary_compose3_function {
+    class [[deprecated]] binary_compose3_function {
       public:
         typedef typename G::argument_type first_argument_type;
         typedef typename H::argument_type second_argument_type;
@@ -376,14 +376,14 @@ namespace QuantLib {
     */
 #if __cplusplus >= 201402L || _MSVC_LANG >= 201402L
     template <class F, class G, class H>
-    QL_DEPRECATED
+    [[deprecated]]
     auto compose3(F&& f, G&& g, H&& h) {
         return [f_ = std::forward<F>(f), g_ = std::forward<G>(g), h_ = std::forward<H>(h)](const auto& x, const auto& y) { return f_(g_(x), h_(y)); };
     }
 #else
     QL_DEPRECATED_DISABLE_WARNING
     template <class F, class G, class H> binary_compose3_function<F, G, H>
-    QL_DEPRECATED
+    [[deprecated]]
     compose3(const F& f, const G& g, const H& h) {
         return binary_compose3_function<F, G, H>(f, g, h);
     }

--- a/ql/math/lexicographicalview.hpp
+++ b/ql/math/lexicographicalview.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                     Deprecated in version 1.26.
     */
     template <class RandomAccessIterator>
-    class QL_DEPRECATED LexicographicalView {
+    class [[deprecated]] LexicographicalView {
       public:
         //! attaches the view with the given dimension to a sequence
         LexicographicalView(const RandomAccessIterator& begin,

--- a/ql/methods/finitedifferences/pdeshortrate.hpp
+++ b/ql/methods/finitedifferences/pdeshortrate.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     /*! \deprecated Use the new finite-differences framework instead.
                     Deprecated in version 1.27.
     */
-    class QL_DEPRECATED PdeShortRate : public PdeSecondOrderParabolic {
+    class [[deprecated]] PdeShortRate : public PdeSecondOrderParabolic {
       public:
         typedef ext::shared_ptr<OneFactorModel::ShortRateDynamics>
                                                                 argument_type;

--- a/ql/methods/finitedifferences/shoutcondition.hpp
+++ b/ql/methods/finitedifferences/shoutcondition.hpp
@@ -36,7 +36,7 @@ namespace QuantLib {
     /*! \deprecated Use the new finite-differences framework instead.
                     Deprecated in version 1.27.
     */
-    class QL_DEPRECATED ShoutCondition : public StandardStepCondition {
+    class [[deprecated]] ShoutCondition : public StandardStepCondition {
       public:
         ShoutCondition(const Array& intrinsicValues,
                        Time resTime,

--- a/ql/methods/montecarlo/lsmbasissystem.hpp
+++ b/ql/methods/montecarlo/lsmbasissystem.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         /*! \deprecated Renamed to PolynomialType.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         typedef PolynomialType PolynomType;
 
         static std::vector<ext::function<Real(Real)> >

--- a/ql/models/calibrationhelper.hpp
+++ b/ql/models/calibrationhelper.hpp
@@ -103,7 +103,7 @@ namespace QuantLib {
                         `termStructure_` to your derived class.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED Handle<YieldTermStructure> termStructure_;
+        [[deprecated]] Handle<YieldTermStructure> termStructure_;
         ext::shared_ptr<PricingEngine> engine_;
         const VolatilityType volatilityType_;
         const Real shift_;

--- a/ql/models/marketmodels/duffsdeviceinnerproduct.hpp
+++ b/ql/models/marketmodels/duffsdeviceinnerproduct.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
 
     */
     template <class InputIterator1, class InputIterator2, class T>
-    QL_DEPRECATED
+    [[deprecated]]
     inline T inner_product(InputIterator1 f1, InputIterator1 l1,
                            InputIterator2 f2, T init) {
 

--- a/ql/money.hpp
+++ b/ql/money.hpp
@@ -101,11 +101,11 @@ namespace QuantLib {
         /*! \deprecated Use Money::Settings::instance().baseCurrency() instead.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED static BaseCurrencyProxy baseCurrency;
+        [[deprecated]] static BaseCurrencyProxy baseCurrency;
         /*! \deprecated Use Money::Settings::instance().conversionType() instead.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED static ConversionTypeProxy conversionType;
+        [[deprecated]] static ConversionTypeProxy conversionType;
     };
 
     //! Per-session settings for the Money class

--- a/ql/patterns/composite.hpp
+++ b/ql/patterns/composite.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
                     Deprecated in version 1.26.
     */
     template <class T>
-    class QL_DEPRECATED Composite : public T {
+    class [[deprecated]] Composite : public T {
       protected:
         std::list<ext::shared_ptr<T> > components_;
         void add(const ext::shared_ptr<T>& c) { components_.push_back(c); }

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -105,7 +105,7 @@ namespace QuantLib {
                         capture the return value from `registerWith`.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED  // to be moved to private section, not removed
+        [[deprecated]]  // to be moved to private section, not removed
         typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
 
         QL_DEPRECATED_DISABLE_WARNING
@@ -279,7 +279,7 @@ namespace QuantLib {
                         the return value from `registerWith`.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED  // to be moved to private section, not removed
+        [[deprecated]]  // to be moved to private section, not removed
         typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
         QL_DEPRECATED_DISABLE_WARNING
         typedef set_type::iterator iterator;
@@ -374,7 +374,7 @@ namespace QuantLib {
         /*! \deprecated Don't use `set_type`; it's not used in the public interface anyway.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED  // to be moved to private section, not removed
+        [[deprecated]]  // to be moved to private section, not removed
         typedef boost::unordered_set<ext::shared_ptr<Observer::Proxy>> set_type;
         QL_DEPRECATED_DISABLE_WARNING
         typedef set_type::iterator iterator;

--- a/ql/pricingengines/vanilla/fdconditions.hpp
+++ b/ql/pricingengines/vanilla/fdconditions.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <typename baseEngine>
-    class QL_DEPRECATED FDShoutCondition : public baseEngine {
+    class [[deprecated]] FDShoutCondition : public baseEngine {
       public:
         FDShoutCondition(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,

--- a/ql/pricingengines/vanilla/fddividendengine.hpp
+++ b/ql/pricingengines/vanilla/fddividendengine.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <template <class> class Scheme = CrankNicolson>
-    class QL_DEPRECATED FDDividendEngineBase : public FDMultiPeriodEngine<Scheme> {
+    class [[deprecated]] FDDividendEngineBase : public FDMultiPeriodEngine<Scheme> {
       public:
         FDDividendEngineBase(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -72,7 +72,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <template <class> class Scheme = CrankNicolson>
-    class QL_DEPRECATED FDDividendEngineMerton73 : public FDDividendEngineBase<Scheme> {
+    class [[deprecated]] FDDividendEngineMerton73 : public FDDividendEngineBase<Scheme> {
       public:
         FDDividendEngineMerton73(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -90,7 +90,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <template <class> class Scheme = CrankNicolson>
-    class QL_DEPRECATED FDDividendEngineShiftScale : public FDDividendEngineBase<Scheme> {
+    class [[deprecated]] FDDividendEngineShiftScale : public FDDividendEngineBase<Scheme> {
       public:
         FDDividendEngineShiftScale(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -109,7 +109,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <template <class> class Scheme = CrankNicolson>
-    class QL_DEPRECATED FDDividendEngine : public FDDividendEngineMerton73<Scheme> {
+    class [[deprecated]] FDDividendEngine : public FDDividendEngineMerton73<Scheme> {
       public:
         FDDividendEngine(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -180,7 +180,7 @@ namespace QuantLib {
 
     namespace detail {
 
-        class QL_DEPRECATED DividendAdder {
+        class [[deprecated]] DividendAdder {
           private:
             const Dividend *dividend;
           public:

--- a/ql/pricingengines/vanilla/fdstepconditionengine.hpp
+++ b/ql/pricingengines/vanilla/fdstepconditionengine.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <template <class> class Scheme = CrankNicolson>
-    class QL_DEPRECATED FDStepConditionEngine :  public FDVanillaEngine {
+    class [[deprecated]] FDStepConditionEngine :  public FDVanillaEngine {
       public:
         FDStepConditionEngine(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,

--- a/ql/pricingengines/vanilla/fdvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdvanillaengine.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
                     Deprecated in version 1.27.
     */
     template <typename base, typename engine>
-    class QL_DEPRECATED FDEngineAdapter : public base, public engine {
+    class [[deprecated]] FDEngineAdapter : public base, public engine {
       public:
         FDEngineAdapter(
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,

--- a/ql/pricingengines/vanilla/mcamericanengine.hpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.hpp
@@ -125,7 +125,7 @@ namespace QuantLib {
         /*! \deprecated Renamed to withPolynomialOrder.
                         Deprecated in version 1.26.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         MakeMCAmericanEngine& withPolynomOrder(Size polynomialOrder);
 
         // conversion to pricing engine

--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -194,21 +194,18 @@
 // emit warning when using deprecated features
 // clang-format off
 #if defined(BOOST_MSVC)       // Microsoft Visual C++
-#    define QL_DEPRECATED __declspec(deprecated)
 #    define QL_DEPRECATED_DISABLE_WARNING \
         __pragma(warning(push))           \
         __pragma(warning(disable : 4996))
 #    define QL_DEPRECATED_ENABLE_WARNING \
         __pragma(warning(pop))
 #elif defined(__GNUC__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                               \
         _Pragma("GCC diagnostic push")                                  \
         _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #    define QL_DEPRECATED_ENABLE_WARNING \
         _Pragma("GCC diagnostic pop")
 #elif defined(__clang__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                                 \
         _Pragma("clang diagnostic push")                                  \
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
@@ -216,11 +213,15 @@
         _Pragma("clang diagnostic pop")
 #else
 // we don't know how to enable it, just define the macros away
-#    define QL_DEPRECATED
 #    define QL_DEPRECATED_DISABLE_WARNING
 #    define QL_DEPRECATED_ENABLE_WARNING
 #endif
 // clang-format on
+
+/*! \deprecated Use the [[deprecated]] attribute instead.
+                Deprecated in version 1.28.
+*/
+#define QL_DEPRECATED [[deprecated]]
 
 /*! \deprecated Use the noexcept keyword instead.
                 Deprecated in version 1.27.

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -188,21 +188,18 @@
 // emit warning when using deprecated features
 // clang-format off
 #if defined(BOOST_MSVC)       // Microsoft Visual C++
-#    define QL_DEPRECATED __declspec(deprecated)
 #    define QL_DEPRECATED_DISABLE_WARNING \
         __pragma(warning(push))           \
         __pragma(warning(disable : 4996))
 #    define QL_DEPRECATED_ENABLE_WARNING \
         __pragma(warning(pop))
 #elif defined(__GNUC__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                               \
         _Pragma("GCC diagnostic push")                                  \
         _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #    define QL_DEPRECATED_ENABLE_WARNING \
         _Pragma("GCC diagnostic pop")
 #elif defined(__clang__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                                 \
         _Pragma("clang diagnostic push")                                  \
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
@@ -210,11 +207,15 @@
         _Pragma("clang diagnostic pop")
 #else
 // we don't know how to enable it, just define the macros away
-#    define QL_DEPRECATED
 #    define QL_DEPRECATED_DISABLE_WARNING
 #    define QL_DEPRECATED_ENABLE_WARNING
 #endif
 // clang-format on
+
+/*! \deprecated Use the [[deprecated]] attribute instead.
+                Deprecated in version 1.28.
+*/
+#define QL_DEPRECATED [[deprecated]]
 
 /*! \deprecated Use the noexcept keyword instead.
                 Deprecated in version 1.27.

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -53,7 +53,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InterpolatedZeroInflationCurve(const Date& referenceDate,
                                        const Calendar& calendar,
                                        const DayCounter& dayCounter,
@@ -102,7 +102,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InterpolatedZeroInflationCurve(const Date& referenceDate,
                                        const Calendar& calendar,
                                        const DayCounter& dayCounter,

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -75,7 +75,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         PiecewiseZeroInflationCurve(
             const Date& referenceDate,
             const Calendar& calendar,

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -63,7 +63,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InflationTermStructure(Rate baseRate,
                                const Period& observationLag,
                                Frequency frequency,
@@ -74,7 +74,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InflationTermStructure(const Date& referenceDate,
                                Rate baseRate,
                                const Period& observationLag,
@@ -87,7 +87,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Rate baseRate,
@@ -114,7 +114,7 @@ namespace QuantLib {
                         Curves can return flat rates over an inflation period.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         virtual bool indexIsInterpolated() const;
 
         //! minimum (base) date
@@ -135,7 +135,7 @@ namespace QuantLib {
                         should be passed one explicitly.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         virtual Handle<YieldTermStructure> nominalTermStructure() const;
 
         //! Functions to set and get seasonality.
@@ -174,7 +174,7 @@ namespace QuantLib {
                         Curves can return flat rates over an inflation period.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         bool indexIsInterpolated_;
         /*! \deprecated Don't use this data member.  If you're
                         inheriting from InflationTermStructure, don't
@@ -184,7 +184,7 @@ namespace QuantLib {
                         explicitly.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         Handle<YieldTermStructure> nominalTermStructure_;
     };
 
@@ -223,7 +223,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         ZeroInflationTermStructure(const DayCounter& dayCounter,
                                    Rate baseZeroRate,
                                    const Period& lag,
@@ -235,7 +235,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         ZeroInflationTermStructure(const Date& referenceDate,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,
@@ -249,7 +249,7 @@ namespace QuantLib {
                         indexIsInterpolated parameter.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,

--- a/ql/termstructures/yield/drifttermstructure.hpp
+++ b/ql/termstructures/yield/drifttermstructure.hpp
@@ -35,7 +35,7 @@ namespace QuantLib {
                     Copy it in your codebase if you need it.
                     Deprecated in version 1.26.
     */
-    class QL_DEPRECATED DriftTermStructure : public ZeroYieldStructure {
+    class [[deprecated]] DriftTermStructure : public ZeroYieldStructure {
       public:
         DriftTermStructure(const Handle<YieldTermStructure>& riskFreeTS,
                            Handle<YieldTermStructure> dividendTS,

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -70,7 +70,7 @@ namespace QuantLib {
         /*! \deprecated Use the constructor without index and averaging method.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         SofrFutureRateHelper(const Handle<Quote>& price,
                              Month referenceMonth,
                              Year referenceYear,
@@ -82,7 +82,7 @@ namespace QuantLib {
         /*! \deprecated Use the constructor without index and averaging method.
                         Deprecated in version 1.25.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,
                              Year referenceYear,

--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -179,7 +179,7 @@ namespace QuantLib {
         /*! \deprecated Use the other constructor.
                         Deprecated in version 1.24.
         */
-        QL_DEPRECATED
+        [[deprecated]]
         UnitedStates()
         : UnitedStates(Settlement) {}
     };


### PR DESCRIPTION
Now that the minimum language version is C++14, we can use the `[[deprecated]]` attribute instead of compiler-specific attributes.