### PR TITLE
Add operators taking Matrix by rvalue reference

### DIFF
--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -57,6 +57,7 @@ namespace QuantLib {
         Matrix(const Matrix&);
         Matrix(Matrix&&) noexcept;
         Matrix(std::initializer_list<std::initializer_list<Real>>);
+        ~Matrix() = default;
 
         Matrix& operator=(const Matrix&);
         Matrix& operator=(Matrix&&) noexcept;
@@ -152,16 +153,35 @@ namespace QuantLib {
     /*! \relates Matrix */
     Matrix operator+(const Matrix&, const Matrix&);
     /*! \relates Matrix */
+    Matrix operator+(const Matrix&, Matrix&&);
+    /*! \relates Matrix */
+    Matrix operator+(Matrix&&, const Matrix&);
+    /*! \relates Matrix */
+    Matrix operator+(Matrix&&, Matrix&&);
+    /*! \relates Matrix */
     Matrix operator-(const Matrix&);
+    /*! \relates Matrix */
+    Matrix operator-(Matrix&&);
     /*! \relates Matrix */
     Matrix operator-(const Matrix&, const Matrix&);
     /*! \relates Matrix */
+    Matrix operator-(const Matrix&, Matrix&&);
+    /*! \relates Matrix */
+    Matrix operator-(Matrix&&, const Matrix&);
+    /*! \relates Matrix */
+    Matrix operator-(Matrix&&, Matrix&&);
+    /*! \relates Matrix */
     Matrix operator*(const Matrix&, Real);
+    /*! \relates Matrix */
+    Matrix operator*(Matrix&&, Real);
     /*! \relates Matrix */
     Matrix operator*(Real, const Matrix&);
     /*! \relates Matrix */
+    Matrix operator*(Real, Matrix&&);
+    /*! \relates Matrix */
     Matrix operator/(const Matrix&, Real);
-
+    /*! \relates Matrix */
+    Matrix operator/(Matrix&&, Real);
 
     // vectorial products
 
@@ -513,10 +533,48 @@ namespace QuantLib {
         return temp;
     }
 
+    inline Matrix operator+(const Matrix& m1, Matrix&& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "added");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m2.begin(), std::plus<>());
+        return std::move(m2);
+    }
+
+    inline Matrix operator+(Matrix&& m1, const Matrix& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "added");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m1.begin(), std::plus<>());
+        return std::move(m1);
+    }
+
+    inline Matrix operator+(Matrix&& m1, Matrix&& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "added");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m1.begin(), std::plus<>());
+        return std::move(m1);
+    }
+
     inline Matrix operator-(const Matrix& m1) {
         Matrix temp(m1.rows(), m1.columns());
         std::transform(m1.begin(), m1.end(), temp.begin(), std::negate<>());
         return temp;
+    }
+
+    inline Matrix operator-(Matrix&& m1) {
+        std::transform(m1.begin(), m1.end(), m1.begin(), std::negate<>());
+        return std::move(m1);
     }
 
     inline Matrix operator-(const Matrix& m1, const Matrix& m2) {
@@ -531,10 +589,48 @@ namespace QuantLib {
         return temp;
     }
 
+    inline Matrix operator-(const Matrix& m1, Matrix&& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "subtracted");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m2.begin(), std::minus<>());
+        return std::move(m2);
+    }
+
+    inline Matrix operator-(Matrix&& m1, const Matrix& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "subtracted");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m1.begin(), std::minus<>());
+        return std::move(m1);
+    }
+
+    inline Matrix operator-(Matrix&& m1, Matrix&& m2) {
+        QL_REQUIRE(m1.rows() == m2.rows() &&
+                   m1.columns() == m2.columns(),
+                   "matrices with different sizes (" <<
+                   m1.rows() << "x" << m1.columns() << ", " <<
+                   m2.rows() << "x" << m2.columns() << ") cannot be "
+                   "subtracted");
+        std::transform(m1.begin(), m1.end(), m2.begin(), m1.begin(), std::minus<>());
+        return std::move(m1);
+    }
+
     inline Matrix operator*(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
         std::transform(m.begin(), m.end(), temp.begin(), [=](Real y) -> Real { return y * x; });
         return temp;
+    }
+
+    inline Matrix operator*(Matrix&& m, Real x) {
+        std::transform(m.begin(), m.end(), m.begin(), [=](Real y) -> Real { return y * x; });
+        return std::move(m);
     }
 
     inline Matrix operator*(Real x, const Matrix& m) {
@@ -543,10 +639,20 @@ namespace QuantLib {
         return temp;
     }
 
+    inline Matrix operator*(Real x, Matrix&& m) {
+        std::transform(m.begin(), m.end(), m.begin(), [=](Real y) -> Real { return x * y; });
+        return std::move(m);
+    }
+
     inline Matrix operator/(const Matrix& m, Real x) {
         Matrix temp(m.rows(),m.columns());
         std::transform(m.begin(), m.end(), temp.begin(), [=](Real y) -> Real { return y / x; });
         return temp;
+    }
+
+    inline Matrix operator/(Matrix&& m, Real x) {
+        std::transform(m.begin(), m.end(), m.begin(), [=](Real y) -> Real { return y / x; });
+        return std::move(m);
     }
 
     inline Array operator*(const Array& v, const Matrix& m) {

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -322,7 +322,7 @@ void ArrayTest::testArrayOperators() {
     const auto real_rvalue_quotient = 1.1 / get_array();
 
     QL_CHECK_CLOSE_ARRAY(lvalue_real_quotient, scalar_quotient_1);
-    QL_CHECK_CLOSE_ARRAY(lvalue_real_quotient, scalar_quotient_1);
+    QL_CHECK_CLOSE_ARRAY(rvalue_real_quotient, scalar_quotient_1);
     QL_CHECK_CLOSE_ARRAY(real_lvalue_quotient, scalar_quotient_2);
     QL_CHECK_CLOSE_ARRAY(real_rvalue_quotient, scalar_quotient_2);
 }

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -791,6 +791,73 @@ void MatricesTest::testSparseMatrixMemory() {
 
 }
 
+#define QL_CHECK_CLOSE_MATRIX(actual, expected)                             \
+    BOOST_REQUIRE(actual.rows() == expected.rows() &&                       \
+                  actual.columns() == expected.columns());                  \
+    for (auto i = 0u; i < actual.rows(); i++) {                             \
+        for (auto j = 0u; j < actual.columns(); j++) {                      \
+            QL_CHECK_CLOSE(actual(i, j), expected(i, j), 100 * QL_EPSILON); \
+        }                                                                   \
+    }                                                                       \
+
+void MatricesTest::testOperators() {
+
+    BOOST_TEST_MESSAGE("Testing matrix operators...");
+
+    auto get_matrix = []() {
+        return Matrix(2, 3, 4.0);
+    };
+
+    const auto m = get_matrix();
+
+    const auto negative = Matrix(2, 3, -4.0);
+    const auto lvalue_negative = -m;
+    const auto rvalue_negative = -get_matrix();
+
+    QL_CHECK_CLOSE_MATRIX(lvalue_negative, negative);
+    QL_CHECK_CLOSE_MATRIX(rvalue_negative, negative);
+
+    const auto matrix_sum = Matrix(2, 3, 8.0);
+    const auto lvalue_lvalue_sum = m + m;
+    const auto lvalue_rvalue_sum = m + get_matrix();
+    const auto rvalue_lvalue_sum = get_matrix() + m;
+    const auto rvalue_rvalue_sum = get_matrix() + get_matrix();
+
+    QL_CHECK_CLOSE_MATRIX(lvalue_lvalue_sum, matrix_sum);
+    QL_CHECK_CLOSE_MATRIX(lvalue_rvalue_sum, matrix_sum);
+    QL_CHECK_CLOSE_MATRIX(rvalue_lvalue_sum, matrix_sum);
+    QL_CHECK_CLOSE_MATRIX(rvalue_rvalue_sum, matrix_sum);
+
+    const auto matrix_difference = Matrix(2, 3, 0.0);
+    const auto lvalue_lvalue_difference = m - m;
+    const auto lvalue_rvalue_difference = m - get_matrix();
+    const auto rvalue_lvalue_difference = get_matrix() - m;
+    const auto rvalue_rvalue_difference = get_matrix() - get_matrix();
+
+    QL_CHECK_CLOSE_MATRIX(lvalue_lvalue_difference, matrix_difference);
+    QL_CHECK_CLOSE_MATRIX(lvalue_rvalue_difference, matrix_difference);
+    QL_CHECK_CLOSE_MATRIX(rvalue_lvalue_difference, matrix_difference);
+    QL_CHECK_CLOSE_MATRIX(rvalue_rvalue_difference, matrix_difference);
+
+    const auto scalar_product = Matrix(2, 3, 6.0);
+    const auto lvalue_real_product = m * 1.5;
+    const auto rvalue_real_product = get_matrix() * 1.5;
+    const auto real_lvalue_product = 1.5 * m;
+    const auto real_rvalue_product = 1.5 * get_matrix();
+
+    QL_CHECK_CLOSE_MATRIX(lvalue_real_product, scalar_product);
+    QL_CHECK_CLOSE_MATRIX(rvalue_real_product, scalar_product);
+    QL_CHECK_CLOSE_MATRIX(real_lvalue_product, scalar_product);
+    QL_CHECK_CLOSE_MATRIX(real_rvalue_product, scalar_product);
+
+    const auto scalar_quotient = Matrix(2, 3, 2.0);
+    const auto lvalue_real_quotient = m / 2.0;
+    const auto rvalue_real_quotient = get_matrix() / 2.0;
+
+    QL_CHECK_CLOSE_MATRIX(lvalue_real_quotient, scalar_quotient);
+    QL_CHECK_CLOSE_MATRIX(rvalue_real_quotient, scalar_quotient);
+}
+
 test_suite* MatricesTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Matrix tests");
 
@@ -808,6 +875,7 @@ test_suite* MatricesTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testMoorePenroseInverse));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testIterativeSolvers));
     suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testInitializers));
+    suite->add(QUANTLIB_TEST_CASE(&MatricesTest::testOperators));
     return suite;
 }
 

--- a/test-suite/matrices.hpp
+++ b/test-suite/matrices.hpp
@@ -43,6 +43,7 @@ class MatricesTest {
     static void testIterativeSolvers();
     static void testInitializers();
     static void testSparseMatrixMemory();
+    static void testOperators();
 
     static boost::unit_test_framework::test_suite* suite();
 };


### PR DESCRIPTION
Continuation of #1606

- For now I have only added overloads for rvalue reference where the return value has the same dimensions as the function argument(s). We can try to support moving matrices with different dimensions, but it will be more tricky.
- I added a defaulted destructor for consistency with the Rule of Five and also fixed a stray typo in the array test.