### PR TITLE
Add separate calendar for SOFR fixing dates

### DIFF
--- a/ql/indexes/ibor/sofr.cpp
+++ b/ql/indexes/ibor/sofr.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
 
     Sofr::Sofr(const Handle<YieldTermStructure>& h)
     : OvernightIndex("SOFR", 0, USDCurrency(),
-                     UnitedStates(UnitedStates::GovernmentBond),
+                     UnitedStates(UnitedStates::SOFR),
                      Actual360(), h) {}
 
 }

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -92,20 +92,15 @@ namespace QuantLib {
     }
 
     UnitedStates::UnitedStates(UnitedStates::Market market) {
-        // all calendar instances on the same market share the same
-        // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                        new UnitedStates::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> liborImpactImpl(
-                                        new UnitedStates::LiborImpactImpl);
-        static ext::shared_ptr<Calendar::Impl> nyseImpl(
-                                        new UnitedStates::NyseImpl);
-        static ext::shared_ptr<Calendar::Impl> governmentImpl(
-                                        new UnitedStates::GovernmentBondImpl);
-        static ext::shared_ptr<Calendar::Impl> nercImpl(
-                                        new UnitedStates::NercImpl);
-        static ext::shared_ptr<Calendar::Impl> federalReserveImpl(
-                                        new UnitedStates::FederalReserveImpl);
+        // all calendar instances on the same market share the same implementation instance
+        static auto settlementImpl = ext::make_shared<UnitedStates::SettlementImpl>();
+        static auto liborImpactImpl = ext::make_shared<UnitedStates::LiborImpactImpl>();
+        static auto nyseImpl = ext::make_shared<UnitedStates::NyseImpl>();
+        static auto governmentImpl = ext::make_shared<UnitedStates::GovernmentBondImpl>();
+        static auto nercImpl = ext::make_shared<UnitedStates::NercImpl>();
+        static auto federalReserveImpl = ext::make_shared<UnitedStates::FederalReserveImpl>();
+        static auto sofrImpl = ext::make_shared<UnitedStates::SofrImpl>();
+
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;
@@ -118,6 +113,9 @@ namespace QuantLib {
             break;
           case GovernmentBond:
             impl_ = governmentImpl;
+            break;
+          case SOFR:
+            impl_ = sofrImpl;
             break;
           case NERC:
             impl_ = nercImpl;
@@ -315,6 +313,14 @@ namespace QuantLib {
             ) return false;
 
         return true;
+    }
+
+
+    bool UnitedStates::SofrImpl::isBusinessDay(const Date& date) const {
+        // Good Friday 2023 was only a half close for SIFMA but SOFR didn't fix
+        if (date == Date(7, April, 2023))
+            return false;
+        return GovernmentBondImpl::isBusinessDay(date);
     }
 
 

--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -147,9 +147,14 @@ namespace QuantLib {
             std::string name() const override { return "New York stock exchange"; }
             bool isBusinessDay(const Date&) const override;
         };
-        class GovernmentBondImpl final : public Calendar::WesternImpl {
+        class GovernmentBondImpl : public Calendar::WesternImpl {
           public:
             std::string name() const override { return "US government bond market"; }
+            bool isBusinessDay(const Date&) const override;
+        };
+        class SofrImpl final : public GovernmentBondImpl {
+          public:
+            std::string name() const override { return "SOFR fixing calendar"; }
             bool isBusinessDay(const Date&) const override;
         };
         class NercImpl final : public Calendar::WesternImpl {
@@ -171,7 +176,8 @@ namespace QuantLib {
                       GovernmentBond, //!< government-bond calendar
                       NERC,           //!< off-peak days for NERC
                       LiborImpact,    //!< Libor impact calendar
-                      FederalReserve  //!< Federal Reserve Bankwire System
+                      FederalReserve, //!< Federal Reserve Bankwire System
+                      SOFR            //!< SOFR fixing calendar
         };
 
         explicit UnitedStates(Market market);

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3603,14 +3603,12 @@ test_suite* CalendarTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testBrazil));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testRussia));
 
-    //    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testItalySettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testItalyExchange));
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKSettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKExchange));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUKMetals));
 
-    //    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanySettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyFrankfurt));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyXetra));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testGermanyEurex));

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -43,6 +43,7 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/unitedkingdom.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
+#include <ql/indexes/ibor/sofr.hpp>
 #include <fstream>
 
 using namespace QuantLib;
@@ -368,6 +369,22 @@ void CalendarTest::testUSNewYorkStockExchange() {
             BOOST_FAIL(histClose[i] << " should be holiday (historical close)");
     }
 }
+
+
+void CalendarTest::testSOFR() {
+    BOOST_TEST_MESSAGE("Testing extra non-fixing day for SOFR...");
+
+    auto fedCalendar = UnitedStates(UnitedStates::GovernmentBond);
+    auto testDate = Date(7, April, 2023); // Good Friday 2023 was only a half close but SOFR didn't fix
+
+    if (fedCalendar.isHoliday(testDate))
+        BOOST_ERROR(testDate << " should not be a holiday for " << fedCalendar.name());
+
+    auto sofr = Sofr();
+    if (sofr.isValidFixingDate(testDate))
+        BOOST_ERROR(testDate << " should not be a fixing date for " << sofr.name());
+}
+
 
 void CalendarTest::testTARGET() {
     BOOST_TEST_MESSAGE("Testing TARGET holiday list...");
@@ -3605,6 +3622,7 @@ test_suite* CalendarTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUSSettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUSGovernmentBondMarket));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testUSNewYorkStockExchange));
+    suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testSOFR));
 
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testSouthKoreanSettlement));
     suite->add(QUANTLIB_TEST_CASE(&CalendarTest::testKoreaStockExchange));

--- a/test-suite/calendars.hpp
+++ b/test-suite/calendars.hpp
@@ -30,14 +30,12 @@ class CalendarTest {
   public:
     static void testRussia();
     static void testBrazil();
-//    static void testItalySettlement();
     static void testItalyExchange();
 
     static void testUKSettlement();
     static void testUKExchange();
     static void testUKMetals();
 
-//    static void testGermanySettlement();
     static void testGermanyFrankfurt();
     static void testGermanyXetra();
     static void testGermanyEurex();

--- a/test-suite/calendars.hpp
+++ b/test-suite/calendars.hpp
@@ -49,6 +49,7 @@ class CalendarTest {
     static void testUSSettlement();
     static void testUSGovernmentBondMarket();
     static void testUSNewYorkStockExchange();
+    static void testSOFR();
 
     static void testSouthKoreanSettlement();
     static void testKoreaStockExchange();


### PR DESCRIPTION
Not always the same as the Government Bond / SIFMA calendar, see the discussion in #1635.