### PR TITLE
Add compile options for AppleClang too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if (QL_ENABLE_DEFAULT_WARNING_LEVEL)
         # warning level 3
         # There are also specific warnings disabled for MSCV in cmake/Platform.cmake.
         add_compile_options(-W3)
-    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         # lots of warnings
         add_compile_options(-Wall -Wno-unknown-pragmas)
     endif()
@@ -125,7 +125,7 @@ if (QL_COMPILE_WARNING_AS_ERROR)
         # or set them manually
         if (MSVC)
             add_compile_options(-WX)
-        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             add_compile_options(-Werror)
         endif()
     endif()


### PR DESCRIPTION
Fix for https://github.com/lballabio/QuantLib/pull/1658

This should now cover all the compilers used in the QuantLib CI.

Here's the [reference](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html) for the full list of compiler IDs.