### PR TITLE
Fixing outside truncation calculation

### DIFF
--- a/ql/pricingengines/vanilla/coshestonengine.cpp
+++ b/ql/pricingengines/vanilla/coshestonengine.cpp
@@ -87,17 +87,16 @@ namespace QuantLib {
         
         // Check if it exceeds the truncation bound
         
-        if (x >= b/2 || x <= a/2){
-        	//returns lower/upper bounds              	
-        	if (payoff->optionType() == Option::Put)
-            	results_.value = std::max(-spot*qf+k*df,0.0);            	
-            else if (payoff->optionType() == Option::Call) {            	
-           		results_.value = std::max(spot*qf-k*df,0.0);
-        	}
-       		else
-            	QL_FAIL("unknown payoff type");
+        if (x >= b/2 || x <= a/2) {
+            //returns lower/upper bounds
+            if (payoff->optionType() == Option::Put)
+                results_.value = std::max(-spot*qf+k*df,0.0);
+            else if (payoff->optionType() == Option::Call)
+           	    results_.value = std::max(spot*qf-k*df,0.0);
+       	    else
+                QL_FAIL("unknown payoff type");
             return;
-		}
+        }
 		
 
         const Real d = 1.0/(b-a);

--- a/ql/pricingengines/vanilla/coshestonengine.cpp
+++ b/ql/pricingengines/vanilla/coshestonengine.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2017 Klaus Spanderen
+ Copyright (C) 2022 Ignacio Anguita
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -83,6 +84,21 @@ namespace QuantLib {
 
         const Real a = x + cum1 - L_*w;
         const Real b = x + cum1 + L_*w;
+        
+        // Check if it exceeds the truncation bound
+        
+        if (x >= b/2 || x <= a/2){
+        	//returns lower/upper bounds              	
+        	if (payoff->optionType() == Option::Put)
+            	results_.value = std::max(-spot*qf+k*df,0.0);            	
+            else if (payoff->optionType() == Option::Call) {            	
+           		results_.value = std::max(spot*qf-k*df,0.0);
+        	}
+       		else
+            	QL_FAIL("unknown payoff type");
+            return;
+		}
+		
 
         const Real d = 1.0/(b-a);
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -2056,12 +2056,12 @@ void HestonModelTest::testCosHestonEngineTruncation() {
     const Real tol = 1e-7;
     const Real error = std::fabs(europeanOption.NPV() - 0.0);
 
-        if (error > tol) {
-            BOOST_ERROR(" failed to reproduce prices with COSHestonEngine"
-                    << "\n    expected:   " << 0.0
-                    << "\n    calculated: " << europeanOption.NPV()
-                    << "\n    difference: " << error);
-        }
+    if (error > tol) {
+        BOOST_ERROR(" failed to reproduce prices with COSHestonEngine"
+                << "\n    expected:   " << 0.0
+                << "\n    calculated: " << europeanOption.NPV()
+                << "\n    difference: " << error);
+    }
     
 }
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2005, 2007, 2009, 2010, 2012, 2014, 2017 Klaus Spanderen
+ Copyright (C) 2022 Ignacio Anguita
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -2016,6 +2017,54 @@ void HestonModelTest::testCosHestonEngine() {
     }
 }
 
+void HestonModelTest::testCosHestonEngineTruncation() {
+    BOOST_TEST_MESSAGE("Testing Heston pricing via COS method outside truncation bounds");
+    
+    SavedSettings backup;
+    
+    const Date todaysDate(22, August, 2022);
+    const Date maturity(23, August, 2022);
+    Settings::instance().evaluationDate() = todaysDate;
+
+    Option::Type type(Option::Call);
+    Real underlying = 100;
+    Real strike = 200;
+    Rate dividendYield = 0;
+    Rate riskFreeRate = 0;
+    DayCounter dayCounter = Actual365Fixed();
+
+    ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(maturity));
+    Handle<Quote> underlyingH(ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+    Handle<YieldTermStructure> riskFreeTS(
+        ext::shared_ptr<YieldTermStructure>(
+            new FlatForward(todaysDate, riskFreeRate, dayCounter)));
+    Handle<YieldTermStructure> dividendTS(
+        ext::shared_ptr<YieldTermStructure>(
+            new FlatForward(todaysDate, dividendYield, dayCounter)));
+
+    ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+    VanillaOption europeanOption(payoff, europeanExercise);
+
+    ext::shared_ptr<HestonProcess> hestonProcess(
+            new HestonProcess(riskFreeTS, dividendTS, underlyingH, .007, .8, .007, .1, -.2));
+    ext::shared_ptr<HestonModel> hestonModel(
+            new HestonModel(hestonProcess));
+    
+    europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                new COSHestonEngine(hestonModel)));
+                
+    const Real tol = 1e-7;
+    const Real error = std::fabs(europeanOption.NPV() - 0.0);
+
+        if (error > tol) {
+            BOOST_ERROR(" failed to reproduce prices with COSHestonEngine"
+                    << "\n    expected:   " << 0.0
+                    << "\n    calculated: " << europeanOption.NPV()
+                    << "\n    difference: " << error);
+        }
+    
+}
+
 void HestonModelTest::testCharacteristicFct() {
     BOOST_TEST_MESSAGE("Testing Heston characteristic function...");
 
@@ -3332,6 +3381,7 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAllIntegrationMethods));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCosHestonCumulants));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCosHestonEngine));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCosHestonEngineTruncation));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testCharacteristicFct));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAndersenPiterbargPricing));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAndersenPiterbargControlVariateIntegrand));

--- a/test-suite/hestonmodel.hpp
+++ b/test-suite/hestonmodel.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2005, 2007, 2010, 2012, 2014 Klaus Spanderen
+ Copyright (C) 2022 Ignacio Anguita
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -47,6 +48,7 @@ class HestonModelTest {
     static void testAllIntegrationMethods();
     static void testCosHestonCumulants();
     static void testCosHestonEngine();
+    static void testCosHestonEngineTruncation();
     static void testCharacteristicFct();
     static void testAndersenPiterbargPricing();
     static void testAndersenPiterbargControlVariateIntegrand();
@@ -61,6 +63,7 @@ class HestonModelTest {
     static void testOptimalControlVariateChoice();
     static void testAsymptoticControlVariate();
     static void testLocalVolFromHestonModel();
+    
 
     static boost::unit_test_framework::test_suite* suite(SpeedLevel);
     static boost::unit_test_framework::test_suite* experimental();


### PR DESCRIPTION
Hi,

This PR is for fixing the issue #1468 . The COS method works weird when the options (specially puts) are OTM with a short expiry.

This is due to the fact that the resulting x log(Strike/forward) gets too big for the truncation, thus yielding incorrect results. There are three main ways to solve that:
* The first one is to return the upper/lower bound of the option if the x exceeds the truncation bounds,which the following paper recommends to be: a/2 and b/2. Doc: https://arxiv.org/pdf/2005.13248.pdf
* The second possible alternative is to raise an exception when something like this happens and ask the user to change the value of L.
* The third alternative is to change the pricing formula and implement the one that the previous document includes.

Since we already have a working formula and this is quite a specific problem I thought it would be easier to just follow alternative 1, returning the european option bounds if the x is outside the truncation bounds.

I have added a test as well to make sure that this fix solves the error encountered in the #1468 issue.

Best,

Ignacio