### PR TITLE
Add indexFixing method to indexed cashflows

### DIFF
--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -207,6 +207,15 @@ namespace QuantLib {
             return notional() * (I1 / I0);
     }
 
+    Real CPICashFlow::indexFixing() const {
+        if (observationDate_ != Date()) {
+            return CPI::laggedFixing(cpiIndex(), observationDate_, observationLag_, interpolation_);
+        } else {
+            // we get to this branch when the deprecated constructor was used; it will be phased out
+            return CPI::laggedFixing(cpiIndex(), fixingDate() + observationLag_, observationLag_,
+                                     interpolation_);
+        }
+    }
 
     CPILeg::CPILeg(const Schedule& schedule,
                    ext::shared_ptr<ZeroInflationIndex> index,

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -178,28 +178,7 @@ namespace QuantLib {
 
     Real CPICashFlow::amount() const {
         Real I0 = baseFixing();
-        Real I1;
-
-        if (observationDate_ != Date()) {
-            I1 = CPI::laggedFixing(cpiIndex(), observationDate_, observationLag_, interpolation_);
-        } else {
-            // we get to this branch when the deprecated constructor was used; it will be phased out
-            if (interpolation() == CPI::AsIndex ) {
-                I1 = index()->fixing(fixingDate());
-            } else {
-                std::pair<Date,Date> dd = inflationPeriod(fixingDate(), frequency());
-                Real indexStart = index()->fixing(dd.first);
-                if (interpolation() == CPI::Linear) {
-                    Real indexEnd = index()->fixing(dd.second+Period(1,Days));
-                    // linear interpolation
-                    I1 = indexStart + (indexEnd - indexStart) * (fixingDate() - dd.first)
-                        / ( (dd.second+Period(1,Days)) - dd.first);
-                } else {
-                    // no interpolation, i.e. flat = constant, so use start-of-period value
-                    I1 = indexStart;
-                }
-            }
-        }
+        Real I1 = indexFixing();
 
         if (growthOnly())
             return notional() * (I1 / I0 - 1.0);

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -176,16 +176,6 @@ namespace QuantLib {
         return baseFixing_;
     }
 
-    Real CPICashFlow::amount() const {
-        Real I0 = baseFixing();
-        Real I1 = indexFixing();
-
-        if (growthOnly())
-            return notional() * (I1 / I0 - 1.0);
-        else
-            return notional() * (I1 / I0);
-    }
-
     Real CPICashFlow::indexFixing() const {
         if (observationDate_ != Date()) {
             return CPI::laggedFixing(cpiIndex(), observationDate_, observationLag_, interpolation_);

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -191,6 +191,8 @@ namespace QuantLib {
 
         ext::shared_ptr<ZeroInflationIndex> cpiIndex() const;
 
+        virtual Real indexFixing() const override;
+
         //! redefined to use baseFixing() and interpolation
         Real amount() const override;
 

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -177,7 +177,7 @@ namespace QuantLib {
 
         //! value used on base date
         /*! This does not have to agree with index on that date. */
-        virtual Real baseFixing() const;
+        Real baseFixing() const override;
         //! you may not have a valid date
         Date baseDate() const override;
 
@@ -191,10 +191,7 @@ namespace QuantLib {
 
         ext::shared_ptr<ZeroInflationIndex> cpiIndex() const;
 
-        virtual Real indexFixing() const override;
-
-        //! redefined to use baseFixing() and interpolation
-        Real amount() const override;
+        Real indexFixing() const override;
 
       protected:
         Real baseFixing_;

--- a/ql/cashflows/indexedcashflow.cpp
+++ b/ql/cashflows/indexedcashflow.cpp
@@ -36,8 +36,8 @@ namespace QuantLib {
     }
 
     Real IndexedCashFlow::amount() const {
-        Real I0 = index_->fixing(baseDate_);
-        Real I1 = index_->fixing(fixingDate_);
+        Real I0 = baseFixing();
+        Real I1 = indexFixing();
 
         if (growthOnly_)
             return notional_ * (I1 / I0 - 1.0);

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2009 Chris Kenyon
+ Copyright (C) 2022 Quaternion Risk Management Ltd
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -59,6 +60,7 @@ namespace QuantLib {
         virtual Date fixingDate() const { return fixingDate_; }
         virtual ext::shared_ptr<Index> index() const { return index_; }
         virtual bool growthOnly() const { return growthOnly_; }
+        virtual Real indexFixing() const { return index_->fixing(fixingDate_); }
         //! \name CashFlow interface
         //@{
         Real amount() const override; // already virtual

--- a/ql/cashflows/indexedcashflow.hpp
+++ b/ql/cashflows/indexedcashflow.hpp
@@ -60,6 +60,7 @@ namespace QuantLib {
         virtual Date fixingDate() const { return fixingDate_; }
         virtual ext::shared_ptr<Index> index() const { return index_; }
         virtual bool growthOnly() const { return growthOnly_; }
+        virtual Real baseFixing() const { return index_->fixing(baseDate()); }
         virtual Real indexFixing() const { return index_->fixing(fixingDate_); }
         //! \name CashFlow interface
         //@{


### PR DESCRIPTION
Override the method for CPI Cashflows and take the interpolation and lagging into account