### PR TITLE
Casts to Real to maintain AAD compatibility

### DIFF
--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             Real S, Real strike, Rate rf, Rate dy, Volatility vol, Time t, Time T)
         : tau(t), K(strike), sigma(vol), sigma2(sigma * sigma), v(sigma * std::sqrt(tau)), r(rf),
           q(dy), dr(std::exp(-r * tau)), dq(std::exp(-q * tau)),
-          ddr((std::abs(r*tau) > 1e-5)? r/(1-dr) : 1/(tau*(1-0.5*r*tau*(1-r*tau/3)))),
+          ddr((std::abs(r*tau) > 1e-5)? Real(r/(1-dr)) : Real(1/(tau*(1-0.5*r*tau*(1-r*tau/3))))),
           omega(2 * (r - q) / sigma2),
           lambda(0.5 *
                  (-(omega - 1) - std::sqrt(squared(omega - 1) + 8 * ddr / sigma2))),


### PR DESCRIPTION
Adds casts to `Real` for the ternary operator operands to maintain compatibility with expression-template based AAD tools.

This fixes the build issue in qlxad flagged here: https://github.com/xcelerit/qlxad/actions/runs/3636090574/jobs/6135760056