### PR TITLE
Make swap functions noexcept

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -137,7 +137,7 @@ namespace QuantLib {
         //! \name Utilities
         //@{
         void resize(Size n);
-        void swap(Array&);  // never throws
+        void swap(Array&) noexcept;
         //@}
 
       private:
@@ -271,7 +271,7 @@ namespace QuantLib {
 
     // utilities
     /*! \relates Array */
-    void swap(Array&, Array&);
+    void swap(Array&, Array&) noexcept;
 
     // format
     /*! \relates Array */
@@ -542,10 +542,9 @@ namespace QuantLib {
         }
     }
 
-    inline void Array::swap(Array& from) {
-        using std::swap;
+    inline void Array::swap(Array& from) noexcept {
         data_.swap(from.data_);
-        swap(n_,from.n_);
+        std::swap(n_, from.n_);
     }
 
     // dot product and norm
@@ -900,7 +899,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline void swap(Array& v, Array& w) {
+    inline void swap(Array& v, Array& w) noexcept {
         v.swap(w);
     }
 

--- a/ql/math/interpolations/multicubicspline.hpp
+++ b/ql/math/interpolations/multicubicspline.hpp
@@ -93,7 +93,7 @@ namespace QuantLib {
             : first(*i), second(i + 1) {}
             Data(const SplineGrid &v)
             : first(v[0]), second(v.begin()+1) {}
-            void swap(Data<X, Y> &d) {
+            void swap(Data<X, Y> &d) noexcept {
                 first.swap(d.first);
                 second.swap(d.second);
             }
@@ -108,7 +108,7 @@ namespace QuantLib {
             Data(const SplineGrid &v)
             : first(v[0]) {}
             Data(std::vector<Real> v) : first(std::move(v)) {}
-            void swap(Data<std::vector<Real>, EmptyArg> &d) {
+            void swap(Data<std::vector<Real>, EmptyArg> &d) noexcept {
                 first.swap(d.first);
             }
             Real operator[](Size n) const {return first[n];}

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -141,7 +141,7 @@ namespace QuantLib {
 
         //! \name Utilities
         //@{
-        void swap(Matrix&);
+        void swap(Matrix&) noexcept;
         //@}
       private:
         std::unique_ptr<Real[]> data_;
@@ -205,7 +205,7 @@ namespace QuantLib {
     Matrix outerProduct(Iterator1 v1begin, Iterator1 v1end, Iterator2 v2begin, Iterator2 v2end);
 
     /*! \relates Matrix */
-    void swap(Matrix&, Matrix&);
+    void swap(Matrix&, Matrix&) noexcept;
 
     /*! \relates Matrix */
     std::ostream& operator<<(std::ostream&, const Matrix&);
@@ -287,11 +287,10 @@ namespace QuantLib {
         return !this->operator==(to); 
     }
 
-    inline void Matrix::swap(Matrix& from) {
-        using std::swap;
+    inline void Matrix::swap(Matrix& from) noexcept {
         data_.swap(from.data_);
-        swap(rows_,from.rows_);
-        swap(columns_,from.columns_);
+        std::swap(rows_, from.rows_);
+        std::swap(columns_, from.columns_);
     }
 
     inline const Matrix& Matrix::operator+=(const Matrix& m) {
@@ -729,7 +728,7 @@ namespace QuantLib {
         return result;
     }
 
-    inline void swap(Matrix& m1, Matrix& m2) {
+    inline void swap(Matrix& m1, Matrix& m2) noexcept {
         m1.swap(m2);
     }
 

--- a/ql/math/sampledcurve.hpp
+++ b/ql/math/sampledcurve.hpp
@@ -82,7 +82,7 @@ namespace QuantLib {
 
         //! \name utilities
         //@{
-        void swap(SampledCurve&);
+        void swap(SampledCurve&) noexcept;
         void setLogGrid(Real min, Real max) {
             setGrid(BoundedLogGrid(min, max, size()-1));
         }
@@ -153,7 +153,7 @@ namespace QuantLib {
     };
 
     /* \relates SampledCurve */
-    void swap(SampledCurve&, SampledCurve&);
+    void swap(SampledCurve&, SampledCurve&) noexcept;
 
     typedef SampledCurve SampledCurveSet;
 
@@ -214,13 +214,12 @@ namespace QuantLib {
         values_ = g;
     }
 
-    inline void SampledCurve::swap(SampledCurve& from) {
-        using std::swap;
+    inline void SampledCurve::swap(SampledCurve& from) noexcept {
         grid_.swap(from.grid_);
         values_.swap(from.values_);
     }
 
-    inline void swap(SampledCurve& c1, SampledCurve& c2) {
+    inline void swap(SampledCurve& c1, SampledCurve& c2) noexcept {
         c1.swap(c2);
     }
 

--- a/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
@@ -75,7 +75,7 @@ namespace QuantLib {
             return coordinates_;
         }
 
-        void swap(FdmLinearOpIterator& iter) {
+        void swap(FdmLinearOpIterator& iter) noexcept {
             std::swap(iter.index_, index_);
             dim_.swap(iter.dim_);
             coordinates_.swap(iter.coordinates_);

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -179,7 +179,7 @@ namespace QuantLib {
         return retVal;
     }
 
-    void NinePointLinearOp::swap(NinePointLinearOp& m) {
+    void NinePointLinearOp::swap(NinePointLinearOp& m) noexcept {
         std::swap(d0_, m.d0_);
         std::swap(d1_, m.d1_);
 
@@ -190,6 +190,6 @@ namespace QuantLib {
         a01_.swap(m.a01_); a21_.swap(m.a21_); a02_.swap(m.a02_);
         a12_.swap(m.a12_); a22_.swap(m.a22_); a11_.swap(m.a11_);
 
-        std::swap(mesher_, m.mesher_);
+        mesher_.swap(m.mesher_);
     }
 }

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.hpp
@@ -46,7 +46,7 @@ namespace QuantLib {
         Array apply(const Array& r) const override;
         NinePointLinearOp mult(const Array& u) const;
 
-        void swap(NinePointLinearOp& m);
+        void swap(NinePointLinearOp& m) noexcept;
 
         SparseMatrix toMatrix() const override;
 

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -80,8 +80,8 @@ namespace QuantLib {
         std::copy(m.upper_.get(), m.upper_.get() + len, upper_.get());
     }
 
-    void TripleBandLinearOp::swap(TripleBandLinearOp& m) {
-        std::swap(mesher_, m.mesher_);
+    void TripleBandLinearOp::swap(TripleBandLinearOp& m) noexcept {
+        mesher_.swap(m.mesher_);
         std::swap(direction_, m.direction_);
 
         i0_.swap(m.i0_); i2_.swap(m.i2_);

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
@@ -58,7 +58,7 @@ namespace QuantLib {
         void axpyb(const Array& a, const TripleBandLinearOp& x,
                    const TripleBandLinearOp& y, const Array& b);
 
-        void swap(TripleBandLinearOp& m);
+        void swap(TripleBandLinearOp& m) noexcept;
 
         SparseMatrix toMatrix() const override;
 

--- a/ql/methods/finitedifferences/tridiagonaloperator.hpp
+++ b/ql/methods/finitedifferences/tridiagonaloperator.hpp
@@ -101,7 +101,7 @@ namespace QuantLib {
         //@}
         //! \name Utilities
         //@{
-        void swap(TridiagonalOperator&);
+        void swap(TridiagonalOperator&) noexcept;
         //@}
         //! encapsulation of time-setting logic
         class TimeSetter {
@@ -118,7 +118,7 @@ namespace QuantLib {
     };
 
     /* \relates TridiagonalOperator */
-    void swap(TridiagonalOperator&, TridiagonalOperator&);
+    void swap(TridiagonalOperator&, TridiagonalOperator&) noexcept;
 
 
     // inline definitions
@@ -178,14 +178,13 @@ namespace QuantLib {
             timeSetter_->setTime(t, *this);
     }
 
-    inline void TridiagonalOperator::swap(TridiagonalOperator& from) {
-        using std::swap;
-        swap(n_, from.n_);
+    inline void TridiagonalOperator::swap(TridiagonalOperator& from) noexcept {
+        std::swap(n_, from.n_);
         diagonal_.swap(from.diagonal_);
         lowerDiagonal_.swap(from.lowerDiagonal_);
         upperDiagonal_.swap(from.upperDiagonal_);
         temp_.swap(from.temp_);
-        swap(timeSetter_, from.timeSetter_);
+        timeSetter_.swap(from.timeSetter_);
     }
 
 
@@ -250,7 +249,7 @@ namespace QuantLib {
     }
 
     inline void swap(TridiagonalOperator& L1,
-                     TridiagonalOperator& L2) {
+                     TridiagonalOperator& L2) noexcept {
         L1.swap(L2);
     }
 

--- a/ql/utilities/clone.hpp
+++ b/ql/utilities/clone.hpp
@@ -50,14 +50,14 @@ namespace QuantLib {
         T& operator*() const;
         T* operator->() const;
         bool empty() const;
-        void swap(Clone<T>& t);
+        void swap(Clone<T>& t) noexcept;
       private:
         std::unique_ptr<T> ptr_;
     };
 
     /*! \relates Clone */
     template <class T>
-    void swap(Clone<T>&, Clone<T>&);
+    void swap(Clone<T>&, Clone<T>&) noexcept;
 
 
     // inline definitions
@@ -114,12 +114,12 @@ namespace QuantLib {
     }
 
     template <class T>
-    inline void Clone<T>::swap(Clone<T>& t) {
+    inline void Clone<T>::swap(Clone<T>& t) noexcept {
         this->ptr_.swap(t.ptr_);
     }
 
     template <class T>
-    inline void swap(Clone<T>& t, Clone<T>& u) {
+    inline void swap(Clone<T>& t, Clone<T>& u) noexcept {
         t.swap(u);
     }
 


### PR DESCRIPTION
Following C++ Core Guideline [F.6](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-noexcept), swap functions should be made `noexcept`.

Most of these functions were already implicitly `noexcept` because they are called from move constructors or move assignment operators that are marked `noexcept`, and now that has been made explicit.