### PR TITLE
Fix Finland, Singapore calendars and broken link

### DIFF
--- a/ql/time/calendars/finland.cpp
+++ b/ql/time/calendars/finland.cpp
@@ -46,8 +46,8 @@ namespace QuantLib {
             || (dd == em+38)
             // Labour Day
             || (d == 1 && m == May)
-            // Midsummer Eve (Friday between June 18-24)
-            || (w == Friday && (d >= 18 && d <= 24) && m == June)
+            // Midsummer Eve (Friday between June 19-25)
+            || (w == Friday && (d >= 19 && d <= 25) && m == June)
             // Independence Day
             || (d == 6 && m == December)
             // Christmas Eve

--- a/ql/time/calendars/finland.hpp
+++ b/ql/time/calendars/finland.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
         <li>Easter Monday</li>
         <li>Ascension Thursday</li>
         <li>Labour Day, May 1st</li>
-        <li>Midsummer Eve (Friday between June 18-24)</li>
+        <li>Midsummer Eve (Friday between June 19-25)</li>
         <li>Independence Day, December 6th</li>
         <li>Christmas Eve, December 24th</li>
         <li>Christmas, December 25th</li>

--- a/ql/time/calendars/singapore.cpp
+++ b/ql/time/calendars/singapore.cpp
@@ -116,7 +116,7 @@ namespace QuantLib {
         if (y == 2019)
         {
             if ( // Chinese New Year
-                ((d == 1 || d == 2) && m == February)
+                ((d == 5 || d == 6) && m == February)
                 // Vesak Poya Day
                 || (d == 20 && m == May)
                 // Hari Raya Puasa

--- a/ql/time/calendars/singapore.hpp
+++ b/ql/time/calendars/singapore.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2004-2010, 2012-2014 only:)
+        (data available for 2004-2010, 2012-2014, 2019-2023 only:)
         <ul>
         <li>Chinese New Year</li>
         <li>Hari Raya Haji</li>

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -342,7 +342,7 @@ namespace QuantLib {
 
 
     bool UnitedStates::FederalReserveImpl::isBusinessDay(const Date& date) const {
-        // see https://www.frbservices.org/holidayschedules/ for details
+        // see https://www.frbservices.org/about/holiday-schedules for details
         Weekday w = date.weekday();
         Day d = date.dayOfMonth();
         Month m = date.month();


### PR DESCRIPTION
Hi,
Fixes: 
- The range for Midsummer's Eve in the Finnish calendar was off by one. Should match up with what the Swedish calendar has instead. This resulted in incorrect holidays for 2027, for example
- Singapore's Chinese New Year was off by some days for 2019
- Link was broken in US calendar implementation

Best,
Fredrik
