### PR TITLE
Adds public holiday in lieu of Christmas 2022 to South Africa calendar

### DIFF
--- a/ql/time/calendars/southafrica.cpp
+++ b/ql/time/calendars/southafrica.cpp
@@ -73,6 +73,8 @@ namespace QuantLib {
             || (d == 22 && m == April && y == 2009)
             // one-shot: Election day 2016
             || (d == 3 && m == August && y == 2016)
+            // one-shot: In lieu of Christmas falling on Sunday in 2022
+            || (d == 27 && m == December && y == 2022)
             )
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;

--- a/ql/time/calendars/southafrica.hpp
+++ b/ql/time/calendars/southafrica.hpp
@@ -50,6 +50,9 @@ namespace QuantLib {
         <li>Election Days</li>
         </ul>
 
+        Note that there are some one-off holidays not listed above.
+        See the implementation for the complete list.
+
         \ingroup calendars
     */
     class SouthAfrica : public Calendar {


### PR DESCRIPTION
Good day, 

An additional public holiday was declared in lieu of Christmas Day falling on a Sunday in 2022.

Here is the announcement by the South Africa government dated 2022-12-08: 
[https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000](https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000)

I have also added a note about one-off holidays to the docstring (c.f. #1516).

---Josh