### PR TITLE
Unify barrier options and dividend barrier options

### DIFF
--- a/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
+++ b/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
@@ -32,6 +32,8 @@ namespace QuantLib {
 
     //! Vanna Volga barrier option engine
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     /*!
         \ingroup barrierengines
     */
@@ -39,6 +41,8 @@ namespace QuantLib {
         : public GenericEngine<DividendBarrierOption::arguments,
                                DividendBarrierOption::results> {
       public:
+
+    QL_DEPRECATED_ENABLE_WARNING
 
         // Constructor
         VannaVolgaBarrierEngine(Handle<DeltaVolQuote> atmVol,
@@ -68,4 +72,4 @@ namespace QuantLib {
 
 }
 
-#endif /*quantlib_fd_black_scholes_barrier_engine_hpp*/
+#endif

--- a/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
+++ b/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
@@ -25,7 +25,7 @@
 #define quantlib_vanna_volga_barrier_engine_hpp
 
 #include <ql/processes/blackscholesprocess.hpp>
-#include <ql/instruments/dividendbarrieroption.hpp>
+#include <ql/instruments/barrieroption.hpp>
 #include <ql/experimental/fx/deltavolquote.hpp>
 
 namespace QuantLib {

--- a/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
+++ b/ql/experimental/barrieroption/vannavolgabarrierengine.hpp
@@ -30,19 +30,12 @@
 
 namespace QuantLib {
 
-    //! Vanna Volga barrier option engine
-
-    QL_DEPRECATED_DISABLE_WARNING
-
+    //! Vanna/Volga barrier option engine
     /*!
         \ingroup barrierengines
     */
-    class VannaVolgaBarrierEngine
-        : public GenericEngine<DividendBarrierOption::arguments,
-                               DividendBarrierOption::results> {
+    class VannaVolgaBarrierEngine : public BarrierOption::engine {
       public:
-
-    QL_DEPRECATED_ENABLE_WARNING
 
         // Constructor
         VannaVolgaBarrierEngine(Handle<DeltaVolQuote> atmVol,

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -50,7 +50,9 @@ namespace QuantLib {
         /* this is a workaround in case an engine is used for both barrier
            and dividend options.  The dividends might have been set by another
            instrument and need to be cleared. */
+        QL_DEPRECATED_DISABLE_WARNING
         auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
+        QL_DEPRECATED_ENABLE_WARNING
         if (arguments != nullptr) {
             arguments->cashFlow.clear();
         }

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -24,6 +24,7 @@
 #include <ql/instruments/dividendbarrieroption.hpp>
 #include <ql/instruments/impliedvolatility.hpp>
 #include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
+#include <ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp>
 #include <memory>
 
 namespace QuantLib {
@@ -66,7 +67,18 @@ namespace QuantLib {
              Size maxEvaluations,
              Volatility minVol,
              Volatility maxVol) const {
+        return impliedVolatility(targetValue, process, DividendSchedule(),
+                                 accuracy, maxEvaluations, minVol, maxVol);
+    }
 
+    Volatility BarrierOption::impliedVolatility(
+             Real targetValue,
+             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const DividendSchedule& dividends,
+             Real accuracy,
+             Size maxEvaluations,
+             Volatility minVol,
+             Volatility maxVol) const {
         QL_REQUIRE(!isExpired(), "option expired");
 
         ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
@@ -78,8 +90,11 @@ namespace QuantLib {
         std::unique_ptr<PricingEngine> engine;
         switch (exercise_->type()) {
           case Exercise::European:
-              engine = std::make_unique<AnalyticBarrierEngine>(newProcess);
-              break;
+            if (dividends.empty())
+                engine = std::make_unique<AnalyticBarrierEngine>(newProcess);
+            else
+                engine = std::make_unique<FdBlackScholesBarrierEngine>(newProcess, dividends);
+            break;
           case Exercise::American:
           case Exercise::Bermudan:
             QL_FAIL("engine not available for non-European barrier option");

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -53,10 +53,10 @@ namespace QuantLib {
            instrument and need to be cleared. */
         QL_DEPRECATED_DISABLE_WARNING
         auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
-        QL_DEPRECATED_ENABLE_WARNING
         if (arguments != nullptr) {
             arguments->cashFlow.clear();
         }
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 

--- a/ql/instruments/barrieroption.hpp
+++ b/ql/instruments/barrieroption.hpp
@@ -29,6 +29,7 @@
 #include <ql/instruments/oneassetoption.hpp>
 #include <ql/instruments/barriertype.hpp>
 #include <ql/instruments/payoffs.hpp>
+#include <ql/instruments/dividendschedule.hpp>
 
 namespace QuantLib {
 
@@ -49,9 +50,11 @@ namespace QuantLib {
                       const ext::shared_ptr<StrikedTypePayoff>& payoff,
                       const ext::shared_ptr<Exercise>& exercise);
         void setupArguments(PricingEngine::arguments*) const override;
+
         /*! \warning see VanillaOption for notes on implied-volatility
                      calculation.
         */
+        //@{
         Volatility impliedVolatility(
              Real price,
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -59,6 +62,15 @@ namespace QuantLib {
              Size maxEvaluations = 100,
              Volatility minVol = 1.0e-7,
              Volatility maxVol = 4.0) const;
+        Volatility impliedVolatility(
+             Real price,
+             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const DividendSchedule& dividends,
+             Real accuracy = 1.0e-4,
+             Size maxEvaluations = 100,
+             Volatility minVol = 1.0e-7,
+             Volatility maxVol = 4.0) const;
+        //@}
       protected:
         // arguments
         Barrier::Type barrierType_;

--- a/ql/instruments/dividendbarrieroption.cpp
+++ b/ql/instruments/dividendbarrieroption.cpp
@@ -41,10 +41,12 @@ namespace QuantLib {
                                        PricingEngine::arguments* args) const {
         BarrierOption::setupArguments(args);
 
+        QL_DEPRECATED_DISABLE_WARNING
         auto* arguments = dynamic_cast<DividendBarrierOption::arguments*>(args);
         QL_REQUIRE(arguments != nullptr, "wrong engine type");
 
         arguments->cashFlow = cashFlow_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 

--- a/ql/instruments/dividendbarrieroption.hpp
+++ b/ql/instruments/dividendbarrieroption.hpp
@@ -58,17 +58,27 @@ namespace QuantLib {
 
 
     //! %Arguments for dividend barrier option calculation
-    class DividendBarrierOption::arguments : public BarrierOption::arguments {
+    /*! \deprecated If you're writing an engine for DividendBarrierOption,
+                    use BarrierOption instead and pass the dividends to the engine.
+                    Deprecated in version 1.30.
+    */
+    class QL_DEPRECATED DividendBarrierOption::arguments : public BarrierOption::arguments {
       public:
         DividendSchedule cashFlow;
         arguments() = default;
         void validate() const override;
     };
 
+    QL_DEPRECATED_DISABLE_WARNING
     //! %Dividend-barrier-option %engine base class
+    /*! \deprecated If you're writing an engine for DividendBarrierOption,
+                    use BarrierOption instead and pass the dividends to the engine.
+                    Deprecated in version 1.30.
+    */
     class DividendBarrierOption::engine
         : public GenericEngine<DividendBarrierOption::arguments,
                                DividendBarrierOption::results> {
+    QL_DEPRECATED_ENABLE_WARNING
       protected:
         bool triggered(Real underlying) const;
     };

--- a/ql/instruments/dividendbarrieroption.hpp
+++ b/ql/instruments/dividendbarrieroption.hpp
@@ -33,8 +33,11 @@
 namespace QuantLib {
 
     //! Single-asset barrier option with discrete dividends
-    /*! \ingroup instruments */
-    class DividendBarrierOption : public BarrierOption {
+    /*! \deprecated Use BarrierOption instead and pass the dividends
+                    to the desired engine.
+                    Deprecated in version 1.30.
+    */
+    class QL_DEPRECATED DividendBarrierOption : public BarrierOption {
       public:
         class arguments;
         class engine;

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -72,7 +72,9 @@ namespace QuantLib {
     void FdBlackScholesBarrierEngine::calculate() const {
 
         // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
         const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
 
         // 1. Mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -190,20 +190,18 @@ namespace QuantLib {
                         schemeDesc_, localVol_, illegalLocalVolOverwrite_));
 
             // Calculate the rebate value
-            ext::shared_ptr<DividendBarrierOption> rebateOption(
-                ext::make_shared<DividendBarrierOption>(arguments_.barrierType,
-                                          arguments_.barrier,
-                                          arguments_.rebate,
-                                          payoff, arguments_.exercise,
-                                          dividendCondition->dividendDates(), 
-                                          dividendCondition->dividends()));
+            auto rebateOption =
+                ext::make_shared<BarrierOption>(arguments_.barrierType,
+                                                arguments_.barrier,
+                                                arguments_.rebate,
+                                                payoff, arguments_.exercise);
             
             const Size min_grid_size = 50;
             const Size rebateDampingSteps 
                 = (dampingSteps_ > 0) ? std::min(Size(1), dampingSteps_/2) : 0; 
 
             rebateOption->setPricingEngine(ext::make_shared<FdBlackScholesRebateEngine>(
-                            process_, tGrid_, std::max(min_grid_size, xGrid_/5), 
+                            process_, dividendSchedule, tGrid_, std::max(min_grid_size, xGrid_/5), 
                             rebateDampingSteps, schemeDesc_, localVol_, 
                             illegalLocalVolOverwrite_));
 

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdblackscholesbarrierengine.hpp
-    \brief Finite-Differences Black Scholes barrier option engine
+    \brief Finite-differences Black/Scholes barrier-option engine
 */
 
 #ifndef quantlib_fd_black_scholes_barrier_engine_hpp
@@ -32,16 +32,17 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Black Scholes barrier option engine
+    QL_DEPRECATED_DISABLE_WARNING
 
-    /*!
-        \ingroup barrierengines
+    //! Finite-differences Black/Scholes barrier-option engine
+    /*! \ingroup barrierengines
 
         \test the correctness of the returned value is tested by
               reproducing results available in web/literature
               and comparison with Black pricing.
     */
     class FdBlackScholesBarrierEngine : public DividendBarrierOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         explicit FdBlackScholesBarrierEngine(
             ext::shared_ptr<GeneralizedBlackScholesProcess> process,
@@ -73,7 +74,6 @@ namespace QuantLib {
         bool localVol_;
         Real illegalLocalVolOverwrite_;
     };
-
 
 }
 

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp
@@ -43,9 +43,18 @@ namespace QuantLib {
     */
     class FdBlackScholesBarrierEngine : public DividendBarrierOption::engine {
       public:
-        // Constructor
         explicit FdBlackScholesBarrierEngine(
             ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+            bool localVol = false,
+            Real illegalLocalVolOverwrite = -Null<Real>());
+
+        explicit FdBlackScholesBarrierEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+            DividendSchedule dividends,
             Size tGrid = 100,
             Size xGrid = 100,
             Size dampingSteps = 0,
@@ -56,14 +65,16 @@ namespace QuantLib {
         void calculate() const override;
 
       private:
-        const ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
-        const Size tGrid_, xGrid_, dampingSteps_;
-        const FdmSchemeDesc schemeDesc_;
-        const bool localVol_;
-        const Real illegalLocalVolOverwrite_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
+        Size tGrid_, xGrid_, dampingSteps_;
+        FdmSchemeDesc schemeDesc_;
+        bool localVol_;
+        Real illegalLocalVolOverwrite_;
     };
 
 
 }
 
-#endif /*quantlib_fd_black_scholes_barrier_engine_hpp*/
+#endif

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -40,7 +40,25 @@ namespace QuantLib {
         const FdmSchemeDesc& schemeDesc,
         bool localVol,
         Real illegalLocalVolOverwrite)
-    : process_(std::move(process)), tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
+    : process_(std::move(process)), explicitDividends_(false),
+      tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc), localVol_(localVol),
+      illegalLocalVolOverwrite_(illegalLocalVolOverwrite) {
+
+        registerWith(process_);
+    }
+
+    FdBlackScholesRebateEngine::FdBlackScholesRebateEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+        DividendSchedule dividends,
+        Size tGrid,
+        Size xGrid,
+        Size dampingSteps,
+        const FdmSchemeDesc& schemeDesc,
+        bool localVol,
+        Real illegalLocalVolOverwrite)
+    : process_(std::move(process)), dividends_(std::move(dividends)), explicitDividends_(true),
+      tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), localVol_(localVol),
       illegalLocalVolOverwrite_(illegalLocalVolOverwrite) {
 
@@ -48,6 +66,9 @@ namespace QuantLib {
     }
 
     void FdBlackScholesRebateEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
 
         // 1. Mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -70,7 +91,7 @@ namespace QuantLib {
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                arguments_.cashFlow));
+                dividendSchedule));
         
         const ext::shared_ptr<FdmMesher> mesher (
             new FdmMesherComposite(equityMesher));
@@ -87,7 +108,7 @@ namespace QuantLib {
         
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
             FdmStepConditionComposite::vanillaComposite(
-                                arguments_.cashFlow, arguments_.exercise, 
+                                dividendSchedule, arguments_.exercise, 
                                 mesher, calculator, 
                                 process_->riskFreeRate()->referenceDate(),
                                 process_->riskFreeRate()->dayCounter());

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -68,7 +68,9 @@ namespace QuantLib {
     void FdBlackScholesRebateEngine::calculate() const {
 
         // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
         const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
 
         // 1. Mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.hpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.hpp
@@ -33,15 +33,23 @@
 namespace QuantLib {
 
     //! Finite-Differences Black Scholes barrier option rebate helper engine
-
     /*!
         \ingroup barrierengines
     */
     class FdBlackScholesRebateEngine : public DividendBarrierOption::engine {
       public:
-        // Constructor
         explicit FdBlackScholesRebateEngine(
             ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+            bool localVol = false,
+            Real illegalLocalVolOverwrite = -Null<Real>());
+
+        explicit FdBlackScholesRebateEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+            DividendSchedule dividends,
             Size tGrid = 100,
             Size xGrid = 100,
             Size dampingSteps = 0,
@@ -52,14 +60,16 @@ namespace QuantLib {
         void calculate() const override;
 
       private:
-        const ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
-        const Size tGrid_, xGrid_, dampingSteps_;
-        const FdmSchemeDesc schemeDesc_;
-        const bool localVol_;
-        const Real illegalLocalVolOverwrite_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
+        Size tGrid_, xGrid_, dampingSteps_;
+        FdmSchemeDesc schemeDesc_;
+        bool localVol_;
+        Real illegalLocalVolOverwrite_;
 };
 
 
 }
 
-#endif /*quantlib_fd_black_scholes_rebate_engine_hpp*/
+#endif

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.hpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdblackscholesrebateengine.hpp
-    \brief Finite-Differences Black Scholes barrier option rebate helper engine
+    \brief Finite-differences Black/Scholes barrier option rebate helper engine
 */
 
 #ifndef quantlib_fd_black_scholes_rebate_engine_hpp
@@ -32,11 +32,12 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Black Scholes barrier option rebate helper engine
-    /*!
-        \ingroup barrierengines
-    */
+    QL_DEPRECATED_DISABLE_WARNING
+
+    //! Finite-differences Black/Scholes barrier-option rebate helper engine
+    /*! \ingroup barrierengines */
     class FdBlackScholesRebateEngine : public DividendBarrierOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         explicit FdBlackScholesRebateEngine(
             ext::shared_ptr<GeneralizedBlackScholesProcess> process,
@@ -67,8 +68,7 @@ namespace QuantLib {
         FdmSchemeDesc schemeDesc_;
         bool localVol_;
         Real illegalLocalVolOverwrite_;
-};
-
+    };
 
 }
 

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -71,7 +71,9 @@ namespace QuantLib {
     void FdHestonBarrierEngine::calculate() const {
 
         // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
         const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
 
         // 1. Mesher
         const ext::shared_ptr<HestonProcess>& process = model_->process();

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -45,10 +45,29 @@ namespace QuantLib {
     : GenericModelEngine<HestonModel,
                          DividendBarrierOption::arguments,
                          DividendBarrierOption::results>(model),
+      explicitDividends_(false), tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)), mixingFactor_(mixingFactor) {}
+
+    FdHestonBarrierEngine::FdHestonBarrierEngine(const ext::shared_ptr<HestonModel>& model,
+                                                 DividendSchedule dividends,
+                                                 Size tGrid,
+                                                 Size xGrid,
+                                                 Size vGrid,
+                                                 Size dampingSteps,
+                                                 const FdmSchemeDesc& schemeDesc,
+                                                 ext::shared_ptr<LocalVolTermStructure> leverageFct,
+                                                 const Real mixingFactor)
+    : GenericModelEngine<HestonModel,
+                         DividendBarrierOption::arguments,
+                         DividendBarrierOption::results>(model),
+      dividends_(std::move(dividends)), explicitDividends_(true),
       tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)), mixingFactor_(mixingFactor) {}
 
     void FdHestonBarrierEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
 
         // 1. Mesher
         const ext::shared_ptr<HestonProcess>& process = model_->process();
@@ -86,7 +105,7 @@ namespace QuantLib {
                 maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                arguments_.cashFlow));
+                dividendSchedule));
 
         const ext::shared_ptr<FdmMesher> mesher (
 			ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
@@ -101,13 +120,17 @@ namespace QuantLib {
 
         // 3.1 Step condition if discrete dividends
         ext::shared_ptr<FdmDividendHandler> dividendCondition(
-			ext::make_shared<FdmDividendHandler>(arguments_.cashFlow, mesher,
+			ext::make_shared<FdmDividendHandler>(dividendSchedule, mesher,
                                    process->riskFreeRate()->referenceDate(),
                                    process->riskFreeRate()->dayCounter(), 0));
 
-        if(!arguments_.cashFlow.empty()) {
+        if (!dividendSchedule.empty()) {
             stepConditions.push_back(dividendCondition);
-            stoppingTimes.push_back(dividendCondition->dividendTimes());
+            std::vector<Time> dividendTimes = dividendCondition->dividendTimes();
+            // this effectively excludes times after maturity
+            for (auto& t: dividendTimes)
+                t = std::min(maturity, t);
+            stoppingTimes.push_back(dividendTimes);
         }
 
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdhestonbarrierengine.hpp
-    \brief Finite-Differences Heston barrier option engine
+    \brief Finite-differences Heston barrier-option engine
 */
 
 #ifndef quantlib_fd_heston_barrier_engine_hpp
@@ -33,13 +33,12 @@
 #include <ql/termstructures/volatility/equityfx/localvoltermstructure.hpp>
 #include <ql/instruments/dividendbarrieroption.hpp>
 
-
 namespace QuantLib {
 
-    //! Finite-Differences Heston Barrier Option engine
+    QL_DEPRECATED_DISABLE_WARNING
 
-    /*!
-        \ingroup barrierengines
+    //! Finite-differences Heston barrier-option engine
+    /*! \ingroup barrierengines
 
         \test the correctness of the returned value is tested by
               reproducing results available in web/literature
@@ -49,6 +48,7 @@ namespace QuantLib {
         : public GenericModelEngine<HestonModel,
                                     DividendBarrierOption::arguments,
                                     DividendBarrierOption::results> {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         explicit FdHestonBarrierEngine(
             const ext::shared_ptr<HestonModel>& model,
@@ -81,7 +81,6 @@ namespace QuantLib {
         ext::shared_ptr<LocalVolTermStructure> leverageFct_;
         Real mixingFactor_;
     };
-
 
 }
 

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.hpp
@@ -50,7 +50,6 @@ namespace QuantLib {
                                     DividendBarrierOption::arguments,
                                     DividendBarrierOption::results> {
       public:
-        // Constructor
         explicit FdHestonBarrierEngine(
             const ext::shared_ptr<HestonModel>& model,
             Size tGrid = 100,
@@ -58,20 +57,32 @@ namespace QuantLib {
             Size vGrid = 50,
             Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-            ext::shared_ptr<LocalVolTermStructure> leverageFct =
-                ext::shared_ptr<LocalVolTermStructure>(),
+            ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
+            Real mixingFactor = 1.0);
+
+        explicit FdHestonBarrierEngine(
+            const ext::shared_ptr<HestonModel>& model,
+            DividendSchedule dividends,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size vGrid = 50,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+            ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
             Real mixingFactor = 1.0);
 
         void calculate() const override;
 
       private:
-        const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
-        const FdmSchemeDesc schemeDesc_;
-        const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
-        const Real mixingFactor_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
+        Size tGrid_, xGrid_, vGrid_, dampingSteps_;
+        FdmSchemeDesc schemeDesc_;
+        ext::shared_ptr<LocalVolTermStructure> leverageFct_;
+        Real mixingFactor_;
     };
 
 
 }
 
-#endif /*quantlib_fd_heston_barrier_engine_hpp*/
+#endif

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -69,7 +69,9 @@ namespace QuantLib {
     void FdHestonRebateEngine::calculate() const {
 
         // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
         const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
 
         // 1. Mesher
         const ext::shared_ptr<HestonProcess>& process = model_->process();

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -32,6 +32,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     FdHestonRebateEngine::FdHestonRebateEngine(const ext::shared_ptr<HestonModel>& model,
                                                Size tGrid,
                                                Size xGrid,
@@ -61,6 +63,8 @@ namespace QuantLib {
       dividends_(std::move(dividends)), explicitDividends_(true),
       tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)), mixingFactor_(mixingFactor) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     void FdHestonRebateEngine::calculate() const {
 

--- a/ql/pricingengines/barrier/fdhestonrebateengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.hpp
@@ -45,9 +45,20 @@ namespace QuantLib {
                                     DividendBarrierOption::arguments,
                                     DividendBarrierOption::results> {
       public:
-        // Constructor
         explicit FdHestonRebateEngine(
             const ext::shared_ptr<HestonModel>& model,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size vGrid = 50,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+            ext::shared_ptr<LocalVolTermStructure> leverageFct =
+                ext::shared_ptr<LocalVolTermStructure>(),
+            Real mixingFactor = 1.0);
+
+        explicit FdHestonRebateEngine(
+            const ext::shared_ptr<HestonModel>& model,
+            DividendSchedule dividends,
             Size tGrid = 100,
             Size xGrid = 100,
             Size vGrid = 50,
@@ -60,6 +71,8 @@ namespace QuantLib {
         void calculate() const override;
 
       private:
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
@@ -69,4 +82,4 @@ namespace QuantLib {
 
 }
 
-#endif /*quantlib_fd_heston_rebate_engine_hpp*/
+#endif

--- a/ql/pricingengines/barrier/fdhestonrebateengine.hpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdhestonrebateengine.hpp
-    \brief Finite-Differences Heston barrier option rebate helper engine
+    \brief Finite-differences Heston barrier-option rebate helper engine
 */
 
 #ifndef quantlib_fd_heston_rebate_engine_hpp
@@ -35,15 +35,15 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Heston Barrier Option rebate helper engine
+    QL_DEPRECATED_DISABLE_WARNING
 
-    /*!
-        \ingroup barrierengines
-    */
+    //! Finite-differences Heston barrier-option rebate helper engine
+    /*! \ingroup barrierengines */
     class FdHestonRebateEngine
         : public GenericModelEngine<HestonModel,
                                     DividendBarrierOption::arguments,
                                     DividendBarrierOption::results> {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         explicit FdHestonRebateEngine(
             const ext::shared_ptr<HestonModel>& model,
@@ -52,8 +52,7 @@ namespace QuantLib {
             Size vGrid = 50,
             Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-            ext::shared_ptr<LocalVolTermStructure> leverageFct =
-                ext::shared_ptr<LocalVolTermStructure>(),
+                ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
             Real mixingFactor = 1.0);
 
         explicit FdHestonRebateEngine(
@@ -64,8 +63,7 @@ namespace QuantLib {
             Size vGrid = 50,
             Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-            ext::shared_ptr<LocalVolTermStructure> leverageFct =
-                ext::shared_ptr<LocalVolTermStructure>(),
+                ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
             Real mixingFactor = 1.0);
 
         void calculate() const override;
@@ -78,7 +76,6 @@ namespace QuantLib {
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
         const Real mixingFactor_;
     };
-
 
 }
 

--- a/test-suite/barrieroption.cpp
+++ b/test-suite/barrieroption.cpp
@@ -1251,10 +1251,14 @@ void BarrierOptionTest::testOldDividendBarrierOption() {
             const Real barrier = barriers[i];
             const Barrier::Type barrierType = barrierTypes[i];
 
+            QL_DEPRECATED_DISABLE_WARNING
+
             DividendBarrierOption barrierOption(
                 barrierType, barrier, rebate, payoff, exercise,
                 std::vector<Date>(1, divDate),
                 std::vector<Real>(1, divAmount));
+
+            QL_DEPRECATED_ENABLE_WARNING
 
             barrierOption.setPricingEngine(engine);
 
@@ -1292,8 +1296,8 @@ void BarrierOptionTest::testDividendBarrierOption() {
     Real strike = 105.0;
     Real rebate = 5.0;
 
-    Real barriers[] = { 80.0, 120.0 };
-    Barrier::Type barrierTypes[] = { Barrier::DownOut, Barrier::UpOut };
+    Real barriers[] = { 80.0, 120.0, 80.0, 120.0 };
+    Barrier::Type barrierTypes[] = { Barrier::DownOut, Barrier::UpOut, Barrier::DownIn, Barrier::UpIn };
 
     Rate r = 0.05;
     Rate q = 0.0;
@@ -1353,10 +1357,12 @@ void BarrierOptionTest::testDividendBarrierOption() {
         rTS->discount(divDate)*rebate,
         (*payoff)(
             (spot - divAmount*rTS->discount(divDate))/rTS->discount(maturity))
-            *rTS->discount(maturity)
+            *rTS->discount(maturity),
+        29.154,
+        4.765
     };
 
-    Real relTol = 1e-4;
+    Real relTol = 2e-4;
     for (Size i=0; i < LENGTH(barriers); ++i) {
         for (Size j=0; j < LENGTH(engines); ++j) {
             Real barrier = barriers[i];
@@ -1490,9 +1496,11 @@ void BarrierOptionTest::testBarrierAndDividendEngine() {
 
     auto option1 = BarrierOption(Barrier::DownIn, 80.0, 0.0, payoff,
                                  ext::make_shared<EuropeanExercise>(Date(1, June, 2023)));
+    QL_DEPRECATED_DISABLE_WARNING
     auto option2 = DividendBarrierOption(Barrier::DownIn, 80.0, 0.0, payoff,
                                          ext::make_shared<EuropeanExercise>(Date(1, June, 2023)),
                                          {Date(1, February, 2023)}, {1.0});
+    QL_DEPRECATED_ENABLE_WARNING
 
     option1.setPricingEngine(engine);
     option2.setPricingEngine(engine);

--- a/test-suite/barrieroption.hpp
+++ b/test-suite/barrieroption.hpp
@@ -35,7 +35,9 @@ class BarrierOptionTest {
     static void testLocalVolAndHestonComparison();
     static void testVannaVolgaSimpleBarrierValues();
     static void testVannaVolgaDoubleBarrierValues();
+    static void testOldDividendBarrierOption();
     static void testDividendBarrierOption();
+    static void testDividendBarrierOptionWithDividendsPastMaturity();
     static void testBarrierAndDividendEngine();
 
     static boost::unit_test_framework::test_suite* suite();

--- a/test-suite/barrieroption.hpp
+++ b/test-suite/barrieroption.hpp
@@ -39,6 +39,7 @@ class BarrierOptionTest {
     static void testDividendBarrierOption();
     static void testDividendBarrierOptionWithDividendsPastMaturity();
     static void testBarrierAndDividendEngine();
+    static void testImpliedVolatility();
 
     static boost::unit_test_framework::test_suite* suite();
     static boost::unit_test_framework::test_suite* experimental();


### PR DESCRIPTION
Being market data and not part of the contract, dividends should be passed to pricing engines and not to instruments.

Doing that allows us to use `BarrierOption` for calculations with or without dividends.  `DividendBarrierOption` and its inner `arguments` and `engine` classes are now deprecated; you can use `BarrierOption` instead.  If you have written an engine for dividend barrier options, implement it in terms of `BarrierOption::arguments` and `BarrierOption::engine` instead and pass the dividends in its constructor.