### PR TITLE
additional test case for schedule

### DIFF
--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -24,6 +24,7 @@
 #include <ql/time/calendars/japan.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/calendars/weekendsonly.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/instruments/creditdefaultswap.hpp>
 #include <map>
 #include <vector>
@@ -283,6 +284,31 @@ void ScheduleTest::testNextToLastWithEomAdjustment() {
     expected[5] = Date(10, August, 1998);
 
     check_dates(schedule, expected);
+}
+
+void ScheduleTest::testEffectiveDateWithEomAdjustment() {
+    BOOST_TEST_MESSAGE(
+        "Testing forward schedule with EOM adjustment and effective date and first date in the same month...");
+
+    Schedule s =
+        MakeSchedule().from(Date(16,January,2023))
+                      .to(Date(16,March,2023))
+                      .withFirstDate(Date(31, January, 2023))
+                      .withCalendar(NullCalendar())
+                      .withTenor(1*Months)
+                      .withConvention(Unadjusted)
+                      .withTerminationDateConvention(Unadjusted)
+                      .forwards()
+                      .endOfMonth();
+
+    std::vector<Date> expected(4);
+    // check that the effective date is not moved to the end of the month
+    expected[0] = Date(16,January,2023);
+    expected[1] = Date(31,January, 2023);
+    expected[2] = Date(28,February, 2023);
+    expected[3] = Date(16,March,2023);
+
+    check_dates(s, expected);
 }
 
 namespace CdsTests {
@@ -1124,6 +1150,7 @@ test_suite* ScheduleTest::suite() {
         &ScheduleTest::testDoubleFirstDateWithEomAdjustment));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testFirstDateWithEomAdjustment));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testNextToLastWithEomAdjustment));
+    suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testEffectiveDateWithEomAdjustment));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testCDS2015Convention));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testCDS2015ConventionGrid));
     suite->add(QUANTLIB_TEST_CASE(&ScheduleTest::testCDSConventionGrid));

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -293,7 +293,7 @@ void ScheduleTest::testEffectiveDateWithEomAdjustment() {
     Schedule s =
         MakeSchedule().from(Date(16,January,2023))
                       .to(Date(16,March,2023))
-                      .withFirstDate(Date(31, January, 2023))
+                      .withFirstDate(Date(31,January,2023))
                       .withCalendar(NullCalendar())
                       .withTenor(1*Months)
                       .withConvention(Unadjusted)
@@ -302,10 +302,10 @@ void ScheduleTest::testEffectiveDateWithEomAdjustment() {
                       .endOfMonth();
 
     std::vector<Date> expected(4);
-    // check that the effective date is not moved to the end of the month
+    // check that the effective date is not moved at the end of the month
     expected[0] = Date(16,January,2023);
-    expected[1] = Date(31,January, 2023);
-    expected[2] = Date(28,February, 2023);
+    expected[1] = Date(31,January,2023);
+    expected[2] = Date(28,February,2023);
     expected[3] = Date(16,March,2023);
 
     check_dates(s, expected);

--- a/test-suite/schedule.hpp
+++ b/test-suite/schedule.hpp
@@ -36,6 +36,7 @@ class ScheduleTest {
     static void testDoubleFirstDateWithEomAdjustment();
     static void testFirstDateWithEomAdjustment();
     static void testNextToLastWithEomAdjustment();
+    static void testEffectiveDateWithEomAdjustment();
     static void testCDS2015Convention();
     static void testCDS2015ConventionGrid();
     static void testCDSConventionGrid();


### PR DESCRIPTION
Additional test case for schedule test suite. This is the original test case that originated issue #895 which has been recently solved by PR #1509.