### PR TITLE
Renamed conflicting preset names `debug`, `release` and `relwithdebinfo`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -89,21 +89,21 @@
       "generator": "Unix Makefiles"
     },
     {
-      "name": "release",
+      "name": "_release",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
-      "name": "debug",
+      "name": "_debug",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "relwithdebinfo",
+      "name": "_relwithdebinfo",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
@@ -114,7 +114,7 @@
       "inherits": [
         "linux-clang-base",
         "make",
-        "debug"
+        "_debug"
       ]
     },
     {
@@ -122,7 +122,7 @@
       "inherits": [
         "linux-clang-base",
         "make",
-        "release"
+        "_release"
       ]
     },
     {
@@ -130,7 +130,7 @@
       "inherits": [
         "linux-clang-base",
         "make",
-        "relwithdebinfo"
+        "_relwithdebinfo"
       ]
     },
     {
@@ -138,7 +138,7 @@
       "inherits": [
         "linux-gcc-base",
         "make",
-        "debug"
+        "_debug"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "inherits": [
         "linux-gcc-base",
         "make",
-        "release"
+        "_release"
       ]
     },
     {
@@ -154,7 +154,7 @@
       "inherits": [
         "linux-gcc-base",
         "make",
-        "relwithdebinfo"
+        "_relwithdebinfo"
       ]
     },
     {
@@ -204,7 +204,7 @@
       "inherits": [
         "linux-gcc-base",
         "make",
-        "debug"
+        "_debug"
       ],
       "cacheVariables": {
         "QL_CLANG_TIDY_OPTIONS": "-warnings-as-errors=*",
@@ -216,7 +216,7 @@
       "inherits": [
         "windows-clang-base",
         "ninja",
-        "release"
+        "_release"
       ]
     },
     {
@@ -224,7 +224,7 @@
       "inherits": [
         "windows-clang-base",
         "ninja",
-        "debug"
+        "_debug"
       ]
     },
     {
@@ -232,7 +232,7 @@
       "inherits": [
         "windows-clang-base",
         "ninja",
-        "relwithdebinfo"
+        "_relwithdebinfo"
       ]
     },
     {
@@ -240,7 +240,7 @@
       "inherits": [
         "windows-msvc-base",
         "ninja",
-        "release"
+        "_release"
       ]
     },
     {
@@ -248,7 +248,7 @@
       "inherits": [
         "windows-msvc-base",
         "ninja",
-        "debug"
+        "_debug"
       ]
     },
     {
@@ -256,7 +256,7 @@
       "inherits": [
         "windows-msvc-base",
         "ninja",
-        "relwithdebinfo"
+        "_relwithdebinfo"
       ]
     },
     {
@@ -264,7 +264,7 @@
       "inherits": [
         "linux-gcc-base",
         "make",
-        "debug"
+        "_debug"
       ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
@@ -280,7 +280,7 @@
       "inherits": [
         "linux-gcc-base",
         "ninja",
-        "release"
+        "_release"
       ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
@@ -303,7 +303,7 @@
       "inherits": [
         "windows-msvc-base",
         "ninja",
-        "release"
+        "_release"
       ],
       "cacheVariables": {
         "CMAKE_CXX_STANDARD": "17",


### PR DESCRIPTION
Unfortunately, I had only a brief look at the changes @eltoder suggested in #1723. The idea of _Modernised CMakePresets.json to make it more useful for developers_ is absolutely right.

However, the new, but hidden presets `debug`, `release` and `relwithdebinfo` conflict with our existing ones in `CMakeUserPresets.json` and also with the default preset names  `CLion` uses.

@eltoder: Any objections to rename them by adding a starting underscore: `_debug` etc.? They are hidden anyhow.

We like the easy to remember calls across all platforms:
```bash
> cmake --preset release
> cmake --build --preset release -j 12 -v
```
I guess it is worth not "burning" these often used preset names?!

Perhaps later on we can rename all presets to start with `ql_` which would be in line e.g. the naming convention for the options?