### PR TITLE
Merge dividend vanilla options into vanilla options

### DIFF
--- a/ql/experimental/finitedifferences/fdornsteinuhlenbeckvanillaengine.hpp
+++ b/ql/experimental/finitedifferences/fdornsteinuhlenbeckvanillaengine.hpp
@@ -33,13 +33,24 @@ namespace QuantLib {
     class YieldTermStructure;
     class OrnsteinUhlenbeckProcess;
 
-    class FdOrnsteinUhlenbeckVanillaEngine
-         : public DividendVanillaOption::engine {
+    QL_DEPRECATED_DISABLE_WARNING
+
+    class FdOrnsteinUhlenbeckVanillaEngine : public DividendVanillaOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        // Constructor
         FdOrnsteinUhlenbeckVanillaEngine(
             ext::shared_ptr<OrnsteinUhlenbeckProcess>,
             const ext::shared_ptr<YieldTermStructure>& rTS,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            Real epsilon = 0.0001,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
+
+        FdOrnsteinUhlenbeckVanillaEngine(
+            ext::shared_ptr<OrnsteinUhlenbeckProcess>,
+            const ext::shared_ptr<YieldTermStructure>& rTS,
+            DividendSchedule dividends,
             Size tGrid = 100,
             Size xGrid = 100,
             Size dampingSteps = 0,
@@ -51,6 +62,8 @@ namespace QuantLib {
       private:
         const ext::shared_ptr<OrnsteinUhlenbeckProcess> process_;
         const ext::shared_ptr<YieldTermStructure> rTS_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, dampingSteps_;
         const Real epsilon_;
         const FdmSchemeDesc schemeDesc_;

--- a/ql/instruments/dividendbarrieroption.hpp
+++ b/ql/instruments/dividendbarrieroption.hpp
@@ -57,12 +57,7 @@ namespace QuantLib {
     };
 
 
-    //! %Arguments for dividend barrier option calculation
-    /*! \deprecated If you're writing an engine for DividendBarrierOption,
-                    use BarrierOption instead and pass the dividends to the engine.
-                    Deprecated in version 1.30.
-    */
-    class QL_DEPRECATED DividendBarrierOption::arguments : public BarrierOption::arguments {
+    class DividendBarrierOption::arguments : public BarrierOption::arguments {
       public:
         DividendSchedule cashFlow;
         arguments() = default;
@@ -70,18 +65,13 @@ namespace QuantLib {
     };
 
     QL_DEPRECATED_DISABLE_WARNING
-    //! %Dividend-barrier-option %engine base class
-    /*! \deprecated If you're writing an engine for DividendBarrierOption,
-                    use BarrierOption instead and pass the dividends to the engine.
-                    Deprecated in version 1.30.
-    */
     class DividendBarrierOption::engine
         : public GenericEngine<DividendBarrierOption::arguments,
                                DividendBarrierOption::results> {
-    QL_DEPRECATED_ENABLE_WARNING
       protected:
         bool triggered(Real underlying) const;
     };
+    QL_DEPRECATED_ENABLE_WARNING
 
 }
 

--- a/ql/instruments/dividendvanillaoption.cpp
+++ b/ql/instruments/dividendvanillaoption.cpp
@@ -56,7 +56,9 @@ namespace QuantLib {
         std::unique_ptr<PricingEngine> engine;
         switch (exercise_->type()) {
           case Exercise::European:
+              QL_DEPRECATED_DISABLE_WARNING
               engine = std::make_unique<AnalyticDividendEuropeanEngine>(newProcess);
+              QL_DEPRECATED_ENABLE_WARNING
               break;
           case Exercise::American:
               engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess);

--- a/ql/instruments/dividendvanillaoption.cpp
+++ b/ql/instruments/dividendvanillaoption.cpp
@@ -56,13 +56,13 @@ namespace QuantLib {
         std::unique_ptr<PricingEngine> engine;
         switch (exercise_->type()) {
           case Exercise::European:
-              QL_DEPRECATED_DISABLE_WARNING
-              engine = std::make_unique<AnalyticDividendEuropeanEngine>(newProcess);
-              QL_DEPRECATED_ENABLE_WARNING
-              break;
+            QL_DEPRECATED_DISABLE_WARNING
+            engine = std::make_unique<AnalyticDividendEuropeanEngine>(newProcess);
+            QL_DEPRECATED_ENABLE_WARNING
+            break;
           case Exercise::American:
-              engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess);
-              break;
+            engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess);
+            break;
           case Exercise::Bermudan:
             QL_FAIL("engine not available for Bermudan option with dividends");
             break;

--- a/ql/instruments/dividendvanillaoption.hpp
+++ b/ql/instruments/dividendvanillaoption.hpp
@@ -33,8 +33,11 @@ namespace QuantLib {
     class GeneralizedBlackScholesProcess;
 
     //! Single-asset vanilla option (no barriers) with discrete dividends
-    /*! \ingroup instruments */
-    class DividendVanillaOption : public OneAssetOption {
+    /*! \deprecated Use VanillaOption instead and pass the dividends
+                    to the desired engine.
+                    Deprecated in version 1.30.
+    */
+    class QL_DEPRECATED DividendVanillaOption : public OneAssetOption {
       public:
         class arguments;
         class engine;
@@ -60,8 +63,6 @@ namespace QuantLib {
         DividendSchedule cashFlow_;
     };
 
-
-    //! %Arguments for dividend vanilla option calculation
     class DividendVanillaOption::arguments : public OneAssetOption::arguments {
       public:
         DividendSchedule cashFlow;
@@ -69,10 +70,11 @@ namespace QuantLib {
         void validate() const override;
     };
 
-    //! %Dividend-vanilla-option %engine base class
+    QL_DEPRECATED_DISABLE_WARNING
     class DividendVanillaOption::engine
         : public GenericEngine<DividendVanillaOption::arguments,
                                DividendVanillaOption::results> {};
+    QL_DEPRECATED_ENABLE_WARNING
 
 }
 

--- a/ql/instruments/vanillaoption.cpp
+++ b/ql/instruments/vanillaoption.cpp
@@ -97,7 +97,9 @@ namespace QuantLib {
         /* this is a workaround in case an engine is used for both vanilla
            and dividend options.  The dividends might have been set by another
            instrument and need to be cleared. */
+        QL_DEPRECATED_DISABLE_WARNING
         auto* arguments = dynamic_cast<DividendVanillaOption::arguments*>(args);
+        QL_DEPRECATED_ENABLE_WARNING
         if (arguments != nullptr) {
             arguments->cashFlow.clear();
         }

--- a/ql/instruments/vanillaoption.cpp
+++ b/ql/instruments/vanillaoption.cpp
@@ -23,6 +23,7 @@
 #include <ql/instruments/impliedvolatility.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
 #include <memory>
 
@@ -41,6 +42,18 @@ namespace QuantLib {
              Size maxEvaluations,
              Volatility minVol,
              Volatility maxVol) const {
+        return impliedVolatility(targetValue, process, DividendSchedule(),
+                                 accuracy, maxEvaluations, minVol, maxVol);
+    }
+
+    Volatility VanillaOption::impliedVolatility(
+             Real targetValue,
+             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const DividendSchedule& dividends,
+             Real accuracy,
+             Size maxEvaluations,
+             Volatility minVol,
+             Volatility maxVol) const {
 
         QL_REQUIRE(!isExpired(), "option expired");
 
@@ -53,12 +66,18 @@ namespace QuantLib {
         std::unique_ptr<PricingEngine> engine;
         switch (exercise_->type()) {
           case Exercise::European:
-              engine = std::make_unique<AnalyticEuropeanEngine>(newProcess);
-              break;
+            if (dividends.empty())
+                engine = std::make_unique<AnalyticEuropeanEngine>(newProcess);
+            else
+                engine = std::make_unique<AnalyticDividendEuropeanEngine>(newProcess, dividends);
+            break;
           case Exercise::American:
           case Exercise::Bermudan:
-              engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess);
-              break;
+            if (dividends.empty())
+                engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess);
+            else
+                engine = std::make_unique<FdBlackScholesVanillaEngine>(newProcess, dividends);
+            break;
           default:
             QL_FAIL("unknown exercise type");
         }

--- a/ql/instruments/vanillaoption.hpp
+++ b/ql/instruments/vanillaoption.hpp
@@ -27,6 +27,7 @@
 
 #include <ql/instruments/oneassetoption.hpp>
 #include <ql/instruments/payoffs.hpp>
+#include <ql/instruments/dividendschedule.hpp>
 
 namespace QuantLib {
 
@@ -57,6 +58,7 @@ namespace QuantLib {
                      value lower than the intrinsic value in the case
                      of American options.
         */
+        //@{
         Volatility impliedVolatility(
              Real price,
              const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
@@ -64,6 +66,16 @@ namespace QuantLib {
              Size maxEvaluations = 100,
              Volatility minVol = 1.0e-7,
              Volatility maxVol = 4.0) const;
+
+        Volatility impliedVolatility(
+             Real price,
+             const ext::shared_ptr<GeneralizedBlackScholesProcess>& process,
+             const DividendSchedule& dividends,
+             Real accuracy = 1.0e-4,
+             Size maxEvaluations = 100,
+             Volatility minVol = 1.0e-7,
+             Volatility maxVol = 4.0) const;
+        //@}
 
         void setupArguments(PricingEngine::arguments*) const override;
     };

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.hpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.hpp
@@ -46,11 +46,9 @@ namespace QuantLib {
             Real xMaxConstraint = Null<Real>(),
             Real eps = 0.0001,
             Real scaleFactor = 1.5,
-            const std::pair<Real, Real>& cPoint
-                = (std::pair<Real, Real>(Null<Real>(), Null<Real>())),
-            const DividendSchedule& dividendSchedule = DividendSchedule(),
-            const ext::shared_ptr<FdmQuantoHelper>& fdmQuantoHelper
-                = ext::shared_ptr<FdmQuantoHelper>(),
+            const std::pair<Real, Real>& cPoint = { Null<Real>(), Null<Real>() },
+            const DividendSchedule& dividendSchedule = {},
+            const ext::shared_ptr<FdmQuantoHelper>& fdmQuantoHelper = {},
             Real spotAdjustment = 0.0);
 
         static ext::shared_ptr<GeneralizedBlackScholesProcess> processHelper(

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -181,39 +181,33 @@ namespace QuantLib {
                                                             arguments_.payoff);
             // Calculate the vanilla option
             
-            auto vanillaOption =
-                ext::make_shared<VanillaOption>(payoff, arguments_.exercise);
+            VanillaOption vanillaOption(payoff, arguments_.exercise);
             
-            vanillaOption->setPricingEngine(
+            vanillaOption.setPricingEngine(
                 ext::make_shared<FdBlackScholesVanillaEngine>(
                         process_, dividendSchedule, tGrid_, xGrid_,
                         0, // dampingSteps
                         schemeDesc_, localVol_, illegalLocalVolOverwrite_));
 
             // Calculate the rebate value
-            auto rebateOption =
-                ext::make_shared<BarrierOption>(arguments_.barrierType,
-                                                arguments_.barrier,
-                                                arguments_.rebate,
-                                                payoff, arguments_.exercise);
+            BarrierOption rebateOption(arguments_.barrierType,
+                                       arguments_.barrier,
+                                       arguments_.rebate,
+                                       payoff, arguments_.exercise);
             
             const Size min_grid_size = 50;
             const Size rebateDampingSteps 
                 = (dampingSteps_ > 0) ? std::min(Size(1), dampingSteps_/2) : 0; 
 
-            rebateOption->setPricingEngine(ext::make_shared<FdBlackScholesRebateEngine>(
+            rebateOption.setPricingEngine(ext::make_shared<FdBlackScholesRebateEngine>(
                             process_, dividendSchedule, tGrid_, std::max(min_grid_size, xGrid_/5), 
                             rebateDampingSteps, schemeDesc_, localVol_, 
                             illegalLocalVolOverwrite_));
 
-            results_.value = vanillaOption->NPV()   + rebateOption->NPV()
-                                                    - results_.value;
-            results_.delta = vanillaOption->delta() + rebateOption->delta()
-                                                    - results_.delta;
-            results_.gamma = vanillaOption->gamma() + rebateOption->gamma()
-                                                    - results_.gamma;
-            results_.theta = vanillaOption->theta() + rebateOption->theta()
-                                                    - results_.theta;
+            results_.value = vanillaOption.NPV()   + rebateOption.NPV()   - results_.value;
+            results_.delta = vanillaOption.delta() + rebateOption.delta() - results_.delta;
+            results_.gamma = vanillaOption.gamma() + rebateOption.gamma() - results_.gamma;
+            results_.theta = vanillaOption.theta() + rebateOption.theta() - results_.theta;
         }
     }
 }

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -20,6 +20,7 @@
 */
 
 #include <ql/exercise.hpp>
+#include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmblackscholesmesher.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmeshercomposite.hpp>
@@ -180,14 +181,12 @@ namespace QuantLib {
                                                             arguments_.payoff);
             // Calculate the vanilla option
             
-            ext::shared_ptr<DividendVanillaOption> vanillaOption(
-                ext::make_shared<DividendVanillaOption>(payoff,arguments_.exercise,
-                                          dividendCondition->dividendDates(), 
-                                          dividendCondition->dividends()));
+            auto vanillaOption =
+                ext::make_shared<VanillaOption>(payoff, arguments_.exercise);
             
             vanillaOption->setPricingEngine(
                 ext::make_shared<FdBlackScholesVanillaEngine>(
-                        process_, tGrid_, xGrid_,
+                        process_, dividendSchedule, tGrid_, xGrid_,
                         0, // dampingSteps
                         schemeDesc_, localVol_, illegalLocalVolOverwrite_));
 

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -185,24 +185,22 @@ namespace QuantLib {
                     ext::dynamic_pointer_cast<StrikedTypePayoff>(
                                                             arguments_.payoff);
             // Calculate the vanilla option
-            auto vanillaOption =
-				ext::make_shared<VanillaOption>(payoff, arguments_.exercise);
-            vanillaOption->setPricingEngine(ext::shared_ptr<PricingEngine>(
+            VanillaOption vanillaOption(payoff, arguments_.exercise);
+            vanillaOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
 				ext::make_shared<FdHestonVanillaEngine>(*model_, dividendSchedule,
                                                         tGrid_, xGrid_,
                                                         vGrid_, dampingSteps_,
                                                         schemeDesc_)));
             // Calculate the rebate value
-            auto rebateOption =
-                ext::make_shared<BarrierOption>(arguments_.barrierType,
-                                                arguments_.barrier,
-                                                arguments_.rebate,
-                                                payoff, arguments_.exercise);
+            BarrierOption rebateOption(arguments_.barrierType,
+                                       arguments_.barrier,
+                                       arguments_.rebate,
+                                       payoff, arguments_.exercise);
             const Size xGridMin = 20;
             const Size vGridMin = 10;
             const Size rebateDampingSteps 
                 = (dampingSteps_ > 0) ? std::min(Size(1), dampingSteps_/2) : 0; 
-            rebateOption->setPricingEngine(
+            rebateOption.setPricingEngine(
                 ext::make_shared<FdHestonRebateEngine>(*model_, dividendSchedule,
                                                        tGrid_,
                                                        std::max(xGridMin, xGrid_/4), 
@@ -210,14 +208,10 @@ namespace QuantLib {
                                                        rebateDampingSteps,
                                                        schemeDesc_));
 
-            results_.value = vanillaOption->NPV()   + rebateOption->NPV()
-                                                    - results_.value;
-            results_.delta = vanillaOption->delta() + rebateOption->delta()
-                                                    - results_.delta;
-            results_.gamma = vanillaOption->gamma() + rebateOption->gamma()
-                                                    - results_.gamma;
-            results_.theta = vanillaOption->theta() + rebateOption->theta()
-                                                    - results_.theta;
+            results_.value = vanillaOption.NPV()   + rebateOption.NPV()   - results_.value;
+            results_.delta = vanillaOption.delta() + rebateOption.delta() - results_.delta;
+            results_.gamma = vanillaOption.gamma() + rebateOption.gamma() - results_.gamma;
+            results_.theta = vanillaOption.theta() + rebateOption.theta() - results_.theta;
         }
     }
 }

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -27,6 +27,7 @@
 #include <ql/methods/finitedifferences/utilities/fdmdirichletboundary.hpp>
 #include <ql/methods/finitedifferences/utilities/fdmdividendhandler.hpp>
 #include <ql/methods/finitedifferences/utilities/fdminnervaluecalculator.hpp>
+#include <ql/instruments/vanillaoption.hpp>
 #include <ql/pricingengines/barrier/fdhestonbarrierengine.hpp>
 #include <ql/pricingengines/barrier/fdhestonrebateengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
@@ -184,14 +185,13 @@ namespace QuantLib {
                     ext::dynamic_pointer_cast<StrikedTypePayoff>(
                                                             arguments_.payoff);
             // Calculate the vanilla option
-            ext::shared_ptr<DividendVanillaOption> vanillaOption(
-				ext::make_shared<DividendVanillaOption>(payoff,arguments_.exercise,
-                                          dividendCondition->dividendDates(), 
-                                          dividendCondition->dividends()));
+            auto vanillaOption =
+				ext::make_shared<VanillaOption>(payoff, arguments_.exercise);
             vanillaOption->setPricingEngine(ext::shared_ptr<PricingEngine>(
-				ext::make_shared<FdHestonVanillaEngine>(*model_, tGrid_, xGrid_,
-                                              vGrid_, dampingSteps_,
-                                              schemeDesc_)));
+				ext::make_shared<FdHestonVanillaEngine>(*model_, dividendSchedule,
+                                                        tGrid_, xGrid_,
+                                                        vGrid_, dampingSteps_,
+                                                        schemeDesc_)));
             // Calculate the rebate value
             auto rebateOption =
                 ext::make_shared<BarrierOption>(arguments_.barrierType,

--- a/ql/pricingengines/vanilla/analyticdividendeuropeanengine.cpp
+++ b/ql/pricingengines/vanilla/analyticdividendeuropeanengine.cpp
@@ -25,12 +25,25 @@
 namespace QuantLib {
 
     AnalyticDividendEuropeanEngine::AnalyticDividendEuropeanEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+        DividendSchedule dividends)
+    : process_(std::move(process)), dividends_(std::move(dividends)),
+      explicitDividends_(true) {
+        registerWith(process_);
+    }
+
+    AnalyticDividendEuropeanEngine::AnalyticDividendEuropeanEngine(
         ext::shared_ptr<GeneralizedBlackScholesProcess> process)
-    : process_(std::move(process)) {
+    : process_(std::move(process)), explicitDividends_(false) {
         registerWith(process_);
     }
 
     void AnalyticDividendEuropeanEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& dividendSchedule = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
 
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "not an European option");
@@ -42,13 +55,13 @@ namespace QuantLib {
         Date settlementDate = process_->riskFreeRate()->referenceDate();
         Real riskless = 0.0;
         Size i;
-        for (i=0; i<arguments_.cashFlow.size(); i++) {
-            const Date cashFlowDate = arguments_.cashFlow[i]->date();
+        for (i=0; i<dividendSchedule.size(); i++) {
+            const Date cashFlowDate = dividendSchedule[i]->date();
 
             if (   cashFlowDate >= settlementDate
                 && cashFlowDate <= arguments_.exercise->lastDate()) {
 
-                riskless += arguments_.cashFlow[i]->amount() *
+                riskless += dividendSchedule[i]->amount() *
                     process_->riskFreeRate()->discount(cashFlowDate) /
                     process_->dividendYield()->discount(cashFlowDate);
             }
@@ -86,20 +99,20 @@ namespace QuantLib {
         results_.vega = black.vega(t);
 
         Real delta_theta = 0.0, delta_rho = 0.0;
-        for (i = 0; i < arguments_.cashFlow.size(); i++) {
-            Date d = arguments_.cashFlow[i]->date();
+        for (i = 0; i < dividendSchedule.size(); i++) {
+            Date d = dividendSchedule[i]->date();
 
             if (   d >= settlementDate
                 && d <= arguments_.exercise->lastDate()) {
 
-                delta_theta -= arguments_.cashFlow[i]->amount() *
+                delta_theta -= dividendSchedule[i]->amount() *
                   (  process_->riskFreeRate()->zeroRate(d,rfdc,Continuous,Annual).rate()
                    - process_->dividendYield()->zeroRate(d,dydc,Continuous,Annual).rate()) *
                   process_->riskFreeRate()->discount(d) /
                   process_->dividendYield()->discount(d);
 
                 Time t = process_->time(d);
-                delta_rho += arguments_.cashFlow[i]->amount() * t *
+                delta_rho += dividendSchedule[i]->amount() * t *
                              process_->riskFreeRate()->discount(t) /
                              process_->dividendYield()->discount(t);
             }

--- a/ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp
@@ -47,7 +47,7 @@ namespace QuantLib {
                         Deprecated in version 1.30.
         */
         QL_DEPRECATED
-        AnalyticDividendEuropeanEngine(ext::shared_ptr<GeneralizedBlackScholesProcess> process);
+        explicit AnalyticDividendEuropeanEngine(ext::shared_ptr<GeneralizedBlackScholesProcess> process);
 
         void calculate() const override;
       private:

--- a/ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp
@@ -29,20 +29,31 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     //! Analytic pricing engine for European options with discrete dividends
     /*! \ingroup vanillaengines
 
         \test the correctness of the returned greeks is tested by
               reproducing numerical derivatives.
     */
-    class AnalyticDividendEuropeanEngine
-        : public DividendVanillaOption::engine {
+    class AnalyticDividendEuropeanEngine : public DividendVanillaOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        AnalyticDividendEuropeanEngine(ext::shared_ptr<GeneralizedBlackScholesProcess>);
-        void calculate() const override;
+        AnalyticDividendEuropeanEngine(ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+                                       DividendSchedule dividends);
+        
+        /*! \deprecated Use the other constructor instead and pass the dividends to the engine.
+                        Deprecated in version 1.30.
+        */
+        QL_DEPRECATED
+        AnalyticDividendEuropeanEngine(ext::shared_ptr<GeneralizedBlackScholesProcess> process);
 
+        void calculate() const override;
       private:
         ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
     };
 
 }

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
@@ -44,6 +44,7 @@ namespace QuantLib {
 
     void FdBatesVanillaEngine::calculate() const {
         FdHestonVanillaEngine helperEngine(model_.currentLink(),
+                                           arguments_.cashFlow,
                                            tGrid_, xGrid_, vGrid_,
                                            dampingSteps_, schemeDesc_);
 

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
@@ -71,8 +71,10 @@ namespace QuantLib {
                                            tGrid_, xGrid_, vGrid_,
                                            dampingSteps_, schemeDesc_);
 
+        QL_DEPRECATED_DISABLE_WARNING
         *dynamic_cast<DividendVanillaOption::arguments*>(
                                helperEngine.getArguments()) = arguments_;
+        QL_DEPRECATED_ENABLE_WARNING
 
         FdmSolverDesc solverDesc = helperEngine.getSolverDesc(2.0);
 

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
@@ -22,12 +22,13 @@
 */
 
 #include <ql/processes/batesprocess.hpp>
-
 #include <ql/methods/finitedifferences/solvers/fdmbatessolver.hpp>
 #include <ql/pricingengines/vanilla/fdbatesvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/fdhestonvanillaengine.hpp>
 
 namespace QuantLib {
+
+    QL_DEPRECATED_DISABLE_WARNING
 
     FdBatesVanillaEngine::FdBatesVanillaEngine(
             const ext::shared_ptr<BatesModel>& model,
@@ -37,14 +38,36 @@ namespace QuantLib {
     : GenericModelEngine<BatesModel,
                          DividendVanillaOption::arguments,
                          DividendVanillaOption::results>(model),
-       tGrid_(tGrid), xGrid_(xGrid),
-       vGrid_(vGrid), dampingSteps_(dampingSteps),
-       schemeDesc_(schemeDesc) {
-    }
+      explicitDividends_(false),
+      tGrid_(tGrid), xGrid_(xGrid),
+      vGrid_(vGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc) {}
+
+    FdBatesVanillaEngine::FdBatesVanillaEngine(
+            const ext::shared_ptr<BatesModel>& model,
+            DividendSchedule dividends,
+            Size tGrid, Size xGrid, 
+            Size vGrid, Size dampingSteps,
+            const FdmSchemeDesc& schemeDesc)
+    : GenericModelEngine<BatesModel,
+                         DividendVanillaOption::arguments,
+                         DividendVanillaOption::results>(model),
+      dividends_(std::move(dividends)), explicitDividends_(true),
+      tGrid_(tGrid), xGrid_(xGrid),
+      vGrid_(vGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     void FdBatesVanillaEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
+
         FdHestonVanillaEngine helperEngine(model_.currentLink(),
-                                           arguments_.cashFlow,
+                                           passedDividends,
                                            tGrid_, xGrid_, vGrid_,
                                            dampingSteps_, schemeDesc_);
 

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.hpp
@@ -18,7 +18,7 @@
 */
 
 /*! \file fdbatesvanillaengine.hpp
-    \brief Partial Integro Finite-Differences Bates vanilla option engine
+    \brief Partial integro finite-differences Bates vanilla option engine
 */
 
 #ifndef quantlib_fd_bates_vanilla_engine_hpp
@@ -31,29 +31,39 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
 
-    //! Partial Integro FiniteDifferences Bates Vanilla Option engine
-
-    /*! \ingroup vanillaengines
-    */
+    //! Partial integro finite-differences Bates vanilla option engine
+    /*! \ingroup vanillaengines */
     class FdBatesVanillaEngine
         : public GenericModelEngine<BatesModel,
                                     DividendVanillaOption::arguments,
                                     DividendVanillaOption::results> {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        explicit FdBatesVanillaEngine(
+        explicit
+        FdBatesVanillaEngine(
             const ext::shared_ptr<BatesModel>& model,
             Size tGrid = 100, Size xGrid = 100, 
             Size vGrid = 50, Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());
 
+        FdBatesVanillaEngine(
+            const ext::shared_ptr<BatesModel>& model,
+            DividendSchedule dividends,
+            Size tGrid = 100, Size xGrid = 100, 
+            Size vGrid = 50, Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());
 
         void calculate() const override;
 
       private:
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
     };
+
 }
 
 #endif

--- a/ql/pricingengines/vanilla/fdblackscholesshoutengine.cpp
+++ b/ql/pricingengines/vanilla/fdblackscholesshoutengine.cpp
@@ -38,19 +38,39 @@ namespace QuantLib {
         Size xGrid,
         Size dampingSteps,
         const FdmSchemeDesc& schemeDesc)
-    : process_(std::move(process)), tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
+    : process_(std::move(process)), explicitDividends_(false),
+      tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc) {
+        registerWith(process_);
+    }
+
+    FdBlackScholesShoutEngine::FdBlackScholesShoutEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+        DividendSchedule dividends,
+        Size tGrid,
+        Size xGrid,
+        Size dampingSteps,
+        const FdmSchemeDesc& schemeDesc)
+    : process_(std::move(process)), dividends_(std::move(dividends)), explicitDividends_(true),
+      tGrid_(tGrid), xGrid_(xGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc) {
         registerWith(process_);
     }
 
     void FdBlackScholesShoutEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
+
         const Date exerciseDate = arguments_.exercise->lastDate();
         const Time maturity = process_->time(exerciseDate);
         const Date settlementDate = process_->riskFreeRate()->referenceDate();
 
         const auto escrowedDividendAdj =
             ext::make_shared<EscrowedDividendAdjustment>(
-                arguments_.cashFlow,
+                passedDividends,
                 process_->riskFreeRate(),
                 process_->dividendYield(),
                 [&](Date d){ return process_->time(d); },
@@ -84,7 +104,7 @@ namespace QuantLib {
                 escrowedDividendAdj, maturity, payoff, mesher, 0);
 
         DividendSchedule zeroDividendSchedule = DividendSchedule();
-        for (const auto& cf: arguments_.cashFlow)
+        for (const auto& cf: passedDividends)
             zeroDividendSchedule.push_back(
                 ext::make_shared<FixedDividend>(0.0, cf->date()));
 

--- a/ql/pricingengines/vanilla/fdblackscholesshoutengine.hpp
+++ b/ql/pricingengines/vanilla/fdblackscholesshoutengine.hpp
@@ -32,7 +32,10 @@ namespace QuantLib {
 
     class GeneralizedBlackScholesProcess;
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     class FdBlackScholesShoutEngine : public DividendVanillaOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         // Constructor
         explicit FdBlackScholesShoutEngine(
@@ -42,13 +45,24 @@ namespace QuantLib {
             Size dampingSteps = 0,
             const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
 
+        FdBlackScholesShoutEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess>,
+            DividendSchedule dividends,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas());
+
         void calculate() const override;
 
       private:
         const ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
     };
+
 }
 
 #endif

--- a/ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdblackscholesvanillaengine.hpp
-    \brief Finite-Differences Black Scholes vanilla option engine
+    \brief Finite-differences Black Scholes vanilla option engine
 */
 
 #ifndef quantlib_fd_black_scholes_vanilla_engine_hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
 
     QL_DEPRECATED_DISABLE_WARNING
 
-    //! Finite-Differences Black Scholes vanilla option engine
+    //! Finite-differences Black Scholes vanilla option engine
     /*! \ingroup vanillaengines
 
         \test the correctness of the returned value is tested by
@@ -49,7 +49,6 @@ namespace QuantLib {
       public:
         enum CashDividendModel { Spot, Escrowed };
 
-        // Constructor
         explicit FdBlackScholesVanillaEngine(
             ext::shared_ptr<GeneralizedBlackScholesProcess>,
             Size tGrid = 100,

--- a/ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp
@@ -32,18 +32,20 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Black Scholes vanilla option engine
+    class FdmQuantoHelper;
+    class GeneralizedBlackScholesProcess;
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    //! Finite-Differences Black Scholes vanilla option engine
     /*! \ingroup vanillaengines
 
         \test the correctness of the returned value is tested by
               reproducing results available in web/literature
               and comparison with Black pricing.
     */
-    class FdmQuantoHelper;
-    class GeneralizedBlackScholesProcess;
-
     class FdBlackScholesVanillaEngine : public DividendVanillaOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
         enum CashDividendModel { Spot, Escrowed };
 
@@ -58,26 +60,52 @@ namespace QuantLib {
             Real illegalLocalVolOverwrite = -Null<Real>(),
             CashDividendModel cashDividendModel = Spot);
 
-        FdBlackScholesVanillaEngine(ext::shared_ptr<GeneralizedBlackScholesProcess>,
-                                    ext::shared_ptr<FdmQuantoHelper> quantoHelper,
-                                    Size tGrid = 100,
-                                    Size xGrid = 100,
-                                    Size dampingSteps = 0,
-                                    const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
-                                    bool localVol = false,
-                                    Real illegalLocalVolOverwrite = -Null<Real>(),
-                                    CashDividendModel cashDividendModel = Spot);
+        FdBlackScholesVanillaEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess>,
+            DividendSchedule dividends,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+            bool localVol = false,
+            Real illegalLocalVolOverwrite = -Null<Real>(),
+            CashDividendModel cashDividendModel = Spot);
+
+        FdBlackScholesVanillaEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess>,
+            ext::shared_ptr<FdmQuantoHelper> quantoHelper,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+            bool localVol = false,
+            Real illegalLocalVolOverwrite = -Null<Real>(),
+            CashDividendModel cashDividendModel = Spot);
+
+        FdBlackScholesVanillaEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess>,
+            DividendSchedule dividends,
+            ext::shared_ptr<FdmQuantoHelper> quantoHelper,
+            Size tGrid = 100,
+            Size xGrid = 100,
+            Size dampingSteps = 0,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Douglas(),
+            bool localVol = false,
+            Real illegalLocalVolOverwrite = -Null<Real>(),
+            CashDividendModel cashDividendModel = Spot);
 
         void calculate() const override;
 
       private:
-        const ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
-        const Size tGrid_, xGrid_, dampingSteps_;
-        const FdmSchemeDesc schemeDesc_;
-        const bool localVol_;
-        const Real illegalLocalVolOverwrite_;
-        const ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
-        const CashDividendModel cashDividendModel_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
+        Size tGrid_, xGrid_, dampingSteps_;
+        FdmSchemeDesc schemeDesc_;
+        bool localVol_;
+        Real illegalLocalVolOverwrite_;
+        ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
+        CashDividendModel cashDividendModel_;
     };
 
 
@@ -101,20 +129,26 @@ namespace QuantLib {
         MakeFdBlackScholesVanillaEngine& withIllegalLocalVolOverwrite(
             Real illegalLocalVolOverwrite);
 
+        MakeFdBlackScholesVanillaEngine& withCashDividends(
+            const std::vector<Date>& dividendDates,
+            const std::vector<Real>& dividendAmounts);
+
         MakeFdBlackScholesVanillaEngine& withCashDividendModel(
             FdBlackScholesVanillaEngine::CashDividendModel cashDividendModel);
 
         operator ext::shared_ptr<PricingEngine>() const;
       private:
         ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        bool explicitDividends_ = false;
         Size tGrid_ = 100, xGrid_ = 100, dampingSteps_ = 0;
         ext::shared_ptr<FdmSchemeDesc> schemeDesc_;
         bool localVol_ = false;
         Real illegalLocalVolOverwrite_;
         ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
-        FdBlackScholesVanillaEngine::CashDividendModel cashDividendModel_ =
-            FdBlackScholesVanillaEngine::Spot;
+        FdBlackScholesVanillaEngine::CashDividendModel cashDividendModel_ = FdBlackScholesVanillaEngine::Spot;
     };
+
 }
 
 #endif

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -42,11 +42,35 @@ namespace QuantLib {
         const Real rho,
         const FdmSchemeDesc& schemeDesc,
         ext::shared_ptr<FdmQuantoHelper> quantoHelper)
-    : tGrid_(tGrid), xGrid_(xGrid), rGrid_(rGrid), dampingSteps_(dampingSteps), rho_(rho),
-      schemeDesc_(schemeDesc), bsProcess_(std::move(bsProcess)), cirProcess_(std::move(cirProcess)),
-      quantoHelper_(std::move(quantoHelper)) {}
+    :  bsProcess_(std::move(bsProcess)), cirProcess_(std::move(cirProcess)),
+       quantoHelper_(std::move(quantoHelper)), explicitDividends_(false),
+       tGrid_(tGrid), xGrid_(xGrid), rGrid_(rGrid), dampingSteps_(dampingSteps),
+       rho_(rho), schemeDesc_(schemeDesc) {}
+
+    FdCIRVanillaEngine::FdCIRVanillaEngine(
+        ext::shared_ptr<CoxIngersollRossProcess> cirProcess,
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess,
+        DividendSchedule dividends,
+        Size tGrid,
+        Size xGrid,
+        Size rGrid,
+        Size dampingSteps,
+        const Real rho,
+        const FdmSchemeDesc& schemeDesc,
+        ext::shared_ptr<FdmQuantoHelper> quantoHelper)
+    : bsProcess_(std::move(bsProcess)), cirProcess_(std::move(cirProcess)),
+      quantoHelper_(std::move(quantoHelper)), dividends_(std::move(dividends)),
+      explicitDividends_(true),
+      tGrid_(tGrid), xGrid_(xGrid), rGrid_(rGrid), dampingSteps_(dampingSteps), rho_(rho),
+      schemeDesc_(schemeDesc) {}
 
     FdmSolverDesc FdCIRVanillaEngine::getSolverDesc(Real) const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
+
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         const Time maturity = bsProcess_->time(arguments_.exercise->lastDate());
@@ -61,7 +85,7 @@ namespace QuantLib {
                 xGrid_, bsProcess_, maturity, payoff->strike(),
                 Null<Real>(), Null<Real>(), 0.0001, 1.5,
                 std::pair<Real, Real>(payoff->strike(), 0.1),
-                arguments_.cashFlow, quantoHelper_,
+                passedDividends, quantoHelper_,
                 0.0));
         
         const ext::shared_ptr<FdmMesher> mesher(
@@ -74,7 +98,7 @@ namespace QuantLib {
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
              FdmStepConditionComposite::vanillaComposite(
-                                 arguments_.cashFlow, arguments_.exercise, 
+                                 passedDividends, arguments_.exercise, 
                                  mesher, calculator,
                                  bsProcess_->riskFreeRate()->referenceDate(),
                                  bsProcess_->riskFreeRate()->dayCounter());
@@ -153,14 +177,35 @@ namespace QuantLib {
         return *this;
     }
 
+    MakeFdCIRVanillaEngine&
+    MakeFdCIRVanillaEngine::withCashDividends(
+            const std::vector<Date>& dividendDates,
+            const std::vector<Real>& dividendAmounts) {
+        dividends_ = DividendVector(dividendDates, dividendAmounts);
+        explicitDividends_ = true;
+        return *this;
+    }
+
     MakeFdCIRVanillaEngine::operator
     ext::shared_ptr<PricingEngine>() const {
-        return ext::make_shared<FdCIRVanillaEngine>(
-            cirProcess_,
-            bsProcess_,
-            tGrid_, xGrid_, rGrid_, dampingSteps_,
-            rho_,
-            *schemeDesc_,
-            quantoHelper_);
+        if (explicitDividends_) {
+            return ext::make_shared<FdCIRVanillaEngine>(
+                cirProcess_,
+                bsProcess_,
+                dividends_,
+                tGrid_, xGrid_, rGrid_, dampingSteps_,
+                rho_,
+                *schemeDesc_,
+                quantoHelper_);
+        } else {
+            return ext::make_shared<FdCIRVanillaEngine>(
+                cirProcess_,
+                bsProcess_,
+                tGrid_, xGrid_, rGrid_, dampingSteps_,
+                rho_,
+                *schemeDesc_,
+                quantoHelper_);
+        }
     }
+
 }

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.hpp
@@ -18,7 +18,7 @@
 */
 
 /*! \file fdcirvanillaengine.hpp
-    \brief Finite-Differences CIR vanilla option engine
+    \brief Finite-differences CIR vanilla option engine
 */
 
 #ifndef quantlib_fd_cir_vanilla_engine_hpp
@@ -34,38 +34,52 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences CIR Vanilla Option engine
+    class FdmQuantoHelper;
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    //! Finite-differences CIR vanilla option engine
     /*! \ingroup vanillaengines
 
         \test the engine has been tested to converge among different schemes.
     */
-    class FdmQuantoHelper;
-
     class FdCIRVanillaEngine : public DividendVanillaOption::engine {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        explicit FdCIRVanillaEngine(ext::shared_ptr<CoxIngersollRossProcess> cirProcess,
-                                    ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess,
-                                    Size tGrid,
-                                    Size xGrid,
-                                    Size vGrid,
-                                    Size dampingSteps,
-                                    Real rho,
-                                    const FdmSchemeDesc& schemeDesc,
-                                    ext::shared_ptr<FdmQuantoHelper> quantoHelper);
+        FdCIRVanillaEngine(ext::shared_ptr<CoxIngersollRossProcess> cirProcess,
+                           ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess,
+                           Size tGrid,
+                           Size xGrid,
+                           Size vGrid,
+                           Size dampingSteps,
+                           Real rho,
+                           const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::ModifiedHundsdorfer(),
+                           ext::shared_ptr<FdmQuantoHelper> quantoHelper = {});
+
+        FdCIRVanillaEngine(ext::shared_ptr<CoxIngersollRossProcess> cirProcess,
+                           ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess,
+                           DividendSchedule dividends,
+                           Size tGrid,
+                           Size xGrid,
+                           Size vGrid,
+                           Size dampingSteps,
+                           Real rho,
+                           const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::ModifiedHundsdorfer(),
+                           ext::shared_ptr<FdmQuantoHelper> quantoHelper = {});
 
         void calculate() const override;
 
         FdmSolverDesc getSolverDesc(Real equityScaleFactor) const;
 
       private:
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess_;
+        ext::shared_ptr<CoxIngersollRossProcess> cirProcess_;
+        ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, rGrid_, dampingSteps_;
         const Real rho_;
         const FdmSchemeDesc schemeDesc_;
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess_;
-        ext::shared_ptr<CoxIngersollRossProcess> cirProcess_;
-        
-        ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
     };
 
     class MakeFdCIRVanillaEngine {
@@ -86,11 +100,17 @@ namespace QuantLib {
         MakeFdCIRVanillaEngine& withFdmSchemeDesc(
             const FdmSchemeDesc& schemeDesc);
 
+        MakeFdCIRVanillaEngine& withCashDividends(
+            const std::vector<Date>& dividendDates,
+            const std::vector<Real>& dividendAmounts);
+
         operator ext::shared_ptr<PricingEngine>() const;
 
       private:
         ext::shared_ptr<CoxIngersollRossProcess> cirProcess_;
         ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess_;
+        DividendSchedule dividends_;
+        bool explicitDividends_ = false;
         const Real rho_;
         Size tGrid_ = 10, xGrid_ = 100, rGrid_ = 100, dampingSteps_ = 0;
         ext::shared_ptr<FdmSchemeDesc> schemeDesc_;

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
@@ -33,6 +33,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     FdHestonHullWhiteVanillaEngine::FdHestonHullWhiteVanillaEngine(
         const ext::shared_ptr<HestonModel>& hestonModel,
         ext::shared_ptr<HullWhiteProcess> hwProcess,
@@ -47,11 +49,39 @@ namespace QuantLib {
     : GenericModelEngine<HestonModel,
                          DividendVanillaOption::arguments,
                          DividendVanillaOption::results>(hestonModel),
-      hwProcess_(std::move(hwProcess)), corrEquityShortRate_(corrEquityShortRate), tGrid_(tGrid),
+      hwProcess_(std::move(hwProcess)), explicitDividends_(false),
+      corrEquityShortRate_(corrEquityShortRate), tGrid_(tGrid),
       xGrid_(xGrid), vGrid_(vGrid), rGrid_(rGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), controlVariate_(controlVariate) {}
 
+    FdHestonHullWhiteVanillaEngine::FdHestonHullWhiteVanillaEngine(
+        const ext::shared_ptr<HestonModel>& hestonModel,
+        ext::shared_ptr<HullWhiteProcess> hwProcess,
+        DividendSchedule dividends,
+        Real corrEquityShortRate,
+        Size tGrid,
+        Size xGrid,
+        Size vGrid,
+        Size rGrid,
+        Size dampingSteps,
+        bool controlVariate,
+        const FdmSchemeDesc& schemeDesc)
+    : GenericModelEngine<HestonModel,
+                         DividendVanillaOption::arguments,
+                         DividendVanillaOption::results>(hestonModel),
+      hwProcess_(std::move(hwProcess)), dividends_(std::move(dividends)), explicitDividends_(true),
+      corrEquityShortRate_(corrEquityShortRate), tGrid_(tGrid),
+      xGrid_(xGrid), vGrid_(vGrid), rGrid_(rGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc), controlVariate_(controlVariate) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
+
     void FdHestonHullWhiteVanillaEngine::calculate() const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
   
         // 1. cache lookup for precalculated results
         for (auto& cachedArgs2result : cachedArgs2results_) {
@@ -65,9 +95,8 @@ namespace QuantLib {
 
                 if ((p1 != nullptr) && p1->strike() == p2->strike() &&
                     p1->optionType() == p2->optionType()) {
-                    QL_REQUIRE(arguments_.cashFlow.empty(),
-                               "multiple strikes engine does "
-                               "not work with discrete dividends");
+                    QL_REQUIRE(passedDividends.empty(),
+                               "multiple strikes engine does not work with discrete dividends");
                     results_ = cachedArgs2result.second;
                     return;
                 }
@@ -101,11 +130,11 @@ namespace QuantLib {
                       maturity, payoff->strike(),
                       Null<Real>(), Null<Real>(), 0.0001, 1.5, 
                       std::pair<Real, Real>(payoff->strike(), 0.1),
-                      arguments_.cashFlow));
+                      passedDividends));
         }
         else {
-            QL_REQUIRE(arguments_.cashFlow.empty(),"multiple strikes engine "
-                       "does not work with discrete dividends");
+            QL_REQUIRE(passedDividends.empty(),
+                       "multiple strikes engine does not work with discrete dividends");
             equityMesher = ext::shared_ptr<Fdm1dMesher>(
                 new FdmBlackScholesMultiStrikeMesher(
                     xGrid_,
@@ -134,7 +163,7 @@ namespace QuantLib {
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
             FdmStepConditionComposite::vanillaComposite(
-                                arguments_.cashFlow, arguments_.exercise, 
+                                passedDividends, arguments_.exercise, 
                                 mesher, calculator, 
                                 hestonProcess->riskFreeRate()->referenceDate(),
                                 hestonProcess->riskFreeRate()->dayCounter());
@@ -167,9 +196,11 @@ namespace QuantLib {
                 ext::make_shared<PlainVanillaPayoff>(
                     payoff->optionType(), strikes_[i]);
             const Real d = payoff->strike()/strikes_[i];
-            
+
+            QL_DEPRECATED_DISABLE_WARNING
             DividendVanillaOption::results& 
                                 results = cachedArgs2results_[i].second;
+            QL_DEPRECATED_ENABLE_WARNING
             results.value = solver->valueAt(spot*d, v0, 0)/d;
             results.delta = solver->deltaAt(spot*d, v0, 0, spot*d*0.01);
             results.gamma = solver->gammaAt(spot*d, v0, 0, spot*d*0.01)*d;
@@ -212,12 +243,17 @@ namespace QuantLib {
     
     void FdHestonHullWhiteVanillaEngine::update() {
         cachedArgs2results_.clear();
-        GenericModelEngine<HestonModel, DividendVanillaOption::arguments,
+        QL_DEPRECATED_DISABLE_WARNING
+        GenericModelEngine<HestonModel,
+                           DividendVanillaOption::arguments,
                            DividendVanillaOption::results>::update();
+        QL_DEPRECATED_ENABLE_WARNING
     }
+
     void FdHestonHullWhiteVanillaEngine::enableMultipleStrikesCaching(
                                         const std::vector<Real>& strikes) {
         strikes_ = strikes;
         update();
     }
+
 }

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.hpp
@@ -18,7 +18,7 @@
 */
 
 /*! \file fdhestonhullwhitevanillaengine.hpp
-    \brief Finite-Differences Heston Hull-White vanilla option engine
+    \brief Finite-differences Heston Hull-White vanilla option engine
 */
 
 #ifndef quantlib_fd_heston_hull_white_vanilla_engine_hpp
@@ -33,8 +33,9 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Heston Hull-White Vanilla Option engine
+    QL_DEPRECATED_DISABLE_WARNING
 
+    //! Finite-differences Heston Hull-White vanilla option engine
     /*! \ingroup vanillaengines
 
         \test the correctness of the returned value is tested by
@@ -45,11 +46,24 @@ namespace QuantLib {
         : public GenericModelEngine<HestonModel,
                                     DividendVanillaOption::arguments,
                                     DividendVanillaOption::results> {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        // Constructor
         FdHestonHullWhiteVanillaEngine(
             const ext::shared_ptr<HestonModel>& model,
             ext::shared_ptr<HullWhiteProcess> hwProcess,
+            Real corrEquityShortRate,
+            Size tGrid = 50,
+            Size xGrid = 100,
+            Size vGrid = 40,
+            Size rGrid = 20,
+            Size dampingSteps = 0,
+            bool controlVariate = true,
+            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer());
+
+        FdHestonHullWhiteVanillaEngine(
+            const ext::shared_ptr<HestonModel>& model,
+            ext::shared_ptr<HullWhiteProcess> hwProcess,
+            DividendSchedule dividends,
             Real corrEquityShortRate,
             Size tGrid = 50,
             Size xGrid = 100,
@@ -67,6 +81,8 @@ namespace QuantLib {
         
       private:
         const ext::shared_ptr<HullWhiteProcess> hwProcess_;
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Real corrEquityShortRate_;
         const Size tGrid_, xGrid_, vGrid_, rGrid_;
         const Size dampingSteps_;
@@ -74,9 +90,13 @@ namespace QuantLib {
         const bool controlVariate_;
         
         std::vector<Real> strikes_;
+        QL_DEPRECATED_DISABLE_WARNING
         mutable std::vector<std::pair<DividendVanillaOption::arguments,
                                       DividendVanillaOption::results> >
                                                             cachedArgs2results_;
+        QL_DEPRECATED_ENABLE_WARNING
     };
+
 }
+
 #endif

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -20,7 +20,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-
 #include <ql/methods/finitedifferences/meshers/fdmblackscholesmesher.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmblackscholesmultistrikemesher.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmhestonvariancemesher.hpp>
@@ -35,6 +34,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     FdHestonVanillaEngine::FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
                                                  Size tGrid,
                                                  Size xGrid,
@@ -46,6 +47,24 @@ namespace QuantLib {
     : GenericModelEngine<HestonModel,
                          DividendVanillaOption::arguments,
                          DividendVanillaOption::results>(model),
+      explicitDividends_(false),
+      tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)),
+      quantoHelper_(ext::shared_ptr<FdmQuantoHelper>()), mixingFactor_(mixingFactor) {}
+
+    FdHestonVanillaEngine::FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
+                                                 DividendSchedule dividends,
+                                                 Size tGrid,
+                                                 Size xGrid,
+                                                 Size vGrid,
+                                                 Size dampingSteps,
+                                                 const FdmSchemeDesc& schemeDesc,
+                                                 ext::shared_ptr<LocalVolTermStructure> leverageFct,
+                                                 const Real mixingFactor)
+    : GenericModelEngine<HestonModel,
+                         DividendVanillaOption::arguments,
+                         DividendVanillaOption::results>(model),
+      dividends_(std::move(dividends)), explicitDividends_(true),
       tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)),
       quantoHelper_(ext::shared_ptr<FdmQuantoHelper>()), mixingFactor_(mixingFactor) {}
@@ -62,12 +81,38 @@ namespace QuantLib {
     : GenericModelEngine<HestonModel,
                          DividendVanillaOption::arguments,
                          DividendVanillaOption::results>(model),
+      explicitDividends_(false),
       tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
       schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)),
       quantoHelper_(std::move(quantoHelper)), mixingFactor_(mixingFactor) {}
 
+    FdHestonVanillaEngine::FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
+                                                 DividendSchedule dividends,
+                                                 ext::shared_ptr<FdmQuantoHelper> quantoHelper,
+                                                 Size tGrid,
+                                                 Size xGrid,
+                                                 Size vGrid,
+                                                 Size dampingSteps,
+                                                 const FdmSchemeDesc& schemeDesc,
+                                                 ext::shared_ptr<LocalVolTermStructure> leverageFct,
+                                                 const Real mixingFactor)
+    : GenericModelEngine<HestonModel,
+                         DividendVanillaOption::arguments,
+                         DividendVanillaOption::results>(model),
+      dividends_(std::move(dividends)), explicitDividends_(true),
+      tGrid_(tGrid), xGrid_(xGrid), vGrid_(vGrid), dampingSteps_(dampingSteps),
+      schemeDesc_(schemeDesc), leverageFct_(std::move(leverageFct)),
+      quantoHelper_(std::move(quantoHelper)), mixingFactor_(mixingFactor) {}
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     FdmSolverDesc FdHestonVanillaEngine::getSolverDesc(Real) const {
+
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
+
         // 1. Mesher
         const ext::shared_ptr<HestonProcess> process = model_->process();
         const Time maturity = process->time(arguments_.exercise->lastDate());
@@ -89,29 +134,29 @@ namespace QuantLib {
         if (strikes_.empty()) {
             equityMesher = ext::shared_ptr<Fdm1dMesher>(
                 new FdmBlackScholesMesher(
-                    xGrid_, 
+                    xGrid_,
                     FdmBlackScholesMesher::processHelper(
                         process->s0(), process->dividendYield(),
                         process->riskFreeRate(), avgVolaEstimate),
                     maturity, payoff->strike(),
                     Null<Real>(), Null<Real>(), 0.0001, 2.0,
                     std::pair<Real, Real>(payoff->strike(), 0.1),
-                    arguments_.cashFlow,
+                    passedDividends,
                     quantoHelper_));
         }
         else {
-            QL_REQUIRE(arguments_.cashFlow.empty(),"multiple strikes engine "
-                       "does not work with discrete dividends");
+            QL_REQUIRE(passedDividends.empty(),
+                       "multiple strikes engine does not work with discrete dividends");
             equityMesher = ext::shared_ptr<Fdm1dMesher>(
                 new FdmBlackScholesMultiStrikeMesher(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
-                      process->s0(), process->dividendYield(), 
+                      process->s0(), process->dividendYield(),
                       process->riskFreeRate(), avgVolaEstimate),
                     maturity, strikes_, 0.0001, 1.5,
-                    std::pair<Real, Real>(payoff->strike(), 0.075)));            
+                    std::pair<Real, Real>(payoff->strike(), 0.075)));
         }
-        
+
         const ext::shared_ptr<FdmMesher> mesher(
             new FdmMesherComposite(equityMesher, vMesher));
 
@@ -120,10 +165,10 @@ namespace QuantLib {
                           new FdmLogInnerValue(arguments_.payoff, mesher, 0));
 
         // 3. Step conditions
-        const ext::shared_ptr<FdmStepConditionComposite> conditions = 
+        const ext::shared_ptr<FdmStepConditionComposite> conditions =
              FdmStepConditionComposite::vanillaComposite(
-                                 arguments_.cashFlow, arguments_.exercise, 
-                                 mesher, calculator, 
+                                 passedDividends, arguments_.exercise,
+                                 mesher, calculator,
                                  process->riskFreeRate()->referenceDate(),
                                  process->riskFreeRate()->dayCounter());
 
@@ -140,6 +185,11 @@ namespace QuantLib {
 
     void FdHestonVanillaEngine::calculate() const {
 
+        // dividends will eventually be moved out of arguments, but for now we need the switch
+        QL_DEPRECATED_DISABLE_WARNING
+        const DividendSchedule& passedDividends = explicitDividends_ ? dividends_ : arguments_.cashFlow;
+        QL_DEPRECATED_ENABLE_WARNING
+
         // cache lookup for precalculated results
         for (auto& cachedArgs2result : cachedArgs2results_) {
             if (cachedArgs2result.first.exercise->type() == arguments_.exercise->type() &&
@@ -152,9 +202,8 @@ namespace QuantLib {
 
                 if ((p1 != nullptr) && p1->strike() == p2->strike() &&
                     p1->optionType() == p2->optionType()) {
-                    QL_REQUIRE(arguments_.cashFlow.empty(),
-                               "multiple strikes engine does "
-                               "not work with discrete dividends");
+                    QL_REQUIRE(passedDividends.empty(),
+                               "multiple strikes engine does not work with discrete dividends");
                     results_ = cachedArgs2result.second;
                     return;
                 }
@@ -167,7 +216,7 @@ namespace QuantLib {
                     Handle<HestonProcess>(process),
                     getSolverDesc(1.5), schemeDesc_,
                     Handle<FdmQuantoHelper>(quantoHelper_), leverageFct_,
-                     mixingFactor_));
+                    mixingFactor_));
 
         const Real v0   = process->v0();
         const Real spot = process->s0()->value();
@@ -176,32 +225,36 @@ namespace QuantLib {
         results_.delta = solver->deltaAt(spot, v0);
         results_.gamma = solver->gammaAt(spot, v0);
         results_.theta = solver->thetaAt(spot, v0);
-        
+
         cachedArgs2results_.resize(strikes_.size());
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         for (Size i=0; i < strikes_.size(); ++i) {
             cachedArgs2results_[i].first.exercise = arguments_.exercise;
-            cachedArgs2results_[i].first.payoff = 
+            cachedArgs2results_[i].first.payoff =
                 ext::make_shared<PlainVanillaPayoff>(
                     payoff->optionType(), strikes_[i]);
             const Real d = payoff->strike()/strikes_[i];
-            
-            DividendVanillaOption::results& 
-                                results = cachedArgs2results_[i].second;
+
+            QL_DEPRECATED_DISABLE_WARNING
+            DividendVanillaOption::results& results = cachedArgs2results_[i].second;
+            QL_DEPRECATED_ENABLE_WARNING
             results.value = solver->valueAt(spot*d, v0)/d;
             results.delta = solver->deltaAt(spot*d, v0);
             results.gamma = solver->gammaAt(spot*d, v0)*d;
-            results.theta = solver->thetaAt(spot*d, v0)/d;                
+            results.theta = solver->thetaAt(spot*d, v0)/d;
         }
     }
-    
+
     void FdHestonVanillaEngine::update() {
         cachedArgs2results_.clear();
-        GenericModelEngine<HestonModel, DividendVanillaOption::arguments,
+        QL_DEPRECATED_DISABLE_WARNING
+        GenericModelEngine<HestonModel,
+                           DividendVanillaOption::arguments,
                            DividendVanillaOption::results>::update();
+        QL_DEPRECATED_ENABLE_WARNING
     }
-    
+
     void FdHestonVanillaEngine::enableMultipleStrikesCaching(
                                         const std::vector<Real>& strikes) {
         strikes_ = strikes;
@@ -257,13 +310,33 @@ namespace QuantLib {
         return *this;
     }
 
+    MakeFdHestonVanillaEngine&
+    MakeFdHestonVanillaEngine::withCashDividends(
+            const std::vector<Date>& dividendDates,
+            const std::vector<Real>& dividendAmounts) {
+        dividends_ = DividendVector(dividendDates, dividendAmounts);
+        explicitDividends_ = true;
+        return *this;
+    }
+
     MakeFdHestonVanillaEngine::operator
     ext::shared_ptr<PricingEngine>() const {
-        return ext::make_shared<FdHestonVanillaEngine>(
-            hestonModel_,
-            quantoHelper_,
-            tGrid_, xGrid_, vGrid_, dampingSteps_,
-            *schemeDesc_,
-            leverageFct_);
+        if (explicitDividends_) {
+            return ext::make_shared<FdHestonVanillaEngine>(
+                hestonModel_,
+                dividends_,
+                quantoHelper_,
+                tGrid_, xGrid_, vGrid_, dampingSteps_,
+                *schemeDesc_,
+                leverageFct_);
+        } else {
+            return ext::make_shared<FdHestonVanillaEngine>(
+                hestonModel_,
+                quantoHelper_,
+                tGrid_, xGrid_, vGrid_, dampingSteps_,
+                *schemeDesc_,
+                leverageFct_);
+        }
     }
+
 }

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.hpp
@@ -20,7 +20,7 @@
 */
 
 /*! \file fdhestonvanillaengine.hpp
-    \brief Finite-Differences Heston vanilla option engine
+    \brief Finite-differences Heston vanilla option engine
 */
 
 #ifndef quantlib_fd_heston_vanilla_engine_hpp
@@ -35,32 +35,42 @@
 
 namespace QuantLib {
 
-    //! Finite-Differences Heston Vanilla Option engine
+    class FdmQuantoHelper;
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    //! Finite-differences Heston vanilla option engine
     /*! \ingroup vanillaengines
 
         \test the correctness of the returned value is tested by
               reproducing results available in web/literature
               and comparison with Black pricing.
     */
-    class FdmQuantoHelper;
-
     class FdHestonVanillaEngine
         : public GenericModelEngine<HestonModel,
                                     DividendVanillaOption::arguments,
                                     DividendVanillaOption::results> {
+        QL_DEPRECATED_ENABLE_WARNING
       public:
-        // Constructor
-        explicit FdHestonVanillaEngine(
-            const ext::shared_ptr<HestonModel>& model,
-            Size tGrid = 100,
-            Size xGrid = 100,
-            Size vGrid = 50,
-            Size dampingSteps = 0,
-            const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-            ext::shared_ptr<LocalVolTermStructure> leverageFct =
-                ext::shared_ptr<LocalVolTermStructure>(),
-            Real mixingFactor = 1.0);
+        explicit
+        FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
+                              Size tGrid = 100,
+                              Size xGrid = 100,
+                              Size vGrid = 50,
+                              Size dampingSteps = 0,
+                              const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+                              ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
+                              Real mixingFactor = 1.0);
+
+        FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
+                              DividendSchedule dividends,
+                              Size tGrid = 100,
+                              Size xGrid = 100,
+                              Size vGrid = 50,
+                              Size dampingSteps = 0,
+                              const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+                              ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
+                              Real mixingFactor = 1.0);
 
         FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
                               ext::shared_ptr<FdmQuantoHelper> quantoHelper,
@@ -69,8 +79,18 @@ namespace QuantLib {
                               Size vGrid = 50,
                               Size dampingSteps = 0,
                               const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
-                              ext::shared_ptr<LocalVolTermStructure> leverageFct =
-                                  ext::shared_ptr<LocalVolTermStructure>(),
+                              ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
+                              Real mixingFactor = 1.0);
+
+        FdHestonVanillaEngine(const ext::shared_ptr<HestonModel>& model,
+                              DividendSchedule dividends,
+                              ext::shared_ptr<FdmQuantoHelper> quantoHelper,
+                              Size tGrid = 100,
+                              Size xGrid = 100,
+                              Size vGrid = 50,
+                              Size dampingSteps = 0,
+                              const FdmSchemeDesc& schemeDesc = FdmSchemeDesc::Hundsdorfer(),
+                              ext::shared_ptr<LocalVolTermStructure> leverageFct = {},
                               Real mixingFactor = 1.0);
 
         void calculate() const override;
@@ -78,11 +98,13 @@ namespace QuantLib {
         // multiple strikes caching engine
         void update() override;
         void enableMultipleStrikesCaching(const std::vector<Real>& strikes);
-        
+
         // helper method for Heston like engines
         FdmSolverDesc getSolverDesc(Real equityScaleFactor) const;
 
       private:
+        DividendSchedule dividends_;
+        bool explicitDividends_;
         const Size tGrid_, xGrid_, vGrid_, dampingSteps_;
         const FdmSchemeDesc schemeDesc_;
         const ext::shared_ptr<LocalVolTermStructure> leverageFct_;
@@ -90,9 +112,11 @@ namespace QuantLib {
         const Real mixingFactor_;
 
         std::vector<Real> strikes_;
+        QL_DEPRECATED_DISABLE_WARNING
         mutable std::vector<std::pair<DividendVanillaOption::arguments,
                                       DividendVanillaOption::results> >
                                                             cachedArgs2results_;
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
     class MakeFdHestonVanillaEngine {
@@ -114,15 +138,22 @@ namespace QuantLib {
         MakeFdHestonVanillaEngine& withLeverageFunction(
             ext::shared_ptr<LocalVolTermStructure>& leverageFct);
 
+        MakeFdHestonVanillaEngine& withCashDividends(
+            const std::vector<Date>& dividendDates,
+            const std::vector<Real>& dividendAmounts);
+
         operator ext::shared_ptr<PricingEngine>() const;
 
       private:
         ext::shared_ptr<HestonModel> hestonModel_;
+        DividendSchedule dividends_;
+        bool explicitDividends_ = false;
         Size tGrid_ = 100, xGrid_ = 100, vGrid_ = 50, dampingSteps_ = 0;
         ext::shared_ptr<FdmSchemeDesc> schemeDesc_;
         ext::shared_ptr<LocalVolTermStructure> leverageFct_;
         ext::shared_ptr<FdmQuantoHelper> quantoHelper_;
     };
+
 }
 
 #endif

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -110,9 +110,9 @@ void DividendOptionTest::testEuropeanValues() {
 
                 QL_DEPRECATED_DISABLE_WARNING
                 ext::shared_ptr<PricingEngine> engine1(new AnalyticDividendEuropeanEngine(stochProcess));
-                QL_DEPRECATED_ENABLE_WARNING
 
                 DividendVanillaOption option1(payoff, exercise, dividendDates, dividends);
+                QL_DEPRECATED_ENABLE_WARNING
                 option1.setPricingEngine(engine1);
 
                 auto engine2 =
@@ -208,10 +208,10 @@ void DividendOptionTest::testEuropeanKnownValue() {
     QL_DEPRECATED_DISABLE_WARNING
     ext::shared_ptr<PricingEngine> engine1(
                             new AnalyticDividendEuropeanEngine(stochProcess));
-    QL_DEPRECATED_ENABLE_WARNING
 
     DividendVanillaOption option1(payoff, exercise,
                                   dividendDates, dividends);
+    QL_DEPRECATED_ENABLE_WARNING
     option1.setPricingEngine(engine1);
 
     auto engine2 = ext::make_shared<AnalyticDividendEuropeanEngine>(
@@ -302,9 +302,9 @@ void DividendOptionTest::testEuropeanStartLimit() {
                 QL_DEPRECATED_DISABLE_WARNING
                 ext::shared_ptr<PricingEngine> engine1(
                     new AnalyticDividendEuropeanEngine(stochProcess));
-                QL_DEPRECATED_ENABLE_WARNING
 
                 DividendVanillaOption option1(payoff, exercise, dividendDates, dividends);
+                QL_DEPRECATED_ENABLE_WARNING
                 option1.setPricingEngine(engine1);
 
                 auto engine2 = ext::make_shared<AnalyticDividendEuropeanEngine>(
@@ -401,9 +401,9 @@ void DividendOptionTest::testEuropeanEndLimit() {
                 QL_DEPRECATED_DISABLE_WARNING
                 ext::shared_ptr<PricingEngine> engine1(
                     new AnalyticDividendEuropeanEngine(stochProcess));
-                QL_DEPRECATED_ENABLE_WARNING
 
                 DividendVanillaOption option1(payoff, exercise, dividendDates, dividends);
+                QL_DEPRECATED_ENABLE_WARNING
                 option1.setPricingEngine(engine1);
 
                 auto engine2 = ext::make_shared<AnalyticDividendEuropeanEngine>(
@@ -499,9 +499,9 @@ void DividendOptionTest::testOldEuropeanGreeks() {
                 QL_DEPRECATED_DISABLE_WARNING
                 ext::shared_ptr<PricingEngine> engine(
                     new AnalyticDividendEuropeanEngine(stochProcess));
-                QL_DEPRECATED_ENABLE_WARNING
 
                 DividendVanillaOption option(payoff, exercise, dividendDates, dividends);
+                QL_DEPRECATED_ENABLE_WARNING
                 option.setPricingEngine(engine);
 
                 for (Real u : underlyings) {

--- a/test-suite/dividendoption.hpp
+++ b/test-suite/dividendoption.hpp
@@ -31,6 +31,7 @@ class DividendOptionTest {
     static void testEuropeanKnownValue();
     static void testEuropeanStartLimit();
     static void testEuropeanEndLimit();
+    static void testOldEuropeanGreeks();
     static void testEuropeanGreeks();
     static void testFdEuropeanValues();
     static void testFdEuropeanGreeks();

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1463,8 +1463,7 @@ void EuropeanOptionTest::testAnalyticEngineDiscountCurve() {
 
 
 void EuropeanOptionTest::testPDESchemes() {
-    BOOST_TEST_MESSAGE("Testing different PDE schemes "
-            "to solve Black-Scholes PDEs...");
+    BOOST_TEST_MESSAGE("Testing different PDE schemes to solve Black-Scholes PDEs...");
 
     SavedSettings backup;
 
@@ -1537,8 +1536,6 @@ void EuropeanOptionTest::testPDESchemes() {
         std::make_pair(trBDF2, "TR-BDF2")
     };
 
-    const Size nEngines = LENGTH(engines);
-
     const ext::shared_ptr<PlainVanillaPayoff> payoff(
         ext::make_shared<PlainVanillaPayoff>(Option::Put, spot->value()));
 
@@ -1563,59 +1560,6 @@ void EuropeanOptionTest::testPDESchemes() {
                        << "\n    calculated: " << calculated << "\n    expected:   " << expected
                        << "\n    difference: " << diff << "\n    tolerance:  " << tol);
         }
-    }
-
-    DividendVanillaOption dividendOption(
-        payoff, exercise,
-        std::vector<Date>(1, today + Period(3, Months)),
-        std::vector<Real>(1, 5.0));
-
-    Array dividendPrices(nEngines);
-    for (Size i=0; i < nEngines; ++i) {
-        dividendOption.setPricingEngine(engines[i].first);
-        dividendPrices[i] = dividendOption.NPV();
-    }
-
-    const Real expectedDiv = std::accumulate(
-        dividendPrices.begin(), dividendPrices.end(), Real(0.0))/nEngines;
-
-    for (Size i=0; i < nEngines; ++i) {
-        const Real calculated = dividendPrices[i];
-        const Real diff = std::fabs(expectedDiv - calculated);
-
-        if (diff > tol) {
-            BOOST_FAIL("Failed to reproduce European option values "
-                    "with dividend and the "
-                    << engines[i].second << " PDE scheme"
-                       << "\n    calculated: " << calculated
-                       << "\n    expected:   " << expectedDiv
-                       << "\n    difference: " << diff
-                       << "\n    tolerance:  " << tol);
-        }
-    }
-
-    // make sure that Douglas and Crank-Nicolson are giving the same result
-    const Size idxDouglas =
-        std::distance(std::begin(engines),
-                      std::find(std::begin(engines), std::end(engines),
-                                std::make_pair(douglas, std::string("Douglas"))));
-    const Real douglasNPV = dividendPrices[idxDouglas];
-
-    const Size idxCrankNicolson =
-        std::distance(std::begin(engines),
-                      std::find(std::begin(engines), std::end(engines),
-                                std::make_pair(crankNicolson, std::string("Crank-Nicolson"))));
-    const Real crankNicolsonNPV = dividendPrices[idxCrankNicolson];
-
-    const Real schemeTol = 1e-12;
-    const Real schemeDiff = std::fabs(crankNicolsonNPV - douglasNPV);
-    if (schemeDiff > schemeTol) {
-        BOOST_FAIL("Failed to reproduce Douglas scheme option values "
-                "with the Crank-Nicolson PDE scheme "
-                   << "\n    Dougles NPV:        " << douglasNPV
-                   << "\n    Crank-Nicolson NPV: " << crankNicolsonNPV
-                   << "\n    difference:         " << schemeDiff
-                   << "\n    tolerance:          " << schemeTol);
     }
 }
 
@@ -1764,9 +1708,11 @@ void EuropeanOptionTest::testVanillaAndDividendEngine() {
 
     auto option1 =
         VanillaOption(payoff, ext::make_shared<AmericanExercise>(today, Date(1, June, 2023)));
+    QL_DEPRECATED_DISABLE_WARNING
     auto option2 = DividendVanillaOption(
         payoff, ext::make_shared<AmericanExercise>(today, Date(1, June, 2023)),
         {Date(1, February, 2023)}, {1.0});
+    QL_DEPRECATED_ENABLE_WARNING
 
     option1.setPricingEngine(engine);
     option2.setPricingEngine(engine);

--- a/test-suite/europeanoption.hpp
+++ b/test-suite/europeanoption.hpp
@@ -32,6 +32,7 @@ class EuropeanOptionTest {
     static void testGreekValues();
     static void testGreeks();
     static void testImpliedVol();
+    static void testImpliedVolWithDividends();
     static void testImpliedVolContainment();
     static void testJRBinomialEngines();
     static void testCRRBinomialEngines();

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -79,7 +79,7 @@ namespace fd_heston_test {
         Real maxStrike() const override { return std::numeric_limits<Real>::max(); }
 
       protected:
-        Volatility localVolImpl(Time t, Real s) const override {
+        Volatility localVolImpl(Time, Real s) const override {
             return alpha_*(squared(s0_ - s) + 25.0);
         }
 
@@ -569,8 +569,7 @@ void FdHestonTest::testFdmHestonBlackScholes() {
 
 void FdHestonTest::testFdmHestonEuropeanWithDividends() {
 
-    BOOST_TEST_MESSAGE("Testing FDM with European option with dividends"
-                       " in Heston model...");
+    BOOST_TEST_MESSAGE("Testing FDM with European option with dividends in Heston model...");
 
     SavedSettings backup;
 
@@ -579,25 +578,24 @@ void FdHestonTest::testFdmHestonEuropeanWithDividends() {
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8));
+    auto hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8);
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(28, March, 2005);
 
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(exerciseDate));
-
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Put, 100));
+    auto exercise = ext::make_shared<AmericanExercise>(exerciseDate);
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100);
 
     const std::vector<Real> dividends(1, 5);
     const std::vector<Date> dividendDates(1, Date(28, September, 2004));
 
-    DividendVanillaOption option(payoff, exercise, dividendDates, dividends);
-    ext::shared_ptr<PricingEngine> engine(
+    QL_DEPRECATED_DISABLE_WARNING
+    DividendVanillaOption option1(payoff, exercise, dividendDates, dividends);
+    QL_DEPRECATED_ENABLE_WARNING
+    ext::shared_ptr<PricingEngine> engine1(
          new FdHestonVanillaEngine(ext::make_shared<HestonModel>(
                              hestonProcess), 50, 100, 50));
-    option.setPricingEngine(engine);
+    option1.setPricingEngine(engine1);
     
     const Real tol = 0.01;
     const Real gammaTol = 0.001;
@@ -605,21 +603,48 @@ void FdHestonTest::testFdmHestonEuropeanWithDividends() {
     const Real deltaExpected = -0.397902;
     const Real gammaExpected =  0.027747;
         
-    if (std::fabs(option.NPV() - npvExpected) > tol) {
+    if (std::fabs(option1.NPV() - npvExpected) > tol) {
         BOOST_ERROR("Failed to reproduce expected npv"
-                    << "\n    calculated: " << option.NPV()
+                    << "\n    calculated: " << option1.NPV()
                     << "\n    expected:   " << npvExpected
                     << "\n    tolerance:  " << tol); 
     }
-    if (std::fabs(option.delta() - deltaExpected) > tol) {
+    if (std::fabs(option1.delta() - deltaExpected) > tol) {
         BOOST_ERROR("Failed to reproduce expected delta"
-                    << "\n    calculated: " << option.delta()
+                    << "\n    calculated: " << option1.delta()
                     << "\n    expected:   " << deltaExpected
                     << "\n    tolerance:  " << tol); 
     }
-    if (std::fabs(option.gamma() - gammaExpected) > gammaTol) {
+    if (std::fabs(option1.gamma() - gammaExpected) > gammaTol) {
         BOOST_ERROR("Failed to reproduce expected gamma"
-                    << "\n    calculated: " << option.gamma()
+                    << "\n    calculated: " << option1.gamma()
+                    << "\n    expected:   " << gammaExpected
+                    << "\n    tolerance:  " << tol); 
+    }
+
+
+    VanillaOption option2(payoff, exercise);
+    auto engine2 = ext::make_shared<FdHestonVanillaEngine>(
+        ext::make_shared<HestonModel>(hestonProcess),
+        DividendVector(dividendDates, dividends),
+        50, 100, 50);
+    option2.setPricingEngine(engine2);
+        
+    if (std::fabs(option2.NPV() - npvExpected) > tol) {
+        BOOST_ERROR("Failed to reproduce expected npv"
+                    << "\n    calculated: " << option2.NPV()
+                    << "\n    expected:   " << npvExpected
+                    << "\n    tolerance:  " << tol); 
+    }
+    if (std::fabs(option2.delta() - deltaExpected) > tol) {
+        BOOST_ERROR("Failed to reproduce expected delta"
+                    << "\n    calculated: " << option2.delta()
+                    << "\n    expected:   " << deltaExpected
+                    << "\n    tolerance:  " << tol); 
+    }
+    if (std::fabs(option2.gamma() - gammaExpected) > gammaTol) {
+        BOOST_ERROR("Failed to reproduce expected gamma"
+                    << "\n    calculated: " << option2.gamma()
                     << "\n    expected:   " << gammaExpected
                     << "\n    tolerance:  " << tol); 
     }
@@ -1097,24 +1122,19 @@ test_suite* FdHestonTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBarrier));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonAmerican));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonIkonenToivanen));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdHestonTest::testFdmHestonEuropeanWithDividends));
-    suite->add(QUANTLIB_TEST_CASE(
-        &FdHestonTest::testFdmHestonIntradayPricing));
+    suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonEuropeanWithDividends));
+    suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonIntradayPricing));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testMethodOfLinesAndCN));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testSpuriousOscillations));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testAmericanCallPutParity));
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &FdHestonTest::testFdmHestonBlackScholes));
-        suite->add(QUANTLIB_TEST_CASE(
-            &FdHestonTest::testFdmHestonConvergence));
+        suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBlackScholes));
+        suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonConvergence));
     }
 
     if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &FdHestonTest::testFdmHestonBarrierVsBlackScholes));
+        suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBarrierVsBlackScholes));
     }
 
     return suite;

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -619,17 +619,26 @@ void HestonModelTest::testFdVanillaVsCached() {
                    << "\n    expected:   " << expected
                    << "\n    error:      " << std::scientific << error);
     }
+}
 
+void HestonModelTest::testFdVanillaWithDividendsVsCached() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for discrete dividends...");
 
-    payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 95.0);
-    s0 = Handle<Quote>(ext::make_shared<SimpleQuote>(100.0));
+    SavedSettings backup;
 
-    riskFreeTS = Handle<YieldTermStructure>(flatRate(0.05, dayCounter));
-    dividendTS = Handle<YieldTermStructure>(flatRate(0.0, dayCounter));
+    Date settlementDate(27, December, 2004);
+    Settings::instance().evaluationDate() = settlementDate;
 
-    exerciseDate = Date(28, March, 2006);
-    exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 95.0);
+
+    auto s0 = Handle<Quote>(ext::make_shared<SimpleQuote>(100.0));
+    auto riskFreeTS = Handle<YieldTermStructure>(flatRate(0.05, dayCounter));
+    auto dividendTS = Handle<YieldTermStructure>(flatRate(0.0, dayCounter));
+
+    auto exerciseDate = Date(28, March, 2006);
+    auto exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     std::vector<Date> dividendDates;
     std::vector<Real> dividends;
@@ -640,9 +649,11 @@ void HestonModelTest::testFdVanillaVsCached() {
         dividends.push_back(1.0);
     }
 
+    QL_DEPRECATED_DISABLE_WARNING
     DividendVanillaOption divOption(payoff, exercise,
                                     dividendDates, dividends);
-    process = ext::make_shared<HestonProcess>(
+    QL_DEPRECATED_ENABLE_WARNING
+    auto process = ext::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0);
     divOption.setPricingEngine(
         MakeFdHestonVanillaEngine(ext::make_shared<HestonModel>(process))
@@ -650,12 +661,13 @@ void HestonModelTest::testFdVanillaVsCached() {
             .withXGrid(400)
             .withVGrid(100)
         );
-    calculated = divOption.NPV();
+
+    Real calculated = divOption.NPV();
     // Value calculated with an independent FD framework, validated with
     // an independent MC framework
-    expected = 12.946;
-    error = std::fabs(calculated - expected);
-    tolerance = 5.0e-3;
+    Real expected = 12.946;
+    Real error = std::fabs(calculated - expected);
+    Real tolerance = 5.0e-3;
 
     if (error > tolerance) {
         BOOST_FAIL("failed to reproduce discrete dividend price with FD engine"
@@ -664,22 +676,54 @@ void HestonModelTest::testFdVanillaVsCached() {
                    << "\n    error:      " << std::scientific << error);
     }
 
+
+    VanillaOption option(payoff, exercise);
+    option.setPricingEngine(
+        MakeFdHestonVanillaEngine(ext::make_shared<HestonModel>(process))
+        .withCashDividends(dividendDates, dividends)
+        .withTGrid(200)
+        .withXGrid(400)
+        .withVGrid(100)
+    );
+
+    calculated = option.NPV();
+    error = std::fabs(calculated - expected);
+
+    if (error > tolerance) {
+        BOOST_FAIL("failed to reproduce discrete dividend price with FD engine"
+                   << "\n    calculated: " << calculated
+                   << "\n    expected:   " << expected
+                   << "\n    error:      " << std::scientific << error);
+    }
+}
+
+void HestonModelTest::testFdAmerican() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for american exercise...");
 
-    dividendTS = Handle<YieldTermStructure>(flatRate(0.03, dayCounter));
-    process = ext::make_shared<HestonProcess>(
+    SavedSettings backup;
+
+    Date settlementDate(27, December, 2004);
+    Settings::instance().evaluationDate() = settlementDate;
+
+    DayCounter dayCounter = ActualActual(ActualActual::ISDA);
+
+    auto s0 = Handle<Quote>(ext::make_shared<SimpleQuote>(100.0));
+    auto riskFreeTS = Handle<YieldTermStructure>(flatRate(0.05, dayCounter));
+    auto dividendTS = Handle<YieldTermStructure>(flatRate(0.03, dayCounter));
+    auto process = ext::make_shared<HestonProcess>(
                    riskFreeTS, dividendTS, s0, 0.04, 1.0, 0.04, 0.001, 0.0);
-    payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 95.0);
-    exercise = ext::make_shared<AmericanExercise>(
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 95.0);
+    auto exerciseDate = Date(28, March, 2006);
+    auto exercise = ext::make_shared<AmericanExercise>(
             settlementDate, exerciseDate);
-    option = VanillaOption(payoff, exercise);
+    auto option = VanillaOption(payoff, exercise);
     option.setPricingEngine(
         MakeFdHestonVanillaEngine(ext::make_shared<HestonModel>(process))
             .withTGrid(200)
             .withXGrid(400)
             .withVGrid(100)
         );
-    calculated = option.NPV();
+    Real calculated = option.NPV();
 
     Handle<BlackVolTermStructure> volTS(flatVol(settlementDate, 0.2,
                                                   dayCounter));
@@ -688,10 +732,10 @@ void HestonModelTest::testFdVanillaVsCached() {
     ext::shared_ptr<PricingEngine> ref_engine(
         ext::make_shared<FdBlackScholesVanillaEngine>(ref_process, 200, 400));
     option.setPricingEngine(ref_engine);
-    expected = option.NPV();
+    Real expected = option.NPV();
 
-    error = std::fabs(calculated - expected);
-    tolerance = 1.0e-3;
+    Real error = std::fabs(calculated - expected);
+    Real tolerance = 1.0e-3;
 
     if (error > tolerance) {
         BOOST_FAIL("failed to reproduce american option price with FD engine"
@@ -3373,6 +3417,9 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticVsCached));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testMultipleStrikesEngine));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testMcVsCached));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdVanillaVsCached));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdVanillaWithDividendsVsCached));
+    suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdAmerican));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAnalyticPiecewiseTimeDependent));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDAXCalibrationOfTimeDependentModel));
     suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testAlanLewisReferencePrices));
@@ -3400,7 +3447,6 @@ test_suite* HestonModelTest::suite(SpeedLevel speed) {
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testDifferentIntegrals));
         suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdBarrierVsCached));
-        suite->add(QUANTLIB_TEST_CASE(&HestonModelTest::testFdVanillaVsCached));
     }
 
     if (speed == Slow) {

--- a/test-suite/hestonmodel.hpp
+++ b/test-suite/hestonmodel.hpp
@@ -37,6 +37,8 @@ class HestonModelTest {
     static void testMcVsCached();
     static void testFdBarrierVsCached();    
     static void testFdVanillaVsCached();    
+    static void testFdVanillaWithDividendsVsCached();    
+    static void testFdAmerican();    
     static void testDifferentIntegrals();
     static void testMultipleStrikesEngine();
     static void testAnalyticPiecewiseTimeDependent();

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -1313,10 +1313,9 @@ void QuantoOptionTest::testAmericanQuantoOption()  {
                     << "\n    calculated Black-Scholes: " << bsCalculated);
     }
 
-    DividendVanillaOption divOption(
+    VanillaOption divOption(
         ext::make_shared<PlainVanillaPayoff>(Option::Call, strike),
-        ext::make_shared<AmericanExercise>(maturity),
-        dividendDates, dividendAmounts);
+        ext::make_shared<AmericanExercise>(maturity));
 
     const Real v0    = vol*vol;
     const Real kappa = 1.0;
@@ -1331,7 +1330,7 @@ void QuantoOptionTest::testAmericanQuantoOption()  {
 
     divOption.setPricingEngine(
         ext::make_shared<FdHestonVanillaEngine>(
-            hestonModel, quantoHelper, 100, 400, 3, 1));
+            hestonModel, dividends, quantoHelper, 100, 400, 3, 1));
 
     const Real hestonCalculated = divOption.NPV();
 
@@ -1352,7 +1351,7 @@ void QuantoOptionTest::testAmericanQuantoOption()  {
 
     divOption.setPricingEngine(
         ext::make_shared<FdHestonVanillaEngine>(
-            hestonModel05, quantoHelper, 100, 400, 3, 1,
+            hestonModel05, dividends, quantoHelper, 100, 400, 3, 1,
             FdmSchemeDesc::Hundsdorfer(), localConstVol));
 
     const Real hestoSlvCalculated = divOption.NPV();


### PR DESCRIPTION
Being market data and not part of the contract, dividends should be passed to pricing engines and not to instruments.

Doing that allows us to use `VanillaOption` for calculations with or without dividends. `DividendVanillaOption` and its inner arguments and engine classes are now deprecated; you can use `VanillaOption` instead. If you have written an engine for dividend vanilla options, implement it in terms of `VanillaOption::arguments` and `VanillaOption::engine` instead and pass the dividends in its constructor.