### PR TITLE
Add King Charles III coronation holiday to UK calendar

### DIFF
--- a/ql/time/calendars/unitedkingdom.cpp
+++ b/ql/time/calendars/unitedkingdom.cpp
@@ -46,6 +46,8 @@ namespace QuantLib {
                 || (d == 29 && m == April && y == 2011)
                 // September 19th, 2022 only (The Queen's Funeral Bank Holiday)
                 || (d == 19 && m == September && y == 2022)
+                // May 8th, 2023 (King Charles III Coronation Bank Holiday)
+                || (d == 8 && m == May && y == 2023)
                 ;
         }
 

--- a/ql/time/calendars/unitedkingdom.hpp
+++ b/ql/time/calendars/unitedkingdom.hpp
@@ -78,6 +78,9 @@ namespace QuantLib {
             Tuesday)</li>
         </ul>
 
+        Note that there are some one-off holidays not listed above.
+        See the implementation for the complete list.
+
         \ingroup calendars
 
         \todo add LIFFE


### PR DESCRIPTION
Hi,
This bank holiday was announced Nov 6th, see press release: https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii.

Side note: These one-off holidays aren't in the docstring yet - maybe they should be added to a special listing?

Best,
Fredrik