### PR TITLE
Restore settings after every test

### DIFF
--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -461,8 +461,6 @@ namespace {
     template <class Engine>
     void testFdGreeks() {
 
-        SavedSettings backup;
-
         std::map<std::string,Real> calculated, expected, tolerance;
         tolerance["delta"]  = 7.0e-4;
         tolerance["gamma"]  = 2.0e-4;
@@ -579,8 +577,6 @@ void AmericanOptionTest::testFdShoutGreeks() {
 void AmericanOptionTest::testFDShoutNPV() {
     BOOST_TEST_MESSAGE("Testing finite-differences shout option pricing...");
 
-    SavedSettings backup;
-
     const auto dc = Actual365Fixed();
     const auto today = Date(4, February, 2021);
     Settings::instance().evaluationDate() = today;
@@ -637,8 +633,6 @@ void AmericanOptionTest::testFDShoutNPV() {
 
 void AmericanOptionTest::testZeroVolFDShoutNPV() {
     BOOST_TEST_MESSAGE("Testing zero volatility shout option pricing with discrete dividends...");
-
-    SavedSettings backup;
 
     const auto dc = Actual365Fixed();
     const auto today = Date(14, February, 2021);
@@ -718,8 +712,6 @@ void AmericanOptionTest::testZeroVolFDShoutNPV() {
 
 void AmericanOptionTest::testLargeDividendShoutNPV() {
     BOOST_TEST_MESSAGE("Testing zero strike shout option pricing with discrete dividends...");
-
-    SavedSettings backup;
 
     const auto dc = Actual365Fixed();
     const auto today = Date(21, February, 2021);
@@ -803,8 +795,6 @@ void AmericanOptionTest::testLargeDividendShoutNPV() {
 void AmericanOptionTest::testEscrowedVsSpotAmericanOption() {
     BOOST_TEST_MESSAGE("Testing escrowed vs spot dividend model for American options...");
 
-    SavedSettings backup;
-
     const auto dc = Actual360();
     const auto today = Date(27, February, 2021);
     Settings::instance().evaluationDate() = today;
@@ -876,8 +866,6 @@ void AmericanOptionTest::testEscrowedVsSpotAmericanOption() {
 
 void AmericanOptionTest::testTodayIsDividendDate() {
     BOOST_TEST_MESSAGE("Testing escrowed vs spot dividend model on dividend dates for American options...");
-
-    SavedSettings backup;
 
     const auto dc = Actual360();
     const auto today = Date(27, February, 2021);
@@ -999,8 +987,6 @@ void AmericanOptionTest::testCallPutParity() {
     BOOST_TEST_MESSAGE("Testing call/put parity for American options...");
 
     // R.L. McDonald, M.D. Schroder: A parity result for American option
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(8, April, 2022);
@@ -1203,8 +1189,6 @@ void AmericanOptionTest::testQdPlusBoundaryConvergence() {
 
 void AmericanOptionTest::testQdAmericanEngines() {
     BOOST_TEST_MESSAGE("Testing QD+ American option pricing...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(1, June, 2022);
@@ -1480,8 +1464,6 @@ void AmericanOptionTest::testAndersenLakeHighPrecisionExample() {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden "
                         "high precision example...");
 
-    SavedSettings backup;
-
     // Example and results are taken from
     //    Leif Andersen, Mark Lake and Dimitri Offengenden (2015)
     //    "High Performance American Option Pricing",
@@ -1579,8 +1561,6 @@ void AmericanOptionTest::testQdEngineStandardExample() {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden "
                         "standard example...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(1, June, 2022);
     Settings::instance().evaluationDate() = today;
@@ -1677,8 +1657,6 @@ void AmericanOptionTest::testBulkQdFpAmericanEngine() {
     //    Leif Andersen, Mark Lake and Dimitri Offengenden (2015)
     //    "High Performance American Option Pricing",
     //    https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2547027
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(1, June, 2022);
@@ -1784,8 +1762,6 @@ void AmericanOptionTest::testQdEngineWithLobattoIntegral() {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden "
                         "with high precision Gauss-Lobatto integration...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(5, November, 2022);
     Settings::instance().evaluationDate() = today;
@@ -1853,8 +1829,6 @@ void AmericanOptionTest::testQdNegativeDividendYield() {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden "
                         "with positive or zero interest rate and "
                         "negative dividend yield...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(5, December, 2022);
@@ -1925,8 +1899,6 @@ void AmericanOptionTest::testQdNegativeDividendYield() {
 void AmericanOptionTest::testBjerksundStenslandEuropeanGreeks() {
     BOOST_TEST_MESSAGE("Testing Bjerksund-Stensland greeks when early "
                        "exercise is not optimal...");
-
-    SavedSettings backup;
 
     const Date today = Date(5, November, 2022);
     Settings::instance().evaluationDate() = today;
@@ -2004,8 +1976,6 @@ void AmericanOptionTest::testBjerksundStenslandEuropeanGreeks() {
 
 void AmericanOptionTest::testBjerksundStenslandAmericanGreeks() {
     BOOST_TEST_MESSAGE("Testing Bjerksund-Stensland American greeks...");
-
-    SavedSettings backup;
 
     const Date today = Date(5, December, 2022);
     Settings::instance().evaluationDate() = today;
@@ -2197,8 +2167,6 @@ void AmericanOptionTest::testBjerksundStenslandAmericanGreeks() {
 
 void AmericanOptionTest::testSingleBjerksundStenslandGreeks() {
     BOOST_TEST_MESSAGE("Testing a single Bjerksund-Stensland greeks set...");
-
-    SavedSettings backup;
 
     const Date today = Date(20, January, 2023);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -150,8 +150,6 @@ namespace andreasen_huge_volatility_interpl_test {
     void testAndreasenHugeVolatilityInterpolation(
         const CalibrationData& data, const CalibrationResults& expected) {
 
-        SavedSettings backup;
-
         const Handle<YieldTermStructure> rTS = data.rTS;
         const Handle<YieldTermStructure> qTS = data.qTS;
 
@@ -448,8 +446,6 @@ void AndreasenHugeVolatilityInterplTest::testTimeDependentInterestRates() {
 
     using namespace andreasen_huge_volatility_interpl_test;
 
-    SavedSettings backup;
-
     const CalibrationData data = AndreasenHugeExampleData();
 
     const DayCounter dc = data.rTS->dayCounter();
@@ -533,8 +529,6 @@ void AndreasenHugeVolatilityInterplTest::testSingleOptionCalibration() {
         "Testing Andreasen-Huge volatility interpolation with "
         "a single option...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(4, January, 2018);
 
@@ -595,8 +589,6 @@ void AndreasenHugeVolatilityInterplTest::testArbitrageFree() {
         "arbitrage free prices...");
 
     using namespace andreasen_huge_volatility_interpl_test;
-
-    SavedSettings backup;
 
     CalibrationData data[] = { BorovkovaExampleData(), arbitrageData() };;
 
@@ -684,8 +676,6 @@ void AndreasenHugeVolatilityInterplTest::testBarrierOptionPricing() {
     BOOST_TEST_MESSAGE(
         "Testing Barrier option pricing with Andreasen-Huge "
          "local volatility surface...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(4, January, 2018);
@@ -838,8 +828,6 @@ void AndreasenHugeVolatilityInterplTest::testPeterAndFabiensExample() {
 
     using namespace andreasen_huge_volatility_interpl_test;
 
-    SavedSettings backup;
-
     const std::pair<CalibrationData, std::vector<Real> > sd = sabrData();
     const CalibrationData& data = sd.first;
     const std::vector<Real>& parameter = sd.second;
@@ -916,8 +904,6 @@ void AndreasenHugeVolatilityInterplTest::testMovingReferenceDate() {
         "Testing that reference date of adapter surface moves along with "
         "evaluation date...");
 
-    SavedSettings backup;
-
     const Date today = Date(4, January, 2018);
     Settings::instance().evaluationDate() = today;
 
@@ -993,8 +979,6 @@ void AndreasenHugeVolatilityInterplTest::testFlatVolCalibration() {
         "Testing Andreasen-Huge example with flat volatility surface...");
 
     using namespace andreasen_huge_volatility_interpl_test;
-
-    SavedSettings backup;
 
     const Date ref(1, November, 2019);
     const DayCounter dc = Actual365Fixed();

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -178,8 +178,6 @@ void AsianOptionTest::testAnalyticContinuousGeometricAveragePriceGreeks() {
     BOOST_TEST_MESSAGE(
        "Testing analytic continuous geometric average-price Asian greeks...");
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]  = 1.0e-5;
     tolerance["gamma"]  = 1.0e-5;
@@ -1323,8 +1321,6 @@ void AsianOptionTest::testAnalyticDiscreteGeometricAveragePriceGreeks() {
 
     BOOST_TEST_MESSAGE("Testing discrete-averaging geometric Asian greeks...");
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]  = 1.0e-5;
     tolerance["gamma"]  = 1.0e-5;
@@ -1863,8 +1859,6 @@ void AsianOptionTest::testAllFixingsInThePast() {
     }
 
     // also check with the evaluation date on last fixing
-
-    SavedSettings backup;
 
     Settings::instance().evaluationDate() = fixingDates.back();
 

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -71,9 +71,6 @@ namespace asset_swap_test {
         Compounding compounding;
         RelinkableHandle<YieldTermStructure> termStructure;
 
-        // clean-up
-        SavedSettings backup;
-
         // initial setup
         CommonVars() {
             Natural swapSettlementDays = 2;

--- a/test-suite/barrieroption.cpp
+++ b/test-suite/barrieroption.cpp
@@ -805,8 +805,6 @@ void BarrierOptionTest::testLocalVolAndHestonComparison() {
     BOOST_TEST_MESSAGE("Testing local volatility and Heston FD engines "
                        "for barrier options...");
 
-    SavedSettings backup;
-
     const Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -943,8 +941,6 @@ void BarrierOptionTest::testVannaVolgaSimpleBarrierValues() {
     BOOST_TEST_MESSAGE("Testing barrier FX options against Vanna/Volga values...");
 
     using namespace barrier_option_test;
-
-    SavedSettings backup;
 
     BarrierFxOptionData values[] = {
 
@@ -1167,8 +1163,6 @@ void BarrierOptionTest::testVannaVolgaSimpleBarrierValues() {
 void BarrierOptionTest::testOldDividendBarrierOption() {
     BOOST_TEST_MESSAGE("Testing old-style barrier option pricing with discrete dividends...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
 
     const Date today(11, February, 2018);
@@ -1284,8 +1278,6 @@ void BarrierOptionTest::testOldDividendBarrierOption() {
 void BarrierOptionTest::testDividendBarrierOption() {
     BOOST_TEST_MESSAGE("Testing barrier option pricing with discrete dividends...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual365Fixed();
 
     Date today(11, February, 2018);
@@ -1393,8 +1385,6 @@ void BarrierOptionTest::testDividendBarrierOption() {
 void BarrierOptionTest::testDividendBarrierOptionWithDividendsPastMaturity() {
     BOOST_TEST_MESSAGE("Testing barrier option pricing with discrete dividends past maturity...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual365Fixed();
 
     Date today(11, February, 2018);
@@ -1479,8 +1469,6 @@ void BarrierOptionTest::testDividendBarrierOptionWithDividendsPastMaturity() {
 void BarrierOptionTest::testBarrierAndDividendEngine() {
     BOOST_TEST_MESSAGE("Testing the use of a single engine for barrier and dividend options...");
 
-    SavedSettings backup;
-
     auto today = Date(1, January, 2023);
     Settings::instance().evaluationDate() = today;
 
@@ -1520,8 +1508,6 @@ void BarrierOptionTest::testBarrierAndDividendEngine() {
 
 void BarrierOptionTest::testImpliedVolatility() {
     BOOST_TEST_MESSAGE("Testing implied volatility for barrier options...");
-
-    SavedSettings backup;
 
     DayCounter dc = Actual365Fixed();
 
@@ -1601,8 +1587,6 @@ void BarrierOptionTest::testImpliedVolatility() {
 
 void BarrierOptionTest::testLowVolatility() {
     BOOST_TEST_MESSAGE("Testing barrier options with low volatility value...");
-
-    SavedSettings backup;
 
     DayCounter dc = Actual365Fixed();
 

--- a/test-suite/batesmodel.cpp
+++ b/test-suite/batesmodel.cpp
@@ -61,8 +61,6 @@ void BatesModelTest::testAnalyticVsBlack() {
 
     BOOST_TEST_MESSAGE("Testing analytic Bates engine against Black formula...");
 
-    SavedSettings backup;
-
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -173,8 +171,6 @@ void BatesModelTest::testAnalyticVsBlack() {
 void BatesModelTest::testAnalyticAndMcVsJumpDiffusion() {
 
     BOOST_TEST_MESSAGE("Testing analytic Bates engine against Merton-76 engine...");
-
-    SavedSettings backup;
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
@@ -302,8 +298,6 @@ void BatesModelTest::testAnalyticVsMCPricing() {
 
     using namespace bates_model_test;
 
-    SavedSettings backup;
-
     Date settlementDate(30, March, 2007);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -382,8 +376,6 @@ void BatesModelTest::testDAXCalibration() {
              "Testing Bates model calibration using DAX volatility data...");
 
     using namespace bates_model_test;
-
-    SavedSettings backup;
 
     Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -59,9 +59,6 @@ namespace bermudan_swaption_test {
 
         RelinkableHandle<YieldTermStructure> termStructure;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             startYears = 1;
@@ -318,7 +315,6 @@ void BermudanSwaptionTest::testTreeEngineTimeSnapping() {
     BOOST_TEST_MESSAGE("Testing snap of exercise dates for discretized swaption...");
 
     Date today = Date(8, Jul, 2021);
-    SavedSettings backup;
     Settings::instance().evaluationDate() = today;
 
     RelinkableHandle<YieldTermStructure> termStructure;

--- a/test-suite/blackdeltacalculator.cpp
+++ b/test-suite/blackdeltacalculator.cpp
@@ -157,8 +157,6 @@ void BlackDeltaCalculatorTest::testDeltaPriceConsistency() {
     // Black Scholes calculator, since premium adjusted deltas can be calculated
     // from spot deltas by adding/subtracting the premium.
 
-    SavedSettings backup;
-
     // actually, value and tol won't be needed for testing
     EuropeanOptionData values[] = {
       //        type, strike,   spot,    rd,    rf,    t,  vol,   value,    tol
@@ -321,8 +319,6 @@ void BlackDeltaCalculatorTest::testPutCallParity(){
     using namespace black_delta_calculator_test;
 
     // Test for put call parity between put and call deltas.
-
-    SavedSettings backup;
 
     /* The data below are from
        "Option pricing formulas", E.G. Haug, McGraw-Hill 1998
@@ -526,8 +522,6 @@ void BlackDeltaCalculatorTest::testAtmCalcs(){
     BOOST_TEST_MESSAGE("Testing delta-neutral ATM quotations...");
 
     using namespace black_delta_calculator_test;
-
-    SavedSettings backup;
 
     DeltaData values[] = {
         {Option::Call, DeltaVolQuote::Spot,     1.421, 0.997306, 0.992266,          0.1180654,  1.608080, 0.15},

--- a/test-suite/blackformula.cpp
+++ b/test-suite/blackformula.cpp
@@ -199,8 +199,6 @@ void BlackFormulaTest::testImpliedVolAdaptiveSuccessiveOverRelaxation() {
     BOOST_TEST_MESSAGE("Testing implied volatility calculation via "
         "adaptive successive over-relaxation...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(12, July, 2017);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/bondforward.cpp
+++ b/test-suite/bondforward.cpp
@@ -34,9 +34,6 @@ namespace bond_forward_test {
         Date today;
         RelinkableHandle<YieldTermStructure> curveHandle;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             today = Date(7, March, 2022);

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -69,9 +69,6 @@ namespace bonds_test {
         Date today;
         Real faceAmount;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             calendar = TARGET();
@@ -1368,8 +1365,6 @@ void BondTest::testExCouponAustralianBond() {
 void BondTest::testBondFromScheduleWithDateVector()
 {
     BOOST_TEST_MESSAGE("Testing South African R2048 bond price using Schedule constructor with Date vector...");
-    SavedSettings backup;
-
     //When pricing bond from Yield To Maturity, use NullCalendar()
     Calendar calendar = NullCalendar();
 
@@ -1635,8 +1630,6 @@ void BondTest::testRiskyBondWithGivenDates() {
 
 void BondTest::testFixedRateBondWithArbitrarySchedule() {
     BOOST_TEST_MESSAGE("Testing fixed-rate bond with arbitrary schedule...");
-    SavedSettings backup;
-
     Calendar calendar = NullCalendar();
 
     Natural settlementDays = 3;
@@ -1679,7 +1672,6 @@ void BondTest::testThirty360BondWithSettlementOn31st(){
         "Testing Thirty/360 bond with settlement on 31st of the month...");
 
     // cusip 3130A0X70, data is from Bloomberg
-    SavedSettings backup;
     Settings::instance().evaluationDate() = Date(28, July, 2017);
 
     Date datedDate(13, February, 2014);

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -52,8 +52,6 @@ namespace {
         RelinkableHandle<YieldTermStructure> termStructure;
         RelinkableHandle<ShortRateModel> model;
 
-        SavedSettings backup;
-
         Date issueDate() const {
             // ensure that we're in mid-coupon
             return calendar.adjust(today - 100*Days);
@@ -580,7 +578,6 @@ void CallableBondTest::testSnappingExerciseDate2ClosestCouponDate() {
 
     auto today = Date(18, May, 2021);
 
-    SavedSettings backup;
     Settings::instance().evaluationDate() = today;
 
     auto calendar = UnitedStates(UnitedStates::FederalReserve);

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -57,10 +57,6 @@ namespace capfloor_test {
         Natural fixingDays;
         RelinkableHandle<YieldTermStructure> termStructure;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars()
         : nominals(1,100) {

--- a/test-suite/capflooredcoupon.cpp
+++ b/test-suite/capflooredcoupon.cpp
@@ -58,9 +58,6 @@ namespace capfloored_coupon_test {
         Integer length;
         Volatility volatility;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             length = 20;           //years

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -45,8 +45,6 @@ void CashFlowsTest::testSettings() {
 
     BOOST_TEST_MESSAGE("Testing cash-flow settings...");
 
-    SavedSettings backup;
-
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
@@ -178,8 +176,6 @@ void CashFlowsTest::testSettings() {
 
 void CashFlowsTest::testAccessViolation() {
     BOOST_TEST_MESSAGE("Testing dynamic cast of coupon in Black pricer...");
-
-    SavedSettings backup;
 
     Date todaysDate(7, April, 2010);
     Date settlementDate(9, April, 2010);

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -195,9 +195,6 @@ namespace catbonds_test {
         Date today;
         Real faceAmount;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             calendar = TARGET();

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -99,8 +99,6 @@ void CdoTest::testHW(unsigned dataSet) {
 
     using namespace cdo_test;
 
-    SavedSettings backup;
-
     Size poolSize = 100;
     Real lambda = 0.01;
 

--- a/test-suite/cdsoption.cpp
+++ b/test-suite/cdsoption.cpp
@@ -38,8 +38,6 @@ void CdsOptionTest::testCached() {
 
     BOOST_TEST_MESSAGE("Testing CDS-option value against cached values...");
 
-    SavedSettings backup;
-
     Date cachedToday = Date(10,December,2007);
     Settings::instance().evaluationDate() = cachedToday;
 

--- a/test-suite/cliquetoption.cpp
+++ b/test-suite/cliquetoption.cpp
@@ -105,8 +105,6 @@ namespace {
     template <class T>
     void testOptionGreeks() {
 
-        SavedSettings backup;
-
         std::map<std::string,Real> calculated, expected, tolerance;
         tolerance["delta"]  = 1.0e-5;
         tolerance["gamma"]  = 1.0e-5;
@@ -270,8 +268,6 @@ void CliquetOptionTest::testPerformanceGreeks() {
 void CliquetOptionTest::testMcPerformance() {
     BOOST_TEST_MESSAGE(
         "Testing Monte Carlo performance engine against analytic results...");
-
-    SavedSettings backup;
 
     Option::Type types[] = { Option::Call, Option::Put };
     Real moneyness[] = { 0.9, 1.1 };

--- a/test-suite/cms.cpp
+++ b/test-suite/cms.cpp
@@ -59,9 +59,6 @@ namespace cms_test {
         std::vector<ext::shared_ptr<CmsCouponPricer> > numericalPricers;
         std::vector<ext::shared_ptr<CmsCouponPricer> > analyticPricers;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
 

--- a/test-suite/cms_normal.cpp
+++ b/test-suite/cms_normal.cpp
@@ -60,9 +60,6 @@ namespace cms_normal_test {
         std::vector<ext::shared_ptr<CmsCouponPricer> > numericalPricers;
         std::vector<ext::shared_ptr<CmsCouponPricer> > analyticPricers;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
 

--- a/test-suite/cmsspread.cpp
+++ b/test-suite/cmsspread.cpp
@@ -82,7 +82,6 @@ struct TestData {
             cmsPricerN, correlation, yts2, 32);
     }
 
-    SavedSettings backup;
     Date refDate;
     Handle<YieldTermStructure> yts2;
     Handle<SwaptionVolatilityStructure> swLn, swSln, swN;

--- a/test-suite/compoundoption.cpp
+++ b/test-suite/compoundoption.cpp
@@ -105,8 +105,6 @@ void CompoundOptionTest::testPutCallParity(){
         { Option::Call, Option::Put,  0.02,           1.6   ,      1.6,     0.013, 0.022,  0.45,     0.5,         0.17},
     };
 
-    SavedSettings backup;
-
     Calendar calendar = TARGET();
 
     DayCounter dc = Actual360();
@@ -238,8 +236,6 @@ void CompoundOptionTest::testValues(){
         { Option::Put, Option::Call,  0.02,           1.6   ,      1.6,  0.013, 0.022,  0.45,     0.5,         0.17,  0.0081,   1.0e-3,  -0.0417,0.0761, -0.0045, -0.0020},
         { Option::Put, Option::Put,  0.02,           1.6   ,      1.6,   0.013, 0.022,  0.45,     0.5,         0.17,  0.0078,   1.0e-3,   0.0413,0.0326, -0.0133, -0.0016}
     };
-
-    SavedSettings backup;
 
     Calendar calendar = TARGET();
 

--- a/test-suite/convertiblebonds.cpp
+++ b/test-suite/convertiblebonds.cpp
@@ -66,9 +66,6 @@ namespace convertible_bonds_test {
 
         Real faceAmount, redemption, conversionRatio;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             calendar = TARGET();
@@ -361,8 +358,6 @@ void ConvertibleBondTest::testRegression() {
 
     BOOST_TEST_MESSAGE(
        "Testing fixed-coupon convertible bond in known regression case...");
-
-    SavedSettings backup;
 
     Date today = Date(23, December, 2008);
     Date tomorrow = today + 1;

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -53,8 +53,6 @@ void CreditDefaultSwapTest::testCachedValue() {
 
     BOOST_TEST_MESSAGE("Testing credit-default swap against cached values...");
 
-    SavedSettings backup;
-
     // Initialize curves
     Settings::instance().evaluationDate() = Date(9,June,2006);
     Date today = Settings::instance().evaluationDate();
@@ -167,8 +165,6 @@ void CreditDefaultSwapTest::testCachedMarketValue() {
 
     BOOST_TEST_MESSAGE(
         "Testing credit-default swap against cached market values...");
-
-    SavedSettings backup;
 
     Settings::instance().evaluationDate() = Date(9,June,2006);
     Date evalDate = Settings::instance().evaluationDate();
@@ -315,8 +311,6 @@ void CreditDefaultSwapTest::testImpliedHazardRate() {
 
     BOOST_TEST_MESSAGE("Testing implied hazard-rate for credit-default swaps...");
 
-    SavedSettings backup;
-
     // Initialize curves
     Calendar calendar = TARGET();
     Date today = calendar.adjust(Date::todaysDate());
@@ -423,8 +417,6 @@ void CreditDefaultSwapTest::testFairSpread() {
     BOOST_TEST_MESSAGE(
         "Testing fair-spread calculation for credit-default swaps...");
 
-    SavedSettings backup;
-
     // Initialize curves
     Calendar calendar = TARGET();
     Date today = calendar.adjust(Date::todaysDate());
@@ -487,8 +479,6 @@ void CreditDefaultSwapTest::testFairUpfront() {
 
     BOOST_TEST_MESSAGE(
         "Testing fair-upfront calculation for credit-default swaps...");
-
-    SavedSettings backup;
 
     // Initialize curves
     Calendar calendar = TARGET();
@@ -578,8 +568,6 @@ void CreditDefaultSwapTest::testIsdaEngine() {
         "Testing ISDA engine calculations for credit-default swaps...");
 
     bool usingAtParCoupons  = IborCoupon::Settings::instance().usingAtParCoupons();
-
-    SavedSettings backup;
 
     Date tradeDate(21, May, 2009);
     Settings::instance().evaluationDate() = tradeDate;
@@ -734,8 +722,6 @@ void CreditDefaultSwapTest::testAccrualRebateAmounts() {
 
     BOOST_TEST_MESSAGE("Testing accrual rebate amounts on credit default swaps...");
 
-    SavedSettings backup;
-
     // The accrual values are taken from various test results on the ISDA CDS model website
     // https://www.cdsmodel.com/cdsmodel/documentation.html.
 
@@ -771,8 +757,6 @@ void CreditDefaultSwapTest::testIsdaCalculatorReconcileSingleQuote ()
 {
     BOOST_TEST_MESSAGE(
         "Testing ISDA engine calculations for a single credit-default swap record (reconciliation)...");
-
-    SavedSettings backup;
 
     Date tradeDate(26, July, 2021);
     Settings::instance().evaluationDate() = tradeDate;
@@ -877,8 +861,6 @@ void CreditDefaultSwapTest::testIsdaCalculatorReconcileSingleWithIssueDateInTheP
 {
     BOOST_TEST_MESSAGE(
         "Testing ISDA engine calculations for a single credit-default swap with issue date in the past...");
-
-    SavedSettings backup;
 
     Date valueDate(26, July, 2021);
     Settings::instance().evaluationDate() = valueDate;

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -63,8 +63,6 @@ namespace crosscurrencyratehelpers_test {
 
         std::vector<XccyTestDatum> basisData;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         ext::shared_ptr<RateHelper>

--- a/test-suite/curvestates.cpp
+++ b/test-suite/curvestates.cpp
@@ -51,9 +51,6 @@ namespace curve_states_test {
         Spread displacement;
         std::vector<DiscountFactor> todaysDiscounts;
 
-        // cleanup
-        SavedSettings backup;
-
         CommonVars() {
             // Times
             calendar = NullCalendar();

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -269,8 +269,6 @@ namespace {
         Real notional = 1.0;
         double tolerance = 1.0e-6;
 
-        // UpfrontCdsHelper::impliedQuote() overrides includeTodaysCashFlows.
-        // Save settings here so we can test that impliedQuote restored settings correctly.
         SavedSettings backup;
         // ensure apple-to-apple comparison
         Settings::instance().includeTodaysCashFlows() = true;
@@ -377,12 +375,16 @@ void DefaultProbabilityCurveTest::testSingleInstrumentBootstrap() {
 void DefaultProbabilityCurveTest::testUpfrontBootstrap() {
     BOOST_TEST_MESSAGE("Testing bootstrap on upfront quotes...");
 
-    // not taken into account, this would prevent the upfront from being used
+    // Setting this to false would prevent the upfront from being used.
+    // By checking that the bootstrap works, we indirectly check that
+    // UpfrontCdsHelper::impliedQuote() overrides it.
     Settings::instance().includeTodaysCashFlows() = false;
 
     testBootstrapFromUpfront<HazardRate,BackwardFlat>();
 
-    // also ensure that we didn't override the flag permanently
+    // This checks that UpfrontCdsHelper::impliedQuote() didn't
+    // override the flag permanently; after the bootstrap, it should
+    // go back to its previous value.
     ext::optional<bool> flag = Settings::instance().includeTodaysCashFlows();
     if (flag != false)
         BOOST_ERROR("Cash-flow settings improperly modified");

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -190,34 +190,37 @@ namespace {
         Real notional = 1.0;
         double tolerance = 1.0e-6;
 
-        // ensure apple-to-apple comparison
-        Settings::instance().includeTodaysCashFlows() = true;
+        {
+            SavedSettings restore;
+            // ensure apple-to-apple comparison
+            Settings::instance().includeTodaysCashFlows() = true;
 
-        for (Size i=0; i<n.size(); i++) {
-            Date protectionStart = today + settlementDays;
-            Date startDate = calendar.adjust(protectionStart, convention);
-            Date endDate = today + n[i]*Years;
+            for (Size i=0; i<n.size(); i++) {
+                Date protectionStart = today + settlementDays;
+                Date startDate = calendar.adjust(protectionStart, convention);
+                Date endDate = today + n[i]*Years;
 
-            Schedule schedule(startDate, endDate, Period(frequency), calendar,
-                              convention, Unadjusted, rule, false);
+                Schedule schedule(startDate, endDate, Period(frequency), calendar,
+                                  convention, Unadjusted, rule, false);
 
-            CreditDefaultSwap cds(Protection::Buyer, notional, quote[i],
-                                  schedule, convention, dayCounter,
-                                  true, true, protectionStart);
-            cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                CreditDefaultSwap cds(Protection::Buyer, notional, quote[i],
+                                      schedule, convention, dayCounter,
+                                      true, true, protectionStart);
+                cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
                            new MidPointCdsEngine(piecewiseCurve, recoveryRate,
                                                  discountCurve)));
 
-            // test
-            Rate inputRate = quote[i];
-            Rate computedRate = cds.fairSpread();
-            if (std::fabs(inputRate - computedRate) > tolerance)
-                BOOST_ERROR(
-                    "\nFailed to reproduce fair spread for " << n[i] <<
-                    "Y credit-default swaps\n"
-                    << std::setprecision(10)
-                    << "    computed rate: " << io::rate(computedRate) << "\n"
-                    << "    input rate:    " << io::rate(inputRate));
+                // test
+                Rate inputRate = quote[i];
+                Rate computedRate = cds.fairSpread();
+                if (std::fabs(inputRate - computedRate) > tolerance)
+                    BOOST_ERROR(
+                                "\nFailed to reproduce fair spread for " << n[i] <<
+                                "Y credit-default swaps\n"
+                                << std::setprecision(10)
+                                << "    computed rate: " << io::rate(computedRate) << "\n"
+                                << "    input rate:    " << io::rate(inputRate));
+            }
         }
     }
 
@@ -269,44 +272,46 @@ namespace {
         Real notional = 1.0;
         double tolerance = 1.0e-6;
 
-        SavedSettings backup;
-        // ensure apple-to-apple comparison
-        Settings::instance().includeTodaysCashFlows() = true;
+        {
+            SavedSettings backup;
+            // ensure apple-to-apple comparison
+            Settings::instance().includeTodaysCashFlows() = true;
 
-        for (Size i=0; i<n.size(); i++) {
-            Date protectionStart = today + settlementDays;
-            Date startDate = protectionStart;
-            Date endDate = cdsMaturity(today, n[i] * Years, rule);
-            Date upfrontDate = calendar.advance(today,
-                                         upfrontSettlementDays,
-                                         Days,
-                                         convention);
+            for (Size i=0; i<n.size(); i++) {
+                Date protectionStart = today + settlementDays;
+                Date startDate = protectionStart;
+                Date endDate = cdsMaturity(today, n[i] * Years, rule);
+                Date upfrontDate = calendar.advance(today,
+                                                    upfrontSettlementDays,
+                                                    Days,
+                                                    convention);
 
-            Schedule schedule(startDate, endDate, Period(frequency), calendar,
-                              convention, Unadjusted, rule, false);
+                Schedule schedule(startDate, endDate, Period(frequency), calendar,
+                                  convention, Unadjusted, rule, false);
 
-            CreditDefaultSwap cds(Protection::Buyer, notional,
-                                  quote[i], fixedRate,
-                                  schedule, convention, dayCounter,
-                                  true, true, protectionStart,
-                                  upfrontDate,
-                                  ext::shared_ptr<Claim>(),
-                                  Actual360(true),
-                                  true, today);
-            cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
+                CreditDefaultSwap cds(Protection::Buyer, notional,
+                                      quote[i], fixedRate,
+                                      schedule, convention, dayCounter,
+                                      true, true, protectionStart,
+                                      upfrontDate,
+                                      ext::shared_ptr<Claim>(),
+                                      Actual360(true),
+                                      true, today);
+                cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
                            new MidPointCdsEngine(piecewiseCurve, recoveryRate,
                                                  discountCurve, true)));
 
-            // test
-            Rate inputUpfront = quote[i];
-            Rate computedUpfront = cds.fairUpfront();
-            if (std::fabs(inputUpfront - computedUpfront) > tolerance)
-                BOOST_ERROR(
-                    "\nFailed to reproduce fair upfront for " << n[i] <<
-                    "Y credit-default swaps\n"
-                    << std::setprecision(10)
-                    << "    computed: " << io::rate(computedUpfront) << "\n"
-                    << "    expected: " << io::rate(inputUpfront));
+                // test
+                Rate inputUpfront = quote[i];
+                Rate computedUpfront = cds.fairUpfront();
+                if (std::fabs(inputUpfront - computedUpfront) > tolerance)
+                    BOOST_ERROR(
+                                "\nFailed to reproduce fair upfront for " << n[i] <<
+                                "Y credit-default swaps\n"
+                                << std::setprecision(10)
+                                << "    computed: " << io::rate(computedUpfront) << "\n"
+                                << "    expected: " << io::rate(inputUpfront));
+            }
         }
     }
 

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -191,7 +191,6 @@ namespace {
         double tolerance = 1.0e-6;
 
         // ensure apple-to-apple comparison
-        SavedSettings backup;
         Settings::instance().includeTodaysCashFlows() = true;
 
         for (Size i=0; i<n.size(); i++) {
@@ -270,6 +269,8 @@ namespace {
         Real notional = 1.0;
         double tolerance = 1.0e-6;
 
+        // UpfrontCdsHelper::impliedQuote() overrides includeTodaysCashFlows.
+        // Save settings here so we can test that impliedQuote restored settings correctly.
         SavedSettings backup;
         // ensure apple-to-apple comparison
         Settings::instance().includeTodaysCashFlows() = true;
@@ -376,7 +377,6 @@ void DefaultProbabilityCurveTest::testSingleInstrumentBootstrap() {
 void DefaultProbabilityCurveTest::testUpfrontBootstrap() {
     BOOST_TEST_MESSAGE("Testing bootstrap on upfront quotes...");
 
-    SavedSettings backup;
     // not taken into account, this would prevent the upfront from being used
     Settings::instance().includeTodaysCashFlows() = false;
 
@@ -396,8 +396,6 @@ void DefaultProbabilityCurveTest::testUpfrontBootstrap() {
 void DefaultProbabilityCurveTest::testIterativeBootstrapRetries() {
 
     BOOST_TEST_MESSAGE("Testing iterative bootstrap with retries...");
-
-    SavedSettings backup;
 
     Date asof(1, Apr, 2020);
     Settings::instance().evaluationDate() = asof;

--- a/test-suite/digitalcoupon.cpp
+++ b/test-suite/digitalcoupon.cpp
@@ -49,9 +49,6 @@ namespace digital_coupon_test {
         Real optionTolerance;
         Real blackTolerance;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             fixingDays = 2;

--- a/test-suite/digitaloption.cpp
+++ b/test-suite/digitaloption.cpp
@@ -511,8 +511,6 @@ void DigitalOptionTest::testCashAtHitOrNothingAmericanGreeks() {
     BOOST_TEST_MESSAGE("Testing American cash-(at-hit)-or-nothing "
                        "digital option greeks...");
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]  = 5.0e-5;
     tolerance["gamma"]  = 5.0e-5;
@@ -668,8 +666,6 @@ void DigitalOptionTest::testMCCashAtHit() {
 
     BOOST_TEST_MESSAGE("Testing Monte Carlo cash-(at-hit)-or-nothing "
                        "American engine...");
-
-    SavedSettings backup;
 
     DigitalOptionData values[] = {
         //        type, strike,   spot,    q,    r,   t,  vol,   value, tol

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -61,8 +61,6 @@ void DividendOptionTest::testEuropeanValues() {
     BOOST_TEST_MESSAGE(
               "Testing dividend European option values with no dividends...");
 
-    SavedSettings backup;
-
     Real tolerance = 1.0e-5;
 
     Option::Type types[] = { Option::Call, Option::Put };
@@ -175,8 +173,6 @@ void DividendOptionTest::testEuropeanKnownValue() {
 
     BOOST_TEST_MESSAGE("Testing dividend European option against known value...");
 
-    SavedSettings backup;
-
     Real tolerance = 1.0e-2;
     Real expected = 3.67;
 
@@ -254,8 +250,6 @@ void DividendOptionTest::testEuropeanStartLimit() {
 
     BOOST_TEST_MESSAGE(
        "Testing dividend European option with a dividend on today's date...");
-
-    SavedSettings backup;
 
     Real tolerance = 1.0e-5;
     Real dividendValue = 10.0;
@@ -350,8 +344,6 @@ void DividendOptionTest::testEuropeanEndLimit() {
 
     BOOST_TEST_MESSAGE(
               "Testing dividend European option values with end limits...");
-
-    SavedSettings backup;
 
     Real tolerance = 1.0e-5;
     Real dividendValue = 10.0;
@@ -448,8 +440,6 @@ void DividendOptionTest::testEuropeanEndLimit() {
 void DividendOptionTest::testOldEuropeanGreeks() {
 
     BOOST_TEST_MESSAGE("Testing old-style dividend European option greeks...");
-
-    SavedSettings backup;
 
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"] = 1.0e-5;
@@ -585,8 +575,6 @@ void DividendOptionTest::testEuropeanGreeks() {
 
     BOOST_TEST_MESSAGE("Testing dividend European option greeks...");
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"] = 1.0e-5;
     tolerance["gamma"] = 1.0e-5;
@@ -720,8 +708,6 @@ void DividendOptionTest::testFdEuropeanValues() {
 
     BOOST_TEST_MESSAGE(
               "Testing finite-difference dividend European option values...");
-
-    SavedSettings backup;
 
     Real tolerance = 1.0e-2;
     Size gridPoints = 400;
@@ -964,8 +950,6 @@ namespace {
 void DividendOptionTest::testFdEuropeanGreeks() {
     BOOST_TEST_MESSAGE("Testing finite-differences dividend European option greeks...");
 
-    SavedSettings backup;
-
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
     Integer lengths[] = { 1, 2 };
@@ -981,8 +965,6 @@ void DividendOptionTest::testFdEuropeanGreeks() {
 void DividendOptionTest::testFdAmericanGreeks() {
     BOOST_TEST_MESSAGE(
              "Testing finite-differences dividend American option greeks...");
-
-    SavedSettings backup;
 
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
@@ -1078,8 +1060,6 @@ void DividendOptionTest::testFdEuropeanDegenerate() {
     BOOST_TEST_MESSAGE(
          "Testing degenerate finite-differences dividend European option...");
 
-    SavedSettings backup;
-
     Date today = Date(27,February,2005);
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
@@ -1094,8 +1074,6 @@ void DividendOptionTest::testFdAmericanDegenerate() {
 
     BOOST_TEST_MESSAGE(
          "Testing degenerate finite-differences dividend American option...");
-
-    SavedSettings backup;
 
     Date today = Date(27,February,2005);
     Settings::instance().evaluationDate() = today;
@@ -1211,8 +1189,6 @@ void DividendOptionTest::testFdEuropeanWithDividendToday() {
     BOOST_TEST_MESSAGE(
          "Testing finite-differences dividend European option with dividend on today's date...");
 
-    SavedSettings backup;
-
     Date today = Date(27,February,2005);
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
@@ -1228,8 +1204,6 @@ void DividendOptionTest::testFdAmericanWithDividendToday() {
     BOOST_TEST_MESSAGE(
          "Testing finite-differences dividend American option with dividend on today's date...");
 
-    SavedSettings backup;
-
     Date today = Date(27,February,2005);
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
@@ -1243,8 +1217,6 @@ void DividendOptionTest::testFdAmericanWithDividendToday() {
 void DividendOptionTest::testEscrowedDividendModel() {
     BOOST_TEST_MESSAGE("Testing finite-difference European engine "
                        "with the escrowed dividend model...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(12, October, 2019);

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -389,8 +389,6 @@ void DoubleBarrierOptionTest::testVannaVolgaDoubleBarrierValues() {
 
     using namespace double_barrier_option_test;
 
-    SavedSettings backup;
-
     DoubleBarrierFxOptionData values[] = {
 
         //            BarrierType, barr.1, barr.2, rebate,         type,    strike,          s,         q,         r,  t, vol25Put,    volAtm,vol25Call,      vol,    result,   tol
@@ -531,8 +529,6 @@ void DoubleBarrierOptionTest::testMonteCarloDoubleBarrierWithAnalytical() {
     BOOST_TEST_MESSAGE("Testing MC double-barrier options against analytical values...");
 
     using namespace double_barrier_option_test;
-
-    SavedSettings backup;
 
     Real tolerance = 0.01; //percentage difference between analytical and monte carlo values to be tolerated
 

--- a/test-suite/doublebinaryoption.cpp
+++ b/test-suite/doublebinaryoption.cpp
@@ -247,8 +247,6 @@ void DoubleBinaryOptionTest::testPdeDoubleBarrierWithAnalytical() {
     BOOST_TEST_MESSAGE("Testing cash-or-nothing double barrier options "
             "against PDE Heston version...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual360();
     const Date todaysDate(30, Jan, 2023);
     const Date maturityDate = todaysDate + Period(1, Years);

--- a/test-suite/equitycashflow.cpp
+++ b/test-suite/equitycashflow.cpp
@@ -48,8 +48,6 @@ namespace equitycashflow_test {
         RelinkableHandle<Quote> spotHandle;
         RelinkableHandle<Quote> correlationHandle;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars() {

--- a/test-suite/equityindex.cpp
+++ b/test-suite/equityindex.cpp
@@ -40,8 +40,6 @@ namespace equityindex_test {
         ext::shared_ptr<Quote> spot;
         RelinkableHandle<Quote> spotHandle;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars(bool addTodaysFixing = true) {

--- a/test-suite/equitytotalreturnswap.cpp
+++ b/test-suite/equitytotalreturnswap.cpp
@@ -48,8 +48,6 @@ namespace equitytotalreturnswap_test {
         RelinkableHandle<Quote> spotHandle;
         ext::shared_ptr<PricingEngine> discountEngine;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars() {

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -196,8 +196,6 @@ void EuropeanOptionTest::testValues() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     /* The data below are from
        "Option pricing formulas", E.G. Haug, McGraw-Hill 1998
     */
@@ -313,8 +311,6 @@ void EuropeanOptionTest::testGreekValues() {
     BOOST_TEST_MESSAGE("Testing European option greek values...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     /* The data below are from
        "Option pricing formulas", E.G. Haug, McGraw-Hill 1998
@@ -605,8 +601,6 @@ void EuropeanOptionTest::testGreeks() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]  = 1.0e-5;
     tolerance["gamma"]  = 1.0e-5;
@@ -758,8 +752,6 @@ void EuropeanOptionTest::testImpliedVol() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     Size maxEvaluations = 100;
     Real tolerance = 1.0e-6;
 
@@ -876,8 +868,6 @@ void EuropeanOptionTest::testImpliedVolWithDividends() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     Size maxEvaluations = 100;
     Real tolerance = 1.0e-6;
 
@@ -993,8 +983,6 @@ void EuropeanOptionTest::testImpliedVolContainment() {
 
     BOOST_TEST_MESSAGE("Testing self-containment of "
                        "implied volatility calculation...");
-
-    SavedSettings backup;
 
     Size maxEvaluations = 100;
     Real tolerance = 1.0e-6;
@@ -1169,8 +1157,6 @@ void EuropeanOptionTest::testJRBinomialEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = JR;
     Size steps = 251;
     Size samples = Null<Size>();
@@ -1188,8 +1174,6 @@ void EuropeanOptionTest::testCRRBinomialEngines() {
                        "against analytic results...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     EngineType engine = CRR;
     Size steps = 501;
@@ -1209,8 +1193,6 @@ void EuropeanOptionTest::testEQPBinomialEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = EQP;
     Size steps = 501;
     Size samples = Null<Size>();
@@ -1228,8 +1210,6 @@ void EuropeanOptionTest::testTGEOBinomialEngines() {
                        "against analytic results...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     EngineType engine = TGEO;
     Size steps = 251;
@@ -1249,8 +1229,6 @@ void EuropeanOptionTest::testTIANBinomialEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = TIAN;
     Size steps = 251;
     Size samples = Null<Size>();
@@ -1268,8 +1246,6 @@ void EuropeanOptionTest::testLRBinomialEngines() {
                        "against analytic results...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     EngineType engine = LR;
     Size steps = 251;
@@ -1289,8 +1265,6 @@ void EuropeanOptionTest::testJOSHIBinomialEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = JOSHI;
     Size steps = 251;
     Size samples = Null<Size>();
@@ -1309,8 +1283,6 @@ void EuropeanOptionTest::testFdEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = FiniteDifferences;
     Size timeSteps = 500;
     Size gridPoints = 500;
@@ -1328,8 +1300,6 @@ void EuropeanOptionTest::testIntegralEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = Integral;
     Size timeSteps = 300;
     Size gridPoints = 300;
@@ -1344,8 +1314,6 @@ void EuropeanOptionTest::testMcEngines() {
                        "against analytic results...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     EngineType engine = PseudoMonteCarlo;
     Size steps = Null<Size>();
@@ -1362,8 +1330,6 @@ void EuropeanOptionTest::testQmcEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = QuasiMonteCarlo;
     Size steps = Null<Size>();
     Size samples = 4095; // 2^12-1
@@ -1379,8 +1345,6 @@ void EuropeanOptionTest::testFFTEngines() {
 
     using namespace european_option_test;
 
-    SavedSettings backup;
-
     EngineType engine = FFT;
     Size steps = Null<Size>();
     Size samples = Null<Size>();
@@ -1394,8 +1358,6 @@ void EuropeanOptionTest::testLocalVolatility() {
     BOOST_TEST_MESSAGE("Testing finite-differences with local volatility...");
 
     using namespace european_option_test;
-
-    SavedSettings backup;
 
     const Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
@@ -1536,8 +1498,6 @@ void EuropeanOptionTest::testAnalyticEngineDiscountCurve() {
     BOOST_TEST_MESSAGE(
         "Testing separate discount curve for analytic European engine...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
@@ -1583,8 +1543,6 @@ void EuropeanOptionTest::testAnalyticEngineDiscountCurve() {
 
 void EuropeanOptionTest::testPDESchemes() {
     BOOST_TEST_MESSAGE("Testing different PDE schemes to solve Black-Scholes PDEs...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(18, February, 2018);
@@ -1686,8 +1644,6 @@ void EuropeanOptionTest::testFdEngineWithNonConstantParameters() {
     BOOST_TEST_MESSAGE("Testing finite-difference European engine "
                        "with non-constant parameters...");
 
-    SavedSettings backup;
-
     Real u = 190.0;
     Volatility v = 0.20;
 
@@ -1742,8 +1698,6 @@ void EuropeanOptionTest::testFdEngineWithNonConstantParameters() {
 void EuropeanOptionTest::testDouglasVsCrankNicolson() {
     BOOST_TEST_MESSAGE("Testing Douglas vs Crank-Nicolson scheme "
                         "for finite-difference European PDE engines...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(5, October, 2018);
@@ -1809,8 +1763,6 @@ void EuropeanOptionTest::testDouglasVsCrankNicolson() {
 
 void EuropeanOptionTest::testVanillaAndDividendEngine() {
     BOOST_TEST_MESSAGE("Testing the use of a single engine for vanilla and dividend options...");
-
-    SavedSettings backup;
 
     auto today = Date(1, January, 2023);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/extendedtrees.cpp
+++ b/test-suite/extendedtrees.cpp
@@ -238,8 +238,6 @@ void ExtendedTreesTest::testJRBinomialEngines() {
 
     using namespace extended_trees_test;
 
-    SavedSettings backup;
-
     EngineType engine = JR;
     Size steps = 251;
     std::map<std::string,Real> relativeTol;
@@ -256,8 +254,6 @@ void ExtendedTreesTest::testCRRBinomialEngines() {
                        "against analytic results...");
 
     using namespace extended_trees_test;
-
-    SavedSettings backup;
 
     EngineType engine = CRR;
     Size steps = 501;
@@ -276,8 +272,6 @@ void ExtendedTreesTest::testEQPBinomialEngines() {
 
     using namespace extended_trees_test;
 
-    SavedSettings backup;
-
     EngineType engine = EQP;
     Size steps = 501;
     std::map<std::string,Real> relativeTol;
@@ -294,8 +288,6 @@ void ExtendedTreesTest::testTGEOBinomialEngines() {
                        "against analytic results...");
 
     using namespace extended_trees_test;
-
-    SavedSettings backup;
 
     EngineType engine = TGEO;
     Size steps = 251;
@@ -314,8 +306,6 @@ void ExtendedTreesTest::testTIANBinomialEngines() {
 
     using namespace extended_trees_test;
 
-    SavedSettings backup;
-
     EngineType engine = TIAN;
     Size steps = 251;
     std::map<std::string,Real> relativeTol;
@@ -333,8 +323,6 @@ void ExtendedTreesTest::testLRBinomialEngines() {
 
     using namespace extended_trees_test;
 
-    SavedSettings backup;
-
     EngineType engine = LR;
     Size steps = 251;
     std::map<std::string,Real> relativeTol;
@@ -351,8 +339,6 @@ void ExtendedTreesTest::testJOSHIBinomialEngines() {
                        "against analytic results...");
 
     using namespace extended_trees_test;
-
-    SavedSettings backup;
 
     EngineType engine = JOSHI;
     Size steps = 251;

--- a/test-suite/fdcev.cpp
+++ b/test-suite/fdcev.cpp
@@ -127,8 +127,6 @@ void FdCevTest::testFdmCevOp() {
     BOOST_TEST_MESSAGE(
             "Testing FDM constant elasticity of variance (CEV) operator...");
 
-    SavedSettings backup;
-
     const Date today = Date(22, February, 2018);
     const DayCounter dc = Actual365Fixed();
     Settings::instance().evaluationDate() = today;

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -94,8 +94,6 @@ void FdHestonTest::testFdmHestonVarianceMesher() {
 
     using namespace fd_heston_test;
 
-    SavedSettings backup;
-
     const Date today = Date(22, February, 2018);
     const DayCounter dc = Actual365Fixed();
     Settings::instance().evaluationDate() = today;
@@ -194,8 +192,6 @@ void FdHestonTest::testFdmHestonBarrierVsBlackScholes() {
     BOOST_TEST_MESSAGE("Testing FDM with barrier option in Heston model...");
 
     using namespace fd_heston_test;
-
-    SavedSettings backup;
 
     NewBarrierOptionData values[] = {
         /* The data below are from
@@ -345,8 +341,6 @@ void FdHestonTest::testFdmHestonBarrier() {
     BOOST_TEST_MESSAGE("Testing FDM with barrier option for Heston model vs "
                        "Black-Scholes model...");
 
-    SavedSettings backup;
-
     Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
@@ -397,8 +391,6 @@ void FdHestonTest::testFdmHestonBarrier() {
 void FdHestonTest::testFdmHestonAmerican() {
 
     BOOST_TEST_MESSAGE("Testing FDM with American option in Heston model...");
-
-    SavedSettings backup;
 
     Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
 
@@ -457,8 +449,6 @@ void FdHestonTest::testFdmHestonIkonenToivanen() {
        stochastic volatility, Samuli Ikonen, Jari Toivanen, 
        http://users.jyu.fi/~tene/papers/reportB12-05.pdf
     */
-    SavedSettings backup;
-
     Handle<YieldTermStructure> rTS(flatRate(0.10, Actual360()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual360()));
 
@@ -500,9 +490,6 @@ void FdHestonTest::testFdmHestonIkonenToivanen() {
 void FdHestonTest::testFdmHestonBlackScholes() {
 
     BOOST_TEST_MESSAGE("Testing FDM Heston with Black Scholes model...");
-
-    SavedSettings backup;
-
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(26, June, 2004);
@@ -570,8 +557,6 @@ void FdHestonTest::testFdmHestonBlackScholes() {
 void FdHestonTest::testFdmHestonEuropeanWithDividends() {
 
     BOOST_TEST_MESSAGE("Testing FDM with European option with dividends in Heston model...");
-
-    SavedSettings backup;
 
     Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
 
@@ -672,8 +657,6 @@ void FdHestonTest::testFdmHestonConvergence() {
     
     BOOST_TEST_MESSAGE("Testing FDM Heston convergence...");
 
-    SavedSettings backup;
-    
     HestonTestData values[] = {
         { 1.5   , 0.04  , 0.3   , -0.9   , 0.025 , 0.0   , 1.0 , 100 },
         { 3.0   , 0.12  , 0.04  , 0.6    , 0.01  , 0.04  , 1.0 , 100 },
@@ -748,8 +731,6 @@ void FdHestonTest::testFdmHestonIntradayPricing() {
 
     BOOST_TEST_MESSAGE("Testing FDM Heston intraday pricing ...");
 
-    SavedSettings backup;
-
     const Option::Type type(Option::Put);
     const Real underlying = 36;
     const Real strike = underlying;
@@ -809,8 +790,6 @@ void FdHestonTest::testFdmHestonIntradayPricing() {
 
 void FdHestonTest::testMethodOfLinesAndCN() {
     BOOST_TEST_MESSAGE("Testing method of lines to solve Heston PDEs...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(21, February, 2018);
@@ -929,8 +908,6 @@ void FdHestonTest::testSpuriousOscillations() {
     BOOST_TEST_MESSAGE("Testing for spurious oscillations when "
             "solving the Heston PDEs...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(7, June, 2018);
 
@@ -1012,8 +989,6 @@ void FdHestonTest::testAmericanCallPutParity() {
     // A. Battauz, M. De Donno,m A. Sbuelz:
     // The put-call symmetry for American options in
     // the Heston stochastic volatility model
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(15, April, 2022);

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -716,8 +716,6 @@ void FdmLinearOpTest::testFdmHestonBarrier() {
 
     BOOST_TEST_MESSAGE("Testing FDM with barrier option in Heston model...");
 
-    SavedSettings backup;
-
     const std::vector<Size> dim = {200, 100};
 
     ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
@@ -804,8 +802,6 @@ void FdmLinearOpTest::testFdmHestonAmerican() {
 
     BOOST_TEST_MESSAGE("Testing FDM with American option in Heston model...");
 
-    SavedSettings backup;
-
     const std::vector<Size> dim = {200, 100};
 
     ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
@@ -876,8 +872,6 @@ void FdmLinearOpTest::testFdmHestonAmerican() {
 void FdmLinearOpTest::testFdmHestonExpress() {
 
     BOOST_TEST_MESSAGE("Testing FDM with express certificate in Heston model...");
-
-    SavedSettings backup;
 
     const std::vector<Size> dim = {200, 100};
 
@@ -1056,8 +1050,6 @@ namespace {
 
 void FdmLinearOpTest::testFdmHestonHullWhiteOp() {
     BOOST_TEST_MESSAGE("Testing FDM with Heston Hull-White model...");
-
-    SavedSettings backup;
 
     const Date today = Date(28, March, 2004);
     Settings::instance().evaluationDate() = today;
@@ -1310,8 +1302,6 @@ void FdmLinearOpTest::testCrankNicolsonWithDamping() {
     BOOST_TEST_MESSAGE("Testing Crank-Nicolson with initial implicit damping steps "
                        "for a digital option...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
@@ -1528,8 +1518,6 @@ void FdmLinearOpTest::testHighInterestRateBlackScholesMesher() {
     BOOST_TEST_MESSAGE("Testing Black-Scholes mesher in a "
             "high interest rate scenario...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(11, February, 2018);
 
@@ -1592,8 +1580,6 @@ void FdmLinearOpTest::testHighInterestRateBlackScholesMesher() {
 void FdmLinearOpTest::testLowVolatilityHighDiscreteDividendBlackScholesMesher() {
     BOOST_TEST_MESSAGE("Testing Black-Scholes mesher in a low volatility and "
             "high discrete dividend scenario...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(28, January, 2018);

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -107,8 +107,6 @@ namespace {
 void FdSabrTest::testFdmSabrOp() {
     BOOST_TEST_MESSAGE("Testing FDM SABR operator...");
 
-    SavedSettings backup;
-
     const Date today = Date(22, February, 2018);
     const DayCounter dc = Actual365Fixed();
     Settings::instance().evaluationDate() = today;
@@ -203,8 +201,6 @@ void FdSabrTest::testFdmSabrOp() {
 void FdSabrTest::testFdmSabrCevPricing() {
     BOOST_TEST_MESSAGE("Testing FDM CEV pricing with trivial SABR model...");
 
-    SavedSettings backup;
-
     const Date today = Date(3, January, 2019);
     const DayCounter dc = Actual365Fixed();
     Settings::instance().evaluationDate() = today;
@@ -267,8 +263,6 @@ void FdSabrTest::testFdmSabrCevPricing() {
 
 void FdSabrTest::testFdmSabrVsVolApproximation() {
     BOOST_TEST_MESSAGE("Testing FDM SABR vs approximations...");
-
-    SavedSettings backup;
 
     const Date today = Date(8, January, 2019);
     const DayCounter dc = Actual365Fixed();
@@ -367,8 +361,6 @@ namespace {
 void FdSabrTest::testOosterleeTestCaseIV() {
     BOOST_TEST_MESSAGE("Testing Chen, Oosterlee and Weide test case IV...");
 
-    SavedSettings backup;
-
     const Date today = Date(8, January, 2019);
     const DayCounter dc = Actual365Fixed();
     Settings::instance().evaluationDate() = today;
@@ -442,8 +434,6 @@ void FdSabrTest::testBenchOpSabrCase() {
      * Pricing–Stochastic and Local Volatility problems
      * https://ir.cwi.nl/pub/28249
      */
-
-    SavedSettings backup;
 
     const Date today = Date(8, January, 2019);
     const DayCounter dc = Actual365Fixed();

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -69,8 +69,6 @@ void FittedBondDiscountCurveTest::testFlatExtrapolation() {
 
     BOOST_TEST_MESSAGE("Testing fitted bond curve with flat extrapolation...");
 
-    SavedSettings savedSettings;
-
     Date asof(15, Jul, 2019);
     Settings::instance().evaluationDate() = asof;
 

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -353,8 +353,6 @@ void ForwardOptionTest::testGreeks() {
 
     BOOST_TEST_MESSAGE("Testing forward option greeks...");
 
-    SavedSettings backup;
-
     testForwardGreeks<ForwardVanillaEngine>();
 }
 
@@ -362,8 +360,6 @@ void ForwardOptionTest::testGreeks() {
 void ForwardOptionTest::testPerformanceGreeks() {
 
     BOOST_TEST_MESSAGE("Testing forward performance option greeks...");
-
-    SavedSettings backup;
 
     testForwardGreeks<ForwardPerformanceVanillaEngine>();
 }
@@ -384,7 +380,6 @@ void ForwardOptionTest::testGreeksInitialization() {
    BOOST_TEST_MESSAGE("Testing forward option greeks initialization...");
 
    DayCounter dc = Actual360();
-   SavedSettings backup;
    Date today = Settings::instance().evaluationDate();
 
    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
@@ -504,7 +499,6 @@ void ForwardOptionTest::testMCPrices() {
    Real s = 100;
 
    DayCounter dc = Actual360();
-   SavedSettings backup;
    Date today = Settings::instance().evaluationDate();
 
    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(s));
@@ -602,7 +596,6 @@ void ForwardOptionTest::testHestonMCPrices() {
        Real rho = -0.93;
 
        DayCounter dc = Actual360();
-       SavedSettings backup;
        Date today = Settings::instance().evaluationDate();
 
        Date exDate = today + 1 * Years;
@@ -753,7 +746,6 @@ void ForwardOptionTest::testHestonAnalyticalVsMCPrices() {
        Real rho = -0.5;
 
        DayCounter dc = Actual360();
-       SavedSettings backup;
        Date today = Settings::instance().evaluationDate();
 
        Date exDate = today + 1 * Years;

--- a/test-suite/gjrgarchmodel.cpp
+++ b/test-suite/gjrgarchmodel.cpp
@@ -203,8 +203,6 @@ void GJRGARCHModelTest::testDAXCalibration() {
     BOOST_TEST_MESSAGE(
          "Testing GJR-GARCH model calibration using DAX volatility data...");
 
-    SavedSettings backup;
-
     Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
 

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -145,8 +145,6 @@ void HestonModelTest::testBlackCalibration() {
     BOOST_TEST_MESSAGE(
        "Testing Heston model calibration using a flat volatility surface...");
 
-    SavedSettings backup;
-
     /* calibrate a Heston model to a constant volatility surface without
        smile. expected result is a vanishing volatility of the volatility.
        In addition theta and v0 should be equal to the constant variance */
@@ -233,8 +231,6 @@ void HestonModelTest::testDAXCalibration() {
     BOOST_TEST_MESSAGE(
              "Testing Heston model calibration using DAX volatility data...");
 
-    SavedSettings backup;
-
     Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -291,8 +287,6 @@ void HestonModelTest::testDAXCalibration() {
 
 void HestonModelTest::testAnalyticVsBlack() {
     BOOST_TEST_MESSAGE("Testing analytic Heston engine against Black formula...");
-
-    SavedSettings backup;
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
@@ -361,8 +355,6 @@ void HestonModelTest::testAnalyticVsBlack() {
 
 void HestonModelTest::testAnalyticVsCached() {
     BOOST_TEST_MESSAGE("Testing analytic Heston engine against cached values...");
-
-    SavedSettings backup;
 
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
@@ -463,8 +455,6 @@ void HestonModelTest::testMcVsCached() {
     BOOST_TEST_MESSAGE(
                 "Testing Monte Carlo Heston engine against cached values...");
 
-    SavedSettings backup;
-
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -519,8 +509,6 @@ void HestonModelTest::testMcVsCached() {
 void HestonModelTest::testFdBarrierVsCached() {
     BOOST_TEST_MESSAGE("Testing FD barrier Heston engine against cached values...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
@@ -574,8 +562,6 @@ void HestonModelTest::testFdBarrierVsCached() {
 void HestonModelTest::testFdVanillaVsCached() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine against cached values...");
 
-    SavedSettings backup;
-
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -620,8 +606,6 @@ void HestonModelTest::testFdVanillaVsCached() {
 
 void HestonModelTest::testFdVanillaWithDividendsVsCached() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for discrete dividends...");
-
-    SavedSettings backup;
 
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
@@ -697,8 +681,6 @@ void HestonModelTest::testFdVanillaWithDividendsVsCached() {
 void HestonModelTest::testFdAmerican() {
     BOOST_TEST_MESSAGE("Testing FD vanilla Heston engine for american exercise...");
 
-    SavedSettings backup;
-
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -759,8 +741,6 @@ void HestonModelTest::testKahlJaeckelCase() {
        Example was also discussed within the Wilmott thread
        "QuantLib code is very high quatlity"
     */
-
-    SavedSettings backup;
 
     Date settlementDate(30, March, 2007);
     Settings::instance().evaluationDate() = settlementDate;
@@ -913,8 +893,6 @@ void HestonModelTest::testDifferentIntegrals() {
     BOOST_TEST_MESSAGE(
        "Testing different numerical Heston integration algorithms...");
 
-    SavedSettings backup;
-
     const Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -1037,8 +1015,6 @@ void HestonModelTest::testDifferentIntegrals() {
 void HestonModelTest::testMultipleStrikesEngine() {
     BOOST_TEST_MESSAGE("Testing multiple-strikes FD Heston engine...");
 
-    SavedSettings backup;
-
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -1118,8 +1094,6 @@ void HestonModelTest::testMultipleStrikesEngine() {
 void HestonModelTest::testAnalyticPiecewiseTimeDependent() {
     BOOST_TEST_MESSAGE("Testing analytic piecewise time dependent Heston prices...");
 
-    SavedSettings backup;
-
     Date settlementDate(27, December, 2004);
     Settings::instance().evaluationDate() = settlementDate;
     DayCounter dayCounter = ActualActual(ActualActual::ISDA);
@@ -1193,8 +1167,6 @@ void HestonModelTest::testAnalyticPiecewiseTimeDependent() {
 void HestonModelTest::testDAXCalibrationOfTimeDependentModel() {
     BOOST_TEST_MESSAGE(
              "Testing time-dependent Heston model calibration...");
-
-    SavedSettings backup;
 
     Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
@@ -1270,8 +1242,6 @@ void HestonModelTest::testAlanLewisReferencePrices() {
      * testing Alan Lewis reference prices posted in
      * http://wilmott.com/messageview.cfm?catid=34&threadid=90957
      */
-
-    SavedSettings backup;
 
     const Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
@@ -1373,8 +1343,6 @@ void HestonModelTest::testAlanLewisReferencePrices() {
 
 void HestonModelTest::testAnalyticPDFHestonEngine() {
     BOOST_TEST_MESSAGE("Testing analytic PDF Heston engine...");
-
-    SavedSettings backup;
 
     const Date settlementDate(5, January, 2014);
     Settings::instance().evaluationDate() = settlementDate;
@@ -1485,8 +1453,6 @@ void HestonModelTest::testAnalyticPDFHestonEngine() {
 void HestonModelTest::testExpansionOnAlanLewisReference() {
     BOOST_TEST_MESSAGE("Testing expansion on Alan Lewis reference prices...");
 
-    SavedSettings backup;
-
     const Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -1574,8 +1540,6 @@ void HestonModelTest::testExpansionOnAlanLewisReference() {
 
 void HestonModelTest::testExpansionOnFordeReference() {
     BOOST_TEST_MESSAGE("Testing expansion on Forde reference prices...");
-
-    SavedSettings backup;
 
     const Real forward = 100.0;
     const Real v0      =  0.04;
@@ -1684,8 +1648,6 @@ namespace {
 void HestonModelTest::testAllIntegrationMethods() {
     BOOST_TEST_MESSAGE("Testing semi-analytic Heston pricing with all "
                        "integration methods...");
-
-    SavedSettings backup;
 
     const Date settlementDate(7, February, 2017);
     Settings::instance().evaluationDate() = settlementDate;
@@ -1905,8 +1867,6 @@ namespace {
 void HestonModelTest::testCosHestonCumulants() {
     BOOST_TEST_MESSAGE("Testing Heston COS cumulants...");
 
-    SavedSettings backup;
-
     const Date settlementDate(7, February, 2017);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -1997,8 +1957,6 @@ void HestonModelTest::testCosHestonCumulants() {
 void HestonModelTest::testCosHestonEngine() {
     BOOST_TEST_MESSAGE("Testing Heston pricing via COS method...");
 
-    SavedSettings backup;
-
     const Date settlementDate(7, February, 2017);
     Settings::instance().evaluationDate() = settlementDate;
 
@@ -2061,8 +2019,6 @@ void HestonModelTest::testCosHestonEngine() {
 void HestonModelTest::testCosHestonEngineTruncation() {
     BOOST_TEST_MESSAGE("Testing Heston pricing via COS method outside truncation bounds...");
     
-    SavedSettings backup;
-    
     const Date todaysDate(22, August, 2022);
     const Date maturity(23, August, 2022);
     Settings::instance().evaluationDate() = todaysDate;
@@ -2108,8 +2064,6 @@ void HestonModelTest::testCosHestonEngineTruncation() {
 
 void HestonModelTest::testCharacteristicFct() {
     BOOST_TEST_MESSAGE("Testing Heston characteristic function...");
-
-    SavedSettings backup;
 
     const Date settlementDate(30, March, 2017);
     Settings::instance().evaluationDate() = settlementDate;
@@ -2158,8 +2112,6 @@ void HestonModelTest::testCharacteristicFct() {
 void HestonModelTest::testAndersenPiterbargPricing() {
     BOOST_TEST_MESSAGE("Testing Andersen-Piterbarg method to "
                        "price under the Heston model...");
-
-    SavedSettings backup;
 
     const Date settlementDate(30, March, 2017);
     Settings::instance().evaluationDate() = settlementDate;
@@ -2292,8 +2244,6 @@ void HestonModelTest::testAndersenPiterbargControlVariateIntegrand() {
     BOOST_TEST_MESSAGE("Testing Andersen-Piterbarg Integrand "
                         "with control variate...");
 
-    SavedSettings backup;
-
     const Date settlementDate(17, April, 2017);
     Settings::instance().evaluationDate() = settlementDate;
     const Date maturityDate = settlementDate + Period(2, Years);
@@ -2422,8 +2372,6 @@ void HestonModelTest::testAndersenPiterbargControlVariateIntegrand() {
 void HestonModelTest::testAndersenPiterbargConvergence() {
     BOOST_TEST_MESSAGE("Testing Andersen-Piterbarg pricing convergence...");
 
-    SavedSettings backup;
-
     const Date settlementDate(5, July, 2002);
     Settings::instance().evaluationDate() = settlementDate;
     const Date maturityDate(5, July, 2003);
@@ -2476,8 +2424,6 @@ void HestonModelTest::testAndersenPiterbargConvergence() {
 void HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF() {
     BOOST_TEST_MESSAGE("Testing piecewise time dependent "
                        "ChF vs Heston ChF...");
-
-    SavedSettings backup;
 
     const Date settlementDate(5, July, 2017);
     Settings::instance().evaluationDate() = settlementDate;
@@ -2537,8 +2483,6 @@ void HestonModelTest::testPiecewiseTimeDependentChFvsHestonChF() {
 void HestonModelTest::testPiecewiseTimeDependentComparison() {
     BOOST_TEST_MESSAGE("Testing piecewise time dependent "
                        "ChF vs Heston ChF...");
-
-    SavedSettings backup;
 
     const Date settlementDate(5, July, 2017);
     Settings::instance().evaluationDate() = settlementDate;
@@ -2674,8 +2618,6 @@ void HestonModelTest::testPiecewiseTimeDependentChFAsymtotic() {
     BOOST_TEST_MESSAGE("Testing piecewise time dependent "
                        "ChF vs Heston ChF...");
 
-    SavedSettings backup;
-
     const Date settlementDate(5, July, 2017);
     Settings::instance().evaluationDate() = settlementDate;
     const Date maturityDate = settlementDate + Period(13, Months);
@@ -2807,8 +2749,6 @@ void HestonModelTest::testSmallSigmaExpansion() {
     BOOST_TEST_MESSAGE("Testing small sigma expansion of "
                        "the characteristic function...");
 
-    SavedSettings backup;
-
     const Date settlementDate(20, March, 2020);
     Settings::instance().evaluationDate() = settlementDate;
     const Date maturityDate = settlementDate + Period(2, Years);
@@ -2884,8 +2824,6 @@ void HestonModelTest::testSmallSigmaExpansion() {
 void HestonModelTest::testSmallSigmaExpansion4ExpFitting() {
     BOOST_TEST_MESSAGE("Testing small sigma expansion for the "
                        "exponential fitting Heston engine...");
-
-    SavedSettings backup;
 
     const Date todaysDate(13, March, 2020);
     Settings::instance().evaluationDate() = todaysDate;
@@ -3004,8 +2942,6 @@ void HestonModelTest::testSmallSigmaExpansion4ExpFitting() {
 void HestonModelTest::testExponentialFitting4StrikesAndMaturities() {
     BOOST_TEST_MESSAGE("Testing exponential fitting Heston engine "
                        "with high precision results for large moneyness...");
-
-    SavedSettings backup;
 
     const Date todaysDate = Date(13, May, 2020);
     Settings::instance().evaluationDate() = todaysDate;
@@ -3221,8 +3157,6 @@ void HestonModelTest::testOptimalControlVariateChoice() {
 void HestonModelTest::testAsymptoticControlVariate() {
     BOOST_TEST_MESSAGE("Testing Heston asymptotic control variate...");
 
-    SavedSettings backup;
-
     const Date todaysDate = Date(4, August, 2020);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -3317,8 +3251,6 @@ void HestonModelTest::testAsymptoticControlVariate() {
 
 void HestonModelTest::testLocalVolFromHestonModel() {
     BOOST_TEST_MESSAGE("Testing Local Volatility pricing from Heston Model...");
-
-    SavedSettings backup;
 
     const auto todaysDate = Date(28, June, 2021);
     Settings::instance().evaluationDate() = todaysDate;

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -154,8 +154,6 @@ namespace {
 void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquation() {
     BOOST_TEST_MESSAGE("Testing Fokker-Planck forward equation for BS process...");
 
-    SavedSettings backup;
-
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate = Date(28, Dec, 2012);
     Settings::instance().evaluationDate() = todaysDate;
@@ -270,8 +268,6 @@ namespace {
 void HestonSLVModelTest::testSquareRootZeroFlowBC() {
     BOOST_TEST_MESSAGE("Testing zero-flow BC for the square root process...");
 
-    SavedSettings backup;
-
     const Real kappa = 1.0;
     const Real theta = 0.4;
     const Real sigma = 0.8;
@@ -362,8 +358,6 @@ void HestonSLVModelTest::testTransformedZeroFlowBC() {
     BOOST_TEST_MESSAGE("Testing zero-flow BC for transformed "
                        "Fokker-Planck forward equation...");
 
-    SavedSettings backup;
-
     const Real kappa = 1.0;
     const Real theta = 0.4;
     const Real sigma = 2.0;
@@ -428,8 +422,6 @@ void HestonSLVModelTest::testSquareRootEvolveWithStationaryDensity() {
 
     // Documentation for this test case:
     // http://www.spanderen.de/2013/05/04/fokker-planck-equation-feller-constraint-and-boundary-conditions/
-    SavedSettings backup;
-
     const Real kappa = 2.5;
     const Real theta = 0.2;
     const Size vGrid = 100;
@@ -506,8 +498,6 @@ void HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity() {
 
     // Documentation for this test case:
     // nowhere yet :)
-    SavedSettings backup;
-
     const Real kappa = 2.5;
     const Real theta = 0.2;
     const Size vGrid = 1000;
@@ -568,8 +558,6 @@ void HestonSLVModelTest::testSquareRootLogEvolveWithStationaryDensity() {
 void HestonSLVModelTest::testSquareRootFokkerPlanckFwdEquation() {
     BOOST_TEST_MESSAGE("Testing Fokker-Planck forward equation "
                        "for the square root process with Dirac start...");
-
-    SavedSettings backup;
 
     const Real kappa = 1.2;
     const Real theta = 0.4;
@@ -679,8 +667,6 @@ namespace {
 
     void hestonFokkerPlanckFwdEquationTest(
         const FokkerPlanckFwdTestCase& testCase) {
-
-        SavedSettings backup;
 
         const DayCounter dc = ActualActual(ActualActual::ISDA);
         const Date todaysDate = Date(28, Dec, 2014);
@@ -1049,8 +1035,6 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
     BOOST_TEST_MESSAGE("Testing Fokker-Planck forward equation "
                        "for the Heston process Log Transformation with leverage LV limiting case...");
 
-    SavedSettings backup;
-
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate = Date(28, Dec, 2012);
     Settings::instance().evaluationDate() = todaysDate;
@@ -1215,8 +1199,6 @@ void HestonSLVModelTest::testHestonFokkerPlanckFwdEquationLogLVLeverage() {
 void HestonSLVModelTest::testBlackScholesFokkerPlanckFwdEquationLocalVol() {
     BOOST_TEST_MESSAGE(
             "Testing Fokker-Planck forward equation for BS Local Vol process...");
-
-    SavedSettings backup;
 
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, July, 2014);
@@ -1464,8 +1446,6 @@ namespace {
 
 
 void HestonSLVModelTest::testFDMCalibration() {
-    SavedSettings backup;
-
     const HestonSLVFokkerPlanckFdmParams plainParams =
         { 201, 301, 1000, 25, 3.0, 0, 2,
           0.1, 1e-4, 10000,
@@ -1512,7 +1492,6 @@ void HestonSLVModelTest::testFDMCalibration() {
 void HestonSLVModelTest::testLocalVolsvSLVPropDensity() {
     BOOST_TEST_MESSAGE("Testing local volatility vs SLV model...");
 
-    SavedSettings backup;
     const Date todaysDate(5, Oct, 2015);
     const Date finalDate = todaysDate + Period(1, Years);
     Settings::instance().evaluationDate() = todaysDate;
@@ -1608,7 +1587,6 @@ void HestonSLVModelTest::testLocalVolsvSLVPropDensity() {
 void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
     BOOST_TEST_MESSAGE("Testing calibration via vanilla options...");
 
-    SavedSettings backup;
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Nov, 2015);
     Settings::instance().evaluationDate() = todaysDate;
@@ -1709,7 +1687,6 @@ void HestonSLVModelTest::testBarrierPricingViaHestonLocalVol() {
 void HestonSLVModelTest::testBarrierPricingMixedModels() {
     BOOST_TEST_MESSAGE("Testing Barrier pricing with mixed models...");
 
-    SavedSettings backup;
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Nov, 2015);
     const Date exerciseDate = todaysDate + Period(1, Years);
@@ -1836,7 +1813,6 @@ void HestonSLVModelTest::testMonteCarloVsFdmPricing() {
         "Testing Monte-Carlo vs FDM Pricing for "
         "Heston SLV models...");
 
-    SavedSettings backup;
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Dec, 2015);
     const Date exerciseDate = todaysDate + Period(1, Years);
@@ -1940,8 +1916,6 @@ void HestonSLVModelTest::testMonteCarloVsFdmPricing() {
 void HestonSLVModelTest::testMonteCarloCalibration() {
     BOOST_TEST_MESSAGE(
         "Testing Monte-Carlo Calibration...");
-
-    SavedSettings backup;
 
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Jan, 2016);
@@ -2063,8 +2037,6 @@ void HestonSLVModelTest::testMonteCarloCalibration() {
 void HestonSLVModelTest::testForwardSkewSLV() {
     BOOST_TEST_MESSAGE("Testing the implied volatility skew of "
         "forward starting options in SLV model...");
-
-    SavedSettings backup;
 
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(5, Jan, 2017);
@@ -2314,8 +2286,6 @@ void HestonSLVModelTest::testMoustacheGraph() {
     BOOST_TEST_MESSAGE(
         "Testing double no touch pricing with SLV and mixing...");
 
-    SavedSettings backup;
-
     /*
      A more detailed description of this test case can found on
      https://hpcquantlib.wordpress.com/2016/01/10/monte-carlo-calibration-of-the-heston-stochastic-local-volatiltiy-model/
@@ -2454,8 +2424,6 @@ void HestonSLVModelTest::testDiffusionAndDriftSlvProcess() {
     BOOST_TEST_MESSAGE(
         "Testing diffusion and drift of the SLV process...");
 
-    SavedSettings backup;
-
     const Date todaysDate(6, June, 2020);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -2566,7 +2534,6 @@ void HestonSLVModelTest::testBarrierPricingMixedModelsMonteCarloVsFdmPricing() {
 
     const Real epsilon = 0.015;
 
-    SavedSettings backup;
     const DayCounter dc = ActualActual(ActualActual::ISDA);
     const Date todaysDate(1, Jul, 2021);
     const Date maturityDate = todaysDate + Period(2, Years);

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -60,8 +60,6 @@ void HybridHestonHullWhiteProcessTest::testBsmHullWhiteEngine() {
     BOOST_TEST_MESSAGE("Testing European option pricing for a BSM process"
                        " with one-factor Hull-White model...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual365Fixed();
 
     const Date today = Date::todaysDate();
@@ -156,8 +154,6 @@ void HybridHestonHullWhiteProcessTest::testCompareBsmHWandHestonHW() {
     BOOST_TEST_MESSAGE("Comparing European option pricing for a BSM process"
                        " with one-factor Hull-White model...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual365Fixed();
 
     const Date today = Date::todaysDate();
@@ -247,8 +243,6 @@ void HybridHestonHullWhiteProcessTest::testCompareBsmHWandHestonHW() {
 
 void HybridHestonHullWhiteProcessTest::testZeroBondPricing() {
     BOOST_TEST_MESSAGE("Testing Monte-Carlo zero bond pricing...");
-
-    SavedSettings backup;
 
     DayCounter dc = Actual360();
     const Date today = Date::todaysDate();
@@ -365,8 +359,6 @@ void HybridHestonHullWhiteProcessTest::testZeroBondPricing() {
 void HybridHestonHullWhiteProcessTest::testMcVanillaPricing() {
     BOOST_TEST_MESSAGE("Testing Monte-Carlo vanilla option pricing...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     const Date today = Date::todaysDate();
 
@@ -454,8 +446,6 @@ void HybridHestonHullWhiteProcessTest::testMcVanillaPricing() {
 void HybridHestonHullWhiteProcessTest::testMcPureHestonPricing() {
     BOOST_TEST_MESSAGE("Testing Monte-Carlo Heston option pricing...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     const Date today = Date::todaysDate();
 
@@ -539,8 +529,6 @@ void HybridHestonHullWhiteProcessTest::testMcPureHestonPricing() {
 void HybridHestonHullWhiteProcessTest::testAnalyticHestonHullWhitePricing() {
     BOOST_TEST_MESSAGE("Testing analytic Heston Hull-White option pricing...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     const Date today = Date::todaysDate();
 
@@ -623,8 +611,6 @@ void HybridHestonHullWhiteProcessTest::testAnalyticHestonHullWhitePricing() {
 
 void HybridHestonHullWhiteProcessTest::testCallableEquityPricing() {
     BOOST_TEST_MESSAGE("Testing the pricing of a callable equity product...");
-
-    SavedSettings backup;
 
     /*
        For the definition of the example product see
@@ -738,8 +724,6 @@ void HybridHestonHullWhiteProcessTest::testDiscretizationError() {
     BOOST_TEST_MESSAGE("Testing the discretization error of the "
                        "Heston Hull-White process...");
 
-    SavedSettings backup;
-
     DayCounter dc = Actual360();
     const Date today = Date::todaysDate();
 
@@ -823,8 +807,6 @@ void HybridHestonHullWhiteProcessTest::testDiscretizationError() {
 
 void HybridHestonHullWhiteProcessTest::testFdmHestonHullWhiteEngine() {
     BOOST_TEST_MESSAGE("Testing the FDM Heston Hull-White engine...");
-
-    SavedSettings backup;
 
     const Date today = Date(28, March, 2004);
     Settings::instance().evaluationDate() = today;
@@ -996,8 +978,6 @@ void HybridHestonHullWhiteProcessTest::testBsmHullWhitePricing() {
 
     using namespace hybrid_heston_hullwhite_process_test;
 
-    SavedSettings backup;
-
     Date today(27, December, 2004);
     Settings::instance().evaluationDate() = today;
 
@@ -1083,8 +1063,6 @@ void HybridHestonHullWhiteProcessTest::testSpatialDiscretizatinError() {
     BOOST_TEST_MESSAGE("Testing spatial convergence speed of Heston engine...");
 
     using namespace hybrid_heston_hullwhite_process_test;
-
-    SavedSettings backup;
 
     Date today(27, December, 2004);
     Settings::instance().evaluationDate() = today;
@@ -1181,8 +1159,6 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
     // Heston    : \nu = 0.12, \kappa = 2.0,
     //             \theta = 0.09, \sigma = 0.5, \rho=-0.75
     // Equity Short rate correlation: -0.5
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Calendar calendar = TARGET();
@@ -1371,8 +1347,6 @@ void HybridHestonHullWhiteProcessTest::testHestonHullWhiteCalibration() {
 }
 
 void HybridHestonHullWhiteProcessTest::testH1HWPricingEngine() {
-
-    SavedSettings backup;
 
     /*
      * Example taken from Lech Aleksander Grzelak,

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -97,8 +97,6 @@ namespace inflation_test {
 void InflationTest::testZeroIndex() {
     BOOST_TEST_MESSAGE("Testing zero inflation indices...");
 
-    SavedSettings backup;
-
     QL_DEPRECATED_DISABLE_WARNING
 
     EUHICP euhicp(true);
@@ -198,8 +196,6 @@ void InflationTest::testZeroTermStructure() {
     BOOST_TEST_MESSAGE("Testing zero inflation term structure...");
 
     using namespace inflation_test;
-
-    SavedSettings backup;
 
     // try the Zero UK
     Calendar calendar = UnitedKingdom();
@@ -585,8 +581,6 @@ void InflationTest::testSeasonalityCorrection() {
 
     using namespace inflation_test;
 
-    SavedSettings backup;
-
     // try the Zero UK
     Calendar calendar = UnitedKingdom();
     Date evaluationDate(13, August, 2007);
@@ -683,8 +677,6 @@ void InflationTest::testSeasonalityCorrection() {
 void InflationTest::testZeroIndexFutureFixing() {
     BOOST_TEST_MESSAGE("Testing that zero inflation indices forecast future fixings...");
 
-    SavedSettings backup;
-
     EUHICP euhicp;
 
     Date sample_date = Date(1,December,2013);
@@ -718,8 +710,6 @@ void InflationTest::testZeroIndexFutureFixing() {
 
 void InflationTest::testInterpolatedZeroTermStructure() {
     BOOST_TEST_MESSAGE("Testing interpolated zero-rate inflation curve...");
-
-    SavedSettings backup;
 
     Date today = Date(27, January, 2022);
     Settings::instance().evaluationDate() = today;
@@ -761,8 +751,6 @@ void InflationTest::testInterpolatedZeroTermStructure() {
 void InflationTest::testQuotedYYIndex() {
     BOOST_TEST_MESSAGE("Testing quoted year-on-year inflation indices...");
 
-    SavedSettings backup;
-
     YYEUHICP yyeuhicp(true);
     if (yyeuhicp.name() != "EU YY_HICP"
         || yyeuhicp.frequency() != Monthly
@@ -799,8 +787,6 @@ void InflationTest::testQuotedYYIndex() {
 
 void InflationTest::testRatioYYIndex() {
     BOOST_TEST_MESSAGE("Testing ratio year-on-year inflation indices...");
-
-    SavedSettings backup;
 
     auto euhicp = ext::make_shared<EUHICP>();
     auto ukrpi = ext::make_shared<UKRPI>();
@@ -920,8 +906,6 @@ void InflationTest::testRatioYYIndex() {
 
 void InflationTest::testOldRatioYYIndex() {
     BOOST_TEST_MESSAGE("Testing old-style ratio year-on-year inflation indices...");
-
-    SavedSettings backup;
 
     QL_DEPRECATED_DISABLE_WARNING
 
@@ -1057,8 +1041,6 @@ void InflationTest::testYYTermStructure() {
     BOOST_TEST_MESSAGE("Testing year-on-year inflation term structure...");
 
     using namespace inflation_test;
-
-    SavedSettings backup;
 
     // try the YY UK
     Calendar calendar = UnitedKingdom();
@@ -1292,8 +1274,6 @@ void InflationTest::testPeriod() {
 void InflationTest::testCpiFlatInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI flat interpolation...");
 
-    SavedSettings backup;
-
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
     QL_DEPRECATED_DISABLE_WARNING
@@ -1339,8 +1319,6 @@ void InflationTest::testCpiFlatInterpolation() {
 
 void InflationTest::testCpiLinearInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI linear interpolation...");
-
-    SavedSettings backup;
 
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
@@ -1395,8 +1373,6 @@ void InflationTest::testCpiLinearInterpolation() {
 
 void InflationTest::testCpiAsIndexInterpolation() {
     BOOST_TEST_MESSAGE("Testing CPI as-index interpolation...");
-
-    SavedSettings backup;
 
     Date today = Date(10, February, 2022);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -102,10 +102,6 @@ namespace inflation_capfloor_test {
         ext::shared_ptr<YoYInflationTermStructure> yoyTS;
         RelinkableHandle<YoYInflationTermStructure> hy;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars()
         : nominals(1,1000000) {

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -107,10 +107,6 @@ namespace inflation_capfloored_coupon_test {
         ext::shared_ptr<YoYInflationTermStructure> yoyTS;
         RelinkableHandle<YoYInflationTermStructure> hy;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars()
         : nominals(1,1000000) {

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -87,10 +87,6 @@ namespace inflation_cpi_bond_test {
         RelinkableHandle<YieldTermStructure> yTS;
         RelinkableHandle<ZeroInflationTermStructure> cpiTS;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             // usual setup

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -118,10 +118,6 @@ namespace inflation_cpi_capfloor_test {
 
         ext::shared_ptr<CPICapFloorTermPriceSurface> cpiCFsurfUK;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars()
         : nominals(1,1000000) {

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -103,10 +103,6 @@ namespace inflation_cpi_swap_test {
         ext::shared_ptr<ZeroInflationTermStructure> cpiTS;
         RelinkableHandle<ZeroInflationTermStructure> hcpi;
 
-        // cleanup
-
-        SavedSettings backup;
-
         // setup
         CommonVars()
         : nominals(1,1000000) {

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -284,8 +284,6 @@ void InflationVolTest::testYoYPriceSurfaceToVol() {
 
     using namespace inflation_volatility_test;
 
-    SavedSettings backup;
-
     setup();
 
     // first get the price surface set up
@@ -373,8 +371,6 @@ void InflationVolTest::testYoYPriceSurfaceToATM() {
                        "to YoY inflation term structure...");
 
     using namespace inflation_volatility_test;
-
-    SavedSettings backup;
 
     setup();
 

--- a/test-suite/instruments.cpp
+++ b/test-suite/instruments.cpp
@@ -70,8 +70,6 @@ void InstrumentTest::testCompositeWhenShiftingDates() {
     BOOST_TEST_MESSAGE(
         "Testing reaction of composite instrument to date changes...");
 
-    SavedSettings backup;
-
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
 

--- a/test-suite/jumpdiffusion.cpp
+++ b/test-suite/jumpdiffusion.cpp
@@ -100,8 +100,6 @@ void JumpDiffusionTest::testMerton76() {
     BOOST_TEST_MESSAGE("Testing Merton 76 jump-diffusion model "
                        "for European options...");
 
-    SavedSettings backup;
-
     /* The data below are from
        "Option pricing formulas", E.G. Haug, McGraw-Hill 1998, pag 9
 
@@ -343,8 +341,6 @@ void JumpDiffusionTest::testMerton76() {
 void JumpDiffusionTest::testGreeks() {
 
     BOOST_TEST_MESSAGE("Testing jump-diffusion option greeks...");
-
-    SavedSettings backup;
 
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]  = 1.0e-4;

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -112,8 +112,6 @@ void LiborMarketModelTest::testSimpleCovarianceModels() {
 
     using namespace libor_market_model_test;
 
-    SavedSettings backup;
-
     const Size size = 10;
     const Real tolerance = 1e-14;
     Size i;
@@ -193,8 +191,6 @@ void LiborMarketModelTest::testCapletPricing() {
 
     bool usingAtParCoupons  = IborCoupon::Settings::instance().usingAtParCoupons();
 
-    SavedSettings backup;
-
     const Size size = 10;
     Real tolerance = usingAtParCoupons ? 1e-12 : 1e-5;
 
@@ -243,8 +239,6 @@ void LiborMarketModelTest::testCalibration() {
     BOOST_TEST_MESSAGE("Testing calibration of a Libor forward model...");
 
     using namespace libor_market_model_test;
-
-    SavedSettings backup;
 
     const Size size = 14;
     const Real tolerance = 8e-3;
@@ -351,8 +345,6 @@ void LiborMarketModelTest::testSwaptionPricing() {
     using namespace libor_market_model_test;
 
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
-
-    SavedSettings backup;
 
     const Size size  = 10;
     const Size steps = 8*size;

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -106,8 +106,6 @@ namespace libor_market_model_process_test {
 void LiborMarketModelProcessTest::testInitialisation() {
     BOOST_TEST_MESSAGE("Testing caplet LMM process initialisation...");
 
-    SavedSettings backup;
-
     DayCounter dayCounter = Actual360();
     RelinkableHandle<YieldTermStructure> termStructure(
         flatRate(Date::todaysDate(), 0.04, dayCounter));
@@ -150,8 +148,6 @@ void LiborMarketModelProcessTest::testLambdaBootstrapping() {
     BOOST_TEST_MESSAGE("Testing caplet LMM lambda bootstrapping...");
 
     using namespace libor_market_model_process_test;
-
-    SavedSettings backup;
 
     Real tolerance = 1e-10;
     Volatility lambdaExpected[]= {14.3010297550, 19.3821411939, 15.9816590141,
@@ -199,8 +195,6 @@ void LiborMarketModelProcessTest::testMonteCarloCapletPricing() {
     BOOST_TEST_MESSAGE("Testing caplet LMM Monte-Carlo caplet pricing...");
 
     using namespace libor_market_model_process_test;
-
-    SavedSettings backup;
 
     /* factor loadings are taken from Hull & White article
        plus extra normalisation to get orthogonal eigenvectors

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -32,8 +32,6 @@ void LinearLeastSquaresRegressionTest::testRegression() {
 
     BOOST_TEST_MESSAGE("Testing linear least-squares regression...");
 
-    SavedSettings backup;
-
     const Real tolerance = 0.05;
 
     const Size nr=100000;
@@ -122,8 +120,6 @@ void LinearLeastSquaresRegressionTest::testMultiDimRegression() {
 
     using namespace linear_least_square_regression_test;
 
-    SavedSettings backup;
-
     const Size nr=100000;
     const Size dims = 4;
     const Real tolerance = 0.01;
@@ -195,8 +191,6 @@ void LinearLeastSquaresRegressionTest::test1dLinearRegression() {
 
     /* Example taken from the QuantLib-User list, see posting
     * Multiple linear regression/weighted regression, Boris Skorodumov */
-
-    SavedSettings backup;
 
     std::vector<Real> x = {2.4, 1.8, 2.5, 3.0, 2.1, 1.2, 2.0, 2.7, 3.6};
     std::vector<Real> y = {7.8, 5.5, 8.0, 9.0, 6.5, 4.0, 6.3, 8.4, 10.2};

--- a/test-suite/margrabeoption.cpp
+++ b/test-suite/margrabeoption.cpp
@@ -288,8 +288,6 @@ void MargrabeOptionTest::testGreeks() {
 
     BOOST_TEST_MESSAGE("Testing analytic European exchange option greeks...");
 
-    SavedSettings backup;
-
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta1"]  = 1.0e-5;
     tolerance["delta2"]  = 1.0e-5;

--- a/test-suite/mclongstaffschwartzengine.cpp
+++ b/test-suite/mclongstaffschwartzengine.cpp
@@ -124,8 +124,6 @@ namespace {
 void MCLongstaffSchwartzEngineTest::testAmericanOption() {
     BOOST_TEST_MESSAGE("Testing Monte-Carlo pricing of American options...");
 
-    SavedSettings backup;
-
     // most of the example taken from the EquityOption.cpp
     const Option::Type type(Option::Put);
     const Real underlying = 36;
@@ -231,8 +229,6 @@ void MCLongstaffSchwartzEngineTest::testAmericanMaxOption() {
     // by Paul Glasserman, 2004 Springer Verlag, p. 462
 
     BOOST_TEST_MESSAGE("Testing Monte-Carlo pricing of American max options...");
-
-    SavedSettings backup;
 
     // most of the example taken from the EquityOption.cpp
     const Option::Type type(Option::Call);

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -55,8 +55,6 @@ void NormalCLVModelTest::testBSCumlativeDistributionFunction() {
     BOOST_TEST_MESSAGE("Testing Black-Scholes cumulative distribution function"
                        " with constant volatility...");
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(22, June, 2016);
     const Date maturity = today + Period(6, Months);
@@ -98,8 +96,6 @@ void NormalCLVModelTest::testBSCumlativeDistributionFunction() {
 
 void NormalCLVModelTest::testHestonCumlativeDistributionFunction() {
     BOOST_TEST_MESSAGE("Testing Heston cumulative distribution function...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(22, June, 2016);
@@ -154,8 +150,6 @@ void NormalCLVModelTest::testHestonCumlativeDistributionFunction() {
 void NormalCLVModelTest::testIllustrative1DExample() {
     BOOST_TEST_MESSAGE(
         "Testing illustrative 1D example of normal CLV model...");
-
-    SavedSettings backup;
 
     // example taken from:
     // A. Grzelak, 2015, The CLV Framework -
@@ -287,8 +281,6 @@ void NormalCLVModelTest::testMonteCarloBSOptionPricing() {
 
     using namespace normal_clv_model_test;
 
-    SavedSettings backup;
-
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(22, June, 2016);
     const Date maturity = today + Period(1, Years);
@@ -382,8 +374,6 @@ void NormalCLVModelTest::testMonteCarloBSOptionPricing() {
 void NormalCLVModelTest::testMoustacheGraph() {
     BOOST_TEST_MESSAGE(
         "Testing double no-touch pricing with normal CLV model...");
-
-    SavedSettings backup;
 
     /*
      The comparison of Black-Scholes and normal CLV prices is derived

--- a/test-suite/nthorderderivativeop.cpp
+++ b/test-suite/nthorderderivativeop.cpp
@@ -708,8 +708,6 @@ void NthOrderDerivativeOpTest::testHigherOrderHestonOptionPricing() {
     BOOST_TEST_MESSAGE("Testing Heston model option pricing convergence with "
             "higher order finite difference operators...");
 
-    SavedSettings backup;
-
     const Array strikes = {50, 75, 90, 100, 110, 125, 150, 200};
 
     const GridSetup initSetup = {
@@ -775,8 +773,6 @@ void NthOrderDerivativeOpTest::testHigherOrderAndRichardsonExtrapolation() {
     BOOST_TEST_MESSAGE(
             "Testing Heston option pricing convergence with "
             "higher order FDM operators and Richardson Extrapolation...");
-
-    SavedSettings backup;
 
     const Real n1 = priceQuality(1.0/25);
     const Real n3

--- a/test-suite/nthtodefault.cpp
+++ b/test-suite/nthtodefault.cpp
@@ -103,8 +103,6 @@ void NthToDefaultTest::testGauss() {
 
     using namespace nth_to_default_test;
 
-    SavedSettings backup;
-
     /*************************
      * Tolerances
      */
@@ -247,8 +245,6 @@ void NthToDefaultTest::testStudent() {
                        "with Student copula...");
 
     using namespace nth_to_default_test;
-
-    SavedSettings backup;
 
     /*************************
      * Tolerances

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -267,7 +267,6 @@ void ObservableTest::testMultiThreadingGlobalSettings() {
 
 void ObservableTest::testDeepUpdate() {
 
-    SavedSettings backup;
     RestoreUpdates guard;
 
     Date refDate = Settings::instance().evaluationDate();
@@ -313,8 +312,6 @@ namespace {
 
 void ObservableTest::testEmptyObserverList() {
 	BOOST_TEST_MESSAGE("Testing unregisterWith call on empty observer...");
-
-    SavedSettings backup;
 
     const ext::shared_ptr<DummyObserver> dummyObserver=ext::make_shared<DummyObserver>();
     dummyObserver->unregisterWith(ext::make_shared<SimpleQuote>(10.0));

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -67,9 +67,6 @@ namespace optionlet_stripper_test {
         Real accuracy;
         Real tolerance;
 
-        // cleanup
-        SavedSettings backup;
-
         CommonVars() {
             accuracy = 1.0e-6;
             tolerance = 2.5e-8;

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -31,9 +31,6 @@ using namespace boost::unit_test_framework;
 namespace overnight_indexed_coupon_tests {
 
     struct CommonVars {
-        // cleanup
-        SavedSettings backup;
-
         Date today;
         Real notional = 10000.0;
         ext::shared_ptr<OvernightIndex> sofr;

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -128,9 +128,6 @@ namespace overnight_indexed_swap_test {
         ext::shared_ptr<IborIndex> swapIndex;
         RelinkableHandle<YieldTermStructure> swapTermStructure;
 
-        // cleanup
-        SavedSettings backup;
-
         // utilities
         ext::shared_ptr<OvernightIndexedSwap>
         makeSwap(Period length,
@@ -440,8 +437,6 @@ void OvernightIndexedSwapTest::testBootstrapRegression() {
     BOOST_TEST_MESSAGE("Testing 1.16 regression with OIS bootstrap...");
 
     using namespace overnight_indexed_swap_test;
-
-    SavedSettings backup;
 
     Datum data[] = {
         { 0,  1, Days,   0.0066   },

--- a/test-suite/pathgenerator.cpp
+++ b/test-suite/pathgenerator.cpp
@@ -145,8 +145,6 @@ void PathGeneratorTest::testPathGenerator() {
 
     BOOST_TEST_MESSAGE("Testing 1-D path generation against cached values...");
 
-    SavedSettings backup;
-
     Settings::instance().evaluationDate() = Date(26,April,2005);
 
     Handle<Quote> x0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
@@ -181,8 +179,6 @@ void PathGeneratorTest::testPathGenerator() {
 void PathGeneratorTest::testMultiPathGenerator() {
 
     BOOST_TEST_MESSAGE("Testing n-D path generation against cached values...");
-
-    SavedSettings backup;
 
     Settings::instance().evaluationDate() = Date(26,April,2005);
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -195,9 +195,6 @@ namespace piecewise_yield_curve_test {
         std::vector<Schedule> schedules;
         ext::shared_ptr<YieldTermStructure> termStructure;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars(Date evaluationDate = Date()) {
             // data
@@ -1078,7 +1075,6 @@ void PiecewiseYieldCurveTest::testDefaultInstantiation() {
 void PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate() {
     BOOST_TEST_MESSAGE("Testing SwapRateHelper last relevant date...");
 
-    SavedSettings backup;
     Settings::instance().evaluationDate() = Date(22, Dec, 2016);
     Date today = Settings::instance().evaluationDate();
 
@@ -1099,8 +1095,6 @@ void PiecewiseYieldCurveTest::testSwapRateHelperLastRelevantDate() {
 
 void PiecewiseYieldCurveTest::testSwapRateHelperSpotDate() {
     BOOST_TEST_MESSAGE("Testing SwapRateHelper spot date...");
-
-    SavedSettings backup;
 
     ext::shared_ptr<IborIndex> usdLibor3m = ext::make_shared<USDLibor>(3 * Months);
 
@@ -1134,8 +1128,6 @@ void PiecewiseYieldCurveTest::testBadPreviousCurve() {
     BOOST_TEST_MESSAGE("Testing bootstrap starting from bad guess...");
 
     using namespace piecewise_yield_curve_test;
-
-    SavedSettings backup;
 
     Datum data[] = {
         {  1, Weeks,  -0.003488 },
@@ -1228,8 +1220,6 @@ void PiecewiseYieldCurveTest::testLargeRates() {
 
     using namespace piecewise_yield_curve_test;
 
-    SavedSettings backup;
-
     Datum data[] = {
         {  1, Weeks,  2.418633 },
         {  2, Weeks,  1.361540 },
@@ -1300,8 +1290,6 @@ void PiecewiseYieldCurveTest::testGlobalBootstrap() {
     BOOST_TEST_MESSAGE("Testing global bootstrap...");
 
     using namespace piecewise_yield_curve_test;
-
-    SavedSettings backup;
 
     Date today(26, Sep, 2019);
     Settings::instance().evaluationDate() = today;
@@ -1387,8 +1375,6 @@ void PiecewiseYieldCurveTest::testGlobalBootstrap() {
 void PiecewiseYieldCurveTest::testIterativeBootstrapRetries() {
 
     BOOST_TEST_MESSAGE("Testing iterative bootstrap with retries...");
-
-    SavedSettings backup;
 
     Date asof(25, Sep, 2019);
     Settings::instance().evaluationDate() = asof;

--- a/test-suite/piecewisezerospreadedtermstructure.cpp
+++ b/test-suite/piecewisezerospreadedtermstructure.cpp
@@ -50,9 +50,6 @@ namespace piecewise_zero_spreaded_term_structure_test {
         Date today;
         Date settlementDate;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             calendar = TARGET();

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -224,8 +224,6 @@ void QuantoOptionTest::testValues() {
 
     BOOST_TEST_MESSAGE("Testing quanto option values...");
 
-    SavedSettings backup;
-
     /* The data below are from
        from "Option pricing formulas", E.G. Haug, McGraw-Hill 1998
     */
@@ -297,8 +295,6 @@ void QuantoOptionTest::testValues() {
 void QuantoOptionTest::testGreeks() {
 
     BOOST_TEST_MESSAGE("Testing quanto option greeks...");
-
-    SavedSettings backup;
 
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]   = 1.0e-5;
@@ -497,8 +493,6 @@ void QuantoOptionTest::testForwardValues() {
 
     BOOST_TEST_MESSAGE("Testing quanto-forward option values...");
 
-    SavedSettings backup;
-
     QuantoForwardOptionData values[] = {
         //   type, moneyness,  spot,  div, risk-free rate, reset, maturity,  vol, fx risk-free rate, fx vol, corr,     result, tol
         // reset=0.0, quanto (not-forward) options
@@ -573,8 +567,6 @@ void QuantoOptionTest::testForwardValues() {
 void QuantoOptionTest::testForwardGreeks() {
 
     BOOST_TEST_MESSAGE("Testing quanto-forward option greeks...");
-
-    SavedSettings backup;
 
     std::map<std::string,Real> calculated, expected, tolerance;
     tolerance["delta"]   = 1.0e-5;
@@ -786,8 +778,6 @@ void QuantoOptionTest::testForwardPerformanceValues() {
 
     BOOST_TEST_MESSAGE("Testing quanto-forward-performance option values...");
 
-    SavedSettings backup;
-
     QuantoForwardOptionData values[] = {
         //   type, moneyness,  spot,  div, risk-free rate, reset, maturity,  vol, fx risk-free rate, fx vol, corr,     result, tol
         // reset=0.0, quanto-(not-forward)-performance options
@@ -865,8 +855,6 @@ void QuantoOptionTest::testForwardPerformanceValues() {
 void QuantoOptionTest::testBarrierValues()  {
 
     BOOST_TEST_MESSAGE("Testing quanto-barrier option values...");
-
-    SavedSettings backup;
 
     QuantoBarrierOptionData values[] = {
          // TODO:  Bench results against an existing prop calculator
@@ -946,8 +934,6 @@ void QuantoOptionTest::testDoubleBarrierValues()  {
 
     BOOST_TEST_MESSAGE("Testing quanto-double-barrier option values...");
 
-    SavedSettings backup;
-
     QuantoDoubleBarrierOptionData values[] = {
          // barrierType,           bar.lo, bar.hi, rebate,         type, spot,  strk,    q,   r,    T,  vol, fx rate, fx vol, corr, result, tol
         { DoubleBarrier::KnockOut,   50.0,  150.0,      0, Option::Call,  100, 100.0, 0.00, 0.1, 0.25, 0.15,    0.05,    0.2,  0.3,  3.4623, 1.0e-4},
@@ -1022,8 +1008,6 @@ void QuantoOptionTest::testDoubleBarrierValues()  {
 void QuantoOptionTest::testFDMQuantoHelper()  {
 
     BOOST_TEST_MESSAGE("Testing FDM quanto helper...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual360();
     const Date today = Date(22, April, 2019);
@@ -1117,8 +1101,6 @@ void QuantoOptionTest::testFDMQuantoHelper()  {
 void QuantoOptionTest::testPDEOptionValues()  {
 
     BOOST_TEST_MESSAGE("Testing quanto-option values with PDEs...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual360();
     const Date today = Date(21, April, 2019);
@@ -1222,8 +1204,6 @@ void QuantoOptionTest::testPDEOptionValues()  {
 void QuantoOptionTest::testAmericanQuantoOption()  {
 
     BOOST_TEST_MESSAGE("Testing American quanto-option values with PDEs...");
-
-    SavedSettings backup;
 
     const DayCounter dc = Actual365Fixed();
     const Date today = Date(21, April, 2019);

--- a/test-suite/rangeaccrual.cpp
+++ b/test-suite/rangeaccrual.cpp
@@ -103,9 +103,6 @@ namespace range_accrual_test {
         Real priceTolerance;
 
 
-        // cleanup
-        SavedSettings backup;
-
         void createYieldCurve() {
 
             // Yield Curve

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -49,8 +49,6 @@ using namespace boost::unit_test_framework;
 void RiskNeutralDensityCalculatorTest::testDensityAgainstOptionPrices() {
     BOOST_TEST_MESSAGE("Testing density against option prices...");
 
-    SavedSettings backup;
-
     const DayCounter dayCounter = Actual365Fixed();
     const Date todaysDate = Settings::instance().evaluationDate();
 
@@ -120,8 +118,6 @@ void RiskNeutralDensityCalculatorTest::testDensityAgainstOptionPrices() {
 
 void RiskNeutralDensityCalculatorTest::testBSMagainstHestonRND() {
     BOOST_TEST_MESSAGE("Testing Black-Scholes-Merton and Heston densities...");
-
-    SavedSettings backup;
 
     const DayCounter dayCounter = Actual365Fixed();
     const Date todaysDate = Settings::instance().evaluationDate();
@@ -287,8 +283,6 @@ void RiskNeutralDensityCalculatorTest::testLocalVolatilityRND() {
     BOOST_TEST_MESSAGE("Testing Fokker-Planck forward equation "
                        "for local volatility process to calculate "
                        "risk neutral densities...");
-
-    SavedSettings backup;
 
     const DayCounter dayCounter = Actual365Fixed();
     const Date todaysDate = Date(28, Dec, 2012);
@@ -561,8 +555,6 @@ void RiskNeutralDensityCalculatorTest::testBlackScholesWithSkew() {
     BOOST_TEST_MESSAGE(
         "Testing probability density for a BSM process "
         "with strike dependent volatility vs local volatility...");
-
-    SavedSettings backup;
 
     const Date todaysDate = Date(3, Oct, 2016);
     Settings::instance().evaluationDate() = todaysDate;

--- a/test-suite/settings.cpp
+++ b/test-suite/settings.cpp
@@ -28,8 +28,6 @@ using namespace boost::unit_test_framework;
 void SettingsTest::testNotificationsOnDateChange() {
     BOOST_TEST_MESSAGE("Testing notifications on evaluation-date change...");
 
-    SavedSettings rollback;
-
 #ifdef QL_HIGH_RESOLUTION_DATE
 
     Date d1(11, February, 2021, 9, 17, 0);

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -62,8 +62,6 @@ void ShortRateModelTest::testCachedHullWhite() {
 
     bool usingAtParCoupons  = IborCoupon::Settings::instance().usingAtParCoupons();
 
-    SavedSettings backup;
-
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
     Settings::instance().evaluationDate() = today;
@@ -137,8 +135,6 @@ void ShortRateModelTest::testCachedHullWhiteFixedReversion() {
     using namespace short_rate_models_test;
 
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
-
-    SavedSettings backup;
 
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
@@ -218,8 +214,6 @@ void ShortRateModelTest::testCachedHullWhite2() {
 
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
 
-    SavedSettings backup;
-
     Date today(15, February, 2002);
     Date settlement(19, February, 2002);
     Settings::instance().evaluationDate() = today;
@@ -297,8 +291,6 @@ void ShortRateModelTest::testSwaps() {
     BOOST_TEST_MESSAGE("Testing Hull-White swap pricing against known values...");
 
     bool usingAtParCoupons = IborCoupon::Settings::instance().usingAtParCoupons();
-
-    SavedSettings backup;
 
     Date today = Settings::instance().evaluationDate();
     Calendar calendar = TARGET();
@@ -429,7 +421,6 @@ void ShortRateModelTest::testFuturesConvexityBias() {
 void ShortRateModelTest::testExtendedCoxIngersollRossDiscountFactor() {
     BOOST_TEST_MESSAGE("Testing zero-bond pricing for extended CIR model...");
 
-    SavedSettings backup;
     const Date today = Settings::instance().evaluationDate();
 
     const Rate rate = 0.1;

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -45,8 +45,6 @@ namespace {
 void SofrFuturesTest::testBootstrap() {
     BOOST_TEST_MESSAGE("Testing bootstrap over SOFR futures...");
 
-    SavedSettings backup;
-
     Date today = Date(26, October, 2018);
     Settings::instance().evaluationDate() = today;
 

--- a/test-suite/squarerootclvmodel.cpp
+++ b/test-suite/squarerootclvmodel.cpp
@@ -80,8 +80,6 @@ void SquareRootCLVModelTest::testSquareRootCLVVanillaPricing() {
 
     using namespace square_root_clv_model;
 
-    SavedSettings backup;
-
     const Date todaysDate(5, Oct, 2016);
     Settings::instance().evaluationDate() = todaysDate;
 
@@ -163,8 +161,6 @@ void SquareRootCLVModelTest::testSquareRootCLVMappingFunction() {
         "Testing mapping function of the square-root kernel process...");
 
     using namespace square_root_clv_model;
-
-    SavedSettings backup;
 
     const Date todaysDate(16, Oct, 2016);
     Settings::instance().evaluationDate() = todaysDate;
@@ -450,8 +446,6 @@ void SquareRootCLVModelTest::testForwardSkew() {
         "Testing forward skew dynamics with square-root kernel process...");
 
     using namespace square_root_clv_model;
-
-    SavedSettings backup;
 
     const Date todaysDate(16, Oct, 2016);
     Settings::instance().evaluationDate() = todaysDate;

--- a/test-suite/subperiodcoupons.cpp
+++ b/test-suite/subperiodcoupons.cpp
@@ -40,8 +40,6 @@ namespace subperiodcoupons_test {
         ext::shared_ptr<IborIndex> euribor;
         RelinkableHandle<YieldTermStructure> euriborHandle;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars() {

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -54,9 +54,6 @@ namespace swap_test {
         Natural settlementDays;
         RelinkableHandle<YieldTermStructure> termStructure;
 
-        // cleanup
-        SavedSettings backup;
-        
         // utilities
         ext::shared_ptr<VanillaSwap>
         makeSwap(Integer length, Rate fixedRate, Spread floatingSpread, DateGeneration::Rule rule = DateGeneration::Forward) const {

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -66,9 +66,6 @@ namespace swaption_test {
         Natural settlementDays;
         RelinkableHandle<YieldTermStructure> termStructure;
 
-        // cleanup
-        SavedSettings backup;
-
         // utilities
         ext::shared_ptr<Swaption> makeSwaption(
             const ext::shared_ptr<VanillaSwap>& swap,

--- a/test-suite/swaptionvolatilitycube.cpp
+++ b/test-suite/swaptionvolatilitycube.cpp
@@ -48,9 +48,6 @@ namespace swaption_volatility_cube_test {
         ext::shared_ptr<SwapIndex> swapIndexBase, shortSwapIndexBase;
         bool vegaWeighedSmileFit;
 
-        // cleanup
-        SavedSettings backup;
-
         // utilities
         void makeAtmVolTest(const SwaptionVolatilityCube& volCube,
                             Real tolerance) {

--- a/test-suite/swaptionvolatilitymatrix.cpp
+++ b/test-suite/swaptionvolatilitymatrix.cpp
@@ -44,9 +44,6 @@ namespace swaption_volatility_matrix_test {
         RelinkableHandle<SwaptionVolatilityStructure> atmVolMatrix;
         Real tolerance;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             conventions.setConventions();

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -77,8 +77,6 @@ void SwingOptionTest::testExtendedOrnsteinUhlenbeckProcess() {
 
     BOOST_TEST_MESSAGE("Testing extended Ornstein-Uhlenbeck process...");
 
-    SavedSettings backup;
-
     const Real speed = 2.5;
     const Volatility vol = 0.70;
     const Real level = 1.43;
@@ -135,8 +133,6 @@ void SwingOptionTest::testFdmExponentialJump1dMesher() {
 
     using namespace swing_option_test;
 
-    SavedSettings backup;
-
     Array x(2, 1.0);
     const Real beta = 100.0;
     const Real eta  = 1.0/0.4;
@@ -185,8 +181,6 @@ void SwingOptionTest::testExtOUJumpVanillaEngine() {
     BOOST_TEST_MESSAGE("Testing finite difference pricer for the Kluge model...");
 
     using namespace swing_option_test;
-
-    SavedSettings backup;
 
     ext::shared_ptr<ExtOUWithJumpsProcess> jumpProcess = createKlugeProcess();
 
@@ -246,8 +240,6 @@ void SwingOptionTest::testExtOUJumpVanillaEngine() {
 void SwingOptionTest::testFdBSSwingOption() {
 
     BOOST_TEST_MESSAGE("Testing Black-Scholes vanilla swing option pricing...");
-
-    SavedSettings backup;
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
@@ -327,8 +319,6 @@ void SwingOptionTest::testExtOUJumpSwingOption() {
     BOOST_TEST_MESSAGE("Testing simple swing option pricing for Kluge model...");
 
     using namespace swing_option_test;
-
-    SavedSettings backup;
 
     Date settlementDate = Date::todaysDate();
     Settings::instance().evaluationDate() = settlementDate;
@@ -484,8 +474,6 @@ void SwingOptionTest::testKlugeChFVanillaPricing() {
             " comparison to moment matching...");
 
     using namespace swing_option_test;
-
-    SavedSettings backup;
 
     Date settlementDate = Date(22, November, 2019);
     Settings::instance().evaluationDate() = settlementDate;

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -53,9 +53,6 @@ namespace term_structures_test {
         ext::shared_ptr<YieldTermStructure> termStructure;
         ext::shared_ptr<YieldTermStructure> dummyTermStructure;
 
-        // cleanup
-        SavedSettings backup;
-
         // setup
         CommonVars() {
             calendar = TARGET();
@@ -359,7 +356,6 @@ void TermStructureTest::testCompositeZeroYieldStructures() {
 
     using namespace term_structures_test;
 
-    SavedSettings backup;
     Settings::instance().evaluationDate() = Date(10, Nov, 2017);
 
     // First curve

--- a/test-suite/ultimateforwardtermstructure.cpp
+++ b/test-suite/ultimateforwardtermstructure.cpp
@@ -61,8 +61,6 @@ namespace ultimate_forward_term_structure_test {
         Period fsp;
         Real alpha;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars() {

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -79,16 +79,12 @@ namespace QuantLib {
             template <class F>
             explicit quantlib_test_case(F test) : test_(test) {}
             void operator()() const {
+                // Restore settings after each test.
+                SavedSettings restore;
                 // Clear all fixings before running a test to avoid interference.
                 IndexManager::instance().clearHistories();
-                Date before = Settings::instance().evaluationDate();
                 BOOST_CHECK(true);
                 test_();
-                Date after = Settings::instance().evaluationDate();
-                if (before != after)
-                    BOOST_ERROR("Evaluation date not reset"
-                                << "\n  before: " << before
-                                << "\n  after:  " << after);
             }
             #if BOOST_VERSION <= 105300
             // defined to avoid unused-variable warnings. It doesn't

--- a/test-suite/variancegamma.cpp
+++ b/test-suite/variancegamma.cpp
@@ -78,8 +78,6 @@ void VarianceGammaTest::testVarianceGamma() {
 
     BOOST_TEST_MESSAGE("Testing variance-gamma model for European options...");
 
-    SavedSettings backup;
-
     VarianceGammaProcessData processes[] = {
     //    spot,    q,    r,sigma,   nu, theta
         { 6000, 0.00, 0.05, 0.20, 0.05, -0.50 },
@@ -212,8 +210,6 @@ void VarianceGammaTest::testSingularityAtZero() {
 
     BOOST_TEST_MESSAGE(
         "Testing variance-gamma model integration around zero...");
-
-    SavedSettings backup;
 
     Real stock = 100;
     Real strike = 98;

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -106,8 +106,6 @@ void VPPTest::testGemanRoncoroniProcess() {
 
     using namespace vpp_test;
 
-    SavedSettings backup;
-
     const Date today = Date(18, December, 2011);
     Settings::instance().evaluationDate() = today;
     const DayCounter dc = ActualActual(ActualActual::ISDA);
@@ -224,8 +222,6 @@ void VPPTest::testSimpleExtOUStorageEngine() {
 
     using namespace vpp_test;
 
-    SavedSettings backup;
-
     Date settlementDate = Date(18, December, 2011);
     Settings::instance().evaluationDate() = settlementDate;
     DayCounter dayCounter = ActualActual(ActualActual::ISDA);
@@ -273,8 +269,6 @@ void VPPTest::testKlugeExtOUSpreadOption() {
     BOOST_TEST_MESSAGE("Testing simple Kluge ext-Ornstein-Uhlenbeck spread option...");
 
     using namespace vpp_test;
-
-    SavedSettings backup;
 
     Date settlementDate = Date(18, December, 2011);
     Settings::instance().evaluationDate() = settlementDate;
@@ -410,8 +404,6 @@ void VPPTest::testVPPIntrinsicValue() {
     BOOST_TEST_MESSAGE("Testing VPP step condition...");
 
     using namespace vpp_test;
-
-    SavedSettings backup;
 
     const Date today = Date(18, December, 2011);
     const DayCounter dc = ActualActual(ActualActual::ISDA);
@@ -562,8 +554,6 @@ void VPPTest::testVPPPricing() {
     BOOST_TEST_MESSAGE("Testing VPP pricing using perfect foresight or FDM...");
 
     using namespace vpp_test;
-
-    SavedSettings backup;
 
     const Date today = Date(18, December, 2011);
     const DayCounter dc = ActualActual(ActualActual::ISDA);
@@ -879,8 +869,6 @@ void VPPTest::testKlugeExtOUMatrixDecomposition() {
     BOOST_TEST_MESSAGE("Testing KlugeExtOU matrix decomposition...");
 
     using namespace vpp_test;
-
-    SavedSettings backup;
 
     const Date today = Date(18, December, 2011);
     Settings::instance().evaluationDate() = today;

--- a/test-suite/zerocouponswap.cpp
+++ b/test-suite/zerocouponswap.cpp
@@ -42,8 +42,6 @@ namespace zerocouponswap_test {
         RelinkableHandle<YieldTermStructure> euriborHandle;
         ext::shared_ptr<PricingEngine> discountEngine;
 
-        // cleanup
-        SavedSettings backup;
         // utilities
 
         CommonVars() {


### PR DESCRIPTION
Instead of adding SavedSettings into every test that changes settings, use it in quantlib_test_case so it applies to every test. This is cheap and makes writing tests easier.