### PR TITLE
register with observables of bootstrap helpers instead of the helpers themselves

### DIFF
--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -294,17 +294,7 @@ namespace QuantLib {
         /*! register with all observables of a given observer. Note
             that this does not include registering with the observer
             itself.
-
-            \deprecated This method was introduced to work around incorrect behaviour caused by
-                        limiting notifications from LazyObject instances to the first notification.
-                        If you have an observer chain A -> B -> C where B is lazy and might
-                        therefore swallow notifications from C, the preferred way to ensure that all
-                        notifications from C reach A is to call alwaysForwardNotifications() on B
-                        instead of registering A with all observables of B.
-
-                        Deprecated in version 1.30.
         */
-        [[deprecated("no longer necessary")]]
         void registerWithObservables(const ext::shared_ptr<Observer>&);
 
         Size unregisterWith(const ext::shared_ptr<Observable>&);

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -131,17 +131,7 @@ namespace QuantLib {
         /*! register with all observables of a given observer. Note
             that this does not include registering with the observer
             itself.
-
-            \deprecated This method was introduced to work around incorrect behaviour caused by
-                        limiting notifications from LazyObject instances to the first notification.
-                        If you have an observer chain A -> B -> C where B is lazy and might
-                        therefore swallow notifications from C, the preferred way to ensure that all
-                        notifications from C reach A is to call alwaysForwardNotifications() on B
-                        instead of registering A with all observables of B.
-
-                        Deprecated in version 1.30.
         */
-        [[deprecated("no longer necessary")]]
         void registerWithObservables(const ext::shared_ptr<Observer>&);
 
         Size unregisterWith(const ext::shared_ptr<Observable>&);

--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -96,9 +96,9 @@ GlobalBootstrap<Curve>::GlobalBootstrap(
 template <class Curve> void GlobalBootstrap<Curve>::setup(Curve *ts) {
     ts_ = ts;
     for (Size j = 0; j < ts_->instruments_.size(); ++j)
-        ts_->registerWith(ts_->instruments_[j]);
+        ts_->registerWithObservables(ts_->instruments_[j]);
     for (Size j = 0; j < additionalHelpers_.size(); ++j)
-        ts_->registerWith(additionalHelpers_[j]);
+        ts_->registerWithObservables(additionalHelpers_[j]);
 
     // do not initialize yet: instruments could be invalid here
     // but valid later when bootstrapping is actually required

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -146,7 +146,7 @@ namespace detail {
         n_ = ts_->instruments_.size();
         QL_REQUIRE(n_ > 0, "no bootstrap helpers given");
         for (Size j=0; j<n_; ++j)
-            ts_->registerWith(ts_->instruments_[j]);
+            ts_->registerWithObservables(ts_->instruments_[j]);
 
         // do not initialize yet: instruments could be invalid here
         // but valid later when bootstrapping is actually required

--- a/ql/termstructures/localbootstrap.hpp
+++ b/ql/termstructures/localbootstrap.hpp
@@ -124,7 +124,7 @@ namespace QuantLib {
                    localisation_ << " required.");
 
         for (Size i=0; i<n; ++i){
-            ts_->registerWith(ts_->instruments_[i]);
+            ts_->registerWithObservables(ts_->instruments_[i]);
         }
     }
 


### PR DESCRIPTION
often the set of helpers will share common observables which we only need to register with once

addresses #1730 