### PR TITLE
Avoid compilation error using `PiecewiseYieldCurve<ConvexMonotone>`

### DIFF
--- a/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -93,9 +93,9 @@ namespace QuantLib {
         static const Size requiredPoints = 2;
         static const Size dataSizeAdjustment = 1;
 
-        explicit ConvexMonotone(Real quadraticity = 0.3,
-                                Real monotonicity = 0.7,
-                                bool forcePositive = true)
+        ConvexMonotone(Real quadraticity = 0.3,
+                       Real monotonicity = 0.7,
+                       bool forcePositive = true)
         : quadraticity_(quadraticity), monotonicity_(monotonicity),
           forcePositive_(forcePositive) {}
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -31,6 +31,7 @@
 #include <ql/math/interpolations/backwardflatinterpolation.hpp>
 #include <ql/math/interpolations/convexmonotoneinterpolation.hpp>
 #include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/math/interpolations/forwardflatinterpolation.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/math/interpolations/loginterpolation.hpp>
 #include <ql/pricingengines/bond/discountingbondengine.hpp>
@@ -1017,6 +1018,26 @@ void PiecewiseYieldCurveTest::testJpyLibor() {
     }
 }
 
+void PiecewiseYieldCurveTest::testDefaultInstantiation() {
+
+    BOOST_TEST_MESSAGE("Testing instantiation of curves without passing an interpolator...");
+
+    using namespace piecewise_yield_curve_test;
+
+    CommonVars vars;
+
+    // no actual tests at runtime; this tests that all these instantiations compile
+    PiecewiseYieldCurve<Discount, Linear> linear(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<Discount, LogLinear> log_linear(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<Discount, Cubic> cubic(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<Discount, DefaultLogCubic> log_cubic(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<Discount, MonotonicLogCubic> monotonic_log_cubic(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<Discount, KrugerLog> kruger_log_cubic(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<ForwardRate, BackwardFlat> backward(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<ForwardRate, ForwardFlat> forward(vars.settlement, vars.instruments, Actual360());
+    PiecewiseYieldCurve<ForwardRate, ConvexMonotone> convex(vars.settlement, vars.instruments, Actual360());
+}
+
 void PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate() {
     BOOST_TEST_MESSAGE("Testing SwapRateHelper last relevant date...");
 
@@ -1436,40 +1457,30 @@ test_suite* PiecewiseYieldCurveTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Piecewise yield curve tests");
 
     // unstable
-    //suite->add(QUANTLIB_TEST_CASE(
-    //             &PiecewiseYieldCurveTest::testLogCubicDiscountConsistency));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testLogLinearDiscountConsistency));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testLinearDiscountConsistency));
+    // suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLogCubicDiscountConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLogLinearDiscountConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLinearDiscountConsistency));
 
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testLinearZeroConsistency));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testSplineZeroConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLinearZeroConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testSplineZeroConsistency));
 
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testLinearForwardConsistency));
-    suite->add(QUANTLIB_TEST_CASE(
-                 &PiecewiseYieldCurveTest::testFlatForwardConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLinearForwardConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testFlatForwardConsistency));
     // unstable
-    //suite->add(QUANTLIB_TEST_CASE(
-    //             &PiecewiseYieldCurveTest::testSplineForwardConsistency));
+    // suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testSplineForwardConsistency));
 
-    suite->add(QUANTLIB_TEST_CASE(
-             &PiecewiseYieldCurveTest::testConvexMonotoneForwardConsistency));
-    suite->add(QUANTLIB_TEST_CASE(
-             &PiecewiseYieldCurveTest::testLocalBootstrapConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testConvexMonotoneForwardConsistency));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLocalBootstrapConsistency));
 
     suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testObservability));
     suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testLiborFixing));
 
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testDefaultInstantiation));
+
     suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testJpyLibor));
 
-    suite->add(QUANTLIB_TEST_CASE(
-               &PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate));
-    suite->add(QUANTLIB_TEST_CASE(
-               &PiecewiseYieldCurveTest::testSwapRateHelperSpotDate));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate));
+    suite->add(QUANTLIB_TEST_CASE(&PiecewiseYieldCurveTest::testSwapRateHelperSpotDate));
 
     if (IborCoupon::Settings::instance().usingAtParCoupons()) {
         // This regression test didn't work with indexed coupons anyway.

--- a/test-suite/piecewiseyieldcurve.hpp
+++ b/test-suite/piecewiseyieldcurve.hpp
@@ -41,6 +41,8 @@ class PiecewiseYieldCurveTest {
     static void testConvexMonotoneForwardConsistency();
     static void testLocalBootstrapConsistency();
 
+    static void testDefaultInstantiation();
+
     static void testObservability();
     static void testLiborFixing();
 


### PR DESCRIPTION
Fixes #1614.

`ConvexMonotone` had an explicit default constructor and could not be used with the `= {}` syntax, forcing callers of `PiecewiseYieldCurve` to pass the parameter to the constructor explicitly.  The `explicit` is now gone.