### PR TITLE
Add ASX Australia calendar, fixes #1582

### DIFF
--- a/ql/time/calendars/australia.cpp
+++ b/ql/time/calendars/australia.cpp
@@ -23,11 +23,22 @@ namespace QuantLib {
 
     Australia::Australia() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Australia::Impl);
-        impl_ = impl;
+        static ext::shared_ptr<Calendar::Impl> settlementImpl(
+                                            new Australia::SettlementImpl);
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
+                                            new Australia::ExchangeImpl);
+        switch (market) {
+          case Settlement:
+            impl_ = settlementImpl;
+            break;
+          case Exchange:
+            impl_ = exchangeImpl;
+            break;
+          default:
+            QL_FAIL("unknown market");
     }
 
-    bool Australia::Impl::isBusinessDay(const Date& date) const {
+    bool Australia::SettlementImpl::isBusinessDay(const Date& date) const {
         Weekday w = date.weekday();
         Day d = date.dayOfMonth(), dd = date.dayOfYear();
         Month m = date.month();
@@ -62,5 +73,36 @@ namespace QuantLib {
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
     }
+
+    bool Australia::ExchangeImpl::isBusinessDay(const Date& date) const {
+        Weekday w = date.weekday();
+        Day d = date.dayOfMonth(), dd = date.dayOfYear();
+        Month m = date.month();
+        Year y = date.year();
+        Day em = easterMonday(y);
+        if (isWeekend(w)
+            // New Year's Day (possibly moved to Monday)
+            || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == January)
+            // Australia Day, January 26th (possibly moved to Monday)
+            || ((d == 26 || ((d == 27 || d == 28) && w == Monday)) &&
+                m == January)
+            // Good Friday
+            || (dd == em-3)
+            // Easter Monday
+            || (dd == em)
+            // ANZAC Day, April 25th
+            || (d == 25 && m == April)
+            // Queen's Birthday, second Monday in June
+            || ((d > 7 && d <= 14) && w == Monday && m == June)
+            // Christmas, December 25th (possibly Monday or Tuesday)
+            || ((d == 25 || (d == 27 && (w == Monday || w == Tuesday)))
+                && m == December)
+            // Boxing Day, December 26th (possibly Monday or Tuesday)
+            || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
+                && m == December)
+            // National Day of Mourning for Her Majesty, September 22 (only 2022)
+            || (d == 22 && m == September && y == 2022))
+            return false; // NOLINT(readability-simplify-boolean-expr)
+        return true;
 
 }

--- a/ql/time/calendars/australia.hpp
+++ b/ql/time/calendars/australia.hpp
@@ -51,13 +51,21 @@ namespace QuantLib {
     */
     class Australia : public Calendar {
       private:
-        class Impl : public Calendar::WesternImpl {
+        class SettlementImpl : public Calendar::WesternImpl {
           public:
-            std::string name() const override { return "Australia"; }
+            std::string name() const override { return "Australia settlement"; }
+            bool isBusinessDay(const Date&) const override;
+        };
+        class ExchangeImpl : public Calendar::WesternImpl {
+          public:
+            std::string name() const override { return "Australia exchange"; }
             bool isBusinessDay(const Date&) const override;
         };
       public:
-        Australia();
+        enum Market { Settlement,     //!< generic settlement calendar
+                      Exchange,       //!< Australia securities-exchange calendar
+        };
+        Australia(Market market = Settlement);
     };
 
 }


### PR DESCRIPTION
Creates new calendar for ASX that is identical to Settlement, but removes Labour Day and the Bank Holiday on the first Monday of August.