### PR TITLE
Fixing test macros for compatibility

### DIFF
--- a/test-suite/daycounters.cpp
+++ b/test-suite/daycounters.cpp
@@ -1240,12 +1240,12 @@ void DayCounterTest::testActualConsistency() {
             const Time t360incl = actual360incl.yearFraction(today, d);
             const Time t36525 = actual36525.yearFraction(today, d);
 
-            BOOST_CHECK_SMALL(t365*365/366.0 - t366, 1e-14);
-            BOOST_CHECK_SMALL(t365*365/364.0 - t364, 1e-14);
-            BOOST_CHECK_SMALL(t365*365/360.0 - t360, 1e-14);
-            BOOST_CHECK_SMALL(t365*365/364.0 - t364, 1e-14);
-            BOOST_CHECK_SMALL(t365*365/365.25 - t36525, 1e-14);
-            BOOST_CHECK_SMALL(t365*365/360.0 - (t360incl*360-1)/360, 1e-14);
+            QL_CHECK_SMALL(t365*365/366.0 - t366, 1e-14);
+            QL_CHECK_SMALL(t365*365/364.0 - t364, 1e-14);
+            QL_CHECK_SMALL(t365*365/360.0 - t360, 1e-14);
+            QL_CHECK_SMALL(t365*365/364.0 - t364, 1e-14);
+            QL_CHECK_SMALL(t365*365/365.25 - t36525, 1e-14);
+            QL_CHECK_SMALL(t365*365/360.0 - (t360incl*360-1)/360, 1e-14);
         }
 }
 


### PR DESCRIPTION
This replaces `BOOST_CHECK_SMALL` with `QL_CHECK_SMALL`, for compatibility in case `Real` is not `double`. 

It fixes the qlxad build, [as demonstrated here](https://github.com/xcelerit/qlxad/actions/runs/4880374907).