### PR TITLE
Convert argentina.cpp to utf-8 to appease clang-15

### DIFF
--- a/ql/time/calendars/argentina.cpp
+++ b/ql/time/calendars/argentina.cpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             || (d >= 15 && d <= 21 && w == Monday && m == June)
             // Independence Day
             || (d == 9 && m == July)
-            // Death of General José de San Martín
+            // Death of General JosÃ© de San MartÃ­n
             || (d >= 15 && d <= 21 && w == Monday && m == August)
             // Columbus Day
             || ((d == 10 || d == 11 || d == 12 || d == 15 || d == 16)


### PR DESCRIPTION
This is quite possibly the most inconsequential PR I ever made but hey -- so CRAN sent me a note to please update two packages re-using some of the QuantLib calendaring sources because `clang++-15` complains (as reported by R analysing the compiler messages)

```
    Found the following significant warnings:
     ql/time/calendars/argentina.cpp:52:36: warning: invalid UTF-8 in comment [-Winvalid-utf8]
     ql/time/calendars/argentina.cpp:52:49: warning: invalid UTF-8 in comment [-Winvalid-utf8]
```

The `file` command concurs (Ubuntu 22.04) here:

```
edd@rob:~/git/quantlib/ql/time/calendars(master)$ file argentina.*           # before
argentina.cpp: C++ source, ISO-8859 text
argentina.hpp: C++ source, Unicode text, UTF-8 text
edd@rob:~/git/quantlib/ql/time/calendars(master)$ file argentina.*           # after
argentina.cpp: C++ source, Unicode text, UTF-8 text
argentina.hpp: C++ source, Unicode text, UTF-8 text
edd@rob:~/git/quantlib/ql/time/calendars(master)$ 
```

As we can see the header file had already been taken care of, now the source file is too.

All it took was to take our 'preferred operating system' and C-x RET f RET selecing 'utf-8' as the encoding.  

No actual code changes.