### PR TITLE
Unsuppress cppcoreguidelines-special-member-functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,6 @@ Checks: >
           -cppcoreguidelines-pro-type-const-cast,
           -cppcoreguidelines-pro-type-member-init,
           -cppcoreguidelines-pro-type-vararg,
-          -cppcoreguidelines-special-member-functions,
         misc-*,
           -misc-confusable-identifiers,
           -misc-const-correctness,
@@ -70,6 +69,8 @@ Checks: >
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:
+  - key:   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: 1
   - key:   modernize-use-default-member-init.UseAssignment
     value: 1
 ...

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -66,7 +66,11 @@ namespace QuantLib {
         };
       public:
         CashFlows() = delete;
+        CashFlows(CashFlows&&) = delete;
         CashFlows(const CashFlows&) = delete;
+        CashFlows& operator=(CashFlows&&) = delete;
+        CashFlows& operator=(const CashFlows&) = delete;
+        ~CashFlows() = default;
 
         //! \name Date functions
         //@{

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -157,7 +157,7 @@ namespace QuantLib {
     namespace {
 
     template<class T>
-    class RestoreVal {
+    class RestoreVal { // NOLINT(cppcoreguidelines-special-member-functions)
         T orig_;
         T &ref_;
     public:

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -69,6 +69,7 @@ namespace QuantLib {
         //! creates the array from an iterable sequence
         template <class ForwardIterator>
         Array(ForwardIterator begin, ForwardIterator end);
+        ~Array() = default;
 
         Array& operator=(const Array&);
         Array& operator=(Array&&) noexcept;
@@ -614,7 +615,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline Array operator+(Array&& v1, Array&& v2) {
+    inline Array operator+(Array&& v1, Array&& v2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(v1.size() == v2.size(),
                    "arrays with different sizes (" << v1.size() << ", "
                    << v2.size() << ") cannot be added");
@@ -674,7 +675,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline Array operator-(Array&& v1, Array&& v2) {
+    inline Array operator-(Array&& v1, Array&& v2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(v1.size() == v2.size(),
                    "arrays with different sizes (" << v1.size() << ", "
                    << v2.size() << ") cannot be subtracted");
@@ -734,7 +735,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline Array operator*(Array&& v1, Array&& v2) {
+    inline Array operator*(Array&& v1, Array&& v2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(v1.size() == v2.size(),
                    "arrays with different sizes (" << v1.size() << ", "
                    << v2.size() << ") cannot be multiplied");
@@ -794,7 +795,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline Array operator/(Array&& v1, Array&& v2) {
+    inline Array operator/(Array&& v1, Array&& v2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(v1.size() == v2.size(),
                    "arrays with different sizes (" << v1.size() << ", "
                    << v2.size() << ") cannot be divided");

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -554,7 +554,7 @@ namespace QuantLib {
         return std::move(m1);
     }
 
-    inline Matrix operator+(Matrix&& m1, Matrix&& m2) {
+    inline Matrix operator+(Matrix&& m1, Matrix&& m2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(m1.rows() == m2.rows() &&
                    m1.columns() == m2.columns(),
                    "matrices with different sizes (" <<
@@ -610,7 +610,7 @@ namespace QuantLib {
         return std::move(m1);
     }
 
-    inline Matrix operator-(Matrix&& m1, Matrix&& m2) {
+    inline Matrix operator-(Matrix&& m1, Matrix&& m2) { // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         QL_REQUIRE(m1.rows() == m2.rows() &&
                    m1.columns() == m2.columns(),
                    "matrices with different sizes (" <<

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -42,6 +42,7 @@ namespace QuantLib {
         NinePointLinearOp(NinePointLinearOp&& m) noexcept;
         NinePointLinearOp& operator=(const NinePointLinearOp& m);
         NinePointLinearOp& operator=(NinePointLinearOp&& m) noexcept;
+        ~NinePointLinearOp() override = default;
 
         Array apply(const Array& r) const override;
         NinePointLinearOp mult(const Array& u) const;

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
@@ -43,6 +43,7 @@ namespace QuantLib {
         TripleBandLinearOp(TripleBandLinearOp&& m) noexcept;
         TripleBandLinearOp& operator=(const TripleBandLinearOp& m);
         TripleBandLinearOp& operator=(TripleBandLinearOp&& m) noexcept;
+        ~TripleBandLinearOp() override = default;
 
         Array apply(const Array& r) const override;
         Array solve_splitting(const Array& r, Real a, Real b = 1.0) const;

--- a/ql/methods/finitedifferences/tridiagonaloperator.hpp
+++ b/ql/methods/finitedifferences/tridiagonaloperator.hpp
@@ -65,6 +65,7 @@ namespace QuantLib {
         TridiagonalOperator(TridiagonalOperator&&) noexcept;
         TridiagonalOperator& operator=(const TridiagonalOperator&);
         TridiagonalOperator& operator=(TridiagonalOperator&&) noexcept;
+        ~TridiagonalOperator() = default;
         //! \name Operator interface
         //@{
         //! apply operator to a given array

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
     //! Object that notifies its changes to a set of observers
     /*! \ingroup patterns */
-    class Observable {
+    class Observable { // NOLINT(cppcoreguidelines-special-member-functions)
         friend class Observer;
         friend class ObservableSettings;
       public:
@@ -98,7 +98,7 @@ namespace QuantLib {
 
     //! Object that gets notified when a given observable changes
     /*! \ingroup patterns */
-    class Observer {
+    class Observer { // NOLINT(cppcoreguidelines-special-member-functions)
       private:
         typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
       public:

--- a/ql/patterns/singleton.hpp
+++ b/ql/patterns/singleton.hpp
@@ -62,6 +62,7 @@ namespace QuantLib {
         Singleton(Singleton&&) = delete;
         Singleton& operator=(const Singleton&) = delete;
         Singleton& operator=(Singleton&&) = delete;
+        ~Singleton() = default;
 
         //! access to the unique instance
         static T& instance();

--- a/ql/settings.hpp
+++ b/ql/settings.hpp
@@ -117,7 +117,7 @@ namespace QuantLib {
 
 
     // helper class to temporarily and safely change the settings
-    class SavedSettings {
+    class SavedSettings { // NOLINT(cppcoreguidelines-special-member-functions)
       public:
         SavedSettings();
         ~SavedSettings();

--- a/ql/termstructures/interpolatedcurve.hpp
+++ b/ql/termstructures/interpolatedcurve.hpp
@@ -39,6 +39,9 @@ namespace QuantLib {
     */
     template <class Interpolator>
     class InterpolatedCurve {
+      public:
+        ~InterpolatedCurve() = default;
+
       protected:
         //! \name Building
         //@{
@@ -47,9 +50,9 @@ namespace QuantLib {
                           const Interpolator& i = Interpolator())
         : times_(std::move(times)), data_(std::move(data)), interpolator_(i) {}
 
-        InterpolatedCurve(const std::vector<Time>& times,
+        InterpolatedCurve(std::vector<Time> times,
                           const Interpolator& i = Interpolator())
-        : times_(times), data_(times.size()), interpolator_(i) {}
+        : times_(std::move(times)), data_(times_.size()), interpolator_(i) {}
 
         InterpolatedCurve(Size n,
                           const Interpolator& i = Interpolator())
@@ -70,6 +73,22 @@ namespace QuantLib {
             times_ = c.times_;
             data_ = c.data_;
             interpolator_ = c.interpolator_;
+            setupInterpolation();
+            return *this;
+        }
+        //@}
+
+        //! \name Moving
+        //@{
+        InterpolatedCurve(InterpolatedCurve&& c) noexcept
+        : times_(std::move(c.times_)), data_(std::move(c.data_)), interpolator_(std::move(c.interpolator_)) {
+            setupInterpolation();
+        }
+
+        InterpolatedCurve& operator=(InterpolatedCurve&& c) noexcept {
+            times_ = std::move(c.times_);
+            data_ = std::move(c.data_);
+            interpolator_ = std::move(c.interpolator_);
             setupInterpolation();
             return *this;
         }

--- a/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
+++ b/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
@@ -61,7 +61,7 @@ namespace QuantLib {
     */
     template<class Model>
     class XabrSwaptionVolatilityCube : public SwaptionVolatilityCube {
-        class Cube {
+        class Cube { // NOLINT(cppcoreguidelines-special-member-functions)
           public:
             Cube() = default;
             Cube(const std::vector<Date>& optionDates,

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -840,7 +840,7 @@ namespace QuantLib {
 
     namespace detail {
 
-        struct FormatResetter {
+        struct FormatResetter { // NOLINT(cppcoreguidelines-special-member-functions)
             // An instance of this object will have undefined behaviour
             // if the object out passed in the constructor is destroyed
             // before this instance

--- a/ql/utilities/clone.hpp
+++ b/ql/utilities/clone.hpp
@@ -51,6 +51,7 @@ namespace QuantLib {
         T* operator->() const;
         bool empty() const;
         void swap(Clone<T>& t) noexcept;
+        ~Clone() = default;
       private:
         std::unique_ptr<T> ptr_;
     };

--- a/ql/utilities/observablevalue.hpp
+++ b/ql/utilities/observablevalue.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
               code should modify the value via re-assignment instead.
     */
     template <class T>
-    class ObservableValue {
+    class ObservableValue { // NOLINT(cppcoreguidelines-special-member-functions)
       public:
         ObservableValue();
         ObservableValue(T&&);

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -74,7 +74,7 @@ namespace inflation_cpi_bond_test {
     }
 
 
-    struct CommonVars {
+    struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
     
         Calendar calendar;
         BusinessDayConvention convention;

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -46,7 +46,7 @@ namespace {
         Size counter_ = 0;
     };
 
-    class RestoreUpdates {
+    class RestoreUpdates { // NOLINT(cppcoreguidelines-special-member-functions)
       public:
         ~RestoreUpdates() {
             ObservableSettings::instance().enableUpdates();

--- a/test-suite/tracing.cpp
+++ b/test-suite/tracing.cpp
@@ -28,7 +28,7 @@ using namespace boost::unit_test_framework;
 
 namespace {
 
-    class TestCaseCleaner {
+    class TestCaseCleaner { // NOLINT(cppcoreguidelines-special-member-functions)
       public:
         TestCaseCleaner() = default;
         ~TestCaseCleaner() {

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -177,7 +177,7 @@ namespace QuantLib {
 
 
     // this cleans up index-fixing histories when destroyed
-    class IndexHistoryCleaner {
+    class IndexHistoryCleaner { // NOLINT(cppcoreguidelines-special-member-functions)
       public:
         IndexHistoryCleaner() = default;
         ~IndexHistoryCleaner();


### PR DESCRIPTION
I added the missing special member function(s) wherever it was straightforward, but for less clear-cut cases I moved the suppression to a comment. It would be good to at some point review the cases that are still suppressed through comments to see if the code can be refactored to follow the guideline.