### PR TITLE
optimize close(), close_enough() functions

### DIFF
--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -57,6 +57,10 @@ namespace QuantLib {
     // inline definitions
 
     inline bool close(Real x, Real y) {
+        // we're duplicating the code here instead of calling close(x,y,42)
+        // for optimization; this allows us to make tolerance constexpr
+        // and shave a few more cycles.
+
         // Deals with +infinity and -infinity representations etc.
         if (x == y)
             return true;
@@ -86,6 +90,8 @@ namespace QuantLib {
     }
 
     inline bool close_enough(Real x, Real y) {
+        // see close() for a note on duplication
+
         // Deals with +infinity and -infinity representations etc.
         if (x == y)
             return true;

--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -57,7 +57,18 @@ namespace QuantLib {
     // inline definitions
 
     inline bool close(Real x, Real y) {
-        return close(x,y,42);
+        // Deals with +infinity and -infinity representations etc.
+        if (x == y)
+            return true;
+
+        Real diff = std::fabs(x-y);
+        constexpr tolerance = 42 * QL_EPSILON;
+
+        if (x == 0.0 || y == 0.0)
+            return diff < (tolerance * tolerance);
+
+        return diff <= tolerance*std::fabs(x) &&
+               diff <= tolerance*std::fabs(y);
     }
 
     inline bool close(Real x, Real y, Size n) {
@@ -67,7 +78,7 @@ namespace QuantLib {
 
         Real diff = std::fabs(x-y), tolerance = n * QL_EPSILON;
 
-        if (x * y == 0.0) // x or y = 0.0
+        if (x == 0.0 || y == 0.0)
             return diff < (tolerance * tolerance);
 
         return diff <= tolerance*std::fabs(x) &&
@@ -75,7 +86,18 @@ namespace QuantLib {
     }
 
     inline bool close_enough(Real x, Real y) {
-        return close_enough(x,y,42);
+        // Deals with +infinity and -infinity representations etc.
+        if (x == y)
+            return true;
+
+        Real diff = std::fabs(x-y);
+        constexpr Real tolerance = 42 * QL_EPSILON;
+
+        if (x == 0.0 || y == 0.0) // x or y = 0.0
+            return diff < (tolerance * tolerance);
+
+        return diff <= tolerance*std::fabs(x) ||
+               diff <= tolerance*std::fabs(y);
     }
 
     inline bool close_enough(Real x, Real y, Size n) {
@@ -85,7 +107,7 @@ namespace QuantLib {
 
         Real diff = std::fabs(x-y), tolerance = n * QL_EPSILON;
 
-        if (x * y == 0.0) // x or y = 0.0
+        if (x == 0.0 || y == 0.0)
             return diff < (tolerance * tolerance);
 
         return diff <= tolerance*std::fabs(x) ||

--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -62,7 +62,7 @@ namespace QuantLib {
             return true;
 
         Real diff = std::fabs(x-y);
-        constexpr tolerance = 42 * QL_EPSILON;
+        constexpr Real tolerance = 42 * QL_EPSILON;
 
         if (x == 0.0 || y == 0.0)
             return diff < (tolerance * tolerance);


### PR DESCRIPTION
This optimises the execution times of close() and close_enough() by
- avoiding to pass 42 to close() to evaluate close_enough()
- avoid multiplication to check if one input is zero

As for the second point see the generated code here https://godbolt.org/z/1a8xKvnfs, the multiplication in check() is relatively expensive. I double-checked this with the following test program
```
#include <boost/timer/timer.hpp>
#include <iostream>

bool check(double x, double y) {
  if (x * y == 0.0)
    return true;
  return false;
}

bool check2(double x, double y) {
  if (x == 0.0 || y == 0.0)
    return true;
  return false;
}

int main() {
  boost::timer::cpu_timer timer;
  std::size_t t = 0;
  for (std::size_t n = 0; n < 1E7; ++n) {
    if (check(n, n + 1)) {
      ++t;
    }
  }
  std::cout << "t=" << t << " mult timer " << timer.elapsed().wall << "\n";

  timer.start();
  t = 0;
  for (std::size_t n = 0; n < 1E7; ++n) {
    if (check2(n, n + 1)) {
      ++t;
    }
  }
  std::cout << "t=" << t << " comp timer " << timer.elapsed().wall << "\n";
}
```
yielding the following results on my mac book
```
closeenough clang++ test.cpp -o test -O3 -lboost_timer 
clang++ test.cpp -o test -O3 -lboost_timer 
closeenough ./test 
./test 
t=1 mult timer 10948243
t=1 comp timer 873409
```
or with avx2
```
closeenough clang++ test.cpp -o test -O3 -mavx2 -lboost_timer 
clang++ test.cpp -o test -O3 -mavx2 -lboost_timer 
closeenough ./test 
./test 
t=1 mult timer 5476684
t=1 comp timer 746246
```
I.e. avoiding the multiplication speeds up the comparison by 5x - 10x.