### PR TITLE
Fixing consistent Real usage

### DIFF
--- a/ql/experimental/barrieroption/suowangdoublebarrierengine.cpp
+++ b/ql/experimental/barrieroption/suowangdoublebarrierengine.cpp
@@ -125,7 +125,7 @@ namespace QuantLib {
             results_.value = european - barrierOut;
         results_.additionalResults["vanilla"] = european;
         results_.additionalResults["barrierOut"] = barrierOut;
-        results_.additionalResults["barrierIn"] = european - barrierOut;
+        results_.additionalResults["barrierIn"] = Real(european - barrierOut);
         results_.additionalResults["rebateIn"] = rebateIn;
     }
 

--- a/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
+++ b/ql/experimental/barrieroption/vannavolgabarrierengine.cpp
@@ -140,28 +140,28 @@ namespace QuantLib {
             results_.value = 0.0;
             results_.additionalResults["VanillaPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["BarrierInPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
-            results_.additionalResults["BarrierOutPrice"] = 0.0;
+            results_.additionalResults["BarrierOutPrice"] = Real(0.0);
         }
         //spot > barrier up&in vanilla
         else if(x0Quote->value() >= arguments_.barrier && arguments_.barrierType == Barrier::UpIn){
             results_.value = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["VanillaPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["BarrierInPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
-            results_.additionalResults["BarrierOutPrice"] = 0.0;
+            results_.additionalResults["BarrierOutPrice"] = Real(0.0);
         }
         //spot < barrier down&out 0
         else if(x0Quote->value() <= arguments_.barrier && arguments_.barrierType == Barrier::DownOut){
             results_.value = 0.0;
             results_.additionalResults["VanillaPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["BarrierInPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
-            results_.additionalResults["BarrierOutPrice"] = 0.0;
+            results_.additionalResults["BarrierOutPrice"] = Real(0.0);
         }
         //spot < barrier down&in vanilla
         else if(x0Quote->value() <= arguments_.barrier && arguments_.barrierType == Barrier::DownIn){
             results_.value = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["VanillaPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
             results_.additionalResults["BarrierInPrice"] = adaptVanDelta_? bsPriceWithSmile_ : vanillaOption;
-            results_.additionalResults["BarrierOutPrice"] = 0.0;
+            results_.additionalResults["BarrierOutPrice"] = Real(0.0);
         }
         else{
 

--- a/ql/experimental/barrieroption/vannavolgadoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/vannavolgadoublebarrierengine.hpp
@@ -164,7 +164,7 @@ namespace QuantLib {
                          adaptVanDelta_ ? bsPriceWithSmile_ : vanillaOption;
                      results_.additionalResults["BarrierInPrice"] =
                          adaptVanDelta_ ? bsPriceWithSmile_ : vanillaOption;
-                     results_.additionalResults["BarrierOutPrice"] = 0.0;
+                     results_.additionalResults["BarrierOutPrice"] = Real(0.0);
                  }
                  // already in
                  else if ((x0Quote->value() > arguments_.barrier_hi ||
@@ -175,7 +175,7 @@ namespace QuantLib {
                          adaptVanDelta_ ? bsPriceWithSmile_ : vanillaOption;
                      results_.additionalResults["BarrierInPrice"] =
                          adaptVanDelta_ ? bsPriceWithSmile_ : vanillaOption;
-                     results_.additionalResults["BarrierOutPrice"] = 0.0;
+                     results_.additionalResults["BarrierOutPrice"] = Real(0.0);
                  } else {
 
                      // set up BS barrier option pricing

--- a/ql/experimental/credit/integralcdoengine.cpp
+++ b/ql/experimental/credit/integralcdoengine.cpp
@@ -121,7 +121,7 @@ namespace QuantLib {
 
         results_.additionalResults["fairPremium"] = fairSpread;
         results_.additionalResults["premiumLegNPV"] = 
-            results_.premiumValue + results_.upfrontPremiumValue;
+            Real(results_.premiumValue + results_.upfrontPremiumValue);
         results_.additionalResults["protectionLegNPV"] = 
             results_.protectionValue;
     }

--- a/ql/experimental/credit/integralntdengine.cpp
+++ b/ql/experimental/credit/integralntdengine.cpp
@@ -178,7 +178,7 @@ namespace QuantLib {
 
         results_.additionalResults["fairPremium"] = results_.fairPremium;
         results_.additionalResults["premiumLegNPV"] = 
-            results_.premiumValue + results_.upfrontPremiumValue;
+            Real(results_.premiumValue + results_.upfrontPremiumValue);
         results_.additionalResults["protectionLegNPV"] = 
             results_.protectionValue;
     }

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -118,7 +118,7 @@ namespace QuantLib {
 
         results_.additionalResults["fairPremium"] = fairSpread;
         results_.additionalResults["premiumLegNPV"] = 
-            results_.premiumValue + results_.upfrontPremiumValue;
+            Real(results_.premiumValue + results_.upfrontPremiumValue);
         results_.additionalResults["protectionLegNPV"] = 
             results_.protectionValue;
     }

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -252,7 +252,7 @@ namespace QuantLib {
             atmForward -= correction;
             results_.additionalResults["spreadCorrection"] = correction;
         } else {
-            results_.additionalResults["spreadCorrection"] = 0.0;
+            results_.additionalResults["spreadCorrection"] = Real(0.0);
         }
         results_.additionalResults["strike"] = strike;
         results_.additionalResults["atmForward"] = atmForward;
@@ -310,7 +310,7 @@ namespace QuantLib {
         results_.additionalResults["delta"] = Spec().delta(
             w, strike, atmForward, stdDev, annuity, displacement);
         results_.additionalResults["timeToExpiry"] = exerciseTime;
-        results_.additionalResults["impliedVolatility"] = stdDev / std::sqrt(exerciseTime);
+        results_.additionalResults["impliedVolatility"] = Real(stdDev / std::sqrt(exerciseTime));
     }
 
     }  // namespace detail

--- a/ql/pricingengines/vanilla/analyticeuropeanengine.cpp
+++ b/ql/pricingengines/vanilla/analyticeuropeanengine.cpp
@@ -110,7 +110,7 @@ namespace QuantLib {
         results_.additionalResults["riskFreeDiscount"] = riskFreeDiscountForFwdEstimation;
         results_.additionalResults["forward"] = forwardPrice;
         results_.additionalResults["strike"] = payoff->strike();
-        results_.additionalResults["volatility"] = std::sqrt(variance / tte);
+        results_.additionalResults["volatility"] = Real(std::sqrt(variance / tte));
         results_.additionalResults["timeToExpiry"] = tte;
     }
 

--- a/ql/pricingengines/vanilla/bjerksundstenslandengine.cpp
+++ b/ql/pricingengines/vanilla/bjerksundstenslandengine.cpp
@@ -149,7 +149,7 @@ namespace QuantLib {
         results.thetaPerDay = black.thetaPerDay(S, t);
 
         results.strikeSensitivity  = black.strikeSensitivity();
-        results.additionalResults["strikeGamma"] = results.gamma*squared(S/X);
+        results.additionalResults["strikeGamma"] = Real(results.gamma*squared(S/X));
         results.additionalResults["exerciseType"] = std::string("European");
 
         return results;
@@ -168,7 +168,7 @@ namespace QuantLib {
         results.thetaPerDay = 0.0;
 
         results.strikeSensitivity = -results.delta;
-        results.additionalResults["strikeGamma"] = 0.0;
+        results.additionalResults["strikeGamma"] = Real(0.0);
         results.additionalResults["exerciseType"] = std::string("Immediate");
 
         return results;
@@ -246,8 +246,8 @@ namespace QuantLib {
                 - 1/(2*std::sqrt(squared(bT/variance - 0.5) + 2.0 * rT/variance))
                   * 2*(bT/variance-0.5)/variance);
             const Real BInfinityDq = -X/squared(beta-1.0)*betaDq;
-            const Real B0Dq = (dD <= rfD) ? 0
-                : X*std::log(rfD)/squared(std::log(dD))*tq;
+            const Real B0Dq = (dD <= rfD) ? Real(0.0)
+                : Real(X*std::log(rfD)/squared(std::log(dD))*tq);
 
             const Real htDq = tq * B0 / (BInfinity - B0)
                 - (bT + 2.0*std::sqrt(variance))
@@ -312,7 +312,7 @@ namespace QuantLib {
                 + 1/(2*std::sqrt(squared(bT/variance - 0.5) + 2.0 * rT/variance))
                   * 2*((bT/variance-0.5)/variance + 1/variance));
             const Real BInfinityDr = -X/squared(beta-1.0)*betaDr;
-            const Real B0Dr = (dD <= rfD) ? 0 : -X*tr/std::log(dD);
+            const Real B0Dr = (dD <= rfD) ? Real(0) : Real(-X*tr/std::log(dD));
             const Real htDr = -tr * B0 / (BInfinity - B0)
                 - (bT + 2.0*std::sqrt(variance))
                     *(B0Dr*(BInfinity - B0) - B0*(BInfinityDr - B0Dr))
@@ -415,7 +415,7 @@ namespace QuantLib {
             results.theta = 365*results.thetaPerDay;
 
             results.strikeSensitivity = results.value/X - S/X*results.delta;
-            results.additionalResults["strikeGamma"] = results.gamma*squared(S/X);
+            results.additionalResults["strikeGamma"] = Real(results.gamma*squared(S/X));
 
             results.additionalResults["exerciseType"] = std::string("American");
         }


### PR DESCRIPTION
This fixes consistent `Real` usage on left an right operands of the `?` operator (required when using expression templates).

It also ensures that all the `additionalResults` fields, which are stored as `boost::any`, capture the `Real` type as intended (and just `double` or an expression).

It fixes the build errors detected here: https://github.com/xcelerit/qlxad/actions/runs/4071447311