### PR TITLE
remove reference to observable settings

### DIFF
--- a/ql/patterns/observable.cpp
+++ b/ql/patterns/observable.cpp
@@ -54,10 +54,10 @@ namespace QuantLib {
 
 
     void Observable::notifyObservers() {
-        if (!settings_.updatesEnabled()) {
+        if (!ObservableSettings::instance().updatesEnabled()) {
             // if updates are only deferred, flag this for later notification
             // these are held centrally by the settings singleton
-            settings_.registerDeferredObservers(observers_);
+            ObservableSettings::instance().registerDeferredObservers(observers_);
         } else if (!observers_.empty()) {
             bool successful = true;
             std::string errMsg;
@@ -159,10 +159,10 @@ namespace QuantLib {
             observers_.erase(observerProxy);
         }
 
-        if (settings_.updatesDeferred()) {
-            std::lock_guard<std::mutex> sLock(settings_.mutex_);
-            if (settings_.updatesDeferred()) {
-                settings_.unregisterDeferredObserver(observerProxy);
+        if (ObservableSettings::instance().updatesDeferred()) {
+            std::lock_guard<std::mutex> sLock(ObservableSettings::instance().mutex_);
+            if (ObservableSettings::instance().updatesDeferred()) {
+                ObservableSettings::instance().unregisterDeferredObserver(observerProxy);
             }
         }
 
@@ -172,29 +172,27 @@ namespace QuantLib {
     }
 
     void Observable::notifyObservers() {
-        if (settings_.updatesEnabled()) {
+        if (ObservableSettings::instance().updatesEnabled()) {
             return (*sig_)();
         }
 
-        std::lock_guard<std::mutex> sLock(settings_.mutex_);
-        if (settings_.updatesEnabled()) {
+        std::lock_guard<std::mutex> sLock(ObservableSettings::instance().mutex_);
+        if (ObservableSettings::instance().updatesEnabled()) {
             return (*sig_)();
         }
-        else if (settings_.updatesDeferred()) {
+        else if (ObservableSettings::instance().updatesDeferred()) {
             std::lock_guard<std::recursive_mutex> lock(mutex_);
             // if updates are only deferred, flag this for later notification
             // these are held centrally by the settings singleton
-            settings_.registerDeferredObservers(observers_);
+            ObservableSettings::instance().registerDeferredObservers(observers_);
         }
     }
 
     Observable::Observable()
-    : sig_(new detail::Signal()),
-      settings_(ObservableSettings::instance()) { }
+    : sig_(new detail::Signal()) { }
 
     Observable::Observable(const Observable&)
-    : sig_(new detail::Signal()),
-      settings_(ObservableSettings::instance()) {
+    : sig_(new detail::Signal()) {
         // the observer set is not copied; no observer asked to
         // register with this object
     }

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -79,7 +79,6 @@ namespace QuantLib {
         std::pair<iterator, bool> registerObserver(Observer*);
         Size unregisterObserver(Observer*);
         set_type observers_;
-        ObservableSettings& settings_;
     };
 
     //! global repository for run-time library settings
@@ -167,7 +166,7 @@ namespace QuantLib {
 
     // inline definitions
 
-    inline Observable::Observable() : settings_(ObservableSettings::instance()) {}
+    inline Observable::Observable() {}
 
     inline void ObservableSettings::registerDeferredObservers(const Observable::set_type& observers) {
         if (updatesDeferred()) {
@@ -179,8 +178,7 @@ namespace QuantLib {
         deferredObservers_.erase(o);
     }
 
-    inline Observable::Observable(const Observable&)
-    : settings_(ObservableSettings::instance()) {
+    inline Observable::Observable(const Observable&) {
         // the observer set is not copied; no observer asked to
         // register with this object
     }
@@ -207,8 +205,8 @@ namespace QuantLib {
     }
 
     inline Size Observable::unregisterObserver(Observer* o) {
-        if (settings_.updatesDeferred())
-            settings_.unregisterDeferredObserver(o);
+        if (ObservableSettings::instance().updatesDeferred())
+            ObservableSettings::instance().unregisterDeferredObserver(o);
 
         return observers_.erase(o);
     }
@@ -411,7 +409,6 @@ namespace QuantLib {
         ext::shared_ptr<detail::Signal> sig_;
         set_type observers_;
         mutable std::recursive_mutex mutex_;
-        ObservableSettings& settings_;
     };
 
     //! global repository for run-time library settings


### PR DESCRIPTION
Background: when we instantiate an `Observable` in a child-thread of the main thread and the child-thread is terminated but the observable instance happens to be still alive, this causes a segfault because the reference to the child-thread's `ObservableSettings` is dangling now.

After the change the observable instance would always use the observable settings of the thread in which it is currently operated on. We should be aware that this potentially changes the behaviour of observables when different threads have different observable settings and the observable is operated on in the different threads. 

My main intend here is to avoid undefined behaviour in situations as described above.  If someone really depends on the current behaviour, this change might break their code. I think this is unlikely though.

I tested a potential performance impact by running the test case #1730. I don't see a different running time. I wouldn't expect this in any case because of the updated singleton implementation where `instance()` just returns a static local variable.

On the positive side, we avoid to store a reference per observable in a member variable.