### PR TITLE
Avoid possible segfault when bootstrapping over OIS rates

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -51,6 +51,10 @@ namespace QuantLib {
 
         overnightIndex_ =
             ext::dynamic_pointer_cast<OvernightIndex>(overnightIndex->clone(termStructureHandle_));
+        // We want to be notified of changes of fixings, but we don't
+        // want notifications from termStructureHandle_ (they would
+        // interfere with bootstrapping.)
+        overnightIndex_->unregisterWith(termStructureHandle_);
 
         registerWith(overnightIndex_);
         registerWith(discountHandle_);
@@ -161,6 +165,10 @@ namespace QuantLib {
 
         auto clonedOvernightIndex =
             ext::dynamic_pointer_cast<OvernightIndex>(overnightIndex->clone(termStructureHandle_));
+        // We want to be notified of changes of fixings, but we don't
+        // want notifications from termStructureHandle_ (they would
+        // interfere with bootstrapping.)
+        clonedOvernightIndex->unregisterWith(termStructureHandle_);
 
         registerWith(clonedOvernightIndex);
         registerWith(discountHandle_);

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -27,6 +27,7 @@
 #include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
@@ -499,6 +500,22 @@ void OvernightIndexedSwapTest::testBootstrapRegression() {
 }
 
 
+void OvernightIndexedSwapTest::test131BootstrapRegression() {
+    BOOST_TEST_MESSAGE("Testing 1.31 regression with OIS bootstrap...");
+
+    Date today(11, December, 2012);
+    Settings::instance().evaluationDate() = today;
+
+    auto eonia = ext::make_shared<Eonia>();
+
+    std::vector<ext::shared_ptr<RateHelper>> helpers;
+    helpers.push_back(ext::make_shared<OISRateHelper>(2, 1 * Weeks, Handle<Quote>(ext::make_shared<SimpleQuote>(0.070/100)), eonia));
+
+    auto curve = PiecewiseYieldCurve<ForwardRate,BackwardFlat>(0, TARGET(), helpers, Actual365Fixed());
+    BOOST_CHECK_NO_THROW(curve.nodes());
+}
+
+
 test_suite* OvernightIndexedSwapTest::suite() {
     auto* suite = BOOST_TEST_SUITE("Overnight-indexed swap tests");
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testFairRate));
@@ -506,11 +523,10 @@ test_suite* OvernightIndexedSwapTest::suite() {
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testCachedValue));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testBootstrap));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testBootstrapWithArithmeticAverage));
-    suite->add(QUANTLIB_TEST_CASE(
-        &OvernightIndexedSwapTest::testBootstrapWithTelescopicDates));
-    suite->add(QUANTLIB_TEST_CASE(
-        &OvernightIndexedSwapTest::testBootstrapWithTelescopicDatesAndArithmeticAverage));
+    suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testBootstrapWithTelescopicDates));
+    suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testBootstrapWithTelescopicDatesAndArithmeticAverage));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testSeasonedSwaps));
     suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::testBootstrapRegression));
+    suite->add(QUANTLIB_TEST_CASE(&OvernightIndexedSwapTest::test131BootstrapRegression));
     return suite;
 }

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -510,6 +510,7 @@ void OvernightIndexedSwapTest::test131BootstrapRegression() {
 
     std::vector<ext::shared_ptr<RateHelper>> helpers;
     helpers.push_back(ext::make_shared<OISRateHelper>(2, 1 * Weeks, Handle<Quote>(ext::make_shared<SimpleQuote>(0.070/100)), eonia));
+    helpers.push_back(ext::make_shared<DatedOISRateHelper>(Date(16, January, 2013), Date(13, February, 2013), Handle<Quote>(ext::make_shared<SimpleQuote>(0.046/100)), eonia));
 
     auto curve = PiecewiseYieldCurve<ForwardRate,BackwardFlat>(0, TARGET(), helpers, Actual365Fixed());
     BOOST_CHECK_NO_THROW(curve.nodes());

--- a/test-suite/overnightindexedswap.hpp
+++ b/test-suite/overnightindexedswap.hpp
@@ -37,6 +37,7 @@ class OvernightIndexedSwapTest {
     static void testBootstrapWithTelescopicDatesAndArithmeticAverage();
     static void testSeasonedSwaps();
     static void testBootstrapRegression();
+    static void test131BootstrapRegression();
     static boost::unit_test_framework::test_suite* suite();
 };
 


### PR DESCRIPTION
See e.g. the added regression test case.