### PR TITLE
New Zealand calendar missing Matariki holiday #1562

### DIFF
--- a/ql/time/calendars/newzealand.cpp
+++ b/ql/time/calendars/newzealand.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
                 && m == December)
             // Boxing Day, December 26th (possibly Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
-                && m == December))
+                && m == December)
             // Matariki, it happens on Friday in June or July
             // official calendar released by the NZ government for the
             // next 30 years
@@ -81,7 +81,7 @@ namespace QuantLib {
             || (d == 14 && m == July && (y == 2023 || y == 2028))
             || (d == 15 && m == July && (y == 2039 || y == 2050))
             || (d == 18 && m == July && y == 2036)
-            || (d == 19 && m == July && (y == 2041 || y == 2047))
+            || (d == 19 && m == July && (y == 2041 || y == 2047)))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }

--- a/ql/time/calendars/newzealand.cpp
+++ b/ql/time/calendars/newzealand.cpp
@@ -62,6 +62,26 @@ namespace QuantLib {
             // Boxing Day, December 26th (possibly Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
                 && m == December))
+            // Matariki, it happens on Friday in June or July
+            // official calendar released by the NZ government for the
+            // next 30 years
+            || (d == 20 && m == June && y == 2025)
+            || (d == 21 && m == June && (y == 2030 || y == 2052))
+            || (d == 24 && m == June && (y == 2022 || y == 2033 || y == 2044))
+            || (d == 25 && m == June && (y == 2027 || y == 2038 || y == 2049))
+            || (d == 28 && m == June && y == 2024)
+            || (d == 29 && m == June && (y == 2035 || y == 2046))
+            || (d == 30 && m == June && y == 2051)
+            || (d == 2  && m == July && y == 2032)
+            || (d == 3  && m == July && (y == 2043 || y == 2048))
+            || (d == 6  && m == July && (y == 2029 || y == 2040))
+            || (d == 7  && m == July && (y == 2034 || y == 2045))
+            || (d == 10 && m == July && (y == 2026 || y == 2037))
+            || (d == 11 && m == July && (y == 2031 || y == 2042))
+            || (d == 14 && m == July && (y == 2023 || y == 2028))
+            || (d == 15 && m == July && (y == 2039 || y == 2050))
+            || (d == 18 && m == July && y == 2036)
+            || (d == 19 && m == July && (y == 2041 || y == 2047))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }

--- a/ql/time/calendars/newzealand.hpp
+++ b/ql/time/calendars/newzealand.hpp
@@ -47,9 +47,12 @@ namespace QuantLib {
         <li>Christmas, December 25th (possibly moved to Monday or Tuesday)</li>
         <li>Boxing Day, December 26th (possibly moved to Monday or
             Tuesday)</li>
+        <li>Matariki, in June or July, official calendar released for years 2022-2052</li>
         </ul>
         \note The holiday rules for New Zealand were documented by
               David Gilbert for IDB (http://www.jrefinery.com/ibd/)
+              The Matariki holiday calendar has been released by the NZ Government
+              (https://www.legislation.govt.nz/act/public/2022/0014/latest/LMS557893.html)
 
         \ingroup calendars
     */


### PR DESCRIPTION
Updated the header file with Doxygen tags and with the link to the NZ government website. Updated the implementation with the Matariki dates. Instead of blindly adding 31 dates I tried to optimize the code as much as possible. Since I am a newbie I am not sure if the coding logic can be optimized further. Thanks in advance for your comments/review.
[Matariki_NZ.ods](https://github.com/lballabio/QuantLib/files/10420359/Matariki_NZ.ods)
