### PR TITLE
Ensure that inflation curves are re-bootstrapped when seasonality is added

### DIFF
--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -32,7 +32,11 @@ namespace QuantLib {
     : TermStructure(dayCounter),
       observationLag_(observationLag), frequency_(frequency),
       baseRate_(baseRate) {
-        setSeasonality(seasonality);
+        if (seasonality != nullptr) {
+            QL_REQUIRE(seasonality->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+            seasonality_ = seasonality;
+        }
     }
 
     InflationTermStructure::InflationTermStructure(
@@ -46,7 +50,11 @@ namespace QuantLib {
     : TermStructure(referenceDate, calendar, dayCounter),
       observationLag_(observationLag), frequency_(frequency),
       baseRate_(baseRate) {
-        setSeasonality(seasonality);
+        if (seasonality != nullptr) {
+            QL_REQUIRE(seasonality->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+            seasonality_ = seasonality;
+        }
     }
 
     InflationTermStructure::InflationTermStructure(
@@ -60,7 +68,11 @@ namespace QuantLib {
     : TermStructure(settlementDays, calendar, dayCounter),
       observationLag_(observationLag), frequency_(frequency),
       baseRate_(baseRate) {
-        setSeasonality(seasonality);
+        if (seasonality != nullptr) {
+            QL_REQUIRE(seasonality->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+            seasonality_ = seasonality;
+        }
     }
 
     void InflationTermStructure::setSeasonality(
@@ -69,10 +81,9 @@ namespace QuantLib {
         seasonality_ = seasonality;
         if (seasonality_ != nullptr) {
             QL_REQUIRE(seasonality_->isConsistent(*this),
-                       "Seasonality inconsistent with "
-                       "inflation term structure");
+                       "Seasonality inconsistent with inflation term structure");
         }
-        notifyObservers();
+        update();
     }
 
 

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -29,13 +29,12 @@ namespace QuantLib {
                                         Frequency frequency,
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
-    : TermStructure(dayCounter),
+    : TermStructure(dayCounter), seasonality_(seasonality),
       observationLag_(observationLag), frequency_(frequency),
       baseRate_(baseRate) {
-        if (seasonality != nullptr) {
-            QL_REQUIRE(seasonality->isConsistent(*this),
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
-            seasonality_ = seasonality;
         }
     }
 
@@ -47,13 +46,11 @@ namespace QuantLib {
                                         const Calendar& calendar,
                                         const DayCounter& dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
-    : TermStructure(referenceDate, calendar, dayCounter),
-      observationLag_(observationLag), frequency_(frequency),
-      baseRate_(baseRate) {
-        if (seasonality != nullptr) {
-            QL_REQUIRE(seasonality->isConsistent(*this),
+    : TermStructure(referenceDate, calendar, dayCounter), seasonality_(seasonality),
+      observationLag_(observationLag), frequency_(frequency), baseRate_(baseRate) {
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
-            seasonality_ = seasonality;
         }
     }
 
@@ -65,13 +62,12 @@ namespace QuantLib {
                                         Frequency frequency,
                                         const DayCounter &dayCounter,
                                         const ext::shared_ptr<Seasonality> &seasonality)
-    : TermStructure(settlementDays, calendar, dayCounter),
+    : TermStructure(settlementDays, calendar, dayCounter), seasonality_(seasonality),
       observationLag_(observationLag), frequency_(frequency),
       baseRate_(baseRate) {
-        if (seasonality != nullptr) {
-            QL_REQUIRE(seasonality->isConsistent(*this),
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
-            seasonality_ = seasonality;
         }
     }
 

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -41,21 +41,21 @@ namespace QuantLib {
                                const Period& observationLag,
                                Frequency frequency,
                                const DayCounter& dayCounter = DayCounter(),
-                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                               const ext::shared_ptr<Seasonality> &seasonality = {});
         InflationTermStructure(const Date& referenceDate,
                                Rate baseRate,
                                const Period& observationLag,
                                Frequency frequency,
                                const Calendar& calendar = Calendar(),
                                const DayCounter& dayCounter = DayCounter(),
-                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                               const ext::shared_ptr<Seasonality> &seasonality = {});
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Rate baseRate,
                                const Period& observationLag,
                                Frequency frequency,
                                const DayCounter& dayCounter = DayCounter(),
-                               const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                               const ext::shared_ptr<Seasonality> &seasonality = {});
         //@}
 
         //! \name Inflation interface
@@ -84,8 +84,7 @@ namespace QuantLib {
         /*! Calling setSeasonality with no arguments means unsetting
             as the default is used to choose unsetting.
         */
-        void setSeasonality(const ext::shared_ptr<Seasonality>& seasonality =
-                                            ext::shared_ptr<Seasonality>());
+        void setSeasonality(const ext::shared_ptr<Seasonality>& seasonality = {});
         ext::shared_ptr<Seasonality> seasonality() const;
         bool hasSeasonality() const;
 
@@ -122,7 +121,7 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
-                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                                   const ext::shared_ptr<Seasonality> &seasonality = {});
 
         ZeroInflationTermStructure(const Date& referenceDate,
                                    const Calendar& calendar,
@@ -130,7 +129,7 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
-                                   const ext::shared_ptr<Seasonality>& seasonality = ext::shared_ptr<Seasonality>());
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
@@ -138,7 +137,7 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
-                                   const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                                   const ext::shared_ptr<Seasonality> &seasonality = {});
         //@}
 
         //! \name Inspectors
@@ -182,7 +181,7 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                                  const ext::shared_ptr<Seasonality> &seasonality = {});
 
         YoYInflationTermStructure(const Date& referenceDate,
                                   const Calendar& calendar,
@@ -191,7 +190,7 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                                  const ext::shared_ptr<Seasonality> &seasonality = {});
 
         YoYInflationTermStructure(Natural settlementDays,
                                   const Calendar& calendar,
@@ -200,7 +199,7 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = ext::shared_ptr<Seasonality>());
+                                  const ext::shared_ptr<Seasonality> &seasonality = {});
         //@}
 
         //! \name Inspectors

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -93,6 +93,338 @@ namespace inflation_test {
 // zero inflation tests, index, termstructure, and swaps
 //===========================================================================================
 
+void InflationTest::testZeroIndex() {
+    BOOST_TEST_MESSAGE("Testing zero inflation indices...");
+
+    SavedSettings backup;
+    IndexHistoryCleaner cleaner;
+
+    QL_DEPRECATED_DISABLE_WARNING
+
+    EUHICP euhicp(true);
+    if (euhicp.name() != "EU HICP"
+        || euhicp.frequency() != Monthly
+        || euhicp.revised()
+        || !euhicp.interpolated()
+        || euhicp.availabilityLag() != 1*Months) {
+        BOOST_ERROR("wrong EU HICP data ("
+                    << euhicp.name() << ", "
+                    << euhicp.frequency() << ", "
+                    << euhicp.revised() << ", "
+                    << euhicp.interpolated() << ", "
+                    << euhicp.availabilityLag() << ")");
+    }
+
+    UKRPI ukrpi;
+    if (ukrpi.name() != "UK RPI"
+        || ukrpi.frequency() != Monthly
+        || ukrpi.revised()
+        || ukrpi.interpolated()
+        || ukrpi.availabilityLag() != 1*Months) {
+        BOOST_ERROR("wrong UK RPI data ("
+                    << ukrpi.name() << ", "
+                    << ukrpi.frequency() << ", "
+                    << ukrpi.revised() << ", "
+                    << ukrpi.interpolated() << ", "
+                    << ukrpi.availabilityLag() << ")");
+    }
+
+    QL_DEPRECATED_ENABLE_WARNING
+
+    // Retrieval test.
+    //----------------
+    // make sure of the evaluation date
+    Date evaluationDate(13, August, 2007);
+    evaluationDate = UnitedKingdom().adjust(evaluationDate);
+    Settings::instance().evaluationDate() = evaluationDate;
+
+    // fixing data
+    Date from(1, January, 2005);
+    Date to(13, August, 2007);
+    Schedule rpiSchedule = MakeSchedule().from(from).to(to)
+    .withTenor(1*Months)
+    .withCalendar(UnitedKingdom())
+    .withConvention(ModifiedFollowing);
+
+    Real fixData[] = { 189.9, 189.9, 189.6, 190.5, 191.6, 192.0,
+        192.2, 192.2, 192.6, 193.1, 193.3, 193.6,
+        194.1, 193.4, 194.2, 195.0, 196.5, 197.7,
+        198.5, 198.5, 199.2, 200.1, 200.4, 201.1,
+        202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+        207.3, 206.1 };
+
+    auto iir = ext::make_shared<UKRPI>();
+    for (Size i=0; i<LENGTH(fixData); i++) {
+        iir->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    Date todayMinusLag = evaluationDate - iir->availabilityLag();
+    std::pair<Date,Date> lim = inflationPeriod(todayMinusLag, iir->frequency());
+    todayMinusLag = lim.first;
+
+    Real eps = 1.0e-8;
+
+    // -1 because last value not yet available,
+    // (no TS so can't forecast).
+    for (Size i=0; i<rpiSchedule.size()-1;i++) {
+        std::pair<Date,Date> lim = inflationPeriod(rpiSchedule[i],
+                                                   iir->frequency());
+        for (Date d=lim.first; d<=lim.second; d++) {
+            if (d < inflationPeriod(todayMinusLag,iir->frequency()).first) {
+                if (std::fabs(iir->fixing(d) - fixData[i]) > eps)
+                    BOOST_ERROR("Fixings not constant within a period: "
+                                << iir->fixing(d)
+                                << ", should be " << fixData[i]);
+            }
+        }
+    }
+}
+
+
+
+void InflationTest::testZeroTermStructure() {
+    BOOST_TEST_MESSAGE("Testing zero inflation term structure...");
+
+    using namespace inflation_test;
+
+    SavedSettings backup;
+    IndexHistoryCleaner cleaner;
+
+    // try the Zero UK
+    Calendar calendar = UnitedKingdom();
+    BusinessDayConvention bdc = ModifiedFollowing;
+    Date evaluationDate(13, August, 2007);
+    evaluationDate = calendar.adjust(evaluationDate);
+    Settings::instance().evaluationDate() = evaluationDate;
+
+    // fixing data
+    Date from(1, January, 2005);
+    Date to(13, August, 2007);
+    Schedule rpiSchedule = MakeSchedule().from(from).to(to)
+    .withTenor(1*Months)
+    .withCalendar(UnitedKingdom())
+    .withConvention(ModifiedFollowing);
+
+    Real fixData[] = {
+        189.9, 189.9, 189.6, 190.5, 191.6, 192.0,
+        192.2, 192.2, 192.6, 193.1, 193.3, 193.6,
+        194.1, 193.4, 194.2, 195.0, 196.5, 197.7,
+        198.5, 198.5, 199.2, 200.1, 200.4, 201.1,
+        202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+        207.3};
+
+    RelinkableHandle<ZeroInflationTermStructure> hz;
+    auto ii = ext::make_shared<UKRPI>(hz);
+    for (Size i=0; i<LENGTH(fixData); i++) {
+        ii->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    Handle<YieldTermStructure> nominalTS(nominalTermStructure());
+
+    // now build the zero inflation curve
+    std::vector<Datum> zcData = {
+        { Date(13, August, 2008), 2.93 },
+        { Date(13, August, 2009), 2.95 },
+        { Date(13, August, 2010), 2.965 },
+        { Date(15, August, 2011), 2.98 },
+        { Date(13, August, 2012), 3.0 },
+        { Date(13, August, 2014), 3.06 },
+        { Date(13, August, 2017), 3.175 },
+        { Date(13, August, 2019), 3.243 },
+        { Date(15, August, 2022), 3.293 },
+        { Date(14, August, 2027), 3.338 },
+        { Date(13, August, 2032), 3.348 },
+        { Date(15, August, 2037), 3.348 },
+        { Date(13, August, 2047), 3.308 },
+        { Date(13, August, 2057), 3.228 }
+    };
+
+    Period observationLag = Period(3, Months);
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
+    Frequency frequency = Monthly;
+
+    auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
+        return ext::make_shared<ZeroCouponInflationSwapHelper>(
+            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, nominalTS);
+    };
+    auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
+
+    Rate baseZeroRate = zcData[0].rate/100.0;
+    ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
+                        new PiecewiseZeroInflationCurve<Linear>(
+                        evaluationDate, calendar, dc, observationLag,
+                        frequency, baseZeroRate, helpers));
+    hz.linkTo(pZITS);
+
+    //===========================================================================================
+    // first check that the quoted swaps are repriced correctly
+
+    const Real eps = 1.0e-6;
+    auto engine = ext::make_shared<DiscountingSwapEngine>(nominalTS);
+    
+    for (Size i=0; i<zcData.size(); i++) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      zcData[i].date,
+                                      calendar, bdc, dc,
+                                      zcData[i].rate/100.0,
+                                      ii, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << zcData[i].rate);
+    }
+
+    //===========================================================================================
+    // now test the forecasting capability of the index.
+
+    from = hz->referenceDate();
+    to = hz->maxDate()-1*Months; // a bit of margin for adjustments
+    Schedule testIndex = MakeSchedule().from(from).to(to)
+                            .withTenor(1*Months)
+                            .withCalendar(UnitedKingdom())
+                            .withConvention(ModifiedFollowing);
+
+    // we are testing UKRPI which is not interpolated
+    Date bd = hz->baseDate();
+    Real bf = ii->fixing(bd);
+    for (const auto& d : testIndex) {
+        Real z = hz->zeroRate(d, Period(0, Days));
+        Real t = hz->dayCounter().yearFraction(bd, inflationPeriod(d, ii->frequency()).first);
+        Real calc = bf * std::pow(1+z, t);
+        if (t<=0)
+            calc = ii->fixing(d,false); // still historical
+        if (std::fabs(calc - ii->fixing(d,true)) > eps)
+            BOOST_ERROR("inflation index does not forecast correctly"
+                        << "\n    date:        " << d
+                        << "\n    base date:   " << bd
+                        << "\n    base fixing: " << bf
+                        << "\n    expected:    " << calc
+                        << "\n    forecast:    " << ii->fixing(d,true));
+    }
+
+    //===========================================================================================
+    // Add a seasonality correction.  The curve should recalculate and still reprice the swaps.
+
+    Date nextBaseDate = inflationPeriod(hz->baseDate(), ii->frequency()).second;
+    Date seasonalityBaseDate(31, January, nextBaseDate.year());
+    vector<Rate> seasonalityFactors = {
+        1.003245,
+        1.000000,
+        0.999715,
+        1.000495,
+        1.000929,
+        0.998687,
+        0.995949,
+        0.994682,
+        0.995949,
+        1.000519,
+        1.003705,
+        1.004186
+    };
+
+    ext::shared_ptr<MultiplicativePriceSeasonality> nonUnitSeasonality =
+        ext::make_shared<MultiplicativePriceSeasonality>(seasonalityBaseDate, Monthly, seasonalityFactors);
+
+    pZITS->setSeasonality(nonUnitSeasonality);
+    
+    for (Size i=0; i<zcData.size(); i++) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      zcData[i].date,
+                                      calendar, bdc, dc,
+                                      zcData[i].rate/100.0,
+                                      ii, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << zcData[i].rate);
+    }
+
+    //==============================================================================
+    // now do an INTERPOLATED index, i.e. repeat everything on a fake version of
+    // UKRPI (to save making another term structure)
+
+    bool interpYES = true;
+    QL_DEPRECATED_DISABLE_WARNING
+    ext::shared_ptr<UKRPI> iiyes(new UKRPI(interpYES, hz));
+    QL_DEPRECATED_ENABLE_WARNING
+    for (Size i=0; i<LENGTH(fixData);i++) {
+        iiyes->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    auto makeHelperYes = [&](const Handle<Quote>& quote, const Date& maturity) {
+        return ext::make_shared<ZeroCouponInflationSwapHelper>(
+            quote, observationLag, maturity, calendar, bdc, dc, iiyes, CPI::AsIndex,
+            Handle<YieldTermStructure>(nominalTS));
+    };
+    auto helpersyes = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelperYes);
+
+    ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITSyes(
+            new PiecewiseZeroInflationCurve<Linear>(
+            evaluationDate, calendar, dc, observationLag,
+            frequency, baseZeroRate, helpersyes));
+
+    hz.linkTo(pZITSyes);
+
+    //===========================================================================================
+    // Test zero coupon swaps
+    
+    for (Size i=0; i<zcData.size(); i++) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      zcData[i].date,
+                                      calendar, bdc, dc,
+                                      zcData[i].rate/100.0,
+                                      iiyes, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << zcData[i].rate);
+    }
+
+    //===========================================================================================
+    // Perform checks on the seasonality for this interpolated index
+
+    pZITSyes->setSeasonality(nonUnitSeasonality);
+
+    for (Size i=0; i<zcData.size(); i++) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      zcData[i].date,
+                                      calendar, bdc, dc,
+                                      zcData[i].rate/100.0,
+                                      iiyes, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << zcData[i].rate);
+    }
+
+    // remove circular refernce
+    hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
+}
+
 namespace inflation_test {
 
 void checkSeasonality(const Handle<ZeroInflationTermStructure>& hz,
@@ -237,97 +569,8 @@ void checkSeasonality(const Handle<ZeroInflationTermStructure>& hz,
 
 }
 
-void InflationTest::testZeroIndex() {
-    BOOST_TEST_MESSAGE("Testing zero inflation indices...");
-
-    SavedSettings backup;
-    IndexHistoryCleaner cleaner;
-
-    QL_DEPRECATED_DISABLE_WARNING
-
-    EUHICP euhicp(true);
-    if (euhicp.name() != "EU HICP"
-        || euhicp.frequency() != Monthly
-        || euhicp.revised()
-        || !euhicp.interpolated()
-        || euhicp.availabilityLag() != 1*Months) {
-        BOOST_ERROR("wrong EU HICP data ("
-                    << euhicp.name() << ", "
-                    << euhicp.frequency() << ", "
-                    << euhicp.revised() << ", "
-                    << euhicp.interpolated() << ", "
-                    << euhicp.availabilityLag() << ")");
-    }
-
-    UKRPI ukrpi;
-    if (ukrpi.name() != "UK RPI"
-        || ukrpi.frequency() != Monthly
-        || ukrpi.revised()
-        || ukrpi.interpolated()
-        || ukrpi.availabilityLag() != 1*Months) {
-        BOOST_ERROR("wrong UK RPI data ("
-                    << ukrpi.name() << ", "
-                    << ukrpi.frequency() << ", "
-                    << ukrpi.revised() << ", "
-                    << ukrpi.interpolated() << ", "
-                    << ukrpi.availabilityLag() << ")");
-    }
-
-    QL_DEPRECATED_ENABLE_WARNING
-
-    // Retrieval test.
-    //----------------
-    // make sure of the evaluation date
-    Date evaluationDate(13, August, 2007);
-    evaluationDate = UnitedKingdom().adjust(evaluationDate);
-    Settings::instance().evaluationDate() = evaluationDate;
-
-    // fixing data
-    Date from(1, January, 2005);
-    Date to(13, August, 2007);
-    Schedule rpiSchedule = MakeSchedule().from(from).to(to)
-    .withTenor(1*Months)
-    .withCalendar(UnitedKingdom())
-    .withConvention(ModifiedFollowing);
-
-    Real fixData[] = { 189.9, 189.9, 189.6, 190.5, 191.6, 192.0,
-        192.2, 192.2, 192.6, 193.1, 193.3, 193.6,
-        194.1, 193.4, 194.2, 195.0, 196.5, 197.7,
-        198.5, 198.5, 199.2, 200.1, 200.4, 201.1,
-        202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
-        207.3, 206.1 };
-
-    auto iir = ext::make_shared<UKRPI>();
-    for (Size i=0; i<LENGTH(fixData); i++) {
-        iir->addFixing(rpiSchedule[i], fixData[i]);
-    }
-
-    Date todayMinusLag = evaluationDate - iir->availabilityLag();
-    std::pair<Date,Date> lim = inflationPeriod(todayMinusLag, iir->frequency());
-    todayMinusLag = lim.first;
-
-    Real eps = 1.0e-8;
-
-    // -1 because last value not yet available,
-    // (no TS so can't forecast).
-    for (Size i=0; i<rpiSchedule.size()-1;i++) {
-        std::pair<Date,Date> lim = inflationPeriod(rpiSchedule[i],
-                                                   iir->frequency());
-        for (Date d=lim.first; d<=lim.second; d++) {
-            if (d < inflationPeriod(todayMinusLag,iir->frequency()).first) {
-                if (std::fabs(iir->fixing(d) - fixData[i]) > eps)
-                    BOOST_ERROR("Fixings not constant within a period: "
-                                << iir->fixing(d)
-                                << ", should be " << fixData[i]);
-            }
-        }
-    }
-}
-
-
-
-void InflationTest::testZeroTermStructure() {
-    BOOST_TEST_MESSAGE("Testing zero inflation term structure...");
+void InflationTest::testSeasonalityCorrection() {
+    BOOST_TEST_MESSAGE("Testing seasonality correction on zero inflation term structure...");
 
     using namespace inflation_test;
 
@@ -336,7 +579,6 @@ void InflationTest::testZeroTermStructure() {
 
     // try the Zero UK
     Calendar calendar = UnitedKingdom();
-    BusinessDayConvention bdc = ModifiedFollowing;
     Date evaluationDate(13, August, 2007);
     evaluationDate = calendar.adjust(evaluationDate);
     Settings::instance().evaluationDate() = evaluationDate;
@@ -357,151 +599,57 @@ void InflationTest::testZeroTermStructure() {
         207.3};
 
     RelinkableHandle<ZeroInflationTermStructure> hz;
-    auto iiUKRPI = ext::make_shared<UKRPI>(hz);
+    auto ii = ext::make_shared<UKRPI>(hz);
     for (Size i=0; i<LENGTH(fixData); i++) {
-        iiUKRPI->addFixing(rpiSchedule[i], fixData[i]);
+        ii->addFixing(rpiSchedule[i], fixData[i]);
     }
 
-    ext::shared_ptr<ZeroInflationIndex> ii = ext::dynamic_pointer_cast<ZeroInflationIndex>(iiUKRPI);
     ext::shared_ptr<YieldTermStructure> nominalTS = nominalTermStructure();
 
-    // now build the zero inflation curve
-    std::vector<Datum> zcData = {
-        { Date(13, August, 2008), 2.93 },
-        { Date(13, August, 2009), 2.95 },
-        { Date(13, August, 2010), 2.965 },
-        { Date(15, August, 2011), 2.98 },
-        { Date(13, August, 2012), 3.0 },
-        { Date(13, August, 2014), 3.06 },
-        { Date(13, August, 2017), 3.175 },
-        { Date(13, August, 2019), 3.243 },
-        { Date(15, August, 2022), 3.293 },
-        { Date(14, August, 2027), 3.338 },
-        { Date(13, August, 2032), 3.348 },
-        { Date(15, August, 2037), 3.348 },
-        { Date(13, August, 2047), 3.308 },
-        { Date(13, August, 2057), 3.228 }
+    std::vector<Date> nodes = {
+        Date(1, June, 2007),
+        Date(1, June, 2008),
+        Date(1, June, 2009),
+        Date(1, June, 2010),
+        Date(1, June, 2011),
+        Date(1, June, 2012),
+        Date(1, June, 2014),
+        Date(1, June, 2017),
+        Date(1, June, 2019),
+        Date(1, June, 2022),
+        Date(1, June, 2027),
+        Date(1, June, 2032),
+        Date(1, June, 2037),
+        Date(1, June, 2047),
+        Date(1, June, 2057)
+    };
+
+    std::vector<Rate> rates = {
+        0.0293,
+        0.0293,
+        0.0295,
+        0.02965,
+        0.0298,
+        0.03,
+        0.0306,
+        0.03175,
+        0.03243,
+        0.03293,
+        0.03338,
+        0.03348,
+        0.03348,
+        0.03308,
+        0.03228
     };
 
     Period observationLag = Period(2,Months);
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
 
-    auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
-        return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex,
-            Handle<YieldTermStructure>(nominalTS));
-    };
-    auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
-
-    Rate baseZeroRate = zcData[0].rate/100.0;
-    ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
-                        new PiecewiseZeroInflationCurve<Linear>(
-                        evaluationDate, calendar, dc, observationLag,
-                        frequency, baseZeroRate, helpers));
-    pZITS->recalculate();
-
-    // first check that the zero rates on the curve match the data
-    // and that the helpers give the correct implied rates
-    const Real eps = 1.0e-8;
-    bool forceLinearInterpolation = false;
-    for (Size i=0; i<zcData.size(); i++) {
-        BOOST_REQUIRE_MESSAGE(std::fabs(zcData[i].rate/100.0
-            - pZITS->zeroRate(zcData[i].date, observationLag, forceLinearInterpolation)) < eps,
-            "ZITS zeroRate != instrument "
-            << pZITS->zeroRate(zcData[i].date, observationLag, forceLinearInterpolation)
-            << " vs " << zcData[i].rate/100.0
-            << " forceLinearInterpolation " << forceLinearInterpolation);
-        BOOST_REQUIRE_MESSAGE(std::fabs(helpers[i]->impliedQuote()
-            - zcData[i].rate/100.0) < eps,
-            "ZITS implied quote != instrument "
-            << helpers[i]->impliedQuote()
-            << " vs " << zcData[i].rate/100.0);
-    }
-
-
-    // now test the forecasting capability of the index.
-    hz.linkTo(pZITS);
-    from = hz->baseDate();
-    to = hz->maxDate()-1*Months; // a bit of margin for adjustments
-    Schedule testIndex = MakeSchedule().from(from).to(to)
-                            .withTenor(1*Months)
-                            .withCalendar(UnitedKingdom())
-                            .withConvention(ModifiedFollowing);
-
-
-    // we are testing UKRPI which is not interpolated
-    Date bd = hz->baseDate();
-    Real bf = ii->fixing(bd);
-    for (const auto& d : testIndex) {
-        Real z = hz->zeroRate(d, Period(0, Days));
-        Real t = hz->dayCounter().yearFraction(bd, d);
-        QL_DEPRECATED_DISABLE_WARNING
-        if(!ii->interpolated()) // because fixing constant over period
-            t = hz->dayCounter().yearFraction(bd,
-                inflationPeriod(d, ii->frequency()).first);
-        QL_DEPRECATED_ENABLE_WARNING
-        Real calc = bf * pow( 1+z, t);
-        if (t<=0)
-            calc = ii->fixing(d,false); // still historical
-        if (std::fabs(calc - ii->fixing(d,true))/10000.0 > eps)
-            BOOST_ERROR("ZC index does not forecast correctly for date " << d
-                        << " from base date " << bd
-                        << " with fixing " << bf
-                        << ", correct:  " << calc
-                        << ", fix: " << ii->fixing(d,true)
-                        << ", t " << t);
-    }
-
-
-    //===========================================================================================
-    // Test zero-inflation-indexed (i.e. cpi ratio) cashflow
-    // just ordinary indexed cashflow with a zero inflation index
-
-    Date baseDate(1, January, 2006);
-    Date fixDate(1, August, 2014);
-    Date payDate=UnitedKingdom().adjust(fixDate+Period(3,Months),ModifiedFollowing);
-    ext::shared_ptr<Index> ind = ext::dynamic_pointer_cast<Index>(ii);
-    BOOST_REQUIRE_MESSAGE(ind,"dynamic_pointer_cast to Index from InflationIndex failed");
-
-    Real notional = 1000000.0;//1m
-    IndexedCashFlow iicf(notional,ind,baseDate,fixDate,payDate);
-    Real correctIndexed = ii->fixing(iicf.fixingDate())/ii->fixing(iicf.baseDate());
-    Real calculatedIndexed = iicf.amount()/iicf.notional();
-    BOOST_REQUIRE_MESSAGE(std::fabs(correctIndexed - calculatedIndexed) < eps,
-               "IndexedCashFlow indexing wrong: " << calculatedIndexed << " vs correct = "
-               << correctIndexed);
-
-
-    //===========================================================================================
-    // Test zero coupon swap
-
-    // first make one ...
-
-    ext::shared_ptr<ZeroInflationIndex> zii = ext::dynamic_pointer_cast<ZeroInflationIndex>(ii);
-    BOOST_REQUIRE_MESSAGE(zii,"dynamic_pointer_cast to ZeroInflationIndex from UKRPI failed");
-    ZeroCouponInflationSwap nzcis(Swap::Payer,
-                                  1000000.0,
-                                  evaluationDate,
-                                  zcData[6].date,    // end date = maturity
-                                  calendar, bdc, dc, zcData[6].rate/100.0, // fixed rate
-                                  zii, observationLag, CPI::AsIndex);
-
-    // N.B. no coupon pricer because it is not a coupon, effect of inflation curve via
-    //      inflation curve attached to the inflation index.
-    Handle<YieldTermStructure> hTS(nominalTS);
-    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
-    nzcis.setPricingEngine(sppe);
-
-    // ... and price it, should be zero
-    BOOST_CHECK_MESSAGE(fabs(nzcis.NPV())<0.00001,"ZCIS does not reprice to zero "
-                        << nzcis.NPV()
-                        << evaluationDate << " to " << zcData[6].date << " becoming " << nzcis.maturityDate()
-                        << " rate " << zcData[6].rate
-                        << " fixed leg " << nzcis.legNPV(0)
-                        << " indexed-predicted inflated leg " << nzcis.legNPV(1)
-                        << " discount " << nominalTS->discount(nzcis.maturityDate())
-                        );
+    auto zeroCurve = ext::make_shared<InterpolatedZeroInflationCurve<Linear>>(
+                                 evaluationDate, calendar, dc, observationLag,
+                                 frequency, nodes, rates);
+    hz.linkTo(zeroCurve);
 
     // Perform checks on the seasonality for this non-interpolated index
     checkSeasonality(hz, ii);
@@ -512,77 +660,14 @@ void InflationTest::testZeroTermStructure() {
 
     bool interpYES = true;
     QL_DEPRECATED_DISABLE_WARNING
-    ext::shared_ptr<UKRPI> iiUKRPIyes(new UKRPI(interpYES, hz));
+    ext::shared_ptr<UKRPI> iiyes(new UKRPI(interpYES, hz));
     QL_DEPRECATED_ENABLE_WARNING
     for (Size i=0; i<LENGTH(fixData);i++) {
-        iiUKRPIyes->addFixing(rpiSchedule[i], fixData[i]);
+        iiyes->addFixing(rpiSchedule[i], fixData[i]);
     }
-
-    ext::shared_ptr<ZeroInflationIndex> iiyes
-        = ext::dynamic_pointer_cast<ZeroInflationIndex>(iiUKRPIyes);
-
-    // now build the zero inflation curve
-    // same data, bigger lag or it will be a self-contradiction
-    Period observationLagyes = Period(3,Months);
-
-    auto makeHelperYes = [&](const Handle<Quote>& quote, const Date& maturity) {
-        return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLagyes, maturity, calendar, bdc, dc, iiyes, CPI::AsIndex,
-            Handle<YieldTermStructure>(nominalTS));
-    };
-    auto helpersyes = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelperYes);
-
-    ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITSyes(
-            new PiecewiseZeroInflationCurve<Linear>(
-            evaluationDate, calendar, dc, observationLagyes,
-            frequency, baseZeroRate, helpersyes));
-
-    pZITSyes->recalculate();
-
-    // For interpolated fixings, the zero rates on the curve no longer match the data.
-    // The helpers still give the correct implied rates, of course.
-    for (Size i=0; i<zcData.size(); i++) {
-        BOOST_CHECK_MESSAGE(std::fabs(helpersyes[i]->impliedQuote()
-                        - zcData[i].rate/100.0) < eps,
-                    "ZITS INTERPOLATED implied quote != instrument "
-                    << helpersyes[i]->impliedQuote()
-                    << " vs " << zcData[i].rate/100.0);
-    }
-
-
-    //===========================================================================================
-    // Test zero coupon swap
-
-    hz.linkTo(pZITSyes);
-
-    ext::shared_ptr<ZeroInflationIndex> ziiyes = ext::dynamic_pointer_cast<ZeroInflationIndex>(iiyes);
-    BOOST_REQUIRE_MESSAGE(ziiyes,"dynamic_pointer_cast to ZeroInflationIndex from UKRPI-I failed");
-    ZeroCouponInflationSwap nzcisyes(Swap::Payer,
-                                     1000000.0,
-                                     evaluationDate,
-                                     zcData[6].date,    // end date = maturity
-                                     calendar, bdc, dc, zcData[6].rate/100.0, // fixed rate
-                                     ziiyes, observationLagyes, CPI::AsIndex);
-
-    // N.B. no coupon pricer because it is not a coupon, effect of inflation curve via
-    //      inflation curve attached to the inflation index.
-    nzcisyes.setPricingEngine(sppe);
-
-    // ... and price it, should be zero
-    BOOST_CHECK_MESSAGE(fabs(nzcisyes.NPV())<0.00001,"ZCIS-I does not reprice to zero "
-                        << nzcisyes.NPV()
-                        << evaluationDate << " to " << zcData[6].date << " becoming " << nzcisyes.maturityDate()
-                        << " rate " << zcData[6].rate
-                        << " fixed leg " << nzcisyes.legNPV(0)
-                        << " indexed-predicted inflated leg " << nzcisyes.legNPV(1)
-                        << " discount " << nominalTS->discount(nzcisyes.maturityDate())
-                        );
 
     // Perform checks on the seasonality for this interpolated index
     checkSeasonality(hz, iiyes);
-
-    // remove circular refernce
-    hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
 }
 
 void InflationTest::testZeroIndexFutureFixing() {
@@ -1250,6 +1335,7 @@ test_suite* InflationTest::suite() {
 
     suite->add(QUANTLIB_TEST_CASE(&InflationTest::testZeroIndex));
     suite->add(QUANTLIB_TEST_CASE(&InflationTest::testZeroTermStructure));
+    suite->add(QUANTLIB_TEST_CASE(&InflationTest::testSeasonalityCorrection));
     suite->add(QUANTLIB_TEST_CASE(&InflationTest::testZeroIndexFutureFixing));
     suite->add(QUANTLIB_TEST_CASE(&InflationTest::testInterpolatedZeroTermStructure));
 

--- a/test-suite/inflation.hpp
+++ b/test-suite/inflation.hpp
@@ -30,6 +30,7 @@ public:
     static void testPeriod();
     static void testZeroIndex();
     static void testZeroTermStructure();
+    static void testSeasonalityCorrection();
     static void testZeroIndexFutureFixing();
     static void testInterpolatedZeroTermStructure();
     static void testYYIndex();


### PR DESCRIPTION
Previously, the curves would notify their observers but wouldn't necessarily recalculate, resulting in a curve that wouldn't reprice the passed quotes rates.