### PR TITLE
Add ThreadSanitizer to CI

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 jobs:
-  sanitize:
+  sanitize-address-undefined:
     runs-on: ubuntu-latest
     container: ghcr.io/lballabio/quantlib-devenv:rolling
     steps:
@@ -16,6 +16,25 @@ jobs:
       run: |
         ./autogen.sh
         ./configure --disable-static CC="gcc" CXX="g++" CXXFLAGS="-O2 -g0 -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -Wall -Wno-unknown-pragmas -Werror"
+        make -j 2
+    - name: Run tests
+      run: |
+        ./test-suite/quantlib-test-suite --log_level=message
+    - name: Run examples
+      run: |
+        make check-examples
+  sanitize-thread:
+    runs-on: ubuntu-latest
+    container: ghcr.io/lballabio/quantlib-devenv:rolling
+    steps:
+    - uses: actions/checkout@v3
+    - name: Compiler version
+      run: |
+        gcc --version
+    - name: Build
+      run: |
+        ./autogen.sh
+        ./configure --disable-static --enable-sessions --enable-thread-safe-observer-pattern CC="gcc" CXX="g++" CXXFLAGS="-O2 -g0 -fsanitize=thread -fno-sanitize-recover=all -Wall -Wno-unknown-pragmas -Werror"
         make -j 2
     - name: Run tests
       run: |


### PR DESCRIPTION
ThreadSanitizer cannot be combined with AddressSanitizer, so the two jobs have to be built separately.

I have enabled sessions and the thread-safe observer pattern for this new CI job, and we can add other options too if they are relevant for ThreadSanitizer.

I see that there are some test cases for the thread-safe observer pattern, but nothing specifically for sessions. Probably we should add some unit tests for this one day.