### PR TITLE
Expose ois schedule

### DIFF
--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -64,26 +64,25 @@ namespace QuantLib {
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
                                                RateAveraging::Type averagingMethod)
-    : Swap(2), type_(type), nominals_(std::move(nominals)),
-      paymentFrequency_(schedule.tenor().frequency()),
+    : Swap(2), type_(type), nominals_(std::move(nominals)), schedule_(schedule),
       paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
       paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag), fixedRate_(fixedRate),
       fixedDC_(std::move(fixedDC)), overnightIndex_(std::move(overnightIndex)), spread_(spread),
       telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
-        initialize(schedule);
+        initialize();
     }
 
-    void OvernightIndexedSwap::initialize(const Schedule& schedule) {
+    void OvernightIndexedSwap::initialize() {
         if (fixedDC_ == DayCounter())
             fixedDC_ = overnightIndex_->dayCounter();
-        legs_[0] = FixedRateLeg(schedule)
+        legs_[0] = FixedRateLeg(schedule_)
                        .withNotionals(nominals_)
                        .withCouponRates(fixedRate_, fixedDC_)
                        .withPaymentLag(paymentLag_)
                        .withPaymentAdjustment(paymentAdjustment_)
                        .withPaymentCalendar(paymentCalendar_);
 
-        legs_[1] = OvernightLeg(schedule, overnightIndex_)
+        legs_[1] = OvernightLeg(schedule_, overnightIndex_)
                        .withNotionals(nominals_)
                        .withSpreads(spread_)
                        .withTelescopicValueDates(telescopicValueDates_)

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -39,15 +39,18 @@ namespace QuantLib {
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
                                                RateAveraging::Type averagingMethod)
-    : Swap(2), type_(type), nominals_(std::vector<Real>(1, nominal)),
-      paymentFrequency_(schedule.tenor().frequency()),
-      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
-      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag), fixedRate_(fixedRate),
-      fixedDC_(std::move(fixedDC)), overnightIndex_(std::move(overnightIndex)), spread_(spread),
-      telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
-
-        initialize(schedule);
-    }
+    : OvernightIndexedSwap(type,
+                           std::vector<Real>(1, nominal),
+                           schedule,
+                           fixedRate,
+                           fixedDC,
+                           overnightIndex,
+                           spread,
+                           paymentLag,
+                           paymentAdjustment,
+                           paymentCalendar,
+                           telescopicValueDates,
+                           averagingMethod) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                std::vector<Real> nominals,
@@ -67,7 +70,6 @@ namespace QuantLib {
       paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag), fixedRate_(fixedRate),
       fixedDC_(std::move(fixedDC)), overnightIndex_(std::move(overnightIndex)), spread_(spread),
       telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
-
         initialize(schedule);
     }
 

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -65,30 +65,27 @@ namespace QuantLib {
                                                bool telescopicValueDates,
                                                RateAveraging::Type averagingMethod)
     : Swap(2), type_(type), nominals_(std::move(nominals)), schedule_(schedule),
-      paymentCalendar_(paymentCalendar.empty() ? schedule.calendar() : paymentCalendar),
-      paymentAdjustment_(paymentAdjustment), paymentLag_(paymentLag), fixedRate_(fixedRate),
-      fixedDC_(std::move(fixedDC)), overnightIndex_(std::move(overnightIndex)), spread_(spread),
-      telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
-        initialize();
-    }
-
-    void OvernightIndexedSwap::initialize() {
+      fixedRate_(fixedRate), fixedDC_(std::move(fixedDC)),
+      overnightIndex_(std::move(overnightIndex)), spread_(spread),
+      averagingMethod_(averagingMethod) {
         if (fixedDC_ == DayCounter())
             fixedDC_ = overnightIndex_->dayCounter();
         legs_[0] = FixedRateLeg(schedule_)
                        .withNotionals(nominals_)
                        .withCouponRates(fixedRate_, fixedDC_)
-                       .withPaymentLag(paymentLag_)
-                       .withPaymentAdjustment(paymentAdjustment_)
-                       .withPaymentCalendar(paymentCalendar_);
+                       .withPaymentLag(paymentLag)
+                       .withPaymentAdjustment(paymentAdjustment)
+                       .withPaymentCalendar(paymentCalendar.empty() ? schedule.calendar() :
+                                                                      paymentCalendar);
 
         legs_[1] = OvernightLeg(schedule_, overnightIndex_)
                        .withNotionals(nominals_)
                        .withSpreads(spread_)
-                       .withTelescopicValueDates(telescopicValueDates_)
-                       .withPaymentLag(paymentLag_)
-                       .withPaymentAdjustment(paymentAdjustment_)
-                       .withPaymentCalendar(paymentCalendar_)
+                       .withTelescopicValueDates(telescopicValueDates)
+                       .withPaymentLag(paymentLag)
+                       .withPaymentAdjustment(paymentAdjustment)
+                       .withPaymentCalendar(paymentCalendar.empty() ? schedule.calendar() :
+                                                                      paymentCalendar)
                        .withAveragingMethod(averagingMethod_);
 
         for (Size j = 0; j < 2; ++j) {

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                                                Natural paymentLag,
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
-                                               bool telescopicValueDates, 
+                                               bool telescopicValueDates,
                                                RateAveraging::Type averagingMethod)
     : Swap(2), type_(type), nominals_(std::vector<Real>(1, nominal)),
       paymentFrequency_(schedule.tenor().frequency()),
@@ -59,7 +59,7 @@ namespace QuantLib {
                                                Natural paymentLag,
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
-                                               bool telescopicValueDates, 
+                                               bool telescopicValueDates,
                                                RateAveraging::Type averagingMethod)
     : Swap(2), type_(type), nominals_(std::move(nominals)),
       paymentFrequency_(schedule.tenor().frequency()),
@@ -72,53 +72,53 @@ namespace QuantLib {
     }
 
     void OvernightIndexedSwap::initialize(const Schedule& schedule) {
-        if (fixedDC_==DayCounter())
+        if (fixedDC_ == DayCounter())
             fixedDC_ = overnightIndex_->dayCounter();
         legs_[0] = FixedRateLeg(schedule)
-            .withNotionals(nominals_)
-            .withCouponRates(fixedRate_, fixedDC_)
-            .withPaymentLag(paymentLag_)
-            .withPaymentAdjustment(paymentAdjustment_)
-            .withPaymentCalendar(paymentCalendar_);
+                       .withNotionals(nominals_)
+                       .withCouponRates(fixedRate_, fixedDC_)
+                       .withPaymentLag(paymentLag_)
+                       .withPaymentAdjustment(paymentAdjustment_)
+                       .withPaymentCalendar(paymentCalendar_);
 
-		legs_[1] = OvernightLeg(schedule, overnightIndex_)
-            .withNotionals(nominals_)
-            .withSpreads(spread_)
-            .withTelescopicValueDates(telescopicValueDates_)
-            .withPaymentLag(paymentLag_)
-            .withPaymentAdjustment(paymentAdjustment_)
-            .withPaymentCalendar(paymentCalendar_)
-            .withAveragingMethod(averagingMethod_);
+        legs_[1] = OvernightLeg(schedule, overnightIndex_)
+                       .withNotionals(nominals_)
+                       .withSpreads(spread_)
+                       .withTelescopicValueDates(telescopicValueDates_)
+                       .withPaymentLag(paymentLag_)
+                       .withPaymentAdjustment(paymentAdjustment_)
+                       .withPaymentCalendar(paymentCalendar_)
+                       .withAveragingMethod(averagingMethod_);
 
-        for (Size j=0; j<2; ++j) {
+        for (Size j = 0; j < 2; ++j) {
             for (auto& i : legs_[j])
                 registerWith(i);
         }
 
         switch (type_) {
-          case Payer:
-            payer_[0] = -1.0;
-            payer_[1] = +1.0;
-            break;
-          case Receiver:
-            payer_[0] = +1.0;
-            payer_[1] = -1.0;
-            break;
-          default:
-            QL_FAIL("Unknown overnight-swap type");
+            case Payer:
+                payer_[0] = -1.0;
+                payer_[1] = +1.0;
+                break;
+            case Receiver:
+                payer_[0] = +1.0;
+                payer_[1] = -1.0;
+                break;
+            default:
+                QL_FAIL("Unknown overnight-swap type");
         }
     }
 
     Real OvernightIndexedSwap::fairRate() const {
         static Spread basisPoint = 1.0e-4;
         calculate();
-        return fixedRate_ - NPV_/(fixedLegBPS()/basisPoint);
+        return fixedRate_ - NPV_ / (fixedLegBPS() / basisPoint);
     }
 
     Spread OvernightIndexedSwap::fairSpread() const {
         static Spread basisPoint = 1.0e-4;
         calculate();
-        return spread_ - NPV_/(overnightLegBPS()/basisPoint);
+        return spread_ - NPV_ / (overnightLegBPS() / basisPoint);
     }
 
     Real OvernightIndexedSwap::fixedLegBPS() const {

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -27,11 +27,11 @@
 #ifndef quantlib_overnight_indexed_swap_hpp
 #define quantlib_overnight_indexed_swap_hpp
 
-#include <ql/instruments/swap.hpp>
 #include <ql/cashflows/rateaveraging.hpp>
-#include <ql/time/daycounter.hpp>
+#include <ql/instruments/swap.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
+#include <ql/time/daycounter.hpp>
 
 namespace QuantLib {
 
@@ -107,7 +107,7 @@ namespace QuantLib {
         BusinessDayConvention paymentAdjustment_;
         Natural paymentLag_;
 
-        //Schedule schedule_;
+        // Schedule schedule_;
 
         Rate fixedRate_;
         DayCounter fixedDC_;
@@ -122,7 +122,7 @@ namespace QuantLib {
     // inline
 
     inline Real OvernightIndexedSwap::nominal() const {
-        QL_REQUIRE(nominals_.size()==1, "varying nominals");
+        QL_REQUIRE(nominals_.size() == 1, "varying nominals");
         return nominals_[0];
     }
 

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -32,6 +32,7 @@
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/daycounter.hpp>
+#include <ql/time/schedule.hpp>
 
 namespace QuantLib {
 
@@ -73,7 +74,8 @@ namespace QuantLib {
         Real nominal() const;
         std::vector<Real> nominals() const { return nominals_; }
 
-        Frequency paymentFrequency() const { return paymentFrequency_; }
+        const Schedule& schedule() const { return schedule_; }
+        Frequency paymentFrequency() const { return schedule_.tenor().frequency(); }
 
         Rate fixedRate() const { return fixedRate_; }
         const DayCounter& fixedDayCount() const { return fixedDC_; }
@@ -98,16 +100,14 @@ namespace QuantLib {
         Spread fairSpread() const;
         //@}
       private:
-        void initialize(const Schedule& schedule);
+        void initialize();
         Type type_;
         std::vector<Real> nominals_;
 
-        Frequency paymentFrequency_;
+        Schedule schedule_;
         Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_;
         Natural paymentLag_;
-
-        // Schedule schedule_;
 
         Rate fixedRate_;
         DayCounter fixedDC_;

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -68,18 +68,50 @@ namespace QuantLib {
                              bool telescopicValueDates = false,
                              RateAveraging::Type averagingMethod = RateAveraging::Compound);
 
+        OvernightIndexedSwap(Type type,
+                             Real nominal,
+                             const Schedule& fixedSchedule,
+                             Rate fixedRate,
+                             DayCounter fixedDC,
+                             const Schedule& overnightSchedule,
+                             ext::shared_ptr<OvernightIndex> overnightIndex,
+                             Spread spread = 0.0,
+                             Natural paymentLag = 0,
+                             BusinessDayConvention paymentAdjustment = Following,
+                             const Calendar& paymentCalendar = Calendar(),
+                             bool telescopicValueDates = false,
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+
+        OvernightIndexedSwap(Type type,
+                             std::vector<Real> nominals,
+                             const Schedule& fixedSchedule,
+                             Rate fixedRate,
+                             DayCounter fixedDC,
+                             const Schedule& overnightSchedule,
+                             ext::shared_ptr<OvernightIndex> overnightIndex,
+                             Spread spread = 0.0,
+                             Natural paymentLag = 0,
+                             BusinessDayConvention paymentAdjustment = Following,
+                             const Calendar& paymentCalendar = Calendar(),
+                             bool telescopicValueDates = false,
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+
         //! \name Inspectors
         //@{
         Type type() const { return type_; }
         Real nominal() const;
         std::vector<Real> nominals() const { return nominals_; }
 
-        const Schedule& schedule() const { return schedule_; }
-        Frequency paymentFrequency() const { return schedule_.tenor().frequency(); }
+        Frequency paymentFrequency() const {
+            return std::max(fixedSchedule_.tenor().frequency(),
+                            overnightSchedule_.tenor().frequency());
+        }
 
+        const Schedule& fixedSchedule() const { return fixedSchedule_; }
         Rate fixedRate() const { return fixedRate_; }
         const DayCounter& fixedDayCount() const { return fixedDC_; }
 
+        const Schedule& overnightSchedule() const { return overnightSchedule_; }
         const ext::shared_ptr<OvernightIndex>& overnightIndex() const { return overnightIndex_; }
         Spread spread() const { return spread_; }
 
@@ -103,11 +135,11 @@ namespace QuantLib {
         Type type_;
         std::vector<Real> nominals_;
 
-        Schedule schedule_;
-
+        Schedule fixedSchedule_;
         Rate fixedRate_;
         DayCounter fixedDC_;
 
+        Schedule overnightSchedule_;
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         Spread spread_;
         RateAveraging::Type averagingMethod_;

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -100,21 +100,16 @@ namespace QuantLib {
         Spread fairSpread() const;
         //@}
       private:
-        void initialize();
         Type type_;
         std::vector<Real> nominals_;
 
         Schedule schedule_;
-        Calendar paymentCalendar_;
-        BusinessDayConvention paymentAdjustment_;
-        Natural paymentLag_;
 
         Rate fixedRate_;
         DayCounter fixedDC_;
 
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         Spread spread_;
-        bool telescopicValueDates_;
         RateAveraging::Type averagingMethod_;
     };
 


### PR DESCRIPTION
This addresses  #1666.

I haven't split the schedule in two yet, but if this looks okay, i will do that. In doing that i will delete the schedule accessor i defined here. I think that should not be a backwards compatibility concern as it will never have appeared in a release.
