### PR TITLE
optimize build time (precompiled headers)

### DIFF
--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2366,6 +2366,24 @@ set_target_properties(ql_library PROPERTIES
     VERSION ${QUANTLIB_VERSION}
     SOVERSION ${QUANTLIB_VERSION_MAJOR})
 
+target_precompile_headers(ql_library
+  PUBLIC
+    <ql/any.hpp>
+    <ql/errors.hpp>
+    <ql/index.hpp>
+    <ql/indexes/indexmanager.hpp>
+    <ql/instrument.hpp>
+    <ql/indexes/interestrateindex.hpp>
+    <ql/math/array.hpp>
+    <ql/math/statistics/incrementalstatistics.hpp>
+    <ql/math/interpolations/cubicinterpolation.hpp>
+    <ql/math/matrix.hpp>
+    <ql/methods/finitedifferences/operators/fdmlinearop.hpp>
+    <ql/patterns/observable.hpp>
+    <ql/qldefines.hpp>
+    <ql/termstructure.hpp>
+)
+
 target_compile_definitions(ql_library PRIVATE
     QL_COMPILATION)
 


### PR DESCRIPTION
Playing with pre-compiled headers as an alternative way to speed up the build - these are pretty easy to add to a cmake build and have quite an impact on parse times:

baseline (target ql_library only)

```
Compilation (1854 times):
  Parsing (frontend):         1270.3 s
  Codegen & opts (backend):    542.4 s
```

after change

```
Compilation (1863 times):
  Parsing (frontend):          512.8 s
  Codegen & opts (backend):    539.1 s
```

Thoughts? Is this a no-brainer or am I overlooking issues introduced by that?