### PR TITLE
Clear all fixings between tests

### DIFF
--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -73,7 +73,6 @@ namespace asset_swap_test {
 
         // clean-up
         SavedSettings backup;
-        IndexHistoryCleaner indexCleaner;
 
         // initial setup
         CommonVars() {

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -509,8 +509,6 @@ void CashFlowsTest::testPartialScheduleLegConstruction() {
 void CashFlowsTest::testFixedIborCouponWithoutForecastCurve() {
     BOOST_TEST_MESSAGE("Testing past ibor coupon without forecast curve...");
 
-    IndexHistoryCleaner cleaner;
-
     Date today = Settings::instance().evaluationDate();
 
     auto index = ext::make_shared<USDLibor>(6*Months);

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -130,7 +130,6 @@ void CmsSpreadTest::testFixings() {
     cms2y->addFixing(d.refDate, 0.04);
     BOOST_CHECK_EQUAL(cms10y2y->fixing(d.refDate),
                       cms10y->fixing(d.refDate) - cms2y->fixing(d.refDate));
-    IndexManager::instance().clearHistories();
 }
 
 namespace {

--- a/test-suite/equitycashflow.cpp
+++ b/test-suite/equitycashflow.cpp
@@ -81,7 +81,6 @@ namespace equitycashflow_test {
 
             equityIndex = ext::make_shared<EquityIndex>("eqIndex", calendar, localCcyInterestHandle,
                                                         dividendHandle, spotHandle);
-            IndexManager::instance().clearHistory(equityIndex->name());
             equityIndex->addFixing(Date(5, January, 2023), 9010.0);
             equityIndex->addFixing(today, 8690.0);
 

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -69,7 +69,6 @@ namespace equityindex_test {
 
             equityIndex = ext::make_shared<EquityIndex>("eqIndex", calendar, interestHandle,
                                                         dividendHandle, spotHandle);
-            IndexManager::instance().clearHistory(equityIndex->name());
 
             today = calendar.adjust(Date(27, January, 2023));
             

--- a/test-suite/equitytotalreturnswap.cpp
+++ b/test-suite/equitytotalreturnswap.cpp
@@ -80,12 +80,10 @@ namespace equitytotalreturnswap_test {
 
             equityIndex = ext::make_shared<EquityIndex>("eqIndex", calendar, interestHandle,
                                                         dividendHandle, spotHandle);
-            IndexManager::instance().clearHistory(equityIndex->name());
             equityIndex->addFixing(Date(5, January, 2023), 9010.0);
             equityIndex->addFixing(today, 8690.0);
 
             sofr = ext::make_shared<Sofr>(interestHandle);
-            IndexManager::instance().clearHistory(sofr->name());
             sofr->addFixing(Date(3, January, 2023), 0.03);
             sofr->addFixing(Date(4, January, 2023), 0.031);
             sofr->addFixing(Date(5, January, 2023), 0.031);
@@ -105,7 +103,6 @@ namespace equitytotalreturnswap_test {
             sofr->addFixing(Date(26, January, 2023), 0.034);
 
             usdLibor = ext::make_shared<USDLibor>(3 * Months, interestHandle);
-            IndexManager::instance().clearHistory(usdLibor->name());
             usdLibor->addFixing(Date(3, January, 2023), 0.035);
 
             interestHandle.linkTo(flatRate(0.0375, dayCount));

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -86,8 +86,6 @@ void IndexTest::testFixingHasHistoricalFixing() {
     while (!euribor6M->isValidFixingDate(today))
         today--;
 
-    IndexManager::instance().clearHistories();
-
     euribor6M->addFixing(today, 0.01);
 
     name = euribor3M->name();

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -98,7 +98,6 @@ void InflationTest::testZeroIndex() {
     BOOST_TEST_MESSAGE("Testing zero inflation indices...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     QL_DEPRECATED_DISABLE_WARNING
 
@@ -201,7 +200,6 @@ void InflationTest::testZeroTermStructure() {
     using namespace inflation_test;
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     // try the Zero UK
     Calendar calendar = UnitedKingdom();
@@ -588,7 +586,6 @@ void InflationTest::testSeasonalityCorrection() {
     using namespace inflation_test;
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     // try the Zero UK
     Calendar calendar = UnitedKingdom();
@@ -687,7 +684,6 @@ void InflationTest::testZeroIndexFutureFixing() {
     BOOST_TEST_MESSAGE("Testing that zero inflation indices forecast future fixings...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     EUHICP euhicp;
 
@@ -766,7 +762,6 @@ void InflationTest::testQuotedYYIndex() {
     BOOST_TEST_MESSAGE("Testing quoted year-on-year inflation indices...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     YYEUHICP yyeuhicp(true);
     if (yyeuhicp.name() != "EU YY_HICP"
@@ -806,7 +801,6 @@ void InflationTest::testRatioYYIndex() {
     BOOST_TEST_MESSAGE("Testing ratio year-on-year inflation indices...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     auto euhicp = ext::make_shared<EUHICP>();
     auto ukrpi = ext::make_shared<UKRPI>();
@@ -928,7 +922,6 @@ void InflationTest::testOldRatioYYIndex() {
     BOOST_TEST_MESSAGE("Testing old-style ratio year-on-year inflation indices...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     QL_DEPRECATED_DISABLE_WARNING
 
@@ -1066,7 +1059,6 @@ void InflationTest::testYYTermStructure() {
     using namespace inflation_test;
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     // try the YY UK
     Calendar calendar = UnitedKingdom();
@@ -1301,7 +1293,6 @@ void InflationTest::testCpiFlatInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI flat interpolation...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
@@ -1350,7 +1341,6 @@ void InflationTest::testCpiLinearInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI linear interpolation...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
@@ -1407,7 +1397,6 @@ void InflationTest::testCpiAsIndexInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI as-index interpolation...");
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Date today = Date(10, February, 2022);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -90,7 +90,6 @@ namespace inflation_cpi_bond_test {
         // cleanup
 
         SavedSettings backup;
-        IndexHistoryCleaner cleaner;
 
         // setup
         CommonVars() {
@@ -173,8 +172,6 @@ namespace inflation_cpi_bond_test {
 void InflationCPIBondTest::testCleanPrice() {
     BOOST_TEST_MESSAGE("Checking cached pricers for CPI bond...");
 
-    IndexManager::instance().clearHistories();
-
     using namespace inflation_cpi_bond_test;
   
     CommonVars common;
@@ -232,8 +229,6 @@ void InflationCPIBondTest::testCleanPrice() {
 
 void InflationCPIBondTest::testCPILegWithoutBaseCPI() {
     BOOST_TEST_MESSAGE("Checking CPI leg with or without explicit base CPI fixing...");
-
-    IndexManager::instance().clearHistories();
 
     using namespace inflation_cpi_bond_test;
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -106,7 +106,6 @@ namespace inflation_cpi_swap_test {
         // cleanup
 
         SavedSettings backup;
-        IndexHistoryCleaner cleaner;
 
         // setup
         CommonVars()

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -33,7 +33,6 @@ namespace overnight_indexed_coupon_tests {
     struct CommonVars {
         // cleanup
         SavedSettings backup;
-        IndexHistoryCleaner cleaner;
 
         Date today;
         Real notional = 10000.0;

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -24,7 +24,6 @@
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/indexes/ibor/jpylibor.hpp>
 #include <ql/indexes/ibor/usdlibor.hpp>
-#include <ql/indexes/indexmanager.hpp>
 #include <ql/instruments/forwardrateagreement.hpp>
 #include <ql/instruments/makevanillaswap.hpp>
 #include <ql/math/comparison.hpp>
@@ -198,7 +197,6 @@ namespace piecewise_yield_curve_test {
 
         // cleanup
         SavedSettings backup;
-        IndexHistoryCleaner cleaner;
 
         // setup
         CommonVars(Date evaluationDate = Date()) {

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -63,7 +63,6 @@ void ShortRateModelTest::testCachedHullWhite() {
     bool usingAtParCoupons  = IborCoupon::Settings::instance().usingAtParCoupons();
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
@@ -140,7 +139,6 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
@@ -221,7 +219,6 @@ void ShortRateModelTest::testCachedHullWhite2() {
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
@@ -302,7 +299,6 @@ void ShortRateModelTest::testSwaps() {
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
 
     SavedSettings backup;
-    IndexHistoryCleaner cleaner;
 
     Date today = Settings::instance().evaluationDate();
     Calendar calendar = TARGET();

--- a/test-suite/utilities.cpp
+++ b/test-suite/utilities.cpp
@@ -19,7 +19,6 @@
 
 #include "utilities.hpp"
 #include <ql/instruments/payoffs.hpp>
-#include <ql/indexes/indexmanager.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
@@ -122,10 +121,4 @@ namespace QuantLib {
             // fall back to absolute error
             return std::fabs(x1-x2);
     }
-
-
-    IndexHistoryCleaner::~IndexHistoryCleaner() {
-        IndexManager::instance().clearHistories();
-    }
-
 }

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -20,6 +20,7 @@
 #ifndef quantlib_test_utilities_hpp
 #define quantlib_test_utilities_hpp
 
+#include <ql/indexes/indexmanager.hpp>
 #include <ql/instruments/payoffs.hpp>
 #include <ql/exercise.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
@@ -78,6 +79,8 @@ namespace QuantLib {
             template <class F>
             explicit quantlib_test_case(F test) : test_(test) {}
             void operator()() const {
+                // Clear all fixings before running a test to avoid interference.
+                IndexManager::instance().clearHistories();
                 Date before = Settings::instance().evaluationDate();
                 BOOST_CHECK(true);
                 test_();
@@ -174,14 +177,6 @@ namespace QuantLib {
     inline Integer timeToDays(Time t, Integer daysPerYear = 360) {
         return Integer(std::lround(t * daysPerYear));
     }
-
-
-    // this cleans up index-fixing histories when destroyed
-    class IndexHistoryCleaner { // NOLINT(cppcoreguidelines-special-member-functions)
-      public:
-        IndexHistoryCleaner() = default;
-        ~IndexHistoryCleaner();
-    };
 
 
     // Allow streaming vectors to error messages.


### PR DESCRIPTION
Centralize cleaning of fixings in quantlib_test_case instead of having each test do this manually.

Fixes #1687