### PR TITLE
Add Botswanan pula currency (BWP)

### DIFF
--- a/ql/currencies/africa.cpp
+++ b/ql/currencies/africa.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004, 2005 StatPro Italia srl
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -127,6 +128,14 @@ namespace QuantLib {
         static ext::shared_ptr<Data> xofData(new Data("West African CFA franc", "XOF", 952, "XOF",
                                                         "", 100, Rounding(), "1$.2f %3%"));
         data_ = xofData;
+    }
+
+    
+    // Botswanan pula
+    BWPCurrency::BWPCurrency() {
+        static ext::shared_ptr<Data> bwpData(
+            new Data("Botswanan pula", "BWP", 72, "P", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = bwpData;
     }
 
 }

--- a/ql/currencies/africa.cpp
+++ b/ql/currencies/africa.cpp
@@ -19,11 +19,6 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
-/*
-    Data from http://fx.sauder.ubc.ca/currency_table.html
-    and http://www.thefinancials.com/vortex/CurrencyFormats.html
-*/
-
 #include <ql/currencies/africa.hpp>
 
 namespace QuantLib {
@@ -85,10 +80,6 @@ namespace QuantLib {
     }
 
     // Nigerian Naira
-    /* ISO-4217 code -> NGN
-     * Corresponding code Number -> 566
-     * The NGN ISO code has a currency exponent of 2 ( i.e subdivided into 100 kobo), 100k = 1NGN.
-     */
     NGNCurrency::NGNCurrency() {
         static ext::shared_ptr<Data> ngnData(
             new Data("Nigerian Naira", "NGN", 566, "N", "K", 100, Rounding(), "%3% %1N.2f"));

--- a/ql/currencies/africa.cpp
+++ b/ql/currencies/africa.cpp
@@ -28,92 +28,25 @@
 
 namespace QuantLib {
 
-    // South-African rand
-    /* The ISO three-letter code is ZAR; the numeric code is 710.
-       It is divided into 100 cents.
-    */
-    ZARCurrency::ZARCurrency() {
-        static ext::shared_ptr<Data> zarData(
-                                new Data("South-African rand", "ZAR", 710,
-                                         "R", "", 100,
-                                         Rounding(),
-                                         "%3% %1$.2f"));
-        data_ = zarData;
-    }
-
-    // Nigerian Naira
-    /* ISO-4217 code -> NGN
-     * Corresponding code Number -> 566
-     * The NGN ISO code has a currency exponent of 2 ( i.e subdivided into 100 kobo), 100k = 1NGN.
-     */
-    NGNCurrency::NGNCurrency() {
-        static ext::shared_ptr<Data> ngnData(
-            new Data("Nigerian Naira", "NGN", 566,
-                     "N", "K", 100,
-                     Rounding(),
-                     "%3% %1N.2f"));
-        data_ = ngnData;
-    }
-    // Tunisian dinar
-    TNDCurrency::TNDCurrency() {
-        static ext::shared_ptr<Data> tndData(
-            new Data("Tunisian dinar", "TND", 788, "TND", "", 1000, Rounding(), "1$.2f %3%"));
-        data_ = tndData;
-    }
-    // Egyptian pound
-    EGPCurrency::EGPCurrency() {
-        static ext::shared_ptr<Data> egpData(
-            new Data("Egyptian pound", "EGP", 818, "EGP", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = egpData;
-    }
-
-    // Mauritian rupee
-    MURCurrency::MURCurrency() {
-        static ext::shared_ptr<Data> murData(
-            new Data("Mauritian rupee", "MUR", 480, "MUR", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = murData;
-    }
-
-    // Ugandan shilling
-    UGXCurrency::UGXCurrency() {
-        static ext::shared_ptr<Data> ugxData(
-            new Data("Ugandan shilling", "UGX", 800, "UGX", "", 1, Rounding(), "1$.2f %3%"));
-        data_ = ugxData;
-    }
-
-    // Zambian kwacha
-    ZMWCurrency::ZMWCurrency() {
-        static ext::shared_ptr<Data> zmwData(
-            new Data("Zambian kwacha", "ZMW", 967, "ZMW", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = zmwData;
-    }
-
-    // Moroccan dirham
-    MADCurrency::MADCurrency() {
-        static ext::shared_ptr<Data> madData(
-            new Data("Moroccan dirham", "MAD", 504, "MAD", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = madData;
-    }
-
-    // Kenyan shilling
-    KESCurrency::KESCurrency() {
-        static ext::shared_ptr<Data> kesData(
-            new Data("Kenyan shilling", "KES", 404, "KES", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = kesData;
-    }
-
-    // Ghanaian cedi
-    GHSCurrency::GHSCurrency() {
-        static ext::shared_ptr<Data> ghsData(
-            new Data("Ghanaian cedi", "GHS", 936, "GHS", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = ghsData;
-    }
-
     // Angolan kwanza
     AOACurrency::AOACurrency() {
         static ext::shared_ptr<Data> aoaData(
             new Data("Angolan kwanza", "AOA", 973, "AOA", "", 100, Rounding(), "1$.2f %3%"));
         data_ = aoaData;
+    }
+
+    // Botswanan pula
+    BWPCurrency::BWPCurrency() {
+        static ext::shared_ptr<Data> bwpData(
+            new Data("Botswanan pula", "BWP", 72, "P", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = bwpData;
+    }
+
+    // Egyptian pound
+    EGPCurrency::EGPCurrency() {
+        static ext::shared_ptr<Data> egpData(
+            new Data("Egyptian pound", "EGP", 818, "EGP", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = egpData;
     }
 
     // Ethiopian birr
@@ -123,19 +56,80 @@ namespace QuantLib {
         data_ = etbData;
     }
 
+    // Ghanaian cedi
+    GHSCurrency::GHSCurrency() {
+        static ext::shared_ptr<Data> ghsData(
+            new Data("Ghanaian cedi", "GHS", 936, "GHS", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = ghsData;
+    }
+
+    // Kenyan shilling
+    KESCurrency::KESCurrency() {
+        static ext::shared_ptr<Data> kesData(
+            new Data("Kenyan shilling", "KES", 404, "KES", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = kesData;
+    }
+
+    // Moroccan dirham
+    MADCurrency::MADCurrency() {
+        static ext::shared_ptr<Data> madData(
+            new Data("Moroccan dirham", "MAD", 504, "MAD", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = madData;
+    }
+
+    // Mauritian rupee
+    MURCurrency::MURCurrency() {
+        static ext::shared_ptr<Data> murData(
+            new Data("Mauritian rupee", "MUR", 480, "MUR", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = murData;
+    }
+
+    // Nigerian Naira
+    /* ISO-4217 code -> NGN
+     * Corresponding code Number -> 566
+     * The NGN ISO code has a currency exponent of 2 ( i.e subdivided into 100 kobo), 100k = 1NGN.
+     */
+    NGNCurrency::NGNCurrency() {
+        static ext::shared_ptr<Data> ngnData(
+            new Data("Nigerian Naira", "NGN", 566, "N", "K", 100, Rounding(), "%3% %1N.2f"));
+        data_ = ngnData;
+    }
+
+    // Tunisian dinar
+    TNDCurrency::TNDCurrency() {
+        static ext::shared_ptr<Data> tndData(
+            new Data("Tunisian dinar", "TND", 788, "TND", "", 1000, Rounding(), "1$.2f %3%"));
+        data_ = tndData;
+    }
+
+    // Ugandan shilling
+    UGXCurrency::UGXCurrency() {
+        static ext::shared_ptr<Data> ugxData(
+            new Data("Ugandan shilling", "UGX", 800, "UGX", "", 1, Rounding(), "1$.2f %3%"));
+        data_ = ugxData;
+    }
+
     // West African CFA franc
     XOFCurrency::XOFCurrency() {
         static ext::shared_ptr<Data> xofData(new Data("West African CFA franc", "XOF", 952, "XOF",
-                                                        "", 100, Rounding(), "1$.2f %3%"));
+                                                      "", 100, Rounding(), "1$.2f %3%"));
         data_ = xofData;
     }
 
-    
-    // Botswanan pula
-    BWPCurrency::BWPCurrency() {
-        static ext::shared_ptr<Data> bwpData(
-            new Data("Botswanan pula", "BWP", 72, "P", "", 100, Rounding(), "1$.2f %3%"));
-        data_ = bwpData;
+    // South-African rand
+    /* The ISO three-letter code is ZAR; the numeric code is 710.
+       It is divided into 100 cents.
+    */
+    ZARCurrency::ZARCurrency() {
+        static ext::shared_ptr<Data> zarData(
+            new Data("South-African rand", "ZAR", 710, "R", "", 100, Rounding(), "%3% %1$.2f"));
+        data_ = zarData;
     }
 
+    // Zambian kwacha
+    ZMWCurrency::ZMWCurrency() {
+        static ext::shared_ptr<Data> zmwData(
+            new Data("Zambian kwacha", "ZMW", 967, "ZMW", "", 100, Rounding(), "1$.2f %3%"));
+        data_ = zmwData;
+    }
 }

--- a/ql/currencies/africa.hpp
+++ b/ql/currencies/africa.hpp
@@ -38,29 +38,24 @@
 
 namespace QuantLib {
 
-    //! South-African rand
-    /*! The ISO three-letter code is ZAR; the numeric code is 710.
-        It is divided into 100 cents.
-
-        \ingroup currencies
-    */
-    class ZARCurrency : public Currency {
-      public:
-        ZARCurrency();
-    };
-
-    class NGNCurrency : public Currency {
-      public:
-        NGNCurrency();
-    };
-    //! Tunisian dinar
-    /*! The ISO three-letter code is TND; the numeric code is 788.
-     It is divided into 1000 millim.
+    // Angolan kwanza
+    /*! The ISO three-letter code is AOA; the numeric code is 973.
+     It is divided into 100 cêntimo.
      \ingroup currencies
-     */
-    class TNDCurrency : public Currency {
+    */
+    class AOACurrency : public Currency {
       public:
-        TNDCurrency();
+        AOACurrency();
+    };
+
+    // Botswanan Pula
+    /*! The ISO three-letter code is BWP; the numeric code is 72.
+     It is divided into 100 thebe.
+     \ingroup currencies
+    */
+    class BWPCurrency : public Currency {
+      public:
+        BWPCurrency();
     };
 
     //! Egyptian pound
@@ -73,54 +68,14 @@ namespace QuantLib {
         EGPCurrency();
     };
 
-    //! Mauritian rupee
-    /*! The ISO three-letter code is MUR; the numeric code is 480.
-     It is divided into 100 cents.
-     \ingroup currencies
-    */
-    class MURCurrency : public Currency {
-      public:
-        MURCurrency();
-    };
-
-    //! Ugandan shilling
-    /*! The ISO three-letter code is UGX; the numeric code is 800.
-    It is the smallest unit.
-     \ingroup currencies
-    */
-    class UGXCurrency : public Currency {
-      public:
-        UGXCurrency();
-    };
-
-    //! Zambian kwacha
-    /*! The ISO three-letter code is ZMW; the numeric code is 967.
-    It is divided into 100 ngwee.
-     \ingroup currencies
-    */
-    class ZMWCurrency : public Currency {
-      public:
-        ZMWCurrency();
-    };
-
-    //! Moroccan dirham
-    /*! The ISO three-letter code is MAD; the numeric code is 504.
+    // Ethiopian birr
+    /*! The ISO three-letter code is ETB; the numeric code is 230.
      It is divided into 100 santim.
      \ingroup currencies
     */
-    class MADCurrency : public Currency {
+    class ETBCurrency : public Currency {
       public:
-        MADCurrency();
-    };
-
-    //! Kenyan shilling
-    /*! The ISO three-letter code is KES; the numeric code is 404.
-     It is divided into 100 cents.
-     \ingroup currencies
-    */
-    class KESCurrency : public Currency {
-      public:
-        KESCurrency();
+        ETBCurrency();
     };
 
     //! Ghanaian cedi
@@ -133,24 +88,59 @@ namespace QuantLib {
         GHSCurrency();
     };
 
-    // Angolan kwanza
-    /*! The ISO three-letter code is AOA; the numeric code is 973.
-     It is divided into 100 cêntimo.
+    //! Kenyan shilling
+    /*! The ISO three-letter code is KES; the numeric code is 404.
+     It is divided into 100 cents.
      \ingroup currencies
     */
-    class AOACurrency : public Currency {
+    class KESCurrency : public Currency {
       public:
-        AOACurrency();
+        KESCurrency();
     };
 
-    // Ethiopian birr
-    /*! The ISO three-letter code is ETB; the numeric code is 230.
+    //! Moroccan dirham
+    /*! The ISO three-letter code is MAD; the numeric code is 504.
      It is divided into 100 santim.
      \ingroup currencies
     */
-    class ETBCurrency : public Currency {
+    class MADCurrency : public Currency {
       public:
-        ETBCurrency();
+        MADCurrency();
+    };
+
+    //! Mauritian rupee
+    /*! The ISO three-letter code is MUR; the numeric code is 480.
+     It is divided into 100 cents.
+     \ingroup currencies
+    */
+    class MURCurrency : public Currency {
+      public:
+        MURCurrency();
+    };
+
+    class NGNCurrency : public Currency {
+      public:
+        NGNCurrency();
+    };
+
+    //! Tunisian dinar
+    /*! The ISO three-letter code is TND; the numeric code is 788.
+     It is divided into 1000 millim.
+     \ingroup currencies
+     */
+    class TNDCurrency : public Currency {
+      public:
+        TNDCurrency();
+    };
+
+    //! Ugandan shilling
+    /*! The ISO three-letter code is UGX; the numeric code is 800.
+    It is the smallest unit.
+     \ingroup currencies
+    */
+    class UGXCurrency : public Currency {
+      public:
+        UGXCurrency();
     };
 
     // West African CFA franc
@@ -163,14 +153,25 @@ namespace QuantLib {
         XOFCurrency();
     };
 
-    // Botswanan Pula
-    /*! The ISO three-letter code is BWP; the numeric code is 72.
-     It is divided into 100 thebe.
+    //! South-African rand
+    /*! The ISO three-letter code is ZAR; the numeric code is 710.
+        It is divided into 100 cents.
+
+        \ingroup currencies
+    */
+    class ZARCurrency : public Currency {
+      public:
+        ZARCurrency();
+    };
+
+    //! Zambian kwacha
+    /*! The ISO three-letter code is ZMW; the numeric code is 967.
+    It is divided into 100 ngwee.
      \ingroup currencies
     */
-    class BWPCurrency : public Currency {
+    class ZMWCurrency : public Currency {
       public:
-        BWPCurrency();
+        ZMWCurrency();
     };
 }
 

--- a/ql/currencies/africa.hpp
+++ b/ql/currencies/africa.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004, 2005 StatPro Italia srl
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -160,6 +161,16 @@ namespace QuantLib {
     class XOFCurrency : public Currency {
       public:
         XOFCurrency();
+    };
+
+    // Botswanan Pula
+    /*! The ISO three-letter code is BWP; the numeric code is 72.
+     It is divided into 100 thebe.
+     \ingroup currencies
+    */
+    class BWPCurrency : public Currency {
+      public:
+        BWPCurrency();
     };
 }
 

--- a/ql/currencies/africa.hpp
+++ b/ql/currencies/africa.hpp
@@ -22,8 +22,7 @@
 /*! \file africa.hpp
     \brief African currencies
 
-    Data from http://fx.sauder.ubc.ca/currency_table.html
-    and http://www.thefinancials.com/vortex/CurrencyFormats.html
+    See <https://www.thefinancials.com/Default.aspx?SubSectionID=curformat>.
 */
 
 #ifndef quantlib_african_currencies_hpp
@@ -118,6 +117,11 @@ namespace QuantLib {
         MURCurrency();
     };
 
+    //! Nigerian Naira
+    /*! The ISO three-letter code is NGN; the numeric code is 566.
+     It is divided into 100 kobo.
+     \ingroup currencies
+    */
     class NGNCurrency : public Currency {
       public:
         NGNCurrency();


### PR DESCRIPTION
Hi,
Small addition to the African currencies. Reference: https://en.wikipedia.org/wiki/Botswana_pula

Best,
Fredrik