### PR TITLE
Include time zero / evaluation date in option date interpolation

### DIFF
--- a/ql/termstructures/volatility/swaption/swaptionvolcube.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube.cpp
@@ -76,8 +76,7 @@ namespace QuantLib {
                    swapIndexBase_->tenor() << ")");
 
         registerWithVolatilitySpread();
-        registerWith(Settings::instance().evaluationDate());
-        evaluationDate_ = Settings::instance().evaluationDate();
+        cachedReferenceDate_ = referenceDate();
     }
 
     void SwaptionVolatilityCube::registerWithVolatilitySpread()

--- a/ql/termstructures/volatility/swaption/swaptionvolcube.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolcube.cpp
@@ -76,7 +76,6 @@ namespace QuantLib {
                    swapIndexBase_->tenor() << ")");
 
         registerWithVolatilitySpread();
-        cachedReferenceDate_ = referenceDate();
     }
 
     void SwaptionVolatilityCube::registerWithVolatilitySpread()

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
@@ -36,25 +36,26 @@ namespace QuantLib {
       optionTenors_(optionTenors),
       optionDates_(nOptionTenors_),
       optionTimes_(nOptionTenors_),
-      optionDatesAsReal_(nOptionTenors_),
+      optionInterpolatorTimes_(nOptionTenors_  + 1),
+      optionInterpolatorDatesAsReal_(nOptionTenors_ + 1),
       nSwapTenors_(swapTenors.size()),
       swapTenors_(swapTenors),
       swapLengths_(nSwapTenors_) {
 
         checkOptionTenors();
+        evaluationDate_ = Settings::instance().evaluationDate();
         initializeOptionDatesAndTimes();
 
         checkSwapTenors();
         initializeSwapLengths();
 
-        optionInterpolator_= LinearInterpolation(optionTimes_.begin(),
-                                                 optionTimes_.end(),
-                                                 optionDatesAsReal_.begin());
+        optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
+                                                 optionInterpolatorTimes_.end(),
+                                                 optionInterpolatorDatesAsReal_.begin());
         optionInterpolator_.update();
         optionInterpolator_.enableExtrapolation();
 
         registerWith(Settings::instance().evaluationDate());
-        evaluationDate_ = Settings::instance().evaluationDate();
     }
 
     SwaptionVolatilityDiscrete::SwaptionVolatilityDiscrete(
@@ -69,7 +70,8 @@ namespace QuantLib {
       optionTenors_(optionTenors),
       optionDates_(nOptionTenors_),
       optionTimes_(nOptionTenors_),
-      optionDatesAsReal_(nOptionTenors_),
+      optionInterpolatorTimes_(nOptionTenors_  + 1),
+      optionInterpolatorDatesAsReal_(nOptionTenors_ + 1),
       nSwapTenors_(swapTenors.size()),
       swapTenors_(swapTenors),
       swapLengths_(nSwapTenors_) {
@@ -80,9 +82,9 @@ namespace QuantLib {
         checkSwapTenors();
         initializeSwapLengths();
 
-        optionInterpolator_= LinearInterpolation(optionTimes_.begin(),
-                                                 optionTimes_.end(),
-                                                 optionDatesAsReal_.begin());
+        optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
+                                                 optionInterpolatorTimes_.end(),
+                                                 optionInterpolatorDatesAsReal_.begin());
         optionInterpolator_.update();
         optionInterpolator_.enableExtrapolation();
     }
@@ -99,7 +101,8 @@ namespace QuantLib {
       optionTenors_(nOptionTenors_),
       optionDates_(optionDates),
       optionTimes_(nOptionTenors_),
-      optionDatesAsReal_(nOptionTenors_),
+      optionInterpolatorTimes_(nOptionTenors_  + 1),
+      optionInterpolatorDatesAsReal_(nOptionTenors_ + 1),
       nSwapTenors_(swapTenors.size()),
       swapTenors_(swapTenors),
       swapLengths_(nSwapTenors_) {
@@ -110,9 +113,9 @@ namespace QuantLib {
         checkSwapTenors();
         initializeSwapLengths();
 
-        optionInterpolator_= LinearInterpolation(optionTimes_.begin(),
-                                                 optionTimes_.end(),
-                                                 optionDatesAsReal_.begin());
+        optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
+                                                 optionInterpolatorTimes_.end(),
+                                                 optionInterpolatorDatesAsReal_.begin());
         optionInterpolator_.update();
         optionInterpolator_.enableExtrapolation();
     }
@@ -152,17 +155,20 @@ namespace QuantLib {
     }
 
     void SwaptionVolatilityDiscrete::initializeOptionDatesAndTimes() const {
+        optionInterpolatorDatesAsReal_[0] = static_cast<Real>(evaluationDate_.serialNumber());
         for (Size i=0; i<nOptionTenors_; ++i) {
             optionDates_[i] = optionDateFromTenor(optionTenors_[i]);
-            optionDatesAsReal_[i] =
+            optionInterpolatorDatesAsReal_[i + 1] =
                 static_cast<Real>(optionDates_[i].serialNumber());
         }
         initializeOptionTimes();
     }
 
     void SwaptionVolatilityDiscrete::initializeOptionTimes() const {
-        for (Size i=0; i<nOptionTenors_; ++i)
-            optionTimes_[i] = timeFromReference(optionDates_[i]);
+        optionInterpolatorTimes_[0] = 0.0;
+        for (Size i = 0; i < nOptionTenors_; ++i) {
+            optionTimes_[i] = optionInterpolatorTimes_[i + 1] = timeFromReference(optionDates_[i]);
+        }
     }
 
     void SwaptionVolatilityDiscrete::initializeSwapLengths() const {

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
@@ -74,13 +74,14 @@ namespace QuantLib {
         mutable std::vector<Date> optionDates_;
         mutable std::vector<Time> optionTimes_;
         mutable Interpolation optionInterpolator_;
+        mutable std::vector<Real> optionDatesAsReal_;
         mutable std::vector<Time> optionInterpolatorTimes_;
         mutable std::vector<Real> optionInterpolatorDatesAsReal_;
 
         Size nSwapTenors_;
         std::vector<Period> swapTenors_;
         mutable std::vector<Time> swapLengths_;
-        mutable Date evaluationDate_;
+        mutable Date cachedReferenceDate_;
       private:
         void checkOptionTenors() const;
         void checkOptionDates(const Date& reference) const;

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.hpp
@@ -73,8 +73,9 @@ namespace QuantLib {
         std::vector<Period> optionTenors_;
         mutable std::vector<Date> optionDates_;
         mutable std::vector<Time> optionTimes_;
-        mutable std::vector<Real> optionDatesAsReal_;
         mutable Interpolation optionInterpolator_;
+        mutable std::vector<Time> optionInterpolatorTimes_;
+        mutable std::vector<Real> optionInterpolatorDatesAsReal_;
 
         Size nSwapTenors_;
         std::vector<Period> swapTenors_;


### PR DESCRIPTION
For times before the first option date `optionDateFromTime()` can return a date < evaluation date. I would suggest to include the evaluation date and t = 0 into the linear interpolation used to do the time to date conversion.