### PR TITLE
Enable normal volatilities in Hagan pricer for CMS coupons

### DIFF
--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
         fixingDate_ = coupon_->fixingDate();
         paymentDate_ = coupon_->date();
         const ext::shared_ptr<SwapIndex>& swapIndex = coupon_->swapIndex();
-        rateCurve_ = *(swapIndex->discountingTermStructure()) ? *(swapIndex->discountingTermStructure()) : *(swapIndex->forwardingTermStructure());
+        rateCurve_ = swapIndex->discountingTermStructure().empty() ? *(swapIndex->forwardingTermStructure()) : *(swapIndex->discountingTermStructure());
 
         Date today = Settings::instance().evaluationDate();
 

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
         fixingDate_ = coupon_->fixingDate();
         paymentDate_ = coupon_->date();
         const ext::shared_ptr<SwapIndex>& swapIndex = coupon_->swapIndex();
-        rateCurve_ = *(swapIndex->discountingTermStructure());
+        rateCurve_ = *(swapIndex->discountingTermStructure()) ? *(swapIndex->discountingTermStructure()) : *(swapIndex->forwardingTermStructure());
 
         Date today = Settings::instance().evaluationDate();
 

--- a/ql/cashflows/conundrumpricer.hpp
+++ b/ql/cashflows/conundrumpricer.hpp
@@ -1,6 +1,8 @@
 /*
  Copyright (C) 2006 Giorgio Facchinetti
  Copyright (C) 2006 Mario Pucci
+ Copyright (C) 2023 Andre Miemiec
+
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -40,9 +42,9 @@ namespace QuantLib {
                                 Real deflator) const = 0;
     };
 
-    class BlackVanillaOptionPricer : public VanillaOptionPricer {
+    class MarketQuotedOptionPricer : public VanillaOptionPricer {
       public:
-        BlackVanillaOptionPricer(
+        MarketQuotedOptionPricer(
                 Rate forwardValue,
                 Date expiryDate,
                 const Period& swapTenor,

--- a/ql/cashflows/conundrumpricer.hpp
+++ b/ql/cashflows/conundrumpricer.hpp
@@ -61,6 +61,12 @@ namespace QuantLib {
         ext::shared_ptr<SmileSection> smile_;
     };
 
+    /*! \deprecated Renamed to MarketQuotedOptionPricer.
+         Deprecated in version 1.31.
+    */
+    [[deprecated("Renamed to MarketQuotedOptionPricer")]]
+    typedef MarketQuotedOptionPricer BlackVanillaOptionPricer;
+
     class GFunction {
       public:
         virtual ~GFunction() = default;

--- a/ql/cashflows/conundrumpricer.hpp
+++ b/ql/cashflows/conundrumpricer.hpp
@@ -256,6 +256,7 @@ namespace QuantLib {
             Real hardUpperLimit = QL_MAX_REAL);
 
         Real upperLimit() const { return upperLimit_; }
+        Real lowerLimit() const { return lowerLimit_; }
         Real stdDeviations() const { return stdDeviationsForUpperLimit_; }
 
         // private:
@@ -314,10 +315,11 @@ namespace QuantLib {
         Real optionletPrice(Option::Type optionType, Rate strike) const override;
         Real swapletPrice() const override;
         Real resetUpperLimit(Real stdDeviationsForUpperLimit) const;
+        Real resetLowerLimit(Real stdDeviationsForLowerLimit) const;
         Real refineIntegration(Real integralValue, const ConundrumIntegrand& integrand) const;
 
-        mutable Real upperLimit_, stdDeviationsForUpperLimit_;
-        const Real lowerLimit_, requiredStdDeviations_ = 8, precision_,
+        mutable Real lowerLimit_, stdDeviationsForLowerLimit_, upperLimit_, stdDeviationsForUpperLimit_;
+        const Real  requiredStdDeviations_ = 8, precision_,
                                 refiningIntegrationTolerance_ = .0001;
         const Real hardUpperLimit_;
     };

--- a/ql/experimental/swaptions/haganirregularswaptionengine.cpp
+++ b/ql/experimental/swaptions/haganirregularswaptionengine.cpp
@@ -1,18 +1,15 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2011, 2012, 2013 Andre Miemiec
+ Copyright (C) 2011, 2012, 2013, 2023 Andre Miemiec
  Copyright (C) 2012 Samuel Tebege
-
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
-
  QuantLib is free software: you can redistribute it and/or modify it
  under the terms of the QuantLib license.  You should have received a
  copy of the license along with this program; if not, please email
  <quantlib-dev@lists.sf.net>. The license is also available online at
  <http://quantlib.org/license.shtml>.
-
  This program is distributed in the hope that it will be useful, but WITHOUT
  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  FOR A PARTICULAR PURPOSE.  See the license for more details.
@@ -42,8 +39,8 @@ namespace QuantLib {
         ext::shared_ptr<IrregularSwap> swap,
         Handle<YieldTermStructure> termStructure,
         Handle<SwaptionVolatilityStructure> volatilityStructure)
-    : swap_(std::move(swap)), termStructure_(std::move(termStructure)),
-      volatilityStructure_(std::move(volatilityStructure)) {
+        : swap_(std::move(swap)), termStructure_(std::move(termStructure)),
+        volatilityStructure_(std::move(volatilityStructure)) {
 
         engine_ = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(termStructure_));
 
@@ -115,22 +112,22 @@ namespace QuantLib {
         Size n = swap_->fixedLeg().size();
 
         //build linear system of equations
-        Matrix arr(n,n,0.0);   
-        Array  rhs(n);                   
+        Matrix arr(n, n, 0.0);
+        Array  rhs(n);
 
 
         //fill the matrix describing the linear system of equations by looping over rows
-        for(Size r = 0; r < n; ++r)
+        for (Size r = 0; r < n; ++r)
         {
 
             ext::shared_ptr<FixedRateCoupon> cpn_r = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
-                        QL_REQUIRE(cpn_r,"Cast to fixed rate coupon failed.");
+            QL_REQUIRE(cpn_r, "Cast to fixed rate coupon failed.");
 
             //looping over columns
-            for(Size c = r; c < n; ++c){
+            for (Size c = r; c < n; ++c) {
 
                 //set homogenous part of lse
-                arr[r][c] = ( fairRates_[c] + lambda_ ) * cpn_r->accrualPeriod();   
+                arr[r][c] = (fairRates_[c] + lambda_) * cpn_r->accrualPeriod();
             }
 
             // add nominal repayment for i-th swap
@@ -138,26 +135,27 @@ namespace QuantLib {
         }
 
 
-        for(Size r = 0; r < n; ++r)
+        for (Size r = 0; r < n; ++r)
         {
             ext::shared_ptr<FixedRateCoupon> cpn_r = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
 
             // set inhomogenity of lse
             Real N_r = cpn_r->nominal();
 
-            if(r < n - 1){
+            if (r < n - 1) {
 
-                ext::shared_ptr<FixedRateCoupon> cpn_rp1 = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r+1]);
+                ext::shared_ptr<FixedRateCoupon> cpn_rp1 = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r + 1]);
 
                 Real N_rp1 = cpn_rp1->nominal();
 
                 rhs[r] = N_r * (cpn_r->rate()) * cpn_r->accrualPeriod() + (N_r - N_rp1);
 
-            } else {
+            }
+            else {
 
                 rhs[r] = N_r * (cpn_r->rate()) * cpn_r->accrualPeriod() + N_r;
 
-            }       
+            }
 
         }
 
@@ -175,8 +173,8 @@ namespace QuantLib {
 
         Real defect = -targetNPV_;
 
-        for (Size i=0; i< weights.size();++i)
-            defect -= Integer(swap_->type()) * lambda*weights[i] * annuities_[i];
+        for (Size i = 0; i < weights.size(); ++i)
+            defect -= Integer(swap_->type()) * lambda * weights[i] * annuities_[i];
 
         return defect;
     }
@@ -187,31 +185,31 @@ namespace QuantLib {
     //creates a standard swap by deducing its conventions from market data objects
     ext::shared_ptr<VanillaSwap> HaganIrregularSwaptionEngine::Basket::component(Size i) const {
 
-        ext::shared_ptr<IborCoupon> iborCpn   = ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg()[0]);
-        QL_REQUIRE(iborCpn,"dynamic cast of float leg coupon failed. Can't find index.");
+        ext::shared_ptr<IborCoupon> iborCpn = ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg()[0]);
+        QL_REQUIRE(iborCpn, "dynamic cast of float leg coupon failed. Can't find index.");
         ext::shared_ptr<IborIndex>  iborIndex = iborCpn->iborIndex();
 
 
-        Period dummySwapLength = Period(1,Years);
-                        
-        ext::shared_ptr<VanillaSwap> memberSwap_ = MakeVanillaSwap(dummySwapLength,iborIndex)
-                                                     .withType(swap_->type())
-                                                     .withEffectiveDate(swap_->startDate())
-                                                     .withTerminationDate(expiries_[i])
-                                                     .withRule(DateGeneration::Backward)
-                                                     .withDiscountingTermStructure(termStructure_);
+        Period dummySwapLength = Period(1, Years);
 
-        Real stdAnnuity = 10000*CashFlows::bps(memberSwap_->fixedLeg(),**termStructure_,true);
+        ext::shared_ptr<VanillaSwap> memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex)
+            .withType(swap_->type())
+            .withEffectiveDate(swap_->startDate())
+            .withTerminationDate(expiries_[i])
+            .withRule(DateGeneration::Backward)
+            .withDiscountingTermStructure(termStructure_);
+
+        Real stdAnnuity = 10000 * CashFlows::bps(memberSwap_->fixedLeg(), **termStructure_, true);
 
         //compute annuity transformed rate
-        Rate transformedRate = (fairRates_[i]+lambda_)*annuities_[i]/stdAnnuity;
+        Rate transformedRate = (fairRates_[i] + lambda_) * annuities_[i] / stdAnnuity;
 
-        memberSwap_ = MakeVanillaSwap(dummySwapLength,iborIndex,transformedRate)
-                                                     .withType(swap_->type())
-                                                     .withEffectiveDate(swap_->startDate())
-                                                     .withTerminationDate(expiries_[i])
-                                                     .withRule(DateGeneration::Backward)
-                                                     .withDiscountingTermStructure(termStructure_);
+        memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex, transformedRate)
+            .withType(swap_->type())
+            .withEffectiveDate(swap_->startDate())
+            .withTerminationDate(expiries_[i])
+            .withRule(DateGeneration::Backward)
+            .withDiscountingTermStructure(termStructure_);
 
 
         return memberSwap_;
@@ -227,8 +225,8 @@ namespace QuantLib {
     HaganIrregularSwaptionEngine::HaganIrregularSwaptionEngine(
         Handle<SwaptionVolatilityStructure> volatilityStructure,
         Handle<YieldTermStructure> termStructure)
-    : termStructure_(std::move(termStructure)),
-      volatilityStructure_(std::move(volatilityStructure)) {
+        : termStructure_(std::move(termStructure)),
+        volatilityStructure_(std::move(volatilityStructure)) {
         registerWith(termStructure_);
         registerWith(volatilityStructure_);
     }
@@ -238,89 +236,89 @@ namespace QuantLib {
 
         //check exercise type
         ext::shared_ptr<Exercise> exercise_ = this->arguments_.exercise;
-        QL_REQUIRE(exercise_->type() == QuantLib::Exercise::European,"swaption must be european");
+        QL_REQUIRE(exercise_->type() == QuantLib::Exercise::European, "swaption must be european");
 
         //extract the underlying irregular swap
-        ext::shared_ptr<IrregularSwap> swap_  = this->arguments_.swap;
+        ext::shared_ptr<IrregularSwap> swap_ = this->arguments_.swap;
 
-        
+
         //Reshuffle spread from float to fixed (, i.e. remove spread from float side by finding the adjusted fixed coupon 
         //such that the NPV of the swap stays constant).
         Leg  fixedLeg = swap_->fixedLeg();
-        Real fxdLgBPS = CashFlows::bps(fixedLeg,**termStructure_,true);
+        Real fxdLgBPS = CashFlows::bps(fixedLeg, **termStructure_, true);
 
         Leg  floatLeg = swap_->floatingLeg();
-        Real fltLgNPV = CashFlows::npv(floatLeg,**termStructure_,true);
-        Real fltLgBPS = CashFlows::bps(floatLeg,**termStructure_,true);
-    
+        Real fltLgNPV = CashFlows::npv(floatLeg, **termStructure_, true);
+        Real fltLgBPS = CashFlows::bps(floatLeg, **termStructure_, true);
 
-        Leg floatCFS,fixedCFS;
+
+        Leg floatCFS, fixedCFS;
 
         floatCFS.clear();
 
         for (auto& j : floatLeg) {
             //retrieve ibor coupon from floating leg
             ext::shared_ptr<IborCoupon> coupon = ext::dynamic_pointer_cast<IborCoupon>(j);
-            QL_REQUIRE(coupon,"dynamic cast of float leg coupon failed.");
+            QL_REQUIRE(coupon, "dynamic cast of float leg coupon failed.");
 
-            ext::shared_ptr<IborCoupon> newCpn = ext::shared_ptr<IborCoupon> (
+            ext::shared_ptr<IborCoupon> newCpn = ext::shared_ptr<IborCoupon>(
                 new  IborCoupon(coupon->date(),
-                coupon->nominal(),
-                coupon->accrualStartDate(),
-                coupon->accrualEndDate(),
-                coupon->fixingDays(),
-                coupon->iborIndex(),
-                coupon->gearing(),
-                0.0,
-                coupon->referencePeriodStart(),
-                coupon->referencePeriodEnd(),
-                coupon->dayCounter(),
-                coupon->isInArrears())); 
+                    coupon->nominal(),
+                    coupon->accrualStartDate(),
+                    coupon->accrualEndDate(),
+                    coupon->fixingDays(),
+                    coupon->iborIndex(),
+                    coupon->gearing(),
+                    0.0,
+                    coupon->referencePeriodStart(),
+                    coupon->referencePeriodEnd(),
+                    coupon->dayCounter(),
+                    coupon->isInArrears()));
 
 
             if (!newCpn->isInArrears())
                 newCpn->setPricer(
-                             ext::shared_ptr<FloatingRateCouponPricer>(
-                                      new BlackIborCouponPricer()));
+                    ext::shared_ptr<FloatingRateCouponPricer>(
+                        new BlackIborCouponPricer()));
 
             floatCFS.push_back(newCpn);
         }
 
 
-        Real sprdLgNPV = fltLgNPV - CashFlows::npv(floatCFS,**termStructure_,true);
-        Rate avgSpread = sprdLgNPV/fltLgBPS/10000;
-            
-        Rate cpn_adjustment = avgSpread*fltLgBPS/fxdLgBPS;
+        Real sprdLgNPV = fltLgNPV - CashFlows::npv(floatCFS, **termStructure_, true);
+        Rate avgSpread = sprdLgNPV / fltLgBPS / 10000;
+
+        Rate cpn_adjustment = avgSpread * fltLgBPS / fxdLgBPS;
 
         fixedCFS.clear();
 
         for (auto& i : fixedLeg) {
             //retrieve fixed rate coupon from fixed leg
             ext::shared_ptr<FixedRateCoupon> coupon = ext::dynamic_pointer_cast<FixedRateCoupon>(i);
-            QL_REQUIRE(coupon,"dynamic cast of fixed leg coupon failed.");
+            QL_REQUIRE(coupon, "dynamic cast of fixed leg coupon failed.");
 
-            ext::shared_ptr<FixedRateCoupon> newCpn = ext::make_shared<FixedRateCoupon> (
+            ext::shared_ptr<FixedRateCoupon> newCpn = ext::make_shared<FixedRateCoupon>(
                 coupon->date(),
                 coupon->nominal(),
-                coupon->rate()-cpn_adjustment,
+                coupon->rate() - cpn_adjustment,
                 coupon->dayCounter(),
                 coupon->accrualStartDate(),
                 coupon->accrualEndDate(),
                 coupon->referencePeriodStart(),
-                coupon->referencePeriodEnd()); 
+                coupon->referencePeriodEnd());
 
             fixedCFS.push_back(newCpn);
         }
 
 
         //this is the irregular swap with spread removed 
-        swap_  =  ext::make_shared<IrregularSwap>(arguments_.swap->type(),fixedCFS,floatCFS);
+        swap_ = ext::make_shared<IrregularSwap>(arguments_.swap->type(), fixedCFS, floatCFS);
 
 
 
         //Sets up the basket by implementing the methodology described in 
         //P.S.Hagan "Callable Swaps and Bermudan 'Exercise into Swaptions'"
-        Basket basket(swap_,termStructure_,volatilityStructure_);  
+        Basket basket(swap_, termStructure_, volatilityStructure_);
 
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -334,7 +332,7 @@ namespace QuantLib {
         s1d.setMaxEvaluations(10000);
         s1d.setLowerBound(minLambda);
         s1d.setUpperBound(maxLambda);
-        s1d.solve(basket,1.0e-8,0.01, minLambda, maxLambda);
+        s1d.solve(basket, 1.0e-8, 0.01, minLambda, maxLambda);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -342,7 +340,7 @@ namespace QuantLib {
         /////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-        results_.value = HKPrice(basket,exercise_);
+        results_.value = HKPrice(basket, exercise_);
     }
 
 
@@ -352,30 +350,34 @@ namespace QuantLib {
     // "Implied interest rate pricing models", Finance Stochast. 2, 275-293 (1998)         //
     /////////////////////////////////////////////////////////////////////////////////////////
 
-    Real  HaganIrregularSwaptionEngine::HKPrice(Basket& basket,ext::shared_ptr<Exercise>& exercise) const {
+    Real  HaganIrregularSwaptionEngine::HKPrice(Basket& basket, ext::shared_ptr<Exercise>& exercise) const {
 
-        // Black 76 Swaption Engine: assumes that the swaptions exercise date equals the swap start date
-        ext::shared_ptr<PricingEngine> blackSwaptionEngine = 
-             ext::shared_ptr<PricingEngine>(new BlackSwaptionEngine(termStructure_,volatilityStructure_));
+        // Swaption Engine: assumes that the swaptions exercise date equals the swap start date
+        QL_REQUIRE((volatilityStructure_->volatilityType() == Normal),
+            "swaptionEngine: only normal volatility implemented.");
+
+
+        ext::shared_ptr<PricingEngine> swaptionEngine = ext::shared_ptr<PricingEngine>(new BachelierSwaptionEngine(termStructure_, volatilityStructure_));
+
 
         //retrieve weights of underlying swaps
         Array weights = basket.weights();
 
         Real npv = 0.0;
 
-        for(Size i=0; i<weights.size(); ++i)
+        for (Size i = 0; i < weights.size(); ++i)
         {
             ext::shared_ptr<VanillaSwap> pvSwap_ = basket.component(i);
-            Swaption swaption = Swaption(pvSwap_,exercise);
-            swaption.setPricingEngine(blackSwaptionEngine);
-            npv += weights[i]*swaption.NPV();
+            Swaption swaption = Swaption(pvSwap_, exercise);
+            swaption.setPricingEngine(swaptionEngine);
+            npv += weights[i] * swaption.NPV();
         }
 
         return npv;
 
     }
 
-    
+
 
 
 }

--- a/ql/experimental/swaptions/haganirregularswaptionengine.cpp
+++ b/ql/experimental/swaptions/haganirregularswaptionengine.cpp
@@ -39,8 +39,8 @@ namespace QuantLib {
         ext::shared_ptr<IrregularSwap> swap,
         Handle<YieldTermStructure> termStructure,
         Handle<SwaptionVolatilityStructure> volatilityStructure)
-        : swap_(std::move(swap)), termStructure_(std::move(termStructure)),
-        volatilityStructure_(std::move(volatilityStructure)) {
+    : swap_(std::move(swap)), termStructure_(std::move(termStructure)),
+      volatilityStructure_(std::move(volatilityStructure)) {
 
         engine_ = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(termStructure_));
 
@@ -102,31 +102,31 @@ namespace QuantLib {
     }
 
 
-    //computes a replication of the swap in terms of a basket of vanilla swaps 
-    //by solving a linear system of equation 
+    // computes a replication of the swap in terms of a basket of vanilla swaps
+    // by solving a linear system of equation
     Array HaganIrregularSwaptionEngine::Basket::compute(Rate lambda) const {
 
-        //update members
+        // update members
         lambda_ = lambda;
 
         Size n = swap_->fixedLeg().size();
 
-        //build linear system of equations
+        // build linear system of equations
         Matrix arr(n, n, 0.0);
-        Array  rhs(n);
+        Array rhs(n);
 
 
-        //fill the matrix describing the linear system of equations by looping over rows
-        for (Size r = 0; r < n; ++r)
-        {
+        // fill the matrix describing the linear system of equations by looping over rows
+        for (Size r = 0; r < n; ++r) {
 
-            ext::shared_ptr<FixedRateCoupon> cpn_r = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
+            ext::shared_ptr<FixedRateCoupon> cpn_r =
+                ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
             QL_REQUIRE(cpn_r, "Cast to fixed rate coupon failed.");
 
-            //looping over columns
+            // looping over columns
             for (Size c = r; c < n; ++c) {
 
-                //set homogenous part of lse
+                // set homogenous part of lse
                 arr[r][c] = (fairRates_[c] + lambda_) * cpn_r->accrualPeriod();
             }
 
@@ -135,28 +135,26 @@ namespace QuantLib {
         }
 
 
-        for (Size r = 0; r < n; ++r)
-        {
-            ext::shared_ptr<FixedRateCoupon> cpn_r = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
+        for (Size r = 0; r < n; ++r) {
+            ext::shared_ptr<FixedRateCoupon> cpn_r =
+                ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r]);
 
             // set inhomogenity of lse
             Real N_r = cpn_r->nominal();
 
             if (r < n - 1) {
 
-                ext::shared_ptr<FixedRateCoupon> cpn_rp1 = ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r + 1]);
+                ext::shared_ptr<FixedRateCoupon> cpn_rp1 =
+                    ext::dynamic_pointer_cast<FixedRateCoupon>(swap_->fixedLeg()[r + 1]);
 
                 Real N_rp1 = cpn_rp1->nominal();
 
                 rhs[r] = N_r * (cpn_r->rate()) * cpn_r->accrualPeriod() + (N_r - N_rp1);
 
-            }
-            else {
+            } else {
 
                 rhs[r] = N_r * (cpn_r->rate()) * cpn_r->accrualPeriod() + N_r;
-
             }
-
         }
 
 
@@ -164,7 +162,6 @@ namespace QuantLib {
 
         return svd.solveFor(rhs);
     }
-
 
 
     Real HaganIrregularSwaptionEngine::Basket::operator()(Rate lambda) const {
@@ -180,40 +177,39 @@ namespace QuantLib {
     }
 
 
-
-
-    //creates a standard swap by deducing its conventions from market data objects
+    // creates a standard swap by deducing its conventions from market data objects
     ext::shared_ptr<VanillaSwap> HaganIrregularSwaptionEngine::Basket::component(Size i) const {
 
-        ext::shared_ptr<IborCoupon> iborCpn = ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg()[0]);
+        ext::shared_ptr<IborCoupon> iborCpn =
+            ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg()[0]);
         QL_REQUIRE(iborCpn, "dynamic cast of float leg coupon failed. Can't find index.");
-        ext::shared_ptr<IborIndex>  iborIndex = iborCpn->iborIndex();
+        ext::shared_ptr<IborIndex> iborIndex = iborCpn->iborIndex();
 
 
         Period dummySwapLength = Period(1, Years);
 
-        ext::shared_ptr<VanillaSwap> memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex)
-            .withType(swap_->type())
-            .withEffectiveDate(swap_->startDate())
-            .withTerminationDate(expiries_[i])
-            .withRule(DateGeneration::Backward)
-            .withDiscountingTermStructure(termStructure_);
+        ext::shared_ptr<VanillaSwap> memberSwap_ =
+            MakeVanillaSwap(dummySwapLength, iborIndex)
+                .withType(swap_->type())
+                .withEffectiveDate(swap_->startDate())
+                .withTerminationDate(expiries_[i])
+                .withRule(DateGeneration::Backward)
+                .withDiscountingTermStructure(termStructure_);
 
         Real stdAnnuity = 10000 * CashFlows::bps(memberSwap_->fixedLeg(), **termStructure_, true);
 
-        //compute annuity transformed rate
+        // compute annuity transformed rate
         Rate transformedRate = (fairRates_[i] + lambda_) * annuities_[i] / stdAnnuity;
 
         memberSwap_ = MakeVanillaSwap(dummySwapLength, iborIndex, transformedRate)
-            .withType(swap_->type())
-            .withEffectiveDate(swap_->startDate())
-            .withTerminationDate(expiries_[i])
-            .withRule(DateGeneration::Backward)
-            .withDiscountingTermStructure(termStructure_);
+                          .withType(swap_->type())
+                          .withEffectiveDate(swap_->startDate())
+                          .withTerminationDate(expiries_[i])
+                          .withRule(DateGeneration::Backward)
+                          .withDiscountingTermStructure(termStructure_);
 
 
         return memberSwap_;
-
     }
 
 
@@ -225,8 +221,8 @@ namespace QuantLib {
     HaganIrregularSwaptionEngine::HaganIrregularSwaptionEngine(
         Handle<SwaptionVolatilityStructure> volatilityStructure,
         Handle<YieldTermStructure> termStructure)
-        : termStructure_(std::move(termStructure)),
-        volatilityStructure_(std::move(volatilityStructure)) {
+    : termStructure_(std::move(termStructure)),
+      volatilityStructure_(std::move(volatilityStructure)) {
         registerWith(termStructure_);
         registerWith(volatilityStructure_);
     }
@@ -234,20 +230,20 @@ namespace QuantLib {
 
     void HaganIrregularSwaptionEngine::calculate() const {
 
-        //check exercise type
+        // check exercise type
         ext::shared_ptr<Exercise> exercise_ = this->arguments_.exercise;
         QL_REQUIRE(exercise_->type() == QuantLib::Exercise::European, "swaption must be european");
 
-        //extract the underlying irregular swap
+        // extract the underlying irregular swap
         ext::shared_ptr<IrregularSwap> swap_ = this->arguments_.swap;
 
 
-        //Reshuffle spread from float to fixed (, i.e. remove spread from float side by finding the adjusted fixed coupon 
-        //such that the NPV of the swap stays constant).
-        Leg  fixedLeg = swap_->fixedLeg();
+        // Reshuffle spread from float to fixed (, i.e. remove spread from float side by finding the
+        // adjusted fixed coupon such that the NPV of the swap stays constant).
+        Leg fixedLeg = swap_->fixedLeg();
         Real fxdLgBPS = CashFlows::bps(fixedLeg, **termStructure_, true);
 
-        Leg  floatLeg = swap_->floatingLeg();
+        Leg floatLeg = swap_->floatingLeg();
         Real fltLgNPV = CashFlows::npv(floatLeg, **termStructure_, true);
         Real fltLgBPS = CashFlows::bps(floatLeg, **termStructure_, true);
 
@@ -257,29 +253,20 @@ namespace QuantLib {
         floatCFS.clear();
 
         for (auto& j : floatLeg) {
-            //retrieve ibor coupon from floating leg
+            // retrieve ibor coupon from floating leg
             ext::shared_ptr<IborCoupon> coupon = ext::dynamic_pointer_cast<IborCoupon>(j);
             QL_REQUIRE(coupon, "dynamic cast of float leg coupon failed.");
 
-            ext::shared_ptr<IborCoupon> newCpn = ext::shared_ptr<IborCoupon>(
-                new  IborCoupon(coupon->date(),
-                    coupon->nominal(),
-                    coupon->accrualStartDate(),
-                    coupon->accrualEndDate(),
-                    coupon->fixingDays(),
-                    coupon->iborIndex(),
-                    coupon->gearing(),
-                    0.0,
-                    coupon->referencePeriodStart(),
-                    coupon->referencePeriodEnd(),
-                    coupon->dayCounter(),
-                    coupon->isInArrears()));
+            ext::shared_ptr<IborCoupon> newCpn = ext::shared_ptr<IborCoupon>(new IborCoupon(
+                coupon->date(), coupon->nominal(), coupon->accrualStartDate(),
+                coupon->accrualEndDate(), coupon->fixingDays(), coupon->iborIndex(),
+                coupon->gearing(), 0.0, coupon->referencePeriodStart(),
+                coupon->referencePeriodEnd(), coupon->dayCounter(), coupon->isInArrears()));
 
 
             if (!newCpn->isInArrears())
                 newCpn->setPricer(
-                    ext::shared_ptr<FloatingRateCouponPricer>(
-                        new BlackIborCouponPricer()));
+                    ext::shared_ptr<FloatingRateCouponPricer>(new BlackIborCouponPricer()));
 
             floatCFS.push_back(newCpn);
         }
@@ -293,36 +280,30 @@ namespace QuantLib {
         fixedCFS.clear();
 
         for (auto& i : fixedLeg) {
-            //retrieve fixed rate coupon from fixed leg
+            // retrieve fixed rate coupon from fixed leg
             ext::shared_ptr<FixedRateCoupon> coupon = ext::dynamic_pointer_cast<FixedRateCoupon>(i);
             QL_REQUIRE(coupon, "dynamic cast of fixed leg coupon failed.");
 
             ext::shared_ptr<FixedRateCoupon> newCpn = ext::make_shared<FixedRateCoupon>(
-                coupon->date(),
-                coupon->nominal(),
-                coupon->rate() - cpn_adjustment,
-                coupon->dayCounter(),
-                coupon->accrualStartDate(),
-                coupon->accrualEndDate(),
-                coupon->referencePeriodStart(),
-                coupon->referencePeriodEnd());
+                coupon->date(), coupon->nominal(), coupon->rate() - cpn_adjustment,
+                coupon->dayCounter(), coupon->accrualStartDate(), coupon->accrualEndDate(),
+                coupon->referencePeriodStart(), coupon->referencePeriodEnd());
 
             fixedCFS.push_back(newCpn);
         }
 
 
-        //this is the irregular swap with spread removed 
+        // this is the irregular swap with spread removed
         swap_ = ext::make_shared<IrregularSwap>(arguments_.swap->type(), fixedCFS, floatCFS);
 
 
-
-        //Sets up the basket by implementing the methodology described in 
-        //P.S.Hagan "Callable Swaps and Bermudan 'Exercise into Swaptions'"
+        // Sets up the basket by implementing the methodology described in
+        // P.S.Hagan "Callable Swaps and Bermudan 'Exercise into Swaptions'"
         Basket basket(swap_, termStructure_, volatilityStructure_);
 
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////
-        //find lambda                                                                                    //
+        // find lambda //
         ///////////////////////////////////////////////////////////////////////////////////////////////////
 
         Bisection s1d;
@@ -336,7 +317,8 @@ namespace QuantLib {
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////
-        //  compute the price of the irreg swaption as the sum of the prices of the regular swaptions  //
+        //  compute the price of the irreg swaption as the sum of the prices of the regular
+        //  swaptions  //
         /////////////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -344,29 +326,29 @@ namespace QuantLib {
     }
 
 
-
     /////////////////////////////////////////////////////////////////////////////////////////
     // Computes irregular swaption price according to P.J. Hunt, J.E. Kennedy:             //
     // "Implied interest rate pricing models", Finance Stochast. 2, 275-293 (1998)         //
     /////////////////////////////////////////////////////////////////////////////////////////
 
-    Real  HaganIrregularSwaptionEngine::HKPrice(Basket& basket, ext::shared_ptr<Exercise>& exercise) const {
+    Real HaganIrregularSwaptionEngine::HKPrice(Basket& basket,
+                                               ext::shared_ptr<Exercise>& exercise) const {
 
         // Swaption Engine: assumes that the swaptions exercise date equals the swap start date
         QL_REQUIRE((volatilityStructure_->volatilityType() == Normal),
-            "swaptionEngine: only normal volatility implemented.");
+                   "swaptionEngine: only normal volatility implemented.");
 
 
-        ext::shared_ptr<PricingEngine> swaptionEngine = ext::shared_ptr<PricingEngine>(new BachelierSwaptionEngine(termStructure_, volatilityStructure_));
+        ext::shared_ptr<PricingEngine> swaptionEngine = ext::shared_ptr<PricingEngine>(
+            new BachelierSwaptionEngine(termStructure_, volatilityStructure_));
 
 
-        //retrieve weights of underlying swaps
+        // retrieve weights of underlying swaps
         Array weights = basket.weights();
 
         Real npv = 0.0;
 
-        for (Size i = 0; i < weights.size(); ++i)
-        {
+        for (Size i = 0; i < weights.size(); ++i) {
             ext::shared_ptr<VanillaSwap> pvSwap_ = basket.component(i);
             Swaption swaption = Swaption(pvSwap_, exercise);
             swaption.setPricingEngine(swaptionEngine);
@@ -374,10 +356,7 @@ namespace QuantLib {
         }
 
         return npv;
-
     }
-
-
 
 
 }

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -30,6 +30,7 @@ set(QL_TEST_SOURCES
     chooseroption.cpp
     cliquetoption.cpp
     cms.cpp
+    cms_normal.cpp
     cmsspread.cpp
     commodityunitofmeasure.cpp
     compiledboostversion.cpp
@@ -201,6 +202,7 @@ set(QL_TEST_HEADERS
     chooseroption.hpp
     cliquetoption.hpp
     cms.hpp
+    cms_normal.hpp
     cmsspread.hpp
     commodityunitofmeasure.hpp
     compiledboostversion.hpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -32,6 +32,7 @@ QL_TEST_SRCS = \
 	chooseroption.cpp \
 	cliquetoption.cpp \
 	cms.cpp \
+	cms_normal.cpp \
 	cmsspread.cpp \
 	commodityunitofmeasure.cpp \
 	compiledboostversion.cpp \
@@ -202,6 +203,7 @@ QL_TEST_HDRS = \
 	chooseroption.hpp \
 	cliquetoption.hpp \
 	cms.hpp \
+	cms_normal.hpp \
 	cmsspread.hpp \
 	commodityunitofmeasure.hpp \
 	compiledboostversion.hpp \

--- a/test-suite/cms.cpp
+++ b/test-suite/cms.cpp
@@ -250,7 +250,7 @@ namespace cms_test {
 
 void CmsTest::testFairRate()  {
 
-    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for coupons...");
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for coupons (lognormal case)...");
 
     using namespace cms_test;
 
@@ -316,7 +316,7 @@ void CmsTest::testFairRate()  {
 
 void CmsTest::testCmsSwap() {
 
-    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for swaps...");
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for swaps (lognormal case)...");
 
     using namespace cms_test;
 
@@ -379,7 +379,7 @@ void CmsTest::testCmsSwap() {
 
 void CmsTest::testParity() {
 
-    BOOST_TEST_MESSAGE("Testing put-call parity for capped-floored CMS coupons...");
+    BOOST_TEST_MESSAGE("Testing put-call parity for capped-floored CMS coupons (lognormal case)...");
 
     using namespace cms_test;
 

--- a/test-suite/cms_normal.cpp
+++ b/test-suite/cms_normal.cpp
@@ -279,7 +279,7 @@ namespace cms_normal_test {
 
 void CmsNormalTest::testFairRate()  {
 
-    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for coupons...");
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for coupons (normal case)...");
 
     using namespace cms_normal_test;
 
@@ -344,7 +344,7 @@ void CmsNormalTest::testFairRate()  {
 
 void CmsNormalTest::testCmsSwap() {
 
-    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for swaps...");
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for swaps (normal case)...");
 
     using namespace cms_normal_test;
 
@@ -406,7 +406,7 @@ void CmsNormalTest::testCmsSwap() {
 
 void CmsNormalTest::testParity() {
 
-    BOOST_TEST_MESSAGE("Testing put-call parity for capped-floored CMS coupons...");
+    BOOST_TEST_MESSAGE("Testing put-call parity for capped-floored CMS coupons (normal case)...");
 
     using namespace cms_normal_test;
 

--- a/test-suite/cms_normal.cpp
+++ b/test-suite/cms_normal.cpp
@@ -1,0 +1,515 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2007 Ferdinando Ametrano
+ Copyright (C) 2006 Giorgio Facchinetti
+ Copyright (C) 2006 Mario Pucci
+ Copyright (C) 2014 Peter Caspers
+ Copyright (C) 2023 Andre Miemiec
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "cms_normal.hpp"
+#include "utilities.hpp"
+#include <ql/instruments/swap.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/swap/euriborswap.hpp>
+#include <ql/cashflows/capflooredcoupon.hpp>
+#include <ql/cashflows/conundrumpricer.hpp>
+#include <ql/cashflows/cashflowvectors.hpp>
+#include <ql/cashflows/lineartsrpricer.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
+#include <ql/termstructures/volatility/swaption/interpolatedswaptionvolatilitycube.hpp>
+#include <ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/schedule.hpp>
+#include <ql/utilities/dataformatters.hpp>
+#include <ql/instruments/makecms.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+namespace cms_normal_test {
+
+    struct CommonVars {
+        // global data
+        RelinkableHandle<YieldTermStructure> termStructure;
+
+        ext::shared_ptr<IborIndex> iborIndex;
+
+        Handle<SwaptionVolatilityStructure> atmVol;
+        Handle<SwaptionVolatilityStructure> SabrVolCube1;
+        Handle<SwaptionVolatilityStructure> SabrVolCube2;
+
+        std::vector<GFunctionFactory::YieldCurveModel> yieldCurveModels;
+        std::vector<ext::shared_ptr<CmsCouponPricer> > numericalPricers;
+        std::vector<ext::shared_ptr<CmsCouponPricer> > analyticPricers;
+
+        // cleanup
+        SavedSettings backup;
+
+        // setup
+        CommonVars() {
+
+            Calendar calendar = TARGET();
+
+            Date referenceDate = calendar.adjust(Date::todaysDate());
+            Settings::instance().evaluationDate() = referenceDate;
+
+            termStructure.linkTo(flatRate(referenceDate, 0.02,
+                                          Actual365Fixed()));
+
+            // ATM Volatility structure
+            std::vector<Period> atmOptionTenors = {1 * Months, 6 * Months, 1 * Years,
+                                                   5 * Years,  10 * Years, 30 * Years};
+
+            std::vector<Period> atmSwapTenors = {1 * Years, 5 * Years, 10 * Years, 30 * Years};
+
+            Matrix m(atmOptionTenors.size(), atmSwapTenors.size());
+            m[0][0]=0.0085; m[0][1]=0.0120; m[0][2]=0.0102; m[0][3]=0.0095;
+            m[1][0]=0.0106;	m[1][1]=0.0104;	m[1][2]=0.0095;	m[1][3]=0.0092;
+            m[2][0]=0.0104;	m[2][1]=0.0099;	m[2][2]=0.0092;	m[2][3]=0.0088;
+            m[3][0]=0.0091;	m[3][1]=0.0086;	m[3][2]=0.0080;	m[3][3]=0.0070;
+            m[4][0]=0.0077;	m[4][1]=0.0073;	m[4][2]=0.0068;	m[4][3]=0.0060;
+            m[5][0]=0.0057;	m[5][1]=0.0055;	m[5][2]=0.0050;	m[5][3]=0.0039;
+
+
+
+            atmVol = Handle<SwaptionVolatilityStructure>(
+                ext::shared_ptr<SwaptionVolatilityStructure>(new
+                    SwaptionVolatilityMatrix(calendar,
+                                             Following,
+                                             atmOptionTenors,
+                                             atmSwapTenors,
+                                             m,
+                                             Actual365Fixed(),
+                                             false,
+                                             QuantLib::VolatilityType::Normal)));
+            
+
+            // Vol cubes
+            std::vector<Period> optionTenors = {{1, Years}, {10, Years}, {30, Years}};
+            std::vector<Period> swapTenors = {{2, Years}, {10, Years}, {30, Years}};
+            std::vector<Spread> strikeSpreads = {-0.020, -0.005, 0.000, 0.005, 0.020};
+
+            Size nRows = optionTenors.size()*swapTenors.size();
+            Size nCols = strikeSpreads.size();
+            Matrix volSpreadsMatrix(nRows, nCols);
+            
+            volSpreadsMatrix[0][0] = -0.0016;
+            volSpreadsMatrix[0][1] = -0.0008;
+            volSpreadsMatrix[0][2] =  0.0000;
+            volSpreadsMatrix[0][3] =  0.0009;
+            volSpreadsMatrix[0][4] =  0.0038;
+
+            volSpreadsMatrix[1][0] =  0.0009;
+            volSpreadsMatrix[1][1] = -0.0003;
+            volSpreadsMatrix[1][2] =  0.0000;
+            volSpreadsMatrix[1][3] =  0.0007;
+            volSpreadsMatrix[1][4] =  0.0035;
+
+            volSpreadsMatrix[2][0] =  0.0025;
+            volSpreadsMatrix[2][1] =  0.0002;
+            volSpreadsMatrix[2][2] =  0.0000;
+            volSpreadsMatrix[2][3] =  0.0002;
+            volSpreadsMatrix[2][4] =  0.0024;
+
+            volSpreadsMatrix[3][0] =  -0.0009;
+            volSpreadsMatrix[3][1] =  -0.0003;
+            volSpreadsMatrix[3][2] =   0.0000;
+            volSpreadsMatrix[3][3] =   0.0003;
+            volSpreadsMatrix[3][4] =   0.0013;
+
+            volSpreadsMatrix[4][0] =  -0.0001;
+            volSpreadsMatrix[4][1] =  -0.0001;
+            volSpreadsMatrix[4][2] =   0.0000;
+            volSpreadsMatrix[4][3] =   0.0001;
+            volSpreadsMatrix[4][4] =   0.0007;
+
+            volSpreadsMatrix[5][0] =   0.0003;
+            volSpreadsMatrix[5][1] =   0.0000;
+            volSpreadsMatrix[5][2] =   0.0000;
+            volSpreadsMatrix[5][3] =   0.0001;
+            volSpreadsMatrix[5][4] =   0.0005;
+
+            volSpreadsMatrix[6][0] =  -0.0004;
+            volSpreadsMatrix[6][1] =  -0.0001;
+            volSpreadsMatrix[6][2] =   0.0000;
+            volSpreadsMatrix[6][3] =   0.0001;
+            volSpreadsMatrix[6][4] =   0.0006;
+
+            volSpreadsMatrix[7][0] =  -0.0001;
+            volSpreadsMatrix[7][1] =   0.0000;
+            volSpreadsMatrix[7][2] =   0.0000;
+            volSpreadsMatrix[7][3] =   0.0000;
+            volSpreadsMatrix[7][4] =   0.0002;
+
+
+            volSpreadsMatrix[8][0] =  -0.0002;
+            volSpreadsMatrix[8][1] =  -0.0001;
+            volSpreadsMatrix[8][2] =   0.0000;
+            volSpreadsMatrix[8][3] =   0.0001;
+            volSpreadsMatrix[8][4] =   0.0002;
+
+
+            std::vector<std::vector<Handle<Quote> > > volSpreads(nRows);
+            for (Size i=0; i<nRows; ++i){
+                volSpreads[i] = std::vector<Handle<Quote> >(nCols);
+                for (Size j=0; j<nCols; ++j) {
+                    volSpreads[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(
+                                    new SimpleQuote(volSpreadsMatrix[i][j])));
+                }
+            }
+
+            iborIndex = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+            /*
+            ext::shared_ptr<SwapIndex> swapIndexBase(new
+                EuriborSwapIsdaFixA(10*Years, termStructure,termStructure));
+            ext::shared_ptr<SwapIndex> shortSwapIndexBase(new
+                EuriborSwapIsdaFixA(2*Years, termStructure,termStructure));
+            */
+
+            ext::shared_ptr<SwapIndex> swapIndexBase(new SwapIndex("swapIndexBase",
+                                                       2*Years,
+                                                       iborIndex->fixingDays(),
+                                                       iborIndex->currency(),
+                                                       iborIndex->fixingCalendar(),
+                                                       1*Years,
+                                                       ModifiedFollowing,
+                                                       Thirty360(Thirty360::EurobondBasis),//EUR
+                                                       iborIndex,
+                                                       termStructure));
+            ext::shared_ptr<SwapIndex> shortSwapIndexBase(new SwapIndex("shortSwapIndexBase",
+                                                       1*Years,
+                                                       iborIndex->fixingDays(),
+                                                       iborIndex->currency(),
+                                                       iborIndex->fixingCalendar(),
+                                                       1*Years,
+                                                       ModifiedFollowing,
+                                                       Thirty360(Thirty360::EurobondBasis),//EUR
+                                                       iborIndex,
+                                                       termStructure));
+
+            bool vegaWeightedSmileFit = false;
+
+            SabrVolCube2 = Handle<SwaptionVolatilityStructure>(
+                ext::make_shared<InterpolatedSwaptionVolatilityCube>(atmVol,
+                                     optionTenors,
+                                     swapTenors,
+                                     strikeSpreads,
+                                     volSpreads,
+                                     swapIndexBase,
+                                     shortSwapIndexBase,
+                                     vegaWeightedSmileFit));
+            SabrVolCube2->enableExtrapolation();
+
+            std::vector<std::vector<Handle<Quote> > > guess(nRows);
+            for (Size i=0; i<nRows; ++i) {
+                guess[i] = std::vector<Handle<Quote> >(4);
+                guess[i][0] =
+                    Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.01)));
+                guess[i][1] =
+                    Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+                guess[i][2] =
+                    Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.3)));
+                guess[i][3] =
+                    Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+            }
+            std::vector<bool> isParameterFixed(4, false);
+            isParameterFixed[1] = true;
+
+            // FIXME
+            bool isAtmCalibrated = false;
+
+            SabrVolCube1 = Handle<SwaptionVolatilityStructure>(
+                ext::shared_ptr<SabrSwaptionVolatilityCube>(new
+                    SabrSwaptionVolatilityCube(atmVol,
+                                     optionTenors,
+                                     swapTenors,
+                                     strikeSpreads,
+                                     volSpreads,
+                                     swapIndexBase,
+                                     shortSwapIndexBase,
+                                     vegaWeightedSmileFit,
+                                     guess,
+                                     isParameterFixed,
+                                     isAtmCalibrated)));
+            SabrVolCube1->enableExtrapolation();
+            
+
+            yieldCurveModels = {GFunctionFactory::Standard,
+                                GFunctionFactory::ExactYield,
+                                GFunctionFactory::ParallelShifts,
+                                GFunctionFactory::NonParallelShifts};
+
+            Handle<Quote> zeroMeanRev(ext::make_shared<SimpleQuote>(0.0));
+
+            numericalPricers.clear();
+            analyticPricers.clear();
+            for (Size j = 0; j < yieldCurveModels.size(); ++j) {
+                numericalPricers.push_back(ext::shared_ptr<CmsCouponPricer>(new 
+                    NumericHaganPricer(atmVol, yieldCurveModels[j], 
+                                        zeroMeanRev)));
+ 
+
+                analyticPricers.push_back(ext::shared_ptr<CmsCouponPricer>(new
+                    AnalyticHaganPricer(atmVol, yieldCurveModels[j],
+                                        zeroMeanRev)));
+            }
+        }
+    };
+
+}
+
+
+void CmsNormalTest::testFairRate()  {
+
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for coupons...");
+
+    using namespace cms_normal_test;
+
+    CommonVars vars;
+
+    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+                                                       10*Years,
+                                                       vars.iborIndex->fixingDays(),
+                                                       vars.iborIndex->currency(),
+                                                       vars.iborIndex->fixingCalendar(),
+                                                       1*Years,
+                                                       ModifiedFollowing,
+                                                       Thirty360(Thirty360::EurobondBasis),//EUR
+                                                       vars.iborIndex,
+                                                       vars.termStructure));
+    // FIXME
+    //ext::shared_ptr<SwapIndex> swapIndex(new
+    //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
+    Date startDate = vars.termStructure->referenceDate() + 20*Years;
+    Date paymentDate = startDate + 1*Years;
+    Date endDate = paymentDate;
+    Real nominal = 1.0;
+    Rate infiniteCap = Null<Real>();
+    Rate infiniteFloor = Null<Real>();
+    Real gearing = 1.0;
+    Spread spread = 0.0;
+    CappedFlooredCmsCoupon coupon(paymentDate, nominal,
+                                  startDate, endDate,
+                                  swapIndex->fixingDays(), swapIndex,
+                                  gearing, spread,
+                                  infiniteCap, infiniteFloor,
+                                  startDate, endDate,
+                                  vars.iborIndex->dayCounter());
+    for (Size j=0; j<vars.yieldCurveModels.size(); ++j) {
+        vars.numericalPricers[j]->setSwaptionVolatility(vars.atmVol);
+        coupon.setPricer(vars.numericalPricers[j]);
+        Rate rate0 = coupon.rate();
+
+        vars.analyticPricers[j]->setSwaptionVolatility(vars.atmVol);
+        coupon.setPricer(vars.analyticPricers[j]);
+        Rate rate1 = coupon.rate();
+
+        Spread difference =  std::fabs(rate1-rate0);
+        Spread tol = 2.0e-4;  //The tolerance used before was 2bp. Semms very low for a coupon with pmt in 20 Years
+
+        if (std::round(10.0*(difference-tol))/10.0 > 0.0 ) // seems a more appropriate comparison to me instead of  difference > tol
+            BOOST_FAIL("\nCoupon payment date: " << paymentDate <<
+                       "\nCoupon start date:   " << startDate <<
+                       "\nCoupon floor:        " << io::rate(infiniteFloor) <<
+                       "\nCoupon gearing:      " << io::rate(gearing) <<
+                       "\nCoupon swap index:   " << swapIndex->name() <<
+                       "\nCoupon spread:       " << io::rate(spread) <<
+                       "\nCoupon cap:          " << io::rate(infiniteCap) <<
+                       "\nCoupon DayCounter:   " << vars.iborIndex->dayCounter()<<
+                       "\nYieldCurve Model:    " << vars.yieldCurveModels[j] <<
+                       "\nNumerical Pricer:    " << io::rate(rate0) <<
+                       "\nAnalytic Pricer:     " << io::rate(rate1) <<
+                       "\ndifference:          " << io::rate(difference) <<
+                       "\ntolerance:           " << io::rate(tol));
+    }
+}
+
+void CmsNormalTest::testCmsSwap() {
+
+    BOOST_TEST_MESSAGE("Testing Hagan-pricer flat-vol equivalence for swaps...");
+
+    using namespace cms_normal_test;
+
+    CommonVars vars;
+
+    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+                                                       10*Years,
+                                                       vars.iborIndex->fixingDays(),
+                                                       vars.iborIndex->currency(),
+                                                       vars.iborIndex->fixingCalendar(),
+                                                       1*Years,
+                                                       ModifiedFollowing,
+                                                       Thirty360(Thirty360::EurobondBasis),//EUR
+                                                       vars.iborIndex,
+                                                       vars.termStructure));
+    // FIXME
+    //ext::shared_ptr<SwapIndex> swapIndex(new
+    //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
+    Spread spread = 0.0;
+    std::vector<Size> swapLengths = {1, 5, 6, 10};   //?is an off-gridpoint a good test?
+    Size n = swapLengths.size();
+    std::vector<ext::shared_ptr<Swap> > cms(n);
+    for (Size i=0; i<n; ++i)
+        // no cap, floor
+        // no gearing, spread
+        cms[i] = MakeCms(Period(swapLengths[i], Years),
+                         swapIndex,
+                         vars.iborIndex, spread);
+
+    for (Size j=0; j<vars.yieldCurveModels.size(); ++j) {
+        vars.numericalPricers[j]->setSwaptionVolatility(vars.atmVol);
+        vars.analyticPricers[j]->setSwaptionVolatility(vars.atmVol);
+        for (Size sl=0; sl<n; ++sl) {
+            setCouponPricer(cms[sl]->leg(0), vars.numericalPricers[j]);
+            Real priceNum = cms[sl]->NPV();
+            setCouponPricer(cms[sl]->leg(0), vars.analyticPricers[j]);
+            Real priceAn = cms[sl]->NPV();
+
+            Real difference =  std::fabs(priceNum-priceAn);
+            Real tol = 2.0e-4;
+
+            if (std::round(10.0*(difference-tol))/10.0 > 0.0 )  // seems a more appropriate comparison to me instead of  difference > tol
+                BOOST_FAIL("\nLength in Years:  " << swapLengths[sl] <<
+                           //"\nfloor:            " << io::rate(infiniteFloor) <<
+                           //"\ngearing:          " << io::rate(gearing) <<
+                           "\nswap index:       " << swapIndex->name() <<
+                           "\nibor index:       " << vars.iborIndex->name() <<
+                           "\nspread:           " << io::rate(spread) <<
+                           //"\ncap:              " << io::rate(infiniteCap) <<
+                           "\nYieldCurve Model: " << vars.yieldCurveModels[j] <<
+                           "\nNumerical Pricer: " << io::rate(priceNum) <<
+                           "\nAnalytic Pricer:  " << io::rate(priceAn) <<
+                           "\ndifference:       " << io::rate(difference) <<
+                           "\ntolerance:        " << io::rate(tol));
+        }
+    }
+
+}
+
+void CmsNormalTest::testParity() {
+
+    BOOST_TEST_MESSAGE("Testing put-call parity for capped-floored CMS coupons...");
+
+    using namespace cms_normal_test;
+
+    CommonVars vars;
+
+    std::vector<Handle<SwaptionVolatilityStructure> > swaptionVols = {
+                           vars.atmVol, vars.SabrVolCube1, vars.SabrVolCube2};
+                           
+  
+
+    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+                                                       10*Years,
+                                                       vars.iborIndex->fixingDays(),
+                                                       vars.iborIndex->currency(),
+                                                       vars.iborIndex->fixingCalendar(),
+                                                       1*Years,
+                                                       ModifiedFollowing,
+                                                       Thirty360(Thirty360::EurobondBasis),//EUR
+                                                       vars.iborIndex,
+                                                       vars.termStructure));
+
+
+
+    Date startDate = vars.termStructure->referenceDate() + 20*Years;
+    Date paymentDate = startDate + 1*Years;
+    Date endDate = paymentDate;
+    Real nominal = 1.0;
+    Rate infiniteCap = Null<Real>();
+    Rate infiniteFloor = Null<Real>();
+    Real gearing = 1.0;
+    Spread spread = 0.0;
+    DiscountFactor discount = vars.termStructure->discount(paymentDate);
+    CappedFlooredCmsCoupon cpn_plain(paymentDate, nominal,
+                                   startDate, endDate,
+                                   swapIndex->fixingDays(),
+                                   swapIndex,
+                                   gearing, spread,
+                                   infiniteCap, infiniteFloor,
+                                   startDate, endDate,
+                                   vars.iborIndex->dayCounter());
+    for (Rate strike = -0.005; strike <= 0.035; strike+=0.01) {
+        CappedFlooredCmsCoupon   cpn_capped(paymentDate, nominal,
+                                        startDate, endDate,
+                                        swapIndex->fixingDays(),
+                                        swapIndex,
+                                        gearing, spread,
+                                        strike, infiniteFloor,
+                                        startDate, endDate,
+                                        vars.iborIndex->dayCounter());
+        CappedFlooredCmsCoupon cpn_floored(paymentDate, nominal,
+                                        startDate, endDate,
+                                        swapIndex->fixingDays(),
+                                        swapIndex,
+                                        gearing, spread,
+                                        infiniteCap, strike,
+                                        startDate, endDate,
+                                        vars.iborIndex->dayCounter());
+
+        for (auto& swaptionVol : swaptionVols) {
+            for (Size j=0; j<vars.yieldCurveModels.size(); ++j) {
+                vars.numericalPricers[j]->setSwaptionVolatility(swaptionVol);
+                vars.analyticPricers[j]->setSwaptionVolatility(swaptionVol);
+                std::vector<ext::shared_ptr<CmsCouponPricer> > pricers(2);
+                pricers[0] = vars.numericalPricers[j];
+                pricers[1] = vars.analyticPricers[j];
+                for (Size k=0; k<pricers.size(); ++k) {   
+                    cpn_plain.setPricer(pricers[k]);
+                    cpn_capped.setPricer(pricers[k]);
+                    cpn_floored.setPricer(pricers[k]);
+                    Real cpn_plain_Price = cpn_plain.price(vars.termStructure);
+                    Real cpn_capped_Price = cpn_capped.price(vars.termStructure);
+                    Real cpn_floored_Price = cpn_floored.price(vars.termStructure);
+                    Real difference = std::fabs(cpn_capped_Price + cpn_floored_Price - cpn_plain_Price 
+                                                - nominal * strike * cpn_plain.accrualPeriod() * discount);
+                    Real tol = 4.0e-5;
+
+                    if (difference > tol)
+                        BOOST_FAIL("\nDiscount Factor:     " << discount <<
+                                   "\nCoupon payment date: " << paymentDate <<
+                                   "\nCoupon start date:   " << startDate <<
+                                   "\nCoupon gearing:      " << io::rate(gearing) <<
+                                   "\nCoupon swap index:   " << swapIndex->name() <<
+                                   "\nCoupon spread:       " << io::rate(spread) <<
+                                   "\nstrike:              " << io::rate(strike) <<
+                                   "\nCoupon DayCounter:   " << vars.iborIndex->dayCounter() <<
+                                   "\nYieldCurve Model:    " << vars.yieldCurveModels[j] <<
+                                   "\nPricerType:          " << (k==0 ? "Numerical Pricer" : "Analytic Pricer") <<
+                                   "\nPlain Coupon with rate=strike:       " << nominal * strike * cpn_plain.accrualPeriod() * discount <<
+                                   "\nPlain Coupon price:       " << io::rate(cpn_plain_Price) <<
+                                   "\nCapped Coupon price:        " << io::rate(cpn_capped_Price) <<
+                                   "\nFloored Coupon price:      " << io::rate(cpn_floored_Price) <<
+                                   "\ndifference:          " << difference <<
+                                   "\ntolerance:           " << io::rate(tol));
+                }
+            }
+        }
+    }
+}
+
+test_suite* CmsNormalTest::suite() {
+    auto* suite = BOOST_TEST_SUITE("Cms normal tests");
+    suite->add(QUANTLIB_TEST_CASE(&CmsNormalTest::testFairRate));
+    suite->add(QUANTLIB_TEST_CASE(&CmsNormalTest::testCmsSwap));
+    suite->add(QUANTLIB_TEST_CASE(&CmsNormalTest::testParity));
+    return suite;
+}

--- a/test-suite/cms_normal.hpp
+++ b/test-suite/cms_normal.hpp
@@ -1,8 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2006 Mario Pucci
-
+ Copyright (C) 2023 Andre Miemiec
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/cms_normal.hpp
+++ b/test-suite/cms_normal.hpp
@@ -1,0 +1,37 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2006 Mario Pucci
+
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#ifndef quantlib_test_cms_normal_hpp
+#define quantlib_test_cms_normal_hpp
+
+#include <boost/test/unit_test.hpp>
+
+/* remember to document new and/or updated tests in the Doxygen
+   comment block of the corresponding class */
+
+class CmsNormalTest {
+  public:
+    static void testFairRate();
+    static void testParity();
+    static void testCmsSwap();
+    static boost::unit_test_framework::test_suite* suite();
+};
+
+#endif

--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -70,6 +70,7 @@
 #include "chooseroption.hpp"
 #include "cliquetoption.hpp"
 #include "cms.hpp"
+#include "cms_normal.hpp"
 #include "cmsspread.hpp"
 #include "commodityunitofmeasure.hpp"
 #include "compiledboostversion.hpp"
@@ -376,6 +377,7 @@ test_suite* init_unit_test_suite(int, char* []) {
     test->add(CashFlowsTest::suite());
     test->add(CliquetOptionTest::suite());
     test->add(CmsTest::suite());
+    test->add(CmsNormalTest::suite());
     test->add(ConvertibleBondTest::suite());
     test->add(CovarianceTest::suite());
     test->add(CPISwapTest::suite());

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -667,6 +667,7 @@
     <ClCompile Include="chooseroption.cpp" />
     <ClCompile Include="cliquetoption.cpp" />
     <ClCompile Include="cms.cpp" />
+    <ClCompile Include="cms_normal.cpp" />
     <ClCompile Include="cmsspread.cpp" />
     <ClCompile Include="commodityunitofmeasure.cpp" />
     <ClCompile Include="compiledboostversion.cpp" />
@@ -837,6 +838,7 @@
     <ClInclude Include="chooseroption.hpp" />
     <ClInclude Include="cliquetoption.hpp" />
     <ClInclude Include="cms.hpp" />
+    <ClInclude Include="cms_normal.hpp" />
     <ClInclude Include="cmsspread.hpp" />
     <ClInclude Include="commodityunitofmeasure.hpp" />
     <ClInclude Include="compiledboostversion.hpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClCompile Include="cms.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cms_normal.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="cmsspread.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -591,6 +594,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="cms.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="cms_normal.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="cmsspread.hpp">


### PR DESCRIPTION
Extended functionality, such that cms pricing can cope with the normal model as well. Renamed the class BlackVanillaOptionPricer into MarketQuotedOptionPricer and changed the method  NumericHaganPricer::resetUpperLimit accordingly. In line 97 the YTM struchture used for discounting was changed from the forwardingTermStructure to the discountingTermStructure.