### PR TITLE
Deprecate transform iterators

### DIFF
--- a/ql/models/volatility/garch.hpp
+++ b/ql/models/volatility/garch.hpp
@@ -39,18 +39,19 @@ namespace QuantLib {
       public:
         typedef TimeSeries<Volatility> time_series;
 
-        /*! \deprecated Unused.
+        /*! \deprecated Use auto or time_series::const_iterator instead.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("If needed, use time_series::const_iterator instead.")]]
         typedef time_series::const_iterator const_iterator;
 
         QL_DEPRECATED_DISABLE_WARNING
 
-        /*! \deprecated Unused.
+        /*! \deprecated If needed, use auto or time_series::const_value_iterator.
+                        Prefer time_series::const_iterator instead.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("If needed, use auto or time_series::const_value_iterator. Prefer time_series::const_iterator instead.")]]
         typedef time_series::const_value_iterator const_value_iterator;
 
         QL_DEPRECATED_ENABLE_WARNING

--- a/ql/models/volatility/garch.hpp
+++ b/ql/models/volatility/garch.hpp
@@ -38,8 +38,22 @@ namespace QuantLib {
     class Garch11 : public VolatilityCompositor {
       public:
         typedef TimeSeries<Volatility> time_series;
+
+        /*! \deprecated Unused.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef time_series::const_iterator const_iterator;
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Unused.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef time_series::const_value_iterator const_value_iterator;
+
+        QL_DEPRECATED_ENABLE_WARNING
 
         enum Mode {
             MomentMatchingGuess,   /*!< The initial guess is a moment
@@ -81,7 +95,8 @@ namespace QuantLib {
             return calculate(quoteSeries, alpha(), beta(), omega());
         }
         void calibrate(const time_series& quoteSeries) override {
-            calibrate(quoteSeries.cbegin_values(), quoteSeries.cend_values());
+            const auto values = quoteSeries.values();
+            calibrate(values.cbegin(), values.cend());
         }
         //@}
 
@@ -93,7 +108,8 @@ namespace QuantLib {
         void calibrate(const time_series& quoteSeries,
                        OptimizationMethod& method,
                        const EndCriteria& endCriteria) {
-            calibrate(quoteSeries.cbegin_values(), quoteSeries.cend_values(),
+            const auto values = quoteSeries.values();
+            calibrate(values.cbegin(), values.cend(),
                       method, endCriteria);
         }
 
@@ -101,7 +117,8 @@ namespace QuantLib {
                        OptimizationMethod& method,
                        const EndCriteria& endCriteria,
                        const Array& initialGuess) {
-            calibrate(quoteSeries.cbegin_values(), quoteSeries.cend_values(),
+            const auto values = quoteSeries.values();
+            calibrate(values.cbegin(), values.cend(),
                       method, endCriteria, initialGuess);
         }
 

--- a/ql/timeseries.hpp
+++ b/ql/timeseries.hpp
@@ -179,42 +179,103 @@ namespace QuantLib {
         //! \name Projection iterators
         //@{
 
+        /*! \deprecated Use const_iterator instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef boost::transform_iterator<projection_time, const_iterator>
                                                           const_time_iterator;
+
+        /*! \deprecated Use const_iterator instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef boost::transform_iterator<projection_value, const_iterator>
                                                          const_value_iterator;
+
+        /*! \deprecated Use const_reverse_iterator instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef boost::transform_iterator<projection_time,
                                           const_reverse_iterator>
                                                   const_reverse_time_iterator;
+
+        /*! \deprecated Use const_reverse_iterator instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         typedef boost::transform_iterator<projection_value,
                                           const_reverse_iterator>
                                                  const_reverse_value_iterator;
 
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use cbegin instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_value_iterator cbegin_values() const {
             return const_value_iterator(cbegin(), get_value);
         }
+
+        /*! \deprecated Use cend instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_value_iterator cend_values() const {
             return const_value_iterator(cend(), get_value);
         }
+
+        /*! \deprecated Use crbegin instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_reverse_value_iterator crbegin_values() const {
             return const_reverse_value_iterator(crbegin(), get_value);
         }
+
+        /*! \deprecated Use crend instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_reverse_value_iterator crend_values() const {
             return const_reverse_value_iterator(crend(), get_value);
         }
 
+        /*! \deprecated Use cbegin instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_time_iterator cbegin_time() const {
             return const_time_iterator(cbegin(), get_time);
         }
+
+        /*! \deprecated Use cend instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_time_iterator cend_time() const {
             return const_time_iterator(cend(), get_time);
         }
+
+        /*! \deprecated Use crbegin instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_reverse_time_iterator crbegin_time() const {
             return const_reverse_time_iterator(crbegin(), get_time);
         }
+
+        /*! \deprecated Use crend instead.
+                        Deprecated in version 1.31.
+        */
+        QL_DEPRECATED
         const_reverse_time_iterator crend_time() const {
             return const_reverse_time_iterator(crend(), get_time);
         }
+
+        QL_DEPRECATED_ENABLE_WARNING
 
         //! \name Utilities
         //@{

--- a/ql/timeseries.hpp
+++ b/ql/timeseries.hpp
@@ -179,98 +179,92 @@ namespace QuantLib {
         //! \name Projection iterators
         //@{
 
-        /*! \deprecated Use const_iterator instead.
+        /*! \deprecated Use const_iterator instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
-        typedef boost::transform_iterator<projection_time, const_iterator>
-                                                          const_time_iterator;
+        [[deprecated("Use const_iterator instead and access the `first` data member.")]]
+        typedef boost::transform_iterator<projection_time, const_iterator> const_time_iterator;
 
-        /*! \deprecated Use const_iterator instead.
+        /*! \deprecated Use const_iterator instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
-        typedef boost::transform_iterator<projection_value, const_iterator>
-                                                         const_value_iterator;
+        [[deprecated("Use const_iterator instead and access the `second` data member.")]]
+        typedef boost::transform_iterator<projection_value, const_iterator> const_value_iterator;
 
-        /*! \deprecated Use const_reverse_iterator instead.
+        /*! \deprecated Use const_reverse_iterator instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
-        typedef boost::transform_iterator<projection_time,
-                                          const_reverse_iterator>
-                                                  const_reverse_time_iterator;
+        [[deprecated("Use const_reverse_iterator instead and access the `first` data member.")]]
+        typedef boost::transform_iterator<projection_time, const_reverse_iterator> const_reverse_time_iterator;
 
-        /*! \deprecated Use const_reverse_iterator instead.
+        /*! \deprecated Use const_reverse_iterator instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
-        typedef boost::transform_iterator<projection_value,
-                                          const_reverse_iterator>
-                                                 const_reverse_value_iterator;
+        [[deprecated("Use const_reverse_iterator instead and access the `second` data member.")]]
+        typedef boost::transform_iterator<projection_value, const_reverse_iterator> const_reverse_value_iterator;
 
         QL_DEPRECATED_DISABLE_WARNING
 
-        /*! \deprecated Use cbegin instead.
+        /*! \deprecated Use cbegin instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use cbegin instead and access the `second` data member.")]]
         const_value_iterator cbegin_values() const {
             return const_value_iterator(cbegin(), get_value);
         }
 
-        /*! \deprecated Use cend instead.
+        /*! \deprecated Use cend instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use cend instead and access the `second` data member.")]]
         const_value_iterator cend_values() const {
             return const_value_iterator(cend(), get_value);
         }
 
-        /*! \deprecated Use crbegin instead.
+        /*! \deprecated Use crbegin instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use crbegin instead and access the `second` data member.")]]
         const_reverse_value_iterator crbegin_values() const {
             return const_reverse_value_iterator(crbegin(), get_value);
         }
 
-        /*! \deprecated Use crend instead.
+        /*! \deprecated Use crend instead and access the `second` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use crend instead and access the `second` data member.")]]
         const_reverse_value_iterator crend_values() const {
             return const_reverse_value_iterator(crend(), get_value);
         }
 
-        /*! \deprecated Use cbegin instead.
+        /*! \deprecated Use cbegin instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use cbegin instead and access the `first` data member.")]]
         const_time_iterator cbegin_time() const {
             return const_time_iterator(cbegin(), get_time);
         }
 
-        /*! \deprecated Use cend instead.
+        /*! \deprecated Use cend instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use cend instead and access the `first` data member.")]]
         const_time_iterator cend_time() const {
             return const_time_iterator(cend(), get_time);
         }
 
-        /*! \deprecated Use crbegin instead.
+        /*! \deprecated Use crbegin instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use crbegin instead and access the `first` data member.")]]
         const_reverse_time_iterator crbegin_time() const {
             return const_reverse_time_iterator(crbegin(), get_time);
         }
 
-        /*! \deprecated Use crend instead.
+        /*! \deprecated Use crend instead and access the `first` data member.
                         Deprecated in version 1.31.
         */
-        QL_DEPRECATED
+        [[deprecated("Use crend instead and access the `first` data member.")]]
         const_reverse_time_iterator crend_time() const {
             return const_reverse_time_iterator(crend(), get_time);
         }

--- a/test-suite/timeseries.cpp
+++ b/test-suite/timeseries.cpp
@@ -88,6 +88,8 @@ void TimeSeriesTest::testIterators() {
 
     // projection iterators
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     std::copy(ts.cbegin_time(), ts.cend_time(), dates.begin());
     if (dates[0] != Date(15, March, 2005)) {
         BOOST_ERROR("date does not match");
@@ -145,6 +147,8 @@ void TimeSeriesTest::testIterators() {
     if (prices[0] != 23) {
         BOOST_ERROR("value does not match");
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     // The following should not compile:
     // std::transform(ts1.crbegin(), ts1.crend(), prices.begin(),


### PR DESCRIPTION
I want to remove `boost::transform_iterator` because it pulls in a ton of boost headers into user code, so as a first step I have deprecated all usages of it.

Besides, I don't think the QuantLib library needs to provide these transform iterators - the basic iterators can be used instead and then dereferenced by user code if required.

There is a small chance that the change to `to_r2` and `costFunction` may break user code if users are calling them directly and not through `calibrate`, but I don't think these functions should have ever been made public in the first place.