### PR TITLE
Replace boost::reverse_iterator with std::reverse_iterator

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -29,7 +29,7 @@
 #include <ql/types.hpp>
 #include <ql/errors.hpp>
 #include <ql/utilities/null.hpp>
-#include <boost/iterator/reverse_iterator.hpp>
+#include <iterator>
 #include <functional>
 #include <algorithm>
 #include <numeric>
@@ -122,8 +122,8 @@ namespace QuantLib {
         typedef Real value_type;
         typedef Real* iterator;
         typedef const Real* const_iterator;
-        typedef boost::reverse_iterator<iterator> reverse_iterator;
-        typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+        typedef std::reverse_iterator<iterator> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
         //! \name Iterator access
         //@{
         const_iterator begin() const;

--- a/ql/math/matrix.hpp
+++ b/ql/math/matrix.hpp
@@ -29,6 +29,7 @@
 #include <ql/math/array.hpp>
 #include <ql/utilities/steppingiterator.hpp>
 #include <initializer_list>
+#include <iterator>
 
 namespace QuantLib {
 
@@ -79,18 +80,18 @@ namespace QuantLib {
 
         typedef Real* iterator;
         typedef const Real* const_iterator;
-        typedef boost::reverse_iterator<iterator> reverse_iterator;
-        typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+        typedef std::reverse_iterator<iterator> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
         typedef Real* row_iterator;
         typedef const Real* const_row_iterator;
-        typedef boost::reverse_iterator<row_iterator> reverse_row_iterator;
-        typedef boost::reverse_iterator<const_row_iterator>
+        typedef std::reverse_iterator<row_iterator> reverse_row_iterator;
+        typedef std::reverse_iterator<const_row_iterator>
                                                 const_reverse_row_iterator;
         typedef step_iterator<iterator> column_iterator;
         typedef step_iterator<const_iterator> const_column_iterator;
-        typedef boost::reverse_iterator<column_iterator>
+        typedef std::reverse_iterator<column_iterator>
                                                    reverse_column_iterator;
-        typedef boost::reverse_iterator<const_column_iterator>
+        typedef std::reverse_iterator<const_column_iterator>
                                              const_reverse_column_iterator;
         //! \name Iterator access
         //@{

--- a/ql/timeseries.hpp
+++ b/ql/timeseries.hpp
@@ -30,7 +30,7 @@
 #include <ql/errors.hpp>
 #include <ql/functional.hpp>
 #include <boost/iterator/transform_iterator.hpp>
-#include <boost/iterator/reverse_iterator.hpp>
+#include <iterator>
 #include <algorithm>
 #include <map>
 #include <vector>
@@ -119,7 +119,7 @@ namespace QuantLib {
         // containers.
         template <class container, class iterator_category>
         struct reverse {
-            typedef boost::reverse_iterator<typename container::const_iterator>
+            typedef std::reverse_iterator<typename container::const_iterator>
                                                        const_reverse_iterator;
             reverse(const container& c) : c_(c) {}
             const_reverse_iterator rbegin() const {


### PR DESCRIPTION
@lballabio Do you remember why this code uses `boost::reverse_iterator` even though `std::reverse_iterator` has been around since before C++11? As far as I can tell, they both have the same requirements (see [here](https://en.cppreference.com/w/cpp/iterator/reverse_iterator) and [here](https://www.boost.org/doc/libs/1_82_0/libs/iterator/doc/reverse_iterator.html#id3)) so I don't think there should have been any benefit of using boost over std originally.

This change affects the public interface, but I think it's fine, because users should be using either `auto` or the `typedef` type, not the underlying type.