### PR TITLE
Use range-bound for loop with FdmLinearOpIterator

### DIFF
--- a/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
+++ b/ql/experimental/finitedifferences/fdmextendedornsteinuhlenbeckop.cpp
@@ -52,12 +52,8 @@ namespace QuantLib {
     void FdmExtendedOrnsteinUhlenbeckOp::setTime(Time t1, Time t2) {
         const Rate r = rTS_->forwardRate(t1, t2, Continuous).rate();
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        Array drift(layout->size());
-        for (FdmLinearOpIterator iter = layout->begin();
-             iter!=endIter; ++iter) {
+        Array drift(mesher_->layout()->size());
+        for (const auto& iter : *mesher_->layout()) {
             const Size i = iter.index();
             drift[i] = process_->drift(0.5*(t1+t2), x_[i]);
         }

--- a/ql/experimental/finitedifferences/fdmextoujumpop.cpp
+++ b/ql/experimental/finitedifferences/fdmextoujumpop.cpp
@@ -72,18 +72,12 @@ namespace QuantLib {
         integroPart_ = SparseMatrix(mesher_->layout()->size(),
                                     mesher_->layout()->size());
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
         Array yLoc(mesher_->layout()->dim()[1]);
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             yLoc[iter.coordinates()[1]] = mesher_->location(iter, 1);
         }
 
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
-
+        for (const auto& iter : *mesher_->layout()) {
             const Size diag = iter.index();
             integroPart_(diag, diag) -= lambda;
 
@@ -99,9 +93,9 @@ namespace QuantLib {
                                        yLoc.end()-1, ys) - yLoc.begin()-1;
 
                 const Real s = (ys-yLoc[l])/(yLoc[l+1]-yLoc[l]);
-                integroPart_(diag, layout->neighbourhood(iter, 1, l-yIndex))
+                integroPart_(diag, mesher_->layout()->neighbourhood(iter, 1, l-yIndex))
                     += weight*lambda*(1-s);
-                integroPart_(diag, layout->neighbourhood(iter, 1, l+1-yIndex))
+                integroPart_(diag, mesher_->layout()->neighbourhood(iter, 1, l+1-yIndex))
                     += weight*lambda*s;
             }
         }

--- a/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstepcondition.cpp
@@ -64,27 +64,24 @@ namespace QuantLib {
 
 
     void FdmVPPStepCondition::applyTo(Array& a, Time t) const {
-        ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
+        const Size nStates = mesher_->layout()->dim()[stateDirection_];
 
-        const Size nStates = layout->dim()[stateDirection_];
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter=layout->begin();iter != endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             a[iter.index()] += evolve(iter, t);
         }
 
-        for (FdmLinearOpIterator iter=layout->begin();iter != endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             if (iter.coordinates()[stateDirection_] == 0U) {
 
                 Array x(nStates);
                 for (Size i=0; i < nStates; ++i) {
-                    x[i] = a[layout->neighbourhood(iter, stateDirection_, i)];
+                    x[i] = a[mesher_->layout()->neighbourhood(iter, stateDirection_, i)];
                 }
 
                 const Real gasPrice = gasPrice_->innerValue(iter, t);
                 x = changeState(gasPrice, x, t);
                 for (Size i=0; i < nStates; ++i) {
-                    a[layout->neighbourhood(iter, stateDirection_, i)] = x[i];
+                    a[mesher_->layout()->neighbourhood(iter, stateDirection_, i)] = x[i];
                 }
             }
         }

--- a/ql/experimental/volatility/zabr.cpp
+++ b/ql/experimental/volatility/zabr.cpp
@@ -163,8 +163,7 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
 
     // initial values
     Array rhs(mesher->layout()->size());
-    for (FdmLinearOpIterator iter = layout->begin(); iter != layout->end();
-         ++iter) {
+    for (const auto& iter : *layout) {
         Real k = mesher->location(iter, 0);
         rhs[iter.index()] = std::max(forward_ - k, 0.0);
     }
@@ -275,8 +274,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     Array rhs(mesher->layout()->size());
     std::vector<Real> f_;
     std::vector<Real> v_;
-    for (FdmLinearOpIterator iter = layout->begin(); iter != layout->end();
-         ++iter) {
+    for (const auto& iter : *layout) {
         Real f = mesher->location(iter, 0);
         // Real v = mesher->location(iter, 0);
         rhs[iter.index()] = std::max(f - strike, 0.0);

--- a/ql/methods/finitedifferences/meshers/fdmmeshercomposite.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmmeshercomposite.cpp
@@ -101,9 +101,7 @@ namespace QuantLib {
     Array FdmMesherComposite::locations(Size direction) const {
         Array retVal(layout_->size());
 
-        const FdmLinearOpIterator endIter = layout_->end();
-        for (FdmLinearOpIterator iter = layout_->begin();
-             iter != endIter; ++iter) {
+        for (const auto& iter : *layout_) {
             retVal[iter.index()] =
                 mesher_[direction]->locations()[iter.coordinates()[direction]];
         }

--- a/ql/methods/finitedifferences/meshers/uniformgridmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/uniformgridmesher.cpp
@@ -48,9 +48,7 @@ namespace QuantLib {
     Array UniformGridMesher::locations(Size d) const {
         Array retVal(layout_->size());
 
-        const FdmLinearOpIterator endIter = layout_->end();
-        for (FdmLinearOpIterator iter = layout_->begin();
-            iter != endIter; ++iter) {
+        for (const auto& iter : *layout_) {
             retVal[iter.index()] = locations_[d][iter.coordinates()[d]];
         }
 

--- a/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdm2dblackscholesop.cpp
@@ -69,12 +69,8 @@ namespace QuantLib {
         opY_.setTime(t1, t2);
 
         if (localVol1_ != nullptr) {
-            const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-
-            Array vol1(layout->size()), vol2(layout->size());
-            for (FdmLinearOpIterator iter = layout->begin();
-                 iter!=endIter; ++iter) {
+            Array vol1(mesher_->layout()->size()), vol2(mesher_->layout()->size());
+            for (const auto& iter : *mesher_->layout()) {
                 const Size i = iter.index();
 
                 if (illegalLocalVolOverwrite_ < 0.0) {

--- a/ql/methods/finitedifferences/operators/fdmbatesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.cpp
@@ -87,16 +87,12 @@ namespace QuantLib {
     }
     
     Array FdmBatesOp::integro(const Array& r) const {
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        
-        QL_REQUIRE(layout->dim().size() == 2, "invalid layout dimension");
+        QL_REQUIRE(mesher_->layout()->dim().size() == 2, "invalid layout dimension");
 
-        Array x(layout->dim()[0]);
-        Matrix f(layout->dim()[1], layout->dim()[0]);
+        Array x(mesher_->layout()->dim()[0]);
+        Matrix f(mesher_->layout()->dim()[1], mesher_->layout()->dim()[0]);
         
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Size i = iter.coordinates()[0];
             const Size j = iter.coordinates()[1];
             
@@ -111,7 +107,7 @@ namespace QuantLib {
         }
         
         Array integral(r.size());
-        for (FdmLinearOpIterator iter=layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Size i = iter.coordinates()[0];
             const Size j = iter.coordinates()[1];
 

--- a/ql/methods/finitedifferences/operators/fdmblackscholesfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesfwdop.cpp
@@ -53,12 +53,8 @@ namespace QuantLib {
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
         if (localVol_ != nullptr) {
-            const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-
-            Array v(layout->size());
-            for (FdmLinearOpIterator iter = layout->begin();
-                iter != endIter; ++iter) {
+            Array v(mesher_->layout()->size());
+            for (const auto& iter : *mesher_->layout()) {
                 const Size i = iter.index();
 
                 if (illegalLocalVolOverwrite_ < 0.0) {

--- a/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmblackscholesop.cpp
@@ -53,12 +53,8 @@ namespace QuantLib {
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
         if (localVol_ != nullptr) {
-            const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-
-            Array v(layout->size());
-            for (FdmLinearOpIterator iter = layout->begin();
-                 iter!=endIter; ++iter) {
+            Array v(mesher_->layout()->size());
+            for (const auto& iter : *mesher_->layout()) {
                 const Size i = iter.index();
 
                 if (illegalLocalVolOverwrite_ < 0.0) {

--- a/ql/methods/finitedifferences/operators/fdmhestonfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonfwdop.cpp
@@ -61,9 +61,8 @@ namespace QuantLib {
               SecondOrderMixedDerivativeOp(0, 1, mesher)
                   .mult(rho_ * mixedSigma_ * mesher->locations(1)))),
       leverageFct_(std::move(leverageFct)), mesher_(mesher) {
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
         // zero flux boundary condition
-        const Size n = layout->dim()[1];
+        const Size n = mesher->layout()->dim()[1];
         const Real lowerBoundaryFactor = mapY_->lowerBoundaryFactor(type);
         const Real upperBoundaryFactor = mapY_->upperBoundaryFactor(type);
 
@@ -75,8 +74,7 @@ namespace QuantLib {
 
         ModTripleBandLinearOp fDx(FirstDerivativeOp(0, mesher));
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[1] == 0) {
                 const Size idx = iter.index();
                 if (!leverageFct_) {
@@ -193,8 +191,7 @@ namespace QuantLib {
     }
 
     Array FdmHestonFwdOp::getLeverageFctSlice(Time t1, Time t2) const {
-        const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-        Array v(layout->size(), 1.0);
+        Array v(mesher_->layout()->size(), 1.0);
 
         if (!leverageFct_)
             return v;
@@ -203,9 +200,7 @@ namespace QuantLib {
         const Time time = std::min(leverageFct_->maxTime(), t);
                                    //std::max(leverageFct_->minTime(), t));
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin();
-             iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Size nx = iter.coordinates()[0];
 
             if (iter.coordinates()[1] == 0) {

--- a/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonhullwhiteop.cpp
@@ -41,12 +41,9 @@ namespace QuantLib {
         // on the boundary s_min and s_max the second derivative
         // d²V/dS² is zero and due to Ito's Lemma the variance term
         // in the drift should vanish.
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             if (   iter.coordinates()[0] == 0
-                || iter.coordinates()[0] == layout->dim()[0]-1) {
+                || iter.coordinates()[0] == mesher_->layout()->dim()[0]-1) {
                 varianceValues_[iter.index()] = 0.0;
             }
         }

--- a/ql/methods/finitedifferences/operators/fdmhestonop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmhestonop.cpp
@@ -42,12 +42,9 @@ namespace QuantLib {
         // on the boundary s_min and s_max the second derivative
         // d^2V/dS^2 is zero and due to Ito's Lemma the variance term
         // in the drift should vanish.
-        ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             if (   iter.coordinates()[0] == 0
-                || iter.coordinates()[0] == layout->dim()[0]-1) {
+                || iter.coordinates()[0] == mesher_->layout()->dim()[0]-1) {
                 varianceValues_[iter.index()] = 0.0;
             }
         }
@@ -74,8 +71,7 @@ namespace QuantLib {
 
     Array FdmHestonEquityPart::getLeverageFctSlice(Time t1, Time t2) const {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-        Array v(layout->size(), 1.0);
+        Array v(mesher_->layout()->size(), 1.0);
 
         if (!leverageFct_) {
             return v;
@@ -83,9 +79,7 @@ namespace QuantLib {
         const Real t = 0.5*(t1+t2);
         const Time time = std::min(leverageFct_->maxTime(), t);
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin();
-             iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Size nx = iter.coordinates()[0];
 
             if (iter.coordinates()[1] == 0) {

--- a/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmlocalvolfwdop.cpp
@@ -42,12 +42,8 @@ namespace QuantLib {
         const Rate r = rTS_->forwardRate(t1, t2, Continuous).rate();
         const Rate q = qTS_->forwardRate(t1, t2, Continuous).rate();
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        Array v(layout->size());
-        for (FdmLinearOpIterator iter = layout->begin();
-            iter != endIter; ++iter) {
+        Array v(mesher_->layout()->size());
+        for (const auto& iter : *mesher_->layout()) {
             const Size i = iter.index();
 
             v[i] = squared(localVol_->localVol(0.5*(t1+t2), x_[i], true));

--- a/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmornsteinuhlenbeckop.cpp
@@ -39,13 +39,10 @@ namespace QuantLib {
     : mesher_(mesher), process_(std::move(process)), rTS_(std::move(rTS)), direction_(direction),
       m_(direction, mesher), mapX_(direction, mesher) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-
-        Array drift(layout->size());
+        Array drift(mesher_->layout()->size());
         const Array x(mesher_->locations(direction));
 
-        for (FdmLinearOpIterator iter=layout->begin(), endIter=layout->end();
-             iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Size i = iter.index();
             drift[i] = process_->drift(0.0, x[i]);
         }

--- a/ql/methods/finitedifferences/operators/fdmsquarerootfwdop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmsquarerootfwdop.cpp
@@ -65,9 +65,7 @@ namespace QuantLib {
             ),
       v_  (mesher->layout()->dim()[direction_]) {
 
-        const FdmLinearOpIterator endIter = mesher->layout()->end();
-        for (FdmLinearOpIterator iter = mesher->layout()->begin();
-            iter != endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Real v = mesher->location(iter, direction_);
             v_[iter.coordinates()[direction_]] = v;
         }
@@ -88,9 +86,7 @@ namespace QuantLib {
         const Real b = -(h(n-1)+h(n))/zeta(n);
         const Real c =  h(n-1)/zetap(n);
 
-        const FdmLinearOpIterator endIter = mesher->layout()->end();
-        for (FdmLinearOpIterator iter = mesher->layout()->begin();
-            iter != endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[direction_] == 0) {
                 const Size idx = iter.index();
                 mapX_->diag(idx)  = beta  + f*b; //*v(n-1);
@@ -110,9 +106,7 @@ namespace QuantLib {
         const Real b = (h(n)+h(n-1))/zeta(n);
         const Real c = -h(n)/zetam(n);
 
-        const FdmLinearOpIterator endIter = mesher->layout()->end();
-        for (FdmLinearOpIterator iter = mesher->layout()->begin();
-            iter != endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[direction_] == n-1) {
                 const Size idx = iter.index();
                 mapX_->diag(idx) = beta   + f*b; //*v(n+1);

--- a/ql/methods/finitedifferences/operators/firstderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/firstderivativeop.cpp
@@ -30,10 +30,7 @@ namespace QuantLib {
                                 const ext::shared_ptr<FdmMesher>& mesher)
     : TripleBandLinearOp(direction, mesher) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size i = iter.index();
             const Real hm = mesher->dminus(iter, direction_);
             const Real hp = mesher->dplus(iter, direction_);
@@ -48,7 +45,7 @@ namespace QuantLib {
                 diag_[i]  = -(upper_[i] = 1/hp);
             }
             else if (   iter.coordinates()[direction_]
-                     == layout->dim()[direction]-1) {
+                     == mesher->layout()->dim()[direction]-1) {
                  // downwinding scheme
                 lower_[i] = -(diag_[i] = 1/hm);
                 upper_[i] = 0.0;

--- a/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/ninepointlinearop.cpp
@@ -53,20 +53,17 @@ namespace QuantLib {
             && d1_ < mesher->layout()->dim().size(),
             "inconsistent derivative directions");
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size i = iter.index();
 
-            i10_[i] = layout->neighbourhood(iter, d1_, -1);
-            i01_[i] = layout->neighbourhood(iter, d0_, -1);
-            i21_[i] = layout->neighbourhood(iter, d0_,  1);
-            i12_[i] = layout->neighbourhood(iter, d1_,  1);
-            i00_[i] = layout->neighbourhood(iter, d0_, -1, d1_, -1);
-            i20_[i] = layout->neighbourhood(iter, d0_,  1, d1_, -1);
-            i02_[i] = layout->neighbourhood(iter, d0_, -1, d1_,  1);
-            i22_[i] = layout->neighbourhood(iter, d0_,  1, d1_,  1);
+            i10_[i] = mesher->layout()->neighbourhood(iter, d1_, -1);
+            i01_[i] = mesher->layout()->neighbourhood(iter, d0_, -1);
+            i21_[i] = mesher->layout()->neighbourhood(iter, d0_,  1);
+            i12_[i] = mesher->layout()->neighbourhood(iter, d1_,  1);
+            i00_[i] = mesher->layout()->neighbourhood(iter, d0_, -1, d1_, -1);
+            i20_[i] = mesher->layout()->neighbourhood(iter, d0_,  1, d1_, -1);
+            i02_[i] = mesher->layout()->neighbourhood(iter, d0_, -1, d1_,  1);
+            i22_[i] = mesher->layout()->neighbourhood(iter, d0_,  1, d1_,  1);
         }
     }
 
@@ -112,9 +109,8 @@ namespace QuantLib {
 
     Array NinePointLinearOp::apply(const Array& u) const {
 
-        const ext::shared_ptr<FdmLinearOpLayout> index=mesher_->layout();
-        QL_REQUIRE(u.size() == index->size(),"inconsistent length of r "
-                    << u.size() << " vs " << index->size());
+        QL_REQUIRE(u.size() == mesher_->layout()->size(),"inconsistent length of r "
+                    << u.size() << " vs " << mesher_->layout()->size());
 
         Array retVal(u.size());
         // direct access to make the following code faster.
@@ -141,11 +137,10 @@ namespace QuantLib {
     }
 
     SparseMatrix NinePointLinearOp::toMatrix() const {
-        const ext::shared_ptr<FdmLinearOpLayout> index = mesher_->layout();
-        const Size n = index->size();
+        const Size n = mesher_->layout()->size();
 
         SparseMatrix retVal(n, n, 9*n);
-        for (Size i=0; i < index->size(); ++i) {
+        for (Size i=0; i < mesher_->layout()->size(); ++i) {
             retVal(i, i00_[i]) += a00_[i];
             retVal(i, i01_[i]) += a01_[i];
             retVal(i, i02_[i]) += a02_[i];

--- a/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/nthorderderivativeop.cpp
@@ -37,14 +37,11 @@ namespace QuantLib {
         const Integer hPoints = nPoints/2;
         const bool isEven = (nPoints == 2*hPoints);
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
         Array xValues = mesher->locations(direction);
         std::set<Real> tmp(xValues.begin(), xValues.end());
         xValues = Array(tmp.begin(), tmp.end()); //unique vector
 
-        const Integer nx(layout->dim()[direction]);
+        const Integer nx(mesher->layout()->dim()[direction]);
 
         QL_REQUIRE(Integer(xValues.size()) == nx,
             "inconsistent set of grid values in direction " << direction);
@@ -55,7 +52,7 @@ namespace QuantLib {
         Array xOffsets(nPoints);
         const ext::function<Real(Real)> emptyFct;
 
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const auto ix = Integer(iter.coordinates()[direction]);
             const Integer offset = std::max(0, hPoints - ix)
                 - std::max(0, hPoints - (nx-((isEven)? 0 : 1) - ix));
@@ -72,7 +69,7 @@ namespace QuantLib {
 
             const Size i = iter.index();
             for (Integer j=0; j < nPoints; ++j) {
-                const Size k = layout->neighbourhood(iter, direction, ilx - ix + j);
+                const Size k = mesher->layout()->neighbourhood(iter, direction, ilx - ix + j);
 
                 m_(i, k) = weights[j];
             }

--- a/ql/methods/finitedifferences/operators/secondderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/secondderivativeop.cpp
@@ -30,10 +30,7 @@ namespace QuantLib {
         const ext::shared_ptr<FdmMesher>& mesher)
     : TripleBandLinearOp(direction, mesher) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size i = iter.index();
             const Real hm = mesher->dminus(iter, direction_);
             const Real hp = mesher->dplus(iter, direction_);
@@ -43,7 +40,7 @@ namespace QuantLib {
             const Real zetap1 = hp*(hm+hp);
 
             const Size co = iter.coordinates()[direction_];
-            if (co == 0 || co == layout->dim()[direction]-1) {
+            if (co == 0 || co == mesher->layout()->dim()[direction]-1) {
                 lower_[i] = diag_[i] = upper_[i] = 0.0;
             }
             else {

--- a/ql/methods/finitedifferences/operators/secondordermixedderivativeop.cpp
+++ b/ql/methods/finitedifferences/operators/secondordermixedderivativeop.cpp
@@ -28,10 +28,7 @@ namespace QuantLib {
         const ext::shared_ptr<FdmMesher>& mesher)
     : NinePointLinearOp(d0, d1, mesher) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size i = iter.index();
             const Real hm_d0 = mesher->dminus(iter, d0_);
             const Real hp_d0 = mesher->dplus(iter, d0_);
@@ -52,17 +49,17 @@ namespace QuantLib {
                 a00_[i] = a01_[i] = a02_[i] = a10_[i] = a20_[i] = 0.0;
                 a21_[i] = a12_[i] = -(a11_[i] = a22_[i] = 1.0/(hp_d0*hp_d1));
             }
-            else if (c0 == layout->dim()[d0_]-1 && c1 == 0) {
+            else if (c0 == mesher->layout()->dim()[d0_]-1 && c1 == 0) {
                 // upper left corner
                 a22_[i] = a21_[i] = a20_[i] = a10_[i] = a00_[i] = 0.0;
                 a11_[i] = a02_[i] = -(a01_[i] = a12_[i] = 1.0/(hm_d0*hp_d1));
             }
-            else if (c0 == 0 && c1 == layout->dim()[d1_]-1) {
+            else if (c0 == 0 && c1 == mesher->layout()->dim()[d1_]-1) {
                 // lower right corner
                 a00_[i] = a01_[i] = a02_[i] = a12_[i] = a22_[i] = 0.0;
                 a20_[i] = a11_[i] = -(a10_[i] = a21_[i] = 1.0/(hp_d0*hm_d1));
             }
-            else if (c0 == layout->dim()[d0_]-1 && c1 == layout->dim()[d1_]-1) {
+            else if (c0 == mesher->layout()->dim()[d0_]-1 && c1 == mesher->layout()->dim()[d1_]-1) {
                 // upper right corner
                 a20_[i] = a21_[i] = a22_[i] = a12_[i] = a02_[i] = 0.0;
                 a10_[i] = a01_[i] = -(a00_[i] = a11_[i] = 1.0/(hm_d0*hm_d1));
@@ -75,7 +72,7 @@ namespace QuantLib {
                 a11_[i] = -(a21_[i] = (hp_d1-hm_d1)/(hp_d0*phi0));
                 a12_[i] = -(a22_[i] = hm_d1/(hp_d0*phip1));
             }
-            else if (c0 == layout->dim()[d0_]-1) {
+            else if (c0 == mesher->layout()->dim()[d0_]-1) {
                 // upper side
                 a20_[i] = a21_[i] = a22_[i] = 0.0;
 
@@ -91,7 +88,7 @@ namespace QuantLib {
                 a11_[i] = -(a12_[i] = (hp_d0-hm_d0)/(zeta0*hp_d1));
                 a21_[i] = -(a22_[i] = hm_d0/(zetap1*hp_d1));
             }
-            else if (c1 == layout->dim()[d1_]-1) {
+            else if (c1 == mesher->layout()->dim()[d1_]-1) {
                 // right side
                 a22_[i] = a12_[i] = a02_[i] = 0.0;
 

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -39,19 +39,16 @@ namespace QuantLib {
       upper_    (new Real[mesher->layout()->size()]),
       mesher_(mesher) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
-        std::vector<Size> newDim(layout->dim());
+        std::vector<Size> newDim(mesher->layout()->dim());
         std::iter_swap(newDim.begin(), newDim.begin()+direction_);
         std::vector<Size> newSpacing = FdmLinearOpLayout(newDim).spacing();
         std::iter_swap(newSpacing.begin(), newSpacing.begin()+direction_);
 
-        for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size i = iter.index();
 
-            i0_[i] = layout->neighbourhood(iter, direction, -1);
-            i2_[i] = layout->neighbourhood(iter, direction,  1);
+            i0_[i] = mesher->layout()->neighbourhood(iter, direction, -1);
+            i2_[i] = mesher->layout()->neighbourhood(iter, direction,  1);
 
             const std::vector<Size>& coordinates = iter.coordinates();
             const Size newIndex =
@@ -192,8 +189,7 @@ namespace QuantLib {
     }
 
     TripleBandLinearOp TripleBandLinearOp::multR(const Array& u) const {
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        const Size size = layout->size();
+        const Size size = mesher_->layout()->size();
         QL_REQUIRE(u.size() == size, "inconsistent size of rhs");
         TripleBandLinearOp retVal(direction_, mesher_);
 
@@ -226,9 +222,7 @@ namespace QuantLib {
     }
 
     Array TripleBandLinearOp::apply(const Array& r) const {
-        const ext::shared_ptr<FdmLinearOpLayout> index = mesher_->layout();
-
-        QL_REQUIRE(r.size() == index->size(), "inconsistent length of r");
+        QL_REQUIRE(r.size() == mesher_->layout()->size(), "inconsistent length of r");
 
         const Real* lptr = lower_.get();
         const Real* dptr = diag_.get();
@@ -238,7 +232,7 @@ namespace QuantLib {
 
         array_type retVal(r.size());
         //#pragma omp parallel for
-        for (Size i=0; i < index->size(); ++i) {
+        for (Size i=0; i < mesher_->layout()->size(); ++i) {
             retVal[i] = r[i0ptr[i]]*lptr[i]+r[i]*dptr[i]+r[i2ptr[i]]*uptr[i];
         }
 
@@ -246,8 +240,7 @@ namespace QuantLib {
     }
 
     SparseMatrix TripleBandLinearOp::toMatrix() const {
-        const ext::shared_ptr<FdmLinearOpLayout> index = mesher_->layout();
-        const Size n = index->size();
+        const Size n = mesher_->layout()->size();
 
         SparseMatrix retVal(n, n, 3*n);
         for (Size i=0; i < n; ++i) {
@@ -261,16 +254,14 @@ namespace QuantLib {
 
 
     Array TripleBandLinearOp::solve_splitting(const Array& r, Real a, Real b) const {
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        QL_REQUIRE(r.size() == layout->size(), "inconsistent size of rhs");
+        QL_REQUIRE(r.size() == mesher_->layout()->size(), "inconsistent size of rhs");
 
 #ifdef QL_EXTRA_SAFETY_CHECKS
-        for (FdmLinearOpIterator iter = layout->begin();
-             iter!=layout->end(); ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const std::vector<Size>& coordinates = iter.coordinates();
             QL_REQUIRE(   coordinates[direction_] != 0
                        || lower_[iter.index()] == 0,"removing non zero entry!");
-            QL_REQUIRE(   coordinates[direction_] != layout->dim()[direction_]-1
+            QL_REQUIRE(   coordinates[direction_] != mesher_->layout()->dim()[direction_]-1
                        || upper_[iter.index()] == 0,"removing non zero entry!");
         }
 #endif
@@ -289,7 +280,7 @@ namespace QuantLib {
         QL_REQUIRE(bet != 0.0, "division by zero");
         retVal[reverseIndex_[0]] = r[rim1]*bet;
 
-        for (Size j=1; j<=layout->size()-1; j++){
+        for (Size j=1; j<=mesher_->layout()->size()-1; j++){
             const Size ri = reverseIndex_[j];
             tmp[j] = a*uptr[rim1]*bet;
 
@@ -301,7 +292,7 @@ namespace QuantLib {
             rim1 = ri;
         }
         // cannot be j>=0 with Size j
-        for (Size j=layout->size()-2; j>0; --j)
+        for (Size j=mesher_->layout()->size()-2; j>0; --j)
             retVal[reverseIndex_[j]] -= tmp[j+1]*retVal[reverseIndex_[j+1]];
         retVal[reverseIndex_[0]] -= tmp[1]*retVal[reverseIndex_[1]];
 

--- a/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm1dimsolver.cpp
@@ -42,16 +42,11 @@ namespace QuantLib {
       x_(solverDesc.mesher->layout()->size()), initialValues_(solverDesc.mesher->layout()->size()),
       resultValues_(solverDesc.mesher->layout()->size()) {
 
-        const ext::shared_ptr<FdmMesher> mesher = solverDesc.mesher;
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *solverDesc.mesher->layout()) {
             initialValues_[iter.index()]
                  = solverDesc_.calculator->avgInnerValue(iter,
                                                          solverDesc.maturity);
-            x_[iter.index()] = mesher->location(iter, 0);
+            x_[iter.index()] = solverDesc.mesher->location(iter, 0);
         }
     }
 

--- a/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm2dimsolver.cpp
@@ -42,24 +42,19 @@ namespace QuantLib {
       initialValues_(solverDesc.mesher->layout()->size()),
       resultValues_(solverDesc.mesher->layout()->dim()[1], solverDesc.mesher->layout()->dim()[0]) {
 
-        const ext::shared_ptr<FdmMesher> mesher = solverDesc.mesher;
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
+        x_.reserve(solverDesc.mesher->layout()->dim()[0]);
+        y_.reserve(solverDesc.mesher->layout()->dim()[1]);
 
-        x_.reserve(layout->dim()[0]);
-        y_.reserve(layout->dim()[1]);
-
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *solverDesc.mesher->layout()) {
             initialValues_[iter.index()]
                  = solverDesc_.calculator->avgInnerValue(iter,
                                                          solverDesc.maturity);
 
             if (iter.coordinates()[1] == 0U) {
-                x_.push_back(mesher->location(iter, 0));
+                x_.push_back(solverDesc.mesher->location(iter, 0));
             }
             if (iter.coordinates()[0] == 0U) {
-                y_.push_back(mesher->location(iter, 1));
+                y_.push_back(solverDesc.mesher->location(iter, 1));
             }
         }
     }

--- a/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdm3dimsolver.cpp
@@ -46,29 +46,24 @@ namespace QuantLib {
           Matrix(solverDesc.mesher->layout()->dim()[1], solverDesc.mesher->layout()->dim()[0])),
       interpolation_(solverDesc.mesher->layout()->dim()[2]) {
 
-        const ext::shared_ptr<FdmMesher> mesher = solverDesc.mesher;
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
+        x_.reserve(solverDesc.mesher->layout()->dim()[0]);
+        y_.reserve(solverDesc.mesher->layout()->dim()[1]);
+        z_.reserve(solverDesc.mesher->layout()->dim()[2]);
 
-        x_.reserve(layout->dim()[0]);
-        y_.reserve(layout->dim()[1]);
-        z_.reserve(layout->dim()[2]);
-
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *solverDesc.mesher->layout()) {
             initialValues_[iter.index()]
                = solverDesc.calculator->avgInnerValue(iter,
                                                       solverDesc.maturity);
 
 
             if ((iter.coordinates()[1] == 0U) && (iter.coordinates()[2] == 0U)) {
-                x_.push_back(mesher->location(iter, 0));
+                x_.push_back(solverDesc.mesher->location(iter, 0));
             }
             if ((iter.coordinates()[0] == 0U) && (iter.coordinates()[2] == 0U)) {
-                y_.push_back(mesher->location(iter, 1));
+                y_.push_back(solverDesc.mesher->location(iter, 1));
             }
             if ((iter.coordinates()[0] == 0U) && (iter.coordinates()[1] == 0U)) {
-                z_.push_back(mesher->location(iter, 2));
+                z_.push_back(solverDesc.mesher->location(iter, 2));
             }
         }
     }

--- a/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
+++ b/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
@@ -87,27 +87,21 @@ namespace QuantLib {
       initialValues_(solverDesc.mesher->layout()->size()),
       extrapolation_(std::vector<bool>(N, false)) {
 
-        const ext::shared_ptr<FdmMesher> mesher = solverDesc.mesher;
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-
-        QL_REQUIRE(layout->dim().size() == N, "solver dim " << N
-                    << "does not fit to layout dim " << layout->size());
+        QL_REQUIRE(solverDesc.mesher->layout()->dim().size() == N, "solver dim " << N
+                    << "does not fit to layout dim " << solverDesc.mesher->layout()->size());
 
         for (Size i=0; i < N; ++i) {
-            x_[i].reserve(layout->dim()[i]);
+            x_[i].reserve(solverDesc.mesher->layout()->dim()[i]);
         }
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
-
+        for (const auto& iter : *solverDesc.mesher->layout()) {
             initialValues_[iter.index()] = solverDesc_.calculator
                                 ->avgInnerValue(iter, solverDesc.maturity);
 
             const std::vector<Size>& c = iter.coordinates();
             for (Size i=0; i < N; ++i) {
                 if ((std::accumulate(c.begin(), c.end(), 0UL) - c[i]) == 0U) {
-                    x_[i].push_back(mesher->location(iter, i));
+                    x_[i].push_back(solverDesc.mesher->location(iter, i));
                 }
             }
         }
@@ -125,12 +119,7 @@ namespace QuantLib {
                  .rollback(rhs, solverDesc_.maturity, 0.0,
                            solverDesc_.timeSteps, solverDesc_.dampingSteps);
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout
-                                               = solverDesc_.mesher->layout();
-
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *solverDesc_.mesher->layout()) {
             setValue(*f_, iter.coordinates(), rhs[iter.index()]);
         }
 
@@ -146,14 +135,10 @@ namespace QuantLib {
 
         calculate();
         const Array& rhs = thetaCondition_->getValues();
-        const ext::shared_ptr<FdmLinearOpLayout> layout
-                                            = solverDesc_.mesher->layout();
 
         data_table f(x_);
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *solverDesc_.mesher->layout()) {
             setValue(f, iter.coordinates(), rhs[iter.index()]);
         }
 

--- a/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.cpp
@@ -30,15 +30,10 @@ namespace QuantLib {
     : mesher_(std::move(mesher)), calculator_(std::move(calculator)) {}
 
     void FdmAmericanStepCondition::applyTo(Array& a, Time t) const {
-        ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-
-        QL_REQUIRE(layout->size() == a.size(),
+        QL_REQUIRE(mesher_->layout()->size() == a.size(),
                    "inconsistent array dimensions");
 
-        const FdmLinearOpIterator endIter = layout->end();
-
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Real innerValue = calculator_->innerValue(iter, t);
             if (innerValue > a[iter.index()]) {
                 a[iter.index()] = innerValue;

--- a/ql/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmbermudanstepcondition.cpp
@@ -46,18 +46,13 @@ namespace QuantLib {
         if (std::find(exerciseTimes_.begin(), exerciseTimes_.end(), t) 
               != exerciseTimes_.end()) {
             
-            ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-
-            QL_REQUIRE(layout->size() == a.size(),
+            QL_REQUIRE(mesher_->layout()->size() == a.size(),
                        "inconsistent array dimensions");
 
-            const FdmLinearOpIterator endIter = layout->end();
-
-            const Size dims = layout->dim().size();
+            const Size dims = mesher_->layout()->dim().size();
             Array locations(dims);
 
-            for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-                ++iter) {
+            for (const auto& iter : *mesher_->layout()) {
                 for (Size i=0; i < dims; ++i)
                     locations[i] = mesher_->location(iter, i);
 

--- a/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
@@ -33,14 +33,10 @@ namespace QuantLib {
     : exerciseTimes_(std::move(exerciseTimes)), mesher_(std::move(mesher)),
       calculator_(std::move(calculator)), changeRate_(changeRate) {
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
+        x_.reserve(mesher_->layout()->dim()[0]);
+        y_.reserve(mesher_->layout()->dim()[1]);
 
-        x_.reserve(layout->dim()[0]);
-        y_.reserve(layout->dim()[1]);
-
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-             ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             if (iter.coordinates()[1] == 0U) {
                 x_.push_back(mesher_->location(iter, 0));
             }
@@ -62,16 +58,10 @@ namespace QuantLib {
             BilinearInterpolation interpl(x_.begin(), x_.end(),
                                           y_.begin(), y_.end(), m);
 
-            const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-
-            QL_REQUIRE(layout->size() == a.size(),
+            QL_REQUIRE(mesher_->layout()->size() == a.size(),
                        "inconsistent array dimensions");
 
-            const FdmLinearOpIterator endIter = layout->end();
-
-            for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-                 ++iter) {
-
+            for (const auto& iter : *mesher_->layout()) {
                 const std::vector<Size>& coor = iter.coordinates();
                 const Real x = x_[coor[0]];
                 const Real y = y_[coor[1]];

--- a/ql/methods/finitedifferences/stepconditions/fdmsimpleswingcondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmsimpleswingcondition.cpp
@@ -44,15 +44,10 @@ namespace QuantLib {
 
             const Size d = std::distance(iter, exerciseTimes_.end());
 
-            const ext::shared_ptr<FdmLinearOpLayout> layout=mesher_->layout();
-
-            QL_REQUIRE(layout->size() == a.size(),
+            QL_REQUIRE(mesher_->layout()->size() == a.size(),
                        "inconsistent array dimensions");
 
-            const FdmLinearOpIterator endIter = layout->end();
-            
-            for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-                 ++iter) {
+            for (const auto& iter : *mesher_->layout()) {
                 
                 const std::vector<Size>& coor = iter.coordinates();
                 
@@ -62,7 +57,7 @@ namespace QuantLib {
                     const Real cashflow = calculator_->innerValue(iter, t);
                     const Real currentValue = a[iter.index()];
                     const Real valuePlusOneExercise
-                         = a[layout->neighbourhood(iter, swingDirection_, 1)];
+                         = a[mesher_->layout()->neighbourhood(iter, swingDirection_, 1)];
                     
                     if (   currentValue < valuePlusOneExercise + cashflow
                         || exercisesUsed + d <=  minExercises_) {

--- a/ql/methods/finitedifferences/utilities/fdmhestongreensfct.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmhestongreensfct.cpp
@@ -52,12 +52,8 @@ namespace QuantLib {
         const Real kappa = process_->kappa();
         const Real sigma = process_->sigma();
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-        const FdmLinearOpIterator endIter = layout->end();
-
         Array p(mesher_->layout()->size());
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *mesher_->layout()) {
             const Real x = mesher_->location(iter, 0);
             const Real v = (trafoType_ != FdmSquareRootFwdOp::Log)
                 ? mesher_->location(iter, 1)

--- a/ql/methods/finitedifferences/utilities/fdmindicesonboundary.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmindicesonboundary.cpp
@@ -35,9 +35,7 @@ namespace QuantLib {
         indices_.resize(hyperSize);
 
         Size i=0;
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-            ++iter) {
+        for (const auto& iter : *layout) {
             if (   (   side == FdmDirichletBoundary::Lower
                     && iter.coordinates()[direction] == 0)
                 || (   side == FdmDirichletBoundary::Upper

--- a/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/fdminnervaluecalculator.cpp
@@ -66,10 +66,7 @@ namespace QuantLib {
             avgInnerValues_.resize(mesher_->layout()->dim()[direction_]);
             std::deque<bool> initialized(avgInnerValues_.size(), false);
 
-            const ext::shared_ptr<FdmLinearOpLayout> layout =
-                mesher_->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-            for (FdmLinearOpIterator i = layout->begin(); i != endIter; ++i) {
+            for (const auto& i : *mesher_->layout()) {
                 const Size xn = i.coordinates()[direction_];
                 if (!initialized[xn]) {
                     initialized[xn]     = true;

--- a/ql/models/equity/hestonslvfdmmodel.cpp
+++ b/ql/models/equity/hestonslvfdmmodel.cpp
@@ -134,9 +134,7 @@ namespace QuantLib {
             }
             else {
                 Array tp(p.size());
-                const FdmLinearOpIterator end = mesher->layout()->end();
-                for (FdmLinearOpIterator iter = mesher->layout()->begin();
-                    iter != end; ++iter) {
+                for (const auto& iter : *mesher->layout()) {
                     const Size idx = iter.index();
                     const Real nu = mesher->location(iter, 1);
 
@@ -165,16 +163,11 @@ namespace QuantLib {
             const ext::shared_ptr<FdmMesherComposite>& newMesher,
             const Interpolator& interp = Interpolator()) {
 
-            const ext::shared_ptr<FdmLinearOpLayout> oldLayout
-                = oldMesher->layout();
-            const ext::shared_ptr<FdmLinearOpLayout> newLayout
-                = newMesher->layout();
-
-            QL_REQUIRE(   oldLayout->size() == newLayout->size()
-                       && oldLayout->size() == p.size(),
+            QL_REQUIRE(   oldMesher->layout()->size() == newMesher->layout()->size()
+                       && oldMesher->layout()->size() == p.size(),
                        "inconsistent mesher or vector size given");
 
-            Matrix m(oldLayout->dim()[1], oldLayout->dim()[0]);
+            Matrix m(oldMesher->layout()->dim()[1], oldMesher->layout()->dim()[0]);
             for (Size i=0; i < m.rows(); ++i) {
                 std::copy(p.begin() + i*m.columns(),
                           p.begin() + (i+1)*m.columns(), m.row_begin(i));
@@ -186,9 +179,7 @@ namespace QuantLib {
                 oldMesher->getFdm1dMeshers()[1]->locations().end(), m);
 
             Array pNew(p.size());
-            const FdmLinearOpIterator endIter = newLayout->end();
-            for (FdmLinearOpIterator iter = newLayout->begin();
-                iter != endIter; ++iter) {
+            for (const auto& iter : *newMesher->layout()) {
                 const Real x = newMesher->location(iter, 0);
                 const Real v = newMesher->location(iter, 1);
 

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -103,13 +103,8 @@ namespace QuantLib {
                 QL_FAIL("unknown interpolation type");
             }
 
-            const ext::shared_ptr<FdmLinearOpLayout> layout =
-                mesher_->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-
-            Array z(layout->size());
-            for (FdmLinearOpIterator iter = layout->begin();
-                 iter!=endIter; ++iter) {
+            Array z(mesher_->layout()->size());
+            for (const auto& iter : *mesher_->layout()) {
                 const Size i = iter.index();
                 const Real lnStrike = mesher_->location(iter, 0);
 

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -98,10 +98,7 @@ namespace {
             if (iter != exerciseTimes_.end()) {
                 Size index = std::distance(exerciseTimes_.begin(), iter);
 
-               ext::shared_ptr<FdmLinearOpLayout> layout = mesher_->layout();
-                const FdmLinearOpIterator endIter = layout->end();
-                for (FdmLinearOpIterator iter = layout->begin();
-                     iter != endIter; ++iter) {
+                for (const auto& iter : *mesher_->layout()) {
                     const Real s = std::exp(mesher_->location(iter, 0));
 
                     if (s > triggerLevels_[index]) {
@@ -249,16 +246,14 @@ void FdmLinearOpTest::testFirstDerivativesMapApply() {
     FirstDerivativeOp map(2, mesher);
 
     Array r(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = index->end();
-
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         r[iter.index()] =  std::sin(mesher->location(iter, 0))
                          + std::cos(mesher->location(iter, 2));
     }
 
     Array t = map.apply(r);
     const Real dz = (boundaries[2].second-boundaries[2].first)/(dim[2]-1);
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size z = iter.coordinates()[2];
 
         const Size z0 = (z > 0) ? z-1 : 1;
@@ -303,9 +298,7 @@ void FdmLinearOpTest::testSecondDerivativesMapApply() {
     ext::shared_ptr<FdmMesher> mesher(
                             new UniformGridMesher(index, boundaries));
     Array r(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = index->end();
-
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
         const Real z = mesher->location(iter, 2);
@@ -316,7 +309,7 @@ void FdmLinearOpTest::testSecondDerivativesMapApply() {
     Array t = SecondDerivativeOp(0, mesher).apply(r);
 
     const Real tol = 5e-2;
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -334,7 +327,7 @@ void FdmLinearOpTest::testSecondDerivativesMapApply() {
     }
 
     t = SecondDerivativeOp(1, mesher).apply(r);
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -352,7 +345,7 @@ void FdmLinearOpTest::testSecondDerivativesMapApply() {
     }
 
     t = SecondDerivativeOp(2, mesher).apply(r);
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -385,9 +378,6 @@ void FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids() {
     const ext::shared_ptr<FdmMesher> meshers(
         new FdmMesherComposite(mesherX, mesherY, mesherZ));
 
-    const ext::shared_ptr<FdmLinearOpLayout> layout = meshers->layout();
-    const FdmLinearOpIterator endIter = layout->end();
-
     const Real tol = 1e-13;
     for (Size direction=0; direction < 3; ++direction) {
 
@@ -398,13 +388,12 @@ void FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids() {
 
         const Array gridPoints = meshers->locations(direction);
 
-        for (FdmLinearOpIterator iter=layout->begin();
-            iter != endIter; ++iter) {
+        for (const auto& iter : *meshers->layout()) {
 
             const Size c = iter.coordinates()[direction];
             const Size index   = iter.index();
-            const Size indexM1 = layout->neighbourhood(iter,direction,-1);
-            const Size indexP1 = layout->neighbourhood(iter,direction,+1);
+            const Size indexM1 = meshers->layout()->neighbourhood(iter,direction,-1);
+            const Size indexP1 = meshers->layout()->neighbourhood(iter,direction,+1);
 
             // test only if not on the boundary
             if (c == 0) {
@@ -447,7 +436,7 @@ void FdmLinearOpTest::testDerivativeWeightsOnNonUniformGrids() {
                             << "\n calculated gamma: " << gamma2);
                 }
             }
-            else if (c == layout->dim()[direction]-1) {
+            else if (c == meshers->layout()->dim()[direction]-1) {
                 Array twoPoints(2);
                 twoPoints[0] = gridPoints.at(indexM1)-gridPoints.at(index);
                 twoPoints[1] = 0.0;
@@ -563,9 +552,8 @@ void FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply() {
         new UniformGridMesher(index, boundaries));
 
     Array r(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = index->end();
 
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
         const Real z = mesher->location(iter, 2);
@@ -577,7 +565,7 @@ void FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply() {
     Array u = SecondOrderMixedDerivativeOp(1, 0, mesher).apply(r);
 
     const Real tol = 5e-2;
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -599,7 +587,7 @@ void FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply() {
 
     t = SecondOrderMixedDerivativeOp(0, 2, mesher).apply(r);
     u = SecondOrderMixedDerivativeOp(2, 0, mesher).apply(r);
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -621,7 +609,7 @@ void FdmLinearOpTest::testSecondOrderMixedDerivativesMapApply() {
 
     t = SecondOrderMixedDerivativeOp(1, 2, mesher).apply(r);
     u = SecondOrderMixedDerivativeOp(2, 1, mesher).apply(r);
-    for (FdmLinearOpIterator iter = index->begin(); iter != endIter; ++iter) {
+    for (const auto& iter : *index) {
         const Size i = iter.index();
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
@@ -754,9 +742,7 @@ void FdmLinearOpTest::testFdmHestonBarrier() {
                                    new FdmHestonOp(mesher, hestonProcess));
 
     Array rhs(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = mesher->layout()->end();
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-         iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
         rhs[iter.index()]=std::max(std::exp(mesher->location(iter,0))-100, 0.0);
     }
 
@@ -776,8 +762,7 @@ void FdmLinearOpTest::testFdmHestonBarrier() {
             ret[i][j] = rhs[i+j*dim[0]];
 
     std::vector<Real> tx, ty;
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-        iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[1] == 0) {
                 tx.push_back(mesher->location(iter, 0));
             }
@@ -846,9 +831,7 @@ void FdmLinearOpTest::testFdmHestonAmerican() {
 
     ext::shared_ptr<Payoff> payoff(new PlainVanillaPayoff(Option::Put, 100.0));
     Array rhs(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = mesher->layout()->end();
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-        iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
             rhs[iter.index()]
                 = payoff->operator ()(std::exp(mesher->location(iter, 0)));
     }
@@ -867,8 +850,7 @@ void FdmLinearOpTest::testFdmHestonAmerican() {
             ret[i][j] = rhs[i+j*dim[0]];
 
     std::vector<Real> tx, ty;
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-        iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[1] == 0) {
                 tx.push_back(mesher->location(iter, 0));
             }
@@ -1104,9 +1086,7 @@ void FdmLinearOpTest::testFdmHestonHullWhiteOp() {
                                  jointProcess->eta()));
 
     Array rhs(mesher->layout()->size());
-    const FdmLinearOpIterator endIter = mesher->layout()->end();
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-        iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
             rhs[iter.index()] = desc.calculator->avgInnerValue(iter, maturity);
     }
 
@@ -1117,8 +1097,7 @@ void FdmLinearOpTest::testFdmHestonHullWhiteOp() {
     hsModel.rollback(rhs, maturity, 0.0, desc.timeSteps);
 
     std::vector<Real> tx, ty, tr, y;
-    for (FdmLinearOpIterator iter = mesher->layout()->begin();
-        iter != endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[1] == 0 && iter.coordinates()[2] == 0) {
                 tx.push_back(mesher->location(iter, 0));
             }
@@ -1382,10 +1361,8 @@ void FdmLinearOpTest::testCrankNicolsonWithDamping() {
                                   new FdmLogInnerValue(payoff, mesher, 0));
 
     Array rhs(layout->size()), x(layout->size());
-    const FdmLinearOpIterator endIter = layout->end();
 
-    for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-         ++iter) {
+    for (const auto& iter : *layout) {
         rhs[iter.index()] = calculator->avgInnerValue(iter, maturity);
         x[iter.index()] = mesher->location(iter, 0);
     }
@@ -1507,11 +1484,8 @@ void FdmLinearOpTest::testFdmMesherIntegral() {
             ext::shared_ptr<Fdm1dMesher>(new Concentrating1dMesher(
                 -2, 1, 5, std::pair<Real, Real>(0.5, 0.1)))));
 
-    const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-
     Array f(mesher->layout()->size());
-    for (FdmLinearOpIterator iter = layout->begin();
-        iter != layout->end(); ++iter) {
+    for (const auto& iter : *mesher->layout()) {
         const Real x = mesher->location(iter, 0);
         const Real y = mesher->location(iter, 1);
         const Real z = mesher->location(iter, 2);

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -638,14 +638,11 @@ namespace {
                        const ext::shared_ptr<FdmMesherComposite>& mesher) {
 
         std::vector<Real> x, y;
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
 
-        x.reserve(layout->dim()[0]);
-        y.reserve(layout->dim()[1]);
+        x.reserve(mesher->layout()->dim()[0]);
+        y.reserve(mesher->layout()->dim()[1]);
 
-        const FdmLinearOpIterator endIter = layout->end();
-        for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-              ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             if (iter.coordinates()[1] == 0U) {
                 x.push_back(mesher->location(iter, 0));
             }
@@ -809,7 +806,6 @@ namespace {
         Array p = FdmHestonGreensFct(mesher, process, testCase.trafoType)
                 .get(eT, testCase.greensAlgorithm);
 
-        const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
         const Real strikes[] = { 50, 80, 90, 100, 110, 120, 150, 200 };
 
         Time t=eT;
@@ -834,8 +830,7 @@ namespace {
                                                          strike));
 
                 Array pd(p.size());
-                for (FdmLinearOpIterator iter = layout->begin();
-                    iter != layout->end(); ++iter) {
+                for (const auto& iter : *mesher->layout()) {
                     const Size idx = iter.index();
                     const Real s = std::exp(mesher->location(iter, 0));
 
@@ -1125,9 +1120,7 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     const Real bsV0 = squared(lvProcess->blackVolatility()->blackVol(0.0, s0, true));
 
     SquareRootProcessRNDCalculator rndCalculator(v0, kappa, theta, sigma);
-    const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-    for (FdmLinearOpIterator iter = layout->begin(); iter != layout->end();
-         ++iter) {
+    for (const auto& iter : *mesher->layout()) {
         const Real x = mesher->location(iter, 0);
         if (v != mesher->location(iter, 1)) {
             v = mesher->location(iter, 1);
@@ -1192,8 +1185,7 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
 			ext::make_shared<CashOrNothingPayoff>(Option::Put, Real(strike), 1.0));
 
         Array pd(p.size());
-        for (FdmLinearOpIterator iter = layout->begin();
-            iter != layout->end(); ++iter) {
+        for (const auto& iter : *mesher->layout()) {
             const Size idx = iter.index();
             const Real s = std::exp(mesher->location(iter, 0));
 

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -251,10 +251,7 @@ void NthOrderDerivativeOpTest::testFirstOrder2PointsOn2DimUniformGrid() {
 
     const SparseMatrix m = NthOrderDerivativeOp(1, 1, 2, mesher).toMatrix();
 
-    const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-    const FdmLinearOpIterator endIter = layout->end();
-
-    for (FdmLinearOpIterator iter = layout->begin(); iter!=endIter; ++iter) {
+    for (const auto& iter : *mesher->layout()) {
         const Size i = iter.index();
         const Size ix = iter.coordinates()[1];
 
@@ -408,9 +405,7 @@ namespace {
             Array varianceValues(0.5*vv);
 
             ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-            FdmLinearOpIterator endIter = layout->end();
-            for (FdmLinearOpIterator iter = layout->begin(); iter != endIter;
-                ++iter) {
+            for (const auto& iter : *layout) {
                 if (   iter.coordinates()[0] == 0
                     || iter.coordinates()[0] == layout->dim()[0]-1) {
                     varianceValues[iter.index()] = 0.0;
@@ -611,14 +606,10 @@ namespace {
             const ext::shared_ptr<PlainVanillaPayoff> payoff =
                 ext::make_shared<PlainVanillaPayoff>(Option::Put, strike);
 
-            const ext::shared_ptr<FdmLinearOpLayout> layout = mesher->layout();
-            const FdmLinearOpIterator endIter = layout->end();
-
-            for (FdmLinearOpIterator iter = layout->begin();
-                 iter!=endIter; ++iter) {
+            for (const auto& iter : *mesher->layout()) {
                 const Size idx = iter.index();
-                const Size idxm1 = layout->neighbourhood(iter,  0,-1);
-                const Size idxp1 = layout->neighbourhood(iter,  0, 1);
+                const Size idxm1 = mesher->layout()->neighbourhood(iter,  0,-1);
+                const Size idxp1 = mesher->layout()->neighbourhood(iter,  0, 1);
 
                 const Size nx = iter.coordinates()[0];
 
@@ -658,7 +649,7 @@ namespace {
             const std::vector<Real>& v =
                 mesher->getFdm1dMeshers()[1]->locations();
 
-            Matrix resultValues_(layout->dim()[1], layout->dim()[0]);
+            Matrix resultValues_(mesher->layout()->dim()[1], mesher->layout()->dim()[0]);
             std::copy(rhs.begin(), rhs.end(), resultValues_.begin());
 
             const ext::shared_ptr<BicubicSpline> interpolation =
@@ -840,10 +831,8 @@ void NthOrderDerivativeOpTest::testCompareFirstDerivativeOp2dUniformGrid() {
     const ext::shared_ptr<FdmMesher> mc(
         ext::make_shared<FdmMesherComposite>(m1, m2));
 
-    const ext::shared_ptr<FdmLinearOpLayout> layout = mc->layout();
-
-    const Size n = layout->dim()[0];
-    const Size m = layout->dim()[1];
+    const Size n = mc->layout()->dim()[0];
+    const Size m = mc->layout()->dim()[1];
 
     SparseMatrix fm = FirstDerivativeOp(0, mc).toMatrix();
     SparseMatrix dm = NthOrderDerivativeOp(0, 1, 3, mc).toMatrix();


### PR DESCRIPTION
This approach has many advantages over the previous code, such as the following:

- Eliminate unnecessary variables
- Prevent needless increasing and decreasing of `shared_ptr` reference counts
- Much more clear and concise to read
- Enforces the correct begin and end iterators in the range