### PR TITLE
Revert SVI constraint changes

### DIFF
--- a/ql/experimental/volatility/sviinterpolation.hpp
+++ b/ql/experimental/volatility/sviinterpolation.hpp
@@ -41,10 +41,9 @@ inline void checkSviParameters(const Real a, const Real b, const Real sigma,
                "a + b sigma sqrt(1-rho^2) (a=" << a << ", b=" << b << ", sigma="
                                                << sigma << ", rho=" << rho
                                                << ") must be non negative");
-    if (tte != 0.0) {
-        QL_REQUIRE(b * (1.0 + std::fabs(rho)) <= 4.0 / tte,
-                   "b(1+|rho|) must be less than or equal to 4/T");
-    }
+    QL_REQUIRE(b * (1.0 + std::fabs(rho)) <= 4.0,
+               "b(1+|rho|) must be less than or equal to 4, (b=" << b << ", rho=" << rho << ")");
+
 }
 
 inline Real sviTotalVariance(const Real a, const Real b, const Real sigma,

--- a/test-suite/svivolatility.cpp
+++ b/test-suite/svivolatility.cpp
@@ -34,8 +34,8 @@ void SviVolatilityTest::testSviSmileSection() {
     // Test time based constructor
     Time tte = 11.0 / 365;
     Real forward = 123.45;
-    Real a = -2.21;
-    Real b = 7.61;
+    Real a = -0.0666;
+    Real b = 0.229;
     Real sigma = 0.337;
     Real rho = 0.439;
     Real m = 0.193;


### PR DESCRIPTION
Hi again,
Before summer, we submitted #1381 - but that was wrong. It was correct as previously written due to how the calibration accounts for the time to expiry in the _a_ and _b_ parameters (which one can also find described in some articles). This differed from a system we compared to and hence the confusion. I've tried to verify this by fitting the SVI smile to a large number of skews, with good results after reverting the change. Apologies from me for this mistake and I'm interested in hearing anyone's thoughts on this. :)

This also updates the test to correctly scale _a_ and _b_.

Best,
Fredrik