### PR TITLE
A few fixes for callable bonds

### DIFF
--- a/ql/experimental/callablebonds/blackcallablebondengine.cpp
+++ b/ql/experimental/callablebonds/blackcallablebondengine.cpp
@@ -107,7 +107,7 @@ namespace QuantLib {
                                           Duration::Modified,
                                           false, exerciseDate);
 
-        Real cashStrike = arguments_.callabilityPrices[0];
+        Real cashStrike = arguments_.callabilityPrices[0] * arguments_.faceAmount / 100.0;
         dayCounter = volatility_->dayCounter();
         Date referenceDate = volatility_->referenceDate();
         Time exerciseTime = dayCounter.yearFraction(referenceDate,
@@ -145,7 +145,7 @@ namespace QuantLib {
         Real fwdCashPrice = (value - spotIncome())/
                             discountCurve_->discount(exerciseDate);
 
-        Real cashStrike = arguments_.callabilityPrices[0];
+        Real cashStrike = arguments_.callabilityPrices[0] * arguments_.faceAmount / 100.0;
 
         Option::Type type = (arguments_.putCallSchedule[0]->type() ==
                              Callability::Call ? Option::Call : Option::Put);

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -30,11 +30,12 @@ namespace QuantLib {
     CallableBond::CallableBond(Natural settlementDays,
                                const Schedule& schedule,
                                DayCounter paymentDayCounter,
+                               Real faceAmount,
                                const Date& issueDate,
                                CallabilitySchedule putCallSchedule)
     : Bond(settlementDays, schedule.calendar(), issueDate),
       paymentDayCounter_(std::move(paymentDayCounter)),
-      putCallSchedule_(std::move(putCallSchedule)) {
+      putCallSchedule_(std::move(putCallSchedule)), faceAmount_(faceAmount) {
 
         maturityDate_ = schedule.dates().back();
 
@@ -394,7 +395,7 @@ namespace QuantLib {
                               const Calendar& exCouponCalendar,
                               BusinessDayConvention exCouponConvention,
                               bool exCouponEndOfMonth)
-    : CallableBond(settlementDays, schedule, accrualDayCounter,
+    : CallableBond(settlementDays, schedule, accrualDayCounter, faceAmount,
                    issueDate, putCallSchedule) {
 
         frequency_ = schedule.tenor().frequency();
@@ -453,6 +454,7 @@ namespace QuantLib {
 
         Date settlement = arguments->settlementDate;
 
+        arguments->faceAmount = faceAmount_;
         arguments->redemption = redemption()->amount();
         arguments->redemptionDate = redemption()->date();
 

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -70,6 +70,20 @@ namespace QuantLib {
             schedules
         */
         Volatility impliedVolatility(
+                              const Bond::Price& targetPrice,
+                              const Handle<YieldTermStructure>& discountCurve,
+                              Real accuracy,
+                              Size maxEvaluations,
+                              Volatility minVol,
+                              Volatility maxVol) const;
+
+        /*! \warning This version of the method takes an NPV as target, not a price.
+
+            \deprecated Use the other overload.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        Volatility impliedVolatility(
                               Real targetValue,
                               const Handle<YieldTermStructure>& discountCurve,
                               Real accuracy,

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -55,6 +55,7 @@ namespace QuantLib {
         class arguments;
         class results;
         class engine;
+
         //! \name Inspectors
         //@{
         //! return the bond's put/call schedule
@@ -62,6 +63,7 @@ namespace QuantLib {
             return putCallSchedule_;
         }
         //@}
+
         //! \name Calculations
         //@{
         //! returns the Black implied forward yield volatility
@@ -138,6 +140,8 @@ namespace QuantLib {
                                 Real bump=2e-4);
         //@}
 
+        void setupArguments(PricingEngine::arguments* args) const override;
+
       protected:
         CallableBond(Natural settlementDays,
                      const Schedule& schedule,
@@ -154,6 +158,16 @@ namespace QuantLib {
         class ImpliedVolHelper;
         // helper class for option adjusted spread calculations
         class NPVSpreadHelper;
+
+      private:
+        /*  Used internally.
+            same as Bond::accruedAmount() but with enable early
+            payments true.  Forces accrued to be calculated in a
+            consistent way for future put/ call dates, which can be
+            problematic in lattice engines when option dates are also
+            coupon dates.
+        */
+        Real accrued(Date settlement) const;
     };
 
     class CallableBond::arguments : public Bond::arguments {
@@ -212,18 +226,6 @@ namespace QuantLib {
                               const Calendar& exCouponCalendar = Calendar(),
                               BusinessDayConvention exCouponConvention = Unadjusted,
                               bool exCouponEndOfMonth = false);
-
-        void setupArguments(PricingEngine::arguments* args) const override;
-
-      private:
-        //! accrued interest used internally, where includeToday = false
-        /*! same as Bond::accruedAmount() but with enable early
-            payments true.  Forces accrued to be calculated in a
-            consistent way for future put/ call dates, which can be
-            problematic in lattice engines when option dates are also
-            coupon dates.
-        */
-        Real accrued(Date settlement) const;
     };
 
     //! callable/puttable zero coupon bond

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -134,37 +134,10 @@ namespace QuantLib {
         DayCounter paymentDayCounter_;
         Frequency frequency_;
         CallabilitySchedule putCallSchedule_;
-        //! must be set by derived classes for impliedVolatility() to work
-        mutable ext::shared_ptr<PricingEngine> blackEngine_;
-        //! Black fwd yield volatility quote handle to internal blackEngine_
-        mutable RelinkableHandle<Quote> blackVolQuote_;
-        //! Black fwd yield volatility quote handle to internal blackEngine_
-        mutable RelinkableHandle<YieldTermStructure> blackDiscountCurve_;
-        //! helper class for Black implied volatility calculation
+        // helper class for Black implied volatility calculation
         class ImpliedVolHelper;
-        friend class ImpliedVolHelper;
-        class ImpliedVolHelper {
-          public:
-            ImpliedVolHelper(const CallableBond& bond,
-                             Real targetValue);
-            Real operator()(Volatility x) const;
-          private:
-            ext::shared_ptr<PricingEngine> engine_;
-            Real targetValue_;
-            ext::shared_ptr<SimpleQuote> vol_;
-            const Instrument::results* results_;
-        };
-        //! Helper class for option adjusted spread calculations
+        // helper class for option adjusted spread calculations
         class NPVSpreadHelper;
-        friend class NPVSpreadHelper;
-        class NPVSpreadHelper {
-        public:
-            explicit NPVSpreadHelper(CallableBond& bond);
-            Real operator()(Spread x) const;
-        private:
-            CallableBond& bond_;
-            const Instrument::results* results_;
-        };
     };
 
     class CallableBond::arguments : public Bond::arguments {

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -144,7 +144,8 @@ namespace QuantLib {
 
       protected:
         CallableBond(Natural settlementDays,
-                     const Schedule& schedule,
+                     const Date& maturityDate,
+                     const Calendar& calendar,
                      DayCounter paymentDayCounter,
                      Real faceAmount,
                      const Date& issueDate = Date(),
@@ -216,12 +217,10 @@ namespace QuantLib {
                               const Schedule& schedule,
                               const std::vector<Rate>& coupons,
                               const DayCounter& accrualDayCounter,
-                              BusinessDayConvention paymentConvention
-                                                                  = Following,
+                              BusinessDayConvention paymentConvention = Following,
                               Real redemption = 100.0,
                               const Date& issueDate = Date(),
-                              const CallabilitySchedule& putCallSchedule
-                                                      = CallabilitySchedule(),
+                              const CallabilitySchedule& putCallSchedule = {},
                               const Period& exCouponPeriod = Period(),
                               const Calendar& exCouponCalendar = Calendar(),
                               BusinessDayConvention exCouponConvention = Unadjusted,
@@ -233,19 +232,17 @@ namespace QuantLib {
 
         \ingroup instruments
     */
-    class CallableZeroCouponBond : public CallableFixedRateBond {
+    class CallableZeroCouponBond : public CallableBond {
       public:
         CallableZeroCouponBond(Natural settlementDays,
                                Real faceAmount,
                                const Calendar& calendar,
                                const Date& maturityDate,
                                const DayCounter& dayCounter,
-                               BusinessDayConvention paymentConvention
-                                                                  = Following,
+                               BusinessDayConvention paymentConvention = Following,
                                Real redemption = 100.0,
                                const Date& issueDate = Date(),
-                               const CallabilitySchedule& putCallSchedule
-                                                     = CallabilitySchedule());
+                               const CallabilitySchedule& putCallSchedule = {});
     };
 
 }

--- a/ql/experimental/callablebonds/callablebond.hpp
+++ b/ql/experimental/callablebonds/callablebond.hpp
@@ -128,12 +128,14 @@ namespace QuantLib {
         CallableBond(Natural settlementDays,
                      const Schedule& schedule,
                      DayCounter paymentDayCounter,
+                     Real faceAmount,
                      const Date& issueDate = Date(),
                      CallabilitySchedule putCallSchedule = CallabilitySchedule());
 
         DayCounter paymentDayCounter_;
         Frequency frequency_;
         CallabilitySchedule putCallSchedule_;
+        Real faceAmount_;
         // helper class for Black implied volatility calculation
         class ImpliedVolHelper;
         // helper class for option adjusted spread calculations
@@ -145,6 +147,7 @@ namespace QuantLib {
         arguments() = default;
         std::vector<Date> couponDates;
         std::vector<Real> couponAmounts;
+        Real faceAmount;
         //! redemption = face amount * redemption / 100.
         Real redemption;
         Date redemptionDate;

--- a/ql/experimental/callablebonds/discretizedcallablefixedratebond.cpp
+++ b/ql/experimental/callablebonds/discretizedcallablefixedratebond.cpp
@@ -94,6 +94,7 @@ namespace QuantLib {
                 }
             }
 
+            adjustedCallabilityPrices_[i] *= arguments_.faceAmount / 100.0;
             callabilityTimes_[i] = callabilityTime;
         }
     }

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -697,10 +697,6 @@ void CallableBondTest::testImpliedVol() {
                                 vars.rollingConvention, 100.0,
                                 vars.issueDate(), callabilities);
 
-    Size timeSteps = 120;
-    bond.setPricingEngine(ext::make_shared<TreeCallableZeroCouponBondEngine>(
-        *(vars.model), timeSteps, vars.termStructure));
-
     Real targetPrice = 73.5;
     Real volatility = bond.impliedVolatility(targetPrice,
                                              vars.termStructure,

--- a/test-suite/callablebonds.hpp
+++ b/test-suite/callablebonds.hpp
@@ -31,6 +31,7 @@ class CallableBondTest {
     static void testDegenerate();
     static void testCached();
     static void testSnappingExerciseDate2ClosestCouponDate();
+    static void testImpliedVol();
     static boost::unit_test_framework::test_suite* suite();
 };
 

--- a/test-suite/callablebonds.hpp
+++ b/test-suite/callablebonds.hpp
@@ -31,6 +31,7 @@ class CallableBondTest {
     static void testDegenerate();
     static void testCached();
     static void testSnappingExerciseDate2ClosestCouponDate();
+    static void testBlackEngine();
     static void testImpliedVol();
     static boost::unit_test_framework::test_suite* suite();
 };


### PR DESCRIPTION
- neither the tree nor the Black engine rescaled the callability premia to the face amount of the bond.  The calculation worked when the face amount was 100, but was incorrect otherwise.  This is now fixed.
- the `impliedVolatility` method was taking a target NPV, not a price, which means that the passed target needed to be scaled according to the face amount.  This implementation is now deprecated, and a new overload was added always taking a price in base 100.

These changes are possibly breaking: the public interface of the bond is still the same (plus the new overload) but the protected constructor had to change and a few protected data members were removed, so if you inherited from this class you might have to make corresponding changes.