### PR TITLE
Reorder header for European currencies.

### DIFF
--- a/ql/currencies/europe.hpp
+++ b/ql/currencies/europe.hpp
@@ -48,6 +48,17 @@ namespace QuantLib {
         BGLCurrency();
     };
 
+    //! Bulgarian lev
+    /*! The ISO three-letter code is BGN; the numeric code is 975.
+        It is divided into 100 stotinki.
+
+        \ingroup currencies
+    */
+    class BGNCurrency : public Currency {
+      public:
+        BGNCurrency();
+    };
+
     //! Belarussian ruble
     /*! The ISO three-letter code is BYR; the numeric code is 974.
         It has no subdivisions.
@@ -123,6 +134,17 @@ namespace QuantLib {
     class GBPCurrency : public Currency {
       public:
         GBPCurrency();
+    };
+
+    //! Georgian lari
+    /*! The ISO three-letter code is GEL; the numeric code is 981.
+        It is divided into 100 tetri.
+
+        \ingroup currencies
+    */
+    class GELCurrency : public Currency {
+      public:
+        GELCurrency();
     };
 
     //! Hungarian forint
@@ -215,6 +237,17 @@ namespace QuantLib {
         RONCurrency();
     };
 
+    //! Serbian dinar
+    /*! The ISO three-letter code is RSD; the numeric code is 941.
+        It is divided into 100 para/napa.
+
+        \ingroup currencies
+    */
+    class RSDCurrency : public Currency {
+      public:
+        RSDCurrency();
+    };
+
     //! Russian ruble
     /*! The ISO three-letter code is RUB; the numeric code is 643.
         It is divided in 100 kopeyki.
@@ -270,6 +303,17 @@ namespace QuantLib {
     class TRYCurrency : public Currency {
       public:
         TRYCurrency();
+    };
+
+    //! Ukrainian hryvnia
+    /*! The ISO three-letter code is UAH; the numeric code is 980.
+        It is divided in 100 kopiykas.
+
+        \ingroup currencies
+    */
+    class UAHCurrency : public Currency {
+    public:
+        UAHCurrency();
     };
 
 
@@ -379,6 +423,19 @@ namespace QuantLib {
         GRDCurrency();
     };
 
+    //! Croatian kuna
+    /*! The ISO three-letter code was HRK; the numeric code was 191.
+        It was divided into 100 lipa.
+
+        Obsoleted by the Euro since 2023.
+
+        \ingroup currencies
+    */
+    class HRKCurrency : public Currency {
+      public:
+        HRKCurrency();
+    };
+
     //! Irish punt
     /*! The ISO three-letter code was IEP; the numeric code was 372.
         It was divided in 100 pence.
@@ -468,57 +525,6 @@ namespace QuantLib {
     class SKKCurrency : public Currency {
       public:
         SKKCurrency();
-    };
-
-    //! Ukrainian hryvnia
-    /*! The ISO three-letter code is UAH; the numeric code is 980.
-        It is divided in 100 kopiykas.
-
-        \ingroup currencies    
-     */
-    class UAHCurrency : public Currency {
-    public:
-        UAHCurrency();
-    };
-
-    //! Serbian dinar
-    /*! The ISO three-letter code is RSD; the numeric code is 941.
-     It is divided into 100 para/napa.
-     \ingroup currencies
-    */
-    class RSDCurrency : public Currency {
-      public:
-        RSDCurrency();
-    };
-
-    //! Croatian kuna
-    /*! The ISO three-letter code is HRK; the numeric code is 191.
-     It is divided into 100 lipa.
-     \ingroup currencies
-    */
-    class HRKCurrency : public Currency {
-      public:
-        HRKCurrency();
-    };
-
-    //! Bulgarian lev
-    /*! The ISO three-letter code is BGN; the numeric code is 975.
-     It is divided into 100 stotinki.
-     \ingroup currencies
-    */
-    class BGNCurrency : public Currency {
-      public:
-        BGNCurrency();
-    };
-
-    //! Georgian lari
-    /*! The ISO three-letter code is GEL; the numeric code is 981.
-     It is divided into 100 tetri.
-     \ingroup currencies
-    */
-    class GELCurrency : public Currency {
-      public:
-        GELCurrency();
     };
 
 }


### PR DESCRIPTION
The alphabetical order was restored, and the entrance of Croatia into Eurozone in 2023 was documented.