### PR TITLE
Allow sharing engines between dividend and non-dividend options

### DIFF
--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -21,6 +21,7 @@
 
 #include <ql/exercise.hpp>
 #include <ql/instruments/barrieroption.hpp>
+#include <ql/instruments/dividendbarrieroption.hpp>
 #include <ql/instruments/impliedvolatility.hpp>
 #include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
 #include <memory>
@@ -45,6 +46,14 @@ namespace QuantLib {
         moreArgs->barrierType = barrierType_;
         moreArgs->barrier = barrier_;
         moreArgs->rebate = rebate_;
+
+        /* this is a workaround in case an engine is used for both barrier
+           and dividend options.  The dividends might have been set by another
+           instrument and need to be cleared. */
+        auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
+        if (arguments != nullptr) {
+            arguments->cashFlow.clear();
+        }
     }
 
 

--- a/ql/instruments/vanillaoption.cpp
+++ b/ql/instruments/vanillaoption.cpp
@@ -72,5 +72,17 @@ namespace QuantLib {
                                                           minVol, maxVol);
     }
 
+    void VanillaOption::setupArguments(PricingEngine::arguments* args) const {
+        OneAssetOption::setupArguments(args);
+
+        /* this is a workaround in case an engine is used for both vanilla
+           and dividend options.  The dividends might have been set by another
+           instrument and need to be cleared. */
+        auto* arguments = dynamic_cast<DividendVanillaOption::arguments*>(args);
+        if (arguments != nullptr) {
+            arguments->cashFlow.clear();
+        }
+    }
+    
 }
 

--- a/ql/instruments/vanillaoption.hpp
+++ b/ql/instruments/vanillaoption.hpp
@@ -64,6 +64,8 @@ namespace QuantLib {
              Size maxEvaluations = 100,
              Volatility minVol = 1.0e-7,
              Volatility maxVol = 4.0) const;
+
+        void setupArguments(PricingEngine::arguments*) const override;
     };
 
 }

--- a/test-suite/barrieroption.hpp
+++ b/test-suite/barrieroption.hpp
@@ -36,6 +36,7 @@ class BarrierOptionTest {
     static void testVannaVolgaSimpleBarrierValues();
     static void testVannaVolgaDoubleBarrierValues();
     static void testDividendBarrierOption();
+    static void testBarrierAndDividendEngine();
 
     static boost::unit_test_framework::test_suite* suite();
     static boost::unit_test_framework::test_suite* experimental();

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1744,38 +1744,71 @@ void EuropeanOptionTest::testDouglasVsCrankNicolson() {
     }
 }
 
+void EuropeanOptionTest::testVanillaAndDividendEngine() {
+    BOOST_TEST_MESSAGE("Testing the use of a single engine for vanilla and dividend options...");
+
+    SavedSettings backup;
+
+    auto today = Date(1, January, 2023);
+    Settings::instance().evaluationDate() = today;
+
+    auto u = Handle<Quote>(ext::make_shared<SimpleQuote>(100.0));
+    auto r = Handle<YieldTermStructure>(ext::make_shared<FlatForward>(today, 0.01, Actual360()));
+    auto sigma = Handle<BlackVolTermStructure>(
+        ext::make_shared<BlackConstantVol>(today, TARGET(), 0.20, Actual360()));
+    auto process = ext::make_shared<BlackScholesProcess>(u, r, sigma);
+
+    auto engine = ext::make_shared<FdBlackScholesVanillaEngine>(process);
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 100.0);
+
+    auto option1 =
+        VanillaOption(payoff, ext::make_shared<AmericanExercise>(today, Date(1, June, 2023)));
+    auto option2 = DividendVanillaOption(
+        payoff, ext::make_shared<AmericanExercise>(today, Date(1, June, 2023)),
+        {Date(1, February, 2023)}, {1.0});
+
+    option1.setPricingEngine(engine);
+    option2.setPricingEngine(engine);
+
+    auto npv_before = option1.NPV();
+    option2.NPV();
+
+    option1.recalculate();
+    auto npv_after = option1.NPV();
+
+    if (npv_after != npv_before) {
+        BOOST_FAIL("Failed to price vanilla option correctly "
+                   "after using the engine on a dividend option: "
+                   << "\n    before usage: " << npv_before
+                   << "\n    after usage:  " << npv_after);
+    }
+}
+
 test_suite* EuropeanOptionTest::suite() {
     auto* suite = BOOST_TEST_SUITE("European option tests");
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testValues));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testGreekValues));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testGreeks));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testImpliedVol));
-    suite->add(QUANTLIB_TEST_CASE(
-                           &EuropeanOptionTest::testImpliedVolContainment));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testImpliedVolContainment));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testJRBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testCRRBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testEQPBinomialEngines));
-    suite->add(QUANTLIB_TEST_CASE(
-                               &EuropeanOptionTest::testTGEOBinomialEngines));
-    suite->add(QUANTLIB_TEST_CASE(
-                               &EuropeanOptionTest::testTIANBinomialEngines));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testTGEOBinomialEngines));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testTIANBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testLRBinomialEngines));
-    suite->add(QUANTLIB_TEST_CASE(
-                              &EuropeanOptionTest::testJOSHIBinomialEngines));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testJOSHIBinomialEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testFdEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testIntegralEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testMcEngines));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testQmcEngines));
-
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testLocalVolatility));
-
-    suite->add(QUANTLIB_TEST_CASE(
-                       &EuropeanOptionTest::testAnalyticEngineDiscountCurve));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testAnalyticEngineDiscountCurve));
     suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testPDESchemes));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &EuropeanOptionTest::testFdEngineWithNonConstantParameters));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &EuropeanOptionTest::testDouglasVsCrankNicolson));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testFdEngineWithNonConstantParameters));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testDouglasVsCrankNicolson));
+    suite->add(QUANTLIB_TEST_CASE(&EuropeanOptionTest::testVanillaAndDividendEngine));
 
     return suite;
 }

--- a/test-suite/europeanoption.hpp
+++ b/test-suite/europeanoption.hpp
@@ -50,6 +50,7 @@ class EuropeanOptionTest {
     static void testPDESchemes();
     static void testDouglasVsCrankNicolson();
     static void testFdEngineWithNonConstantParameters();
+    static void testVanillaAndDividendEngine();
 
     static boost::unit_test_framework::test_suite* suite();
     static boost::unit_test_framework::test_suite* experimental();


### PR DESCRIPTION
This works around #1540.  The use case doesn't make a lot of sense — either the underlying has announced dividends or it doesn't — but there might be reasons, I guess.

In the long term, dividend options should be folded into their non-dividend counterpart and the dividends should go in the engine, together with the rest of the market info.