### PR TITLE
Make Option::payoff() and Option::exercise() const

### DIFF
--- a/ql/option.hpp
+++ b/ql/option.hpp
@@ -42,8 +42,8 @@ namespace QuantLib {
         Option(ext::shared_ptr<Payoff> payoff, ext::shared_ptr<Exercise> exercise)
         : payoff_(std::move(payoff)), exercise_(std::move(exercise)) {}
         void setupArguments(PricingEngine::arguments*) const override;
-        ext::shared_ptr<Payoff> payoff() { return payoff_; }
-        ext::shared_ptr<Exercise> exercise() { return exercise_; };
+        ext::shared_ptr<Payoff> payoff() const { return payoff_; }
+        ext::shared_ptr<Exercise> exercise() const { return exercise_; };
       protected:
         // arguments
         ext::shared_ptr<Payoff> payoff_;


### PR DESCRIPTION
I guess `payoff()` and `exercise()` should be `const`.

Or is there a use case where we want to change them after setup of the `Option`?