### PR TITLE
Change boost::unordered_set to std::unordered_set

### DIFF
--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -43,6 +43,12 @@
 #include <boost/math/bindings/rr.hpp>
 #endif
 
+#if BOOST_VERSION < 106700
+#include <boost/functional/hash.hpp>
+#else
+#include <boost/container_hash/hash.hpp>
+#endif
+
 #include <boost/math/special_functions/erf.hpp>
 
 #include <unordered_map>

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -33,9 +33,23 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/patterns/singleton.hpp>
 #include <ql/shared_ptr.hpp>
 #include <ql/types.hpp>
-#include <boost/unordered_set.hpp>
 #include <unordered_set>
 #include <set>
+
+#if !defined(QL_USE_STD_SHARED_PTR) && BOOST_VERSION < 107400
+
+namespace std {
+
+    template<typename T>
+    struct hash<boost::shared_ptr<T>> {
+        std::size_t operator()(const boost::shared_ptr<T>& ptr) const noexcept {
+            return std::hash<typename boost::shared_ptr<T>::element_type*>()(ptr.get());
+        }
+    };
+
+}
+
+#endif
 
 #ifndef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
 
@@ -100,7 +114,7 @@ namespace QuantLib {
     /*! \ingroup patterns */
     class Observer { // NOLINT(cppcoreguidelines-special-member-functions)
       private:
-        typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
+        typedef std::unordered_set<ext::shared_ptr<Observable>> set_type;
       public:
         typedef set_type::iterator iterator;
 
@@ -263,7 +277,7 @@ namespace QuantLib {
         friend class Observable;
         friend class ObservableSettings;
       private:
-        typedef boost::unordered_set<ext::shared_ptr<Observable> > set_type;
+        typedef std::unordered_set<ext::shared_ptr<Observable>> set_type;
       public:
         typedef set_type::iterator iterator;
 
@@ -352,7 +366,7 @@ namespace QuantLib {
         friend class Observer;
         friend class ObservableSettings;
       private:
-        typedef boost::unordered_set<ext::shared_ptr<Observer::Proxy>> set_type;
+        typedef std::unordered_set<ext::shared_ptr<Observer::Proxy>> set_type;
       public:
         typedef set_type::iterator iterator;
 

--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -33,6 +33,12 @@
 #include <iomanip>
 #include <ctime>
 
+#if BOOST_VERSION < 106700
+#include <boost/functional/hash.hpp>
+#else
+#include <boost/container_hash/hash.hpp>
+#endif
+
 #if defined(BOOST_NO_STDC_NAMESPACE)
     namespace std { using ::time; using ::time_t; using ::tm;
                     using ::gmtime; using ::localtime; }


### PR DESCRIPTION
Follow up to https://github.com/lballabio/QuantLib/pull/1287#discussion_r780647564

- Added some includes that must have been previously pulled in through `boost/unordered_set.hpp`.
- Added a specialization for `std::hash` based on [the implemention in Boost](https://github.com/boostorg/smart_ptr/blob/bcb2566e744a0467a980c3648d9e92b7c8ccb2bf/include/boost/smart_ptr/shared_ptr.hpp#L1230-L1236).