### PR TITLE
Replace boost::hash with std::hash

### DIFF
--- a/ql/time/date.cpp
+++ b/ql/time/date.cpp
@@ -29,14 +29,16 @@
 #include <ql/errors.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/functional/hash.hpp>
+#include <functional>
 #include <iomanip>
 #include <ctime>
 
+#ifdef QL_HIGH_RESOLUTION_DATE
 #if BOOST_VERSION < 106700
 #include <boost/functional/hash.hpp>
 #else
 #include <boost/container_hash/hash.hpp>
+#endif
 #endif
 
 #if defined(BOOST_NO_STDC_NAMESPACE)
@@ -848,8 +850,7 @@ namespace QuantLib {
         boost::hash_combine(seed, d.dateTime().time_of_day().total_nanoseconds());
         return seed;
 #else
-
-        return boost::hash<Date::serial_type>()(d.serialNumber());
+        return std::hash<Date::serial_type>()(d.serialNumber());
 #endif
     }
 


### PR DESCRIPTION
1. Use `std::hash` instead of `boost::hash` on the underlying serial type.
2. Replace duped `boost/functional/hash.hpp` header with the one for `std::hash`.
3. Only pull in headers for `boost::hash_combine` when `QL_HIGH_RESOLUTION_DATE` is defined.