### PR TITLE
Allow moving value into `ObservableValue`

### DIFF
--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -33,8 +33,8 @@ namespace QuantLib {
         return data_[to_upper_copy(name)].value();
     }
 
-    void IndexManager::setHistory(const string& name, const TimeSeries<Real>& history) {
-        data_[to_upper_copy(name)] = history;
+    void IndexManager::setHistory(const string& name, TimeSeries<Real> history) {
+        data_[to_upper_copy(name)] = std::move(history);
     }
 
     ext::shared_ptr<Observable> IndexManager::notifier(const string& name) const {
@@ -44,8 +44,8 @@ namespace QuantLib {
     std::vector<string> IndexManager::histories() const {
         std::vector<string> temp;
         temp.reserve(data_.size());
-        for (history_map::const_iterator i = data_.begin(); i != data_.end(); ++i)
-            temp.push_back(i->first);
+        for (const auto& i : data_)
+            temp.push_back(i.first);
         return temp;
     }
 

--- a/ql/indexes/indexmanager.hpp
+++ b/ql/indexes/indexmanager.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         //! returns the (possibly empty) history of the index fixings
         const TimeSeries<Real>& getHistory(const std::string& name) const;
         //! stores the historical fixings of the index
-        void setHistory(const std::string& name, const TimeSeries<Real>&);
+        void setHistory(const std::string& name, TimeSeries<Real> history);
         //! observer notifying of changes in the index fixings
         ext::shared_ptr<Observable> notifier(const std::string& name) const;
         //! returns all names of the indexes for which fixings were stored
@@ -58,8 +58,7 @@ namespace QuantLib {
         bool hasHistoricalFixing(const std::string& name, const Date& fixingDate) const;
 
       private:
-        typedef std::map<std::string, ObservableValue<TimeSeries<Real> > > history_map;
-        mutable history_map data_;
+        mutable std::map<std::string, ObservableValue<TimeSeries<Real>>> data_;
     };
 
 }

--- a/ql/utilities/observablevalue.hpp
+++ b/ql/utilities/observablevalue.hpp
@@ -42,10 +42,13 @@ namespace QuantLib {
     class ObservableValue {
       public:
         ObservableValue();
+        ObservableValue(T&&);
         ObservableValue(const T&);
         ObservableValue(const ObservableValue<T>&);
+        ~ObservableValue() = default;
         //! \name controlled assignment
         //@{
+        ObservableValue<T>& operator=(T&&);
         ObservableValue<T>& operator=(const T&);
         ObservableValue<T>& operator=(const ObservableValue<T>&);
         //@}
@@ -67,12 +70,23 @@ namespace QuantLib {
     : value_(), observable_(new Observable) {}
 
     template <class T>
+    ObservableValue<T>::ObservableValue(T&& t)
+    : value_(std::move(t)), observable_(new Observable) {}
+
+    template <class T>
     ObservableValue<T>::ObservableValue(const T& t)
     : value_(t), observable_(new Observable) {}
 
     template <class T>
     ObservableValue<T>::ObservableValue(const ObservableValue<T>& t)
     : value_(t.value_), observable_(new Observable) {}
+
+    template <class T>
+    ObservableValue<T>& ObservableValue<T>::operator=(T&& t) {
+        value_ = std::move(t);
+        observable_->notifyObservers();
+        return *this;
+    }
 
     template <class T>
     ObservableValue<T>& ObservableValue<T>::operator=(const T& t) {


### PR DESCRIPTION
Currently `ObservableValue` has only copy constructors and copy assignment operators defined, but it would be nice to support move semantics as well, specifically to avoid the mandatory copy in `IndexManager::setHistory`.

I initialize `observable_` with `new Observable`, same as in the copy constructors and copy assignment operators. However `new` can throw, so I've had to suppress the `performance-noexcept-move-constructor` check, which isn't great. Can `observable_` simply be moved from instead? If so, why isn't its value copied from in the existing methods?

If making `ObservableValue` is not desirable for whatever reason, then we should at least explicitly delete the move constructors and move assignment operators to make the intention clear.