### PR TITLE
Add required packages for icpx compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,10 @@ if (NOT DEFINED QL_BOOST_VERSION)
     endif()
 endif()
 
+if (CMAKE_CXX_COMPILER STREQUAL "icpx")
+    find_package(IntelDPCPP REQUIRED)
+endif()
+
 find_package(Boost ${QL_BOOST_VERSION} REQUIRED)
 
 # Do not warn about Boost versions higher than 1.58.0


### PR DESCRIPTION
This pulls in the required CMake package in order to use Intel's new compiler based on their [instructions](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-setup/use-the-command-line/use-cmake-with-the-intel-oneapi-dpc-c-compiler.html).

Note that the [default](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/floating-point-options/fp-model-fp.html) floating point mode of `-fp-model=fast=1` is too imprecise for the current test thresholds. In order to get all the unit tests passing, `-fp-model=precise` must be added to `CMAKE_CXX_FLAGS`, but I'm not sure where is the best place to document this for users.

Incidentally, I'm also seeing a lot of test failures when I compile QuantLib with g++12 and `-ffast-math` even though some of the tests explicitly adjust the threshold when `__FAST_MATH__` is defined. Was it ever a goal to have all the tests pass with fast math? If so, then should we make an issue to get the tests passing again with fast math for gcc and other compilers?