### PR TITLE
Pass dim by value to FdmLinearOpLayout and move

### DIFF
--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -130,10 +130,19 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
         (Size)std::ceil(expiryTime_ * 24); // number of steps in dimension t
     const Size dampingSteps = 5;           // thereof damping steps
 
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
     // Layout
     std::vector<Size> dim(1, size);
     const ext::shared_ptr<FdmLinearOpLayout> layout(
         new FdmLinearOpLayout(dim));
+
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
     // Mesher
     const ext::shared_ptr<Fdm1dMesher> m1(new Concentrating1dMesher(

--- a/ql/methods/finitedifferences/meshers/fdmmeshercomposite.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmmeshercomposite.cpp
@@ -33,7 +33,7 @@ namespace QuantLib {
             for (Size i=0; i < dim.size(); ++i) {
                 dim[i] = meshers[i]->size();
             }
-            return ext::make_shared<FdmLinearOpLayout>(dim);
+            return ext::make_shared<FdmLinearOpLayout>(std::move(dim));
         }
     }
 

--- a/ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearoplayout.hpp
@@ -33,13 +33,13 @@ namespace QuantLib {
 
     class FdmLinearOpLayout {
       public:
-        explicit FdmLinearOpLayout(const std::vector<Size>& dim)
-        : dim_(dim), spacing_(dim.size()) {
+        explicit FdmLinearOpLayout(std::vector<Size> dim)
+        : dim_(std::move(dim)), spacing_(dim_.size()) {
             spacing_[0] = 1;
-            std::partial_sum(dim.begin(), dim.end()-1,
+            std::partial_sum(dim_.begin(), dim_.end()-1,
                 spacing_.begin()+1, std::multiplies<>());
 
-            size_ = spacing_.back()*dim.back();
+            size_ = spacing_.back()*dim_.back();
         }
 
         FdmLinearOpIterator begin() const {


### PR DESCRIPTION
Looks like GCC 12 doesn't like when `dim` is of size 1, but this case seems to be valid so I've suppressed the warning for now. There's probably a better way to deal with this warning.