### PR TITLE
Modernised CMakePresets.json to make it more useful for developers

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
         cmake --preset linux-ci-build-with-nonstandard-options -L
         cd build/linux-ci-build-with-nonstandard-options
         cmake --build . --verbose
-        cmake --build . --target install
+        sudo cmake --build . --target install
     - name: Test
       run: |
         quantlib-test-suite --log_level=message

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,8 +47,9 @@ jobs:
     - name: Compile
       run: |
         cmake --preset linux-ci-build-with-nonstandard-options -L
-        cmake --build --preset linux-ci-build-with-nonstandard-options --verbose
-        sudo cmake --build --preset linux-ci-build-with-nonstandard-options --target install
+        cd build/linux-ci-build-with-nonstandard-options
+        cmake --build . --verbose
+        cmake --build . --target install
     - name: Test
       run: |
         quantlib-test-suite --log_level=message
@@ -146,8 +147,9 @@ jobs:
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Vc\Auxiliary\Build\vcvarsall.bat" amd64 -vcvars_ver=14.3 || exit 1
         cmake --preset windows-ci-build-with-nonstandard-options -L
-        cmake --build --preset windows-ci-build-with-nonstandard-options --verbose
-        cmake --build --preset windows-ci-build-with-nonstandard-options --target install
+        cd build/windows-ci-build-with-nonstandard-options
+        cmake --build . --verbose
+        cmake --build . --target install
     - name: Test
       run: |
         & "C:\Program Files (x86)\QuantLib\bin\quantlib-test-suite" --log_level=message

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Check
       run: |
         cmake --preset linux-ci-build-with-clang-tidy
-        cmake --build --preset linux-ci-build-with-clang-tidy -j1
+        cd build/linux-ci-build-with-clang-tidy
+        cmake --build . -j1
     - uses: peter-evans/create-pull-request@v5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,8 +41,7 @@
       "name": "linux-base",
       "hidden": true,
       "generator": "Unix Makefiles",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
+      "binaryDir": "${sourceDir}/build/${presetName}",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,99 +1,252 @@
 {
-  "version": 2,
+  "version": 3,
   "configurePresets": [
     {
-      "name": "linux-clang-debug",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
+      "name": "windows-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-msvc-x64"
+        }
+      }
+    },
+    {
+      "name": "windows-clang-base",
+      "hidden": true,
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-clang-x64"
+        }
+      }
+    },
+    {
+      "name": "linux-base",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
+        },
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "linux-gcc-x64",
+          "hostOS": [
+            "Linux"
+          ]
+        }
+      }
+    },
+    {
+      "name": "linux-gcc-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "linux-clang-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
         "CMAKE_CXX_COMPILER": "clang++"
       }
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja"
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "relwithdebinfo",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "linux-clang-debug",
+      "inherits": [
+        "linux-clang-base",
+        "debug"
+      ]
     },
     {
       "name": "linux-clang-release",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_COMPILER": "clang++"
-      }
+      "inherits": [
+        "linux-clang-base",
+        "release"
+      ]
+    },
+    {
+      "name": "linux-clang-relwithdebinfo",
+      "inherits": [
+        "linux-clang-base",
+        "relwithdebinfo"
+      ]
     },
     {
       "name": "linux-gcc-debug",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_COMPILER": "g++"
-      }
+      "inherits": [
+        "linux-gcc-base",
+        "debug"
+      ]
     },
     {
       "name": "linux-gcc-release",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_COMPILER": "g++"
-      }
+      "inherits": [
+        "linux-gcc-base",
+        "release"
+      ]
     },
     {
-      "name": "windows-clang-x64",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang-cl",
-        "CMAKE_C_COMPILER": "clang-cl"
-      },
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-clang-x64",
-          "hostOS": [
-            "Windows"
-          ]
-        }
-      }
+      "name": "linux-gcc-relwithdebinfo",
+      "inherits": [
+        "linux-gcc-base",
+        "relwithdebinfo"
+      ]
     },
     {
-      "name": "windows-msvc-x64",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-msvc-x64",
-          "hostOS": [
-            "Windows"
-          ]
-        }
-      }
+      "name": "linux-clang-ninja-debug",
+      "inherits": [
+        "linux-clang-debug",
+        "ninja"
+      ]
+    },
+    {
+      "name": "linux-clang-ninja-release",
+      "inherits": [
+        "linux-clang-release",
+        "ninja"
+      ]
+    },
+    {
+      "name": "linux-clang-ninja-relwithdebinfo",
+      "inherits": [
+        "linux-clang-relwithdebinfo",
+        "ninja"
+      ]
+    },
+    {
+      "name": "linux-gcc-ninja-debug",
+      "inherits": [
+        "linux-gcc-debug",
+        "ninja"
+      ]
+    },
+    {
+      "name": "linux-gcc-ninja-release",
+      "inherits": [
+        "linux-gcc-release",
+        "ninja"
+      ]
+    },
+    {
+      "name": "linux-gcc-ninja-relwithdebinfo",
+      "inherits": [
+        "linux-gcc-relwithdebinfo",
+        "ninja"
+      ]
+    },
+    {
+      "name": "windows-clang-release",
+      "inherits": [
+        "windows-clang-base",
+        "release"
+      ]
+    },
+    {
+      "name": "windows-clang-debug",
+      "inherits": [
+        "windows-clang-base",
+        "debug"
+      ]
+    },
+    {
+      "name": "windows-clang-relwithdebinfo",
+      "inherits": [
+        "windows-clang-base",
+        "relwithdebinfo"
+      ]
+    },
+    {
+      "name": "windows-msvc-release",
+      "inherits": [
+        "windows-base",
+        "release"
+      ]
+    },
+    {
+      "name": "windows-msvc-debug",
+      "inherits": [
+        "windows-base",
+        "debug"
+      ]
+    },
+    {
+      "name": "windows-msvc-relwithdebinfo",
+      "inherits": [
+        "windows-base",
+        "relwithdebinfo"
+      ]
     },
     {
       "name": "linux-gcc-debug-with-clang-tidy",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
+      "inherits": [
+        "linux-gcc-base",
+        "debug"
+      ],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_COMPILER": "g++",
         "QL_CLANG_TIDY_OPTIONS": "-warnings-as-errors=*",
         "QL_USE_CLANG_TIDY": "ON"
       }
     },
     {
       "name": "linux-ci-build-with-clang-tidy",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Unix Makefiles",
+      "inherits": [
+        "linux-gcc-base",
+        "debug"
+      ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_UNITY_BUILD": "ON",
         "QL_CLANG_TIDY": "clang-tidy-15",
         "QL_CLANG_TIDY_OPTIONS": "-quiet;-fix",
@@ -103,13 +256,14 @@
     },
     {
       "name": "linux-ci-build-with-nonstandard-options",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja",
+      "inherits": [
+        "linux-gcc-base",
+        "ninja",
+        "release"
+      ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
         "BUILD_SHARED_LIBS": false,
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_CXX_STANDARD": "17",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
         "QL_ENABLE_SESSIONS": "ON",
@@ -124,14 +278,11 @@
     },
     {
       "name": "windows-ci-build-with-nonstandard-options",
-      "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
+      "inherits": [
+        "windows-base",
+        "release"
+      ],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_STANDARD": "17",
         "CMAKE_UNITY_BUILD": "ON",
         "QL_ENABLE_SESSIONS": "ON",
@@ -143,70 +294,7 @@
         "QL_USE_STD_CLASSES": "ON",
         "QL_COMPILE_WARNING_AS_ERROR": "ON",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-msvc-x64",
-          "hostOS": [
-            "Windows"
-          ]
-        }
       }
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "linux-clang-debug",
-      "configurePreset": "linux-clang-debug"
-    },
-    {
-      "name": "linux-clang-release",
-      "configurePreset": "linux-clang-release"
-    },
-    {
-      "name": "linux-gcc-debug",
-      "configurePreset": "linux-gcc-debug"
-    },
-    {
-      "name": "linux-gcc-release",
-      "configurePreset": "linux-gcc-release"
-    },
-    {
-      "name": "linux-gcc-debug-with-clang-tidy",
-      "configurePreset": "linux-gcc-debug-with-clang-tidy"
-    },
-    {
-      "name": "windows-clang-x64-debug",
-      "configurePreset": "windows-clang-x64",
-      "configuration": "Debug"
-    },
-    {
-      "name": "windows-clang-x64-release",
-      "configurePreset": "windows-clang-x64",
-      "configuration": "Release"
-    },
-    {
-      "name": "windows-msvc-x64-debug",
-      "configurePreset": "windows-msvc-x64",
-      "configuration": "Debug"
-    },
-    {
-      "name": "windows-msvc-x64-release",
-      "configurePreset": "windows-msvc-x64",
-      "configuration": "Release"
-    },
-    {
-      "name": "linux-ci-build-with-clang-tidy",
-      "configurePreset": "linux-ci-build-with-clang-tidy"
-    },
-    {
-      "name": "linux-ci-build-with-nonstandard-options",
-      "configurePreset": "linux-ci-build-with-nonstandard-options"
-    },
-    {
-      "name": "windows-ci-build-with-nonstandard-options",
-      "configurePreset": "windows-ci-build-with-nonstandard-options",
-      "configuration": "Release"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,11 +4,7 @@
     {
       "name": "windows-base",
       "hidden": true,
-      "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
-      "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl.exe"
-      },
       "architecture": {
         "value": "x64",
         "strategy": "external"
@@ -17,6 +13,14 @@
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-msvc-base",
+      "hidden": true,
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl.exe"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -40,7 +44,6 @@
     {
       "name": "linux-base",
       "hidden": true,
-      "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "condition": {
         "type": "equals",
@@ -81,6 +84,11 @@
       "generator": "Ninja"
     },
     {
+      "name": "make",
+      "hidden": true,
+      "generator": "Unix Makefiles"
+    },
+    {
       "name": "release",
       "hidden": true,
       "cacheVariables": {
@@ -105,6 +113,7 @@
       "name": "linux-clang-debug",
       "inherits": [
         "linux-clang-base",
+        "make",
         "debug"
       ]
     },
@@ -112,6 +121,7 @@
       "name": "linux-clang-release",
       "inherits": [
         "linux-clang-base",
+        "make",
         "release"
       ]
     },
@@ -119,6 +129,7 @@
       "name": "linux-clang-relwithdebinfo",
       "inherits": [
         "linux-clang-base",
+        "make",
         "relwithdebinfo"
       ]
     },
@@ -126,6 +137,7 @@
       "name": "linux-gcc-debug",
       "inherits": [
         "linux-gcc-base",
+        "make",
         "debug"
       ]
     },
@@ -133,6 +145,7 @@
       "name": "linux-gcc-release",
       "inherits": [
         "linux-gcc-base",
+        "make",
         "release"
       ]
     },
@@ -140,6 +153,7 @@
       "name": "linux-gcc-relwithdebinfo",
       "inherits": [
         "linux-gcc-base",
+        "make",
         "relwithdebinfo"
       ]
     },
@@ -186,51 +200,10 @@
       ]
     },
     {
-      "name": "windows-clang-release",
-      "inherits": [
-        "windows-clang-base",
-        "release"
-      ]
-    },
-    {
-      "name": "windows-clang-debug",
-      "inherits": [
-        "windows-clang-base",
-        "debug"
-      ]
-    },
-    {
-      "name": "windows-clang-relwithdebinfo",
-      "inherits": [
-        "windows-clang-base",
-        "relwithdebinfo"
-      ]
-    },
-    {
-      "name": "windows-msvc-release",
-      "inherits": [
-        "windows-base",
-        "release"
-      ]
-    },
-    {
-      "name": "windows-msvc-debug",
-      "inherits": [
-        "windows-base",
-        "debug"
-      ]
-    },
-    {
-      "name": "windows-msvc-relwithdebinfo",
-      "inherits": [
-        "windows-base",
-        "relwithdebinfo"
-      ]
-    },
-    {
       "name": "linux-gcc-debug-with-clang-tidy",
       "inherits": [
         "linux-gcc-base",
+        "make",
         "debug"
       ],
       "cacheVariables": {
@@ -239,9 +212,58 @@
       }
     },
     {
+      "name": "windows-clang-release",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "release"
+      ]
+    },
+    {
+      "name": "windows-clang-debug",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "debug"
+      ]
+    },
+    {
+      "name": "windows-clang-relwithdebinfo",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "relwithdebinfo"
+      ]
+    },
+    {
+      "name": "windows-msvc-release",
+      "inherits": [
+        "windows-msvc-base",
+        "ninja",
+        "release"
+      ]
+    },
+    {
+      "name": "windows-msvc-debug",
+      "inherits": [
+        "windows-msvc-base",
+        "ninja",
+        "debug"
+      ]
+    },
+    {
+      "name": "windows-msvc-relwithdebinfo",
+      "inherits": [
+        "windows-msvc-base",
+        "ninja",
+        "relwithdebinfo"
+      ]
+    },
+    {
       "name": "linux-ci-build-with-clang-tidy",
       "inherits": [
         "linux-gcc-base",
+        "make",
         "debug"
       ],
       "cacheVariables": {
@@ -278,7 +300,8 @@
     {
       "name": "windows-ci-build-with-nonstandard-options",
       "inherits": [
-        "windows-base",
+        "windows-msvc-base",
+        "ninja",
         "release"
       ],
       "cacheVariables": {


### PR DESCRIPTION
This PR modernises the `CMakePresets.json` to make it more useful and less repetitive for developers (not just for CI/CD). 

## Configure Presets

It defines a set of hidden, base configurations, and uses `inherit` to combine them into user-accessible configure presets for each Windows/Linux with MSVC/Clang/GCC. This makes the dropdown with the Visual Studio "Open Folder" feature look like this for a Windows target:

![image](https://github.com/lballabio/QuantLib/assets/107129969/8f35dba2-d1fe-465d-8565-8065a208ffe3)

When selecting a remote or WSL Linux target machine, the drop-down looks like this:

![image](https://github.com/lballabio/QuantLib/assets/107129969/638f4edc-c3b3-4f32-a4e0-bceffcad0fb0)

For Linux, both Unix Makefiles (default) and Ninja generator presets are there.

The same configuration presets are of course also available on the command-line with `cmake --preset xxxx`. 

The build directory is set to `${sourceDir}/build/${presetName}`, so all presets can live side-by-side. The corresponding CI/CD workflow jobs have been adjusted to use the new path.

## Build Presets

The build presets have been removed - they didn't add any additional configuration to what's already covered by the configure presets and were quite repetitive. The Visual Studio IDE works just fine without, and for building on the command-line, users can just do:

```bash
cd build/name-of-preset
cmake --build . 
```

## Developer-specific Adjustments

Often developers want to add their own configurations or settings in their own presets. This can be done if they add a `CMakeUserPresets.json` file to the QuantLib root and add additional configurations. With the new hidden base configurations in this PR, it makes it easier to inherit combinations that users need and add new settings, for example:

`CMakeUserPresets.json`
```json
{
  "version": 3,
  "configurePresets": [
    {
      "name": "my-preset-debug",
      "inherits": [
        "windows-clang-base",
        "debug"
      ],
      "cacheVariables": {
        "QL_USE_STD_CLASSES": "ON"
      }
    }
  ]
}
```

## Build Speedup Visual Studio 

The current CMake-based Visual Studio MSBuild generators (multi-config), for example when using the CMake GUI to generate projects and solutions, show very poor build performance. It's barely usable as it is. This PR makes the presets much more usable out of the box for Windows users.

To compare - on a box with 18 cores (36 hyperthreads), with CMake-generated VS2022 project files, fresh release build (Xeon W-2295 CPU):

### MSBuild project files: 24min 36sec
### Ninja                :  3min 5sec **(nearly 8x faster)**


## Documentation Changes

Once this PR is accepted, we will prepare a change to the QuantLib [build doc on the website](https://www.quantlib.org/install/cmake.shtml) which will explain better how to use the presets and how to setup user presets.