### PR TITLE
Added `MakeSwaption::withIndexedCoupons(...)` and `MakeSwaption::withAtParCoupons(...)`

### DIFF
--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -98,7 +98,8 @@ namespace QuantLib {
             .withFixedLegConvention(bdc)
             .withFixedLegTerminationDateConvention(bdc)
             .withType(underlyingType_)
-            .withNominal(nominal_);
+            .withNominal(nominal_)
+            .withIndexedCoupons(useIndexedCoupons_);
 
         ext::shared_ptr<Swaption> swaption(new Swaption(
             underlyingSwap_, exercise_, delivery_, settlementMethod_));
@@ -141,6 +142,16 @@ namespace QuantLib {
 
     MakeSwaption& MakeSwaption::withNominal(Real n) {
         nominal_ = n;
+        return *this;
+    }
+
+    MakeSwaption& MakeSwaption::withIndexedCoupons(const boost::optional<bool>& b) {
+        useIndexedCoupons_ = b;
+        return *this;
+    }
+
+    MakeSwaption& MakeSwaption::withAtParCoupons(bool b) {
+        useIndexedCoupons_ = !b;
         return *this;
     }
 

--- a/ql/instruments/makeswaption.hpp
+++ b/ql/instruments/makeswaption.hpp
@@ -60,6 +60,8 @@ namespace QuantLib {
         MakeSwaption& withOptionConvention(BusinessDayConvention bdc);
         MakeSwaption& withExerciseDate(const Date&);
         MakeSwaption& withUnderlyingType(Swap::Type type);
+        MakeSwaption& withIndexedCoupons(const boost::optional<bool>& b = true);
+        MakeSwaption& withAtParCoupons(bool b = true);
 
         MakeSwaption& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
@@ -78,6 +80,7 @@ namespace QuantLib {
         Rate strike_;
         Swap::Type underlyingType_;
         Real nominal_;
+        boost::optional<bool> useIndexedCoupons_;
 
         ext::shared_ptr<PricingEngine> engine_;
     };


### PR DESCRIPTION
Makes it easier e.g. to create test cases for both coupon types.