### PR TITLE
Don't normalize days to weeks in interest-rate index

### DIFF
--- a/ql/indexes/interestrateindex.cpp
+++ b/ql/indexes/interestrateindex.cpp
@@ -35,7 +35,9 @@ namespace QuantLib {
     : familyName_(std::move(familyName)), tenor_(tenor), fixingDays_(fixingDays),
       currency_(std::move(currency)), dayCounter_(std::move(dayCounter)),
       fixingCalendar_(std::move(fixingCalendar)) {
-        tenor_.normalize();
+        // tenor_.normalize() does too much; we want to leave days alone
+        if (tenor.units() == Months && tenor.length() % 12 == 0)
+            tenor_ = Period(tenor.length() / 12, Years);
 
         std::ostringstream out;
         out << familyName_;

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -21,6 +21,8 @@
 #include "utilities.hpp"
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual360.hpp>
 #include <ql/utilities/dataformatters.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
@@ -125,9 +127,38 @@ void IndexTest::testFixingHasHistoricalFixing() {
     testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 }
 
+void IndexTest::testTenorNormalization() {
+    BOOST_TEST_MESSAGE("Testing that interest-rate index tenor is normalized correctly...");
+
+    auto i12m = IborIndex("foo", 12*Months, 2, Currency(),
+                          TARGET(), Following, false, Actual360());
+    auto i1y = IborIndex("foo", 1*Years, 2, Currency(),
+                         TARGET(), Following, false, Actual360());
+
+    if (i12m.name() != i1y.name())
+        BOOST_ERROR("12M index and 1Y index yield different names");
+
+
+    auto i6d = IborIndex("foo", 6*Days, 2, Currency(),
+                         TARGET(), Following, false, Actual360());
+    auto i7d = IborIndex("foo", 7*Days, 2, Currency(),
+                         TARGET(), Following, false, Actual360());
+
+    Date testDate(28, April, 2023);
+    Date maturity6d = i6d.maturityDate(testDate);
+    Date maturity7d = i7d.maturityDate(testDate);
+
+    if (maturity6d >= maturity7d) {
+        BOOST_ERROR("inconsistent maturity dates and tenors"
+                    << "\n  maturity date for 6-days index: " << maturity6d
+                    << "\n  maturity date for 7-days index: " << maturity7d);
+    }
+}
+
 test_suite* IndexTest::suite() {
     auto* suite = BOOST_TEST_SUITE("index tests");
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingObservability));
     suite->add(QUANTLIB_TEST_CASE(&IndexTest::testFixingHasHistoricalFixing));
+    suite->add(QUANTLIB_TEST_CASE(&IndexTest::testTenorNormalization));
     return suite;
 }

--- a/test-suite/indexes.hpp
+++ b/test-suite/indexes.hpp
@@ -29,6 +29,7 @@ class IndexTest {
   public:
     static void testFixingObservability();
     static void testFixingHasHistoricalFixing();
+    static void testTenorNormalization();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
Fixes the effects of #1696 on interest-rate indexes.