### PR TITLE
Use bitmask in BespokeCalendar

### DIFF
--- a/ql/time/calendars/bespokecalendar.cpp
+++ b/ql/time/calendars/bespokecalendar.cpp
@@ -30,7 +30,7 @@ namespace QuantLib {
     }
 
     bool BespokeCalendar::Impl::isWeekend(Weekday w) const {
-        return (weekend_.find(w) != weekend_.end());
+        return (weekend_mask_ & (1 << w)) != 0;
     }
 
     bool BespokeCalendar::Impl::isBusinessDay(const Date& date) const {
@@ -38,7 +38,7 @@ namespace QuantLib {
     }
 
     void BespokeCalendar::Impl::addWeekend(Weekday w) {
-        weekend_.insert(w);
+        weekend_mask_ |= (1 << w);
     }
 
 

--- a/ql/time/calendars/bespokecalendar.hpp
+++ b/ql/time/calendars/bespokecalendar.hpp
@@ -47,8 +47,8 @@ namespace QuantLib {
             bool isBusinessDay(const Date&) const override;
             void addWeekend(Weekday);
           private:
-            std::set<Weekday> weekend_;
             std::string name_;
+            unsigned int weekend_mask_ = 0;
         };
         ext::shared_ptr<BespokeCalendar::Impl> bespokeImpl_;
       public:


### PR DESCRIPTION
Replace std::set with a bitmask, which is more efficient.