### PR TITLE
Move clang-analyzer-optin.cplusplus.VirtualCall suppressions to comments

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,6 @@ Checks: >
           -clang-analyzer-core.UndefinedBinaryOperatorResult,
           -clang-analyzer-core.uninitialized.Assign,
           -clang-analyzer-optin.cplusplus.UninitializedObject,
-          -clang-analyzer-optin.cplusplus.VirtualCall,
           -clang-analyzer-optin.performance.Padding,
           -clang-analyzer-security.FloatLoopCounter,
         cppcoreguidelines-*,

--- a/ql/cashflows/capflooredinflationcoupon.cpp
+++ b/ql/cashflows/capflooredinflationcoupon.cpp
@@ -70,8 +70,7 @@ namespace QuantLib {
                          underlying->referencePeriodStart(),
                          underlying->referencePeriodEnd()),
       underlying_(underlying), isFloored_(false), isCapped_(false) {
-
-        setCommon(cap, floor);
+        CappedFlooredYoYInflationCoupon::setCommon(cap, floor);
         registerWith(underlying);
     }
 

--- a/ql/cashflows/capflooredinflationcoupon.cpp
+++ b/ql/cashflows/capflooredinflationcoupon.cpp
@@ -70,7 +70,9 @@ namespace QuantLib {
                          underlying->referencePeriodStart(),
                          underlying->referencePeriodEnd()),
       underlying_(underlying), isFloored_(false), isCapped_(false) {
+        QL_DEPRECATED_DISABLE_WARNING
         CappedFlooredYoYInflationCoupon::setCommon(cap, floor);
+        QL_DEPRECATED_ENABLE_WARNING
         registerWith(underlying);
     }
 

--- a/ql/cashflows/capflooredinflationcoupon.hpp
+++ b/ql/cashflows/capflooredinflationcoupon.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
         \f]
      */
     class CappedFlooredYoYInflationCoupon : public YoYInflationCoupon {
-    public:
+      public:
         // we may watch an underlying coupon ...
         CappedFlooredYoYInflationCoupon(
                 const ext::shared_ptr<YoYInflationCoupon>& underlying,
@@ -90,7 +90,9 @@ namespace QuantLib {
                              fixingDays, index, observationLag,  dayCounter,
                              gearing, spread, refPeriodStart, refPeriodEnd),
           isFloored_(false), isCapped_(false) {
+            QL_DEPRECATED_DISABLE_WARNING
             setCommon(cap, floor);
+            QL_DEPRECATED_ENABLE_WARNING
         }
 
         //! \name augmented Coupon interface
@@ -125,7 +127,15 @@ namespace QuantLib {
 
         void setPricer(const ext::shared_ptr<YoYInflationCouponPricer>&);
 
-    protected:
+      protected:
+        // to be made private and non-virtual after deprecation, not removed
+        /*! \deprecated Do not use this method and rely on its being
+                        called by the constructor of the base class.
+                        If you have overridden it, move the code to the
+                        constructor of your derived class.
+                        Deprecated in version 1.30.
+        */
+        QL_DEPRECATED
         virtual void setCommon(Rate cap, Rate floor);
 
         // data, we only use underlying_ if it was constructed that way,

--- a/ql/experimental/averageois/arithmeticoisratehelper.cpp
+++ b/ql/experimental/averageois/arithmeticoisratehelper.cpp
@@ -47,7 +47,7 @@ namespace QuantLib {
         registerWith(overnightIndex_);
         registerWith(discountHandle_);
         registerWith(spread_);
-        initializeDates();
+        ArithmeticOISRateHelper::initializeDates();
     }
 
     void ArithmeticOISRateHelper::initializeDates() {

--- a/ql/experimental/lattices/extendedbinomialtree.cpp
+++ b/ql/experimental/lattices/extendedbinomialtree.cpp
@@ -90,7 +90,7 @@ namespace QuantLib {
 
         dx_ = std::sqrt(process->variance(0.0, x0_, dt_)+
             this->driftStep(0.0)*this->driftStep(0.0));
-        pu_ = 0.5 + 0.5*this->driftStep(0.0)/this->dxStep(0.0);
+        pu_ = 0.5 + 0.5*this->driftStep(0.0) / ExtendedTrigeorgis::dxStep(0.0);
         pd_ = 1.0 - pu_;
 
         QL_REQUIRE(pu_<=1.0, "negative probability");

--- a/ql/experimental/termstructures/basisswapratehelpers.cpp
+++ b/ql/experimental/termstructures/basisswapratehelpers.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         registerWith(otherIndex_);
         registerWith(discountHandle_);
 
-        initializeDates();
+        IborIborBasisSwapRateHelper::initializeDates();
     }
 
     void IborIborBasisSwapRateHelper::initializeDates() {
@@ -144,7 +144,7 @@ namespace QuantLib {
         registerWith(otherIndex_);
         registerWith(discountHandle_);
 
-        initializeDates();
+        OvernightIborBasisSwapRateHelper::initializeDates();
     }
 
     void OvernightIborBasisSwapRateHelper::initializeDates() {

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -164,8 +164,7 @@ namespace QuantLib {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
         registerWith(collateralHandle_);
-
-        initializeDates();
+        CrossCurrencyBasisSwapRateHelperBase::initializeDates();
     }
 
     void CrossCurrencyBasisSwapRateHelperBase::initializeDates() {

--- a/ql/experimental/variancegamma/variancegammamodel.cpp
+++ b/ql/experimental/variancegamma/variancegammamodel.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
             arguments_[2] = ConstantParameter(process->theta(),
                 NoConstraint());
 
-            generateArguments();
+            VarianceGammaModel::generateArguments();
 
             registerWith(process_->riskFreeRate());
             registerWith(process_->dividendYield());

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
       frequency_(frequency), availabilityLag_(availabilityLag), currency_(std::move(currency)) {
         name_ = region_.name() + " " + familyName_;
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(name()));
+        registerWith(IndexManager::instance().notifier(InflationIndex::name()));
     }
     QL_DEPRECATED_ENABLE_WARNING
 

--- a/ql/legacy/libormarketmodels/lmexpcorrmodel.cpp
+++ b/ql/legacy/libormarketmodels/lmexpcorrmodel.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
      corrMatrix_(size, size),
      pseudoSqrt_(size, size) {
         arguments_[0] = ConstantParameter(rho, PositiveConstraint());
-        generateArguments();
+        LmExponentialCorrelationModel::generateArguments();
     }
 
     Matrix LmExponentialCorrelationModel::correlation(Time, const Array&) const {

--- a/ql/legacy/libormarketmodels/lmlinexpcorrmodel.cpp
+++ b/ql/legacy/libormarketmodels/lmlinexpcorrmodel.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
      factors_((factors != Null<Size>()) ? factors : size) {
         arguments_[0] = ConstantParameter(rho, BoundaryConstraint(-1.0, 1.0));
         arguments_[1] = ConstantParameter(beta, PositiveConstraint());
-        generateArguments();
+        LmLinearExponentialCorrelationModel::generateArguments();
     }
 
     Matrix LmLinearExponentialCorrelationModel::correlation(Time, const Array&) const {

--- a/ql/math/interpolations/bicubicsplineinterpolation.hpp
+++ b/ql/math/interpolations/bicubicsplineinterpolation.hpp
@@ -53,7 +53,7 @@ namespace QuantLib {
             : Interpolation2D::templateImpl<I1,I2,M>(xBegin,xEnd,
                                                      yBegin,yEnd,
                                                      zData) {
-                calculate();
+                BicubicSplineImpl::calculate();
             }
             void calculate() override {
                 splines_.resize(this->zData_.rows());

--- a/ql/math/interpolations/bilinearinterpolation.hpp
+++ b/ql/math/interpolations/bilinearinterpolation.hpp
@@ -41,7 +41,7 @@ namespace QuantLib {
             : Interpolation2D::templateImpl<I1,I2,M>(xBegin,xEnd,
                                                      yBegin,yEnd,
                                                      zData) {
-                calculate();
+                BilinearInterpolationImpl::calculate();
             }
             void calculate() override {}
             Real value(Real x, Real y) const override {

--- a/ql/math/interpolations/flatextrapolation2d.hpp
+++ b/ql/math/interpolations/flatextrapolation2d.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
           public:
             FlatExtrapolator2DImpl(ext::shared_ptr<Interpolation2D> decoratedInterpolation)
             : decoratedInterp_(std::move(decoratedInterpolation)) {
-                calculate();
+                FlatExtrapolator2DImpl::calculate();
             }
             Real xMin() const override { return decoratedInterp_->xMin(); }
             Real xMax() const override { return decoratedInterp_->xMax(); }

--- a/ql/models/equity/gjrgarchmodel.cpp
+++ b/ql/models/equity/gjrgarchmodel.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         constraint_ = ext::shared_ptr<Constraint>(
             new CompositeConstraint(*constraint_, VolatilityConstraint()));
 
-        generateArguments();
+        GJRGARCHModel::generateArguments();
 
         registerWith(process_->riskFreeRate());
         registerWith(process_->dividendYield());

--- a/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
+++ b/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
                               bool withFellerConstraint)
     : CoxIngersollRoss(x0, theta, k, sigma, withFellerConstraint),
       TermStructureConsistentModel(termStructure){
-        generateArguments();
+        ExtendedCoxIngersollRoss::generateArguments();
     }
 
     ext::shared_ptr<Lattice> ExtendedCoxIngersollRoss::tree(

--- a/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
       TermStructureConsistentModel(termStructure) {
         b_ = NullParameter();
         lambda_ = NullParameter();
-        generateArguments();
+        HullWhite::generateArguments();
 
         registerWith(termStructure);
     }

--- a/ql/models/shortrate/twofactormodels/g2.cpp
+++ b/ql/models/shortrate/twofactormodels/g2.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         eta_   = ConstantParameter(eta,   PositiveConstraint());
         rho_   = ConstantParameter(rho,   BoundaryConstraint(-1.0, 1.0));
 
-        generateArguments();
+        G2::generateArguments();
 
         registerWith(termStructure);
     }

--- a/ql/pricingengines/vanilla/analytichestonhullwhiteengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonhullwhiteengine.cpp
@@ -29,8 +29,7 @@ namespace QuantLib {
         Size integrationOrder)
     : AnalyticHestonEngine(hestonModel, integrationOrder),
       hullWhiteModel_(std::move(hullWhiteModel)) {
-
-        update();
+        AnalyticHestonHullWhiteEngine::update();
         registerWith(hullWhiteModel_);
     }
 
@@ -41,8 +40,7 @@ namespace QuantLib {
         Size maxEvaluations)
     : AnalyticHestonEngine(hestonModel, relTolerance, maxEvaluations),
       hullWhiteModel_(std::move(hullWhiteModel)) {
-
-        update();
+        AnalyticHestonHullWhiteEngine::update();
         registerWith(hullWhiteModel_);
     }
 

--- a/ql/pricingengines/vanilla/analytichestonhullwhiteengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonhullwhiteengine.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
         Size integrationOrder)
     : AnalyticHestonEngine(hestonModel, integrationOrder),
       hullWhiteModel_(std::move(hullWhiteModel)) {
-        AnalyticHestonHullWhiteEngine::update();
+        setParameters();
         registerWith(hullWhiteModel_);
     }
 
@@ -40,14 +40,12 @@ namespace QuantLib {
         Size maxEvaluations)
     : AnalyticHestonEngine(hestonModel, relTolerance, maxEvaluations),
       hullWhiteModel_(std::move(hullWhiteModel)) {
-        AnalyticHestonHullWhiteEngine::update();
+        setParameters();
         registerWith(hullWhiteModel_);
     }
 
     void AnalyticHestonHullWhiteEngine::update() {
-        a_ = hullWhiteModel_->params()[0];
-        sigma_ = hullWhiteModel_->params()[1];
-
+        setParameters();
         AnalyticHestonEngine::update();
     }
 
@@ -64,6 +62,11 @@ namespace QuantLib {
         }
 
         AnalyticHestonEngine::calculate();
+    }
+
+    void AnalyticHestonHullWhiteEngine::setParameters() {
+        a_ = hullWhiteModel_->params()[0];
+        sigma_ = hullWhiteModel_->params()[1];
     }
 
 }

--- a/ql/pricingengines/vanilla/analytichestonhullwhiteengine.hpp
+++ b/ql/pricingengines/vanilla/analytichestonhullwhiteengine.hpp
@@ -84,6 +84,7 @@ namespace QuantLib {
         const ext::shared_ptr<HullWhite> hullWhiteModel_;
 
       private:
+        void setParameters();
         mutable Real m_;
         mutable Real a_, sigma_;
     };

--- a/ql/processes/hestonslvprocess.cpp
+++ b/ql/processes/hestonslvprocess.cpp
@@ -35,7 +35,7 @@ namespace QuantLib {
     : mixingFactor_(mixingFactor), hestonProcess_(hestonProcess),
       leverageFct_(std::move(leverageFct)) {
         registerWith(hestonProcess);
-        update();
+        HestonSLVProcess::update();
     };
 
     void HestonSLVProcess::update() {

--- a/ql/processes/hestonslvprocess.cpp
+++ b/ql/processes/hestonslvprocess.cpp
@@ -35,16 +35,12 @@ namespace QuantLib {
     : mixingFactor_(mixingFactor), hestonProcess_(hestonProcess),
       leverageFct_(std::move(leverageFct)) {
         registerWith(hestonProcess);
-        HestonSLVProcess::update();
+        setParameters();
     };
 
     void HestonSLVProcess::update() {
-        v0_    = hestonProcess_->v0();
-        kappa_ = hestonProcess_->kappa();
-        theta_ = hestonProcess_->theta();
-        sigma_ = hestonProcess_->sigma();
-        rho_   = hestonProcess_->rho();
-        mixedSigma_ = mixingFactor_ * sigma_;
+        setParameters();
+        StochasticProcess::update();
     }
 
     Array HestonSLVProcess::drift(Time t, const Array& x) const {
@@ -119,4 +115,14 @@ namespace QuantLib {
 
         return retVal;
     }
+
+    void HestonSLVProcess::setParameters() {
+        v0_    = hestonProcess_->v0();
+        kappa_ = hestonProcess_->kappa();
+        theta_ = hestonProcess_->theta();
+        sigma_ = hestonProcess_->sigma();
+        rho_   = hestonProcess_->rho();
+        mixedSigma_ = mixingFactor_ * sigma_;
+    }
+
 }

--- a/ql/processes/hestonslvprocess.hpp
+++ b/ql/processes/hestonslvprocess.hpp
@@ -77,6 +77,10 @@ namespace QuantLib {
 
         const ext::shared_ptr<HestonProcess> hestonProcess_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
+
+        void setParameters();
     };
+
 }
+
 #endif

--- a/ql/termstructures/inflation/seasonality.cpp
+++ b/ql/termstructures/inflation/seasonality.cpp
@@ -35,6 +35,7 @@ namespace QuantLib {
 
     void MultiplicativePriceSeasonality::validate() const
     {
+        // NOLINTBEGIN(clang-analyzer-optin.cplusplus.VirtualCall)
         switch (this->frequency()) {
             case Semiannual:        //2
             case EveryFourthMonth:  //3
@@ -56,6 +57,7 @@ namespace QuantLib {
                         << ", only semi-annual through daily permitted.");
             break;
         }
+        // NOLINTEND(clang-analyzer-optin.cplusplus.VirtualCall)
     }
 
 
@@ -89,7 +91,7 @@ namespace QuantLib {
     MultiplicativePriceSeasonality::MultiplicativePriceSeasonality(const Date& seasonalityBaseDate, const Frequency frequency,
                                                                    const std::vector<Rate>& seasonalityFactors)
     {
-        set(seasonalityBaseDate, frequency, seasonalityFactors);
+        MultiplicativePriceSeasonality::set(seasonalityBaseDate, frequency, seasonalityFactors);
     }
 
     void MultiplicativePriceSeasonality::set(const Date& seasonalityBaseDate, const Frequency frequency,
@@ -101,6 +103,7 @@ namespace QuantLib {
             seasonalityFactors_[i] = seasonalityFactors[i];
         }
         seasonalityBaseDate_ = seasonalityBaseDate;
+        // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
         validate();
     }
 

--- a/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
             times_[i] = dayCounter.yearFraction(referenceDate_, dates[i]);
         }
 
-        generateArguments();
+        GridModelLocalVolSurface::generateArguments();
     }
 
     void GridModelLocalVolSurface::update() {

--- a/ql/termstructures/volatility/kahalesmilesection.cpp
+++ b/ql/termstructures/volatility/kahalesmilesection.cpp
@@ -54,10 +54,10 @@ namespace QuantLib {
         // and do as if we were in a lognormal setting
 
         for (Real& i : k_) {
-            i += shift();
+            i += KahaleSmileSection::shift();
         }
 
-        f_ += shift();
+        f_ += KahaleSmileSection::shift();
 
         compute();
     }
@@ -90,8 +90,8 @@ namespace QuantLib {
                 if (interpolate_)
                     c1p = (secl + sec) / 2;
                 else {
-                    c1p = -source_->digitalOptionPrice(
-                        k1 - shift() + gap_ / 2.0, Option::Call, 1.0, gap_);
+                    // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
+                    c1p = -source_->digitalOptionPrice(k1 - shift() + gap_ / 2.0, Option::Call, 1.0, gap_);
                     QL_REQUIRE(secl < c1p && c1p <= 0.0, "dummy");
                     // can not extrapolate so throw exception which is caught
                     // below
@@ -108,6 +108,7 @@ namespace QuantLib {
                 // which are not monotonic or greater than 1.0
                 // due to numerical effects. Move to the next index in
                 // these cases.
+                // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
                 Real dig = digitalOptionPrice((k1 - shift()) / 2.0, Option::Call,
                                               1.0, gap_);
                 QL_REQUIRE(dig >= -c1p && dig <= 1.0, "dummy");

--- a/ql/termstructures/volatility/kahalesmilesection.cpp
+++ b/ql/termstructures/volatility/kahalesmilesection.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
         // only shifted lognormal smile sections are supported
 
         QL_REQUIRE(source->volatilityType() == ShiftedLognormal,
-                   "KahaleSmileSection only supports shifted lognormal source "
-                   "sections");
+                   "KahaleSmileSection only supports shifted lognormal source sections");
 
         ssutils_ = ext::make_shared<SmileSectionUtils>(
             *source, moneynessGrid, atm, deleteArbitragePoints);
@@ -54,10 +53,10 @@ namespace QuantLib {
         // and do as if we were in a lognormal setting
 
         for (Real& i : k_) {
-            i += KahaleSmileSection::shift();
+            i += source_->shift();
         }
 
-        f_ += KahaleSmileSection::shift();
+        f_ += source_->shift();
 
         compute();
     }
@@ -90,8 +89,7 @@ namespace QuantLib {
                 if (interpolate_)
                     c1p = (secl + sec) / 2;
                 else {
-                    // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-                    c1p = -source_->digitalOptionPrice(k1 - shift() + gap_ / 2.0, Option::Call, 1.0, gap_);
+                    c1p = -source_->digitalOptionPrice(k1 - source_->shift() + gap_ / 2.0, Option::Call, 1.0, gap_);
                     QL_REQUIRE(secl < c1p && c1p <= 0.0, "dummy");
                     // can not extrapolate so throw exception which is caught
                     // below
@@ -108,9 +106,7 @@ namespace QuantLib {
                 // which are not monotonic or greater than 1.0
                 // due to numerical effects. Move to the next index in
                 // these cases.
-                // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
-                Real dig = digitalOptionPrice((k1 - shift()) / 2.0, Option::Call,
-                                              1.0, gap_);
+                Real dig = digitalOptionPrice((k1 - source_->shift()) / 2.0, Option::Call, 1.0, gap_);
                 QL_REQUIRE(dig >= -c1p && dig <= 1.0, "dummy");
                 if(static_cast<int>(leftIndex_) < forcedLeftIndex_) {
                     leftIndex_++;

--- a/ql/termstructures/volatility/smilesection.cpp
+++ b/ql/termstructures/volatility/smilesection.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
             referenceDate_ = Settings::instance().evaluationDate();
         } else
             referenceDate_ = referenceDate;
-        initializeExerciseTime();
+        SmileSection::initializeExerciseTime();
     }
 
     SmileSection::SmileSection(Time exerciseTime,

--- a/ql/termstructures/volatility/swaption/cmsmarket.cpp
+++ b/ql/termstructures/volatility/swaption/cmsmarket.cpp
@@ -102,7 +102,7 @@ namespace QuantLib {
             }
         }
         // probably useless
-        performCalculations();
+        CmsMarket::performCalculations();
     }
 
     void CmsMarket::performCalculations() const {

--- a/ql/termstructures/yield/nonlinearfittingmethods.cpp
+++ b/ql/termstructures/yield/nonlinearfittingmethods.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
           constrainAtZero, weights, optimizationMethod, l2, minCutoffTime, maxCutoffTime),
           numCoeffs_(numCoeffs), fixedKappa_(fixedKappa) 
     {
-        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
+        QL_REQUIRE(ExponentialSplinesFitting::size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
@@ -49,7 +49,7 @@ namespace QuantLib {
                                                  minCutoffTime, maxCutoffTime),
           numCoeffs_(numCoeffs),fixedKappa_(fixedKappa) 
     {
-        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
+        QL_REQUIRE(ExponentialSplinesFitting::size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     ExponentialSplinesFitting::ExponentialSplinesFitting(bool constrainAtZero,
@@ -59,7 +59,7 @@ namespace QuantLib {
     : FittedBondDiscountCurve::FittingMethod(constrainAtZero, weights, ext::shared_ptr<OptimizationMethod>(), Array(),0.0,QL_MAX_REAL),
           numCoeffs_(numCoeffs), fixedKappa_(fixedKappa)
     {
-        QL_REQUIRE(size() > 0, "At least 1 unconstrained coefficient required");
+        QL_REQUIRE(ExponentialSplinesFitting::size() > 0, "At least 1 unconstrained coefficient required");
     }
 
     std::unique_ptr<FittedBondDiscountCurve::FittingMethod>

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         registerWith(discountHandle_);
 
         pillarDate_ = customPillarDate;
-        initializeDates();
+        OISRateHelper::initializeDates();
     }
 
     void OISRateHelper::initializeDates() {

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -299,7 +299,7 @@ namespace QuantLib {
                       tenor, fixingDays,
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
-        initializeDates();
+        DepositRateHelper::initializeDates();
     }
 
     DepositRateHelper::DepositRateHelper(Rate rate,
@@ -314,21 +314,21 @@ namespace QuantLib {
                       tenor, fixingDays,
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
-        initializeDates();
+        DepositRateHelper::initializeDates();
     }
 
     DepositRateHelper::DepositRateHelper(const Handle<Quote>& rate,
                                          const ext::shared_ptr<IborIndex>& i)
     : RelativeDateRateHelper(rate) {
         iborIndex_ = i->clone(termStructureHandle_);
-        initializeDates();
+        DepositRateHelper::initializeDates();
     }
 
     DepositRateHelper::DepositRateHelper(Rate rate,
                                          const ext::shared_ptr<IborIndex>& i)
     : RelativeDateRateHelper(rate) {
         iborIndex_ = i->clone(termStructureHandle_);
-        initializeDates();
+        DepositRateHelper::initializeDates();
     }
 
     Real DepositRateHelper::impliedQuote() const {
@@ -394,7 +394,7 @@ namespace QuantLib {
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(Rate rate,
@@ -422,7 +422,7 @@ namespace QuantLib {
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(const Handle<Quote>& rate,
@@ -441,7 +441,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(Rate rate,
@@ -458,7 +458,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(const Handle<Quote>& rate,
@@ -482,7 +482,7 @@ namespace QuantLib {
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(Rate rate,
@@ -506,7 +506,7 @@ namespace QuantLib {
                       Currency(), calendar, convention,
                       endOfMonth, dayCounter, termStructureHandle_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(const Handle<Quote>& rate,
@@ -523,7 +523,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(Rate rate,
@@ -540,7 +540,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(const Handle<Quote>& rate,
@@ -558,7 +558,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     FraRateHelper::FraRateHelper(Rate rate,
@@ -576,7 +576,7 @@ namespace QuantLib {
         iborIndex_->unregisterWith(termStructureHandle_);
         registerWith(iborIndex_);
         pillarDate_ = customPillarDate;
-        initializeDates();
+        FraRateHelper::initializeDates();
     }
 
     Real FraRateHelper::impliedQuote() const {
@@ -704,7 +704,7 @@ namespace QuantLib {
         registerWith(discountHandle_);
 
         pillarDate_ = customPillarDate;
-        initializeDates();
+        SwapRateHelper::initializeDates();
     }
 
     SwapRateHelper::SwapRateHelper(const Handle<Quote>& rate,
@@ -741,7 +741,7 @@ namespace QuantLib {
         registerWith(discountHandle_);
 
         pillarDate_ = customPillarDate;
-        initializeDates();
+        SwapRateHelper::initializeDates();
     }
 
     SwapRateHelper::SwapRateHelper(Rate rate,
@@ -772,7 +772,7 @@ namespace QuantLib {
         registerWith(discountHandle_);
 
         pillarDate_ = customPillarDate;
-        initializeDates();
+        SwapRateHelper::initializeDates();
     }
 
     SwapRateHelper::SwapRateHelper(Rate rate,
@@ -809,7 +809,7 @@ namespace QuantLib {
         registerWith(discountHandle_);
 
         pillarDate_ = customPillarDate;
-        initializeDates();
+        SwapRateHelper::initializeDates();
     }
 
     void SwapRateHelper::initializeDates() {
@@ -919,7 +919,7 @@ namespace QuantLib {
       iborIndex_(std::move(iborIndex)) {
         registerWith(iborIndex_);
         registerWith(bmaIndex_);
-        initializeDates();
+        BMASwapRateHelper::initializeDates();
     }
 
     void BMASwapRateHelper::initializeDates() {
@@ -1020,7 +1020,7 @@ namespace QuantLib {
         else
             jointCalendar_ = JointCalendar(tradingCalendar_, cal_,
                                            JoinHolidays);
-        initializeDates();
+        FxSwapRateHelper::initializeDates();
     }
 
     void FxSwapRateHelper::initializeDates() {


### PR DESCRIPTION
Ideally there should be no need to suppress this check, because no virtual functions should be called in any constructors or destructors as a general design rule. However, user code probably depends on the current behavior, so I have left the current behavior as is and have simply moved the suppression to comments so that at least any new code can be flagged before it is released.