### PR TITLE
EOM forward schedule corner case - effectiveDate and firstDate falling in the same month & year

### DIFF
--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -377,6 +377,13 @@ namespace QuantLib {
                 // the last otherwise.
                 if (*rule_ == DateGeneration::Backward)
                     d2 = Date::endOfMonth(dates_.back());
+                // corner case, does nothing but prevents to clip the effective
+                // date to end of month when the first date is in the same
+                // month and same year of the effective date
+                else if (firstDate_ != Date()
+                         && (effectiveDate.month() == firstDate_.month()
+                         &&  effectiveDate.year() == firstDate_.year())
+                        ) ;
                 else
                     d1 = Date::endOfMonth(dates_.front());
             }

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -24,6 +24,7 @@
 #include <ql/time/calendars/japan.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/calendars/weekendsonly.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/instruments/creditdefaultswap.hpp>
 #include <map>
 #include <vector>
@@ -1074,6 +1075,32 @@ void ScheduleTest::testTruncation() {
     BOOST_CHECK(t.isRegular().front() == true);
 }
 
+void ScheduleTest::testEomAdjustmentWithFirstDate() {
+    BOOST_TEST_MESSAGE(
+        "Testing forward schedule effective date not changed with EOM adjustment...");
+
+    Schedule s =
+        MakeSchedule().from(Date(16, January, 2023))
+                      .to(Date(16, March, 2023))
+                      .withCalendar(NullCalendar())
+                      .withTenor(1 * Months)
+                      .withConvention(Unadjusted)
+                      .withTerminationDateConvention(Unadjusted)
+                      .forwards()
+                      .endOfMonth()
+                      .withFirstDate(Date(31, January, 2023));
+
+    std::vector<Date> expected(4);
+    // Effective date is not moved to EOM when the first
+    // date is in the same month of the effective date. 
+    expected[0] = Date(16, January, 2023);
+    expected[1] = Date(31, January, 2023);
+    expected[2] = Date(28, February, 2023);
+    expected[3] = Date(16, March, 2023);;
+
+    check_dates(s, expected);
+}
+
 test_suite* ScheduleTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Schedule tests");
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testDailySchedule));
@@ -1103,5 +1130,6 @@ test_suite* ScheduleTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFirstDateOnMaturity));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testNextToLastDateOnStart));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testTruncation));
+    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testEomAdjustmentWithFirstDate));
     return suite;
 }

--- a/test-suite/schedule.hpp
+++ b/test-suite/schedule.hpp
@@ -49,6 +49,7 @@ class ScheduleTest {
     static void testFirstDateOnMaturity();
     static void testNextToLastDateOnStart();
     static void testTruncation();
+    static void testEomAdjustmentWithFirstDate();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Should fix #895 
The corner case where effectiveDate and firstDate are falling in the same month & year.
It is avoiding that that the effectiveDate is clipped to the end of month.