### PR TITLE
Pre-calculate the `FixedRateCoupon::amount()`

### DIFF
--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -38,9 +38,14 @@ namespace QuantLib {
                                      const Date& refPeriodStart,
                                      const Date& refPeriodEnd,
                                      const Date& exCouponDate)
-    : Coupon(paymentDate, nominal, accrualStartDate, accrualEndDate,
-             refPeriodStart, refPeriodEnd, exCouponDate),
-      rate_(InterestRate(rate, dayCounter, Simple, Annual)) {}
+    : FixedRateCoupon(paymentDate,
+                      nominal,
+                      InterestRate(rate, dayCounter, Simple, Annual),
+                      accrualStartDate,
+                      accrualEndDate,
+                      refPeriodStart,
+                      refPeriodEnd,
+                      exCouponDate) {}
 
     FixedRateCoupon::FixedRateCoupon(const Date& paymentDate,
                                      Real nominal,
@@ -57,17 +62,10 @@ namespace QuantLib {
              refPeriodStart,
              refPeriodEnd,
              exCouponDate),
-      rate_(std::move(interestRate)) {}
-
-    Real FixedRateCoupon::amount() const {
-        calculate();
-        return amount_;
-    }
-
-    void FixedRateCoupon::performCalculations() const {
-        amount_ = nominal() * (rate_.compoundFactor(accrualStartDate_, accrualEndDate_,
-                                                    refPeriodStart_, refPeriodEnd_) -
-                               1.0);
+      rate_(std::move(interestRate)) {
+        amount_ = Coupon::nominal() * (rate_.compoundFactor(accrualStartDate_, accrualEndDate_,
+                                                            refPeriodStart_, refPeriodEnd_) -
+                                       1.0);
     }
 
     Real FixedRateCoupon::accruedAmount(const Date& d) const {

--- a/ql/cashflows/fixedratecoupon.hpp
+++ b/ql/cashflows/fixedratecoupon.hpp
@@ -60,13 +60,9 @@ namespace QuantLib {
                         const Date& refPeriodEnd = Date(),
                         const Date& exCouponDate = Date());
         //@}
-        //! \name LazyObject interface
-        //@{
-        void performCalculations() const override;
-        //@}
         //! \name CashFlow interface
         //@{
-        Real amount() const override;
+        Real amount() const override { return amount_; }
         //@}
         //! \name Coupon interface
         //@{
@@ -81,7 +77,7 @@ namespace QuantLib {
         //@}
       private:
         InterestRate rate_;
-        mutable Real amount_;
+        Real amount_;
     };
 
 


### PR DESCRIPTION
We can calculate the `FixedRateCoupon::amount()` in the constructor as it will never change.

Therefore, we can skip calling `virtual void LazyObject::calculate() const` each time the amount is requested. That the `amount()` is never requested is very unlikely (probably only when the `FixedRateCoupon` is already expired) so this might slightly improve performance.