### PR TITLE
Add operator*() to FdmLinearOpIterator

### DIFF
--- a/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
@@ -58,6 +58,11 @@ namespace QuantLib {
             }
         }
 
+        // this is not really a dereference, but is intended to make this class compatible with range-bound for loops
+        const FdmLinearOpIterator& operator*() const {
+            return *this;
+        }
+
         bool operator!=(const FdmLinearOpIterator& iterator) const {
             return index_ != iterator.index_;
         }


### PR DESCRIPTION
This enables `FdmLinearOpIterator` to be used in a modern range-bound for loop, like so:

```c++
for (const auto& iter : *layout) {
    setValue(*f_, iter.coordinates(), rhs[iter.index()]);
}
```

Instead of the less modern style currently found in the codebase:

```c++
const FdmLinearOpIterator endIter = layout->end();
for (FdmLinearOpIterator iter = layout->begin(); iter != endIter; ++iter) {
    setValue(*f_, iter.coordinates(), rhs[iter.index()]);
}
```

As mentioned in the code comment I added, this overloaded dereference operator does not really dereference the iterator, but rather returns a reference to the iterator itself. It seems that `FdmLinearOpIterator` wasn't designed to be a lightweight iterator - it even copies a vector in its constructor! - so it's a bit confusing to call it an "iterator", but it's probably too late to change that design now. The least we can do is make it compatible with modern syntax.