### PR TITLE
Unsuppress modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,7 +48,6 @@ Checks: >
           -modernize-avoid-c-arrays,
           -modernize-macro-to-enum,
           -modernize-return-braced-init-list,
-          -modernize-use-emplace,
           -modernize-use-trailing-return-type,
           -modernize-use-using,
         performance-*,

--- a/ql/currencies/exchangeratemanager.cpp
+++ b/ql/currencies/exchangeratemanager.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
                                   const Date& startDate,
                                   const Date& endDate) {
         Key k = hash(rate.source(), rate.target());
-        data_[k].push_front(Entry(rate,startDate,endDate));
+        data_[k].emplace_front(rate,startDate,endDate);
     }
 
     ExchangeRate ExchangeRateManager::lookup(const Currency& source,

--- a/ql/experimental/commodities/commodity.cpp
+++ b/ql/experimental/commodities/commodity.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
     void Commodity::addPricingError(PricingError::Level errorLevel,
                                     const std::string& error,
                                     const std::string& detail) const {
-        pricingErrors_.push_back(PricingError(errorLevel, error, detail));
+        pricingErrors_.emplace_back(errorLevel, error, detail);
     }
 
 

--- a/ql/methods/montecarlo/lsmbasissystem.cpp
+++ b/ql/methods/montecarlo/lsmbasissystem.cpp
@@ -164,7 +164,7 @@ namespace QuantLib {
         VF_A ret;
         // 0-th order term
         VF_R term(dim, pathBasis[0]);
-        ret.push_back(MultiDimFct(term));
+        ret.emplace_back(MultiDimFct(term));
         // start with all 0 tuple
         VV tuples(1, std::vector<Size>(dim));
         // add multi-factor terms
@@ -175,7 +175,7 @@ namespace QuantLib {
             for (auto& tuple : tuples) {
                 for(Size k=0; k<dim; ++k)
                     term[k] = pathBasis[tuple[k]];
-                ret.push_back(MultiDimFct(term));
+                ret.emplace_back(MultiDimFct(term));
             }
         }
         return ret;

--- a/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
@@ -135,10 +135,9 @@ namespace QuantLib {
             ext::shared_ptr<StrikedTypePayoff> payoff(
                                             new PlainVanillaPayoff(type, *k));
             if ( k == strikes.begin() )
-                optionWeights.push_back(std::make_pair(payoff,slope));
+                optionWeights.emplace_back(payoff,slope);
             else
-                optionWeights.push_back(
-                                   std::make_pair(payoff, slope - prevSlope));
+                optionWeights.emplace_back(payoff, slope - prevSlope);
             prevSlope = slope;
         }
     }

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.cpp
@@ -247,8 +247,7 @@ namespace QuantLib {
             const Real strike = payoff->strike();
             strikes.insert(strike);
 
-            calibrationSet_.push_back(
-                std::make_pair(ext::make_shared<VanillaOption>(payoff, exercise), i.second));
+            calibrationSet_.emplace_back(ext::make_shared<VanillaOption>(payoff, exercise), i.second);
 
             registerWith(i.second);
         }

--- a/ql/termstructures/volatility/optionlet/strippedoptionlet.cpp
+++ b/ql/termstructures/volatility/optionlet/strippedoptionlet.cpp
@@ -69,7 +69,7 @@ namespace QuantLib {
         checkInputs();
 
         for (Size i = 0; i < nOptionletDates_; ++i)
-            optionletVolatilities_.push_back(vector<Volatility>(strikes[i].size()));
+            optionletVolatilities_.emplace_back(strikes[i].size());
 
         registerWith(Settings::instance().evaluationDate());
         registerWithMarketData();

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -131,14 +131,14 @@ namespace andreasen_huge_volatility_interpl_test {
 
                     const Volatility impliedVol = i[j];
 
-                    calibrationSet.push_back(std::make_pair(
+                    calibrationSet.emplace_back(
                         ext::make_shared<VanillaOption>(
                             ext::make_shared<PlainVanillaPayoff>(
                                 (strike < spot->value())? Option::Put
                                                         : Option::Call,
                                 strike),
                             ext::make_shared<EuropeanExercise>(maturity)),
-                        ext::make_shared<SimpleQuote>(impliedVol))
+                        ext::make_shared<SimpleQuote>(impliedVol)
                     );
                 }
             }
@@ -295,12 +295,12 @@ namespace andreasen_huge_volatility_interpl_test {
 
                 if (std::fabs(mn) < 3.71*vol) {
 
-                    calibrationSet.push_back(std::make_pair(
+                    calibrationSet.emplace_back(
                         ext::make_shared<VanillaOption>(
                             ext::make_shared<PlainVanillaPayoff>(
                                 Option::Call, strike),
                             ext::make_shared<EuropeanExercise>(maturityDate)),
-                        ext::make_shared<SimpleQuote>(vol)));
+                        ext::make_shared<SimpleQuote>(vol));
                 }
             }
         }
@@ -331,12 +331,12 @@ namespace andreasen_huge_volatility_interpl_test {
             const Date maturityDate = today + Period(maturities[i], Months);
             const Volatility vol = vols[i];
 
-            calibrationSet.push_back(std::make_pair(
+            calibrationSet.emplace_back(
                 ext::make_shared<VanillaOption>(
                     ext::make_shared<PlainVanillaPayoff>(
                         Option::Call, strike),
                     ext::make_shared<EuropeanExercise>(maturityDate)),
-                ext::make_shared<SimpleQuote>(vol)));
+                ext::make_shared<SimpleQuote>(vol));
         }
 
         return { spot, rTS, qTS, calibrationSet };
@@ -542,11 +542,11 @@ void AndreasenHugeVolatilityInterplTest::testSingleOptionCalibration() {
     const Date maturity = today + Period(1, Years);
     Handle<Quote> spot(ext::make_shared<SimpleQuote>(strike));
 
-    calibrationSet.push_back(std::make_pair(
+    calibrationSet.emplace_back(
         ext::make_shared<VanillaOption>(
             ext::make_shared<PlainVanillaPayoff>(Option::Call, strike),
             ext::make_shared<EuropeanExercise>(maturity)),
-        ext::make_shared<SimpleQuote>(vol)));
+        ext::make_shared<SimpleQuote>(vol));
 
     const AndreasenHugeVolatilityInterpl::InterpolationType interpl[] = {
         AndreasenHugeVolatilityInterpl::Linear,
@@ -713,12 +713,12 @@ void AndreasenHugeVolatilityInterplTest::testBarrierOptionPricing() {
             const Real mn = std::log(spot->value()/strike)/std::sqrt(t);
 
             if (std::fabs(mn) < 3.07*vol) {
-                calibrationSet.push_back(std::make_pair(
+                calibrationSet.emplace_back(
                     ext::make_shared<VanillaOption>(
                         ext::make_shared<PlainVanillaPayoff>(
                             Option::Call, strike),
                         ext::make_shared<EuropeanExercise>(maturityDate)),
-                    ext::make_shared<SimpleQuote>(vol)));
+                    ext::make_shared<SimpleQuote>(vol));
             }
         }
     }
@@ -799,12 +799,12 @@ namespace andreasen_huge_volatility_interpl_test {
         for (Real strike : strikes) {
             const Volatility vol = sabrVolatility(strike, forward, maturity, alpha, beta, nu, rho);
 
-            calibrationSet.push_back(std::make_pair(
+            calibrationSet.emplace_back(
                 ext::make_shared<VanillaOption>(
                     ext::make_shared<PlainVanillaPayoff>(
                         Option::Call, strike),
                     ext::make_shared<EuropeanExercise>(maturityDate)),
-                ext::make_shared<SimpleQuote>(vol)));
+                ext::make_shared<SimpleQuote>(vol));
         }
 
         const Handle<YieldTermStructure> rTS(flatRate(today, forward, dc));
@@ -1019,7 +1019,7 @@ void AndreasenHugeVolatilityInterplTest::testFlatVolCalibration() {
                               (strike>fwd)? Option::Call : Option::Put, strike),
                           exercise);
 
-                calibrationSet.push_back(std::make_pair(option, vol));
+                calibrationSet.emplace_back(option, vol);
             }
         }
     }

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -406,7 +406,7 @@ void CatBondTest::testCatBondInDoomScenario() {
                  DateGeneration::Backward, false);
 
     ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
-    events->push_back(std::pair<Date, Real>(Date(30,November,2004), 1000));
+    events->emplace_back(Date(30,November,2004), 1000);
     ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
         events, 
         Date(30,November,2004), Date(30,November,2008)));
@@ -471,7 +471,7 @@ void CatBondTest::testCatBondWithDoomOnceInTenYears() {
                  DateGeneration::Backward, false);
 
     ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
-    events->push_back(std::pair<Date, Real>(Date(30,November,2008), 1000));
+    events->emplace_back(Date(30,November,2008), 1000);
     ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
         events, 
         Date(30,November,2004), Date(30,November,2044)));
@@ -554,7 +554,7 @@ void CatBondTest::testCatBondWithDoomOnceInTenYearsProportional() {
                  DateGeneration::Backward, false);
 
     ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
-    events->push_back(std::pair<Date, Real>(Date(30,November,2008), 1000));
+    events->emplace_back(Date(30,November,2008), 1000);
     ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
         events, 
         Date(30,November,2004), Date(30,November,2044)));

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -512,7 +512,7 @@ void SwingOptionTest::testKlugeChFVanillaPricing() {
         - sig*sig/(4*alpha)*(1-std::exp(-2*alpha*t))
         - lambda/beta*std::log((eta-std::exp(-beta*t))/(eta-1.0));
 
-    shape->push_back(Shape::value_type(t, ps));
+    shape->emplace_back(t, ps);
 
     const Real expected =
         RichardsonExtrapolation(


### PR DESCRIPTION
The `modernize-use-emplace` check offers a fix, so this will show up in the weekly clang-tidy fixes job from now on.