### PR TITLE
Avoid null-pointer access

### DIFF
--- a/ql/processes/merton76process.cpp
+++ b/ql/processes/merton76process.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
                                      Handle<Quote> logJMean,
                                      Handle<Quote> logJVol,
                                      const ext::shared_ptr<discretization>& disc)
-    : blackProcess_(
+    : StochasticProcess1D(disc), blackProcess_(
           new BlackScholesMertonProcess(stateVariable, dividendTS, riskFreeTS, blackVolTS, disc)),
       jumpIntensity_(std::move(jumpInt)), logMeanJump_(std::move(logJMean)),
       logJumpVolatility_(std::move(logJVol)) {

--- a/ql/processes/merton76process.hpp
+++ b/ql/processes/merton76process.hpp
@@ -47,9 +47,9 @@ namespace QuantLib {
         //! \name StochasticProcess1D interface
         //@{
         Real x0() const override;
-        Real drift(Time, Real) const override { QL_FAIL("not implemented"); }
-        Real diffusion(Time, Real) const override { QL_FAIL("not implemented"); }
-        Real apply(Real, Real) const override { QL_FAIL("not implemented"); }
+        Real drift(Time, Real) const override { QL_FAIL("Merton76Process does not implement drift"); }
+        Real diffusion(Time, Real) const override { QL_FAIL("Merton76Process does not implement diffusion"); }
+        Real apply(Real, Real) const override { QL_FAIL("Merton76Process does not implement apply"); }
         //@}
         Time time(const Date&) const override;
         //! \name Inspectors


### PR DESCRIPTION
The passed `discretization` instance would not be copied into the process' own data member, resulting in a null pointer access if some of the methods were called.