### PR TITLE
Save a historical fixing map access

### DIFF
--- a/ql/timeseries.hpp
+++ b/ql/timeseries.hpp
@@ -94,15 +94,15 @@ namespace QuantLib {
         //@{
         //! returns the (possibly null) datum corresponding to the given date
         T operator[](const Date& d) const {
-            if (values_.find(d) != values_.end())
-                return values_[d];
-            else
+            typename Container::const_iterator found = values_.find(d);
+            if (found == values_.cend())
                 return Null<T>();
+            return found->second;
         }
         T& operator[](const Date& d) {
-            if (values_.find(d) == values_.end())
-                values_[d] = Null<T>();
-            return values_[d];
+            typename Container::iterator found =
+                values_.insert(std::pair<Date, T>(d, Null<T>())).first;
+            return found->second;
         }
         //@}
 


### PR DESCRIPTION
This addresses #1726.

For the const operator[], this simply uses the iterator returned by find.

For the non-const operator[], which can insert a null, this changes to using [map::insert](https://en.cppreference.com/w/cpp/container/map/insert), which has exactly the behaviour we want - "returns a reference to the value that is mapped to a key equivalent to key, performing an insertion if such key does not already exist".