### PR TITLE
Optional redemption argument for amortizing bond constructors

### DIFF
--- a/ql/instruments/bonds/amortizingcmsratebond.cpp
+++ b/ql/instruments/bonds/amortizingcmsratebond.cpp
@@ -38,7 +38,8 @@ namespace QuantLib {
                                     const std::vector<Rate>& caps,
                                     const std::vector<Rate>& floors,
                                     bool inArrears,
-                                    const Date& issueDate)
+                                    const Date& issueDate,
+                                    const std::vector<Real>& redemptions)
     : Bond(settlementDays, schedule.calendar(), issueDate) {
 
         maturityDate_ = schedule.endDate();
@@ -54,7 +55,7 @@ namespace QuantLib {
             .withFloors(floors)
             .inArrears(inArrears);
 
-        addRedemptionsToCashflows();
+        addRedemptionsToCashflows(redemptions);
 
         QL_ENSURE(!cashflows().empty(), "bond with no cashflows!");
 

--- a/ql/instruments/bonds/amortizingcmsratebond.hpp
+++ b/ql/instruments/bonds/amortizingcmsratebond.hpp
@@ -47,9 +47,10 @@ namespace QuantLib {
                     const std::vector<Rate>& caps = {},
                     const std::vector<Rate>& floors = {},
                     bool inArrears = false,
-                    const Date& issueDate = Date());
+                    const Date& issueDate = Date(),
+                    const std::vector<Real>& redemptions = { 100.0 });
     };
-
+    
 }
 
 #endif

--- a/ql/instruments/bonds/amortizingfixedratebond.cpp
+++ b/ql/instruments/bonds/amortizingfixedratebond.cpp
@@ -35,7 +35,9 @@ namespace QuantLib {
                                       const Period& exCouponPeriod,
                                       const Calendar& exCouponCalendar,
                                       const BusinessDayConvention exCouponConvention,
-                                      bool exCouponEndOfMonth)
+                                      bool exCouponEndOfMonth,
+                                      const std::vector<Real>& redemptions,
+                                      Natural paymentLag)
     : Bond(settlementDays, schedule.calendar(), issueDate),
       frequency_(schedule.tenor().frequency()),
       dayCounter_(accrualDayCounter) {
@@ -49,9 +51,10 @@ namespace QuantLib {
             .withExCouponPeriod(exCouponPeriod,
                                 exCouponCalendar,
                                 exCouponConvention,
-                                exCouponEndOfMonth);
+                                exCouponEndOfMonth)
+            .withPaymentLag(paymentLag);
 
-        addRedemptionsToCashflows();
+        addRedemptionsToCashflows(redemptions);
 
         QL_ENSURE(!cashflows().empty(), "bond with no cashflows!");
     }
@@ -89,6 +92,7 @@ namespace QuantLib {
         addRedemptionsToCashflows();
     }
 
+  
     AmortizingFixedRateBond::AmortizingFixedRateBond(
                                       Natural settlementDays,
                                       const std::vector<Real>& notionals,

--- a/ql/instruments/bonds/amortizingfixedratebond.hpp
+++ b/ql/instruments/bonds/amortizingfixedratebond.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     //! amortizing fixed-rate bond
     class AmortizingFixedRateBond : public Bond {
       public:
-        AmortizingFixedRateBond(Natural settlementDays,
+      AmortizingFixedRateBond(Natural settlementDays,
                                 const std::vector<Real>& notionals,
                                 const Schedule& schedule,
                                 const std::vector<Rate>& coupons,
@@ -44,7 +44,10 @@ namespace QuantLib {
                                 const Period& exCouponPeriod = Period(),
                                 const Calendar& exCouponCalendar = Calendar(),
                                 BusinessDayConvention exCouponConvention = Unadjusted,
-                                bool exCouponEndOfMonth = false);
+                                bool exCouponEndOfMonth = false,
+                                const std::vector<Real>& redemptions = { 100.0 },
+                                Natural PaymentLag = 0);
+
 
         /*! \deprecated Use the other constructor after calling sinkingSchedule
                         and sinkingNotionals to generate the required parameters.
@@ -79,6 +82,7 @@ namespace QuantLib {
                                 BusinessDayConvention exCouponConvention = Unadjusted,
                                 bool exCouponEndOfMonth = false);
 
+ 
         Frequency frequency() const { return frequency_; }
         const DayCounter& dayCounter() const { return dayCounter_; }
       protected:

--- a/ql/instruments/bonds/amortizingfloatingratebond.cpp
+++ b/ql/instruments/bonds/amortizingfloatingratebond.cpp
@@ -25,14 +25,15 @@
 
 namespace QuantLib {
 
-    AmortizingFloatingRateBond::AmortizingFloatingRateBond(
+
+   AmortizingFloatingRateBond::AmortizingFloatingRateBond(
                                     Natural settlementDays,
                                     const std::vector<Real>& notionals,
                                     const Schedule& schedule,
                                     const ext::shared_ptr<IborIndex>& index,
                                     const DayCounter& paymentDayCounter,
                                     BusinessDayConvention paymentConvention,
-                                    Natural fixingDays,
+                                    Natural fixingDays, Natural paymentLag,
                                     const std::vector<Real>& gearings,
                                     const std::vector<Spread>& spreads,
                                     const std::vector<Rate>& caps,
@@ -42,7 +43,8 @@ namespace QuantLib {
                                     const Period& exCouponPeriod,
                                     const Calendar& exCouponCalendar,
                                     const BusinessDayConvention exCouponConvention,
-                                    bool exCouponEndOfMonth)
+                                    bool exCouponEndOfMonth,
+                                    const std::vector<Real>& redemptions)
     : Bond(settlementDays, schedule.calendar(), issueDate) {
 
         maturityDate_ = schedule.endDate();
@@ -52,6 +54,7 @@ namespace QuantLib {
             .withPaymentDayCounter(paymentDayCounter)
             .withPaymentAdjustment(paymentConvention)
             .withFixingDays(fixingDays)
+            .withPaymentLag(paymentLag)
             .withGearings(gearings)
             .withSpreads(spreads)
             .withCaps(caps)
@@ -62,7 +65,7 @@ namespace QuantLib {
                                 exCouponEndOfMonth)
             .inArrears(inArrears);
 
-        addRedemptionsToCashflows();
+        addRedemptionsToCashflows(redemptions);
 
         QL_ENSURE(!cashflows().empty(), "bond with no cashflows!");
 

--- a/ql/instruments/bonds/amortizingfloatingratebond.hpp
+++ b/ql/instruments/bonds/amortizingfloatingratebond.hpp
@@ -34,6 +34,7 @@ namespace QuantLib {
     //! amortizing floating-rate bond (possibly capped and/or floored)
     class AmortizingFloatingRateBond : public Bond {
       public:
+        
         AmortizingFloatingRateBond(Natural settlementDays,
                                    const std::vector<Real>& notional,
                                    const Schedule& schedule,
@@ -41,6 +42,7 @@ namespace QuantLib {
                                    const DayCounter& accrualDayCounter,
                                    BusinessDayConvention paymentConvention = Following,
                                    Natural fixingDays = Null<Natural>(),
+                                   Natural paymentLag = Null<Natural>(),
                                    const std::vector<Real>& gearings = { 1.0 },
                                    const std::vector<Spread>& spreads = { 0.0 },
                                    const std::vector<Rate>& caps = {},
@@ -50,9 +52,10 @@ namespace QuantLib {
                                    const Period& exCouponPeriod = Period(),
                                    const Calendar& exCouponCalendar = Calendar(),
                                    BusinessDayConvention exCouponConvention = Unadjusted,
-                                   bool exCouponEndOfMonth = false);
-    };
-
+                                   bool exCouponEndOfMonth = false,
+                                   const std::vector<Real>& redemptions = { 100.0 });
+  };
+  
 }
 
 #endif


### PR DESCRIPTION
The amortizing bond constructors have been extended by adding a redemptions vector argument that is passed as an argument to the addRedemptionsToCashflows function. This is a vector with values between 0 and 100 that represents the proportion of principal payments which would be calculated by taking the difference between notionals for each payment period. This allows these functions to be used for pools of loans where a certain proportion of the underlying
loans are subject to defaults and losses.