### PR TITLE
Equity index

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -822,6 +822,7 @@
     <ClInclude Include="ql\experimental\volatility\zabrsmilesection.hpp" />
     <ClInclude Include="ql\indexes\all.hpp" />
     <ClInclude Include="ql\indexes\bmaindex.hpp" />
+    <ClInclude Include="ql\indexes\equityindex.hpp" />
     <ClInclude Include="ql\indexes\ibor\all.hpp" />
     <ClInclude Include="ql\indexes\ibor\aonia.hpp" />
     <ClInclude Include="ql\indexes\ibor\audlibor.hpp" />
@@ -1031,7 +1032,7 @@
     <ClInclude Include="ql\math\interpolations\backwardflatlinearinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\bicubicsplineinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\bilinearinterpolation.hpp" />
-    <ClInclude Include="ql\math\interpolations\chebyshevinterpolation.hpp" />    
+    <ClInclude Include="ql\math\interpolations\chebyshevinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\convexmonotoneinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\cubicinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\extrapolation.hpp" />
@@ -2117,6 +2118,7 @@
     <ClCompile Include="ql\experimental\volatility\volcube.cpp" />
     <ClCompile Include="ql\experimental\volatility\zabr.cpp" />
     <ClCompile Include="ql\indexes\bmaindex.cpp" />
+    <ClCompile Include="ql\indexes\equityindex.cpp" />
     <ClCompile Include="ql\indexes\ibor\bibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\eonia.cpp" />
     <ClCompile Include="ql\indexes\ibor\estr.cpp" />
@@ -2255,12 +2257,12 @@
     <ClCompile Include="ql\math\integrals\integral.cpp" />
     <ClCompile Include="ql\math\integrals\kronrodintegral.cpp" />
     <ClCompile Include="ql\math\integrals\segmentintegral.cpp" />
-    <ClCompile Include="ql\math\interpolations\chebyshevinterpolation.cpp" />    
+    <ClCompile Include="ql\math\interpolations\chebyshevinterpolation.cpp" />
     <ClCompile Include="ql\math\matrix.cpp" />
     <ClCompile Include="ql\math\matrixutilities\basisincompleteordered.cpp" />
     <ClCompile Include="ql\math\matrixutilities\bicgstab.cpp" />
     <ClCompile Include="ql\math\matrixutilities\choleskydecomposition.cpp" />
-    <ClCompile Include="ql\math\matrixutilities\expm.cpp" />    
+    <ClCompile Include="ql\math\matrixutilities\expm.cpp" />
     <ClCompile Include="ql\math\matrixutilities\factorreduction.cpp" />
     <ClCompile Include="ql\math\matrixutilities\getcovariance.cpp" />
     <ClCompile Include="ql\math\matrixutilities\gmres.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4424,6 +4424,9 @@
     <ClInclude Include="ql\indexes\inflation\ukhicp.hpp">
       <Filter>indexes\inflation</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\equityindex.hpp">
+      <Filter>indexes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ql\methods\montecarlo\brownianbridge.cpp">
@@ -7146,6 +7149,9 @@
     </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\utilities\fdmhestongreensfct.cpp">
       <Filter>methods\finitedifferences\utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\equityindex.cpp">
+      <Filter>indexes</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -234,6 +234,7 @@ set(QL_SOURCES
     experimental/volatility/zabr.cpp
     index.cpp
     indexes/bmaindex.cpp
+    indexes/equityindex.cpp
     indexes/ibor/bibor.cpp
     indexes/ibor/eonia.cpp
     indexes/ibor/estr.cpp
@@ -1233,6 +1234,7 @@ set(QL_HEADERS
     handle.hpp
     index.hpp
     indexes/bmaindex.hpp
+    indexes/equityindex.hpp
     indexes/ibor/aonia.hpp
     indexes/ibor/audlibor.hpp
     indexes/ibor/bbsw.hpp

--- a/ql/indexes/Makefile.am
+++ b/ql/indexes/Makefile.am
@@ -7,6 +7,7 @@ this_includedir=${includedir}/${subdir}
 this_include_HEADERS = \
     all.hpp \
     bmaindex.hpp \
+    equityindex.hpp \
     iborindex.hpp \
     indexmanager.hpp \
     inflationindex.hpp \
@@ -16,6 +17,7 @@ this_include_HEADERS = \
 
 cpp_files = \
     bmaindex.cpp \
+    equityindex.cpp \
     iborindex.cpp \
     indexmanager.cpp \
     inflationindex.cpp \

--- a/ql/indexes/all.hpp
+++ b/ql/indexes/all.hpp
@@ -2,6 +2,7 @@
 /* Add the files to be included into Makefile.am instead. */
 
 #include <ql/indexes/bmaindex.hpp>
+#include <ql/indexes/equityindex.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/indexes/indexmanager.hpp>
 #include <ql/indexes/inflationindex.hpp>

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -50,11 +50,19 @@ namespace QuantLib {
 
         if (fixingDate <= today) {
             // today's fixing is required
-            // even without enforcing today's fixing
+            // even without enforcing it
             return pastFixing(fixingDate);
         }
 
         return forecastFixing(fixingDate);
+    }
+
+    Real EquityIndex::pastFixing(const Date& fixingDate) const {
+        QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
+        Real result = timeSeries()[fixingDate];
+
+        QL_REQUIRE(result != Null<Real>(), "Missing " << name() << " fixing for " << fixingDate);
+        return result;
     }
 
     Real EquityIndex::forecastFixing(const Date& fixingDate) const {
@@ -62,6 +70,7 @@ namespace QuantLib {
                    "null interest rate term structure set to this instance of " << name());
 
         Date today = Settings::instance().evaluationDate();
+        
         Real spot = pastFixing(today);
 
         Real forward;

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -79,6 +79,7 @@ namespace QuantLib {
                    "null interest rate term structure set to this instance of " << name());
 
         Date today = Settings::instance().evaluationDate();
+        today = settlementCalendar_.adjust(today, BusinessDayConvention::Preceding);
 
         Real spot = resolveSpot(spot_, pastFixing(today));
 

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -19,7 +19,6 @@
 
 #include <ql/indexes/equityindex.hpp>
 #include <ql/settings.hpp>
-#include <sstream>
 #include <utility>
 
 namespace QuantLib {

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -24,13 +24,11 @@
 namespace QuantLib {
 
     EquityIndex::EquityIndex(std::string name,
-                             Currency currency,
                              Calendar fixingCalendar,
                              Handle<YieldTermStructure> interest,
                              Handle<YieldTermStructure> dividend)
-    : name_(std::move(name)), currency_(std::move(currency)),
-      interest_(std::move(interest)), dividend_(std::move(dividend)),
-      settlementCalendar_(std::move(fixingCalendar)) {
+    : name_(std::move(name)), settlementCalendar_(std::move(fixingCalendar)),
+      interest_(std::move(interest)), dividend_(std::move(dividend)) {
 
         registerWith(interest_);
         registerWith(dividend_);
@@ -38,7 +36,7 @@ namespace QuantLib {
         registerWith(IndexManager::instance().notifier(EquityIndex::name()));
     }
 
-    Rate EquityIndex::fixing(const Date& fixingDate, bool forecastTodaysFixing) const {
+    Real EquityIndex::fixing(const Date& fixingDate, bool forecastTodaysFixing) const {
 
         QL_REQUIRE(isValidFixingDate(fixingDate), "Fixing date " << fixingDate << " is not valid");
 
@@ -46,14 +44,8 @@ namespace QuantLib {
 
         if (fixingDate > today || (fixingDate == today && forecastTodaysFixing))
             return forecastFixing(fixingDate);
-
-        if (fixingDate <= today) {
-            // today's fixing is required
-            // even without enforcing it
-            return pastFixing(fixingDate);
-        }
-
-        return forecastFixing(fixingDate);
+        
+        return pastFixing(fixingDate);
     }
 
     Real EquityIndex::pastFixing(const Date& fixingDate) const {
@@ -83,7 +75,6 @@ namespace QuantLib {
 
     ext::shared_ptr<EquityIndex> EquityIndex::clone(const Handle<YieldTermStructure>& interest,
                                                     const Handle<YieldTermStructure>& dividend) const {
-        return ext::make_shared<EquityIndex>(name(), currency(), fixingCalendar(), interest,
-                                             dividend);
+        return ext::make_shared<EquityIndex>(name(), fixingCalendar(), interest, dividend);
     }
 }

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -23,6 +23,14 @@
 
 namespace QuantLib {
 
+    namespace {
+        Real resolveSpot(const Handle<Quote>& spot, Real todaysFixing) {
+            QL_REQUIRE(!spot.empty() || todaysFixing != Null<Real>(),
+                       "Cannot forecast equity index, missing both spot and historical index");
+            return spot.empty() ? todaysFixing : spot->value();
+        }
+    }
+
     EquityIndex::EquityIndex(std::string name,
                              Calendar fixingCalendar,
                              Handle<YieldTermStructure> interest,
@@ -72,7 +80,7 @@ namespace QuantLib {
 
         Date today = Settings::instance().evaluationDate();
 
-        Real spot = spot_.empty() ? pastFixing(today) : spot_->value();
+        Real spot = resolveSpot(spot_, pastFixing(today));
 
         Real forward;
         if (!dividend_.empty()) {

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -1,0 +1,23 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2023 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/indexes/equityindex.hpp>
+#include <ql/settings.hpp>
+#include <sstream>
+#include <utility>

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -47,18 +47,23 @@ namespace QuantLib {
         if (fixingDate > today || (fixingDate == today && forecastTodaysFixing))
             return forecastFixing(fixingDate);
 
+        Real result = pastFixing(fixingDate);
+
+        if (result != Null<Real>())
+            // if historical fixing is present use it
+            return result;
+        
         if (fixingDate == today && !spot_.empty())
+            // Today's fixing is missing, but spot is
+            // provided, so use it as proxy
             return spot_->value();
         
-        return pastFixing(fixingDate);
+        QL_FAIL("Missing " << name() << " fixing for " << fixingDate);
     }
 
     Real EquityIndex::pastFixing(const Date& fixingDate) const {
         QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
-        Real result = timeSeries()[fixingDate];
-
-        QL_REQUIRE(result != Null<Real>(), "Missing " << name() << " fixing for " << fixingDate);
-        return result;
+        return timeSeries()[fixingDate];
     }
 
     Real EquityIndex::forecastFixing(const Date& fixingDate) const {

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -24,10 +24,10 @@
 namespace QuantLib {
 
     namespace {
-        Real resolveSpot(const Handle<Quote>& spot, Real lastFixingDate) {
-            QL_REQUIRE(!spot.empty() || lastFixingDate != Null<Real>(),
+        Real resolveSpot(const Handle<Quote>& spot, Real lastFixing) {
+            QL_REQUIRE(!spot.empty() || lastFixing != Null<Real>(),
                        "Cannot forecast equity index, missing both spot and historical index");
-            return spot.empty() ? lastFixingDate : spot->value();
+            return spot.empty() ? lastFixing : spot->value();
         }
     }
 

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -61,7 +61,6 @@ namespace QuantLib {
     class EquityIndex : public Index, public Observer {
       public:
         EquityIndex(std::string name,
-                    Currency currency,
                     Calendar fixingCalendar,
                     Handle<YieldTermStructure> interest = {},
                     Handle<YieldTermStructure> dividend = {});
@@ -79,7 +78,6 @@ namespace QuantLib {
         //@}
         //! \name Inspectors
         //@{
-        const Currency& currency() const { return currency_; }
         //! the rate curve used to forecast fixings
         Handle<YieldTermStructure> equityInterestRateCurve() const { return interest_; }
         //! the dividend curve used to forecast fixings
@@ -98,15 +96,11 @@ namespace QuantLib {
                 const Handle<YieldTermStructure>& interest,
                 const Handle<YieldTermStructure>& dividend) const;
         // @}
-
-      protected:
+      private:
         std::string name_;
-        Currency currency_;
+        Calendar settlementCalendar_;
         Handle<YieldTermStructure> interest_;
         Handle<YieldTermStructure> dividend_;
-
-      private:
-        Calendar settlementCalendar_;
     };
 
     inline bool EquityIndex::isValidFixingDate(const Date& d) const {

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -56,14 +56,17 @@ namespace QuantLib {
         where \f$ P_{F}(t, T) \f$ is a discount factor of the equity
         forward term structure.
 
-        To forecast future fixings, the index requires today's fixing.
+        To forecast future fixings, the user can either provide a
+        handle to the current index spot. If spot handle is empty,
+        today's fixing will be used, instead.
     */
     class EquityIndex : public Index, public Observer {
       public:
         EquityIndex(std::string name,
                     Calendar fixingCalendar,
                     Handle<YieldTermStructure> interest = {},
-                    Handle<YieldTermStructure> dividend = {});
+                    Handle<YieldTermStructure> dividend = {},
+                    Handle<Quote> spot = {});
 
         //! \name Index interface
         //@{
@@ -82,6 +85,8 @@ namespace QuantLib {
         Handle<YieldTermStructure> equityInterestRateCurve() const { return interest_; }
         //! the dividend curve used to forecast fixings
         Handle<YieldTermStructure> equityDividendCurve() const { return dividend_; }
+        //! index spot value
+        Handle<Quote> spot() const { return spot_; }
         //@}
         //! \name Fixing calculations
         //@{
@@ -91,16 +96,18 @@ namespace QuantLib {
         // @}
         //! \name Other methods
         //@{
-        //! returns a copy of itself linked to a different forwarding curve
-        virtual ext::shared_ptr<EquityIndex> clone(
-                const Handle<YieldTermStructure>& interest,
-                const Handle<YieldTermStructure>& dividend) const;
+        //! returns a copy of itself linked to different interest, dividend curves
+        //! or spot quote
+        virtual ext::shared_ptr<EquityIndex> clone(const Handle<YieldTermStructure>& interest,
+                                                   const Handle<YieldTermStructure>& dividend,
+                                                   const Handle<Quote>& spot) const;
         // @}
       private:
         std::string name_;
         Calendar settlementCalendar_;
         Handle<YieldTermStructure> interest_;
         Handle<YieldTermStructure> dividend_;
+        Handle<Quote> spot_;
     };
 
     inline bool EquityIndex::isValidFixingDate(const Date& d) const {

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -68,7 +68,6 @@ namespace QuantLib {
 
       protected:
         std::string name_;
-        Natural settlementDays_;
         Currency currency_;
         Handle<YieldTermStructure> rate_;
         Handle<YieldTermStructure> dividend_;
@@ -82,14 +81,6 @@ namespace QuantLib {
     }
 
     inline void EquityIndex::update() { notifyObservers(); }
-
-    inline Real EquityIndex::pastFixing(const Date& fixingDate) const {
-        QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
-        Real result = timeSeries()[fixingDate];
-
-        QL_REQUIRE(result != Null<Real>(), "Missing " << name() << " fixing for " << fixingDate);
-        return result;
-    }
 }
 
 #endif

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
         EquityIndex(std::string name,
                     Currency currency,
                     Calendar fixingCalendar,
-                    Handle<YieldTermStructure> rate = {},
+                    Handle<YieldTermStructure> interest = {},
                     Handle<YieldTermStructure> dividend = {});
 
         //! \name Index interface
@@ -55,7 +55,7 @@ namespace QuantLib {
         //@{
         const Currency& currency() const { return currency_; }
         //! the rate curve used to forecast fixings
-        Handle<YieldTermStructure> equityInterestRateCurve() const { return rate_; }
+        Handle<YieldTermStructure> equityInterestRateCurve() const { return interest_; }
         //! the dividend curve used to forecast fixings
         Handle<YieldTermStructure> equityDividendCurve() const { return dividend_; }
         //@}
@@ -65,11 +65,18 @@ namespace QuantLib {
         virtual Real forecastFixing(const Date& fixingDate) const;
         virtual Real pastFixing(const Date& fixingDate) const;
         // @}
+        //! \name Other methods
+        //@{
+        //! returns a copy of itself linked to a different forwarding curve
+        virtual ext::shared_ptr<EquityIndex> clone(
+                const Handle<YieldTermStructure>& interest,
+                const Handle<YieldTermStructure>& dividend) const;
+        // @}
 
       protected:
         std::string name_;
         Currency currency_;
-        Handle<YieldTermStructure> rate_;
+        Handle<YieldTermStructure> interest_;
         Handle<YieldTermStructure> dividend_;
 
       private:

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -1,0 +1,94 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2023 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file equityindex.hpp
+    \brief base class for equity indexes
+*/
+
+#ifndef quantlib_equityindex_hpp
+#define quantlib_equityindex_hpp
+
+#include <ql/index.hpp>
+#include <ql/time/calendar.hpp>
+#include <ql/currency.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+
+namespace QuantLib {
+
+    //! base class for equity indexes
+    class EquityIndex : public Index, public Observer {
+      public:
+        EquityIndex(std::string name,
+                    Natural settlementDays,
+                    Currency currency,
+                    Calendar fixingCalendar,
+                    Handle<YieldTermStructure> rate = {},
+                    Handle<YieldTermStructure> dividend = {});
+
+        //! \name Index interface
+        //@{
+        std::string name() const override { return name_; }
+        Calendar fixingCalendar() const override { return settlementCalendar_; }
+        bool isValidFixingDate(const Date& fixingDate) const override;
+        Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
+        //@}
+        //! \name Observer interface
+        //@{
+        void update() override;
+        //@}
+        //! \name Inspectors
+        //@{
+        Natural settlementDays() const { return settlementDays_; }
+        Date settlementDate(const Date& valueDate) const;
+        const Currency& currency() const { return currency_; }
+        //! the rate curve used to forecast fixings
+        Handle<YieldTermStructure> equityInterestRateCurve() const { return rate_; }
+        //! the dividend curve used to forecast fixings
+        Handle<YieldTermStructure> equityDividendCurve() const { return dividend_; }
+        //@}
+        //! \name Fixing calculations
+        //@{
+        //! It can be overridden to implement particular conventions
+        virtual Rate forecastFixing(const Date& fixingDate) const;
+        virtual Rate pastFixing(const Date& fixingDate) const;
+        // @}
+
+      protected:
+        std::string name_;
+        Natural settlementDays_;
+        Currency currency_;
+        Calendar settlementCalendar_;
+        Handle<YieldTermStructure> rate_;
+        Handle<YieldTermStructure> dividend_;
+    };
+
+    inline bool EquityIndex::isValidFixingDate(const Date& d) const {
+        return fixingCalendar().isBusinessDay(d);
+    }
+
+    inline void EquityIndex::update() { notifyObservers(); }
+
+    inline Date EquityIndex::settlementDate(const Date& valueDate) const {
+        Date fixingDate =
+            fixingCalendar().advance(valueDate, +static_cast<Integer>(settlementDays_), Days);
+        return fixingDate;
+    }
+}
+
+#endif

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -31,7 +31,33 @@
 
 namespace QuantLib {
 
-    //! base class for equity indexes
+    //! Base class for equity indexes
+    /*! The equity index object allows to retrieve past fixings,
+        as well as project future fixings using either both
+        the risk free interest rate term structure and the dividend
+        term structure, or just the interest rate term structure
+        in which case one can provide a term structure of equity
+        forwards implied from, e.g. option prices.
+        
+        In case of the first method, the forward is calculated as:
+        \f[
+        I(t, T) = I(t, t) \frac{P_{D}(t, T)}{P_{R}(t, T)},
+        \f]
+        where \f$ I(t, t) \f$ is today's value of the index,
+        \f$ P_{D}(t, T) \f$ is a discount factor of the dividend
+        curve at future time \f$ T \f$, and \f$ P_{R}(t, T) \f$ is
+        a discount factor of the risk free curve at future time
+        \f$ T \f$.
+
+        In case of the latter method, the forward is calculated as:
+        \f[
+        I(t, T) = I(t, t) \frac{1}{P_{F}(t, T)},
+        \f]
+        where \f$ P_{F}(t, T) \f$ is a discount factor of the equity
+        forward term structure.
+
+        To forecast future fixings, the index requires today's fixing.
+    */
     class EquityIndex : public Index, public Observer {
       public:
         EquityIndex(std::string name,

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -71,7 +71,7 @@ namespace QuantLib {
         //! \name Index interface
         //@{
         std::string name() const override { return name_; }
-        Calendar fixingCalendar() const override { return settlementCalendar_; }
+        Calendar fixingCalendar() const override { return fixingCalendar_; }
         bool isValidFixingDate(const Date& fixingDate) const override;
         Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
         //@}
@@ -104,7 +104,7 @@ namespace QuantLib {
         // @}
       private:
         std::string name_;
-        Calendar settlementCalendar_;
+        Calendar fixingCalendar_;
         Handle<YieldTermStructure> interest_;
         Handle<YieldTermStructure> dividend_;
         Handle<Quote> spot_;

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -50,6 +50,7 @@ set(QL_TEST_SOURCES
     dividendoption.cpp
     doublebarrieroption.cpp
     doublebinaryoption.cpp
+    equityindex.cpp
     europeanoption.cpp
     everestoption.cpp
     exchangerate.cpp
@@ -218,6 +219,7 @@ set(QL_TEST_HEADERS
     dividendoption.hpp
     doublebarrieroption.hpp
     doublebinaryoption.hpp
+    equityindex.hpp
     europeanoption.hpp
     everestoption.hpp
     exchangerate.hpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -52,6 +52,7 @@ QL_TEST_SRCS = \
 	dividendoption.cpp \
 	doublebarrieroption.cpp \
 	doublebinaryoption.cpp \
+	equityindex.cpp \
 	europeanoption.cpp \
 	everestoption.cpp \
 	exchangerate.cpp \
@@ -219,6 +220,7 @@ QL_TEST_HDRS = \
 	dividendoption.hpp \
 	doublebarrieroption.hpp \
 	doublebinaryoption.hpp \
+	equityindex.hpp \
 	europeanoption.hpp \
 	everestoption.hpp \
 	exchangerate.hpp \

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -52,7 +52,6 @@ namespace equityindex_test {
         Date today;
         Calendar calendar;
         DayCounter dayCount;
-        Currency currency;
 
         ext::shared_ptr<EquityIndex> equityIndex;
         RelinkableHandle<YieldTermStructure> interestHandle;
@@ -65,10 +64,9 @@ namespace equityindex_test {
         CommonVars() {
             calendar = TARGET();
             dayCount = Actual365Fixed();
-            currency = EURCurrency();
 
-            equityIndex = ext::make_shared<EquityIndex>("eqIndex", currency, calendar,
-                                                        interestHandle, dividendHandle);
+            equityIndex =
+                ext::make_shared<EquityIndex>("eqIndex", calendar, interestHandle, dividendHandle);
 
             equityIndex->addFixing(Date(31, January, 2023), 8690.0);
 
@@ -191,15 +189,15 @@ void EquityIndexTest::testFixingObservability() {
 
     CommonVars vars;
 
-    ext::shared_ptr<EquityIndex> i1 = ext::make_shared<EquityIndex>(
-        "observableEquityIndex", vars.currency, vars.calendar);
+    ext::shared_ptr<EquityIndex> i1 =
+        ext::make_shared<EquityIndex>("observableEquityIndex", vars.calendar);
 
     Flag flag;
     flag.registerWith(i1);
     flag.lower();
 
     ext::shared_ptr<Index> i2 =
-        ext::make_shared<EquityIndex>("observableEquityIndex", vars.currency, vars.calendar);
+        ext::make_shared<EquityIndex>("observableEquityIndex", vars.calendar);
 
     i2->addFixing(vars.today, 100.0);
     if (!flag.isUp())

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -67,8 +67,8 @@ namespace equityindex_test {
             dayCount = Actual365Fixed();
             currency = EURCurrency();
 
-            equityIndex = ext::shared_ptr<EquityIndex>(
-                new EquityIndex("eqIndex", currency, calendar, interestHandle, dividendHandle));
+            equityIndex = ext::make_shared<EquityIndex>("eqIndex", currency, calendar,
+                                                        interestHandle, dividendHandle);
 
             equityIndex->addFixing(Date(31, January, 2023), 8690.0);
 

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -200,7 +200,7 @@ void EquityIndexTest::testFixingObservability() {
 
     i2->addFixing(vars.today, 100.0);
     if (!flag.isUp())
-        BOOST_FAIL("Observer was not notified of added Euribor fixing");
+        BOOST_FAIL("Observer was not notified of added equity index fixing");
 }
 
 test_suite* EquityIndexTest::suite() {

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -150,8 +150,9 @@ void EquityIndexTest::testErrorWhenInvalidFixingDate() {
 
     CommonVars vars;
 
-    BOOST_CHECK_EXCEPTION(vars.equityIndex->fixing(Date(1, January, 2023)), Error,
-                          ExpErrorPred("Fixing date January 1st, 2023 is not valid"));
+    BOOST_CHECK_EXCEPTION(
+        vars.equityIndex->fixing(Date(1, January, 2023)), Error,
+        equityindex_test::ExpErrorPred("Fixing date January 1st, 2023 is not valid"));
 }
 
 void EquityIndexTest::testErrorWhenFixingMissing() {
@@ -161,8 +162,9 @@ void EquityIndexTest::testErrorWhenFixingMissing() {
 
     CommonVars vars;
 
-    BOOST_CHECK_EXCEPTION(vars.equityIndex->fixing(Date(2, January, 2023)), Error,
-                          ExpErrorPred("Missing eqIndex fixing for January 2nd, 2023"));
+    BOOST_CHECK_EXCEPTION(
+        vars.equityIndex->fixing(Date(2, January, 2023)), Error,
+        equityindex_test::ExpErrorPred("Missing eqIndex fixing for January 2nd, 2023"));
 }
 
 void EquityIndexTest::testErrorWhenInterestHandleMissing() {
@@ -178,7 +180,8 @@ void EquityIndexTest::testErrorWhenInterestHandleMissing() {
         vars.equityIndex->clone(Handle<YieldTermStructure>(), Handle<YieldTermStructure>());
 
     BOOST_CHECK_EXCEPTION(equityIndexExDiv->fixing(forecastedDate), Error,
-                          ExpErrorPred("null interest rate term structure set to this instance of eqIndex"));
+                          equityindex_test::ExpErrorPred(
+                              "null interest rate term structure set to this instance of eqIndex"));
 }
 
 void EquityIndexTest::testFixingObservability() {

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -72,7 +72,7 @@ namespace equityindex_test {
                                                         dividendHandle, spotHandle);
             IndexManager::instance().clearHistory(equityIndex->name());
 
-            today = calendar.adjust(Date(31, January, 2023));
+            today = calendar.adjust(Date(27, January, 2023));
             
             if (addTodaysFixing)
                 equityIndex->addFixing(today, 8690.0);
@@ -304,6 +304,24 @@ void EquityIndexTest::testFixingObservability() {
         BOOST_FAIL("Observer was not notified of added equity index fixing");
 }
 
+void EquityIndexTest::testNoErrorIfTodayIsNotBusinessDay() {
+    BOOST_TEST_MESSAGE("Testing no error if today is not a business day...");
+
+    using namespace equityindex_test;
+
+    CommonVars vars;
+
+    Date today(28, January, 2023);
+    Date forecastedDate(20, May, 2030);
+
+    Settings::instance().evaluationDate() = today;
+
+    auto equityIndex =
+        vars.equityIndex->clone(vars.interestHandle, vars.dividendHandle, Handle<Quote>());
+
+    BOOST_REQUIRE_NO_THROW(vars.equityIndex->fixing(forecastedDate));
+}
+
 test_suite* EquityIndexTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Equity index tests");
 
@@ -319,6 +337,7 @@ test_suite* EquityIndexTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testErrorWhenFixingMissing));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testErrorWhenInterestHandleMissing));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testFixingObservability));
+    suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testNoErrorIfTodayIsNotBusinessDay));
 
     return suite;
 }

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -204,7 +204,6 @@ void EquityIndexTest::testFixingForecastWithoutSpotAndHistoricalFixing() {
     using namespace equityindex_test;
 
     CommonVars vars(false);
-    const Real tolerance = 1.0e-1;
 
     Date forecastedDate(20, May, 2030);
 

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -1,0 +1,89 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ Copyright (C) 2023 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "equityindex.hpp"
+#include "utilities.hpp"
+#include <ql/indexes/equityindex.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/currencies/europe.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace equityindex_test {
+
+    struct CommonVars {
+
+        Date today;
+        Calendar calendar;
+        DayCounter dayCount;
+        Currency currency;
+
+        ext::shared_ptr<EquityIndex> equityIndex;
+        RelinkableHandle<YieldTermStructure> interestHandle;
+        RelinkableHandle<YieldTermStructure> dividendHandle;
+
+        // cleanup
+        SavedSettings backup;
+        // utilities
+
+        CommonVars() {
+            calendar = TARGET();
+            dayCount = Actual365Fixed();
+            currency = EURCurrency();
+
+            equityIndex = ext::shared_ptr<EquityIndex>(
+                new EquityIndex("eqIndex", currency, calendar, interestHandle, dividendHandle));
+
+            equityIndex->addFixing(Date(10, February, 2021), 9450.0);
+            equityIndex->addFixing(Date(31, January, 2023), 8690.0);
+
+            today = calendar.adjust(Date(31, January, 2023));
+            Settings::instance().evaluationDate() = today;
+
+            interestHandle.linkTo(flatRate(today, 0.03, dayCount));
+            dividendHandle.linkTo(flatRate(today, 0.01, dayCount));
+        }
+    };
+}
+
+void EquityIndexTest::testTodaysFixingForecast() {
+    BOOST_TEST_MESSAGE("Testing todays fixing forecast...");
+
+    using namespace equityindex_test;
+
+    CommonVars vars;
+    const Real tolerance = 1.0e-8;
+
+    Real forecastedFixing = vars.equityIndex->fixing(vars.today, true);
+    Real pastFixing = vars.equityIndex->pastFixing(vars.today);
+
+    if ((std::fabs(pastFixing - forecastedFixing) > tolerance))
+        BOOST_ERROR("forecasted fixing should be equal to past fixing\n"
+                    << "    past fixing:    " << pastFixing << "\n"
+                    << "    forecasted fixing:    " << forecastedFixing << "\n");
+
+}
+
+test_suite* EquityIndexTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("Equity index tests");
+
+    suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testTodaysFixingForecast));
+
+    return suite;
+}

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -198,6 +198,25 @@ void EquityIndexTest::testFixingForecastWithoutSpot() {
                     << "    expected forecast:    " << expectedForecast << "\n");
 }
 
+void EquityIndexTest::testFixingForecastWithoutSpotAndHistoricalFixing() {
+    BOOST_TEST_MESSAGE("Testing fixing forecast without spot handle and historical fixing...");
+
+    using namespace equityindex_test;
+
+    CommonVars vars(false);
+    const Real tolerance = 1.0e-1;
+
+    Date forecastedDate(20, May, 2030);
+
+    auto equityIndexExSpot =
+        vars.equityIndex->clone(vars.interestHandle, vars.dividendHandle, Handle<Quote>());
+
+    BOOST_CHECK_EXCEPTION(
+        equityIndexExSpot->fixing(forecastedDate), Error,
+        equityindex_test::ExpErrorPred(
+            "Cannot forecast equity index, missing both spot and historical index"));
+}
+
 void EquityIndexTest::testSpotChange() {
     BOOST_TEST_MESSAGE("Testing spot change...");
 
@@ -294,6 +313,8 @@ test_suite* EquityIndexTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testFixingForecast));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testFixingForecastWithoutDividend));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testFixingForecastWithoutSpot));
+    suite->add(
+        QUANTLIB_TEST_CASE(&EquityIndexTest::testFixingForecastWithoutSpotAndHistoricalFixing));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testSpotChange));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testErrorWhenInvalidFixingDate));
     suite->add(QUANTLIB_TEST_CASE(&EquityIndexTest::testErrorWhenFixingMissing));

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -189,14 +189,14 @@ void EquityIndexTest::testFixingObservability() {
     CommonVars vars;
 
     ext::shared_ptr<EquityIndex> i1 = ext::make_shared<EquityIndex>(
-        "observable", vars.currency, vars.calendar);
+        "observableEquityIndex", vars.currency, vars.calendar);
 
     Flag flag;
     flag.registerWith(i1);
     flag.lower();
 
     ext::shared_ptr<Index> i2 =
-        ext::make_shared<EquityIndex>("observable", vars.currency, vars.calendar);
+        ext::make_shared<EquityIndex>("observableEquityIndex", vars.currency, vars.calendar);
 
     i2->addFixing(vars.today, 100.0);
     if (!flag.isUp())

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -35,6 +35,7 @@ class EquityIndexTest {
     static void testErrorWhenFixingMissing();
     static void testErrorWhenInterestHandleMissing();
     static void testFixingObservability();
+    static void testNoErrorIfTodayIsNotBusinessDay();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -29,6 +29,7 @@ class EquityIndexTest {
     static void testFixingForecast();
     static void testFixingForecastWithoutDividend();
     static void testFixingForecastWithoutSpot();
+    static void testFixingForecastWithoutSpotAndHistoricalFixing();
     static void testSpotChange();
     static void testErrorWhenInvalidFixingDate();
     static void testErrorWhenFixingMissing();

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -25,6 +25,8 @@
 class EquityIndexTest {
   public:
     static void testTodaysFixingForecast();
+    static void testFixingForecast();
+    static void testFixingForecastWithoutDividend();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -25,6 +25,7 @@
 class EquityIndexTest {
   public:
     static void testTodaysFixing();
+    static void testTodaysFixingWithSpotAsProxy();
     static void testFixingForecast();
     static void testFixingForecastWithoutDividend();
     static void testFixingForecastWithoutSpot();

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -24,9 +24,11 @@
 
 class EquityIndexTest {
   public:
-    static void testTodaysFixingForecast();
+    static void testTodaysFixing();
     static void testFixingForecast();
     static void testFixingForecastWithoutDividend();
+    static void testFixingForecastWithoutSpot();
+    static void testSpotChange();
     static void testErrorWhenInvalidFixingDate();
     static void testErrorWhenFixingMissing();
     static void testErrorWhenInterestHandleMissing();

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -27,6 +27,10 @@ class EquityIndexTest {
     static void testTodaysFixingForecast();
     static void testFixingForecast();
     static void testFixingForecastWithoutDividend();
+    static void testErrorWhenInvalidFixingDate();
+    static void testErrorWhenFixingMissing();
+    static void testErrorWhenInterestHandleMissing();
+    static void testFixingObservability();
 
     static boost::unit_test_framework::test_suite* suite();
 };

--- a/test-suite/equityindex.hpp
+++ b/test-suite/equityindex.hpp
@@ -1,0 +1,32 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2023 Marcin Rybacki
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_equityindex_hpp
+#define quantlib_test_equityindex_hpp
+
+#include <boost/test/unit_test.hpp>
+
+class EquityIndexTest {
+  public:
+    static void testTodaysFixingForecast();
+
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -92,6 +92,7 @@
 #include "doublebinaryoption.hpp"
 #include "europeanoption.hpp"
 #include "everestoption.hpp"
+#include "equityindex.hpp"
 #include "exchangerate.hpp"
 #include "extendedtrees.hpp"
 #include "extensibleoptions.hpp"
@@ -386,6 +387,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(DigitalOptionTest::suite());
     test->add(DistributionTest::suite(speed));
     test->add(DividendOptionTest::suite());
+    test->add(EquityIndexTest::suite());
     test->add(EuropeanOptionTest::suite());
     test->add(ExchangeRateTest::suite());
     test->add(FastFourierTransformTest::suite());

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -687,6 +687,7 @@
     <ClCompile Include="dividendoption.cpp" />
     <ClCompile Include="doublebarrieroption.cpp" />
     <ClCompile Include="doublebinaryoption.cpp" />
+    <ClCompile Include="equityindex.cpp" />
     <ClCompile Include="europeanoption.cpp" />
     <ClCompile Include="everestoption.cpp" />
     <ClCompile Include="exchangerate.cpp" />
@@ -854,6 +855,7 @@
     <ClInclude Include="dividendoption.hpp" />
     <ClInclude Include="doublebarrieroption.hpp" />
     <ClInclude Include="doublebinaryoption.hpp" />
+    <ClInclude Include="equityindex.hpp" />
     <ClInclude Include="europeanoption.hpp" />
     <ClInclude Include="everestoption.hpp" />
     <ClInclude Include="exchangerate.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -504,6 +504,9 @@
     <ClCompile Include="svivolatility.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="equityindex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="americanoption.hpp">
@@ -1005,6 +1008,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="svivolatility.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="equityindex.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
In this PR I would like to suggest introducing a base equity index class which is used to retrieve historical fixings as well as default logic for forecasting future ones. It could be extended to facilitate e.g. quanto-ed or compo-ed index projections.

If this PR is approved, next step would be to introduce an equity total return swap instrument which would utilize the index class.

Looking forward to your feedback.

This may also be useful for #1195 

