### PR TITLE
Implement iterator_adaptor with standard library

### DIFF
--- a/ql/utilities/steppingiterator.hpp
+++ b/ql/utilities/steppingiterator.hpp
@@ -24,8 +24,10 @@
 #ifndef quantlib_stepping_iterator_hpp
 #define quantlib_stepping_iterator_hpp
 
+#include <ql/errors.hpp>
 #include <ql/types.hpp>
-#include <boost/iterator/iterator_adaptor.hpp>
+#include <iterator>
+#include <type_traits>
 
 namespace QuantLib {
 
@@ -34,38 +36,176 @@ namespace QuantLib {
         steps of \f$ n \f$ positions, where \f$ n \f$ is a positive
         integer given upon construction.
     */
+#ifdef __cpp_concepts
+    template <std::random_access_iterator Iterator>
+#else
     template <class Iterator>
-    class step_iterator :
-        public boost::iterator_adaptor<step_iterator<Iterator>, Iterator> {
+#endif
+    class step_iterator {
       private:
-        typedef boost::iterator_adaptor<step_iterator<Iterator>, Iterator>
-                                                                      super_t;
+        Iterator base_{};
         // a Size would mess up integer division in distance_to
-        BigInteger step_;
+        BigInteger step_{};
+
       public:
+        using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
+        using difference_type = typename std::iterator_traits<Iterator>::difference_type;
+        using value_type = typename std::iterator_traits<Iterator>::value_type;
+        using pointer = typename std::iterator_traits<Iterator>::pointer;
+        using reference = typename std::iterator_traits<Iterator>::reference;
+
         step_iterator() = default;
+
         explicit step_iterator(const Iterator& base, Size step)
-        : super_t(base), step_(static_cast<BigInteger>(step)) {}
+        : base_(base), step_(static_cast<BigInteger>(step)) {}
+
         template <class OtherIterator>
         step_iterator(const step_iterator<OtherIterator>& i,
-                      typename boost::enable_if_convertible
-                      <OtherIterator,Iterator>::type* = 0)
-        : super_t(i.base()), step_(static_cast<BigInteger>(i.step())) {}
+                      typename std::enable_if<std::is_convertible
+                      <OtherIterator, Iterator>::value>::type* = 0)
+        : base_(i.base_), step_(static_cast<BigInteger>(i.step())) {}
+
         // inspector
         Size step() const { return static_cast<Size>(this->step_); }
-        // iterator adapter interface
+
+        /*! \deprecated This class no longer inherits from boost::iterator_adaptor`.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use the boost::iterator_adaptor interface.")]]
+        Iterator base() const { return base_; }
+
+        /*! \deprecated This class no longer inherits from boost::iterator_adaptor`.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use the boost::iterator_adaptor interface.")]]
         void increment() {
-            std::advance(this->base_reference(), step_);
+            std::advance(base_, step_);
         }
+
+        /*! \deprecated This class no longer inherits from boost::iterator_adaptor`.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use the boost::iterator_adaptor interface.")]]
         void decrement() {
-            std::advance(this->base_reference(), -step_);
+            std::advance(base_, -step_);
         }
-        void advance(typename super_t::difference_type n) {
-            this->base_reference() += n*(this->step_);
+
+        /*! \deprecated This class no longer inherits from boost::iterator_adaptor`.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use the boost::iterator_adaptor interface.")]]
+        void advance(typename std::iterator_traits<Iterator>::difference_type n) {
+            base_ += n*(this->step_);
         }
-        typename super_t::difference_type
+
+        /*! \deprecated This class no longer inherits from boost::iterator_adaptor`.
+                        Deprecated in version 1.31.
+        */
+        [[deprecated("Do not use the boost::iterator_adaptor interface.")]]
+        typename std::iterator_traits<Iterator>::difference_type
         distance_to(const step_iterator& i) const {
-            return (i.base()-this->base())/(this->step_);
+            return (i.base_ - base_) / step_;
+        }
+
+        step_iterator& operator=(const step_iterator& other) {
+            base_ = other.base_;
+            step_ = other.step_;
+            return *this;
+        }
+
+        step_iterator& operator++() {
+            base_ += step_;
+            return *this;
+        }
+
+        step_iterator operator++(int) {
+            auto tmp = *this;
+            base_ += step_;
+            return tmp;
+        }
+
+        reference operator*() const {
+            return *base_;
+        }
+
+        step_iterator& operator--() {
+            base_ -= step_;
+            return *this;
+        }
+
+        step_iterator operator--(int) {
+            auto tmp = *this;
+            base_ -= step_;
+            return tmp;
+        }
+
+        step_iterator& operator+=(Size n) {
+            base_ += n * step_;
+            return *this;
+        }
+
+        step_iterator& operator-=(Size n) {
+            base_ -= n * step_;
+            return *this;
+        }
+
+        reference operator[](Size n) const {
+            return *(base_ + n * step_);
+        }
+
+        friend step_iterator operator+(const step_iterator& i, Size n) {
+            return step_iterator(i.base_ + n * i.step_, i.step_);
+        }
+
+        friend step_iterator operator+(Size n, const step_iterator& i) {
+            return step_iterator(i.base_ + n * i.step_, i.step_);
+        }
+
+        friend step_iterator operator-(const step_iterator& i, Size n) {
+            return step_iterator(i.base_ - n * i.step_, i.step_);
+        }
+
+        friend difference_type operator-(const step_iterator& lhs, const step_iterator& rhs) {
+#ifdef QL_EXTRA_SAFETY_CHECKS
+            QL_REQUIRE(lhs.step_ == rhs.step_, "step_iterators with different step cannot be added or subtracted");
+#endif
+            return (lhs.base_ - rhs.base_) / lhs.step_;
+        }
+
+        friend bool operator==(const step_iterator& lhs, const step_iterator& rhs) {
+            return lhs.base_ == rhs.base_ && lhs.step_ == rhs.step_;
+        }
+
+        friend bool operator!=(const step_iterator& lhs, const step_iterator& rhs) {
+            return lhs.base_ != rhs.base_ || lhs.step_ != rhs.step_;
+        }
+
+        friend bool operator<(const step_iterator& lhs, const step_iterator& rhs) {
+#ifdef QL_EXTRA_SAFETY_CHECKS
+            QL_REQUIRE(lhs.step_ == rhs.step_, "step_iterators with different step cannot be compared");
+#endif
+            return lhs.base_ < rhs.base_;
+        }
+
+        friend bool operator>(const step_iterator& lhs, const step_iterator& rhs) {
+#ifdef QL_EXTRA_SAFETY_CHECKS
+            QL_REQUIRE(lhs.step_ == rhs.step_, "step_iterators with different step cannot be compared");
+#endif
+            return lhs.base_ > rhs.base_;
+        }
+
+        friend bool operator<=(const step_iterator& lhs, const step_iterator& rhs) {
+#ifdef QL_EXTRA_SAFETY_CHECKS
+            QL_REQUIRE(lhs.step_ == rhs.step_, "step_iterators with different step cannot be compared");
+#endif
+            return lhs.base_ <= rhs.base_;
+        }
+
+        friend bool operator>=(const step_iterator& lhs, const step_iterator& rhs) {
+#ifdef QL_EXTRA_SAFETY_CHECKS
+            QL_REQUIRE(lhs.step_ == rhs.step_, "step_iterators with different step cannot be compared");
+#endif
+            return lhs.base_ >= rhs.base_;
         }
     };
 

--- a/test-suite/matrices.cpp
+++ b/test-suite/matrices.cpp
@@ -35,6 +35,7 @@
 #include <ql/math/matrixutilities/sparsematrix.hpp>
 #include <ql/math/randomnumbers/mt19937uniformrng.hpp>
 #include <cmath>
+#include <iterator>
 #include <utility>
 #include <numeric>
 
@@ -42,6 +43,13 @@ using namespace QuantLib;
 using namespace boost::unit_test_framework;
 
 using std::fabs;
+
+#ifdef __cpp_concepts
+static_assert(std::random_access_iterator<Matrix::column_iterator>);
+static_assert(std::random_access_iterator<Matrix::const_column_iterator>);
+static_assert(std::random_access_iterator<Matrix::reverse_column_iterator>);
+static_assert(std::random_access_iterator<Matrix::const_reverse_column_iterator>);
+#endif
 
 namespace matrices_test {
 


### PR DESCRIPTION
C++20 makes it easy to implement iterators without `boost::iterator_adaptor` because the requirements are checked at compile-time based on the relevant iterator concept, which in this case is [`std::random_access_iterator`](https://en.cppreference.com/w/cpp/iterator/random_access_iterator). The change is backwards-compatible for older compilers as well.

In addition the same concept can be used to constrain the type of underlying iterator used with `step_iterator`, which I have done for compilers that support concepts.

Lastly, I added a few `QL_REQUIRE` to check for operations on incompatible iterators but I'm not sure whether we should add more checks in other places as well.
