### PR TITLE
Deprecate a few bond constructors.

### DIFF
--- a/ql/instruments/bonds/cmsratebond.hpp
+++ b/ql/instruments/bonds/cmsratebond.hpp
@@ -45,17 +45,12 @@ namespace QuantLib {
                     const Schedule& schedule,
                     const ext::shared_ptr<SwapIndex>& index,
                     const DayCounter& paymentDayCounter,
-                    BusinessDayConvention paymentConvention
-                                    = Following,
+                    BusinessDayConvention paymentConvention = Following,
                     Natural fixingDays = Null<Natural>(),
-                    const std::vector<Real>& gearings
-                                    = std::vector<Real>(1, 1.0),
-                    const std::vector<Spread>& spreads
-                                    = std::vector<Spread>(1, 0.0),
-                    const std::vector<Rate>& caps
-                                    = std::vector<Rate>(),
-                    const std::vector<Rate>& floors
-                                    = std::vector<Rate>(),
+                    const std::vector<Real>& gearings = { 1.0 },
+                    const std::vector<Spread>& spreads = { 0.0 },
+                    const std::vector<Rate>& caps = {},
+                    const std::vector<Rate>& floors = {},
                     bool inArrears = false,
                     Real redemption = 100.0,
                     const Date& issueDate = Date());

--- a/ql/instruments/bonds/fixedratebond.hpp
+++ b/ql/instruments/bonds/fixedratebond.hpp
@@ -60,8 +60,11 @@ namespace QuantLib {
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false,
                       const DayCounter& firstPeriodDayCounter = DayCounter());
-        /*! simple annual compounding coupon rates
-            with internal schedule calculation */
+
+        /*! \deprecated Use the constructor taking a schedule.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
         FixedRateBond(Natural settlementDays,
                       const Calendar& couponCalendar,
                       Real faceAmount,
@@ -83,7 +86,12 @@ namespace QuantLib {
                       BusinessDayConvention exCouponConvention = Unadjusted,
                       bool exCouponEndOfMonth = false,
                       const DayCounter& firstPeriodDayCounter = DayCounter());
-        //! generic compounding and frequency InterestRate coupons
+
+        /*! \deprecated Build a FixedRateLeg instead and use it
+                        to create an instance of the base Bond class.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
         FixedRateBond(Natural settlementDays,
                       Real faceAmount,
                       const Schedule& schedule,

--- a/ql/instruments/bonds/floatingratebond.hpp
+++ b/ql/instruments/bonds/floatingratebond.hpp
@@ -48,10 +48,10 @@ namespace QuantLib {
                          const DayCounter& accrualDayCounter,
                          BusinessDayConvention paymentConvention = Following,
                          Natural fixingDays = Null<Natural>(),
-                         const std::vector<Real>& gearings = std::vector<Real>(1, 1.0),
-                         const std::vector<Spread>& spreads = std::vector<Spread>(1, 0.0),
-                         const std::vector<Rate>& caps = std::vector<Rate>(),
-                         const std::vector<Rate>& floors = std::vector<Rate>(),
+                         const std::vector<Real>& gearings = { 1.0 },
+                         const std::vector<Spread>& spreads = { 0.0 },
+                         const std::vector<Rate>& caps = {},
+                         const std::vector<Rate>& floors = {},
                          bool inArrears = false,
                          Real redemption = 100.0,
                          const Date& issueDate = Date(),
@@ -59,6 +59,11 @@ namespace QuantLib {
                          const Calendar& exCouponCalendar = Calendar(),
                          BusinessDayConvention exCouponConvention = Unadjusted,
                          bool exCouponEndOfMonth = false);
+        
+        /*! \deprecated Use the other constructor.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
         FloatingRateBond(Natural settlementDays,
                          Real faceAmount,
                          const Date& startDate,
@@ -70,10 +75,10 @@ namespace QuantLib {
                          BusinessDayConvention accrualConvention = Following,
                          BusinessDayConvention paymentConvention = Following,
                          Natural fixingDays = Null<Natural>(),
-                         const std::vector<Real>& gearings = std::vector<Real>(1, 1.0),
-                         const std::vector<Spread>& spreads = std::vector<Spread>(1, 0.0),
-                         const std::vector<Rate>& caps = std::vector<Rate>(),
-                         const std::vector<Rate>& floors = std::vector<Rate>(),
+                         const std::vector<Real>& gearings = { 1.0 },
+                         const std::vector<Spread>& spreads = { 0.0 },
+                         const std::vector<Rate>& caps = {},
+                         const std::vector<Rate>& floors = {},
                          bool inArrears = false,
                          Real redemption = 100.0,
                          const Date& issueDate = Date(),

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -1025,7 +1025,6 @@ void BondTest::testBrazilianCached() {
 
     Natural settlementDays = 1;
     Real faceAmount = 1000.0;
-    Real redemption = 100.0;
     Date today(6,June,2007);
     Date issueDate(1,January,2007);
 
@@ -1077,13 +1076,15 @@ void BondTest::testBrazilianCached() {
                           Unadjusted, Unadjusted,
                           DateGeneration::Backward, false);
 
-        FixedRateBond bond(settlementDays,
-            faceAmount,
-            schedule,
-            couponRates,
-            Following,
-            redemption,
-            issueDate);
+        Leg coupons = FixedRateLeg(schedule)
+            .withNotionals(faceAmount)
+            .withCouponRates(couponRates)
+            .withPaymentAdjustment(Following);
+
+        Bond bond(settlementDays,
+                  schedule.calendar(),
+                  issueDate,
+                  coupons);
 
         Real cachedPrice = prices[bondIndex];
         Real price = faceAmount *


### PR DESCRIPTION
The idea is to have a single, most used constructor for each kind of bond and to use the generic constructors in the Bond class for special cases.  This makes it a lot more convenient to use the constructors in languages (like Python or C#) that support some kind of syntax for keyword arguments.