### PR TITLE
Expose an IBOR coupon's decision about whether it has fixed or not

### DIFF
--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -88,8 +88,24 @@ namespace QuantLib {
         return fixingDate_;
     }
 
-    Rate IborCoupon::indexFixing() const {
+    bool IborCoupon::hasFixed() const {
+        Date today = QuantLib::Settings::instance().evaluationDate();
 
+        if (fixingDate_ > today) {
+            return false;
+        } else if (fixingDate_ < today) {
+            return true;
+        } else {
+            // fixingDate_ == today
+            if (QuantLib::Settings::instance().enforcesTodaysHistoricFixings()) {
+                return true;
+            } else {
+                return index_->hasHistoricalFixing(fixingDate_);
+            }
+        }
+    }
+
+    Rate IborCoupon::indexFixing() const {
         initializeCachedData();
 
         /* instead of just returning index_->fixing(fixingValueDate_)

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -114,34 +114,15 @@ namespace QuantLib {
            1) allows to save date/time recalculations, and
            2) takes into account par coupon needs
         */
-        Date today = QuantLib::Settings::instance().evaluationDate();
 
-        if (fixingDate_>today)
-            return iborIndex_->forecastFixing(fixingValueDate_,
-                                              fixingEndDate_,
-                                              spanningTime_);
-
-        if (fixingDate_<today ||
-            QuantLib::Settings::instance().enforcesTodaysHistoricFixings()) {
-            // do not catch exceptions
+        if (hasFixed()) {
             Rate result = index_->pastFixing(fixingDate_);
             QL_REQUIRE(result != Null<Real>(),
                        "Missing " << index_->name() << " fixing for " << fixingDate_);
             return result;
+        } else {
+            return iborIndex_->forecastFixing(fixingValueDate_, fixingEndDate_, spanningTime_);
         }
-
-        try {
-            Rate result = index_->pastFixing(fixingDate_);
-            if (result!=Null<Real>())
-                return result;
-            else
-                ;   // fall through and forecast
-        } catch (Error&) {
-                ;   // fall through and forecast
-        }
-        return iborIndex_->forecastFixing(fixingValueDate_,
-                                          fixingEndDate_,
-                                          spanningTime_);
     }
 
     void IborCoupon::setPricer(const ext::shared_ptr<FloatingRateCouponPricer>& pricer) {

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -56,6 +56,7 @@ namespace QuantLib {
         //! \name Inspectors
         //@{
         const ext::shared_ptr<IborIndex>& iborIndex() const { return iborIndex_; }
+        bool hasFixed() const;
         //@}
         //! \name FloatingRateCoupon interface
         //@{

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -574,29 +574,27 @@ IborCoupon iborCouponForFixingDate(const ext::shared_ptr<IborIndex>& index, Date
 }
 
 BOOST_AUTO_TEST_CASE(testIborCouponKnowsWhenitHasFixed) {
-    BOOST_TEST_MESSAGE("Testing ibor coupon knowing when it has fixed...");
+    BOOST_TEST_MESSAGE("Testing that ibor coupon knows when it has fixed...");
 
     Date today = Settings::instance().evaluationDate();
 
     auto index = ext::make_shared<Euribor3M>();
-    index->clearFixings();
     auto calendar = index->fixingCalendar();
-
-    bool defaultEnforcesTodaysHistoricFixings =
-        QuantLib::Settings::instance().enforcesTodaysHistoricFixings();
 
     {
         IborCoupon coupon = iborCouponForFixingDate(index, calendar.advance(today, -1, Days));
+        index->clearFixings();
         // this should not throw an exception if the fixing is missing
         BOOST_CHECK_EQUAL(coupon.hasFixed(), true);
+        // but this should
+        BOOST_CHECK_THROW(coupon.rate(), Error);
     }
 
     {
         IborCoupon coupon = iborCouponForFixingDate(index, today);
         QuantLib::Settings::instance().enforcesTodaysHistoricFixings() = false;
+        index->clearFixings();
         BOOST_CHECK_EQUAL(coupon.hasFixed(), false);
-        QuantLib::Settings::instance().enforcesTodaysHistoricFixings() =
-            defaultEnforcesTodaysHistoricFixings;
     }
 
     {
@@ -604,17 +602,14 @@ BOOST_AUTO_TEST_CASE(testIborCouponKnowsWhenitHasFixed) {
         QuantLib::Settings::instance().enforcesTodaysHistoricFixings() = false;
         index->addFixing(coupon.fixingDate(), 0.01);
         BOOST_CHECK_EQUAL(coupon.hasFixed(), true);
-        QuantLib::Settings::instance().enforcesTodaysHistoricFixings() =
-            defaultEnforcesTodaysHistoricFixings;
-        index->addFixing(coupon.fixingDate(), Null<Real>(), true);
     }
 
     {
         IborCoupon coupon = iborCouponForFixingDate(index, today);
         QuantLib::Settings::instance().enforcesTodaysHistoricFixings() = true;
+        index->clearFixings();
         BOOST_CHECK_EQUAL(coupon.hasFixed(), true);
-        QuantLib::Settings::instance().enforcesTodaysHistoricFixings() =
-            defaultEnforcesTodaysHistoricFixings;
+        BOOST_CHECK_THROW(coupon.rate(), Error);
     }
 
     {


### PR DESCRIPTION
It is sometimes useful to look at an IBOR coupon and know whether it is based on a historical fixing or a forecast. This change exposes that decision, and also - IMHO! - cleans up the code to get a fixing a little.

This change does mean that for fixings today, we now call Index::pastFixing twice. Personally i don't think that's a big deal (especially since  #1731). Otherwise, i think the functional and non-functional behaviour is the same.

I think this method would probably make sense in FloatingRateCoupon, using the same logic. I could pull it up if you think that would be useful. However, in that case, we should think about what OvernightIndexedCoupon.
