### PR TITLE
Add `SabrSmileSection` constructor taking a fixed reference date.

### DIFF
--- a/ql/termstructures/volatility/sabrsmilesection.cpp
+++ b/ql/termstructures/volatility/sabrsmilesection.cpp
@@ -41,10 +41,22 @@ namespace QuantLib {
                                        const DayCounter& dc,
                                        const Real shift,
                                        VolatilityType volatilityType)
-        : SmileSection(d, dc,Date(),volatilityType,shift),
+        : SmileSection(d, dc, Date(), volatilityType, shift),
           forward_(forward), shift_(shift) {
         initialise(sabrParams);
-     }
+    }
+
+    SabrSmileSection::SabrSmileSection(const Date& d,
+                                       Rate forward,
+                                       const std::vector<Real>& sabrParams,
+                                       const Date& referenceDate,
+                                       const DayCounter& dc,
+                                       const Real shift,
+                                       VolatilityType volatilityType)
+    : SmileSection(d, dc, referenceDate, volatilityType, shift),
+      forward_(forward), shift_(shift) {
+        initialise(sabrParams);
+    }
 
     void SabrSmileSection::initialise(const std::vector<Real>& sabrParams) {
 

--- a/ql/termstructures/volatility/sabrsmilesection.hpp
+++ b/ql/termstructures/volatility/sabrsmilesection.hpp
@@ -41,9 +41,21 @@ namespace QuantLib {
         SabrSmileSection(const Date& d,
                          Rate forward,
                          const std::vector<Real>& sabrParameters,
+                         const Date& referenceDate = Date(),
                          const DayCounter& dc = Actual365Fixed(),
                          Real shift = 0.0,
                          VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
+        /*! \deprecated Use the constructor taking an optional reference date.
+                        Deprecated in version 1.28.
+        */
+        QL_DEPRECATED
+        SabrSmileSection(const Date& d,
+                         Rate forward,
+                         const std::vector<Real>& sabrParameters,
+                         const DayCounter& dc,
+                         Real shift = 0.0,
+                         VolatilityType volatilityType = VolatilityType::ShiftedLognormal);
+
         Real minStrike() const override { return -shift_; }
         Real maxStrike() const override { return QL_MAX_REAL; }
         Real atmLevel() const override { return forward_; }


### PR DESCRIPTION
This prevents the resulting object from recalculating when the evaluation date changes.