### PR TITLE
Corrections to Turkish, Danish, and Austrian calendars

### DIFF
--- a/ql/time/calendars/austria.hpp
+++ b/ql/time/calendars/austria.hpp
@@ -84,7 +84,7 @@ namespace QuantLib {
       public:
         //! Austrian calendars
         enum Market { Settlement,     //!< generic settlement calendar
-                      Exchange        //!< Paris stock-exchange calendar
+                      Exchange        //!< Vienna stock-exchange calendar
         };
         explicit Austria(Market market = Settlement);
     };

--- a/ql/time/calendars/denmark.cpp
+++ b/ql/time/calendars/denmark.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2003 StatPro Italia srl
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -44,16 +45,22 @@ namespace QuantLib {
             || (dd == em+25)
             // Ascension
             || (dd == em+38)
+            // Day after Ascension
+            || (dd == em+39)
             // Whit Monday
             || (dd == em+49)
             // New Year's Day
             || (d == 1  && m == January)
             // Constitution Day, June 5th
             || (d == 5  && m == June)
+            // Christmas Eve
+            || (d == 24 && m == December)
             // Christmas
             || (d == 25 && m == December)
             // Boxing Day
-            || (d == 26 && m == December))
+            || (d == 26 && m == December)
+            // New Year's Eve
+            || (d == 31 && m == December))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }

--- a/ql/time/calendars/denmark.cpp
+++ b/ql/time/calendars/denmark.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
             // Ascension
             || (dd == em+38)
             // Day after Ascension
-            || (dd == em+39)
+            || (dd == em+39 && y >= 2009)
             // Whit Monday
             || (dd == em+49)
             // New Year's Day

--- a/ql/time/calendars/denmark.hpp
+++ b/ql/time/calendars/denmark.hpp
@@ -38,7 +38,7 @@ namespace QuantLib {
         <li>Easter Monday</li>
         <li>General Prayer Day, 25 days after Easter Monday</li>
         <li>Ascension</li>
-        <li>Day after Ascension</li>
+        <li>Day after Ascension (from 2009)</li>
         <li>Whit (Pentecost) Monday </li>
         <li>New Year's Day, January 1st</li>
         <li>Constitution Day, June 5th</li>

--- a/ql/time/calendars/denmark.hpp
+++ b/ql/time/calendars/denmark.hpp
@@ -38,12 +38,18 @@ namespace QuantLib {
         <li>Easter Monday</li>
         <li>General Prayer Day, 25 days after Easter Monday</li>
         <li>Ascension</li>
+        <li>Day after Ascension</li>
         <li>Whit (Pentecost) Monday </li>
         <li>New Year's Day, January 1st</li>
         <li>Constitution Day, June 5th</li>
+        <li>Christmas Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Boxing Day, December 26th</li>
+        <li>New Year's Eve, December 31st</li>
         </ul>
+
+        See: https://www.nasdaqomxnordic.com/tradinghours, 
+        and: https://www.nationalbanken.dk/da/Kontakt/aabningstider/Sider/default.aspx
 
         \ingroup calendars
     */

--- a/ql/time/calendars/turkey.cpp
+++ b/ql/time/calendars/turkey.cpp
@@ -4,6 +4,7 @@
  Copyright (C) 2005 Sercan Atalik
  Copyright (C) 2010 StatPro Italia srl
  Copyright (C) 2018 Matthias Lungwitz
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -156,10 +157,8 @@ namespace QuantLib {
 				|| (m == August && d >= 21 && d <= 24))
 				return false;
 		} else if (y == 2019) {
-		// Note: Holidays >= 2019 are not yet officially anounced by borsaistanbul.com
-		// and need further validation
 			// Ramadan
-			if ((m == June && d >= 5 && d <= 7)
+			if ((m == June && d >= 4 && d <= 6)
 				// Kurban
 				|| (m == August && d >= 11 && d <= 14))
 				return false;
@@ -167,27 +166,29 @@ namespace QuantLib {
 			// Ramadan
 			if ((m == May && d >= 24 && d <= 26)
 				// Kurban
-				|| (m == July && d >= 30 && d <= 31))
+				|| (m == July && d == 31) || (m == August && d >= 1 && d <= 3))
 				return false;
 		} else if (y == 2021) {
 			// Ramadan
-			if ((m == May && d >= 13 && d <= 14)
+			if ((m == May && d >= 13 && d <= 15)
 				// Kurban
-				|| (m == July && d >= 19 && d <= 22))
+				|| (m == July && d >= 20 && d <= 23))
 				return false;
 		} else if (y == 2022) {
 			// Ramadan
-			if ((m == May && d >= 3 && d <= 5)
+			if ((m == May && d >= 2 && d <= 4)
 				// Kurban
 				|| (m == July && d >= 9 && d <= 12))
 				return false;
 		} else if (y == 2023) {
 			// Ramadan
-			if ((m == April && d >= 22 && d <= 24)
+			if ((m == April && d >= 21 && d <= 23)
 				// Kurban
 				|| (m == June && d >= 28 && d <= 30))
 				return false;
 		} else if (y == 2024) {
+		// Note: Holidays >= 2024 are not yet officially anounced by borsaistanbul.com
+		// and need further validation
 			// Ramadan
 			if ((m == April && d >= 10 && d <= 12)
 				// Kurban

--- a/ql/time/calendars/turkey.cpp
+++ b/ql/time/calendars/turkey.cpp
@@ -184,6 +184,7 @@ namespace QuantLib {
 			// Ramadan
 			if ((m == April && d >= 21 && d <= 23)
 				// Kurban
+                // July 1 is also a holiday but falls on a Saturday which is already flagged
 				|| (m == June && d >= 28 && d <= 30))
 				return false;
 		} else if (y == 2024) {

--- a/ql/time/calendars/turkey.hpp
+++ b/ql/time/calendars/turkey.hpp
@@ -33,7 +33,7 @@ namespace QuantLib {
     //! Turkish calendar
     /*! Holidays for the Istanbul Stock Exchange:
         (data from
-         <http://borsaistanbul.com/en/products-and-markets/official-holidays>
+         <https://borsaistanbul.com/en/sayfa/3631/official-holidays>
 		 and
 		 <https://feiertagskalender.ch/index.php?geo=3539&hl=en>):
         <ul>
@@ -46,7 +46,7 @@ namespace QuantLib {
         <li>Democracy and National Unity Day, July 15th</li>
         <li>Victory Day, August 30th</li>
         <li>Republic Day, October 29th</li>
-        <li>Local Holidays (Kurban, Ramadan - dates need further validation for >= 2019) </li>
+        <li>Local Holidays (Kurban, Ramadan - dates need further validation for >= 2024) </li>
         </ul>
 
         \ingroup calendars

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -9,6 +9,7 @@
  Copyright (C) 2020 Piotr Siejda
  Copyright (C) 2020 Leonardo Arcari
  Copyright (C) 2020 Kline s.r.l.
+ Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,6 +32,7 @@
 #include <ql/time/calendars/bespokecalendar.hpp>
 #include <ql/time/calendars/brazil.hpp>
 #include <ql/time/calendars/china.hpp>
+#include <ql/time/calendars/denmark.hpp>
 #include <ql/time/calendars/germany.hpp>
 #include <ql/time/calendars/italy.hpp>
 #include <ql/time/calendars/japan.hpp>
@@ -1366,6 +1368,65 @@ void CalendarTest::testBrazil() {
                                  << hol.size() << " calculated holidays");
 }
 
+void CalendarTest::testDenmark() {
+
+    BOOST_TEST_MESSAGE("Testing Denmark holiday list...");
+
+    std::vector<Date> expectedHol;
+    expectedHol.emplace_back(1, January, 2020);
+    expectedHol.emplace_back(9, April, 2020);
+    expectedHol.emplace_back(10, April, 2020);
+    expectedHol.emplace_back(13, April, 2020);
+    expectedHol.emplace_back(8, May, 2020);
+    expectedHol.emplace_back(21, May, 2020);
+    expectedHol.emplace_back(22, May, 2020);
+    expectedHol.emplace_back(1, June, 2020);
+    expectedHol.emplace_back(5, June, 2020);
+    expectedHol.emplace_back(24, December, 2020);
+    expectedHol.emplace_back(25, December, 2020);
+    // Saturday: expectedHol.emplace_back(26, December, 2020);
+    expectedHol.emplace_back(31, December, 2020);
+
+    expectedHol.emplace_back(1, January, 2021);
+    expectedHol.emplace_back(1, April, 2021);
+    expectedHol.emplace_back(2, April, 2021);
+    expectedHol.emplace_back(5, April, 2021);
+    expectedHol.emplace_back(30, April, 2021);
+    expectedHol.emplace_back(13, May, 2021);
+    expectedHol.emplace_back(14, May, 2021);
+    expectedHol.emplace_back(24, May, 2021);
+    // Saturday: expectedHol.emplace_back(5, June, 2021);
+    expectedHol.emplace_back(24, December, 2021);
+    // Saturday: expectedHol.emplace_back(25, December, 2021);
+    // Sunday: expectedHol.emplace_back(26, December, 2021);
+    expectedHol.emplace_back(31, December, 2021);
+
+    // Saturday: expectedHol.emplace_back(1, January, 2022);
+    expectedHol.emplace_back(14, April, 2022);
+    expectedHol.emplace_back(15, April, 2022);
+    expectedHol.emplace_back(18, April, 2022);
+    expectedHol.emplace_back(13, May, 2022);
+    expectedHol.emplace_back(26, May, 2022);
+    expectedHol.emplace_back(27, May, 2022);
+    // Sunday: expectedHol.emplace_back(5, June, 2022);
+    expectedHol.emplace_back(6, June, 2022);
+    // Saturday: expectedHol.emplace_back(24, December, 2022);
+    // Sunday: expectedHol.emplace_back(25, December, 2022);
+    expectedHol.emplace_back(26, December, 2022);
+    // Saturday: expectedHol.emplace_back(31, December, 2022);
+
+    Calendar c = Denmark();
+    std::vector<Date> hol = c.holidayList(Date(1, January, 2020), Date(31, December, 2022));
+
+    for (Size i = 0; i < std::min<Size>(hol.size(), expectedHol.size()); i++) {
+        if (hol[i] != expectedHol[i])
+            BOOST_FAIL("expected holiday was " << expectedHol[i] << " while calculated holiday is "
+                                               << hol[i]);
+    }
+    if (hol.size() != expectedHol.size())
+        BOOST_FAIL("there were " << expectedHol.size() << " expected holidays, while there are "
+                                 << hol.size() << " calculated holidays");
+}
 
 void CalendarTest::testSouthKoreanSettlement() {
     BOOST_TEST_MESSAGE("Testing South-Korean settlement holiday list...");
@@ -2217,6 +2278,8 @@ test_suite* CalendarTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyEurex));
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testTARGET));
+
+    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testDenmark));
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUSSettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUSGovernmentBondMarket));

--- a/test-suite/calendars.hpp
+++ b/test-suite/calendars.hpp
@@ -44,6 +44,8 @@ class CalendarTest {
 
     static void testTARGET();
 
+    static void testDenmark();
+
     static void testUSSettlement();
     static void testUSGovernmentBondMarket();
     static void testUSNewYorkStockExchange();


### PR DESCRIPTION
Changes:
- Updates bad link in Turkey's calendar impl
- Corrects specific Turkish holidays between 2019 and 2023. Feel free to help verify this. (many date ranges were off-by-one, presumably also the >2024 holidays)
- Adds three missing holidays to the Denmark calendar. Also adds a test for 2022-2022 holidays vs Bloomberg
- Fixes a comment in the Austrian calendar