### PR TITLE
Add correct accrual calculation for CPI coupons

### DIFF
--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -135,6 +135,17 @@ namespace QuantLib {
             InflationCoupon::accept(v);
     }
 
+    Real CPICoupon::accruedAmount(const Date& d) const {
+        if (d <= accrualStartDate_ || d > paymentDate_) {
+            return 0.0;
+        } else {
+            auto pricer = ext::dynamic_pointer_cast<CPICouponPricer>(pricer_);
+            QL_REQUIRE(pricer, "pricer not set or of wrong type");
+            pricer->initialize(*this);
+            return nominal() * pricer->accruedRate(d) * accruedPeriod(d);
+        }
+    }
+
     Rate CPICoupon::indexRatio(Date d) const {
 
         Rate I0 = baseCPI();

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -135,6 +135,24 @@ namespace QuantLib {
             InflationCoupon::accept(v);
     }
 
+    Rate CPICoupon::indexRatio(Date d) const {
+
+        Rate I0 = baseCPI();
+
+        if (I0 == Null<Rate>()) {
+            I0 = CPI::laggedFixing(cpiIndex(),
+                                   baseDate() + observationLag(),
+                                   observationLag(),
+                                   observationInterpolation());
+        }
+
+        Rate I1 = CPI::laggedFixing(cpiIndex(),
+                                    d,
+                                    observationLag(),
+                                    observationInterpolation());
+
+        return I1 / I0;
+    }
 
     bool CPICoupon::checkPricerImpl(
             const ext::shared_ptr<InflationCouponPricer>&pricer) const {

--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -29,65 +29,41 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     CPICoupon::CPICoupon(Real baseCPI,
                          const Date& paymentDate,
                          Real nominal,
                          const Date& startDate,
                          const Date& endDate,
-                         const ext::shared_ptr<ZeroInflationIndex>& zeroIndex,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
                          const Period& observationLag,
                          CPI::InterpolationType observationInterpolation,
                          const DayCounter& dayCounter,
                          Real fixedRate,
-                         Spread spread,
                          const Date& refPeriodStart,
                          const Date& refPeriodEnd,
                          const Date& exCouponDate)
-    : CPICoupon(baseCPI,
-                Null<Date>(),
-                paymentDate,
-                nominal,
-                startDate,
-                endDate,
-                zeroIndex,
-                observationLag,
-                observationInterpolation,
-                dayCounter,
-                fixedRate,
-                spread,
-                refPeriodStart,
-                refPeriodEnd,
-                exCouponDate) {}
+    : CPICoupon(baseCPI, paymentDate, nominal, startDate, endDate, index,
+                observationLag, observationInterpolation, dayCounter,
+                fixedRate, 0.0, refPeriodStart, refPeriodEnd, exCouponDate) {}
 
     CPICoupon::CPICoupon(const Date& baseDate,
                          const Date& paymentDate,
                          Real nominal,
                          const Date& startDate,
                          const Date& endDate,
-                         const ext::shared_ptr<ZeroInflationIndex>& zeroIndex,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
                          const Period& observationLag,
                          CPI::InterpolationType observationInterpolation,
                          const DayCounter& dayCounter,
                          Real fixedRate,
-                         Spread spread,
                          const Date& refPeriodStart,
                          const Date& refPeriodEnd,
                          const Date& exCouponDate)
-    : CPICoupon(Null<Real>(),
-                baseDate,
-                paymentDate,
-                nominal,
-                startDate,
-                endDate,
-                zeroIndex,
-                observationLag,
-                observationInterpolation,
-                dayCounter,
-                fixedRate,
-                spread,
-                refPeriodStart,
-                refPeriodEnd,
-                exCouponDate) {}
+    : CPICoupon(baseDate, paymentDate, nominal, startDate, endDate, index,
+                observationLag, observationInterpolation, dayCounter,
+                fixedRate, 0.0, refPeriodStart, refPeriodEnd, exCouponDate) {}
 
     CPICoupon::CPICoupon(Real baseCPI,
                          const Date& baseDate,
@@ -95,7 +71,24 @@ namespace QuantLib {
                          Real nominal,
                          const Date& startDate,
                          const Date& endDate,
-                         const ext::shared_ptr<ZeroInflationIndex>& zeroIndex,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
+                         const Period& observationLag,
+                         CPI::InterpolationType observationInterpolation,
+                         const DayCounter& dayCounter,
+                         Real fixedRate,
+                         const Date& refPeriodStart,
+                         const Date& refPeriodEnd,
+                         const Date& exCouponDate)
+    : CPICoupon(baseCPI, baseDate, paymentDate, nominal, startDate, endDate, index,
+                observationLag, observationInterpolation, dayCounter,
+                fixedRate, 0.0, refPeriodStart, refPeriodEnd, exCouponDate) {}
+
+    CPICoupon::CPICoupon(Real baseCPI,
+                         const Date& paymentDate,
+                         Real nominal,
+                         const Date& startDate,
+                         const Date& endDate,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
                          const Period& observationLag,
                          CPI::InterpolationType observationInterpolation,
                          const DayCounter& dayCounter,
@@ -104,17 +97,46 @@ namespace QuantLib {
                          const Date& refPeriodStart,
                          const Date& refPeriodEnd,
                          const Date& exCouponDate)
-    : InflationCoupon(paymentDate,
-                      nominal,
-                      startDate,
-                      endDate,
-                      0,
-                      zeroIndex,
-                      observationLag,
-                      dayCounter,
-                      refPeriodStart,
-                      refPeriodEnd,
-                      exCouponDate),
+    : CPICoupon(baseCPI, Null<Date>(), paymentDate, nominal, startDate, endDate, index,
+                observationLag, observationInterpolation, dayCounter,
+                fixedRate, spread, refPeriodStart, refPeriodEnd, exCouponDate) {}
+
+    CPICoupon::CPICoupon(const Date& baseDate,
+                         const Date& paymentDate,
+                         Real nominal,
+                         const Date& startDate,
+                         const Date& endDate,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
+                         const Period& observationLag,
+                         CPI::InterpolationType observationInterpolation,
+                         const DayCounter& dayCounter,
+                         Real fixedRate,
+                         Spread spread,
+                         const Date& refPeriodStart,
+                         const Date& refPeriodEnd,
+                         const Date& exCouponDate)
+    : CPICoupon(Null<Real>(), baseDate, paymentDate, nominal, startDate, endDate, index,
+                observationLag, observationInterpolation, dayCounter,
+                fixedRate, spread, refPeriodStart, refPeriodEnd, exCouponDate) {}
+
+    CPICoupon::CPICoupon(Real baseCPI,
+                         const Date& baseDate,
+                         const Date& paymentDate,
+                         Real nominal,
+                         const Date& startDate,
+                         const Date& endDate,
+                         const ext::shared_ptr<ZeroInflationIndex>& index,
+                         const Period& observationLag,
+                         CPI::InterpolationType observationInterpolation,
+                         const DayCounter& dayCounter,
+                         Real fixedRate,
+                         Spread spread,
+                         const Date& refPeriodStart,
+                         const Date& refPeriodEnd,
+                         const Date& exCouponDate)
+    : InflationCoupon(paymentDate, nominal, startDate, endDate, 0,
+                      index, observationLag, dayCounter,
+                      refPeriodStart, refPeriodEnd, exCouponDate),
       baseCPI_(baseCPI), fixedRate_(fixedRate), spread_(spread),
       observationInterpolation_(observationInterpolation), baseDate_(baseDate) {
 
@@ -126,6 +148,7 @@ namespace QuantLib {
                    "|baseCPI_| < 1e-16, future divide-by-zero problem");
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 
     void CPICoupon::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<CPICoupon>*>(&v);
@@ -387,6 +410,7 @@ namespace QuantLib {
                                     paymentDayCounter_, start, end, refStart, refEnd, exCouponDate));
                 } else { // zero inflation coupon
                     if (detail::noOption(caps_, floors_, i)) { // just swaplet
+                        QL_DEPRECATED_DISABLE_WARNING
                         leg.push_back(ext::make_shared<CPICoupon>
                                     (baseCPI_,    // all have same base for ratio
                                      baseDate,
@@ -399,6 +423,7 @@ namespace QuantLib {
                                      detail::get(fixedRates_, i, 0.0),
                                      detail::get(spreads_, i, 0.0),
                                      refStart, refEnd, exCouponDate));
+                        QL_DEPRECATED_ENABLE_WARNING
                     } else  {     // cap/floorlet
                         QL_FAIL("caps/floors on CPI coupons not implemented.");
                     }

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -107,13 +107,6 @@ namespace QuantLib {
         //! spread paid over the fixing of the underlying index
         Spread spread() const;
 
-        //! the ratio between the end index fixing and the base CPI
-        /*! This might include adjustments calculated by the pricer */
-        Rate adjustedIndexGrowth() const;
-
-        //! the index value observed (with a lag) at the end date
-        Rate indexFixing() const override;
-
         //! base value for the CPI index
         /*! \warning make sure that the interpolation used to create
                      this is what you are using for the fixing,
@@ -129,10 +122,22 @@ namespace QuantLib {
 
         //! index used
         ext::shared_ptr<ZeroInflationIndex> cpiIndex() const;
+        //@}
 
-        //! the ratio between the index fixing at the given date and the base CPI
+        //! \name Calculations
+        //@{
+        Real accruedAmount(const Date&) const override;
+
+        //! the index value observed (with a lag) at the end date
+        Rate indexFixing() const override;
+
+        //! the ratio between the index fixing at the passed date and the base CPI
         /*! No adjustments are applied */
         Rate indexRatio(Date d) const;
+
+        //! the ratio between the end index fixing and the base CPI
+        /*! This might include adjustments calculated by the pricer */
+        Rate adjustedIndexGrowth() const;
         //@}
 
         //! \name Visitability

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -54,7 +54,9 @@ namespace QuantLib {
     */
     class CPICoupon : public InflationCoupon {
       public:
-        CPICoupon(Real baseCPI, // user provided, could be arbitrary
+        //! \name Constructors
+        //@{
+        CPICoupon(Real baseCPI,
                   const Date& paymentDate,
                   Real nominal,
                   const Date& startDate,
@@ -63,8 +65,7 @@ namespace QuantLib {
                   const Period& observationLag,
                   CPI::InterpolationType observationInterpolation,
                   const DayCounter& dayCounter,
-                  Real fixedRate, // aka gearing
-                  Spread spread = 0.0,
+                  Real fixedRate,
                   const Date& refPeriodStart = Date(),
                   const Date& refPeriodEnd = Date(),
                   const Date& exCouponDate = Date());
@@ -78,8 +79,7 @@ namespace QuantLib {
                   const Period& observationLag,
                   CPI::InterpolationType observationInterpolation,
                   const DayCounter& dayCounter,
-                  Real fixedRate, // aka gearing
-                  Spread spread = 0.0,
+                  Real fixedRate,
                   const Date& refPeriodStart = Date(),
                   const Date& refPeriodEnd = Date(),
                   const Date& exCouponDate = Date());
@@ -94,17 +94,83 @@ namespace QuantLib {
                   const Period& observationLag,
                   CPI::InterpolationType observationInterpolation,
                   const DayCounter& dayCounter,
-                  Real fixedRate, // aka gearing
-                  Spread spread = 0.0,
+                  Real fixedRate,
                   const Date& refPeriodStart = Date(),
                   const Date& refPeriodEnd = Date(),
                   const Date& exCouponDate = Date());
+
+        /*! \deprecated Use one of the constructors without spread.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
+        CPICoupon(Real baseCPI, // user provided, could be arbitrary
+                  const Date& paymentDate,
+                  Real nominal,
+                  const Date& startDate,
+                  const Date& endDate,
+                  const ext::shared_ptr<ZeroInflationIndex>& index,
+                  const Period& observationLag,
+                  CPI::InterpolationType observationInterpolation,
+                  const DayCounter& dayCounter,
+                  Real fixedRate,
+                  Spread spread,
+                  const Date& refPeriodStart = Date(),
+                  const Date& refPeriodEnd = Date(),
+                  const Date& exCouponDate = Date());
+
+        /*! \deprecated Use one of the constructors without spread.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
+        CPICoupon(const Date& baseDate, // user provided, could be arbitrary
+                  const Date& paymentDate,
+                  Real nominal,
+                  const Date& startDate,
+                  const Date& endDate,
+                  const ext::shared_ptr<ZeroInflationIndex>& index,
+                  const Period& observationLag,
+                  CPI::InterpolationType observationInterpolation,
+                  const DayCounter& dayCounter,
+                  Real fixedRate,
+                  Spread spread,
+                  const Date& refPeriodStart = Date(),
+                  const Date& refPeriodEnd = Date(),
+                  const Date& exCouponDate = Date());
+
+        /*! \deprecated Use one of the constructors without spread.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
+        CPICoupon(Real baseCPI, // user provided, could be arbitrary
+                  const Date& baseDate,
+                  const Date& paymentDate,
+                  Real nominal,
+                  const Date& startDate,
+                  const Date& endDate,
+                  const ext::shared_ptr<ZeroInflationIndex>& index,
+                  const Period& observationLag,
+                  CPI::InterpolationType observationInterpolation,
+                  const DayCounter& dayCounter,
+                  Real fixedRate,
+                  Spread spread,
+                  const Date& refPeriodStart = Date(),
+                  const Date& refPeriodEnd = Date(),
+                  const Date& exCouponDate = Date());
+        //@}
+
+        QL_DEPRECATED_DISABLE_WARNING
+        ~CPICoupon() override = default;
+        QL_DEPRECATED_ENABLE_WARNING
 
         //! \name Inspectors
         //@{
         //! fixed rate that will be inflated by the index ratio
         Real fixedRate() const;
-        //! spread paid over the fixing of the underlying index
+
+        /*! \deprecated Do not use this method. A spread doesn't make sense for this coupon.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this method. A spread doesn't make sense for this coupon.")]]
         Spread spread() const;
 
         //! base value for the CPI index
@@ -147,6 +213,10 @@ namespace QuantLib {
       protected:
         Real baseCPI_;
         Real fixedRate_;
+        /*! \deprecated Don't use this data member. A spread doesn't make sense for this coupon.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this data member. A spread doesn't make sense for this coupon.")]]
         Spread spread_;
         CPI::InterpolationType observationInterpolation_;
         Date baseDate_;
@@ -201,10 +271,8 @@ namespace QuantLib {
     //! Helper class building a sequence of capped/floored CPI coupons.
     /*! Also allowing for the inflated notional at the end...
         especially if there is only one date in the schedule.
-        If a fixedRate is zero you get a FixedRateCoupon, otherwise
+        If the fixed rate is zero you get a FixedRateCoupon, otherwise
         you get a ZeroInflationCoupon.
-
-        payoff is: spread + fixedRate x index
     */
     class CPILeg {
       public:
@@ -221,7 +289,15 @@ namespace QuantLib {
         CPILeg& withPaymentCalendar(const Calendar&);
         CPILeg& withObservationInterpolation(CPI::InterpolationType);
         CPILeg& withSubtractInflationNominal(bool);
+        /*! \deprecated Do not use this method. A spread doesn't make sense for these coupons.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this method. A spread doesn't make sense for these coupons.")]]
         CPILeg& withSpreads(Spread spread);
+        /*! \deprecated Do not use this method. A spread doesn't make sense for these coupons.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this method. A spread doesn't make sense for these coupons.")]]
         CPILeg& withSpreads(const std::vector<Spread>& spreads);
         CPILeg& withCaps(Rate cap);
         CPILeg& withCaps(const std::vector<Rate>& caps);
@@ -241,7 +317,7 @@ namespace QuantLib {
         Real baseCPI_;
         Period observationLag_;
         std::vector<Real> notionals_;
-        std::vector<Real> fixedRates_;  // aka gearing
+        std::vector<Real> fixedRates_;
         DayCounter paymentDayCounter_;
         BusinessDayConvention paymentAdjustment_ = ModifiedFollowing;
         Calendar paymentCalendar_;
@@ -264,11 +340,15 @@ namespace QuantLib {
     }
 
     inline Real CPICoupon::spread() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return spread_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     inline Rate CPICoupon::adjustedIndexGrowth() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return (rate()-spread())/fixedRate();
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     inline Rate CPICoupon::indexFixing() const {

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -129,6 +129,10 @@ namespace QuantLib {
 
         //! index used
         ext::shared_ptr<ZeroInflationIndex> cpiIndex() const;
+
+        //! the ratio between the index fixing at the given date and the base CPI
+        /*! No adjustments are applied */
+        Rate indexRatio(Date d) const;
         //@}
 
         //! \name Visitability

--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -143,11 +143,14 @@ namespace QuantLib {
 
 
     Rate CPICouponPricer::swapletRate() const {
-        // This way we do not require the index to have
-        // a yield curve, i.e. we do not get the problem
-        // that a discounting-instrument-pricer is used
-        // with a different yield curve
         return gearing_ * adjustedFixing() + spread_;
+        // after deprecating and removing adjustedFixing:
+        // return accruedRate(coupon_->accrualEndDate());
+    }
+
+
+    Rate CPICouponPricer::accruedRate(Date settlementDate) const {
+        return gearing_ * coupon_->indexRatio(settlementDate) + spread_;
     }
 
 }

--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -112,17 +112,7 @@ namespace QuantLib {
         if (fixing != Null<Rate>())
             return fixing;
 
-        Rate I0 = coupon_->baseCPI();
-
-        if (I0 == Null<Rate>()) {
-            I0 = CPI::laggedFixing(coupon_->cpiIndex(),
-                                   coupon_->baseDate() + coupon_->observationLag(),
-                                   coupon_->observationLag(), coupon_->observationInterpolation());
-        }
-
-        Rate I1 = coupon_->indexFixing();
-
-        return I1 / I0;
+        return coupon_->indexRatio(coupon_->accrualEndDate());
     }
 
 

--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -109,6 +109,9 @@ namespace QuantLib {
 
 
     Rate CPICouponPricer::adjustedFixing(Rate fixing) const {
+        if (fixing != Null<Rate>())
+            return fixing;
+
         Rate I0 = coupon_->baseCPI();
 
         if (I0 == Null<Rate>()) {
@@ -119,10 +122,7 @@ namespace QuantLib {
 
         Rate I1 = coupon_->indexFixing();
 
-        if (fixing == Null<Rate>())
-            fixing = I1 / I0;
-
-        return fixing;
+        return I1 / I0;
     }
 
 

--- a/ql/cashflows/cpicouponpricer.cpp
+++ b/ql/cashflows/cpicouponpricer.cpp
@@ -23,6 +23,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     CPICouponPricer::CPICouponPricer(Handle<YieldTermStructure> nominalTermStructure)
     : nominalTermStructure_(std::move(nominalTermStructure)) {
         registerWith(nominalTermStructure_);
@@ -35,6 +37,7 @@ namespace QuantLib {
         registerWith(nominalTermStructure_);
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 
     void CPICouponPricer::setCapletVolatility(
        const Handle<CPIVolatilitySurface>& capletVol) {
@@ -100,10 +103,12 @@ namespace QuantLib {
             Real stdDev =
             std::sqrt(capletVolatility()->totalVariance(fixingDate,
                                                         effStrike));
+            QL_DEPRECATED_DISABLE_WARNING
             return optionletPriceImp(optionType,
                                      effStrike,
                                      adjustedFixing(),
                                      stdDev);
+            QL_DEPRECATED_ENABLE_WARNING
         }
     }
 
@@ -119,7 +124,9 @@ namespace QuantLib {
     void CPICouponPricer::initialize(const InflationCoupon& coupon) {
         coupon_ = dynamic_cast<const CPICoupon*>(&coupon);
         gearing_ = coupon_->fixedRate();
+        QL_DEPRECATED_DISABLE_WARNING
         spread_ = coupon_->spread();
+        QL_DEPRECATED_ENABLE_WARNING
         paymentDate_ = coupon_->date();
 
         // past or future fixing is managed in YoYInflationIndex::fixing()
@@ -143,14 +150,18 @@ namespace QuantLib {
 
 
     Rate CPICouponPricer::swapletRate() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return gearing_ * adjustedFixing() + spread_;
+        QL_DEPRECATED_ENABLE_WARNING
         // after deprecating and removing adjustedFixing:
         // return accruedRate(coupon_->accrualEndDate());
     }
 
 
     Rate CPICouponPricer::accruedRate(Date settlementDate) const {
+        QL_DEPRECATED_DISABLE_WARNING
         return gearing_ * coupon_->indexRatio(settlementDate) + spread_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -43,6 +43,10 @@ namespace QuantLib {
         explicit CPICouponPricer(Handle<CPIVolatilitySurface> capletVol,
                                  Handle<YieldTermStructure> nominalTermStructure = Handle<YieldTermStructure>());
 
+        QL_DEPRECATED_DISABLE_WARNING
+        ~CPICouponPricer() override = default;
+        QL_DEPRECATED_ENABLE_WARNING
+
         virtual Handle<CPIVolatilitySurface> capletVolatility() const{
             return capletVol_;
         }
@@ -83,6 +87,11 @@ namespace QuantLib {
         */
         virtual Real optionletPriceImp(Option::Type, Real strike,
                                        Real forward, Real stdDev) const;
+
+        /*! \deprecated Don't use this method.  In derived classes, override accruedRate.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this method. In derived classes, override accruedRate.")]]
         virtual Rate adjustedFixing(Rate fixing = Null<Rate>()) const;
 
         // data
@@ -90,6 +99,10 @@ namespace QuantLib {
         Handle<YieldTermStructure> nominalTermStructure_;
         const CPICoupon* coupon_;
         Real gearing_;
+        /*! \deprecated Don't use this data member. A spread doesn't make sense for this coupon.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use this data member. A spread doesn't make sense for these coupons.")]]
         Spread spread_;
         Real discount_;
     };

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -84,7 +84,7 @@ namespace QuantLib {
                                        Real forward, Real stdDev) const;
         virtual Rate adjustedFixing(Rate fixing = Null<Rate>()) const;
 
-        //! data
+        // data
         Handle<CPIVolatilitySurface> capletVol_;
         Handle<YieldTermStructure> nominalTermStructure_;
         const CPICoupon* coupon_;

--- a/ql/cashflows/cpicouponpricer.hpp
+++ b/ql/cashflows/cpicouponpricer.hpp
@@ -66,6 +66,7 @@ namespace QuantLib {
         void initialize(const InflationCoupon&) override;
         //@}
 
+        virtual Rate accruedRate(Date settlementDate) const;
 
       protected:
         virtual Real optionletPrice(Option::Type optionType,

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -171,6 +171,8 @@ namespace inflation_cpi_bond_test {
 
 
 void InflationCPIBondTest::testCleanPrice() {
+    BOOST_TEST_MESSAGE("Checking cached pricers for CPI bond...");
+
     IndexManager::instance().clearHistories();
 
     using namespace inflation_cpi_bond_test;
@@ -204,13 +206,21 @@ void InflationCPIBondTest::testCleanPrice() {
                  observationInterpolation, fixedSchedule,
                  fixedRates, fixedDayCount, fixedPaymentConvention);
 
-    ext::shared_ptr<DiscountingBondEngine> engine(
-                                 new DiscountingBondEngine(common.yTS));
+    auto engine = ext::make_shared<DiscountingBondEngine>(common.yTS);
     bond.setPricingEngine(engine);
 
-    Real storedPrice = 383.01816406;
-    Real calculated = bond.cleanPrice();
+    Real storedPrice = 384.71666770;
+    Real calculated = bond.dirtyPrice();
     Real tolerance = 1.0e-8;
+    if (std::fabs(calculated-storedPrice) > tolerance) {
+        BOOST_FAIL("failed to reproduce expected CPI-bond dirty price"
+                   << std::fixed << std::setprecision(12)
+                   << "\n  expected:   " << storedPrice
+                   << "\n  calculated: " << calculated);
+    }
+
+    storedPrice = 383.04297558;
+    calculated = bond.cleanPrice();
     if (std::fabs(calculated-storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
                    << std::fixed << std::setprecision(12)
@@ -221,6 +231,8 @@ void InflationCPIBondTest::testCleanPrice() {
 
 
 void InflationCPIBondTest::testCPILegWithoutBaseCPI() {
+    BOOST_TEST_MESSAGE("Checking CPI leg with or without explicit base CPI fixing...");
+
     IndexManager::instance().clearHistories();
 
     using namespace inflation_cpi_bond_test;
@@ -292,7 +304,7 @@ void InflationCPIBondTest::testCPILegWithoutBaseCPI() {
                    << "\n clean npv of leg with explicit baseCPI: " << cleanPriceWithBaseCPI);
     }
     // Compare to expected price
-    Real storedPrice = 383.01816406;
+    Real storedPrice = 383.04297558;
     if (std::fabs(cleanPriceWithBaseDate - storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
                    << std::fixed << std::setprecision(12) << "\n  expected:   " << storedPrice


### PR DESCRIPTION
The accrued amount for CPI coupons is now based on the index ratio at settlement date.

Also:
- added inspector to retrieve the index ratio at a given date;
- deprecated the use of a spread, which doesn't really make sense for CPI coupons;
- additional `accruedRate` interface for `CPICouponPricer` and deprecation of `adjustedFixing`.