### PR TITLE
Fix double/Real consistency for maintaining AAD compatibility

### DIFF
--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -170,7 +170,7 @@ void LiborMarketModelTest::testSimpleCovarianceModels() {
 
         for (Size k=0; k<size; ++k) {
             Real expected = 0;
-            if (k>2*t) {
+            if (static_cast<Real>(k) > 2 * t) {
                 const Real T = fixingTimes[k];
                 expected=(a*(T-t)+d)*std::exp(-b*(T-t)) + c;
             }

--- a/test-suite/xoshiro256starstar.cpp
+++ b/test-suite/xoshiro256starstar.cpp
@@ -170,16 +170,16 @@ void Xoshiro256StarStarTest::testMeanAndStdDevOfNextReal() {
         }
         randoms.push_back(next);
     }
-    auto mean = std::accumulate(randoms.begin(), randoms.end(), 0.0) / randoms.size();
-    auto meanError = std::fabs(0.5 - mean);
+    Real mean = std::accumulate(randoms.begin(), randoms.end(), Real(0.0)) / randoms.size();
+    Real meanError = std::fabs(0.5 - mean);
     if (meanError > 0.005) {
         BOOST_ERROR("Mean " << mean << " for seed 1 is not close to 0.5.");
     }
-    std::vector<double> diff(randoms.size());
+    std::vector<Real> diff(randoms.size());
     std::transform(randoms.begin(), randoms.end(), diff.begin(),
-                   [mean](double x) { return x - mean; });
-    auto stdDev = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0) / randoms.size();
-    auto stdDevError = std::fabs(1.0 / 12.0 - stdDev);
+                   [mean](Real x) -> Real { return x - mean; });
+    Real stdDev = std::inner_product(diff.begin(), diff.end(), diff.begin(), Real(0.0)) / randoms.size();
+    Real stdDevError = std::fabs(1.0 / 12.0 - stdDev);
     if (stdDevError > 0.00005) {
         BOOST_ERROR("Standard deviation " << stdDev << " for seed 1 is not close to 1/12.");
     }


### PR DESCRIPTION
This fixes consistent usage of `Real` with the new xoshiro256 random generator.

It fixes the build issues with XAD seen here: https://github.com/auto-differentiation/quantlib-xad/actions/runs/6414891338 
This is the fixed build: https://github.com/auto-differentiation/quantlib-xad/actions/runs/6417063131