### PR TITLE
Drop General Prayer Day from DK calendar from 2024

### DIFF
--- a/ql/time/calendars/denmark.cpp
+++ b/ql/time/calendars/denmark.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
             // Easter Monday
             || (dd == em)
             // General Prayer Day
-            || (dd == em+25)
+            || (dd == em+25 && y <= 2023)
             // Ascension
             || (dd == em+38)
             // Day after Ascension

--- a/ql/time/calendars/denmark.hpp
+++ b/ql/time/calendars/denmark.hpp
@@ -36,7 +36,7 @@ namespace QuantLib {
         <li>Maunday Thursday</li>
         <li>Good Friday</li>
         <li>Easter Monday</li>
-        <li>General Prayer Day, 25 days after Easter Monday</li>
+        <li>General Prayer Day, 25 days after Easter Monday (up until 2023)</li>
         <li>Ascension</li>
         <li>Day after Ascension (from 2009)</li>
         <li>Whit (Pentecost) Monday </li>


### PR DESCRIPTION
"Store Bededag" was recently removed in Denmark following a vote in the parliament. The various Danish calendars I've seen now reflect this, e.g.: https://www.nasdaqomxnordic.com/digitalAssets/111/111618_trading-calendar-2022.pdf not listing 2024-04-26. 