### PR TITLE
Fix sign of fair upfront in ISDA engine for CDS

### DIFF
--- a/ql/instruments/makecds.cpp
+++ b/ql/instruments/makecds.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
     MakeCreditDefaultSwap::operator ext::shared_ptr<CreditDefaultSwap>() const {
 
-        Date tradeDate = Settings::instance().evaluationDate();
+        Date tradeDate = (tradeDate_ != Null<Date>()) ? tradeDate_ : Settings::instance().evaluationDate();
         Date upfrontDate = WeekendsOnly().advance(tradeDate, cashSettlementDays_, Days);
 
         Date protectionStart;
@@ -131,4 +131,10 @@ namespace QuantLib {
         engine_ = engine;
         return *this;
     }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withTradeDate(const Date& tradeDate) {
+        tradeDate_ = tradeDate;
+        return *this;
+    }
+
 }

--- a/ql/instruments/makecds.hpp
+++ b/ql/instruments/makecds.hpp
@@ -53,6 +53,8 @@ namespace QuantLib {
 
         MakeCreditDefaultSwap& withPricingEngine(const ext::shared_ptr<PricingEngine>&);
 
+        MakeCreditDefaultSwap& withTradeDate(const Date& tradeDate);
+
       private:
         Protection::Side side_;
         Real nominal_;
@@ -65,6 +67,7 @@ namespace QuantLib {
         DayCounter lastPeriodDayCounter_;
         DateGeneration::Rule rule_;
         Natural cashSettlementDays_;
+        Date tradeDate_;
 
         ext::shared_ptr<PricingEngine> engine_;
     };

--- a/ql/pricingengines/credit/isdacdsengine.cpp
+++ b/ql/pricingengines/credit/isdacdsengine.cpp
@@ -307,14 +307,19 @@ namespace QuantLib {
                 arguments_.accrualRebate->amount();
         }
 
-        Real upfrontSign = Protection::Seller != 0U ? 1.0 : -1.0;
-
-        if (arguments_.side == Protection::Seller) {
+        Real upfrontSign = 1.0;
+        switch (arguments_.side) {
+          case Protection::Seller:
             results_.defaultLegNPV *= -1.0;
             results_.accrualRebateNPV *= -1.0;
-        } else {
+            break;
+          case Protection::Buyer:
             results_.couponLegNPV *= -1.0;
-            results_.upfrontNPV *= -1.0;
+            results_.upfrontNPV   *= -1.0;
+            upfrontSign = -1.0;
+            break;
+          default:
+            QL_FAIL("unknown protection side");
         }
 
         results_.value = results_.defaultLegNPV + results_.couponLegNPV +

--- a/test-suite/creditdefaultswap.hpp
+++ b/test-suite/creditdefaultswap.hpp
@@ -34,6 +34,8 @@ class CreditDefaultSwapTest {
     static void testFairUpfront();
     static void testIsdaEngine();
     static void testAccrualRebateAmounts();
+    static void testIsdaCalculatorReconcileSingleQuote();
+    static void testIsdaCalculatorReconcileSingleWithIssueDateInThePast();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
The fair upfront was calculated with the correct amount but the wrong sign when buying protection — or at least, a sign inconsistent with the behavior of the existing instrument and engines, which treat the upfront as positive when paid by the buyer of the protection.  Because of this, a CDS created with the returned fair upfront would not have null NPV.  This is now fixed.

Also, the `MakeCreditDefaultSwap` class can now take the trade date (instead of always assuming the current evaluation date, which remains the default) and the calculation of the accrual rebate was refactored for clarity.