### PR TITLE
Register instruments with evaluation date

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -2818,6 +2818,7 @@
     <ClCompile Include="ql\exchangerate.cpp" />
     <ClCompile Include="ql\exercise.cpp" />
     <ClCompile Include="ql\index.cpp" />
+    <ClCompile Include="ql\instrument.cpp" />
     <ClCompile Include="ql\interestrate.cpp" />
     <ClCompile Include="ql\money.cpp" />
     <ClCompile Include="ql\optional.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -6648,6 +6648,7 @@
     <ClCompile Include="ql\exercise.cpp" />
     <ClCompile Include="ql\rebatedexercise.cpp" />
     <ClCompile Include="ql\index.cpp" />
+    <ClCompile Include="ql\instrument.cpp" />
     <ClCompile Include="ql\interestrate.cpp" />
     <ClCompile Include="ql\money.cpp" />
     <ClCompile Include="ql\optional.cpp" />

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -259,6 +259,7 @@ set(QL_SOURCES
     indexes/swap/jpyliborswap.cpp
     indexes/swap/usdliborswap.cpp
     indexes/swapindex.cpp
+    instrument.cpp
     instruments/asianoption.cpp
     instruments/assetswap.cpp
     instruments/averagetype.cpp

--- a/ql/Makefile.am
+++ b/ql/Makefile.am
@@ -73,6 +73,7 @@ cpp_files = \
 	exchangerate.cpp \
 	exercise.cpp \
     index.cpp \
+    instrument.cpp \
     interestrate.cpp \
     money.cpp \
     optional.cpp \

--- a/ql/instrument.cpp
+++ b/ql/instrument.cpp
@@ -1,0 +1,49 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
+ Copyright (C) 2003, 2004, 2005, 2006, 2007 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/instrument.hpp>
+#include <ql/settings.hpp>
+
+namespace QuantLib {
+
+    Instrument::Instrument()
+    : NPV_(Null<Real>()), errorEstimate_(Null<Real>()) {
+        // this makes sense in general (if the evaluation date
+        // changes, you probably want to recalculate) and can also
+        // help avoid some edge cases when lazy objects only forward
+        // their first notification.
+        registerWith(Settings::instance().evaluationDate());
+    }
+
+    void Instrument::setPricingEngine(const ext::shared_ptr<PricingEngine>& e) {
+        if (engine_ != nullptr)
+            unregisterWith(engine_);
+        engine_ = e;
+        if (engine_ != nullptr)
+            registerWith(engine_);
+        // trigger (lazy) recalculation and notify observers
+        update();
+    }
+
+    void Instrument::setupArguments(PricingEngine::arguments*) const {
+        QL_FAIL("Instrument::setupArguments() not implemented");
+    }
+
+}

--- a/ql/instrument.hpp
+++ b/ql/instrument.hpp
@@ -126,23 +126,6 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline Instrument::Instrument() : NPV_(Null<Real>()), errorEstimate_(Null<Real>()) {}
-
-    inline void Instrument::setPricingEngine(
-                                  const ext::shared_ptr<PricingEngine>& e) {
-        if (engine_ != nullptr)
-            unregisterWith(engine_);
-        engine_ = e;
-        if (engine_ != nullptr)
-            registerWith(engine_);
-        // trigger (lazy) recalculation and notify observers
-        update();
-    }
-
-    inline void Instrument::setupArguments(PricingEngine::arguments*) const {
-        QL_FAIL("Instrument::setupArguments() not implemented");
-    }
-
     inline void Instrument::calculate() const {
         if (!calculated_) {
             if (isExpired()) {


### PR DESCRIPTION
This makes sense in general (if the evaluation date changes, you probably want to recalculate) and can also help avoid some (not all) edge cases when lazy objects only forward their first notification.