### PR TITLE
Modernize Examples

### DIFF
--- a/Examples/BasketLosses/BasketLosses.cpp
+++ b/Examples/BasketLosses/BasketLosses.cpp
@@ -63,7 +63,7 @@ int main(int, char* []) {
         std::vector<std::string> names;
         for(Size i=0; i<hazardRates.size(); i++)
             names.push_back(std::string("Acme") + std::to_string(i));
-        std::vector<Handle<DefaultProbabilityTermStructure> > defTS;
+        std::vector<Handle<DefaultProbabilityTermStructure>> defTS;
         for (Real& hazardRate : hazardRates) {
             defTS.emplace_back(
                 ext::make_shared<FlatHazardRate>(0, TARGET(), hazardRate, Actual365Fixed()));
@@ -79,14 +79,14 @@ int main(int, char* []) {
             issuers.emplace_back(curves);
         }
 
-        ext::shared_ptr<Pool> thePool = ext::make_shared<Pool>();
+        auto thePool = ext::make_shared<Pool>();
         for(Size i=0; i<hazardRates.size(); i++)
             thePool->add(names[i], issuers[i], NorthAmericaCorpDefaultKey(
                     EURCurrency(), QuantLib::SeniorSec, Period(), 1.));
 
         std::vector<DefaultProbKey> defaultKeys(hazardRates.size(), 
             NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
-        ext::shared_ptr<Basket> theBskt = ext::make_shared<Basket>(
+        auto theBskt = ext::make_shared<Basket>(
             todaysDate, 
             names, std::vector<Real>(hazardRates.size(), 100.), thePool,
          //   0.0, 0.78);
@@ -98,29 +98,26 @@ int main(int, char* []) {
 
         std::vector<Real> recoveries(hazardRates.size(), 0.4);
 
-        Date calcDate(TARGET().advance(Settings::instance().evaluationDate(), 
+        Date calcDate(TARGET().advance(Settings::instance().evaluationDate(),
             Period(60, Months)));
         Real factorValue = 0.05;
-        std::vector<std::vector<Real> > fctrsWeights(hazardRates.size(), 
+        std::vector<std::vector<Real>> fctrsWeights(hazardRates.size(),
             std::vector<Real>(1, std::sqrt(factorValue)));
 
         // --- LHP model --------------------------
         #ifndef QL_PATCH_SOLARIS
-        ext::shared_ptr<DefaultLossModel> lmGLHP(
-            ext::make_shared<GaussianLHPLossModel>(
-                fctrsWeights[0][0] * fctrsWeights[0][0], recoveries));
+        auto lmGLHP = ext::make_shared<GaussianLHPLossModel>(
+                fctrsWeights[0][0] * fctrsWeights[0][0], recoveries);
         theBskt->setLossModel(lmGLHP);
 
         std::cout << "GLHP Expected 10-Yr Losses: "  << std::endl;
         std::cout << theBskt->expectedTrancheLoss(calcDate) << std::endl;
 
         // --- G Binomial model --------------------
-        ext::shared_ptr<GaussianConstantLossLM> ktLossLM(
-            ext::make_shared<GaussianConstantLossLM>(fctrsWeights, 
-            recoveries, LatentModelIntegrationType::GaussianQuadrature, 
-            GaussianCopulaPolicy::initTraits()));
-        ext::shared_ptr<DefaultLossModel> lmBinomial(
-            ext::make_shared<GaussianBinomialLossModel>(ktLossLM));
+        auto ktLossLM = ext::make_shared<GaussianConstantLossLM>(fctrsWeights,
+            recoveries, LatentModelIntegrationType::GaussianQuadrature,
+            GaussianCopulaPolicy::initTraits());
+        auto lmBinomial = ext::make_shared<GaussianBinomialLossModel>(ktLossLM);
         theBskt->setLossModel(lmBinomial);
 
         std::cout << "Gaussian Binomial Expected 10-Yr Losses: "  << std::endl;
@@ -131,14 +128,12 @@ int main(int, char* []) {
         // --- T Binomial model --------------------
         TCopulaPolicy::initTraits initT;
         initT.tOrders = std::vector<Integer>(2, 3);
-        ext::shared_ptr<TConstantLossLM> ktTLossLM(
-            ext::make_shared<TConstantLossLM>(fctrsWeights, 
+        auto ktTLossLM = ext::make_shared<TConstantLossLM>(fctrsWeights,
             recoveries, 
             //LatentModelIntegrationType::GaussianQuadrature,
               LatentModelIntegrationType::Trapezoid,
-            initT));
-        ext::shared_ptr<DefaultLossModel> lmTBinomial(
-            ext::make_shared<TBinomialLossModel>(ktTLossLM));
+            initT);
+        auto lmTBinomial = ext::make_shared<TBinomialLossModel>(ktTLossLM);
         theBskt->setLossModel(lmTBinomial);
 
         std::cout << "T Binomial Expected 10-Yr Losses: "  << std::endl;
@@ -147,16 +142,14 @@ int main(int, char* []) {
         // --- G Inhomogeneous model ---------------
         Size numSimulations = 100000;
         #ifndef QL_PATCH_SOLARIS
-        ext::shared_ptr<GaussianConstantLossLM> gLM(
-            ext::make_shared<GaussianConstantLossLM>(fctrsWeights, 
+        auto gLM = ext::make_shared<GaussianConstantLossLM>(fctrsWeights,
             recoveries,
             LatentModelIntegrationType::GaussianQuadrature,
             // g++ requires this when using make_shared
-            GaussianCopulaPolicy::initTraits()));
+            GaussianCopulaPolicy::initTraits());
 
         Size numBuckets = 100;
-        ext::shared_ptr<DefaultLossModel> inhomogeneousLM(
-            ext::make_shared<IHGaussPoolLossModel>(gLM, numBuckets));
+        auto inhomogeneousLM = ext::make_shared<IHGaussPoolLossModel>(gLM, numBuckets);
         theBskt->setLossModel(inhomogeneousLM);
 
         std::cout << "G Inhomogeneous Expected 10-Yr Losses: "  << std::endl;
@@ -166,14 +159,12 @@ int main(int, char* []) {
         // Gaussian random joint default model:
         // Size numCoresUsed = 4;
         // Sobol, many cores
-        ext::shared_ptr<DefaultLossModel> rdlmG(
-            ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy, 
+        auto rdlmG = ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy,
             RandomSequenceGenerator<
-                BoxMullerGaussianRng<MersenneTwisterUniformRng> > > >(gLM, 
-                    recoveries, numSimulations, 1.e-6, 2863311530UL));
-        //ext::shared_ptr<DefaultLossModel> rdlmG(
-        //    ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy> >(gLM, 
-        //        recoveries, numSimulations, 1.e-6, 2863311530));
+                BoxMullerGaussianRng<MersenneTwisterUniformRng>>>>(gLM,
+                    recoveries, numSimulations, 1.e-6, 2863311530UL);
+        //auto rdlmG = ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy>>(gLM,
+        //        recoveries, numSimulations, 1.e-6, 2863311530);
         theBskt->setLossModel(rdlmG);
 
         std::cout << "Random G Expected 10-Yr Losses: "  << std::endl;
@@ -182,14 +173,12 @@ int main(int, char* []) {
 
         // --- StudentT Random model ---------------------
         // Sobol, many cores
-        ext::shared_ptr<DefaultLossModel> rdlmT(
-            ext::make_shared<RandomDefaultLM<TCopulaPolicy, 
+        auto rdlmT = ext::make_shared<RandomDefaultLM<TCopulaPolicy,
             RandomSequenceGenerator<
-                PolarStudentTRng<MersenneTwisterUniformRng> > > >(ktTLossLM, 
-                    recoveries, numSimulations, 1.e-6, 2863311530UL));
-        //ext::shared_ptr<DefaultLossModel> rdlmT(
-        //    ext::make_shared<RandomDefaultLM<TCopulaPolicy> >(ktTLossLM, 
-        //        recoveries, numSimulations, 1.e-6, 2863311530));
+                PolarStudentTRng<MersenneTwisterUniformRng>>>>(ktTLossLM,
+                    recoveries, numSimulations, 1.e-6, 2863311530UL);
+        //auto rdlmT = ext::make_shared<RandomDefaultLM<TCopulaPolicy>>(ktTLossLM,
+        //        recoveries, numSimulations, 1.e-6, 2863311530);
         theBskt->setLossModel(rdlmT);
 
         std::cout << "Random T Expected 10-Yr Losses: "  << std::endl;
@@ -198,24 +187,23 @@ int main(int, char* []) {
 
         // Spot Loss latent model: 
         #ifndef QL_PATCH_SOLARIS
-        std::vector<std::vector<Real> > fctrsWeightsRR(2 * hazardRates.size(), 
+        std::vector<std::vector<Real>> fctrsWeightsRR(2 * hazardRates.size(),
             std::vector<Real>(1, std::sqrt(factorValue)));
         Real modelA = 2.2;
-        ext::shared_ptr<GaussianSpotLossLM> sptLG(new GaussianSpotLossLM(
+        auto sptLG = ext::make_shared<GaussianSpotLossLM>(
             fctrsWeightsRR, recoveries, modelA,
             LatentModelIntegrationType::GaussianQuadrature,
-            GaussianCopulaPolicy::initTraits()));
-        ext::shared_ptr<TSpotLossLM> sptLT(new TSpotLossLM(fctrsWeightsRR, 
+            GaussianCopulaPolicy::initTraits());
+        auto sptLT = ext::make_shared<TSpotLossLM>(fctrsWeightsRR,
             recoveries, modelA,
-            LatentModelIntegrationType::GaussianQuadrature, initT));
+            LatentModelIntegrationType::GaussianQuadrature, initT);
 
 
         // --- G Random Loss model ---------------------
         // Gaussian random joint default model:
         // Sobol, many cores
-        ext::shared_ptr<DefaultLossModel> rdLlmG(
-            ext::make_shared<RandomLossLM<GaussianCopulaPolicy> >(sptLG, 
-                numSimulations, 1.e-6, 2863311530UL));
+        auto rdLlmG = ext::make_shared<RandomLossLM<GaussianCopulaPolicy>>(sptLG,
+                numSimulations, 1.e-6, 2863311530UL);
         theBskt->setLossModel(rdLlmG);
 
         std::cout << "Random Loss G Expected 10-Yr Losses: "  << std::endl;
@@ -224,9 +212,8 @@ int main(int, char* []) {
         // --- T Random Loss model ---------------------
         // Gaussian random joint default model:
         // Sobol, many cores
-        ext::shared_ptr<DefaultLossModel> rdLlmT(
-            ext::make_shared<RandomLossLM<TCopulaPolicy> >(sptLT, 
-                numSimulations, 1.e-6, 2863311530UL));
+        auto rdLlmT = ext::make_shared<RandomLossLM<TCopulaPolicy>>(sptLT,
+                numSimulations, 1.e-6, 2863311530UL);
         theBskt->setLossModel(rdLlmT);
 
         std::cout << "Random Loss T Expected 10-Yr Losses: "  << std::endl;
@@ -239,27 +226,25 @@ int main(int, char* []) {
         std::vector<Real> bcLossPercentages;
         bcLossPercentages.push_back(0.03);
         bcLossPercentages.push_back(0.12);
-        std::vector<std::vector<Handle<Quote> > > correls;
+        std::vector<std::vector<Handle<Quote>>> correls;
         // 
-        std::vector<Handle<Quote> > corr1Y;
+        std::vector<Handle<Quote>> corr1Y;
         // 3%
         corr1Y.emplace_back(
-            ext::shared_ptr<Quote>(new SimpleQuote(fctrsWeights[0][0] * fctrsWeights[0][0])));
+            ext::make_shared<SimpleQuote>(fctrsWeights[0][0] * fctrsWeights[0][0]));
         // 12%
         corr1Y.emplace_back(
-            ext::shared_ptr<Quote>(new SimpleQuote(fctrsWeights[0][0] * fctrsWeights[0][0])));
+            ext::make_shared<SimpleQuote>(fctrsWeights[0][0] * fctrsWeights[0][0]));
         correls.push_back(corr1Y);
-        std::vector<Handle<Quote> > corr2Y;
+        std::vector<Handle<Quote>> corr2Y;
         // 3%
         corr2Y.emplace_back(
-            ext::shared_ptr<Quote>(new SimpleQuote(fctrsWeights[0][0] * fctrsWeights[0][0])));
+            ext::make_shared<SimpleQuote>(fctrsWeights[0][0] * fctrsWeights[0][0]));
         // 12%
         corr2Y.emplace_back(
-            ext::shared_ptr<Quote>(new SimpleQuote(fctrsWeights[0][0] * fctrsWeights[0][0])));
+            ext::make_shared<SimpleQuote>(fctrsWeights[0][0] * fctrsWeights[0][0]));
         correls.push_back(corr2Y);
-        ext::shared_ptr<BaseCorrelationTermStructure<BilinearInterpolation> > 
-          correlSurface(
-            new BaseCorrelationTermStructure<BilinearInterpolation>(
+        auto correlSurface = ext::make_shared<BaseCorrelationTermStructure<BilinearInterpolation>>(
                 // first one would do, all should be the same.
                 defTS[0]->settlementDays(),
                 defTS[0]->calendar(),
@@ -267,14 +252,10 @@ int main(int, char* []) {
                 bcTenors,
                 bcLossPercentages,
                 correls,
-                Actual365Fixed()
-            )
-        );
-        Handle<BaseCorrelationTermStructure<BilinearInterpolation> > 
-            correlHandle(correlSurface);
-        ext::shared_ptr<DefaultLossModel> bcLMG_LHP_Bilin(
-            ext::make_shared<GaussianLHPFlatBCLM>(correlHandle, recoveries,
-                GaussianCopulaPolicy::initTraits()));
+                Actual365Fixed());
+        Handle<BaseCorrelationTermStructure<BilinearInterpolation>> correlHandle(correlSurface);
+        auto bcLMG_LHP_Bilin = ext::make_shared<GaussianLHPFlatBCLM>(correlHandle, recoveries,
+                GaussianCopulaPolicy::initTraits());
 
         theBskt->setLossModel(bcLMG_LHP_Bilin);
 

--- a/Examples/BasketLosses/BasketLosses.cpp
+++ b/Examples/BasketLosses/BasketLosses.cpp
@@ -220,12 +220,8 @@ int main(int, char* []) {
         std::cout << theBskt->expectedTrancheLoss(calcDate) << std::endl;
 
         // Base Correlation model set up to test coherence with base LHP model
-        std::vector<Period> bcTenors;
-        bcTenors.emplace_back(1, Years);
-        bcTenors.emplace_back(5, Years);
-        std::vector<Real> bcLossPercentages;
-        bcLossPercentages.push_back(0.03);
-        bcLossPercentages.push_back(0.12);
+        std::vector<Period> bcTenors = {{1, Years}, {5, Years}};
+        std::vector<Real> bcLossPercentages = {0.03, 0.12};
         std::vector<std::vector<Handle<Quote>>> correls;
         // 
         std::vector<Handle<Quote>> corr1Y;

--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -94,27 +94,27 @@ int main(int, char* []) {
          Rate zc6mQuote=0.0145;
          Rate zc1yQuote=0.0194;
 
-         ext::shared_ptr<Quote> zc3mRate(new SimpleQuote(zc3mQuote));
-         ext::shared_ptr<Quote> zc6mRate(new SimpleQuote(zc6mQuote));
-         ext::shared_ptr<Quote> zc1yRate(new SimpleQuote(zc1yQuote));
+         auto zc3mRate = ext::make_shared<SimpleQuote>(zc3mQuote);
+         auto zc6mRate = ext::make_shared<SimpleQuote>(zc6mQuote);
+         auto zc1yRate = ext::make_shared<SimpleQuote>(zc1yQuote);
 
          DayCounter zcBondsDayCounter = Actual365Fixed();
 
-         ext::shared_ptr<RateHelper> zc3m(new DepositRateHelper(
+         auto zc3m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(zc3mRate),
                  3*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, zcBondsDayCounter));
-         ext::shared_ptr<RateHelper> zc6m(new DepositRateHelper(
+                 true, zcBondsDayCounter);
+         auto zc6m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(zc6mRate),
                  6*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, zcBondsDayCounter));
-         ext::shared_ptr<RateHelper> zc1y(new DepositRateHelper(
+                 true, zcBondsDayCounter);
+         auto zc1y = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(zc1yRate),
                  1*Years, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, zcBondsDayCounter));
+                 true, zcBondsDayCounter);
 
         // setup bonds
         Real redemption = 100.0;
@@ -153,10 +153,9 @@ int main(int, char* []) {
                 102.140625
         };
 
-        std::vector< ext::shared_ptr<SimpleQuote> > quote;
+        std::vector<ext::shared_ptr<SimpleQuote>> quote;
         for (Real marketQuote : marketQuotes) {
-            ext::shared_ptr<SimpleQuote> cp(new SimpleQuote(marketQuote));
-            quote.push_back(cp);
+            quote.push_back(ext::make_shared<SimpleQuote>(marketQuote));
         }
 
         RelinkableHandle<Quote> quoteHandle[numberOfBonds];
@@ -165,14 +164,14 @@ int main(int, char* []) {
         }
 
         // Definition of the rate helpers
-        std::vector<ext::shared_ptr<BondHelper> > bondsHelpers;
+        std::vector<ext::shared_ptr<BondHelper>> bondsHelpers;
 
         for (Size i=0; i<numberOfBonds; i++) {
 
             Schedule schedule(issueDates[i], maturities[i], Period(Semiannual), UnitedStates(UnitedStates::GovernmentBond),
                     Unadjusted, Unadjusted, DateGeneration::Backward, false);
 
-            ext::shared_ptr<FixedRateBondHelper> bondHelper(new FixedRateBondHelper(
+            auto bondHelper = ext::make_shared<FixedRateBondHelper>(
                     quoteHandle[i],
                     settlementDays,
                     100.0,
@@ -181,13 +180,12 @@ int main(int, char* []) {
                     ActualActual(ActualActual::Bond),
                     Unadjusted,
                     redemption,
-                    issueDates[i]));
+                    issueDates[i]);
 
             // the above could also be done by creating a
             // FixedRateBond instance and writing:
             //
-            // ext::shared_ptr<BondHelper> bondHelper(
-            //         new BondHelper(quoteHandle[i], bond));
+            // auto bondHelper = ext::make_shared<BondHelper>(quoteHandle[i], bond);
             //
             // This would also work for bonds that still don't have a
             // specialized helper, such as floating-rate bonds.
@@ -206,7 +204,7 @@ int main(int, char* []) {
              ActualActual(ActualActual::ISDA);
 
          // A depo-bond curve
-         std::vector<ext::shared_ptr<RateHelper> > bondInstruments;
+         std::vector<ext::shared_ptr<RateHelper>> bondInstruments;
 
          // Adding the ZC bonds to the curve for the short end
          bondInstruments.push_back(zc3m);
@@ -218,10 +216,8 @@ int main(int, char* []) {
              bondInstruments.push_back(bondsHelpers[i]);
          }
 
-         ext::shared_ptr<YieldTermStructure> bondDiscountingTermStructure(
-                 new PiecewiseYieldCurve<Discount,LogLinear>(
-                         settlementDate, bondInstruments,
-                         termStructureDayCounter));
+         auto bondDiscountingTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount,LogLinear>>(
+                         settlementDate, bondInstruments, termStructureDayCounter);
 
          // Building of the Libor forecasting curve
          // deposits
@@ -248,18 +244,18 @@ int main(int, char* []) {
          // or some kind of data feed.
 
          // deposits
-         ext::shared_ptr<Quote> d1wRate(new SimpleQuote(d1wQuote));
-         ext::shared_ptr<Quote> d1mRate(new SimpleQuote(d1mQuote));
-         ext::shared_ptr<Quote> d3mRate(new SimpleQuote(d3mQuote));
-         ext::shared_ptr<Quote> d6mRate(new SimpleQuote(d6mQuote));
-         ext::shared_ptr<Quote> d9mRate(new SimpleQuote(d9mQuote));
-         ext::shared_ptr<Quote> d1yRate(new SimpleQuote(d1yQuote));
+         auto d1wRate = ext::make_shared<SimpleQuote>(d1wQuote);
+         auto d1mRate = ext::make_shared<SimpleQuote>(d1mQuote);
+         auto d3mRate = ext::make_shared<SimpleQuote>(d3mQuote);
+         auto d6mRate = ext::make_shared<SimpleQuote>(d6mQuote);
+         auto d9mRate = ext::make_shared<SimpleQuote>(d9mQuote);
+         auto d1yRate = ext::make_shared<SimpleQuote>(d1yQuote);
          // swaps
-         ext::shared_ptr<Quote> s2yRate(new SimpleQuote(s2yQuote));
-         ext::shared_ptr<Quote> s3yRate(new SimpleQuote(s3yQuote));
-         ext::shared_ptr<Quote> s5yRate(new SimpleQuote(s5yQuote));
-         ext::shared_ptr<Quote> s10yRate(new SimpleQuote(s10yQuote));
-         ext::shared_ptr<Quote> s15yRate(new SimpleQuote(s15yQuote));
+         auto s2yRate = ext::make_shared<SimpleQuote>(s2yQuote);
+         auto s3yRate = ext::make_shared<SimpleQuote>(s3yQuote);
+         auto s5yRate = ext::make_shared<SimpleQuote>(s5yQuote);
+         auto s10yRate = ext::make_shared<SimpleQuote>(s10yQuote);
+         auto s15yRate = ext::make_shared<SimpleQuote>(s15yQuote);
 
          /*********************
           ***  RATE HELPERS ***
@@ -273,70 +269,70 @@ int main(int, char* []) {
          // deposits
          DayCounter depositDayCounter = Actual360();
 
-         ext::shared_ptr<RateHelper> d1w(new DepositRateHelper(
+         auto d1w = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d1wRate),
                  1*Weeks, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
-         ext::shared_ptr<RateHelper> d1m(new DepositRateHelper(
+                 true, depositDayCounter);
+         auto d1m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d1mRate),
                  1*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
-         ext::shared_ptr<RateHelper> d3m(new DepositRateHelper(
+                 true, depositDayCounter);
+         auto d3m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d3mRate),
                  3*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
-         ext::shared_ptr<RateHelper> d6m(new DepositRateHelper(
+                 true, depositDayCounter);
+         auto d6m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d6mRate),
                  6*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
-         ext::shared_ptr<RateHelper> d9m(new DepositRateHelper(
+                 true, depositDayCounter);
+         auto d9m = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d9mRate),
                  9*Months, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
-         ext::shared_ptr<RateHelper> d1y(new DepositRateHelper(
+                 true, depositDayCounter);
+         auto d1y = ext::make_shared<DepositRateHelper>(
                  Handle<Quote>(d1yRate),
                  1*Years, fixingDays,
                  calendar, ModifiedFollowing,
-                 true, depositDayCounter));
+                 true, depositDayCounter);
 
          // setup swaps
-         Frequency swFixedLegFrequency = Annual;
-         BusinessDayConvention swFixedLegConvention = Unadjusted;
-         DayCounter swFixedLegDayCounter = Thirty360(Thirty360::European);
-         ext::shared_ptr<IborIndex> swFloatingLegIndex(new Euribor6M);
+         auto swFixedLegFrequency = Annual;
+         auto swFixedLegConvention = Unadjusted;
+         auto swFixedLegDayCounter = Thirty360(Thirty360::European);
+         auto swFloatingLegIndex = ext::make_shared<Euribor6M>();
 
          const Period forwardStart(1*Days);
 
-         ext::shared_ptr<RateHelper> s2y(new SwapRateHelper(
+         auto s2y = ext::make_shared<SwapRateHelper>(
                  Handle<Quote>(s2yRate), 2*Years,
                  calendar, swFixedLegFrequency,
                  swFixedLegConvention, swFixedLegDayCounter,
-                 swFloatingLegIndex, Handle<Quote>(),forwardStart));
-         ext::shared_ptr<RateHelper> s3y(new SwapRateHelper(
+                 swFloatingLegIndex, Handle<Quote>(), forwardStart);
+         auto s3y = ext::make_shared<SwapRateHelper>(
                  Handle<Quote>(s3yRate), 3*Years,
                  calendar, swFixedLegFrequency,
                  swFixedLegConvention, swFixedLegDayCounter,
-                 swFloatingLegIndex, Handle<Quote>(),forwardStart));
-         ext::shared_ptr<RateHelper> s5y(new SwapRateHelper(
+                 swFloatingLegIndex, Handle<Quote>(), forwardStart);
+         auto s5y = ext::make_shared<SwapRateHelper>(
                  Handle<Quote>(s5yRate), 5*Years,
                  calendar, swFixedLegFrequency,
                  swFixedLegConvention, swFixedLegDayCounter,
-                 swFloatingLegIndex, Handle<Quote>(),forwardStart));
-         ext::shared_ptr<RateHelper> s10y(new SwapRateHelper(
+                 swFloatingLegIndex, Handle<Quote>(), forwardStart);
+         auto s10y = ext::make_shared<SwapRateHelper>(
                  Handle<Quote>(s10yRate), 10*Years,
                  calendar, swFixedLegFrequency,
                  swFixedLegConvention, swFixedLegDayCounter,
-                 swFloatingLegIndex, Handle<Quote>(),forwardStart));
-         ext::shared_ptr<RateHelper> s15y(new SwapRateHelper(
+                 swFloatingLegIndex, Handle<Quote>(), forwardStart);
+         auto s15y = ext::make_shared<SwapRateHelper>(
                  Handle<Quote>(s15yRate), 15*Years,
                  calendar, swFixedLegFrequency,
                  swFixedLegConvention, swFixedLegDayCounter,
-                 swFloatingLegIndex, Handle<Quote>(),forwardStart));
+                 swFloatingLegIndex, Handle<Quote>(), forwardStart);
 
 
          /*********************
@@ -347,7 +343,7 @@ int main(int, char* []) {
          // ActualActual::ISDA ensures that 30 years is 30.0
 
          // A depo-swap curve
-         std::vector<ext::shared_ptr<RateHelper> > depoSwapInstruments;
+         std::vector<ext::shared_ptr<RateHelper>> depoSwapInstruments;
          depoSwapInstruments.push_back(d1w);
          depoSwapInstruments.push_back(d1m);
          depoSwapInstruments.push_back(d3m);
@@ -359,10 +355,9 @@ int main(int, char* []) {
          depoSwapInstruments.push_back(s5y);
          depoSwapInstruments.push_back(s10y);
          depoSwapInstruments.push_back(s15y);
-         ext::shared_ptr<YieldTermStructure> depoSwapTermStructure(
-                 new PiecewiseYieldCurve<Discount,LogLinear>(
+         auto depoSwapTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(
                          settlementDate, depoSwapInstruments,
-                         termStructureDayCounter));
+                         termStructureDayCounter);
 
          // Term structures that will be used for pricing:
          // the one used for discounting cash flows
@@ -378,8 +373,7 @@ int main(int, char* []) {
          Real faceAmount = 100;
 
          // Pricing engine
-         ext::shared_ptr<PricingEngine> bondEngine(
-                 new DiscountingBondEngine(discountingTermStructure));
+         auto bondEngine = ext::make_shared<DiscountingBondEngine>(discountingTermStructure);
 
          // Zero coupon bond
          ZeroCouponBond zeroCouponBond(
@@ -414,8 +408,7 @@ int main(int, char* []) {
          // Should and will be priced on another curve later...
 
          RelinkableHandle<YieldTermStructure> liborTermStructure;
-         const ext::shared_ptr<IborIndex> libor3m(
-                 new USDLibor(Period(3,Months),liborTermStructure));
+         const auto libor3m = ext::make_shared<USDLibor>(Period(3, Months), liborTermStructure);
          libor3m->addFixing(Date(17, July, 2008),0.0278625);
 
          Schedule floatingBondSchedule(Date(21, October, 2005),
@@ -453,13 +446,12 @@ int main(int, char* []) {
          Volatility volatility = 0.0;
          Handle<OptionletVolatilityStructure> vol;
          vol = Handle<OptionletVolatilityStructure>(
-                 ext::shared_ptr<OptionletVolatilityStructure>(new
-                         ConstantOptionletVolatility(
+                 ext::make_shared<ConstantOptionletVolatility>(
                                  settlementDays,
                                  calendar,
                                  ModifiedFollowing,
                                  volatility,
-                                 Actual365Fixed())));
+                                 Actual365Fixed()));
 
          pricer->setCapletVolatility(vol);
          setCouponPricer(floatingRateBond.cashflows(),pricer);

--- a/Examples/CDS/CDS.cpp
+++ b/Examples/CDS/CDS.cpp
@@ -65,7 +65,7 @@ void example01() {
     Settings::instance().evaluationDate() = todaysDate;
 
     // dummy curve
-    ext::shared_ptr<Quote> flatRate(new SimpleQuote(0.01));
+    auto flatRate = ext::make_shared<SimpleQuote>(0.01);
     Handle<YieldTermStructure> tsCurve(
         ext::make_shared<FlatForward>(
             todaysDate, Handle<Quote>(flatRate), Actual365Fixed()));
@@ -95,21 +95,19 @@ void example01() {
             calendar.adjust(settlementDate + tenors[i], Following));
     }
 
-    std::vector<ext::shared_ptr<DefaultProbabilityHelper> > instruments;
+    std::vector<ext::shared_ptr<DefaultProbabilityHelper>> instruments;
     for (Size i = 0; i < 4; i++) {
-        instruments.push_back(ext::shared_ptr<DefaultProbabilityHelper>(
-            new SpreadCdsHelper(Handle<Quote>(ext::shared_ptr<Quote>(
-                                    new SimpleQuote(quoted_spreads[i]))),
+        instruments.push_back(ext::make_shared<SpreadCdsHelper>(
+                                Handle<Quote>(ext::make_shared<SimpleQuote>(quoted_spreads[i])),
                                 tenors[i], settlementDays, calendar, Quarterly, Following,
                                 DateGeneration::TwentiethIMM, Actual365Fixed(),
-                                recovery_rate, tsCurve)));
+                                recovery_rate, tsCurve));
     }
 
     // Bootstrap hazard rates
-    ext::shared_ptr<PiecewiseDefaultCurve<HazardRate, BackwardFlat> >
-    hazardRateStructure(new PiecewiseDefaultCurve<HazardRate, BackwardFlat>(
-        todaysDate, instruments, Actual365Fixed()));
-    vector<pair<Date, Real> > hr_curve_data = hazardRateStructure->nodes();
+    auto hazardRateStructure = ext::make_shared<PiecewiseDefaultCurve<HazardRate, BackwardFlat>>(
+        todaysDate, instruments, Actual365Fixed());
+    vector<pair<Date, Real>> hr_curve_data = hazardRateStructure->nodes();
 
     cout << "Calibrated hazard rate values: " << endl;
     for (auto& i : hr_curve_data) {
@@ -132,8 +130,7 @@ void example01() {
     // reprice instruments
     Real nominal = 1000000.0;
     Handle<DefaultProbabilityTermStructure> probability(hazardRateStructure);
-    ext::shared_ptr<PricingEngine> engine(
-        new MidPointCdsEngine(probability, recovery_rate, tsCurve));
+    auto engine = ext::make_shared<MidPointCdsEngine>(probability, recovery_rate, tsCurve);
 
     Schedule cdsSchedule = MakeSchedule()
                                .from(settlementDate)
@@ -231,80 +228,73 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
 
     // set up ISDA IR curve helpers
 
-    ext::shared_ptr<DepositRateHelper> dp1m =
-        ext::make_shared<DepositRateHelper>(0.000060, 1 * Months, 2,
+    auto dp1m = ext::make_shared<DepositRateHelper>(0.000060, 1 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
-    ext::shared_ptr<DepositRateHelper> dp2m =
-        ext::make_shared<DepositRateHelper>(0.000450, 2 * Months, 2,
+    auto dp2m = ext::make_shared<DepositRateHelper>(0.000450, 2 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
-    ext::shared_ptr<DepositRateHelper> dp3m =
-        ext::make_shared<DepositRateHelper>(0.000810, 3 * Months, 2,
+    auto dp3m = ext::make_shared<DepositRateHelper>(0.000810, 3 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
-    ext::shared_ptr<DepositRateHelper> dp6m =
-        ext::make_shared<DepositRateHelper>(0.001840, 6 * Months, 2,
+    auto dp6m = ext::make_shared<DepositRateHelper>(0.001840, 6 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
-    ext::shared_ptr<DepositRateHelper> dp9m =
-        ext::make_shared<DepositRateHelper>(0.002560, 9 * Months, 2,
+    auto dp9m = ext::make_shared<DepositRateHelper>(0.002560, 9 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
-    ext::shared_ptr<DepositRateHelper> dp12m =
-        ext::make_shared<DepositRateHelper>(0.003370, 12 * Months, 2,
+    auto dp12m = ext::make_shared<DepositRateHelper>(0.003370, 12 * Months, 2,
                                               TARGET(), ModifiedFollowing,
                                               false, Actual360());
 
     // intentionally we do not provide a fixing for the euribor index used for
     // bootstrapping in order to be compliant with the ISDA specification
 
-    ext::shared_ptr<IborIndex> euribor6m =
-        ext::make_shared<Euribor>(Euribor(6 * Months));
+    auto euribor6m = ext::make_shared<Euribor>(Euribor(6 * Months));
 
     DayCounter thirty360 = Thirty360(Thirty360::BondBasis);
 
-    ext::shared_ptr<SwapRateHelper> sw2y = ext::make_shared<SwapRateHelper>(
+    auto sw2y = ext::make_shared<SwapRateHelper>(
         0.002230, 2 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw3y = ext::make_shared<SwapRateHelper>(
+    auto sw3y = ext::make_shared<SwapRateHelper>(
         0.002760, 3 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw4y = ext::make_shared<SwapRateHelper>(
+    auto sw4y = ext::make_shared<SwapRateHelper>(
         0.003530, 4 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw5y = ext::make_shared<SwapRateHelper>(
+    auto sw5y = ext::make_shared<SwapRateHelper>(
         0.004520, 5 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw6y = ext::make_shared<SwapRateHelper>(
+    auto sw6y = ext::make_shared<SwapRateHelper>(
         0.005720, 6 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw7y = ext::make_shared<SwapRateHelper>(
+    auto sw7y = ext::make_shared<SwapRateHelper>(
         0.007050, 7 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw8y = ext::make_shared<SwapRateHelper>(
+    auto sw8y = ext::make_shared<SwapRateHelper>(
         0.008420, 8 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw9y = ext::make_shared<SwapRateHelper>(
+    auto sw9y = ext::make_shared<SwapRateHelper>(
         0.009720, 9 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw10y = ext::make_shared<SwapRateHelper>(
+    auto sw10y = ext::make_shared<SwapRateHelper>(
         0.010900, 10 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw12y = ext::make_shared<SwapRateHelper>(
+    auto sw12y = ext::make_shared<SwapRateHelper>(
         0.012870, 12 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw15y = ext::make_shared<SwapRateHelper>(
+    auto sw15y = ext::make_shared<SwapRateHelper>(
         0.014970, 15 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw20y = ext::make_shared<SwapRateHelper>(
+    auto sw20y = ext::make_shared<SwapRateHelper>(
         0.017000, 20 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw30y = ext::make_shared<SwapRateHelper>(
+    auto sw30y = ext::make_shared<SwapRateHelper>(
         0.018210, 30 * Years, TARGET(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
 
-    std::vector<ext::shared_ptr<RateHelper> > isdaRateHelper;
+    std::vector<ext::shared_ptr<RateHelper>> isdaRateHelper;
 
     isdaRateHelper.push_back(dp1m);
     isdaRateHelper.push_back(dp2m);
@@ -327,7 +317,7 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
     isdaRateHelper.push_back(sw30y);
 
     Handle<YieldTermStructure> rateTs(
-        ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear> >(
+        ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(
             0, WeekendsOnly(), isdaRateHelper, Actual365Fixed()));
     rateTs->enableExtrapolation();
 
@@ -341,25 +331,23 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
     }
 
     // build reference credit curve (flat)
-    ext::shared_ptr<DefaultProbabilityTermStructure> defaultTs0 =
-        ext::make_shared<FlatHazardRate>(0, WeekendsOnly(), 0.016739207493630,Actual365Fixed());
+    auto defaultTs0 = ext::make_shared<FlatHazardRate>(0, WeekendsOnly(), 0.016739207493630, Actual365Fixed());
 
     // reference CDS
     Schedule sched( Date(22,September,2014), Date(20,December,2019), 3*Months,
             WeekendsOnly(), Following, Unadjusted, DateGeneration::CDS, false, Date(), Date() );
-    ext::shared_ptr<CreditDefaultSwap> trade =
-        ext::make_shared<CreditDefaultSwap>(
+    auto trade = ext::make_shared<CreditDefaultSwap>(
             Protection::Buyer, 100000000.0, 0.01, sched,
                                   Following, Actual360(), true, true,
                                   Date(22,October,2014), ext::shared_ptr<Claim>(),
                                   Actual360(true), true);
 
-    ext::shared_ptr<FixedRateCoupon> cp = ext::dynamic_pointer_cast<FixedRateCoupon>(trade->coupons()[0]);
+    auto cp = ext::dynamic_pointer_cast<FixedRateCoupon>(trade->coupons()[0]);
     std::cout << "first period = " << cp->accrualStartDate() << " to " << cp->accrualEndDate() <<
         " accrued amount = " << cp->accruedAmount(Date(24,October,2014)) << std::endl;
 
     // price with isda engine
-    ext::shared_ptr<IsdaCdsEngine> engine = ext::make_shared<IsdaCdsEngine>(
+    auto engine = ext::make_shared<IsdaCdsEngine>(
             Handle<DefaultProbabilityTermStructure>(defaultTs0), 0.4, rateTs,
             false, IsdaCdsEngine::Taylor, IsdaCdsEngine::NoBias, IsdaCdsEngine::Piecewise);
 
@@ -369,17 +357,17 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
 
 
     // build credit curve with one cds
-    std::vector<ext::shared_ptr<DefaultProbabilityHelper> > isdaCdsHelper;
+    std::vector<ext::shared_ptr<DefaultProbabilityHelper>> isdaCdsHelper;
 
-    ext::shared_ptr<CdsHelper> cds5y(new SpreadCdsHelper(
+    auto cds5y = ext::make_shared<SpreadCdsHelper>(
         0.00672658551, 4 * Years + 6 * Months, 1, WeekendsOnly(), Quarterly,
         Following, DateGeneration::CDS, Actual360(), 0.4, rateTs, true, true,
-        Date(), Actual360(true), true, CreditDefaultSwap::ISDA));
+        Date(), Actual360(true), true, CreditDefaultSwap::ISDA);
 
     isdaCdsHelper.push_back(cds5y);
 
     Handle<DefaultProbabilityTermStructure> defaultTs(ext::make_shared<
-        PiecewiseDefaultCurve<SurvivalProbability, LogLinear> >(
+        PiecewiseDefaultCurve<SurvivalProbability, LogLinear>>(
         0, WeekendsOnly(), isdaCdsHelper, Actual365Fixed()));
 
     std::cout << "ISDA credit curve: " << std::endl;
@@ -394,15 +382,15 @@ std::copy(cdsSchedule.begin(), cdsSchedule.end(),
 
     // // set up sample CDS trade
 
-    // ext::shared_ptr<CreditDefaultSwap> trade =
+    // auto trade =
     //     MakeCreditDefaultSwap(5 * Years, 0.03);
 
     // // set up isda engine
 
-    // // ext::shared_ptr<IsdaCdsEngine> isdaPricer =
+    // // auto isdaPricer =
     // //     ext::make_shared<IsdaCdsEngine>(
     // //         isdaCdsHelper, 0.4, isdaRateHelper);
-    // ext::shared_ptr<IsdaCdsEngine> isdaPricer =
+    // auto isdaPricer =
     //     ext::make_shared<IsdaCdsEngine>(defaultTs,0.40,rateTs);
 
     // check the curves built by the engine
@@ -447,85 +435,79 @@ void example03() {
     DayCounter actual360 = Actual360();
     DayCounter thirty360 = Thirty360(Thirty360::BondBasis);
 
-    ext::shared_ptr<DepositRateHelper> dp1m =
-        ext::make_shared<DepositRateHelper>(0.00445, 1 * Months, 2,
+    auto dp1m = ext::make_shared<DepositRateHelper>(0.00445, 1 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
-    ext::shared_ptr<DepositRateHelper> dp2m =
-        ext::make_shared<DepositRateHelper>(0.00949, 2 * Months, 2,
+    auto dp2m = ext::make_shared<DepositRateHelper>(0.00949, 2 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
-    ext::shared_ptr<DepositRateHelper> dp3m =
-        ext::make_shared<DepositRateHelper>(0.01234, 3 * Months, 2,
+    auto dp3m = ext::make_shared<DepositRateHelper>(0.01234, 3 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
-    ext::shared_ptr<DepositRateHelper> dp6m =
-        ext::make_shared<DepositRateHelper>(0.01776, 6 * Months, 2,
+    auto dp6m = ext::make_shared<DepositRateHelper>(0.01776, 6 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
-    ext::shared_ptr<DepositRateHelper> dp9m =
-        ext::make_shared<DepositRateHelper>(0.01935, 9 * Months, 2,
+    auto dp9m = ext::make_shared<DepositRateHelper>(0.01935, 9 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
-    ext::shared_ptr<DepositRateHelper> dp1y =
-        ext::make_shared<DepositRateHelper>(0.02084, 12 * Months, 2,
+    auto dp1y = ext::make_shared<DepositRateHelper>(0.02084, 12 * Months, 2,
                                               WeekendsOnly(), ModifiedFollowing,
                                               false, actual360);
 
     // this index is probably not important since we are not using
     // IborCoupon::Settings::instance().usingAtParCoupons() == false
     // - define it "isda compliant" anyway
-    ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<IborIndex>(
+    auto euribor6m = ext::make_shared<IborIndex>(
         "IsdaIbor", 6 * Months, 2, EURCurrency(), WeekendsOnly(),
         ModifiedFollowing, false, actual360);
 
-    ext::shared_ptr<SwapRateHelper> sw2y = ext::make_shared<SwapRateHelper>(
+    auto sw2y = ext::make_shared<SwapRateHelper>(
         0.01652, 2 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw3y = ext::make_shared<SwapRateHelper>(
+    auto sw3y = ext::make_shared<SwapRateHelper>(
         0.02018, 3 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw4y = ext::make_shared<SwapRateHelper>(
+    auto sw4y = ext::make_shared<SwapRateHelper>(
         0.02303, 4 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw5y = ext::make_shared<SwapRateHelper>(
+    auto sw5y = ext::make_shared<SwapRateHelper>(
         0.02525, 5 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw6y = ext::make_shared<SwapRateHelper>(
+    auto sw6y = ext::make_shared<SwapRateHelper>(
         0.02696, 6 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw7y = ext::make_shared<SwapRateHelper>(
+    auto sw7y = ext::make_shared<SwapRateHelper>(
         0.02825, 7 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw8y = ext::make_shared<SwapRateHelper>(
+    auto sw8y = ext::make_shared<SwapRateHelper>(
         0.02931, 8 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw9y = ext::make_shared<SwapRateHelper>(
+    auto sw9y = ext::make_shared<SwapRateHelper>(
         0.03017, 9 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw10y = ext::make_shared<SwapRateHelper>(
+    auto sw10y = ext::make_shared<SwapRateHelper>(
         0.03092, 10 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw11y = ext::make_shared<SwapRateHelper>(
+    auto sw11y = ext::make_shared<SwapRateHelper>(
         0.03160, 11 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw12y = ext::make_shared<SwapRateHelper>(
+    auto sw12y = ext::make_shared<SwapRateHelper>(
         0.03231, 12 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw15y = ext::make_shared<SwapRateHelper>(
+    auto sw15y = ext::make_shared<SwapRateHelper>(
         0.03367, 15 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw20y = ext::make_shared<SwapRateHelper>(
+    auto sw20y = ext::make_shared<SwapRateHelper>(
         0.03419, 20 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw25y = ext::make_shared<SwapRateHelper>(
+    auto sw25y = ext::make_shared<SwapRateHelper>(
         0.03411, 25 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
-    ext::shared_ptr<SwapRateHelper> sw30y = ext::make_shared<SwapRateHelper>(
+    auto sw30y = ext::make_shared<SwapRateHelper>(
         0.03412, 30 * Years, WeekendsOnly(), Annual, ModifiedFollowing, thirty360,
         euribor6m);
 
-    std::vector<ext::shared_ptr<RateHelper> > isdaYieldHelpers;
+    std::vector<ext::shared_ptr<RateHelper>> isdaYieldHelpers;
 
     isdaYieldHelpers.push_back(dp1m);
     isdaYieldHelpers.push_back(dp2m);
@@ -551,38 +533,38 @@ void example03() {
 
     // build yield curve
     Handle<YieldTermStructure> isdaYts = Handle<YieldTermStructure>(
-            ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear> >(
+            ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(
                 0, WeekendsOnly(), isdaYieldHelpers, Actual365Fixed()));
     isdaYts->enableExtrapolation();
 
 
     CreditDefaultSwap::PricingModel model = CreditDefaultSwap::ISDA;
-    ext::shared_ptr<CdsHelper> cds6m(new SpreadCdsHelper(
+    auto cds6m = ext::make_shared<SpreadCdsHelper>(
         0.007927, 6 * Months, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
-    ext::shared_ptr<CdsHelper> cds1y(new SpreadCdsHelper(
+        Actual360(true), true, model);
+    auto cds1y = ext::make_shared<SpreadCdsHelper>(
         0.007927, 1 * Years, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
-    ext::shared_ptr<CdsHelper> cds3y(new SpreadCdsHelper(
+        Actual360(true), true, model);
+    auto cds3y = ext::make_shared<SpreadCdsHelper>(
         0.012239, 3 * Years, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
-    ext::shared_ptr<CdsHelper> cds5y(new SpreadCdsHelper(
+        Actual360(true), true, model);
+    auto cds5y = ext::make_shared<SpreadCdsHelper>(
         0.016979, 5 * Years, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
-    ext::shared_ptr<CdsHelper> cds7y(new SpreadCdsHelper(
+        Actual360(true), true, model);
+    auto cds7y = ext::make_shared<SpreadCdsHelper>(
         0.019271, 7 * Years, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
-    ext::shared_ptr<CdsHelper> cds10y(new SpreadCdsHelper(
+        Actual360(true), true, model);
+    auto cds10y = ext::make_shared<SpreadCdsHelper>(
         0.020860, 10 * Years, 1, WeekendsOnly(), Quarterly, Following,
         DateGeneration::CDS, Actual360(), 0.4, isdaYts, true, true, Date(),
-        Actual360(true), true, model));
+        Actual360(true), true, model);
 
-    std::vector<ext::shared_ptr<DefaultProbabilityHelper> > isdaCdsHelpers;
+    std::vector<ext::shared_ptr<DefaultProbabilityHelper>> isdaCdsHelpers;
 
     isdaCdsHelpers.push_back(cds6m);
     isdaCdsHelpers.push_back(cds1y);
@@ -592,15 +574,13 @@ void example03() {
     isdaCdsHelpers.push_back(cds10y);
 
     // build credit curve
-    Handle<DefaultProbabilityTermStructure> isdaCts =
+    auto isdaCts =
     Handle<DefaultProbabilityTermStructure>(ext::make_shared<
-        PiecewiseDefaultCurve<SurvivalProbability, LogLinear> >(
+        PiecewiseDefaultCurve<SurvivalProbability, LogLinear>>(
             0, WeekendsOnly(), isdaCdsHelpers, Actual365Fixed()));
 
     // set up isda engine
-    ext::shared_ptr<IsdaCdsEngine> isdaPricer =
-        ext::make_shared<IsdaCdsEngine>(
-            isdaCts, 0.4, isdaYts);
+    auto isdaPricer = ext::make_shared<IsdaCdsEngine>(isdaCts, 0.4, isdaYts);
 
     // check the curves
     std::cout << "ISDA yield curve:" << std::endl;

--- a/Examples/CallableBonds/CallableBonds.cpp
+++ b/Examples/CallableBonds/CallableBonds.cpp
@@ -46,12 +46,11 @@ ext::shared_ptr<YieldTermStructure>
              const DayCounter& dc,
              const Compounding& compounding,
              const Frequency& frequency) {
-    return ext::shared_ptr<YieldTermStructure>(
-                                       new FlatForward(today,
-                                                       Handle<Quote>(forward),
-                                                       dc,
-                                                       compounding,
-                                                       frequency));
+    return ext::make_shared<FlatForward>(today,
+                                         Handle<Quote>(forward),
+                                         dc,
+                                         compounding,
+                                         frequency);
 }
 
 
@@ -62,7 +61,7 @@ ext::shared_ptr<YieldTermStructure>
              const Compounding &compounding,
              const Frequency &frequency) {
     return flatRate(today,
-            ext::shared_ptr<Quote>(new SimpleQuote(forward)),
+            ext::make_shared<SimpleQuote>(forward),
             dc,
             compounding,
             frequency);
@@ -162,11 +161,9 @@ int main(int, char* [])
 
         Real sigma = QL_EPSILON; // core dumps if zero on Cygwin
 
-        ext::shared_ptr<ShortRateModel> hw0(
-                       new HullWhite(termStructure,reversionParameter,sigma));
+        auto hw0 = ext::make_shared<HullWhite>(termStructure,reversionParameter,sigma);
 
-        ext::shared_ptr<PricingEngine> engine0(
-                      new TreeCallableFixedRateBondEngine(hw0,gridIntervals));
+        auto engine0 = ext::make_shared<TreeCallableFixedRateBondEngine>(hw0,gridIntervals);
 
         CallableFixedRateBond callableBond(settlementDays, faceAmount, sch,
                                            vector<Rate>(1, coupon),
@@ -199,11 +196,9 @@ int main(int, char* [])
 
         cout << "sigma/vol (%) = " << 100.*sigma << endl;
 
-        ext::shared_ptr<ShortRateModel> hw1(
-                       new HullWhite(termStructure,reversionParameter,sigma));
+        auto hw1 = ext::make_shared<HullWhite>(termStructure,reversionParameter,sigma);
 
-        ext::shared_ptr<PricingEngine> engine1(
-                      new TreeCallableFixedRateBondEngine(hw1,gridIntervals));
+        auto engine1 = ext::make_shared<TreeCallableFixedRateBondEngine>(hw1,gridIntervals);
 
         callableBond.setPricingEngine(engine1);
 
@@ -225,11 +220,9 @@ int main(int, char* [])
 
         sigma = .03;
 
-        ext::shared_ptr<ShortRateModel> hw2(
-                     new HullWhite(termStructure, reversionParameter, sigma));
+        auto hw2 = ext::make_shared<HullWhite>(termStructure, reversionParameter, sigma);
 
-        ext::shared_ptr<PricingEngine> engine2(
-                      new TreeCallableFixedRateBondEngine(hw2,gridIntervals));
+        auto engine2 = ext::make_shared<TreeCallableFixedRateBondEngine>(hw2,gridIntervals);
 
         callableBond.setPricingEngine(engine2);
 
@@ -255,11 +248,9 @@ int main(int, char* [])
 
         sigma = .06;
 
-        ext::shared_ptr<ShortRateModel> hw3(
-                     new HullWhite(termStructure, reversionParameter, sigma));
+        auto hw3 = ext::make_shared<HullWhite>(termStructure, reversionParameter, sigma);
 
-        ext::shared_ptr<PricingEngine> engine3(
-                      new TreeCallableFixedRateBondEngine(hw3,gridIntervals));
+        auto engine3 = ext::make_shared<TreeCallableFixedRateBondEngine>(hw3,gridIntervals);
 
         callableBond.setPricingEngine(engine3);
 
@@ -285,11 +276,9 @@ int main(int, char* [])
 
         sigma = .12;
 
-        ext::shared_ptr<ShortRateModel> hw4(
-                     new HullWhite(termStructure, reversionParameter, sigma));
+        auto hw4 = ext::make_shared<HullWhite>(termStructure, reversionParameter, sigma);
 
-        ext::shared_ptr<PricingEngine> engine4(
-                      new TreeCallableFixedRateBondEngine(hw4,gridIntervals));
+        auto engine4 = ext::make_shared<TreeCallableFixedRateBondEngine>(hw4,gridIntervals);
 
         callableBond.setPricingEngine(engine4);
 

--- a/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -104,8 +104,7 @@ int main(int, char* []) {
 
         // Assume dividends are paid every 6 months.
         for (Date d = today + 6*Months; d < exerciseDate; d += 6*Months) {
-            dividends.push_back(
-                      ext::shared_ptr<Dividend>(new FixedDividend(1.0, d)));
+            dividends.push_back(ext::make_shared<FixedDividend>(1.0, d));
         }
 
         DayCounter dayCounter = Actual365Fixed();
@@ -142,45 +141,34 @@ int main(int, char* []) {
                   << std::endl;
         std::cout << rule << std::endl;
 
-        ext::shared_ptr<Exercise> exercise(
-                                          new EuropeanExercise(exerciseDate));
-        ext::shared_ptr<Exercise> amExercise(
-                                          new AmericanExercise(settlementDate,
-                                                               exerciseDate));
+        auto exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
+        auto amExercise = ext::make_shared<AmericanExercise>(settlementDate, exerciseDate);
 
-        Handle<Quote> underlyingH(
-            ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+        Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(underlying));
 
         Handle<YieldTermStructure> flatTermStructure(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
 
         Handle<YieldTermStructure> flatDividendTS(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, dividendYield, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
 
         Handle<BlackVolTermStructure> flatVolTS(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(settlementDate, calendar,
-                                     volatility, dayCounter)));
+            ext::make_shared<BlackConstantVol>(settlementDate, calendar, volatility, dayCounter));
 
         auto stochasticProcess = ext::make_shared<BlackScholesMertonProcess>(
             underlyingH, flatDividendTS, flatTermStructure, flatVolTS);
 
         Size timeSteps = 801;
 
-        Handle<Quote> creditSpread(
-                       ext::shared_ptr<Quote>(new SimpleQuote(spreadRate)));
+        Handle<Quote> creditSpread(ext::make_shared<SimpleQuote>(spreadRate));
 
-        ext::shared_ptr<Quote> rate(new SimpleQuote(riskFreeRate));
+        auto rate = ext::make_shared<SimpleQuote>(riskFreeRate);
 
         Handle<YieldTermStructure> discountCurve(
-                ext::shared_ptr<YieldTermStructure>(
-                    new FlatForward(today, Handle<Quote>(rate), dayCounter)));
+                ext::make_shared<FlatForward>(today, Handle<Quote>(rate), dayCounter));
 
-        ext::shared_ptr<PricingEngine> engine(
-                  new BinomialConvertibleEngine<JarrowRudd>(stochasticProcess,
-                                                            timeSteps, creditSpread, dividends));
+        auto engine = ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess,
+                                                            timeSteps, creditSpread, dividends);
 
         ConvertibleFixedCouponBond europeanBond(
                             exercise, conversionRatio, callability,
@@ -195,10 +183,8 @@ int main(int, char* []) {
         americanBond.setPricingEngine(engine);
 
         method = "Jarrow-Rudd";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                  new BinomialConvertibleEngine<JarrowRudd>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                  new BinomialConvertibleEngine<JarrowRudd>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -206,10 +192,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Cox-Ross-Rubinstein";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-           new BinomialConvertibleEngine<CoxRossRubinstein>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-           new BinomialConvertibleEngine<CoxRossRubinstein>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<CoxRossRubinstein>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<CoxRossRubinstein>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -217,12 +201,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Additive equiprobabilities";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                   new BinomialConvertibleEngine<AdditiveEQPBinomialTree>(
-                                                            stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                   new BinomialConvertibleEngine<AdditiveEQPBinomialTree>(
-                                                            stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<AdditiveEQPBinomialTree>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<AdditiveEQPBinomialTree>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -230,10 +210,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Trigeorgis";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                  new BinomialConvertibleEngine<Trigeorgis>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                  new BinomialConvertibleEngine<Trigeorgis>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Trigeorgis>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Trigeorgis>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -241,10 +219,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Tian";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                        new BinomialConvertibleEngine<Tian>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                        new BinomialConvertibleEngine<Tian>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Tian>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Tian>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -252,10 +228,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Leisen-Reimer";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialConvertibleEngine<LeisenReimer>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialConvertibleEngine<LeisenReimer>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<LeisenReimer>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<LeisenReimer>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -263,10 +237,8 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Joshi";
-        europeanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialConvertibleEngine<Joshi4>(stochasticProcess, timeSteps, creditSpread, dividends)));
-        americanBond.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialConvertibleEngine<Joshi4>(stochasticProcess, timeSteps, creditSpread, dividends)));
+        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Joshi4>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Joshi4>>(stochasticProcess, timeSteps, creditSpread, dividends));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()

--- a/Examples/ConvertibleBonds/ConvertibleBonds.cpp
+++ b/Examples/ConvertibleBonds/ConvertibleBonds.cpp
@@ -167,24 +167,20 @@ int main(int, char* []) {
         Handle<YieldTermStructure> discountCurve(
                 ext::make_shared<FlatForward>(today, Handle<Quote>(rate), dayCounter));
 
-        auto engine = ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess,
-                                                            timeSteps, creditSpread, dividends);
-
         ConvertibleFixedCouponBond europeanBond(
                             exercise, conversionRatio, callability,
                             issueDate, settlementDays,
                             coupons, bondDayCount, schedule, redemption);
-        europeanBond.setPricingEngine(engine);
 
         ConvertibleFixedCouponBond americanBond(
                           amExercise, conversionRatio, callability,
                           issueDate, settlementDays,
                           coupons, bondDayCount, schedule, redemption);
-        americanBond.setPricingEngine(engine);
 
         method = "Jarrow-Rudd";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto jrEngine = ext::make_shared<BinomialConvertibleEngine<JarrowRudd>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(jrEngine);
+        americanBond.setPricingEngine(jrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -192,8 +188,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Cox-Ross-Rubinstein";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<CoxRossRubinstein>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<CoxRossRubinstein>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto crrEngine = ext::make_shared<BinomialConvertibleEngine<CoxRossRubinstein>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(crrEngine);
+        americanBond.setPricingEngine(crrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -201,8 +198,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Additive equiprobabilities";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<AdditiveEQPBinomialTree>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<AdditiveEQPBinomialTree>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto aeqpEngine = ext::make_shared<BinomialConvertibleEngine<AdditiveEQPBinomialTree>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(aeqpEngine);
+        americanBond.setPricingEngine(aeqpEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -210,8 +208,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Trigeorgis";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Trigeorgis>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Trigeorgis>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto trEngine = ext::make_shared<BinomialConvertibleEngine<Trigeorgis>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(trEngine);
+        americanBond.setPricingEngine(trEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -219,8 +218,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Tian";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Tian>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Tian>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto tianEngine = ext::make_shared<BinomialConvertibleEngine<Tian>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(tianEngine);
+        americanBond.setPricingEngine(tianEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -228,8 +228,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Leisen-Reimer";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<LeisenReimer>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<LeisenReimer>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto lrEngine = ext::make_shared<BinomialConvertibleEngine<LeisenReimer>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(lrEngine);
+        americanBond.setPricingEngine(lrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()
@@ -237,8 +238,9 @@ int main(int, char* []) {
                   << std::endl;
 
         method = "Joshi";
-        europeanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Joshi4>>(stochasticProcess, timeSteps, creditSpread, dividends));
-        americanBond.setPricingEngine(ext::make_shared<BinomialConvertibleEngine<Joshi4>>(stochasticProcess, timeSteps, creditSpread, dividends));
+        auto joshiEngine = ext::make_shared<BinomialConvertibleEngine<Joshi4>>(stochasticProcess, timeSteps, creditSpread, dividends);
+        europeanBond.setPricingEngine(joshiEngine);
+        americanBond.setPricingEngine(joshiEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanBond.NPV()

--- a/Examples/EquityOption/EquityOption.cpp
+++ b/Examples/EquityOption/EquityOption.cpp
@@ -254,19 +254,23 @@ int main(int, char* []) {
 
         // Binomial method: Jarrow-Rudd
         method = "Binomial Jarrow-Rudd";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
+        auto jrEngine = ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(jrEngine);
+        bermudanOption.setPricingEngine(jrEngine);
+        americanOption.setPricingEngine(jrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
                   << std::setw(widths[2]) << std::left << bermudanOption.NPV()
                   << std::setw(widths[3]) << std::left << americanOption.NPV()
                   << std::endl;
+
+        // Binomial method: Cox-Ross-Rubinstein
         method = "Binomial Cox-Ross-Rubinstein";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
+        auto crrEngine = ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(crrEngine);
+        bermudanOption.setPricingEngine(crrEngine);
+        americanOption.setPricingEngine(crrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -276,9 +280,10 @@ int main(int, char* []) {
 
         // Binomial method: Additive equiprobabilities
         method = "Additive equiprobabilities";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
+        auto aeqpEngine = ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(aeqpEngine);
+        bermudanOption.setPricingEngine(aeqpEngine);
+        americanOption.setPricingEngine(aeqpEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -288,9 +293,10 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Trigeorgis
         method = "Binomial Trigeorgis";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
+        auto trigeorgisEngine = ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(trigeorgisEngine);
+        bermudanOption.setPricingEngine(trigeorgisEngine);
+        americanOption.setPricingEngine(trigeorgisEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -300,9 +306,10 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Tian
         method = "Binomial Tian";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
+        auto tianEngine = ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(tianEngine);
+        bermudanOption.setPricingEngine(tianEngine);
+        americanOption.setPricingEngine(tianEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -312,9 +319,10 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Leisen-Reimer
         method = "Binomial Leisen-Reimer";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
+        auto lrEngine = ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(lrEngine);
+        bermudanOption.setPricingEngine(lrEngine);
+        americanOption.setPricingEngine(lrEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -324,9 +332,10 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Joshi
         method = "Binomial Joshi";
-        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
-        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
-        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
+        auto joshiEngine = ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps);
+        europeanOption.setPricingEngine(joshiEngine);
+        bermudanOption.setPricingEngine(joshiEngine);
+        americanOption.setPricingEngine(joshiEngine);
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()

--- a/Examples/EquityOption/EquityOption.cpp
+++ b/Examples/EquityOption/EquityOption.cpp
@@ -91,32 +91,23 @@ int main(int, char* []) {
         for (Integer i=1; i<=4; i++)
             exerciseDates.push_back(settlementDate + 3*i*Months);
 
-        ext::shared_ptr<Exercise> europeanExercise(
-                                         new EuropeanExercise(maturity));
+        auto europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
 
-        ext::shared_ptr<Exercise> bermudanExercise(
-                                         new BermudanExercise(exerciseDates));
+        auto bermudanExercise = ext::make_shared<BermudanExercise>(exerciseDates);
 
-        ext::shared_ptr<Exercise> americanExercise(
-                                         new AmericanExercise(settlementDate,
-                                                              maturity));
+        auto americanExercise = ext::make_shared<AmericanExercise>(settlementDate, maturity);
 
-        Handle<Quote> underlyingH(
-            ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+        Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(underlying));
 
         // bootstrap the yield/dividend/vol curves
         Handle<YieldTermStructure> flatTermStructure(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
         Handle<YieldTermStructure> flatDividendTS(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, dividendYield, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
         Handle<BlackVolTermStructure> flatVolTS(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(settlementDate, calendar, volatility,
-                                     dayCounter)));
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                                        new PlainVanillaPayoff(type, strike));
+            ext::make_shared<BlackConstantVol>(settlementDate, calendar, volatility,
+                                     dayCounter));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
         auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
                 underlyingH, flatDividendTS, flatTermStructure, flatVolTS);
 
@@ -129,8 +120,7 @@ int main(int, char* []) {
 
         // Black-Scholes for European
         method = "Black-Scholes";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                     new AnalyticEuropeanEngine(bsmProcess)));
+        europeanOption.setPricingEngine(ext::make_shared<AnalyticEuropeanEngine>(bsmProcess));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -146,9 +136,8 @@ int main(int, char* []) {
         Real sigma_r = 0.15;
         Real riskPremium = 0.0;
         Real correlation = 0.5;
-        ext::shared_ptr<Vasicek> vasicekProcess(new Vasicek(r0, a, b, sigma_r, riskPremium));
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new AnalyticBlackVasicekEngine(bsmProcess, vasicekProcess, correlation)));
+        auto vasicekProcess = ext::make_shared<Vasicek>(r0, a, b, sigma_r, riskPremium);
+        europeanOption.setPricingEngine(ext::make_shared<AnalyticBlackVasicekEngine>(bsmProcess, vasicekProcess, correlation));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -158,14 +147,11 @@ int main(int, char* []) {
 
         // semi-analytic Heston for European
         method = "Heston semi-analytic";
-        ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(flatTermStructure, flatDividendTS,
+        auto hestonProcess = ext::make_shared<HestonProcess>(flatTermStructure, flatDividendTS,
                               underlyingH, volatility*volatility,
-                              1.0, volatility*volatility, 0.001, 0.0));
-        ext::shared_ptr<HestonModel> hestonModel(
-                                              new HestonModel(hestonProcess));
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                     new AnalyticHestonEngine(hestonModel)));
+                              1.0, volatility*volatility, 0.001, 0.0);
+        auto hestonModel = ext::make_shared<HestonModel>(hestonProcess);
+        europeanOption.setPricingEngine(ext::make_shared<AnalyticHestonEngine>(hestonModel));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -175,14 +161,12 @@ int main(int, char* []) {
 
         // semi-analytic Bates for European
         method = "Bates semi-analytic";
-        ext::shared_ptr<BatesProcess> batesProcess(
-            new BatesProcess(flatTermStructure, flatDividendTS,
+        auto batesProcess = ext::make_shared<BatesProcess>(flatTermStructure, flatDividendTS,
                              underlyingH, volatility*volatility,
                              1.0, volatility*volatility, 0.001, 0.0,
-                             1e-14, 1e-14, 1e-14));
-        ext::shared_ptr<BatesModel> batesModel(new BatesModel(batesProcess));
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                                new BatesEngine(batesModel)));
+                             1e-14, 1e-14, 1e-14);
+        auto batesModel = ext::make_shared<BatesModel>(batesProcess);
+        europeanOption.setPricingEngine(ext::make_shared<BatesEngine>(batesModel));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -192,8 +176,7 @@ int main(int, char* []) {
 
         // Barone-Adesi and Whaley approximation for American
         method = "Barone-Adesi/Whaley";
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                       new BaroneAdesiWhaleyApproximationEngine(bsmProcess)));
+        americanOption.setPricingEngine(ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(bsmProcess));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << "N/A"
@@ -203,8 +186,7 @@ int main(int, char* []) {
 
         // Bjerksund and Stensland approximation for American
         method = "Bjerksund/Stensland";
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BjerksundStenslandApproximationEngine(bsmProcess)));
+        americanOption.setPricingEngine(ext::make_shared<BjerksundStenslandApproximationEngine>(bsmProcess));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << "N/A"
@@ -245,8 +227,7 @@ int main(int, char* []) {
 
         // Integral
         method = "Integral";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                             new IntegralEngine(bsmProcess)));
+        europeanOption.setPricingEngine(ext::make_shared<IntegralEngine>(bsmProcess));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -257,7 +238,7 @@ int main(int, char* []) {
         // Finite differences
         Size timeSteps = 801;
         method = "Finite differences";
-        ext::shared_ptr<PricingEngine> fdengine =
+        auto fdengine =
             ext::make_shared<FdBlackScholesVanillaEngine>(bsmProcess,
                                                           timeSteps,
                                                           timeSteps-1);
@@ -273,12 +254,9 @@ int main(int, char* []) {
 
         // Binomial method: Jarrow-Rudd
         method = "Binomial Jarrow-Rudd";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<JarrowRudd>(bsmProcess,timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<JarrowRudd>(bsmProcess,timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<JarrowRudd>(bsmProcess,timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -286,15 +264,9 @@ int main(int, char* []) {
                   << std::setw(widths[3]) << std::left << americanOption.NPV()
                   << std::endl;
         method = "Binomial Cox-Ross-Rubinstein";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<CoxRossRubinstein>(bsmProcess,
-                                                                   timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<CoxRossRubinstein>(bsmProcess,
-                                                                   timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<CoxRossRubinstein>(bsmProcess,
-                                                                   timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -304,15 +276,9 @@ int main(int, char* []) {
 
         // Binomial method: Additive equiprobabilities
         method = "Additive equiprobabilities";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<AdditiveEQPBinomialTree>(bsmProcess,
-                                                                   timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<AdditiveEQPBinomialTree>(bsmProcess,
-                                                                   timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<AdditiveEQPBinomialTree>(bsmProcess,
-                                                                   timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -322,12 +288,9 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Trigeorgis
         method = "Binomial Trigeorgis";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<Trigeorgis>(bsmProcess,timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<Trigeorgis>(bsmProcess,timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<Trigeorgis>(bsmProcess,timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -337,12 +300,9 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Tian
         method = "Binomial Tian";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<Tian>(bsmProcess,timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<Tian>(bsmProcess,timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<Tian>(bsmProcess,timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Tian>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -352,12 +312,9 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Leisen-Reimer
         method = "Binomial Leisen-Reimer";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-              new BinomialVanillaEngine<LeisenReimer>(bsmProcess,timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-              new BinomialVanillaEngine<LeisenReimer>(bsmProcess,timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-              new BinomialVanillaEngine<LeisenReimer>(bsmProcess,timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -367,12 +324,9 @@ int main(int, char* []) {
 
         // Binomial method: Binomial Joshi
         method = "Binomial Joshi";
-        europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new BinomialVanillaEngine<Joshi4>(bsmProcess,timeSteps)));
-        bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new BinomialVanillaEngine<Joshi4>(bsmProcess,timeSteps)));
-        americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new BinomialVanillaEngine<Joshi4>(bsmProcess,timeSteps)));
+        europeanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
+        bermudanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
+        americanOption.setPricingEngine(ext::make_shared<BinomialVanillaEngine<Joshi4>>(bsmProcess, timeSteps));
         std::cout << std::setw(widths[0]) << std::left << method
                   << std::fixed
                   << std::setw(widths[1]) << std::left << europeanOption.NPV()
@@ -384,8 +338,7 @@ int main(int, char* []) {
         timeSteps = 1;
         method = "MC (crude)";
         Size mcSeed = 42;
-        ext::shared_ptr<PricingEngine> mcengine1;
-        mcengine1 = MakeMCEuropeanEngine<PseudoRandom>(bsmProcess)
+        auto mcengine1 = MakeMCEuropeanEngine<PseudoRandom>(bsmProcess)
             .withSteps(timeSteps)
             .withAbsoluteTolerance(0.02)
             .withSeed(mcSeed);
@@ -402,8 +355,7 @@ int main(int, char* []) {
         method = "QMC (Sobol)";
         Size nSamples = 32768;  // 2^15
 
-        ext::shared_ptr<PricingEngine> mcengine2;
-        mcengine2 = MakeMCEuropeanEngine<LowDiscrepancy>(bsmProcess)
+        auto mcengine2 = MakeMCEuropeanEngine<LowDiscrepancy>(bsmProcess)
             .withSteps(timeSteps)
             .withSamples(nSamples);
         europeanOption.setPricingEngine(mcengine2);
@@ -416,8 +368,7 @@ int main(int, char* []) {
 
         // Monte Carlo Method: MC (Longstaff Schwartz)
         method = "MC (Longstaff Schwartz)";
-        ext::shared_ptr<PricingEngine> mcengine3;
-        mcengine3 = MakeMCAmericanEngine<PseudoRandom>(bsmProcess)
+        auto mcengine3 = MakeMCAmericanEngine<PseudoRandom>(bsmProcess)
             .withSteps(100)
             .withAntitheticVariate()
             .withCalibrationSamples(4096)

--- a/Examples/FRA/FRA.cpp
+++ b/Examples/FRA/FRA.cpp
@@ -49,8 +49,7 @@ int main(int, char* []) {
          *********************/
 
         RelinkableHandle<YieldTermStructure> euriborTermStructure;
-        ext::shared_ptr<IborIndex> euribor3m(
-                                       new Euribor3M(euriborTermStructure));
+        auto euribor3m = ext::make_shared<Euribor3M>(euriborTermStructure);
 
         Date todaysDate = Date(23, May, 2006);
         Settings::instance().evaluationDate() = todaysDate;
@@ -85,16 +84,11 @@ int main(int, char* []) {
 
 
         // FRAs
-        ext::shared_ptr<SimpleQuote> fra1x4Rate(
-                                      new SimpleQuote(threeMonthFraQuote[1]));
-        ext::shared_ptr<SimpleQuote> fra2x5Rate(
-                                      new SimpleQuote(threeMonthFraQuote[2]));
-        ext::shared_ptr<SimpleQuote> fra3x6Rate(
-                                      new SimpleQuote(threeMonthFraQuote[3]));
-        ext::shared_ptr<SimpleQuote> fra6x9Rate(
-                                      new SimpleQuote(threeMonthFraQuote[6]));
-        ext::shared_ptr<SimpleQuote> fra9x12Rate(
-                                      new SimpleQuote(threeMonthFraQuote[9]));
+        auto fra1x4Rate = ext::make_shared<SimpleQuote>(threeMonthFraQuote[1]);
+        auto fra2x5Rate = ext::make_shared<SimpleQuote>(threeMonthFraQuote[2]);
+        auto fra3x6Rate = ext::make_shared<SimpleQuote>(threeMonthFraQuote[3]);
+        auto fra6x9Rate = ext::make_shared<SimpleQuote>(threeMonthFraQuote[6]);
+        auto fra9x12Rate = ext::make_shared<SimpleQuote>(threeMonthFraQuote[9]);
 
         RelinkableHandle<Quote> h1x4;  h1x4.linkTo(fra1x4Rate);
         RelinkableHandle<Quote> h2x5;  h2x5.linkTo(fra2x5Rate);
@@ -115,30 +109,25 @@ int main(int, char* []) {
         BusinessDayConvention convention = euribor3m->businessDayConvention();
         bool endOfMonth = euribor3m->endOfMonth();
 
-        ext::shared_ptr<RateHelper> fra1x4(
-                           new FraRateHelper(h1x4, 1, 4,
+        auto fra1x4 = ext::make_shared<FraRateHelper>(h1x4, 1, 4,
                                              fixingDays, calendar, convention,
-                                             endOfMonth, fraDayCounter));
+                                             endOfMonth, fraDayCounter);
 
-        ext::shared_ptr<RateHelper> fra2x5(
-                           new FraRateHelper(h2x5, 2, 5,
+        auto fra2x5 = ext::make_shared<FraRateHelper>(h2x5, 2, 5,
                                              fixingDays, calendar, convention,
-                                             endOfMonth, fraDayCounter));
+                                             endOfMonth, fraDayCounter);
 
-        ext::shared_ptr<RateHelper> fra3x6(
-                           new FraRateHelper(h3x6, 3, 6,
+        auto fra3x6 = ext::make_shared<FraRateHelper>(h3x6, 3, 6,
                                              fixingDays, calendar, convention,
-                                             endOfMonth, fraDayCounter));
+                                             endOfMonth, fraDayCounter);
 
-        ext::shared_ptr<RateHelper> fra6x9(
-                           new FraRateHelper(h6x9, 6, 9,
+        auto fra6x9 = ext::make_shared<FraRateHelper>(h6x9, 6, 9,
                                              fixingDays, calendar, convention,
-                                             endOfMonth, fraDayCounter));
+                                             endOfMonth, fraDayCounter);
 
-        ext::shared_ptr<RateHelper> fra9x12(
-                           new FraRateHelper(h9x12, 9, 12,
+        auto fra9x12 = ext::make_shared<FraRateHelper>(h9x12, 9, 12,
                                              fixingDays, calendar, convention,
-                                             endOfMonth, fraDayCounter));
+                                             endOfMonth, fraDayCounter);
 
 
         /*********************
@@ -151,7 +140,7 @@ int main(int, char* []) {
             ActualActual(ActualActual::ISDA);
 
         // A FRA curve
-        std::vector<ext::shared_ptr<RateHelper> > fraInstruments;
+        std::vector<ext::shared_ptr<RateHelper>> fraInstruments;
 
         fraInstruments.push_back(fra1x4);
         fraInstruments.push_back(fra2x5);
@@ -159,10 +148,9 @@ int main(int, char* []) {
         fraInstruments.push_back(fra6x9);
         fraInstruments.push_back(fra9x12);
 
-        ext::shared_ptr<YieldTermStructure> fraTermStructure(
-                     new PiecewiseYieldCurve<Discount,LogLinear>(
+        auto fraTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(
                                          settlementDate, fraInstruments,
-                                         termStructureDayCounter));
+                                         termStructureDayCounter);
 
         /***********************
          ***  construct FRA's ***

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -87,10 +87,9 @@ int main(int, char* []) {
             i = 100.0;
         }
 
-        std::vector< ext::shared_ptr<SimpleQuote> > quote;
+        std::vector< ext::shared_ptr<SimpleQuote>> quote;
         for (Real i : cleanPrice) {
-            ext::shared_ptr<SimpleQuote> cp(new SimpleQuote(i));
-            quote.push_back(cp);
+            quote.push_back(ext::make_shared<SimpleQuote>(i));
         }
 
         RelinkableHandle<Quote> quoteHandle[numberOfBonds];
@@ -127,8 +126,8 @@ int main(int, char* []) {
         cout << "Bonds' settlement date: " << bondSettlementDate << endl;
         cout << "Calculating fit for 15 bonds....." << endl << endl;
 
-        std::vector<ext::shared_ptr<BondHelper> > instrumentsA;
-        std::vector<ext::shared_ptr<RateHelper> > instrumentsB;
+        std::vector<ext::shared_ptr<BondHelper>> instrumentsA;
+        std::vector<ext::shared_ptr<RateHelper>> instrumentsB;
 
         for (Size j=0; j<LENGTH(lengths); j++) {
 
@@ -138,25 +137,23 @@ int main(int, char* []) {
                               calendar, accrualConvention, accrualConvention,
                               DateGeneration::Backward, false);
 
-            ext::shared_ptr<BondHelper> helperA(
-                     new FixedRateBondHelper(quoteHandle[j],
+            auto helperA = ext::make_shared<FixedRateBondHelper>(quoteHandle[j],
                                              bondSettlementDays,
                                              100.0,
                                              schedule,
                                              std::vector<Rate>(1,coupons[j]),
                                              dc,
                                              convention,
-                                             redemption));
+                                             redemption);
 
-            ext::shared_ptr<RateHelper> helperB(
-                     new FixedRateBondHelper(quoteHandle[j],
+            auto helperB = ext::make_shared<FixedRateBondHelper>(quoteHandle[j],
                                              bondSettlementDays,
                                              100.0,
                                              schedule,
                                              std::vector<Rate>(1, coupons[j]),
                                              dc,
                                              convention,
-                                             redemption));
+                                             redemption);
             instrumentsA.push_back(helperA);
             instrumentsB.push_back(helperB);
         }
@@ -166,50 +163,46 @@ int main(int, char* []) {
         Real tolerance = 1.0e-10;
         Size max = 5000;
 
-        ext::shared_ptr<YieldTermStructure> ts0 (
-              new PiecewiseYieldCurve<Discount,LogLinear>(curveSettlementDays,
+        auto ts0 = ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(curveSettlementDays,
                                                           calendar,
                                                           instrumentsB,
-                                                          dc));
+                                                          dc);
 
         ExponentialSplinesFitting exponentialSplines(constrainAtZero);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts1 (
-                  new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts1 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                               calendar,
                                               instrumentsA,
                                               dc,
                                               exponentialSplines,
                                               tolerance,
-                                              max));
+                                              max);
 
         printOutput("(a) exponential splines", ts1);
 
 
         SimplePolynomialFitting simplePolynomial(3, constrainAtZero);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts2 (
-                    new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts2 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                 calendar,
                                                 instrumentsA,
                                                 dc,
                                                 simplePolynomial,
                                                 tolerance,
-                                                max));
+                                                max);
 
         printOutput("(b) simple polynomial", ts2);
 
 
         NelsonSiegelFitting nelsonSiegel;
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts3 (
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts3 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar,
                                                     instrumentsA,
                                                     dc,
                                                     nelsonSiegel,
                                                     tolerance,
-                                                    max));
+                                                    max);
 
         printOutput("(c) Nelson-Siegel", ts3);
 
@@ -227,27 +220,25 @@ int main(int, char* []) {
 
         CubicBSplinesFitting cubicBSplines(knotVector, constrainAtZero);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts4 (
-                       new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts4 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                    calendar,
                                                    instrumentsA,
                                                    dc,
                                                    cubicBSplines,
                                                    tolerance,
-                                                   max));
+                                                   max);
 
         printOutput("(d) cubic B-splines", ts4);
 
         SvenssonFitting svensson;
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts5 (
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts5 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar,
                                                     instrumentsA,
                                                     dc,
                                                     svensson,
                                                     tolerance,
-                                                    max));
+                                                    max);
 
         printOutput("(e) Svensson", ts5);
 
@@ -258,28 +249,26 @@ int main(int, char* []) {
                                     ext::make_shared<NelsonSiegelFitting>(),
                                     discountCurve);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts6 (
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts6 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar,
                                                     instrumentsA,
                                                     dc,
                                                     nelsonSiegelSpread,
                                                     tolerance,
-                                                    max));
+                                                    max);
 
         printOutput("(f) Nelson-Siegel spread", ts6);
 
         //Fixed kappa, and 7 coefficients
         ExponentialSplinesFitting exponentialSplinesFixed(constrainAtZero,7,0.02);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts7(
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts7 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar, 
                                                     instrumentsA, 
                                                     dc, 
                                                     exponentialSplinesFixed, 
                                                     tolerance, 
-                                                    max));
+                                                    max);
 
         printOutput("(g) exponential splines, fixed kappa", ts7);
 
@@ -302,7 +291,7 @@ int main(int, char* []) {
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
-            std::vector<ext::shared_ptr<CashFlow> > cfs =
+            std::vector<ext::shared_ptr<CashFlow>> cfs =
                 instrumentsA[i]->bond()->cashflows();
 
             Size cfSize = instrumentsA[i]->bond()->cashflows().size();
@@ -392,7 +381,7 @@ int main(int, char* []) {
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
-            std::vector<ext::shared_ptr<CashFlow> > cfs =
+            std::vector<ext::shared_ptr<CashFlow>> cfs =
                 instrumentsA[i]->bond()->cashflows();
 
             Size cfSize = instrumentsA[i]->bond()->cashflows().size();
@@ -454,89 +443,81 @@ int main(int, char* []) {
         Settings::instance().evaluationDate() = today;
         bondSettlementDate = calendar.advance(today, bondSettlementDays*Days);
 
-        ext::shared_ptr<YieldTermStructure> ts00 (
-              new PiecewiseYieldCurve<Discount,LogLinear>(curveSettlementDays,
+        auto ts00 = ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(curveSettlementDays,
                                                           calendar,
                                                           instrumentsB,
-                                                          dc));
+                                                          dc);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts11 (
-                  new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts11 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                               calendar,
                                               instrumentsA,
                                               dc,
                                               exponentialSplines,
                                               tolerance,
-                                              max));
+                                              max);
 
         printOutput("(a) exponential splines", ts11);
 
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts22 (
-                    new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts22 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                 calendar,
                                                 instrumentsA,
                                                 dc,
                                                 simplePolynomial,
                                                 tolerance,
-                                                max));
+                                                max);
 
         printOutput("(b) simple polynomial", ts22);
 
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts33 (
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts33 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar,
                                                     instrumentsA,
                                                     dc,
                                                     nelsonSiegel,
                                                     tolerance,
-                                                    max));
+                                                    max);
 
         printOutput("(c) Nelson-Siegel", ts33);
 
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts44 (
-                       new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts44 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                    calendar,
                                                    instrumentsA,
                                                    dc,
                                                    cubicBSplines,
                                                    tolerance,
-                                                   max));
+                                                   max);
 
         printOutput("(d) cubic B-splines", ts44);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts55 (
-                       new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts55 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                    calendar,
                                                    instrumentsA,
                                                    dc,
                                                    svensson,
                                                    tolerance,
-                                                   max));
+                                                   max);
 
         printOutput("(e) Svensson", ts55);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts66 (
-                        new FittedBondDiscountCurve(curveSettlementDays,
+        auto ts66 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays,
                                                     calendar,
                                                     instrumentsA,
                                                     dc,
                                                     nelsonSiegelSpread,
                                                     tolerance,
-                                                    max));
+                                                    max);
 
         printOutput("(f) Nelson-Siegel spread", ts66);
 
-        ext::shared_ptr<FittedBondDiscountCurve> ts77(
-                        new FittedBondDiscountCurve(curveSettlementDays, 
+        auto ts77 = ext::make_shared<FittedBondDiscountCurve>(curveSettlementDays, 
                                                     calendar, 
                                                     instrumentsA, 
                                                     dc, 
                                                     exponentialSplinesFixed, 
                                                     tolerance, 
-                                                    max));
+                                                    max);
 
         printOutput("(g) exponential, fixed kappa", ts77);
 
@@ -553,7 +534,7 @@ int main(int, char* []) {
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
-            std::vector<ext::shared_ptr<CashFlow> > cfs =
+            std::vector<ext::shared_ptr<CashFlow>> cfs =
                 instrumentsA[i]->bond()->cashflows();
 
             Size cfSize = instrumentsA[i]->bond()->cashflows().size();
@@ -639,7 +620,7 @@ int main(int, char* []) {
 
         for (Size i=0; i<instrumentsA.size(); i++) {
 
-            std::vector<ext::shared_ptr<CashFlow> > cfs =
+            std::vector<ext::shared_ptr<CashFlow>> cfs =
                 instrumentsA[i]->bond()->cashflows();
 
             Size cfSize = instrumentsA[i]->bond()->cashflows().size();

--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -51,7 +51,7 @@ using namespace QuantLib;
 // helper function that prints a basket of calibrating swaptions to std::cout
 
 void printBasket(
-    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &basket) {
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper>> &basket) {
     std::cout << "\n" << std::left << std::setw(20) << "Expiry" << std::setw(20)
               << "Maturity" << std::setw(20) << "Nominal" << std::setw(14)
               << "Rate" << std::setw(12) << "Pay/Rec" << std::setw(14)
@@ -63,7 +63,7 @@ void printBasket(
                  "===================="
                  "==================" << std::endl;
     for (const auto& j : basket) {
-        ext::shared_ptr<SwaptionHelper> helper = ext::dynamic_pointer_cast<SwaptionHelper>(j);
+        auto helper = ext::dynamic_pointer_cast<SwaptionHelper>(j);
         Date endDate = helper->underlyingSwap()->fixedSchedule().dates().back();
         Real nominal = helper->underlyingSwap()->nominal();
         Real vol = helper->volatility()->value();
@@ -84,7 +84,7 @@ void printBasket(
 // helper function that prints the result of a model calibration to std::cout
 
 void printModelCalibration(
-    const std::vector<ext::shared_ptr<BlackCalibrationHelper> > &basket,
+    const std::vector<ext::shared_ptr<BlackCalibrationHelper>> &basket,
     const Array &volatility) {
 
     std::cout << "\n" << std::left << std::setw(20) << "Expiry" << std::setw(14)
@@ -99,8 +99,7 @@ void printModelCalibration(
                  "====================" << std::endl;
 
     for (Size j = 0; j < basket.size(); ++j) {
-        ext::shared_ptr<SwaptionHelper> helper =
-            ext::dynamic_pointer_cast<SwaptionHelper>(basket[j]);
+        auto helper = ext::dynamic_pointer_cast<SwaptionHelper>(basket[j]);
         Date expiry = helper->swaption()->exercise()->date(0);
         std::ostringstream expiryString;
         expiryString << expiry;
@@ -147,8 +146,7 @@ int main(int argc, char *argv[]) {
         Handle<YieldTermStructure> ytsOis(ext::make_shared<FlatForward>(
             0, TARGET(), oisQuote, Actual365Fixed()));
 
-        ext::shared_ptr<IborIndex> euribor6m =
-            ext::make_shared<Euribor>(6 * Months, yts6m);
+        auto euribor6m = ext::make_shared<Euribor>(6 * Months, yts6m);
 
         std::cout
             << "\nWe assume a multicurve setup, for simplicity with flat yield "
@@ -183,8 +181,7 @@ int main(int argc, char *argv[]) {
                                   ModifiedFollowing, DateGeneration::Forward,
                                   false);
 
-        ext::shared_ptr<NonstandardSwap> underlying =
-            ext::make_shared<NonstandardSwap>(VanillaSwap(
+        auto underlying = ext::make_shared<NonstandardSwap>(VanillaSwap(
                 Swap::Payer, 1.0, fixedSchedule, strike, Thirty360(Thirty360::BondBasis),
                 floatingSchedule, euribor6m, 0.00, Actual360()));
 
@@ -193,10 +190,8 @@ int main(int argc, char *argv[]) {
             exerciseDates.push_back(
                 TARGET().advance(fixedSchedule[i], -2 * Days));
 
-        ext::shared_ptr<Exercise> exercise =
-            ext::make_shared<BermudanExercise>(exerciseDates, false);
-        ext::shared_ptr<NonstandardSwaption> swaption =
-            ext::make_shared<NonstandardSwaption>(underlying, exercise);
+        auto exercise = ext::make_shared<BermudanExercise>(exerciseDates, false);
+        auto swaption = ext::make_shared<NonstandardSwaption>(underlying, exercise);
 
         std::cout
             << "\nThe model is a one factor Hull White model with piecewise "
@@ -218,13 +213,12 @@ int main(int argc, char *argv[]) {
                "\nwhere explicitly specified (e.g. in a swaption pricing "
                "engine)." << std::endl;
 
-        ext::shared_ptr<Gsr> gsr = ext::make_shared<Gsr>(
-            yts6m, stepDates, sigmas, reversion);
+        auto gsr = ext::make_shared<Gsr>(yts6m, stepDates, sigmas, reversion);
 
-        ext::shared_ptr<PricingEngine> swaptionEngine =
+        auto swaptionEngine =
             ext::make_shared<Gaussian1dSwaptionEngine>(gsr, 64, 7.0, true,
                                                          false, ytsOis);
-        ext::shared_ptr<PricingEngine> nonstandardSwaptionEngine =
+        auto nonstandardSwaptionEngine =
             ext::make_shared<Gaussian1dNonstandardSwaptionEngine>(
                 gsr, 64, 7.0, true, false, Handle<Quote>(), ytsOis);
 
@@ -239,11 +233,11 @@ int main(int argc, char *argv[]) {
 
         std::cout << "\nThe resulting basket looks as follows:" << std::endl;
 
-        ext::shared_ptr<SwapIndex> swapBase =
+        auto swapBase =
             ext::make_shared<EuriborSwapIsdaFixA>(10 * Years, yts6m, ytsOis);
 
         
-        std::vector<ext::shared_ptr<BlackCalibrationHelper> > basket =
+        std::vector<ext::shared_ptr<BlackCalibrationHelper>> basket =
             swaption->calibrationBasket(swapBase, *swaptionVol,
                                         BasketGeneratingEngine::Naive);
         printBasket(basket);
@@ -346,12 +340,11 @@ int main(int argc, char *argv[]) {
         }
         std::vector<Real> strikes(nominalFixed.size(), strike);
 
-        ext::shared_ptr<NonstandardSwap> underlying2(new NonstandardSwap(
+        auto underlying2 = ext::make_shared<NonstandardSwap>(
             Swap::Payer, nominalFixed, nominalFloating, fixedSchedule,
             strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, 1.0, 0.0,
-            Actual360()));
-        ext::shared_ptr<NonstandardSwaption> swaption2 =
-            ext::make_shared<NonstandardSwaption>(underlying2, exercise);
+            Actual360());
+        auto swaption2 = ext::make_shared<NonstandardSwaption>(underlying2, exercise);
 
         swaption2->setPricingEngine(nonstandardSwaptionEngine);
 
@@ -382,25 +375,21 @@ int main(int argc, char *argv[]) {
         std::vector<Real> nominalFloating2(nominalFloating.size(),
                                            0.0); // null the second leg
 
-        ext::shared_ptr<NonstandardSwap> underlying3(new NonstandardSwap(
+        auto underlying3 = ext::make_shared<NonstandardSwap>(
             Swap::Receiver, nominalFixed2, nominalFloating2,
             fixedSchedule, strikes, Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m,
             1.0, 0.0, Actual360(), false,
-            true)); // final capital exchange
+            true); // final capital exchange
 
-        ext::shared_ptr<RebatedExercise> exercise2 =
-            ext::make_shared<RebatedExercise>(*exercise, -1.0, 2, TARGET());
+        auto exercise2 = ext::make_shared<RebatedExercise>(*exercise, -1.0, 2, TARGET());
 
-        ext::shared_ptr<NonstandardSwaption> swaption3 =
-            ext::make_shared<NonstandardSwaption>(underlying3, exercise2);
+        auto swaption3 = ext::make_shared<NonstandardSwaption>(underlying3, exercise2);
 
-        ext::shared_ptr<SimpleQuote> oas0 =
-            ext::make_shared<SimpleQuote>(0.0);
-        ext::shared_ptr<SimpleQuote> oas100 =
-            ext::make_shared<SimpleQuote>(0.01);
+        auto oas0 = ext::make_shared<SimpleQuote>(0.0);
+        auto oas100 = ext::make_shared<SimpleQuote>(0.01);
         RelinkableHandle<Quote> oas(oas0);
 
-        ext::shared_ptr<PricingEngine> nonstandardSwaptionEngine2 =
+        auto nonstandardSwaptionEngine2 =
             ext::make_shared<Gaussian1dNonstandardSwaptionEngine>(
                 gsr, 64, 7.0, true, false, oas); // change discounting to 6m
 
@@ -477,17 +466,15 @@ int main(int argc, char *argv[]) {
                "\n6M swaption. The maturity is again 10 years and the option"
                "\nis exercisable on a yearly basis" << std::endl;
 
-        ext::shared_ptr<FloatFloatSwap> underlying4(new FloatFloatSwap(
+        auto underlying4 = ext::make_shared<FloatFloatSwap>(
                 Swap::Payer, 1.0, 1.0, fixedSchedule, swapBase,
                 Thirty360(Thirty360::BondBasis), floatingSchedule, euribor6m, Actual360(), false,
-                false, 1.0, 0.0, Null<Real>(), Null<Real>(), 1.0, 0.0010));
+                false, 1.0, 0.0, Null<Real>(), Null<Real>(), 1.0, 0.0010);
 
-        ext::shared_ptr<FloatFloatSwaption> swaption4 =
-            ext::make_shared<FloatFloatSwaption>(underlying4, exercise);
+        auto swaption4 = ext::make_shared<FloatFloatSwaption>(underlying4, exercise);
 
-        ext::shared_ptr<Gaussian1dFloatFloatSwaptionEngine>
-            floatSwaptionEngine(new Gaussian1dFloatFloatSwaptionEngine(
-                    gsr, 64, 7.0, true, false, Handle<Quote>(), ytsOis, true));
+        auto floatSwaptionEngine = ext::make_shared<Gaussian1dFloatFloatSwaptionEngine>(
+                    gsr, 64, 7.0, true, false, Handle<Quote>(), ytsOis, true);
 
         swaption4->setPricingEngine(floatSwaptionEngine);
 
@@ -501,15 +488,13 @@ int main(int argc, char *argv[]) {
 
         const Leg &leg0 = underlying4->leg(0);
         const Leg &leg1 = underlying4->leg(1);
-        ext::shared_ptr<CmsCouponPricer> cmsPricer =
-            ext::make_shared<LinearTsrPricer>(swaptionVol, reversionQuote);
+        auto cmsPricer = ext::make_shared<LinearTsrPricer>(swaptionVol, reversionQuote);
         auto iborPricer = ext::make_shared<BlackIborCouponPricer>();
 
         setCouponPricer(leg0, cmsPricer);
         setCouponPricer(leg1, iborPricer);
 
-        ext::shared_ptr<PricingEngine> swapPricer =
-            ext::make_shared<DiscountingSwapEngine>(ytsOis);
+        auto swapPricer = ext::make_shared<DiscountingSwapEngine>(ytsOis);
 
         underlying4->setPricingEngine(swapPricer);
 
@@ -574,17 +559,15 @@ int main(int argc, char *argv[]) {
         const std::vector<Date>& cmsFixingDates(markovStepDates);
         std::vector<Real> markovSigmas(markovStepDates.size() + 1, 0.01);
         std::vector<Period> tenors(cmsFixingDates.size(), 10 * Years);
-        ext::shared_ptr<MarkovFunctional> markov =
-            ext::make_shared<MarkovFunctional>(
+        auto markov = ext::make_shared<MarkovFunctional>(
                 yts6m, reversion, markovStepDates, markovSigmas, swaptionVol,
                 cmsFixingDates, tenors, swapBase,
                 MarkovFunctional::ModelSettings().withYGridPoints(16));
 
-        ext::shared_ptr<Gaussian1dSwaptionEngine> swaptionEngineMarkov =
+        auto swaptionEngineMarkov =
             ext::make_shared<Gaussian1dSwaptionEngine>(markov, 8, 5.0, true,
                                                          false, ytsOis);
-        ext::shared_ptr<Gaussian1dFloatFloatSwaptionEngine>
-            floatEngineMarkov =
+        auto floatEngineMarkov =
                 ext::make_shared<Gaussian1dFloatFloatSwaptionEngine>(
                     markov, 16, 7.0, true, false, Handle<Quote>(), ytsOis,
                     true);

--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -190,10 +190,8 @@ void testFirefly() {
     Size agents = 150;
     Real vola = 1.5;
     Real intense = 1.0;
-    ext::shared_ptr<FireflyAlgorithm::Intensity> intensity =
-        ext::make_shared<ExponentialIntensity>(10.0, 1e-8, intense);
-    ext::shared_ptr<FireflyAlgorithm::RandomWalk> randomWalk =
-        ext::make_shared<LevyFlightWalk>(vola, 0.5, 1.0, seed);
+    auto intensity = ext::make_shared<ExponentialIntensity>(10.0, 1e-8, intense);
+    auto randomWalk = ext::make_shared<LevyFlightWalk>(vola, 0.5, 1.0, seed);
     std::cout << "Function eggholder, Agents: " << agents
             << ", Vola: " << vola << ", Intensity: " << intense << std::endl;
     TestFunction f(eggholder);
@@ -305,10 +303,8 @@ void testPSO(Size n){
     std::cout << "Function: rosenbrock, Dimensions: " << n
             << ", Agents: " << agents << ", K-neighbors: " << kneighbor
             << ", Threshold: " << threshold << std::endl;
-    ext::shared_ptr<ParticleSwarmOptimization::Topology> topology =
-        ext::make_shared<KNeighbors>(kneighbor);
-    ext::shared_ptr<ParticleSwarmOptimization::Inertia> inertia =
-        ext::make_shared<LevyFlightInertia>(1.5, threshold, seed);
+    auto topology = ext::make_shared<KNeighbors>(kneighbor);
+    auto inertia = ext::make_shared<LevyFlightInertia>(1.5, threshold, seed);
     TestFunction f(rosenbrock);
     ParticleSwarmOptimization pso(agents, topology, inertia, 2.05, 2.05, seed);
     EndCriteria ec(10000, 1000, 1.0e-8, 1.0e-8, 1.0e-8);

--- a/Examples/LatentModel/LatentModel.cpp
+++ b/Examples/LatentModel/LatentModel.cpp
@@ -60,7 +60,7 @@ int main(int, char* []) {
         std::vector<std::string> names;
         for(Size i=0; i<hazardRates.size(); i++)
             names.push_back(std::string("Acme") + std::to_string(i));
-        std::vector<Handle<DefaultProbabilityTermStructure> > defTS;
+        std::vector<Handle<DefaultProbabilityTermStructure>> defTS;
         defTS.reserve(hazardRates.size());
         for (Real& hazardRate : hazardRates)
             defTS.emplace_back(
@@ -75,7 +75,7 @@ int main(int, char* []) {
             issuers.emplace_back(curves);
         }
 
-        ext::shared_ptr<Pool> thePool = ext::make_shared<Pool>();
+        auto thePool = ext::make_shared<Pool>();
         for(Size i=0; i<hazardRates.size(); i++)
             thePool->add(names[i], issuers[i], NorthAmericaCorpDefaultKey(
                     EURCurrency(), QuantLib::SeniorSec, Period(), 1.));
@@ -84,10 +84,10 @@ int main(int, char* []) {
             NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
         // Recoveries are irrelevant in this example but must be given as the 
         //   lib stands.
-        std::vector<ext::shared_ptr<RecoveryRateModel> > rrModels(
+        std::vector<ext::shared_ptr<RecoveryRateModel>> rrModels(
             hazardRates.size(), ext::make_shared<ConstantRecoveryModel>(
             ConstantRecoveryModel(0.5, SeniorSec)));
-        ext::shared_ptr<Basket> theBskt = ext::make_shared<Basket>(
+        auto theBskt = ext::make_shared<Basket>(
             todaysDate, names, std::vector<Real>(hazardRates.size(), 100.), 
             thePool);
         /* --------------------------------------------------------------
@@ -95,16 +95,15 @@ int main(int, char* []) {
         -------------------------------------------------------------- */
         // Latent model factors, corresponds to the first entry in Table1 of the
         //   publication mentioned. It is a single factor model
-        std::vector<std::vector<Real> > fctrsWeights(hazardRates.size(), 
+        std::vector<std::vector<Real>> fctrsWeights(hazardRates.size(),
             std::vector<Real>(1, std::sqrt(0.1)));
         // --- Default Latent models -------------------------------------
         #ifndef QL_PATCH_SOLARIS
         // Gaussian integrable joint default model:
-        ext::shared_ptr<GaussianDefProbLM> lmG(new 
-            GaussianDefProbLM(fctrsWeights, 
+        auto lmG = ext::make_shared<GaussianDefProbLM>(fctrsWeights,
             LatentModelIntegrationType::GaussianQuadrature,
 			GaussianCopulaPolicy::initTraits() // otherwise gcc screams
-			));
+			);
         #endif
         // Define StudentT copula
         // this is as far as we can be from the Gaussian, 2 T_3 factors:
@@ -112,10 +111,9 @@ int main(int, char* []) {
         TCopulaPolicy::initTraits iniT;
         iniT.tOrders = ordersT;
         // StudentT integrable joint default model:
-        ext::shared_ptr<TDefProbLM> lmT(new TDefProbLM(fctrsWeights, 
+        auto lmT = ext::make_shared<TDefProbLM>(fctrsWeights,
             // LatentModelIntegrationType::GaussianQuadrature,
-            LatentModelIntegrationType::Trapezoid,
-            iniT));
+            LatentModelIntegrationType::Trapezoid, iniT);
 
         // --- Default Loss models ----------------------------------------
         // Gaussian random joint default model:
@@ -123,14 +121,12 @@ int main(int, char* []) {
         // Size numCoresUsed = 4;
         #ifndef QL_PATCH_SOLARIS
         // Sobol, many cores
-        ext::shared_ptr<DefaultLossModel> rdlmG(
-            ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy> >(lmG, 
-                std::vector<Real>(), numSimulations, 1.e-6, 2863311530UL));
+        auto rdlmG = ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy>>(lmG,
+            std::vector<Real>(), numSimulations, 1.e-6, 2863311530UL);
         #endif
         // StudentT random joint default model:
-        ext::shared_ptr<DefaultLossModel> rdlmT(
-            ext::make_shared<RandomDefaultLM<TCopulaPolicy> >(lmT, 
-            std::vector<Real>(), numSimulations, 1.e-6, 2863311530UL));
+        auto rdlmT = ext::make_shared<RandomDefaultLM<TCopulaPolicy>>(lmT,
+            std::vector<Real>(), numSimulations, 1.e-6, 2863311530UL);
 
         /* --------------------------------------------------------------
                         DUMP SOME RESULTS
@@ -179,7 +175,7 @@ int main(int, char* []) {
 
         Date correlDate = TARGET().advance(
             Settings::instance().evaluationDate(), Period(12, Months));
-        std::vector<std::vector<Real> > correlsGlm, correlsTlm, correlsGrand, 
+        std::vector<std::vector<Real>> correlsGlm, correlsTlm, correlsGrand,
             correlsTrand;
         //
         lmT->resetBasket(theBskt);

--- a/Examples/MarketModels/MarketModels.cpp
+++ b/Examples/MarketModels/MarketModels.cpp
@@ -69,7 +69,7 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 
 using namespace QuantLib;
 
-std::vector<std::vector<Matrix> >
+std::vector<std::vector<Matrix>>
 theVegaBumps(bool factorwiseBumping, const ext::shared_ptr<MarketModel>& marketModel, bool doCaps) {
     Real multiplierCutOff = 50.0;
     Real projectionTolerance = 1E-4;
@@ -114,7 +114,7 @@ theVegaBumps(bool factorwiseBumping, const ext::shared_ptr<MarketModel>& marketM
         multiplierCutOff, // if vector length grows by more than this discard
         projectionTolerance);      // if vector projection before scaling less than this discard
 
-    std::vector<std::vector<Matrix> > theBumps;
+    std::vector<std::vector<Matrix>> theBumps;
 
     bumpFinder.GetVegaBumps(theBumps);
 
@@ -165,8 +165,8 @@ int Bermudan()
     SwapRateTrigger naifStrategy(rateTimes, swapTriggers, exerciseTimes);
 
     // Longstaff-Schwartz exercise strategy
-    std::vector<std::vector<NodeData> > collectedData;
-    std::vector<std::vector<Real> > basisCoefficients;
+    std::vector<std::vector<NodeData>> collectedData;
+    std::vector<std::vector<Real>> basisCoefficients;
 
     // control that does nothing, need it because some control is expected
     NothingExerciseValue control(rateTimes);
@@ -234,13 +234,13 @@ int Bermudan()
 
     FlatVol  calibration(
         volatilities,
-        ext::shared_ptr<PiecewiseConstantCorrelation>(new  ExponentialForwardCorrelation(correlations)),
+        ext::make_shared<ExponentialForwardCorrelation>(correlations),
         evolution,
         numberOfFactors,
         initialRates,
         displacements);
 
-    ext::shared_ptr<MarketModel> marketModel(new FlatVol(calibration));
+    auto marketModel = ext::make_shared<FlatVol>(calibration);
 
     // we use a factory since there is data that will only be known later
     SobolBrownianGeneratorFactory generatorFactory(
@@ -254,7 +254,7 @@ int Bermudan()
         numeraires   // numeraires for each step
         );
 
-    ext::shared_ptr<MarketModelEvolver> evolverPtr(new LogNormalFwdRatePc(evolver));
+    auto evolverPtr = ext::make_shared<LogNormalFwdRatePc>(evolver);
 
     int t1= clock();
 
@@ -353,7 +353,7 @@ int Bermudan()
         Clone<MarketModelPathwiseMultiProduct> callableProductPathwisePtr(callableProductPathwise.clone());
 
 
-        std::vector<std::vector<Matrix> > theBumps(theVegaBumps(allowFactorwiseBumping,
+        std::vector<std::vector<Matrix>> theBumps(theVegaBumps(allowFactorwiseBumping,
             marketModel,
             doCaps));
 
@@ -397,12 +397,12 @@ int Bermudan()
 
     MTBrownianGeneratorFactory uFactory(seed+142);
 
-    ext::shared_ptr<MarketModelEvolver> upperEvolver(new LogNormalFwdRatePc( ext::shared_ptr<MarketModel>(new FlatVol(calibration)),
+    auto upperEvolver = ext::make_shared<LogNormalFwdRatePc>(ext::make_shared<FlatVol>(calibration),
             uFactory,
             numeraires   // numeraires for each step
-            ));
+            );
 
-    std::vector<ext::shared_ptr<MarketModelEvolver> > innerEvolvers;
+    std::vector<ext::shared_ptr<MarketModelEvolver>> innerEvolvers;
 
     std::valarray<bool> isExerciseTime =   isInSubset(evolution.evolutionTimes(),    exerciseStrategy.exerciseTimes());
 
@@ -411,10 +411,10 @@ int Bermudan()
         if (isExerciseTime[s])
         {
             MTBrownianGeneratorFactory iFactory(seed+s);
-            ext::shared_ptr<MarketModelEvolver> e =ext::shared_ptr<MarketModelEvolver> (static_cast<MarketModelEvolver*>(new   LogNormalFwdRatePc(ext::shared_ptr<MarketModel>(new FlatVol(calibration)),
+            auto e = ext::make_shared<LogNormalFwdRatePc>(ext::make_shared<FlatVol>(calibration),
                     uFactory,
-                    numeraires ,  // numeraires for each step
-                    s)));
+                    numeraires,  // numeraires for each step
+                    s);
 
             innerEvolvers.push_back(e);
         }
@@ -498,8 +498,8 @@ int InverseFloater(Real rateLevel)
     SwapRateTrigger naifStrategy(rateTimes, swapTriggers, exerciseTimes);
 
     // Longstaff-Schwartz exercise strategy
-    std::vector<std::vector<NodeData> > collectedData;
-    std::vector<std::vector<Real> > basisCoefficients;
+    std::vector<std::vector<NodeData>> collectedData;
+    std::vector<std::vector<Real>> basisCoefficients;
 
     // control that does nothing, need it because some control is expected
     NothingExerciseValue control(rateTimes);
@@ -574,13 +574,13 @@ int InverseFloater(Real rateLevel)
 
     FlatVol  calibration(
         volatilities,
-        ext::shared_ptr<PiecewiseConstantCorrelation>(new  ExponentialForwardCorrelation(correlations)),
+        ext::make_shared<ExponentialForwardCorrelation>(correlations),
         evolution,
         numberOfFactors,
         initialRates,
         displacements);
 
-    ext::shared_ptr<MarketModel> marketModel(new FlatVol(calibration));
+    auto marketModel = ext::make_shared<FlatVol>(calibration);
 
     // we use a factory since there is data that will only be known later
     SobolBrownianGeneratorFactory generatorFactory(
@@ -594,7 +594,7 @@ int InverseFloater(Real rateLevel)
         numeraires   // numeraires for each step
         );
 
-    ext::shared_ptr<MarketModelEvolver> evolverPtr(new LogNormalFwdRatePc(evolver));
+    auto evolverPtr = ext::make_shared<LogNormalFwdRatePc>(evolver);
 
     int t1= clock();
 
@@ -689,7 +689,7 @@ int InverseFloater(Real rateLevel)
         Clone<MarketModelPathwiseMultiProduct> callableProductPathwisePtr(callableProductPathwise.clone());
 
 
-        std::vector<std::vector<Matrix> > theBumps(theVegaBumps(allowFactorwiseBumping,
+        std::vector<std::vector<Matrix>> theBumps(theVegaBumps(allowFactorwiseBumping,
             marketModel,
             doCaps));
 
@@ -735,12 +735,12 @@ int InverseFloater(Real rateLevel)
     MTBrownianGeneratorFactory uFactory(seed+142);
 
 
-    ext::shared_ptr<MarketModelEvolver> upperEvolver(new LogNormalFwdRatePc( ext::shared_ptr<MarketModel>(new FlatVol(calibration)),
+    auto upperEvolver = ext::make_shared<LogNormalFwdRatePc>(ext::make_shared<FlatVol>(calibration),
             uFactory,
             numeraires   // numeraires for each step
-            ));
+            );
 
-    std::vector<ext::shared_ptr<MarketModelEvolver> > innerEvolvers;
+    std::vector<ext::shared_ptr<MarketModelEvolver>> innerEvolvers;
 
     std::valarray<bool> isExerciseTime =   isInSubset(evolution.evolutionTimes(),    exerciseStrategy.exerciseTimes());
 
@@ -749,10 +749,10 @@ int InverseFloater(Real rateLevel)
         if (isExerciseTime[s])
         {
             MTBrownianGeneratorFactory iFactory(seed+s);
-            ext::shared_ptr<MarketModelEvolver> e =ext::shared_ptr<MarketModelEvolver> (static_cast<MarketModelEvolver*>(new   LogNormalFwdRatePc(ext::shared_ptr<MarketModel>(new FlatVol(calibration)),
+            auto e = ext::make_shared<LogNormalFwdRatePc>(ext::make_shared<FlatVol>(calibration),
                     uFactory,
                     numeraires ,  // numeraires for each step
-                    s)));
+                    s);
 
             innerEvolvers.push_back(e);
         }

--- a/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
+++ b/Examples/MulticurveBootstrapping/MulticurveBootstrapping.cpp
@@ -87,9 +87,9 @@ int main(int, char* []) {
         *********************/
 
         DayCounter termStructureDayCounter = Actual365Fixed();
-        std::vector<ext::shared_ptr<RateHelper> > eoniaInstruments;
+        std::vector<ext::shared_ptr<RateHelper>> eoniaInstruments;
 
-        ext::shared_ptr<Eonia> eonia(new Eonia);
+        auto eonia = ext::make_shared<Eonia>();
 
         // a SimpleQuote instance stores a value which can be manually changed;
         // other Quote subclasses could read the value from a database
@@ -191,10 +191,8 @@ int main(int, char* []) {
 
         // curve
 
-        ext::shared_ptr<YieldTermStructure> eoniaTermStructure(
-            new PiecewiseYieldCurve<Discount, Cubic>(
-                todaysDate, eoniaInstruments,
-                termStructureDayCounter) );
+        auto eoniaTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, Cubic>>(
+                todaysDate, eoniaInstruments, termStructureDayCounter);
 
         eoniaTermStructure->enableExtrapolation();
 
@@ -207,9 +205,9 @@ int main(int, char* []) {
         **    EURIBOR 6M CURVE   **
         ***************************/
 
-        std::vector<ext::shared_ptr<RateHelper> > euribor6MInstruments;
+        std::vector<ext::shared_ptr<RateHelper>> euribor6MInstruments;
 
-        ext::shared_ptr<IborIndex> euribor6M(new Euribor6M);
+        auto euribor6M = ext::make_shared<Euribor6M>();
 
         // deposits
 
@@ -298,11 +296,10 @@ int main(int, char* []) {
         // The tolerance is passed in an explicit bootstrap object. Depending on
         // the bootstrap algorithm, it's possible to pass other parameters.
         double tolerance = 1.0e-15;
-        ext::shared_ptr<YieldTermStructure> euribor6MTermStructure(
-            new PiecewiseYieldCurve<Discount, Cubic>(
+        auto euribor6MTermStructure = ext::make_shared<PiecewiseYieldCurve<Discount, Cubic>>(
                 settlementDate, euribor6MInstruments,
                 termStructureDayCounter,
-                PiecewiseYieldCurve<Discount, Cubic>::bootstrap_type(tolerance)));
+                PiecewiseYieldCurve<Discount, Cubic>::bootstrap_type(tolerance));
 
         // This curve will be used for forward-rate forecasting
 
@@ -325,8 +322,7 @@ int main(int, char* []) {
 
         // floating leg
         Frequency floatingLegFrequency = Semiannual;
-        ext::shared_ptr<IborIndex> euriborIndex(
-                                     new Euribor6M(forecastingTermStructure));
+        auto euriborIndex = ext::make_shared<Euribor6M>(forecastingTermStructure);
         Spread spread = 0.0;
 
         Integer lengthInYears = 5;
@@ -407,8 +403,7 @@ int main(int, char* []) {
         Rate fairRate;
         Spread fairSpread;
 
-        ext::shared_ptr<PricingEngine> swapEngine(
-                         new DiscountingSwapEngine(discountingTermStructure));
+        auto swapEngine = ext::make_shared<DiscountingSwapEngine>(discountingTermStructure);
 
         spot5YearSwap.setPricingEngine(swapEngine);
         oneYearForward5YearSwap.setPricingEngine(swapEngine);
@@ -459,8 +454,7 @@ int main(int, char* []) {
         // value contained in the Quote triggers a new bootstrapping
         // of the curve and a repricing of the swap.
 
-        ext::shared_ptr<SimpleQuote> fiveYearsRate =
-            ext::dynamic_pointer_cast<SimpleQuote>(s5yRate);
+        auto fiveYearsRate = ext::dynamic_pointer_cast<SimpleQuote>(s5yRate);
         fiveYearsRate->setValue(0.0090);
 
         std::cout << dblrule << std::endl;

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -70,10 +70,10 @@ int main() {
     Real valueQuad = intg(f);
     #endif
 
-    std::vector<ext::shared_ptr<Integrator> > integrals;
+    std::vector<ext::shared_ptr<Integrator>> integrals;
     for(Size i=0; i<dimension; i++)
         integrals.push_back(
-        ext::make_shared<TrapezoidIntegral<Default> >(1.e-4, 20));
+        ext::make_shared<TrapezoidIntegral<Default>>(1.e-4, 20));
     std::vector<Real> a_limits(integrals.size(), -4.);
     std::vector<Real> b_limits(integrals.size(), 4.);
     MultidimIntegral testIntg(integrals);

--- a/Examples/Repo/Repo.cpp
+++ b/Examples/Repo/Repo.cpp
@@ -81,16 +81,14 @@ int main(int, char* []) {
         Settings::instance().evaluationDate() = repoSettlementDate;
 
         RelinkableHandle<YieldTermStructure> bondCurve;
-        bondCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                       new FlatForward(repoSettlementDate,
+        bondCurve.linkTo(ext::make_shared<FlatForward>(repoSettlementDate,
                                                        .01, // dummy rate
                                                        bondDayCountConvention,
                                                        Compounded,
-                                                       bondCouponFrequency)));
+                                                       bondCouponFrequency));
 
         /*
-        ext::shared_ptr<FixedRateBond> bond(
-                       new FixedRateBond(faceAmount,
+        auto bond = ext::make_shared<FixedRateBond>(faceAmount,
                                          bondIssueDate,
                                          bondDatedDate,
                                          bondMaturityDate,
@@ -102,7 +100,7 @@ int main(int, char* []) {
                                          bondBusinessDayConvention,
                                          bondBusinessDayConvention,
                                          bondRedemption,
-                                         bondCurve));
+                                         bondCurve);
         */
 
         Schedule bondSchedule(bondDatedDate, bondMaturityDate,
@@ -110,38 +108,34 @@ int main(int, char* []) {
                               bondCalendar,bondBusinessDayConvention,
                               bondBusinessDayConvention,
                               DateGeneration::Backward,false);
-        ext::shared_ptr<FixedRateBond> bond(
-                       new FixedRateBond(bondSettlementDays,
+        auto bond = ext::make_shared<FixedRateBond>(bondSettlementDays,
                                          faceAmount,
                                          bondSchedule,
                                          std::vector<Rate>(1,bondCoupon),
                                          bondDayCountConvention,
                                          bondBusinessDayConvention,
                                          bondRedemption,
-                                         bondIssueDate));
-        bond->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                       new DiscountingBondEngine(bondCurve)));
+                                         bondIssueDate);
+        bond->setPricingEngine(ext::make_shared<DiscountingBondEngine>(bondCurve));
 
-        bondCurve.linkTo(ext::shared_ptr<YieldTermStructure> (
-                   new FlatForward(repoSettlementDate,
+        bondCurve.linkTo(ext::make_shared<FlatForward>(repoSettlementDate,
                                    bond->yield(bondCleanPrice,
                                                bondDayCountConvention,
                                                Compounded,
                                                bondCouponFrequency),
                                    bondDayCountConvention,
                                    Compounded,
-                                   bondCouponFrequency)));
+                                   bondCouponFrequency));
 
         Position::Type fwdType = Position::Long;
         double dummyStrike = 91.5745;
 
         RelinkableHandle<YieldTermStructure> repoCurve;
-        repoCurve.linkTo(ext::shared_ptr<YieldTermStructure> (
-                                       new FlatForward(repoSettlementDate,
+        repoCurve.linkTo(ext::make_shared<FlatForward>(repoSettlementDate,
                                                        repoRate,
                                                        repoDayCountConvention,
                                                        repoCompounding,
-                                                       repoCompoundFreq)));
+                                                       repoCompoundFreq));
 
 
         BondForward bondFwd(repoSettlementDate, repoDeliveryDate, fwdType, dummyStrike,


### PR DESCRIPTION
As discussed in https://github.com/lballabio/QuantLib/pull/1758#issuecomment-1664025486, here is a first pass at modernizing the examples by introducing `auto` and `ext::make_shared`. I also removed spaces between angle brackets for a more modern feel.

I tried to preserve the existing formatting as much as possible, but feel free to reformat the changed lines if you prefer.

We can add `auto` in a lot more places, both in the examples and the main library, just let me know if you think now is the time.