### PR TITLE
Change FdmLinearOpIterator to pass by value and move

### DIFF
--- a/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
@@ -38,10 +38,10 @@ namespace QuantLib {
         explicit FdmLinearOpIterator(Size index = 0)
         : index_(index) {}
 
-        explicit FdmLinearOpIterator(const std::vector<Size>& dim)
+        explicit FdmLinearOpIterator(std::vector<Size> dim)
         : index_(0),
-          dim_(dim),
-          coordinates_(dim.size(), 0) {}
+          dim_(std::move(dim)),
+          coordinates_(dim_.size(), 0) {}
 
         FdmLinearOpIterator(std::vector<Size> dim, std::vector<Size> coordinates, Size index)
         : index_(index), dim_(std::move(dim)), coordinates_(std::move(coordinates)) {}


### PR DESCRIPTION
This is already the case for the other constructor that takes `dim`, `coordinates`, and `index`.