### PR TITLE
Add UKHICP inflation index

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -864,6 +864,7 @@
     <ClInclude Include="ql\indexes\inflation\aucpi.hpp" />
     <ClInclude Include="ql\indexes\inflation\euhicp.hpp" />
     <ClInclude Include="ql\indexes\inflation\frhicp.hpp" />
+    <ClInclude Include="ql\indexes\inflation\ukhicp.hpp" />
     <ClInclude Include="ql\indexes\inflation\ukrpi.hpp" />
     <ClInclude Include="ql\indexes\inflation\uscpi.hpp" />
     <ClInclude Include="ql\indexes\inflation\zacpi.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4421,6 +4421,9 @@
     <ClInclude Include="ql\methods\finitedifferences\operators\modtriplebandlinearop.hpp">
       <Filter>methods\finitedifferences\operators</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\inflation\ukhicp.hpp">
+      <Filter>indexes\inflation</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ql\methods\montecarlo\brownianbridge.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -1273,6 +1273,7 @@ set(QL_HEADERS
     indexes/inflation/aucpi.hpp
     indexes/inflation/euhicp.hpp
     indexes/inflation/frhicp.hpp
+    indexes/inflation/ukhicp.hpp
     indexes/inflation/ukrpi.hpp
     indexes/inflation/uscpi.hpp
     indexes/inflation/zacpi.hpp

--- a/ql/indexes/inflation/Makefile.am
+++ b/ql/indexes/inflation/Makefile.am
@@ -7,6 +7,7 @@ this_include_HEADERS = \
     aucpi.hpp \
     euhicp.hpp \
     frhicp.hpp \
+	ukhicp.hpp \
     ukrpi.hpp \
     uscpi.hpp \
     zacpi.hpp

--- a/ql/indexes/inflation/ukhicp.hpp
+++ b/ql/indexes/inflation/ukhicp.hpp
@@ -1,0 +1,41 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file ukhicp.hpp
+    \brief UK HICP index
+*/
+
+#ifndef quantlib_ukhicp_hpp
+#define quantlib_ukhicp_hpp
+
+#include <ql/currencies/europe.hpp>
+#include <ql/indexes/inflationindex.hpp>
+
+namespace QuantLib {
+
+    //! UK HICP index
+    class UKHICP : public ZeroInflationIndex {
+      public:
+        explicit UKHICP(const Handle<ZeroInflationTermStructure>& ts = {})
+        : ZeroInflationIndex(
+              "HICP", UKRegion(), false, Monthly, Period(1, Months), GBPCurrency(), ts) {}
+    };
+}
+
+#endif

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -23,6 +23,7 @@
 #include <ql/cashflows/indexedcashflow.hpp>
 #include <ql/indexes/inflation/ukrpi.hpp>
 #include <ql/indexes/inflation/euhicp.hpp>
+#include <ql/indexes/inflation/ukhicp.hpp>
 #include <ql/termstructures/inflation/piecewisezeroinflationcurve.hpp>
 #include <ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
@@ -127,6 +128,18 @@ void InflationTest::testZeroIndex() {
                     << ukrpi.revised() << ", "
                     << ukrpi.interpolated() << ", "
                     << ukrpi.availabilityLag() << ")");
+    }
+
+    UKHICP ukhicp;
+    if (ukhicp.name() != "UK HICP"
+        || ukhicp.frequency() != Monthly
+        || ukhicp.revised() 
+        || ukhicp.availabilityLag() != 1 * Months) {
+        BOOST_ERROR("wrong UK HICP data ("
+                    << ukhicp.name() << ", "
+                    << ukhicp.frequency() << ", "
+                    << ukhicp.revised() << ", "
+                    << ", " << ukhicp.availabilityLag() << ")");
     }
 
     QL_DEPRECATED_ENABLE_WARNING


### PR DESCRIPTION
This adds the UKHICP index along with a basic test. Seeing as other HICP constructors taking the `interpolated` argument have all been deprecated, I've removed that entirely from our additions. Let me know if anything looks fishy.

Best,
Fredrik