### PR TITLE
Make `Handle` default constructor non-explicit.

### DIFF
--- a/ql/handle.hpp
+++ b/ql/handle.hpp
@@ -73,7 +73,9 @@ namespace QuantLib {
                      destroyed before the pointed object does.
         */
         //@{
-        explicit Handle(const ext::shared_ptr<T>& p = ext::shared_ptr<T>(),
+        Handle()
+        : Handle(ext::shared_ptr<T>()) {}
+        explicit Handle(const ext::shared_ptr<T>& p,
                         bool registerAsObserver = true)
         : link_(new Link(p,registerAsObserver)) {}
         //@}

--- a/ql/indexes/bmaindex.hpp
+++ b/ql/indexes/bmaindex.hpp
@@ -39,8 +39,7 @@ namespace QuantLib {
     */
     class BMAIndex : public InterestRateIndex {
       public:
-        explicit BMAIndex(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+        explicit BMAIndex(const Handle<YieldTermStructure>& h = {});
         //! \name Index interface
         //@{
         /*! BMA is fixed weekly on Wednesdays.

--- a/ql/indexes/ibor/aonia.hpp
+++ b/ql/indexes/ibor/aonia.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     */
     class Aonia : public OvernightIndex {
       public:
-        explicit Aonia(const Handle<YieldTermStructure>& h =
-                              Handle<YieldTermStructure>())
+        explicit Aonia(const Handle<YieldTermStructure>& h = {})
         : OvernightIndex("Aonia", 0, AUDCurrency(),
                          Australia(),
                          Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/audlibor.hpp
+++ b/ql/indexes/ibor/audlibor.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     class AUDLibor : public Libor {
       public:
         AUDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                     Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("AUDLibor", tenor,
                 2,
                 AUDCurrency(),

--- a/ql/indexes/ibor/bbsw.hpp
+++ b/ql/indexes/ibor/bbsw.hpp
@@ -39,8 +39,7 @@ namespace QuantLib {
     class Bbsw : public IborIndex {
       public:
         Bbsw(const Period& tenor,
-             const Handle<YieldTermStructure>& h =
-                             Handle<YieldTermStructure>())
+             const Handle<YieldTermStructure>& h = {})
         : IborIndex("Bbsw", tenor,
                     0, // settlement days
                     AUDCurrency(), Australia(),
@@ -55,48 +54,42 @@ namespace QuantLib {
     //! 1-month %Bbsw index
     class Bbsw1M : public Bbsw {
       public:
-        explicit Bbsw1M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw1M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(1, Months), h) {}
     };
 
     //! 2-months %Bbsw index
     class Bbsw2M : public Bbsw {
       public:
-        explicit Bbsw2M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw2M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(2, Months), h) {}
     };
 
     //! 3-months %Bbsw index
     class Bbsw3M : public Bbsw {
       public:
-        explicit Bbsw3M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw3M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(3, Months), h) {}
     };
 
     //! 4-months %Bbsw index
     class Bbsw4M : public Bbsw {
       public:
-        explicit Bbsw4M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw4M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(4, Months), h) {}
     };
 
     //! 5-months %Bbsw index
     class Bbsw5M : public Bbsw {
       public:
-        explicit Bbsw5M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw5M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(5, Months), h) {}
     };
 
     //! 6-months %Bbsw index
     class Bbsw6M : public Bbsw {
       public:
-        explicit Bbsw6M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bbsw6M(const Handle<YieldTermStructure>& h = {})
         : Bbsw(Period(6, Months), h) {}
     };
 

--- a/ql/indexes/ibor/bibor.hpp
+++ b/ql/indexes/ibor/bibor.hpp
@@ -34,16 +34,14 @@ namespace QuantLib {
     class Bibor : public IborIndex {
       public:
         Bibor(const Period& tenor,
-                const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+              const Handle<YieldTermStructure>& h = {});
     };
 
 
     //! 1-week %Bibor index
     class BiborSW : public Bibor {
       public:
-        explicit BiborSW(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit BiborSW(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(1, Weeks), h) {}
     };
 
@@ -51,48 +49,42 @@ namespace QuantLib {
     //! 1-month %Euribor index
     class Bibor1M : public Bibor {
       public:
-        explicit Bibor1M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor1M(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(1, Months), h) {}
     };
 
     //! 2-months %Euribor index
     class Bibor2M : public Bibor {
       public:
-        explicit Bibor2M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor2M(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(2, Months), h) {}
     };
 
     //! 3-months %Bibor index
     class Bibor3M : public Bibor {
       public:
-        explicit Bibor3M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor3M(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(3, Months), h) {}
     };
 
     //! 6-months %Bibor index
     class Bibor6M : public Bibor {
       public:
-        explicit Bibor6M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor6M(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(6, Months), h) {}
     };
 
     //! 9-months %Bibor index
     class Bibor9M : public Bibor {
       public:
-        explicit Bibor9M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor9M(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(9, Months), h) {}
     };
 
     //! 1-year %Bibor index
     class Bibor1Y : public Bibor {
       public:
-        explicit Bibor1Y(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Bibor1Y(const Handle<YieldTermStructure>& h = {})
         : Bibor(Period(1, Years), h) {}
     };
 

--- a/ql/indexes/ibor/bkbm.hpp
+++ b/ql/indexes/ibor/bkbm.hpp
@@ -39,8 +39,7 @@ namespace QuantLib {
     class Bkbm : public IborIndex {
       public:
         Bkbm(const Period& tenor,
-             const Handle<YieldTermStructure>& h =
-                             Handle<YieldTermStructure>())
+             const Handle<YieldTermStructure>& h = {})
         : IborIndex("Bkbm", tenor,
                     0, // settlement days
                     NZDCurrency(), NewZealand(),
@@ -55,48 +54,42 @@ namespace QuantLib {
     //! 1-month %Bkbm index
     class Bkbm1M : public Bkbm {
       public:
-        explicit Bkbm1M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm1M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(1, Months), h) {}
     };
 
     //! 2-months %Bkbm index
     class Bkbm2M : public Bkbm {
       public:
-        explicit Bkbm2M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm2M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(2, Months), h) {}
     };
 
     //! 3-months %Bkbm index
     class Bkbm3M : public Bkbm {
       public:
-        explicit Bkbm3M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm3M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(3, Months), h) {}
     };
 
     //! 4-months %Bkbm index
     class Bkbm4M : public Bkbm {
       public:
-        explicit Bkbm4M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm4M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(4, Months), h) {}
     };
 
     //! 5-months %Bkbm index
     class Bkbm5M : public Bkbm {
       public:
-        explicit Bkbm5M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm5M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(5, Months), h) {}
     };
 
     //! 6-months %Bkbm index
     class Bkbm6M : public Bkbm {
       public:
-        explicit Bkbm6M(const Handle<YieldTermStructure>& h =
-                               Handle<YieldTermStructure>())
+        explicit Bkbm6M(const Handle<YieldTermStructure>& h = {})
         : Bkbm(Period(6, Months), h) {}
     };
 

--- a/ql/indexes/ibor/cadlibor.hpp
+++ b/ql/indexes/ibor/cadlibor.hpp
@@ -45,8 +45,7 @@ namespace QuantLib {
     class CADLibor : public Libor {
       public:
         CADLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("CADLibor", tenor,
                 0,
                 CADCurrency(),
@@ -57,8 +56,7 @@ namespace QuantLib {
     //! Overnight %CAD %Libor index
     class CADLiborON : public DailyTenorLibor {
       public:
-        explicit CADLiborON(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit CADLiborON(const Handle<YieldTermStructure>& h = {})
         : DailyTenorLibor("CADLibor",
                           0,
                           CADCurrency(),

--- a/ql/indexes/ibor/cdor.hpp
+++ b/ql/indexes/ibor/cdor.hpp
@@ -44,8 +44,7 @@ namespace QuantLib {
     class Cdor : public IborIndex {
       public:
         Cdor(const Period& tenor,
-             const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+             const Handle<YieldTermStructure>& h = {})
         : IborIndex("CDOR", tenor, 0, CADCurrency(),
                     Canada(), ModifiedFollowing, false,
                     Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/chflibor.hpp
+++ b/ql/indexes/ibor/chflibor.hpp
@@ -43,8 +43,7 @@ namespace QuantLib {
     class CHFLibor : public Libor {
       public:
         CHFLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("CHFLibor", tenor,
                 2,
                 CHFCurrency(),
@@ -56,8 +55,7 @@ namespace QuantLib {
     class DailyTenorCHFLibor : public DailyTenorLibor {
       public:
         DailyTenorCHFLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                           const Handle<YieldTermStructure>& h = {})
         : DailyTenorLibor("CHFLibor", settlementDays,
                           CHFCurrency(),
                           Switzerland(),

--- a/ql/indexes/ibor/dkklibor.hpp
+++ b/ql/indexes/ibor/dkklibor.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     class DKKLibor : public Libor {
       public:
         DKKLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("DKKLibor", tenor,
                 2,
                 DKKCurrency(),

--- a/ql/indexes/ibor/eonia.hpp
+++ b/ql/indexes/ibor/eonia.hpp
@@ -31,8 +31,7 @@ namespace QuantLib {
     //! %Eonia (Euro Overnight Index Average) rate fixed by the ECB.
     class Eonia : public OvernightIndex {
       public:
-        explicit Eonia(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+        explicit Eonia(const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/estr.hpp
+++ b/ql/indexes/ibor/estr.hpp
@@ -31,8 +31,7 @@ namespace QuantLib {
     //! %ESTR (Euro Short-Term Rate) rate fixed by the ECB.
     class Estr : public OvernightIndex {
       public:
-        explicit Estr(const Handle<YieldTermStructure>& h =
-                      Handle<YieldTermStructure>());
+        explicit Estr(const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/euribor.hpp
+++ b/ql/indexes/ibor/euribor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
     class Euribor : public IborIndex {
       public:
         Euribor(const Period& tenor,
-                const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                const Handle<YieldTermStructure>& h = {});
     };
 
     //! Actual/365 %Euribor index
@@ -54,127 +53,111 @@ namespace QuantLib {
     class Euribor365 : public IborIndex {
       public:
         Euribor365(const Period& tenor,
-                   const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                   const Handle<YieldTermStructure>& h = {});
     };
 
     //! 1-week %Euribor index
     class EuriborSW : public Euribor {
       public:
-        explicit EuriborSW(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EuriborSW(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(1, Weeks), h) {}
     };
 
     //! 2-weeks %Euribor index
     class Euribor2W : public Euribor {
       public:
-        explicit Euribor2W(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor2W(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(2, Weeks), h) {}
     };
 
     //! 3-weeks %Euribor index
     class Euribor3W : public Euribor {
       public:
-        explicit Euribor3W(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor3W(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(3, Weeks), h) {}
     };
 
     //! 1-month %Euribor index
     class Euribor1M : public Euribor {
       public:
-        explicit Euribor1M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor1M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(1, Months), h) {}
     };
 
     //! 2-months %Euribor index
     class Euribor2M : public Euribor {
       public:
-        explicit Euribor2M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor2M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(2, Months), h) {}
     };
 
     //! 3-months %Euribor index
     class Euribor3M : public Euribor {
       public:
-        explicit Euribor3M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor3M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(3, Months), h) {}
     };
 
     //! 4-months %Euribor index
     class Euribor4M : public Euribor {
       public:
-        explicit Euribor4M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor4M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(4, Months), h) {}
     };
 
     //! 5-months %Euribor index
     class Euribor5M : public Euribor {
       public:
-        explicit Euribor5M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor5M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(5, Months), h) {}
     };
 
     //! 6-months %Euribor index
     class Euribor6M : public Euribor {
       public:
-        explicit Euribor6M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor6M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(6, Months), h) {}
     };
 
     //! 7-months %Euribor index
     class Euribor7M : public Euribor {
       public:
-        explicit Euribor7M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor7M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(7, Months), h) {}
     };
 
     //! 8-months %Euribor index
     class Euribor8M : public Euribor {
       public:
-        explicit Euribor8M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor8M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(8, Months), h) {}
     };
 
     //! 9-months %Euribor index
     class Euribor9M : public Euribor {
       public:
-        explicit Euribor9M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor9M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(9, Months), h) {}
     };
 
     //! 10-months %Euribor index
     class Euribor10M : public Euribor {
       public:
-        explicit Euribor10M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor10M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(10, Months), h) {}
     };
 
     //! 11-months %Euribor index
     class Euribor11M : public Euribor {
       public:
-        explicit Euribor11M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor11M(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(11, Months), h) {}
     };
 
     //! 1-year %Euribor index
     class Euribor1Y : public Euribor {
       public:
-        explicit Euribor1Y(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor1Y(const Handle<YieldTermStructure>& h = {})
         : Euribor(Period(1, Years), h) {}
     };
 
@@ -182,120 +165,105 @@ namespace QuantLib {
     //! 1-week %Euribor365 index
     class Euribor365_SW : public Euribor365 {
       public:
-        explicit Euribor365_SW(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_SW(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(1, Weeks), h) {}
     };
 
     //! 2-weeks %Euribor365 index
     class Euribor365_2W : public Euribor365 {
       public:
-        explicit Euribor365_2W(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_2W(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(2, Weeks), h) {}
     };
 
     //! 3-weeks %Euribor365 index
     class Euribor365_3W : public Euribor365 {
       public:
-        explicit Euribor365_3W(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_3W(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(3, Weeks), h) {}
     };
 
     //! 1-month %Euribor365 index
     class Euribor365_1M : public Euribor365 {
       public:
-        explicit Euribor365_1M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_1M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(1, Months), h) {}
     };
 
     //! 2-months %Euribor365 index
     class Euribor365_2M : public Euribor365 {
       public:
-        explicit Euribor365_2M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_2M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(2, Months), h) {}
     };
 
     //! 3-months %Euribor365 index
     class Euribor365_3M : public Euribor365 {
       public:
-        explicit Euribor365_3M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_3M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(3, Months), h) {}
     };
 
     //! 4-months %Euribor365 index
     class Euribor365_4M : public Euribor365 {
       public:
-        explicit Euribor365_4M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_4M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(4, Months), h) {}
     };
 
     //! 5-months %Euribor365 index
     class Euribor365_5M : public Euribor365 {
       public:
-        explicit Euribor365_5M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_5M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(5, Months), h) {}
     };
 
     //! 6-months %Euribor365 index
     class Euribor365_6M : public Euribor365 {
       public:
-        explicit Euribor365_6M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_6M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(6, Months), h) {}
     };
 
     //! 7-months %Euribor365 index
     class Euribor365_7M : public Euribor365 {
       public:
-        explicit Euribor365_7M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_7M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(7, Months), h) {}
     };
 
     //! 8-months %Euribor365 index
     class Euribor365_8M : public Euribor365 {
       public:
-        explicit Euribor365_8M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_8M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(8, Months), h) {}
     };
 
     //! 9-months %Euribor365 index
     class Euribor365_9M : public Euribor365 {
       public:
-        explicit Euribor365_9M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_9M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(9, Months), h) {}
     };
 
     //! 10-months %Euribor365 index
     class Euribor365_10M : public Euribor365 {
       public:
-        explicit Euribor365_10M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_10M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(10, Months), h) {}
     };
 
     //! 11-months %Euribor365 index
     class Euribor365_11M : public Euribor365 {
       public:
-        explicit Euribor365_11M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_11M(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(11, Months), h) {}
     };
 
     //! 1-year %Euribor365 index
     class Euribor365_1Y : public Euribor365 {
       public:
-        explicit Euribor365_1Y(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit Euribor365_1Y(const Handle<YieldTermStructure>& h = {})
         : Euribor365(Period(1, Years), h) {}
     };
 

--- a/ql/indexes/ibor/eurlibor.hpp
+++ b/ql/indexes/ibor/eurlibor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
     class EURLibor : public IborIndex {
       public:
         EURLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                 const Handle<YieldTermStructure>& h = {});
         /*! \name Date calculations
 
             See <https://www.theice.com/marketdata/reports/170>.
@@ -68,31 +67,27 @@ namespace QuantLib {
     class DailyTenorEURLibor : public IborIndex {
       public:
         DailyTenorEURLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                           const Handle<YieldTermStructure>& h = {});
     };
 
     //! Overnight %EUR %Libor index
     class EURLiborON : public DailyTenorEURLibor {
       public:
-        explicit EURLiborON(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLiborON(const Handle<YieldTermStructure>& h = {})
         : DailyTenorEURLibor(0, h) {}
     };
 
     //! 1-week %EUR %Libor index
     class EURLiborSW : public EURLibor {
       public:
-        explicit EURLiborSW(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLiborSW(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(1, Weeks), h) {}
     };
 
     //! 2-weeks %EUR %Libor index
     class EURLibor2W : public EURLibor {
       public:
-        explicit EURLibor2W(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor2W(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(2, Weeks), h) {}
     };
 
@@ -100,96 +95,84 @@ namespace QuantLib {
     //! 1-month %EUR %Libor index
     class EURLibor1M : public EURLibor {
       public:
-        explicit EURLibor1M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor1M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(1, Months), h) {}
     };
 
     //! 2-months %EUR %Libor index
     class EURLibor2M : public EURLibor {
       public:
-        explicit EURLibor2M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor2M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(2, Months), h) {}
     };
 
     //! 3-months %EUR %Libor index
     class EURLibor3M : public EURLibor {
       public:
-        explicit EURLibor3M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor3M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(3, Months), h) {}
     };
 
     //! 4-months %EUR %Libor index
     class EURLibor4M : public EURLibor {
       public:
-        explicit EURLibor4M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor4M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(4, Months), h) {}
     };
 
     //! 5-months %EUR %Libor index
     class EURLibor5M : public EURLibor {
       public:
-        explicit EURLibor5M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor5M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(5, Months), h) {}
     };
 
     //! 6-months %EUR %Libor index
     class EURLibor6M : public EURLibor {
       public:
-        explicit EURLibor6M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor6M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(6, Months), h) {}
     };
 
     //! 7-months %EUR %Libor index
     class EURLibor7M : public EURLibor{
       public:
-        explicit EURLibor7M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor7M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(7, Months), h) {}
     };
 
     //! 8-months %EUR %Libor index
     class EURLibor8M : public EURLibor {
       public:
-        explicit EURLibor8M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor8M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(8, Months), h) {}
     };
 
     //! 9-months %EUR %Libor index
     class EURLibor9M : public EURLibor {
       public:
-        explicit EURLibor9M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor9M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(9, Months), h) {}
     };
 
     //! 10-months %EUR %Libor index
     class EURLibor10M : public EURLibor {
       public:
-        explicit EURLibor10M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor10M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(10, Months), h) {}
     };
 
     //! 11-months %EUR %Libor index
     class EURLibor11M : public EURLibor {
       public:
-        explicit EURLibor11M(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor11M(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(11, Months), h) {}
     };
 
     //! 1-year %EUR %Libor index
     class EURLibor1Y : public EURLibor {
       public:
-        explicit EURLibor1Y(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit EURLibor1Y(const Handle<YieldTermStructure>& h = {})
         : EURLibor(Period(1, Years), h) {}
     };
 

--- a/ql/indexes/ibor/fedfunds.hpp
+++ b/ql/indexes/ibor/fedfunds.hpp
@@ -32,8 +32,7 @@ namespace QuantLib {
     /*! (for balances held at the Federal Reserve) */
     class FedFunds : public OvernightIndex {
       public:
-        explicit FedFunds(const Handle<YieldTermStructure>& h =
-                                                Handle<YieldTermStructure>());
+        explicit FedFunds(const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/gbplibor.hpp
+++ b/ql/indexes/ibor/gbplibor.hpp
@@ -40,8 +40,7 @@ namespace QuantLib {
     class GBPLibor : public Libor {
       public:
         GBPLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("GBPLibor", tenor,
                 0,
                 GBPCurrency(),
@@ -53,8 +52,7 @@ namespace QuantLib {
     class DailyTenorGBPLibor : public DailyTenorLibor {
       public:
         DailyTenorGBPLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                           const Handle<YieldTermStructure>& h = {})
         : DailyTenorLibor("GBPLibor", settlementDays,
                           GBPCurrency(),
                           UnitedKingdom(UnitedKingdom::Exchange),
@@ -64,8 +62,7 @@ namespace QuantLib {
     //! Overnight %GBP %Libor index
     class GBPLiborON : public DailyTenorGBPLibor {
       public:
-        explicit GBPLiborON(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit GBPLiborON(const Handle<YieldTermStructure>& h = {})
         : DailyTenorGBPLibor(0, h) {}
     };
 

--- a/ql/indexes/ibor/jibar.hpp
+++ b/ql/indexes/ibor/jibar.hpp
@@ -40,8 +40,7 @@ namespace QuantLib {
     class Jibar : public IborIndex {
       public:
         Jibar(const Period& tenor,
-              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+              const Handle<YieldTermStructure>& h = {})
         : IborIndex("Jibar", tenor, 0, ZARCurrency(),
                 SouthAfrica(), ModifiedFollowing, false,
                 Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/jpylibor.hpp
+++ b/ql/indexes/ibor/jpylibor.hpp
@@ -44,8 +44,7 @@ namespace QuantLib {
     class JPYLibor : public Libor {
       public:
         JPYLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("JPYLibor", tenor,
                 2,
                 JPYCurrency(),
@@ -57,8 +56,7 @@ namespace QuantLib {
     class DailyTenorJPYLibor : public DailyTenorLibor {
       public:
         DailyTenorJPYLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                           const Handle<YieldTermStructure>& h = {})
         : DailyTenorLibor("JPYLibor", settlementDays,
                           JPYCurrency(),
                           Japan(),

--- a/ql/indexes/ibor/libor.hpp
+++ b/ql/indexes/ibor/libor.hpp
@@ -43,8 +43,7 @@ namespace QuantLib {
               const Currency& currency,
               const Calendar& financialCenterCalendar,
               const DayCounter& dayCounter,
-              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+              const Handle<YieldTermStructure>& h = {});
         /*! \name Date calculations
 
             See <https://www.theice.com/marketdata/reports/170>.
@@ -78,8 +77,7 @@ namespace QuantLib {
                         const Currency& currency,
                         const Calendar& financialCenterCalendar,
                         const DayCounter& dayCounter,
-                        const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                        const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/mosprime.hpp
+++ b/ql/indexes/ibor/mosprime.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
 	class Mosprime : public IborIndex {
 	public:
 		Mosprime(const Period& tenor,
-			const Handle<YieldTermStructure>& h =
-			Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
 			: IborIndex("MOSPRIME", tenor, (tenor == 1 * Days ? 0 : 1), RUBCurrency(),
 				Russia(), ModifiedFollowing, false,
 				ActualActual(ActualActual::ISDA), h) {}

--- a/ql/indexes/ibor/nzdlibor.hpp
+++ b/ql/indexes/ibor/nzdlibor.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     class NZDLibor : public Libor {
       public:
         NZDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("NZDLibor", tenor,
                 2,
                 NZDCurrency(),

--- a/ql/indexes/ibor/nzocr.hpp
+++ b/ql/indexes/ibor/nzocr.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     */
     class Nzocr : public OvernightIndex {
       public:
-        explicit Nzocr(const Handle<YieldTermStructure>& h =
-                              Handle<YieldTermStructure>())
+        explicit Nzocr(const Handle<YieldTermStructure>& h = {})
         : OvernightIndex("Nzocr", 0, NZDCurrency(),
                          NewZealand(),
                          Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/pribor.hpp
+++ b/ql/indexes/ibor/pribor.hpp
@@ -44,8 +44,7 @@ namespace QuantLib {
 	class Pribor : public IborIndex {
 	public:
 		Pribor(const Period& tenor,
-			const Handle<YieldTermStructure>& h =
-			Handle<YieldTermStructure>())
+               const Handle<YieldTermStructure>& h = {})
 			: IborIndex("PRIBOR", tenor, (tenor == 1 * Days ? 0 : 2), CZKCurrency(),
 				CzechRepublic(), ModifiedFollowing, false,
 				Actual360(), h) {}

--- a/ql/indexes/ibor/robor.hpp
+++ b/ql/indexes/ibor/robor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
 	class Robor : public IborIndex {
 	public:
 		Robor(const Period& tenor,
-			const Handle<YieldTermStructure>& h =
-			Handle<YieldTermStructure>())
+              const Handle<YieldTermStructure>& h = {})
 			: IborIndex("ROBOR", tenor, (tenor == 1 * Days ? 0 : 2), RONCurrency(),
 				Romania(), ModifiedFollowing, false,
 				Actual360(), h) {}

--- a/ql/indexes/ibor/seklibor.hpp
+++ b/ql/indexes/ibor/seklibor.hpp
@@ -39,8 +39,7 @@ namespace QuantLib {
     class SEKLibor : public Libor {
       public:
         SEKLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("SEKLibor", tenor,
                 2,
                 SEKCurrency(),

--- a/ql/indexes/ibor/shibor.hpp
+++ b/ql/indexes/ibor/shibor.hpp
@@ -32,7 +32,7 @@ namespace QuantLib {
       public:
         Shibor(
             const Period& tenor,
-            const Handle<YieldTermStructure>& h = Handle<YieldTermStructure>());
+            const Handle<YieldTermStructure>& h = {});
 
         ext::shared_ptr<IborIndex>
         clone(const Handle<YieldTermStructure>& forwarding) const override;

--- a/ql/indexes/ibor/sofr.hpp
+++ b/ql/indexes/ibor/sofr.hpp
@@ -31,8 +31,7 @@ namespace QuantLib {
     //! %Sofr (Secured Overnight Financing Rate) index.
     class Sofr : public OvernightIndex {
       public:
-        explicit Sofr(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+        explicit Sofr(const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/sonia.hpp
+++ b/ql/indexes/ibor/sonia.hpp
@@ -31,8 +31,7 @@ namespace QuantLib {
     //! %Sonia (Sterling Overnight Index Average) rate.
     class Sonia : public OvernightIndex {
       public:
-        explicit Sonia(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+        explicit Sonia(const Handle<YieldTermStructure>& h = {});
     };
 
 }

--- a/ql/indexes/ibor/thbfix.hpp
+++ b/ql/indexes/ibor/thbfix.hpp
@@ -53,8 +53,7 @@ namespace QuantLib {
     class THBFIX : public IborIndex {
       public:
         THBFIX(const Period& tenor,
-               const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+               const Handle<YieldTermStructure>& h = {})
         : IborIndex("THBFIX", tenor,
                     2,
                     THBCurrency(),

--- a/ql/indexes/ibor/tibor.hpp
+++ b/ql/indexes/ibor/tibor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
     class Tibor : public IborIndex {
       public:
         Tibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+              const Handle<YieldTermStructure>& h = {})
         : IborIndex("Tibor", tenor, 2, JPYCurrency(),
                     Japan(), ModifiedFollowing,
                     false, Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/tona.hpp
+++ b/ql/indexes/ibor/tona.hpp
@@ -38,8 +38,7 @@ namespace QuantLib {
     */
     class Tona : public OvernightIndex {
       public:
-        explicit Tona(const Handle<YieldTermStructure>& h =
-                              Handle<YieldTermStructure>())
+        explicit Tona(const Handle<YieldTermStructure>& h = {})
         : OvernightIndex("Tona", 0, JPYCurrency(),
                          Japan(),
                          Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/trlibor.hpp
+++ b/ql/indexes/ibor/trlibor.hpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     class TRLibor : public IborIndex {
       public:
         TRLibor(const Period& tenor,
-                const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                const Handle<YieldTermStructure>& h = {})
         : IborIndex("TRLibor", tenor, 0, TRYCurrency(),
                     Turkey(), ModifiedFollowing, false,
                     Actual360(), h) {}

--- a/ql/indexes/ibor/usdlibor.hpp
+++ b/ql/indexes/ibor/usdlibor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
     class USDLibor : public Libor {
       public:
         USDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                 const Handle<YieldTermStructure>& h = {})
         : Libor("USDLibor", tenor,
                 2,
                 USDCurrency(),
@@ -55,8 +54,7 @@ namespace QuantLib {
     class DailyTenorUSDLibor : public DailyTenorLibor {
       public:
         DailyTenorUSDLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+                           const Handle<YieldTermStructure>& h = {})
         : DailyTenorLibor("USDLibor", settlementDays,
                           USDCurrency(),
                           UnitedStates(UnitedStates::LiborImpact),
@@ -66,8 +64,7 @@ namespace QuantLib {
     //! Overnight %USD %Libor index
     class USDLiborON : public DailyTenorUSDLibor {
       public:
-        explicit USDLiborON(const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+        explicit USDLiborON(const Handle<YieldTermStructure>& h = {})
         : DailyTenorUSDLibor(0, h) {}
     };
 }

--- a/ql/indexes/ibor/wibor.hpp
+++ b/ql/indexes/ibor/wibor.hpp
@@ -42,8 +42,7 @@ namespace QuantLib {
 	class Wibor : public IborIndex {
 	public:
 		Wibor(const Period& tenor,
-			const Handle<YieldTermStructure>& h =
-			Handle<YieldTermStructure>())
+              const Handle<YieldTermStructure>& h = {})
 			: IborIndex("WIBOR", tenor, (tenor == 1 * Days ? 0 : 2), PLNCurrency(),
 				Poland(), ModifiedFollowing, false,
 				Actual365Fixed(), h) {}

--- a/ql/indexes/ibor/zibor.hpp
+++ b/ql/indexes/ibor/zibor.hpp
@@ -43,8 +43,7 @@ namespace QuantLib {
     class Zibor : public IborIndex {
       public:
         Zibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>())
+              const Handle<YieldTermStructure>& h = {})
         : IborIndex("Zibor", tenor, 2, CHFCurrency(),
                 Switzerland(), ModifiedFollowing, false,
                 Actual360(), h) {}

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                   BusinessDayConvention convention,
                   bool endOfMonth,
                   const DayCounter& dayCounter,
-                  Handle<YieldTermStructure> h = Handle<YieldTermStructure>());
+                  Handle<YieldTermStructure> h = {});
         //! \name InterestRateIndex interface
         //@{
         Date maturityDate(const Date& valueDate) const override;
@@ -92,8 +92,7 @@ namespace QuantLib {
                        const Currency& currency,
                        const Calendar& fixingCalendar,
                        const DayCounter& dayCounter,
-                       const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                       const Handle<YieldTermStructure>& h = {});
         //! returns a copy of itself linked to a different forwarding curve
         ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
     };

--- a/ql/indexes/swap/chfliborswap.hpp
+++ b/ql/indexes/swap/chfliborswap.hpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     class ChfLiborSwapIsdaFix : public SwapIndex {
       public:
         ChfLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                            const Handle<YieldTermStructure>& h = {});
         ChfLiborSwapIsdaFix(const Period& tenor,
                             const Handle<YieldTermStructure>& forwarding,
                             const Handle<YieldTermStructure>& discounting);

--- a/ql/indexes/swap/euriborswap.hpp
+++ b/ql/indexes/swap/euriborswap.hpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     class EuriborSwapIsdaFixA : public SwapIndex {
       public:
         EuriborSwapIsdaFixA(const Period& tenor,
-                            const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                            const Handle<YieldTermStructure>& h = {});
         EuriborSwapIsdaFixA(const Period& tenor,
                             const Handle<YieldTermStructure>& forwarding,
                             const Handle<YieldTermStructure>& discounting);
@@ -61,8 +60,7 @@ namespace QuantLib {
     class EuriborSwapIsdaFixB : public SwapIndex {
       public:
         EuriborSwapIsdaFixB(const Period& tenor,
-                            const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                            const Handle<YieldTermStructure>& h = {});
         EuriborSwapIsdaFixB(const Period& tenor,
                             const Handle<YieldTermStructure>& forwarding,
                             const Handle<YieldTermStructure>& discounting);
@@ -78,8 +76,7 @@ namespace QuantLib {
     class EuriborSwapIfrFix : public SwapIndex {
       public:
         EuriborSwapIfrFix(const Period& tenor,
-                          const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                          const Handle<YieldTermStructure>& h = {});
         EuriborSwapIfrFix(const Period& tenor,
                           const Handle<YieldTermStructure>& forwarding,
                           const Handle<YieldTermStructure>& discounting);

--- a/ql/indexes/swap/eurliborswap.hpp
+++ b/ql/indexes/swap/eurliborswap.hpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     class EurLiborSwapIsdaFixA : public SwapIndex {
       public:
         EurLiborSwapIsdaFixA(const Period& tenor,
-                             const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                             const Handle<YieldTermStructure>& h = {});
         EurLiborSwapIsdaFixA(const Period& tenor,
                              const Handle<YieldTermStructure>& forwarding,
                              const Handle<YieldTermStructure>& discounting);
@@ -61,8 +60,7 @@ namespace QuantLib {
     class EurLiborSwapIsdaFixB : public SwapIndex {
       public:
         EurLiborSwapIsdaFixB(const Period& tenor,
-                             const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                             const Handle<YieldTermStructure>& h = {});
         EurLiborSwapIsdaFixB(const Period& tenor,
                              const Handle<YieldTermStructure>& forwarding,
                              const Handle<YieldTermStructure>& discounting);
@@ -79,8 +77,7 @@ namespace QuantLib {
     class EurLiborSwapIfrFix : public SwapIndex {
       public:
         EurLiborSwapIfrFix(const Period& tenor,
-                           const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                           const Handle<YieldTermStructure>& h = {});
         EurLiborSwapIfrFix(const Period& tenor,
                            const Handle<YieldTermStructure>& forwarding,
                            const Handle<YieldTermStructure>& discounting);

--- a/ql/indexes/swap/gbpliborswap.hpp
+++ b/ql/indexes/swap/gbpliborswap.hpp
@@ -41,8 +41,7 @@ namespace QuantLib {
     class GbpLiborSwapIsdaFix : public SwapIndex {
       public:
         GbpLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                            const Handle<YieldTermStructure>& h = {});
         GbpLiborSwapIsdaFix(const Period& tenor,
                             const Handle<YieldTermStructure>& forwarding,
                             const Handle<YieldTermStructure>& discounting);

--- a/ql/indexes/swap/jpyliborswap.hpp
+++ b/ql/indexes/swap/jpyliborswap.hpp
@@ -40,11 +40,10 @@ namespace QuantLib {
     class JpyLiborSwapIsdaFixAm : public SwapIndex {
       public:
         JpyLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                              const Handle<YieldTermStructure>& h = {});
         JpyLiborSwapIsdaFixAm(const Period& tenor,
                               const Handle<YieldTermStructure>& forwarding,
-                             const Handle<YieldTermStructure>& discounting);
+                              const Handle<YieldTermStructure>& discounting);
     };
 
     //! %JpyLiborSwapIsdaFixPm index base class
@@ -59,11 +58,10 @@ namespace QuantLib {
     class JpyLiborSwapIsdaFixPm : public SwapIndex {
       public:
         JpyLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                              const Handle<YieldTermStructure>& h = {});
         JpyLiborSwapIsdaFixPm(const Period& tenor,
                               const Handle<YieldTermStructure>& forwarding,
-                             const Handle<YieldTermStructure>& discounting);
+                              const Handle<YieldTermStructure>& discounting);
     };
 
 }

--- a/ql/indexes/swap/usdliborswap.hpp
+++ b/ql/indexes/swap/usdliborswap.hpp
@@ -40,8 +40,7 @@ namespace QuantLib {
     class UsdLiborSwapIsdaFixAm : public SwapIndex {
       public:
         UsdLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                              const Handle<YieldTermStructure>& h = {});
         UsdLiborSwapIsdaFixAm(const Period& tenor,
                               const Handle<YieldTermStructure>& forwarding,
                               const Handle<YieldTermStructure>& discounting);
@@ -59,8 +58,7 @@ namespace QuantLib {
     class UsdLiborSwapIsdaFixPm : public SwapIndex {
       public:
         UsdLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h =
-                                    Handle<YieldTermStructure>());
+                              const Handle<YieldTermStructure>& h = {});
         UsdLiborSwapIsdaFixPm(const Period& tenor,
                               const Handle<YieldTermStructure>& forwarding,
                               const Handle<YieldTermStructure>& discounting);

--- a/ql/termstructures/credit/defaultdensitystructure.hpp
+++ b/ql/termstructures/credit/defaultdensitystructure.hpp
@@ -49,20 +49,20 @@ namespace QuantLib {
         //@{
         DefaultDensityStructure(
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         DefaultDensityStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         DefaultDensityStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
       protected:
         //! \name DefaultProbabilityTermStructure implementation

--- a/ql/termstructures/credit/hazardratestructure.hpp
+++ b/ql/termstructures/credit/hazardratestructure.hpp
@@ -54,20 +54,20 @@ namespace QuantLib {
         //@{
         HazardRateStructure(
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         HazardRateStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         HazardRateStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
       protected:
         /*! \name Calculations

--- a/ql/termstructures/credit/interpolateddefaultdensitycurve.hpp
+++ b/ql/termstructures/credit/interpolateddefaultdensitycurve.hpp
@@ -44,10 +44,9 @@ namespace QuantLib {
             const std::vector<Real>& densities,
             const DayCounter& dayCounter,
             const Calendar& calendar = Calendar(),
-            const std::vector<Handle<Quote> >& jumps =
-                                                std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedDefaultDensityCurve(
             const std::vector<Date>& dates,
             const std::vector<Real>& densities,
@@ -74,22 +73,22 @@ namespace QuantLib {
       protected:
         InterpolatedDefaultDensityCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedDefaultDensityCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedDefaultDensityCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         //! \name DefaultDensityStructure implementation
         //@{
         Real defaultDensityImpl(Time) const override;

--- a/ql/termstructures/credit/interpolatedhazardratecurve.hpp
+++ b/ql/termstructures/credit/interpolatedhazardratecurve.hpp
@@ -45,10 +45,9 @@ namespace QuantLib {
             const std::vector<Rate>& hazardRates,
             const DayCounter& dayCounter,
             const Calendar& cal = Calendar(),
-            const std::vector<Handle<Quote> >& jumps =
-                                                std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedHazardRateCurve(
             const std::vector<Date>& dates,
             const std::vector<Rate>& hazardRates,
@@ -75,22 +74,22 @@ namespace QuantLib {
       protected:
         InterpolatedHazardRateCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedHazardRateCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedHazardRateCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         //! \name DefaultProbabilityTermStructure implementation
         //@{
         Real hazardRateImpl(Time) const override;

--- a/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
+++ b/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
@@ -42,9 +42,9 @@ namespace QuantLib {
             const std::vector<Probability>& probabilities,
             const DayCounter& dayCounter,
             const Calendar& calendar = Calendar(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedSurvivalProbabilityCurve(
             const std::vector<Date>& dates,
             const std::vector<Probability>& probabilities,
@@ -71,22 +71,22 @@ namespace QuantLib {
       protected:
         InterpolatedSurvivalProbabilityCurve(
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedSurvivalProbabilityCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedSurvivalProbabilityCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         //! \name DefaultProbabilityTermStructure implementation
         //@{
         Probability survivalProbabilityImpl(Time) const override;

--- a/ql/termstructures/credit/piecewisedefaultcurve.hpp
+++ b/ql/termstructures/credit/piecewisedefaultcurve.hpp
@@ -69,10 +69,10 @@ namespace QuantLib {
             const Date& referenceDate,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             const DayCounter& dayCounter,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& i = Interpolator(),
-            bootstrap_type bootstrap = bootstrap_type())
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& i = {},
+            bootstrap_type bootstrap = {})
         : base_curve(referenceDate, dayCounter, jumps, jumpDates, i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
@@ -87,7 +87,7 @@ namespace QuantLib {
                const Interpolator& i,
                const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(referenceDate, dayCounter,
-                     std::vector<Handle<Quote> >(), std::vector<Date>(), i),
+                     {}, {}, i),
           instruments_(instruments), accuracy_(1.0e-12), bootstrap_(bootstrap) {
             bootstrap_.setup(this);
         }
@@ -97,10 +97,7 @@ namespace QuantLib {
                               const DayCounter& dayCounter,
                               bootstrap_type bootstrap)
         : base_curve(referenceDate,
-                     dayCounter,
-                     std::vector<Handle<Quote> >(),
-                     std::vector<Date>(),
-                     Interpolator()),
+                     dayCounter),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
             bootstrap_.setup(this);
@@ -111,10 +108,10 @@ namespace QuantLib {
             const Calendar& calendar,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             const DayCounter& dayCounter,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& i = Interpolator(),
-            bootstrap_type bootstrap = bootstrap_type())
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& i = {},
+            bootstrap_type bootstrap = {})
         : base_curve(settlementDays, calendar, dayCounter, jumps, jumpDates, i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
@@ -130,7 +127,7 @@ namespace QuantLib {
                const Interpolator& i,
                const bootstrap_type& bootstrap = bootstrap_type())
         : base_curve(settlementDays, calendar, dayCounter,
-                     std::vector<Handle<Quote> >(), std::vector<Date>(), i),
+                     {}, {}, i),
           instruments_(instruments), accuracy_(1.0e-12), bootstrap_(bootstrap) {
             bootstrap_.setup(this);
         }
@@ -142,9 +139,7 @@ namespace QuantLib {
                                                                   instruments,
                const DayCounter& dayCounter,
                const bootstrap_type& bootstrap)
-        : base_curve(settlementDays, calendar, dayCounter,
-                     std::vector<Handle<Quote> >(), std::vector<Date>(),
-                     Interpolator()),
+        : base_curve(settlementDays, calendar, dayCounter),
           instruments_(instruments), accuracy_(1.0e-12), bootstrap_(bootstrap) {
             bootstrap_.setup(this);
         }
@@ -164,13 +159,13 @@ namespace QuantLib {
             const std::vector<ext::shared_ptr<typename Traits::helper> >& instruments,
             const DayCounter& dayCounter,
             const ext::shared_ptr<OneFactorAffineModel>& model,
-            const Interpolator& i = Interpolator(),
-            const bootstrap_type& bootstrap = bootstrap_type())
+            const Interpolator& i = {},
+            const bootstrap_type& bootstrap = {})
         : base_curve(referenceDate,
                      dayCounter,
                      model,
-                     std::vector<Handle<Quote> >(),
-                     std::vector<Date>(),
+                     {},
+                     {},
                      i),
           instruments_(instruments), accuracy_(1.0e-12), bootstrap_(bootstrap) {
             bootstrap_.setup(this);

--- a/ql/termstructures/credit/survivalprobabilitystructure.hpp
+++ b/ql/termstructures/credit/survivalprobabilitystructure.hpp
@@ -49,20 +49,20 @@ namespace QuantLib {
         //@{
         SurvivalProbabilityStructure(
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         SurvivalProbabilityStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         SurvivalProbabilityStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
       protected:
         //! \name DefaultProbabilityTermStructure implementation

--- a/ql/termstructures/defaulttermstructure.hpp
+++ b/ql/termstructures/defaulttermstructure.hpp
@@ -47,20 +47,20 @@ namespace QuantLib {
         //@{
         DefaultProbabilityTermStructure(
             const DayCounter& dc = DayCounter(),
-            std::vector<Handle<Quote> > jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            std::vector<Handle<Quote> > jumps = {},
+            const std::vector<Date>& jumpDates = {});
         DefaultProbabilityTermStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dc = DayCounter(),
-            std::vector<Handle<Quote> > jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            std::vector<Handle<Quote> > jumps = {},
+            const std::vector<Date>& jumpDates = {});
         DefaultProbabilityTermStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dc = DayCounter(),
-            std::vector<Handle<Quote> > jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            std::vector<Handle<Quote> > jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
 
         /*! \name Survival probabilities

--- a/ql/termstructures/volatility/optionlet/optionletstripper.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper.hpp
@@ -68,7 +68,7 @@ namespace QuantLib {
       protected:
         OptionletStripper(const ext::shared_ptr<CapFloorTermVolSurface>&,
                           ext::shared_ptr<IborIndex> iborIndex_,
-                          Handle<YieldTermStructure> discount = Handle<YieldTermStructure>(),
+                          Handle<YieldTermStructure> discount = {},
                           VolatilityType type = ShiftedLognormal,
                           Real displacement = 0.0);
         ext::shared_ptr<CapFloorTermVolSurface> termVolSurface_;

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
             Rate switchStrikes = Null<Rate>(),
             Real accuracy = 1.0e-6,
             Natural maxIter = 100,
-            const Handle<YieldTermStructure>& discount = Handle<YieldTermStructure>(),
+            const Handle<YieldTermStructure>& discount = {},
             VolatilityType type = ShiftedLognormal,
             Real displacement = 0.0,
             bool dontThrow = false);

--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -47,9 +47,9 @@ namespace QuantLib {
             const std::vector<DiscountFactor>& dfs,
             const DayCounter& dayCounter,
             const Calendar& cal = Calendar(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedDiscountCurve(
             const std::vector<Date>& dates,
             const std::vector<DiscountFactor>& dfs,
@@ -77,20 +77,20 @@ namespace QuantLib {
       protected:
         explicit InterpolatedDiscountCurve(
             const DayCounter&,
-            const Interpolator& interpolator = Interpolator());
+            const Interpolator& interpolator = {});
         InterpolatedDiscountCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedDiscountCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
 
         //! \name YieldTermStructure implementation
         //@{

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -46,10 +46,9 @@ namespace QuantLib {
             const std::vector<Rate>& forwards,
             const DayCounter& dayCounter,
             const Calendar& cal = Calendar(),
-            const std::vector<Handle<Quote> >& jumps =
-                                                std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedForwardCurve(
             const std::vector<Date>& dates,
             const std::vector<Rate>& forwards,
@@ -77,20 +76,20 @@ namespace QuantLib {
       protected:
         explicit InterpolatedForwardCurve(
             const DayCounter&,
-            const Interpolator& interpolator = Interpolator());
+            const Interpolator& interpolator = {});
         InterpolatedForwardCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedForwardCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
 
         //! \name ForwardRateStructure implementation
         //@{

--- a/ql/termstructures/yield/forwardstructure.hpp
+++ b/ql/termstructures/yield/forwardstructure.hpp
@@ -54,14 +54,14 @@ namespace QuantLib {
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         ForwardRateStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dayCounter = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
       protected:
         /*! \name Calculations

--- a/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
+++ b/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
@@ -43,9 +43,9 @@ class InterpolatedSimpleZeroCurve : public YieldTermStructure, protected Interpo
     // constructor
     InterpolatedSimpleZeroCurve(const std::vector<Date> &dates, const std::vector<Rate> &yields,
                                 const DayCounter &dayCounter, const Calendar &calendar = Calendar(),
-                                const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
-                                const std::vector<Date> &jumpDates = std::vector<Date>(),
-                                const Interpolator &interpolator = Interpolator());
+                                const std::vector<Handle<Quote> > &jumps = {},
+                                const std::vector<Date> &jumpDates = {},
+                                const Interpolator &interpolator = {});
     InterpolatedSimpleZeroCurve(const std::vector<Date> &dates, const std::vector<Rate> &yields,
                                 const DayCounter &dayCounter, const Calendar &calendar,
                                 const Interpolator &interpolator);
@@ -65,15 +65,15 @@ class InterpolatedSimpleZeroCurve : public YieldTermStructure, protected Interpo
     //@}
   protected:
     explicit InterpolatedSimpleZeroCurve(const DayCounter &,
-                                         const Interpolator &interpolator = Interpolator());
+                                         const Interpolator &interpolator = {});
     InterpolatedSimpleZeroCurve(const Date &referenceDate, const DayCounter &,
-                                const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
-                                const std::vector<Date> &jumpDates = std::vector<Date>(),
-                                const Interpolator &interpolator = Interpolator());
+                                const std::vector<Handle<Quote> > &jumps = {},
+                                const std::vector<Date> &jumpDates = {},
+                                const Interpolator &interpolator = {});
     InterpolatedSimpleZeroCurve(Natural settlementDays, const Calendar &, const DayCounter &,
-                                const std::vector<Handle<Quote> > &jumps = std::vector<Handle<Quote> >(),
-                                const std::vector<Date> &jumpDates = std::vector<Date>(),
-                                const Interpolator &interpolator = Interpolator());
+                                const std::vector<Handle<Quote> > &jumps = {},
+                                const std::vector<Date> &jumpDates = {},
+                                const Interpolator &interpolator = {});
 
     //! \name YieldTermStructure implementation
     //@{

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -38,7 +38,7 @@ namespace QuantLib {
                       const Handle<Quote>& fixedRate,
                       ext::shared_ptr<OvernightIndex> overnightIndex,
                       // exogenous discounting curve
-                      Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+                      Handle<YieldTermStructure> discountingCurve = {},
                       bool telescopicValueDates = false,
                       Natural paymentLag = 0,
                       BusinessDayConvention paymentConvention = Following,
@@ -97,7 +97,7 @@ namespace QuantLib {
             const Handle<Quote>& fixedRate,
             const ext::shared_ptr<OvernightIndex>& overnightIndex,
             // exogenous discounting curve
-            Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+            Handle<YieldTermStructure> discountingCurve = {},
             bool telescopicValueDates = false,
             RateAveraging::Type averagingMethod = RateAveraging::Compound);
         //! \name RateHelper interface

--- a/ql/termstructures/yield/overnightindexfutureratehelper.hpp
+++ b/ql/termstructures/yield/overnightindexfutureratehelper.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
                                        // delivery date
                                        const Date& maturityDate,
                                        const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                                       const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+                                       const Handle<Quote>& convexityAdjustment = {},
                                        RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         //! \name RateHelper interface
@@ -76,7 +76,7 @@ namespace QuantLib {
                              Year referenceYear,
                              Frequency referenceFreq,
                              const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                             const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+                             const Handle<Quote>& convexityAdjustment = {},
                              RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
         /*! \deprecated Use the constructor without index and averaging method.
@@ -95,7 +95,7 @@ namespace QuantLib {
                              Month referenceMonth,
                              Year referenceYear,
                              Frequency referenceFreq,
-                             const Handle<Quote>& convexityAdjustment = Handle<Quote>());
+                             const Handle<Quote>& convexityAdjustment = {});
 
         SofrFutureRateHelper(Real price,
                              Month referenceMonth,

--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -76,10 +76,10 @@ namespace QuantLib {
             const Date& referenceDate,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             const DayCounter& dayCounter,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& i = Interpolator(),
-            bootstrap_type bootstrap = bootstrap_type())
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& i = {},
+            bootstrap_type bootstrap = {})
         : base_curve(referenceDate, dayCounter, jumps, jumpDates, i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
@@ -92,7 +92,7 @@ namespace QuantLib {
                             const Interpolator& i,
                             bootstrap_type bootstrap = bootstrap_type())
         : base_curve(
-              referenceDate, dayCounter, std::vector<Handle<Quote> >(), std::vector<Date>(), i),
+              referenceDate, dayCounter, {}, {}, i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
             bootstrap_.setup(this);
@@ -103,10 +103,7 @@ namespace QuantLib {
                             const DayCounter& dayCounter,
                             bootstrap_type bootstrap)
         : base_curve(referenceDate,
-                     dayCounter,
-                     std::vector<Handle<Quote> >(),
-                     std::vector<Date>(),
-                     Interpolator()),
+                     dayCounter),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
             bootstrap_.setup(this);
@@ -117,10 +114,10 @@ namespace QuantLib {
             const Calendar& calendar,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             const DayCounter& dayCounter,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& i = Interpolator(),
-            bootstrap_type bootstrap = bootstrap_type())
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& i = {},
+            bootstrap_type bootstrap = {})
         : base_curve(settlementDays, calendar, dayCounter, jumps, jumpDates, i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
@@ -136,8 +133,8 @@ namespace QuantLib {
         : base_curve(settlementDays,
                      calendar,
                      dayCounter,
-                     std::vector<Handle<Quote> >(),
-                     std::vector<Date>(),
+                     {},
+                     {},
                      i),
           instruments_(std::move(instruments)), accuracy_(1.0e-12),
           bootstrap_(std::move(bootstrap)) {
@@ -151,9 +148,7 @@ namespace QuantLib {
                                                                   instruments,
                const DayCounter& dayCounter,
                const bootstrap_type& bootstrap)
-        : base_curve(settlementDays, calendar, dayCounter,
-                     std::vector<Handle<Quote> >(), std::vector<Date>(),
-                     Interpolator()),
+        : base_curve(settlementDays, calendar, dayCounter),
           instruments_(instruments),
           accuracy_(1.0e-12), bootstrap_(bootstrap) {
             bootstrap_.setup(this);

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
                           BusinessDayConvention convention,
                           bool endOfMonth,
                           const DayCounter& dayCounter,
-                          Handle<Quote> convexityAdjustment = Handle<Quote>(),
+                          Handle<Quote> convexityAdjustment = {},
                           Futures::Type type = Futures::IMM);
         FuturesRateHelper(Real price,
                           const Date& iborStartDate,
@@ -74,7 +74,7 @@ namespace QuantLib {
                           const Date& iborStartDate,
                           const Date& iborEndDate,
                           const DayCounter& dayCounter,
-                          Handle<Quote> convexityAdjustment = Handle<Quote>(),
+                          Handle<Quote> convexityAdjustment = {},
                           Futures::Type type = Futures::IMM);
         FuturesRateHelper(Real price,
                           const Date& iborStartDate,
@@ -85,7 +85,7 @@ namespace QuantLib {
         FuturesRateHelper(const Handle<Quote>& price,
                           const Date& iborStartDate,
                           const ext::shared_ptr<IborIndex>& iborIndex,
-                          const Handle<Quote>& convexityAdjustment = Handle<Quote>(),
+                          const Handle<Quote>& convexityAdjustment = {},
                           Futures::Type type = Futures::IMM);
         FuturesRateHelper(Real price,
                           const Date& iborStartDate,
@@ -261,10 +261,10 @@ namespace QuantLib {
       public:
         SwapRateHelper(const Handle<Quote>& rate,
                        const ext::shared_ptr<SwapIndex>& swapIndex,
-                       Handle<Quote> spread = Handle<Quote>(),
+                       Handle<Quote> spread = {},
                        const Period& fwdStart = 0 * Days,
                        // exogenous discounting curve
-                       Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+                       Handle<YieldTermStructure> discountingCurve = {},
                        Pillar::Choice pillar = Pillar::LastRelevantDate,
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
@@ -278,10 +278,10 @@ namespace QuantLib {
                        DayCounter fixedDayCount,
                        // floating leg
                        const ext::shared_ptr<IborIndex>& iborIndex,
-                       Handle<Quote> spread = Handle<Quote>(),
+                       Handle<Quote> spread = {},
                        const Period& fwdStart = 0 * Days,
                        // exogenous discounting curve
-                       Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+                       Handle<YieldTermStructure> discountingCurve = {},
                        Natural settlementDays = Null<Natural>(),
                        Pillar::Choice pillar = Pillar::LastRelevantDate,
                        Date customPillarDate = Date(),
@@ -289,10 +289,10 @@ namespace QuantLib {
                        const boost::optional<bool>& useIndexedCoupons = boost::none);
         SwapRateHelper(Rate rate,
                        const ext::shared_ptr<SwapIndex>& swapIndex,
-                       Handle<Quote> spread = Handle<Quote>(),
+                       Handle<Quote> spread = {},
                        const Period& fwdStart = 0 * Days,
                        // exogenous discounting curve
-                       Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+                       Handle<YieldTermStructure> discountingCurve = {},
                        Pillar::Choice pillar = Pillar::LastRelevantDate,
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
@@ -306,10 +306,10 @@ namespace QuantLib {
                        DayCounter fixedDayCount,
                        // floating leg
                        const ext::shared_ptr<IborIndex>& iborIndex,
-                       Handle<Quote> spread = Handle<Quote>(),
+                       Handle<Quote> spread = {},
                        const Period& fwdStart = 0 * Days,
                        // exogenous discounting curve
-                       Handle<YieldTermStructure> discountingCurve = Handle<YieldTermStructure>(),
+                       Handle<YieldTermStructure> discountingCurve = {},
                        Natural settlementDays = Null<Natural>(),
                        Pillar::Choice pillar = Pillar::LastRelevantDate,
                        Date customPillarDate = Date(),

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -48,10 +48,9 @@ namespace QuantLib {
             const std::vector<Rate>& yields,
             const DayCounter& dayCounter,
             const Calendar& calendar = Calendar(),
-            const std::vector<Handle<Quote> >& jumps =
-                                                std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator(),
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {},
             Compounding compounding = Continuous,
             Frequency frequency = Annual);
         InterpolatedZeroCurve(
@@ -85,20 +84,20 @@ namespace QuantLib {
       protected:
         explicit InterpolatedZeroCurve(
             const DayCounter&,
-            const Interpolator& interpolator = Interpolator());
+            const Interpolator& interpolator = {});
         InterpolatedZeroCurve(
             const Date& referenceDate,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
         InterpolatedZeroCurve(
             Natural settlementDays,
             const Calendar&,
             const DayCounter&,
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>(),
-            const Interpolator& interpolator = Interpolator());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {},
+            const Interpolator& interpolator = {});
 
         //! \name ZeroYieldStructure implementation
         //@{

--- a/ql/termstructures/yield/zeroyieldstructure.hpp
+++ b/ql/termstructures/yield/zeroyieldstructure.hpp
@@ -54,14 +54,14 @@ namespace QuantLib {
             const Date& referenceDate,
             const Calendar& calendar = Calendar(),
             const DayCounter& dc = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         ZeroYieldStructure(
             Natural settlementDays,
             const Calendar& calendar,
             const DayCounter& dc = DayCounter(),
-            const std::vector<Handle<Quote> >& jumps = std::vector<Handle<Quote> >(),
-            const std::vector<Date>& jumpDates = std::vector<Date>());
+            const std::vector<Handle<Quote> >& jumps = {},
+            const std::vector<Date>& jumpDates = {});
         //@}
       protected:
         /*! \name Calculations

--- a/ql/termstructures/yieldtermstructure.hpp
+++ b/ql/termstructures/yieldtermstructure.hpp
@@ -52,13 +52,13 @@ namespace QuantLib {
         YieldTermStructure(const Date& referenceDate,
                            const Calendar& cal = Calendar(),
                            const DayCounter& dc = DayCounter(),
-                           std::vector<Handle<Quote> > jumps = std::vector<Handle<Quote> >(),
-                           const std::vector<Date>& jumpDates = std::vector<Date>());
+                           std::vector<Handle<Quote> > jumps = {},
+                           const std::vector<Date>& jumpDates = {});
         YieldTermStructure(Natural settlementDays,
                            const Calendar& cal,
                            const DayCounter& dc = DayCounter(),
-                           std::vector<Handle<Quote> > jumps = std::vector<Handle<Quote> >(),
-                           const std::vector<Date>& jumpDates = std::vector<Date>());
+                           std::vector<Handle<Quote> > jumps = {},
+                           const std::vector<Date>& jumpDates = {});
         //@}
 
         /*! \name Discount factors


### PR DESCRIPTION
This allows using `{}` for an empty handle in default parameters.  Some were converted, to work as examples.