### PR TITLE
use `std::set` everywhere to store observers, observables

### DIFF
--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -33,7 +33,6 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/patterns/singleton.hpp>
 #include <ql/shared_ptr.hpp>
 #include <ql/types.hpp>
-#include <unordered_set>
 #include <set>
 
 #if !defined(QL_USE_STD_SHARED_PTR) && BOOST_VERSION < 107400
@@ -99,7 +98,7 @@ namespace QuantLib {
       private:
         ObservableSettings() = default;
 
-        typedef std::unordered_set<Observer*> set_type;
+        typedef std::set<Observer*> set_type;
         typedef set_type::iterator iterator;
 
         void registerDeferredObservers(const Observable::set_type& observers);
@@ -114,7 +113,7 @@ namespace QuantLib {
     /*! \ingroup patterns */
     class Observer { // NOLINT(cppcoreguidelines-special-member-functions)
       private:
-        typedef std::unordered_set<ext::shared_ptr<Observable>> set_type;
+        typedef std::set<ext::shared_ptr<Observable>> set_type;
       public:
         typedef set_type::iterator iterator;
 
@@ -289,7 +288,7 @@ namespace QuantLib {
         friend class Observable;
         friend class ObservableSettings;
       private:
-        typedef std::unordered_set<ext::shared_ptr<Observable>> set_type;
+        typedef std::set<ext::shared_ptr<Observable>> set_type;
       public:
         typedef set_type::iterator iterator;
 
@@ -390,7 +389,7 @@ namespace QuantLib {
         friend class Observer;
         friend class ObservableSettings;
       private:
-        typedef std::unordered_set<ext::shared_ptr<Observer::Proxy>> set_type;
+        typedef std::set<ext::shared_ptr<Observer::Proxy>> set_type;
       public:
         typedef set_type::iterator iterator;
 


### PR DESCRIPTION
addresses #1743 