### PR TITLE
Remove copy on key compare

### DIFF
--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -18,43 +18,39 @@
 */
 
 #include <ql/indexes/indexmanager.hpp>
-#include <boost/algorithm/string/case_conv.hpp>
-
-using boost::algorithm::to_upper_copy;
-using std::string;
 
 namespace QuantLib {
 
-    bool IndexManager::hasHistory(const string& name) const {
-        return data_.find(to_upper_copy(name)) != data_.end();
+    bool IndexManager::hasHistory(const std::string& name) const {
+        return data_.find(name) != data_.end();
     }
 
-    const TimeSeries<Real>& IndexManager::getHistory(const string& name) const {
-        return data_[to_upper_copy(name)].value();
+    const TimeSeries<Real>& IndexManager::getHistory(const std::string& name) const {
+        return data_[name].value();
     }
 
-    void IndexManager::setHistory(const string& name, TimeSeries<Real> history) {
-        data_[to_upper_copy(name)] = std::move(history);
+    void IndexManager::setHistory(const std::string& name, TimeSeries<Real> history) {
+        data_[name] = std::move(history);
     }
 
-    ext::shared_ptr<Observable> IndexManager::notifier(const string& name) const {
-        return data_[to_upper_copy(name)];
+    ext::shared_ptr<Observable> IndexManager::notifier(const std::string& name) const {
+        return data_[name];
     }
 
-    std::vector<string> IndexManager::histories() const {
-        std::vector<string> temp;
+    std::vector<std::string> IndexManager::histories() const {
+        std::vector<std::string> temp;
         temp.reserve(data_.size());
         for (const auto& i : data_)
             temp.push_back(i.first);
         return temp;
     }
 
-    void IndexManager::clearHistory(const string& name) { data_.erase(to_upper_copy(name)); }
+    void IndexManager::clearHistory(const std::string& name) { data_.erase(name); }
 
     void IndexManager::clearHistories() { data_.clear(); }
 
     bool IndexManager::hasHistoricalFixing(const std::string& name, const Date& fixingDate) const {
-        auto const& indexIter = data_.find(to_upper_copy(name));
+        auto const& indexIter = data_.find(name);
         return (indexIter != data_.end()) &&
                ((*indexIter).second.value()[fixingDate] != Null<Real>());
     }

--- a/ql/indexes/indexmanager.hpp
+++ b/ql/indexes/indexmanager.hpp
@@ -27,7 +27,8 @@
 #include <ql/patterns/singleton.hpp>
 #include <ql/timeseries.hpp>
 #include <ql/utilities/observablevalue.hpp>
-
+#include <algorithm>
+#include <cctype>
 
 namespace QuantLib {
 
@@ -58,7 +59,15 @@ namespace QuantLib {
         bool hasHistoricalFixing(const std::string& name, const Date& fixingDate) const;
 
       private:
-        mutable std::map<std::string, ObservableValue<TimeSeries<Real>>> data_;
+        struct CaseInsensitiveCompare {
+          bool operator()(const std::string& s1, const std::string& s2) const {
+            return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(), s2.end(), [](const auto& c1, const auto& c2) {
+              return std::toupper(static_cast<unsigned char>(c1)) < std::toupper(static_cast<unsigned char>(c2));
+            });
+          }
+        };
+
+        mutable std::map<std::string, ObservableValue<TimeSeries<Real>>, CaseInsensitiveCompare> data_;
     };
 
 }

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -22,6 +22,7 @@
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/utilities/dataformatters.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -92,10 +93,18 @@ void IndexTest::testFixingHasHistoricalFixing() {
     name = euribor3M->name();
     testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
     testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_upper_copy(euribor3M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_lower_copy(euribor3M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     name = euribor6M->name();
     testCase(name, fixingFound, euribor6M->hasHistoricalFixing(today));
     testCase(name, fixingFound, euribor6M_a->hasHistoricalFixing(today));
+    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_upper_copy(euribor6M->name());
+    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_lower_copy(euribor6M->name());
     testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     IndexManager::instance().clearHistories();
@@ -103,13 +112,20 @@ void IndexTest::testFixingHasHistoricalFixing() {
     name = euribor3M->name();
     testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
     testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_upper_copy(euribor3M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_lower_copy(euribor3M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     name = euribor6M->name();
     testCase(name, fixingNotFound, euribor6M->hasHistoricalFixing(today));
     testCase(name, fixingNotFound, euribor6M_a->hasHistoricalFixing(today));
     testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_upper_copy(euribor6M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
+    name = boost::to_lower_copy(euribor6M->name());
+    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 }
-
 
 test_suite* IndexTest::suite() {
     auto* suite = BOOST_TEST_SUITE("index tests");


### PR DESCRIPTION
I've replaced the key lookup in `IndexManager` with an implementation that does not copy the key while preserving the case-insensitivity.

The `CaseInsensitiveCompare` class might be useful in other places as well, so I'll be happy to take suggestions for a better home for it if anyone has any ideas.