### PR TITLE
Rework check on test times

### DIFF
--- a/.github/workflows/test-times.yml
+++ b/.github/workflows/test-times.yml
@@ -22,16 +22,20 @@ jobs:
         ./autogen.sh
         ./configure --disable-static CC="ccache gcc" CXX="ccache g++" CXXFLAGS="-O2 -g0"
         make -j 2
-    - name: Run tests
+    - name: Run faster tests
       run: |
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,faster.xml:HRF,message -- --faster
+    - name: Run fast tests
+      run: |
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,fast.xml:HRF,message -- --fast
+    - name: Run all tests
+      run: |
         ./test-suite/quantlib-test-suite --logger=JUNIT,warning,all.xml:HRF,message
     - name: Save test times
       uses: actions/upload-artifact@v3
       with:
         name: test-reports
-        path: ./all.xml
+        path: ./*.xml
     - name: Check test times
       run: |
         python ./tools/check_test_times.py

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -1056,35 +1056,26 @@ void AndreasenHugeVolatilityInterplTest::testFlatVolCalibration() {
 test_suite* AndreasenHugeVolatilityInterplTest::suite(SpeedLevel speed) {
     auto* suite = BOOST_TEST_SUITE("Andreasen-Huge volatility interpolation tests");
 
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testSingleOptionCalibration));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testArbitrageFree));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testPeterAndFabiensExample));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testDifferentOptimizers));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testMovingReferenceDate));
-    suite->add(QUANTLIB_TEST_CASE(
-        &AndreasenHugeVolatilityInterplTest::testFlatVolCalibration));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testSingleOptionCalibration));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testArbitrageFree));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testPeterAndFabiensExample));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testDifferentOptimizers));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testMovingReferenceDate));
+    suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testFlatVolCalibration));
+
+    if (speed <= Fast) {
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testAndreasenHugePut));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testAndreasenHugeCall));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testAndreasenHugeCallPut));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testLinearInterpolation));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testPiecewiseConstantInterpolation));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testTimeDependentInterestRates));
+    }
 
     if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testAndreasenHugePut));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testAndreasenHugeCall));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testAndreasenHugeCallPut));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testLinearInterpolation));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testPiecewiseConstantInterpolation));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testBarrierOptionPricing));
-        suite->add(QUANTLIB_TEST_CASE(
-            &AndreasenHugeVolatilityInterplTest::testTimeDependentInterestRates));
+        suite->add(QUANTLIB_TEST_CASE(&AndreasenHugeVolatilityInterplTest::testBarrierOptionPricing));
     }
+
     return suite;
 }
 

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -381,7 +381,7 @@ test_suite* BermudanSwaptionTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&BermudanSwaptionTest::testCachedValues));
     suite->add(QUANTLIB_TEST_CASE(&BermudanSwaptionTest::testTreeEngineTimeSnapping));
 
-    if (speed == Slow) {
+    if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&BermudanSwaptionTest::testCachedG2Values));
     }
 

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -753,7 +753,7 @@ test_suite* DistributionTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testInvCDFviaStochasticCollocation));
     suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testSankaranApproximation));
 
-    if (speed == Slow) {
+    if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&DistributionTest::testBivariateCumulativeStudentVsBivariate));
     }
 

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -636,12 +636,9 @@ void DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical() {
 
 }
 
-test_suite* DoubleBarrierOptionTest::suite(SpeedLevel speed) {
+test_suite* DoubleBarrierOptionTest::suite(SpeedLevel) {
     auto* suite = BOOST_TEST_SUITE("DoubleBarrier");
-
-    if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(&DoubleBarrierOptionTest::testEuropeanHaugValues));
-    }
+    suite->add(QUANTLIB_TEST_CASE(&DoubleBarrierOptionTest::testEuropeanHaugValues));
 
     return suite;
 }

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -1127,13 +1127,10 @@ test_suite* FdHestonTest::suite(SpeedLevel speed) {
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testMethodOfLinesAndCN));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testSpuriousOscillations));
     suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testAmericanCallPutParity));
+    suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBlackScholes));
 
     if (speed <= Fast) {
-        suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBlackScholes));
         suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonConvergence));
-    }
-
-    if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&FdHestonTest::testFdmHestonBarrierVsBlackScholes));
     }
 

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -2756,12 +2756,12 @@ test_suite* HestonSLVModelTest::suite(SpeedLevel speed) {
     if (speed <= Fast) {
         suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage));
         suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMonteCarloVsFdmPricing));
+        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol));
     }
 
     if (speed == Slow) {
         suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testHestonFokkerPlanckFwdEquation));
         suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMonteCarloCalibration));
-        suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol));
         suite->add(QUANTLIB_TEST_CASE(&HestonSLVModelTest::testMoustacheGraph));
     }
 

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -461,19 +461,15 @@ void ShortRateModelTest::testExtendedCoxIngersollRossDiscountFactor() {
     }
 }
 
-test_suite* ShortRateModelTest::suite(SpeedLevel speed) {
+test_suite* ShortRateModelTest::suite(SpeedLevel) {
     auto* suite = BOOST_TEST_SUITE("Short-rate model tests");
 
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testCachedHullWhite));
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testCachedHullWhiteFixedReversion));
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testCachedHullWhite2));
     suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testFuturesConvexityBias));
-    suite->add(QUANTLIB_TEST_CASE(
-        &ShortRateModelTest::testExtendedCoxIngersollRossDiscountFactor));
-
-    if (speed == Slow) {
-        suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testSwaps));
-    }
+    suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testExtendedCoxIngersollRossDiscountFactor));
+    suite->add(QUANTLIB_TEST_CASE(&ShortRateModelTest::testSwaps));
 
     return suite;
 }


### PR DESCRIPTION
- more tolerant of occasional slow tests;
- now also points out fast tests incorrectly classified as slow