### PR TITLE
Added missing `#include <algorithm>` in `asianoption.cpp`

### DIFF
--- a/ql/instruments/asianoption.cpp
+++ b/ql/instruments/asianoption.cpp
@@ -21,6 +21,7 @@
 #include <ql/instruments/asianoption.hpp>
 #include <ql/time/date.hpp>
 #include <ql/settings.hpp>
+#include <algorithm>
 #include <utility>
 
 namespace QuantLib {


### PR DESCRIPTION
In some constellations the include in `ql/instruments/asianoption.cpp` does not work properly.

https://github.com/ralfkonrad/QuantLib/actions/runs/4841614333/jobs/8627997949#step:5:920
https://github.com/ralfkonrad/QuantLib/actions/runs/4830441525/jobs/8606675127#step:5:172