### PR TITLE
Replace boost::thread with std::thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,15 +125,7 @@ if (NOT DEFINED QL_BOOST_VERSION)
     endif()
 endif()
 
-if (NOT DEFINED QL_BOOST_COMPONENTS)
-    set(QL_BOOST_COMPONENTS "")
-    # Boost thread needed for sessions, singleton thread-safe init and thread-safe observer pattern
-    if(QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
-        set(QL_BOOST_COMPONENTS "${QL_BOOST_COMPONENTS};thread")
-    endif()
-endif()
-
-find_package(Boost ${QL_BOOST_VERSION} REQUIRED COMPONENTS ${QL_BOOST_COMPONENTS})
+find_package(Boost ${QL_BOOST_VERSION} REQUIRED)
 
 # Do not warn about Boost versions higher than 1.58.0
 set(Boost_NO_WARN_NEW_VERSIONS ON)
@@ -150,20 +142,16 @@ if (NOT DEFINED THREADS_PREFER_PTHREAD_FLAG)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
 endif()
 
-set(QL_THREAD_LIBRARIES)
-
-if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER)
+# Add Threads dependency when any of the threading features are enabled
+if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER OR QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
     find_package(Threads REQUIRED)
-    set(QL_THREAD_LIBRARIES Threads::Threads ${QL_THREAD_LIBRARIES})
     # Parallel test runner needs library rt on *nix for shm_open, etc.
-    if (UNIX AND NOT APPLE)
+    if (QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER AND UNIX AND NOT APPLE)
         find_library(RT_LIBRARY rt REQUIRED)
-        set(QL_THREAD_LIBRARIES ${RT_LIBRARY} ${QL_THREAD_LIBRARIES})
+        set(QL_THREAD_LIBRARIES Threads::Threads ${RT_LIBRARY})
+    else()
+        set(QL_THREAD_LIBRARIES Threads::Threads)
     endif()
-endif()
-
-if (QL_ENABLE_SESSIONS OR QL_ENABLE_SINGLETON_THREAD_SAFE_INIT OR QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN)
-    set(QL_THREAD_LIBRARIES Boost::thread ${QL_THREAD_LIBRARIES})
 endif()
 
 # If available, use PIC for shared libs and PIE for executables

--- a/Examples/Makefile.am
+++ b/Examples/Makefile.am
@@ -30,7 +30,7 @@ else
 noinst_PROGRAMS = $(EXAMPLES)
 endif
 
-LDADDS = ../ql/libQuantLib.la ${BOOST_THREAD_LIB}
+LDADDS = ../ql/libQuantLib.la ${PTHREAD_LIB}
 
 BasketLosses_BasketLosses_SOURCES = BasketLosses/BasketLosses.cpp
 BasketLosses_BasketLosses_LDADD = $(LDADDS)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -153,63 +153,38 @@ AC_DEFUN([QL_CHECK_BOOST_UNIT_TEST],
  fi
 ])
 
-# QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM
+# QL_CHECK_BOOST_SIGNALS2
 # ------------------------
-# Check whether the Boost thread and system is available
-AC_DEFUN([QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM],
-[AC_MSG_CHECKING([whether Boost thread, signals2 and system are available])
+# Check whether Boost signals2 is available
+AC_DEFUN([QL_CHECK_BOOST_SIGNALS2],
+[AC_MSG_CHECKING([whether Boost signals2 is available])
  AC_REQUIRE([AC_PROG_CC])
  ql_original_LIBS=$LIBS
  ql_original_CXXFLAGS=$CXXFLAGS
- CC_BASENAME=`basename $CC`
- CC_VERSION=`echo "__GNUC__ __GNUC_MINOR__" | $CC -E -x c - | tail -n 1 | $SED -e "s/ //"`
- for suffix in "" \
-               "-$CC_BASENAME$CC_VERSION" \
-               "-$CC_BASENAME" \
-               "-mt-$CC_BASENAME$CC_VERSION" \
-               "-$CC_BASENAME$CC_VERSION-mt" \
-               "-x$CC_BASENAME$CC_VERSION-mt" \
-               "-mt-$CC_BASENAME" \
-               "-$CC_BASENAME-mt" \
-               "-mt" ; do
-     boost_thread_lib="-lboost_thread$suffix -lboost_system$suffix"
-     LIBS="$ql_original_LIBS $boost_thread_lib"
-     CXXFLAGS="$ql_original_CXXFLAGS -pthread"
-     boost_thread_found=no
-     AC_LINK_IFELSE([AC_LANG_SOURCE(
-         [@%:@include <boost/thread/locks.hpp>
-          @%:@include <boost/thread/recursive_mutex.hpp>
-          @%:@include <boost/signals2/signal.hpp>
-          
-          #ifndef BOOST_THREAD_PLATFORM_PTHREAD
-          #error only pthread is supported on this plattform
-          #endif
-    
-          int main() {
-            boost::recursive_mutex m;
-            boost::lock_guard<boost::recursive_mutex> lock(m);
-      
-            boost::signals2::signal<void()> sig;
-      
-            return 0;
-          }
-         ])],
-         [boost_thread_found=$boost_thread_lib
-          break],
-         [])
- done
+ LIBS="$ql_original_LIBS -pthread"
+ CXXFLAGS="$ql_original_CXXFLAGS -pthread"
+ boost_signals2_found=no
+ AC_LINK_IFELSE([AC_LANG_SOURCE(
+     [@%:@include <boost/signals2/signal.hpp>
+
+      int main() {
+        boost::signals2::signal<void()> sig;
+      }
+     ])],
+     [boost_signals2_found=yes
+      break],
+     [])
  LIBS="$ql_original_LIBS"
  CXXFLAGS="$ql_original_CXXFLAGS"
      
- if test "$boost_thread_found" = no ; then
+ if test "$boost_signals2_found" = no ; then
      AC_MSG_RESULT([no])
-     AC_SUBST([BOOST_THREAD_LIB],[""])
-     AC_MSG_ERROR([Boost thread, signals2 and system libraries not found. 
-         These libraries are required by the thread-safe observer pattern
-         or by the parallel unit test runner.])
+     AC_SUBST([PTHREAD_LIB],[""])
+     AC_MSG_ERROR([Boost signals2 library not found.
+         This library is required by the thread-safe observer pattern.])
  else
      AC_MSG_RESULT([yes])
-     AC_SUBST([BOOST_THREAD_LIB],[$boost_thread_lib])
+     AC_SUBST([PTHREAD_LIB],["-pthread"])
      AC_SUBST([PTHREAD_CXXFLAGS],["-pthread"])
      AC_SUBST([CXXFLAGS],["${CXXFLAGS} -pthread"])
  fi

--- a/configure.ac
+++ b/configure.ac
@@ -41,16 +41,6 @@ if test [ -n "$ql_boost_include_path" ] ; then
    AC_SUBST([BOOST_INCLUDE],["-isystem ${ql_boost_include_path}"])
    AC_SUBST([CPPFLAGS],["${CPPFLAGS} -isystem ${ql_boost_include_path}"])
 fi
-AC_ARG_WITH([boost-lib],
-            AS_HELP_STRING([--with-boost-lib=LIB_PATH],
-                           [Supply the location of Boost libraries]),
-            [ql_boost_lib_path="`cd ${withval} 2>/dev/null && pwd`"],
-            [ql_boost_lib_path=""])
-if test [ -n "$ql_boost_lib_path" ] ; then
-   AC_SUBST([BOOST_LIB],["-L${ql_boost_lib_path}"])
-   AC_SUBST([LDFLAGS],["${LDFLAGS} -L${ql_boost_lib_path}"])
-fi
-
 
 # Continue setup
 
@@ -276,9 +266,9 @@ AC_MSG_RESULT([$ql_use_safe_singleton_init])
 
 if test "$ql_use_sessions" = "yes" || test "$ql_use_tsop" = "yes" || test "$ql_use_safe_singleton_init" = "yes"; then
    QL_CHECK_BOOST_VERSION_1_58_OR_HIGHER
-   QL_CHECK_BOOST_TEST_THREAD_SIGNALS2_SYSTEM
+   QL_CHECK_BOOST_SIGNALS2
 else
-   AC_SUBST([BOOST_THREAD_LIB],[""])
+   AC_SUBST([PTHREAD_LIB],[""])
 fi
 
 AC_MSG_CHECKING([whether to enable parallel unit test runner])

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2350,9 +2350,6 @@ target_include_directories(ql_library SYSTEM PUBLIC
     ${Boost_INCLUDE_DIRS}
     ${OpenMP_CXX_INCLUDE_DIRS})
 
-target_link_directories(ql_library PUBLIC
-    ${BOOST_LIBRARY_DIRS})
-
 target_link_libraries(ql_library PUBLIC
     ${OpenMP_CXX_LIBRARIES})
 

--- a/ql/auto_link.hpp
+++ b/ql/auto_link.hpp
@@ -61,15 +61,4 @@
 #  pragma message("Will (need to) link to lib file: " QL_LIB_NAME)
 #endif
 
-/* Also, these Boost libraries might be needed */
-#if defined(QL_ENABLE_SESSIONS) || defined(QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN) || defined(QL_ENABLE_SINGLETON_THREAD_SAFE_INIT)
-#  define BOOST_LIB_NAME boost_system
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
-#  define BOOST_LIB_NAME boost_thread
-#  include <boost/config/auto_link.hpp>
-#  undef BOOST_LIB_NAME
-#endif
-
-
 #endif

--- a/ql/patterns/observable.cpp
+++ b/ql/patterns/observable.cpp
@@ -97,7 +97,7 @@ namespace QuantLib {
           public:
             typedef boost::signals2::signal_type<
                 void(),
-                boost::signals2::keywords::mutex_type<boost::recursive_mutex> >
+                boost::signals2::keywords::mutex_type<std::recursive_mutex> >
                 ::type signal_type;
 
             void connect(const signal_type::slot_type& slot) {
@@ -140,7 +140,7 @@ namespace QuantLib {
 
     void Observable::registerObserver(const ext::shared_ptr<Observer::Proxy>& observerProxy) {
         {
-            boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+            std::lock_guard<std::recursive_mutex> lock(mutex_);
             observers_.insert(observerProxy);
         }
 
@@ -155,12 +155,12 @@ namespace QuantLib {
     void Observable::unregisterObserver(const ext::shared_ptr<Observer::Proxy>& observerProxy,
                                         bool disconnect) {
         {
-            boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+            std::lock_guard<std::recursive_mutex> lock(mutex_);
             observers_.erase(observerProxy);
         }
 
         if (settings_.updatesDeferred()) {
-            boost::lock_guard<boost::mutex> sLock(settings_.mutex_);
+            std::lock_guard<std::mutex> sLock(settings_.mutex_);
             if (settings_.updatesDeferred()) {
                 settings_.unregisterDeferredObserver(observerProxy);
             }
@@ -176,12 +176,12 @@ namespace QuantLib {
             return (*sig_)();
         }
 
-        boost::lock_guard<boost::mutex> sLock(settings_.mutex_);
+        std::lock_guard<std::mutex> sLock(settings_.mutex_);
         if (settings_.updatesEnabled()) {
             return (*sig_)();
         }
         else if (settings_.updatesDeferred()) {
-            boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+            std::lock_guard<std::recursive_mutex> lock(mutex_);
             // if updates are only deferred, flag this for later notification
             // these are held centrally by the settings singleton
             settings_.registerDeferredObservers(observers_);

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -256,12 +256,11 @@ namespace QuantLib {
 
 #else
 
-#include <boost/atomic.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/recursive_mutex.hpp>
 #include <boost/smart_ptr/owner_less.hpp>
+#include <atomic>
+#include <mutex>
 #include <set>
+#include <thread>
 
 namespace QuantLib {
 
@@ -323,7 +322,7 @@ namespace QuantLib {
             }
 
             void update() const {
-                boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+                std::lock_guard<std::recursive_mutex> lock(mutex_);
                 if (active_) {
                     // c++17 is required if used with std::shared_ptr<T>
                     const ext::weak_ptr<Observer> o
@@ -344,18 +343,18 @@ namespace QuantLib {
             }
 
             void deactivate() {
-                boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+                std::lock_guard<std::recursive_mutex> lock(mutex_);
                 active_ = false;
             }
 
         private:
             bool active_;
-            mutable boost::recursive_mutex mutex_;
+            mutable std::recursive_mutex mutex_;
             Observer* const observer_;
         };
 
         ext::shared_ptr<Proxy> proxy_;
-        mutable boost::recursive_mutex mutex_;
+        mutable std::recursive_mutex mutex_;
 
         QL_DEPRECATED_DISABLE_WARNING
         set_type observables_;
@@ -400,7 +399,7 @@ namespace QuantLib {
         set_type observers_;
         QL_DEPRECATED_ENABLE_WARNING
 
-        mutable boost::recursive_mutex mutex_;
+        mutable std::recursive_mutex mutex_;
 
         ObservableSettings& settings_;
     };
@@ -412,7 +411,7 @@ namespace QuantLib {
 
       public:
         void disableUpdates(bool deferred=false) {
-            boost::lock_guard<boost::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
             updatesType_ = (deferred) ? UpdatesDeferred : 0;
         }
         void enableUpdates();
@@ -432,10 +431,10 @@ namespace QuantLib {
         void unregisterDeferredObserver(const ext::shared_ptr<Observer::Proxy>& proxy);
 
         set_type deferredObservers_;
-        mutable boost::mutex mutex_;
+        mutable std::mutex mutex_;
 
         enum UpdateType { UpdatesEnabled = 1, UpdatesDeferred = 2} ;
-        boost::atomic<int> updatesType_;
+        std::atomic<int> updatesType_;
     };
 
 
@@ -453,7 +452,7 @@ namespace QuantLib {
     }
 
     inline void ObservableSettings::enableUpdates() {
-        boost::lock_guard<boost::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
 
         // if there are outstanding deferred updates, do the notification
         updatesType_ = UpdatesEnabled;
@@ -504,7 +503,7 @@ namespace QuantLib {
         proxy_.reset(new Proxy(this));
 
         {
-             boost::lock_guard<boost::recursive_mutex> lock(o.mutex_);
+             std::lock_guard<std::recursive_mutex> lock(o.mutex_);
              observables_ = o.observables_;
         }
 
@@ -513,7 +512,7 @@ namespace QuantLib {
     }
 
     inline Observer& Observer::operator=(const Observer& o) {
-        boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
             proxy_.reset(new Proxy(this));
         }
@@ -522,7 +521,7 @@ namespace QuantLib {
             observable->unregisterObserver(proxy_, true);
 
         {
-            boost::lock_guard<boost::recursive_mutex> lock(o.mutex_);
+            std::lock_guard<std::recursive_mutex> lock(o.mutex_);
             observables_ = o.observables_;
         }
         for (const auto& observable : observables_)
@@ -532,7 +531,7 @@ namespace QuantLib {
     }
 
     inline Observer::~Observer() {
-        boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (proxy_)
             proxy_->deactivate();
 
@@ -542,7 +541,7 @@ namespace QuantLib {
 
     inline std::pair<Observer::iterator, bool>
     Observer::registerWith(const ext::shared_ptr<Observable>& h) {
-        boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
             proxy_.reset(new Proxy(this));
         }
@@ -557,7 +556,7 @@ namespace QuantLib {
     inline void
     Observer::registerWithObservables(const ext::shared_ptr<Observer>& o) {
         if (o) {
-            boost::lock_guard<boost::recursive_mutex> lock(o->mutex_);
+            std::lock_guard<std::recursive_mutex> lock(o->mutex_);
 
             for (const auto& observable : o->observables_)
                 registerWith(observable);
@@ -566,7 +565,7 @@ namespace QuantLib {
 
     inline
     Size Observer::unregisterWith(const ext::shared_ptr<Observable>& h) {
-        boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
 
         if (h && proxy_)  {
             h->unregisterObserver(proxy_, true);
@@ -576,7 +575,7 @@ namespace QuantLib {
     }
 
     inline void Observer::unregisterWithAll() {
-        boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+        std::lock_guard<std::recursive_mutex> lock(mutex_);
 
         for (const auto& observable : observables_)
             observable->unregisterObserver(proxy_, true);

--- a/quantlib-config.in
+++ b/quantlib-config.in
@@ -42,7 +42,7 @@ while test $# -gt 0; do
       echo -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP14_CXXFLAGS@
       ;;
     --libs)
-      echo -L@libdir@ @BOOST_LIB@ -lQuantLib @OPENMP_CXXFLAGS@ @BOOST_THREAD_LIB@
+      echo -L@libdir@ -lQuantLib @OPENMP_CXXFLAGS@ @PTHREAD_LIB@
       ;;
     *)
       echo "${usage}" 1>&2

--- a/quantlib.pc.in
+++ b/quantlib.pc.in
@@ -7,4 +7,4 @@ Name: QuantLib
 Description: The free/open-source library for quantitative finance.
 Version: @PACKAGE_VERSION@
 Cflags: -I@includedir@ @BOOST_INCLUDE@ @OPENMP_CXXFLAGS@ @PTHREAD_CXXFLAGS@ @CPP14_CXXFLAGS@
-Libs: -L@libdir@ @BOOST_LIB@ -lQuantLib @OPENMP_CXXFLAGS@ @BOOST_THREAD_LIB@
+Libs: -L@libdir@ -lQuantLib @OPENMP_CXXFLAGS@ @PTHREAD_LIB@

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -442,10 +442,10 @@ EXTRA_DIST =
 endif
 
 quantlib_test_suite_LDADD = libUnitMain.la ${top_builddir}/ql/libQuantLib.la \
-                            ${BOOST_THREAD_LIB} ${BOOST_INTERPROCESS_LIB}
+                            ${PTHREAD_LIB} ${BOOST_INTERPROCESS_LIB}
 
 quantlib_benchmark_LDADD = libUnitMain.la ${top_builddir}/ql/libQuantLib.la \
-                           ${BOOST_THREAD_LIB}
+                           ${PTHREAD_LIB}
 
 TESTS = quantlib-test-suite$(EXEEXT)
 TESTS_ENVIRONMENT = BOOST_TEST_LOG_LEVEL=message BOOST_TEST_COLOR_OUTPUT=false

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -28,8 +28,8 @@
 #include <ql/termstructures/volatility/optionlet/strippedoptionletadapter.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
-#include <utility>
-
+#include <chrono>
+#include <thread>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -110,10 +110,9 @@ void ObservableTest::testObservableSettings() {
 
 #ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
 
-#include <boost/atomic.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/thread.hpp>
+#include <atomic>
+#include <mutex>
+#include <thread>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <list>
@@ -135,18 +134,18 @@ namespace {
         static int instanceCounter() { return instanceCounter_; }
 
       private:
-        boost::atomic<int> counter_;
-        static boost::atomic<int> instanceCounter_;
+        std::atomic<int> counter_;
+        static std::atomic<int> instanceCounter_;
     };
 
-    boost::atomic<int> MTUpdateCounter::instanceCounter_(0);
+    std::atomic<int> MTUpdateCounter::instanceCounter_(0);
 
     class GarbageCollector {
       public:
         GarbageCollector() : terminate_(false) { }
 
         void addObj(const ext::shared_ptr<MTUpdateCounter>& updateCounter) {
-            boost::lock_guard<boost::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
             objList.push_back(updateCounter);
         }
 
@@ -154,20 +153,20 @@ namespace {
             while(!terminate_) {
                 Size objListSize;
                 {
-                    boost::lock_guard<boost::mutex> lock(mutex_);
+                    std::lock_guard<std::mutex> lock(mutex_);
                     objListSize = objList.size();
                 }
 
                 if (objListSize > 20) {
                     // trigger gc
                     while (objListSize > 0) {
-                        boost::lock_guard<boost::mutex> lock(mutex_);
+                        std::lock_guard<std::mutex> lock(mutex_);
                         objList.pop_front();
                         objListSize = objList.size();
                     }
                 }
 
-                boost::this_thread::sleep(boost::posix_time::milliseconds(2));
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
             }
             objList.clear();
         }
@@ -176,8 +175,8 @@ namespace {
             terminate_ = true;
         }
       private:
-        boost::mutex mutex_;
-        boost::atomic<bool> terminate_;
+        std::mutex mutex_;
+        std::atomic<bool> terminate_;
 
         std::list<ext::shared_ptr<MTUpdateCounter> > objList;
     };
@@ -195,7 +194,7 @@ void ObservableTest::testAsyncGarbagCollector() {
     const ext::shared_ptr<SimpleQuote> quote(new SimpleQuote(-1.0));
 
     GarbageCollector gc;
-    boost::thread workerThread(&GarbageCollector::run, &gc);
+    std::thread workerThread(&GarbageCollector::run, &gc);
 
     for (Size i=0; i < 10000; ++i) {
         const ext::shared_ptr<MTUpdateCounter> observer(new MTUpdateCounter);
@@ -224,7 +223,7 @@ void ObservableTest::testMultiThreadingGlobalSettings() {
     ObservableSettings::instance().disableUpdates(true);
 
     GarbageCollector gc;
-    boost::thread workerThread(&GarbageCollector::run, &gc);
+    std::thread workerThread(&GarbageCollector::run, &gc);
 
     typedef std::list<ext::shared_ptr<MTUpdateCounter> > local_list_type;
     local_list_type localList;


### PR DESCRIPTION
- This removes the last Boost link-time dependency and so I have removed the `--with-boost-lib` flag. If you prefer, we can add it back and print a warning that it has no effect.
- There will be conflicts with #1377 but those conflicts can be easily resolved.
- `std::shared_timed_mutex` is the correct replacement for `boost::shared_mutex` because it was renamed at the last minute. See [this post](https://stackoverflow.com/a/40207246) for more info. Perhaps `std::shared_timed_mutex` can be replaced with `std::shared_mutex` in QuantLib once the language version changes to C++17.