### PR TITLE
Fix compile error on GCC 12

### DIFF
--- a/ql/currencies/exchangeratemanager.cpp
+++ b/ql/currencies/exchangeratemanager.cpp
@@ -22,6 +22,7 @@
 #include <ql/currencies/europe.hpp>
 #include <ql/currencies/america.hpp>
 #include <ql/settings.hpp>
+#include <algorithm>
 
 namespace QuantLib {
 

--- a/ql/experimental/credit/basket.cpp
+++ b/ql/experimental/credit/basket.cpp
@@ -22,6 +22,7 @@
 #include <ql/experimental/credit/defaultlossmodel.hpp>
 #include <ql/experimental/credit/loss.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
+#include <algorithm>
 #include <numeric>
 #include <utility>
 

--- a/ql/termstructures/volatility/smilesectionutils.cpp
+++ b/ql/termstructures/volatility/smilesectionutils.cpp
@@ -19,6 +19,7 @@
 
 #include <ql/termstructures/volatility/smilesectionutils.hpp>
 #include <ql/math/comparison.hpp>
+#include <algorithm>
 
 namespace QuantLib {
 


### PR DESCRIPTION
There are few places where `std::find()` and `std::find_if()` are used, but `<algorithm>` are not `#include`-ed.