### PR TITLE
Avoid passing `Handle<ZeroInflationIndex>` to CPI cap/floor

### DIFF
--- a/ql/experimental/inflation/cpicapfloorengines.cpp
+++ b/ql/experimental/inflation/cpicapfloorengines.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
 
 
         } else {
-            std::pair<Date,Date> dd = inflationPeriod(effectiveMaturity, arguments_.infIndex->frequency());
+            std::pair<Date,Date> dd = inflationPeriod(effectiveMaturity, arguments_.index->frequency());
             Real priceStart = 0.0;
 
             if (arguments_.type == Option::Call) {

--- a/ql/instruments/cpicapfloor.cpp
+++ b/ql/instruments/cpicapfloor.cpp
@@ -33,6 +33,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     CPICapFloor::CPICapFloor(Option::Type type,
                              Real nominal,
                              const Date& startDate, // start date of contract (only)
@@ -43,37 +45,57 @@ namespace QuantLib {
                              Calendar payCalendar,
                              BusinessDayConvention payConvention,
                              Rate strike,
-                             Handle<ZeroInflationIndex> infIndex,
+                             const ext::shared_ptr<ZeroInflationIndex>& infIndex,
+                             const Period& observationLag,
+                             CPI::InterpolationType observationInterpolation)
+    : CPICapFloor(type, nominal, startDate, baseCPI, maturity, fixCalendar, fixConvention,
+                  payCalendar, payConvention, strike, Handle<ZeroInflationIndex>(infIndex),
+                  observationLag, observationInterpolation) {}
+
+    CPICapFloor::CPICapFloor(Option::Type type,
+                             Real nominal,
+                             const Date& startDate, // start date of contract (only)
+                             Real baseCPI,
+                             const Date& maturity, // this is pre-adjustment!
+                             Calendar fixCalendar,
+                             BusinessDayConvention fixConvention,
+                             Calendar payCalendar,
+                             BusinessDayConvention payConvention,
+                             Rate strike,
+                             const Handle<ZeroInflationIndex>& infIndex,
                              const Period& observationLag,
                              CPI::InterpolationType observationInterpolation)
     : type_(type), nominal_(nominal), startDate_(startDate), baseCPI_(baseCPI), maturity_(maturity),
       fixCalendar_(std::move(fixCalendar)), fixConvention_(fixConvention),
       payCalendar_(std::move(payCalendar)), payConvention_(payConvention), strike_(strike),
-      infIndex_(std::move(infIndex)), observationLag_(observationLag),
-      observationInterpolation_(observationInterpolation) {
-        QL_REQUIRE(fixCalendar_ != Calendar(),"CPICapFloor: fixing calendar may not be null.");
-        QL_REQUIRE(payCalendar_ != Calendar(),"CPICapFloor: payment calendar may not be null.");
+      index_(*infIndex), observationLag_(observationLag),
+      observationInterpolation_(observationInterpolation), infIndex_(infIndex) {
+        QL_REQUIRE(index_, "no inflation index passed");
+        QL_REQUIRE(fixCalendar_ != Calendar(), "no fixing calendar passed");
+        QL_REQUIRE(payCalendar_ != Calendar(), "no payment calendar passed");
 
         if (observationInterpolation_ == CPI::Flat  ||
-            (observationInterpolation_ == CPI::AsIndex && !infIndex_->interpolated())
+            (observationInterpolation_ == CPI::AsIndex && !index_->interpolated())
             ) {
-            QL_REQUIRE(observationLag_ >= infIndex_->availabilityLag(),
+            QL_REQUIRE(observationLag_ >= index_->availabilityLag(),
                        "CPIcapfloor's observationLag must be at least availabilityLag of inflation index: "
                        <<"when the observation is effectively flat"
-                       << observationLag_ << " vs " << infIndex_->availabilityLag());
+                       << observationLag_ << " vs " << index_->availabilityLag());
         }
         if (observationInterpolation_ == CPI::Linear ||
-            (observationInterpolation_ == CPI::AsIndex && infIndex_->interpolated())
+            (observationInterpolation_ == CPI::AsIndex && index_->interpolated())
             ) {
-            QL_REQUIRE(observationLag_ > infIndex_->availabilityLag(),
+            QL_REQUIRE(observationLag_ > index_->availabilityLag(),
                        "CPIcapfloor's observationLag must be greater than availabilityLag of inflation index: "
                        <<"when the observation is effectively linear"
-                       << observationLag_ << " vs " << infIndex_->availabilityLag());
+                       << observationLag_ << " vs " << index_->availabilityLag());
         }
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 
-    //! when you fix - but remember that there is an observation interpolation factor as well
+
+    // when you fix - but remember that there is an observation interpolation factor as well
     Date CPICapFloor::fixingDate() const {
         return fixCalendar_.adjust(maturity_ - observationLag_, fixConvention_);
     }
@@ -113,10 +135,13 @@ namespace QuantLib {
         arguments->fixDate = fixingDate();
         arguments->payDate = payDate();
         arguments->strike = strike_;
-        arguments->infIndex = infIndex_;
+        arguments->index = index_;
         arguments->observationLag = observationLag_;
         arguments->observationInterpolation = observationInterpolation_;
 
+        QL_DEPRECATED_DISABLE_WARNING
+        arguments->infIndex = infIndex_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/ql/instruments/cpicapfloor.cpp
+++ b/ql/instruments/cpicapfloor.cpp
@@ -119,16 +119,4 @@ namespace QuantLib {
 
     }
 
-
-    void CPICapFloor::results::reset() {
-        Instrument::results::reset();
-    }
-
-
-    void CPICapFloor::fetchResults(const PricingEngine::results* r) const {
-        Instrument::fetchResults(r);
-    }
-
-
-
 }

--- a/ql/instruments/cpicapfloor.hpp
+++ b/ql/instruments/cpicapfloor.hpp
@@ -63,6 +63,7 @@ namespace QuantLib {
       public:
         class arguments;
         class engine;
+
         CPICapFloor(Option::Type type,
                     Real nominal,
                     const Date& startDate, // start date of contract (only)
@@ -73,7 +74,25 @@ namespace QuantLib {
                     Calendar payCalendar,
                     BusinessDayConvention payConvention,
                     Rate strike,
-                    Handle<ZeroInflationIndex> infIndex,
+                    const ext::shared_ptr<ZeroInflationIndex>& inflationIndex,
+                    const Period& observationLag,
+                    CPI::InterpolationType observationInterpolation = CPI::AsIndex);
+
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        CPICapFloor(Option::Type type,
+                    Real nominal,
+                    const Date& startDate, // start date of contract (only)
+                    Real baseCPI,
+                    const Date& maturity, // this is pre-adjustment!
+                    Calendar fixCalendar,
+                    BusinessDayConvention fixConvention,
+                    Calendar payCalendar,
+                    BusinessDayConvention payConvention,
+                    Rate strike,
+                    const Handle<ZeroInflationIndex>& infIndex,
                     const Period& observationLag,
                     CPI::InterpolationType observationInterpolation = CPI::AsIndex);
 
@@ -85,9 +104,19 @@ namespace QuantLib {
         Rate strike() const { return strike_; }
         Date fixingDate() const;
         Date payDate() const;
-        Handle<ZeroInflationIndex> inflationIndex() const { return infIndex_; }
+        const ext::shared_ptr<ZeroInflationIndex>& index() const { return index_; }
         Period observationLag() const { return observationLag_; }
         //@}
+
+        /*! \deprecated Use the `index` method instead.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        Handle<ZeroInflationIndex> inflationIndex() const {
+            QL_DEPRECATED_DISABLE_WARNING
+            return infIndex_;
+            QL_DEPRECATED_ENABLE_WARNING
+        }
 
         //! \name Instrument interface
         //@{
@@ -106,9 +135,15 @@ namespace QuantLib {
         Calendar payCalendar_;
         BusinessDayConvention payConvention_;
         Rate strike_;
-        Handle<ZeroInflationIndex> infIndex_;
+        ext::shared_ptr<ZeroInflationIndex> index_;
         Period observationLag_;
         CPI::InterpolationType observationInterpolation_;
+
+        /*! \deprecated Use the `index_` data member instead.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        Handle<ZeroInflationIndex> infIndex_;
     };
 
 
@@ -122,9 +157,15 @@ namespace QuantLib {
         Calendar fixCalendar, payCalendar;
         BusinessDayConvention fixConvention, payConvention;
         Rate strike;
-        Handle<ZeroInflationIndex> infIndex;
+        ext::shared_ptr<ZeroInflationIndex> index;
         Period observationLag;
         CPI::InterpolationType observationInterpolation;
+
+        /*! \deprecated Use the `index` data member instead.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        Handle<ZeroInflationIndex> infIndex;
 
         void validate() const override;
     };

--- a/ql/instruments/cpicapfloor.hpp
+++ b/ql/instruments/cpicapfloor.hpp
@@ -58,11 +58,10 @@ namespace QuantLib {
      We do not inherit from Option, although this would be reasonable,
      because we do not have that degree of generality.
 
-     */
+    */
     class CPICapFloor : public Instrument {
-    public:
+      public:
         class arguments;
-        class results;
         class engine;
         CPICapFloor(Option::Type type,
                     Real nominal,
@@ -94,10 +93,9 @@ namespace QuantLib {
         //@{
         bool isExpired() const override;
         void setupArguments(PricingEngine::arguments*) const override;
-        void fetchResults(const PricingEngine::results* r) const override;
         //@}
 
-    protected:
+      protected:
         Option::Type type_;
         Real nominal_;
         Date startDate_, fixDate_, payDate_;
@@ -114,8 +112,8 @@ namespace QuantLib {
     };
 
 
-    class CPICapFloor::arguments : public virtual PricingEngine::arguments{
-    public:
+    class CPICapFloor::arguments : public virtual PricingEngine::arguments {
+      public:
         Option::Type type;
         Real nominal;
         Date startDate, fixDate, payDate;
@@ -131,16 +129,8 @@ namespace QuantLib {
         void validate() const override;
     };
 
-
-    class CPICapFloor::results : public Instrument::results {
-    public:
-      void reset() override;
-    };
-
-
     class CPICapFloor::engine : public GenericEngine<CPICapFloor::arguments,
-                                                     CPICapFloor::results> {
-    };
+                                                     CPICapFloor::results> {};
 
 }
 

--- a/ql/instruments/cpicapfloor.hpp
+++ b/ql/instruments/cpicapfloor.hpp
@@ -96,6 +96,10 @@ namespace QuantLib {
                     const Period& observationLag,
                     CPI::InterpolationType observationInterpolation = CPI::AsIndex);
 
+        QL_DEPRECATED_DISABLE_WARNING
+        ~CPICapFloor() override = default;
+        QL_DEPRECATED_ENABLE_WARNING
+
         //! \name Inspectors
         //@{
         Option::Type type() const { return type_; }
@@ -149,6 +153,11 @@ namespace QuantLib {
 
     class CPICapFloor::arguments : public virtual PricingEngine::arguments {
       public:
+        QL_DEPRECATED_DISABLE_WARNING
+        arguments() = default;
+        ~arguments() override = default;
+        QL_DEPRECATED_ENABLE_WARNING
+
         Option::Type type;
         Real nominal;
         Date startDate, fixDate, payDate;

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -107,7 +107,6 @@ namespace inflation_cpi_capfloor_test {
         std::vector<Date> zciisD;
         std::vector<Rate> zciisR;
         ext::shared_ptr<UKRPI> ii;
-        RelinkableHandle<ZeroInflationIndex> hii;
         Size zciisDataLength;
 
         RelinkableHandle<YieldTermStructure> nominalUK;
@@ -268,7 +267,6 @@ namespace inflation_cpi_capfloor_test {
                                     ii->frequency(), baseZeroRate, helpers));
             pCPIts->recalculate();
             cpiUK.linkTo(pCPIts);
-            hii.linkTo(ii);
 
             // make sure that the index has the latest zero inflation term structure
             hcpi.linkTo(pCPIts);
@@ -424,7 +422,7 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
     Calendar fixCalendar = UnitedKingdom(), payCalendar = UnitedKingdom();
     BusinessDayConvention fixConvention(Unadjusted), payConvention(ModifiedFollowing);
     Rate strike(0.03);
-    Real baseCPI = common.hii->fixing(fixCalendar.adjust(startDate-common.observationLag,fixConvention));
+    Real baseCPI = common.ii->fixing(fixCalendar.adjust(startDate-common.observationLag,fixConvention));
     CPI::InterpolationType observationInterpolation = CPI::AsIndex;
     CPICapFloor aCap(Option::Call,
                      nominal,
@@ -436,7 +434,7 @@ void InflationCPICapFloorTest::cpicapfloorpricer() {
                      payCalendar,
                      payConvention,
                      strike,
-                     common.hii,
+                     common.ii,
                      common.observationLag,
                      observationInterpolation);
 


### PR DESCRIPTION
It doesn't make sense to change the index once the instrument is defined.