### PR TITLE
Consistent use of Real and Testing Macros

### DIFF
--- a/ql/math/comparison.hpp
+++ b/ql/math/comparison.hpp
@@ -66,7 +66,7 @@ namespace QuantLib {
             return true;
 
         Real diff = std::fabs(x-y);
-        constexpr Real tolerance = 42 * QL_EPSILON;
+        constexpr double tolerance = 42 * QL_EPSILON;
 
         if (x == 0.0 || y == 0.0)
             return diff < (tolerance * tolerance);
@@ -97,7 +97,7 @@ namespace QuantLib {
             return true;
 
         Real diff = std::fabs(x-y);
-        constexpr Real tolerance = 42 * QL_EPSILON;
+        constexpr double tolerance = 42 * QL_EPSILON;
 
         if (x == 0.0 || y == 0.0) // x or y = 0.0
             return diff < (tolerance * tolerance);

--- a/ql/termstructures/defaulttermstructure.hpp
+++ b/ql/termstructures/defaulttermstructure.hpp
@@ -219,7 +219,7 @@ namespace QuantLib {
    inline
     Rate DefaultProbabilityTermStructure::hazardRateImpl(Time t) const {
         Probability S = survivalProbability(t, true);
-        return S == 0.0 ? 0.0 : defaultDensity(t, true)/S;
+        return S == 0.0 ? Rate(0.0) : defaultDensity(t, true)/S;
     }
 
     inline Rate DefaultProbabilityTermStructure::hazardRate(Time t,

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -33,8 +33,8 @@
 namespace QuantLib {
 
     namespace detail {
-        constexpr Rate avgInflation = 0.02;
-        constexpr Rate maxInflation = 0.5;
+        constexpr double avgInflation = 0.02;
+        constexpr double maxInflation = 0.5;
     }
 
     //! Bootstrap traits to use for PiecewiseZeroInflationCurve

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -712,7 +712,7 @@ void CreditDefaultSwapTest::testIsdaEngine() {
                         .withSide(Protection::Buyer)
                         .withPricingEngine(engine);
 
-                BOOST_CHECK_SMALL(conventionalTradeBuy->NPV(), tolerance);
+                QL_CHECK_SMALL(conventionalTradeBuy->NPV(), tolerance);
 
                 ext::shared_ptr<CreditDefaultSwap> conventionalTradeSell =
                     MakeCreditDefaultSwap(termDate, 0.01)
@@ -721,7 +721,7 @@ void CreditDefaultSwapTest::testIsdaEngine() {
                         .withSide(Protection::Seller)
                         .withPricingEngine(engine);
 
-                BOOST_CHECK_SMALL(conventionalTradeSell->NPV(), tolerance);
+                QL_CHECK_SMALL(conventionalTradeSell->NPV(), tolerance);
 
                 l++;
             }
@@ -848,24 +848,25 @@ void CreditDefaultSwapTest::testIsdaCalculatorReconcileSingleQuote ()
             .withPricingEngine(engine);
 
 
-    double npv = conventionalTrade->NPV();
-    double calculated_upfront = conventionalTrade->notional() * conventionalTrade->fairUpfront();
-    double df = calculated_upfront / npv;  //to take into account of the discount to cash settlement
-    double derived_accrual = df * (npv -
+    Real npv = conventionalTrade->NPV();
+    Real calculated_upfront = conventionalTrade->notional() * conventionalTrade->fairUpfront();
+    Real df = calculated_upfront / npv; // to take into account of the discount to cash settlement
+    Real derived_accrual =
+        df * (npv -
                                    conventionalTrade->defaultLegNPV() -
                                    conventionalTrade->couponLegNPV());
 
-    double calculated_accrual = conventionalTrade->accrualRebate()->amount();
+    Real calculated_accrual = conventionalTrade->accrualRebate()->amount();
 
     auto settlement_date = conventionalTrade->accrualRebate()->date();
 
-    BOOST_CHECK_CLOSE(npv, markitValue, tolerance);
+    QL_CHECK_CLOSE(npv, markitValue, tolerance);
 
-    BOOST_CHECK_CLOSE(calculated_upfront, df*markitValue, tolerance);
+    QL_CHECK_CLOSE(calculated_upfront, df * markitValue, tolerance);
 
-    BOOST_CHECK_CLOSE(derived_accrual, expected_accrual, tolerance);
+    QL_CHECK_CLOSE(derived_accrual, expected_accrual, tolerance);
 
-    BOOST_CHECK_CLOSE(calculated_accrual, expected_accrual, tolerance);
+    QL_CHECK_CLOSE(calculated_accrual, expected_accrual, tolerance);
 
     BOOST_CHECK_EQUAL(settlement_date, WeekendsOnly().advance(tradeDate,3, TimeUnit::Days));
 
@@ -962,14 +963,14 @@ void CreditDefaultSwapTest::testIsdaCalculatorReconcileSingleWithIssueDateInTheP
             .withTradeDate(tradeDate);
 
 
-    double npv = conventionalTrade->NPV();
-    double calculated_accrual = npv -
+    Real npv = conventionalTrade->NPV();
+    Real calculated_accrual = npv -
                                 conventionalTrade->defaultLegNPV() -
                                 conventionalTrade->couponLegNPV();
 
-    BOOST_CHECK_CLOSE(npv, markitValue, tolerance);
+    QL_CHECK_CLOSE(npv, markitValue, tolerance);
 
-    BOOST_CHECK_CLOSE(calculated_accrual, expected_accrual, tolerance);
+    QL_CHECK_CLOSE(calculated_accrual, expected_accrual, tolerance);
 }
 
 test_suite* CreditDefaultSwapTest::suite() {


### PR DESCRIPTION
This PR fixes consistency issues with the use of `Real` and consistent use of the test comparison macros.