### PR TITLE
Add holiday for National Day of Mourning to Australian calendar

### DIFF
--- a/ql/time/calendars/australia.cpp
+++ b/ql/time/calendars/australia.cpp
@@ -56,7 +56,9 @@ namespace QuantLib {
                 && m == December)
             // Boxing Day, December 26th (possibly Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
-                && m == December))
+                && m == December)
+            // National Day of Mourning for Her Majesty, September 22 (only 2022)
+            || (d == 22 && m == September && y == 2022))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }

--- a/ql/time/calendars/australia.hpp
+++ b/ql/time/calendars/australia.hpp
@@ -44,6 +44,7 @@ namespace QuantLib {
         <li>Christmas, December 25th (possibly moved to Monday or Tuesday)</li>
         <li>Boxing Day, December 26th (possibly moved to Monday or
             Tuesday)</li>
+        <li>National Day of Mourning for Her Majesty, September 22, 2022</li>
         </ul>
 
         \ingroup calendars


### PR DESCRIPTION
Hi,
This was announced sometime in September. ASX also confirmed being closed on the day. See notice here: https://asxonline.com/content/asxonline/public/notices/2022/september/0987.22.09.html

Best,
Fredrik