### PR TITLE
Deprecate Currency::format

### DIFF
--- a/ql/currency.cpp
+++ b/ql/currency.cpp
@@ -29,6 +29,22 @@ namespace QuantLib {
             return out << "null currency";
     }
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    Currency::Data::Data(std::string name,
+                         std::string code,
+                         Integer numericCode,
+                         std::string symbol,
+                         std::string fractionSymbol,
+                         Integer fractionsPerUnit,
+                         const Rounding& rounding,
+                         Currency triangulationCurrency,
+                         std::set<std::string> minorUnitCodes)
+    : name(std::move(name)), code(std::move(code)), numeric(numericCode), symbol(std::move(symbol)),
+      fractionSymbol(std::move(fractionSymbol)), fractionsPerUnit(fractionsPerUnit),
+      rounding(rounding), triangulated(std::move(triangulationCurrency)),
+      minorUnitCodes(std::move(minorUnitCodes)) {}
+
     Currency::Data::Data(std::string name,
                          std::string code,
                          Integer numericCode,
@@ -51,6 +67,25 @@ namespace QuantLib {
                        const std::string& fractionSymbol,
                        Integer fractionsPerUnit,
                        const Rounding& rounding,
+                       const Currency& triangulationCurrency,
+                       const std::set<std::string>& minorUnitCodes)
+    : data_(ext::make_shared<Currency::Data>(name,
+                                             code,
+                                             numericCode,
+                                             symbol,
+                                             fractionSymbol,
+                                             fractionsPerUnit,
+                                             rounding,
+                                             triangulationCurrency,
+                                             minorUnitCodes)) {}
+
+    Currency::Currency(const std::string& name,
+                       const std::string& code,
+                       Integer numericCode,
+                       const std::string& symbol,
+                       const std::string& fractionSymbol,
+                       Integer fractionsPerUnit,
+                       const Rounding& rounding,
                        const std::string& formatString,
                        const Currency& triangulationCurrency,
                        const std::set<std::string>& minorUnitCodes)
@@ -64,5 +99,7 @@ namespace QuantLib {
                                              formatString,
                                              triangulationCurrency,
                                              minorUnitCodes)) {}
-}
 
+    QL_DEPRECATED_ENABLE_WARNING
+
+}

--- a/ql/currency.hpp
+++ b/ql/currency.hpp
@@ -51,6 +51,19 @@ namespace QuantLib {
                  const std::string& fractionSymbol,
                  Integer fractionsPerUnit,
                  const Rounding& rounding,
+                 const Currency& triangulationCurrency = Currency(),
+                 const std::set<std::string>& minorUnitCodes = {});
+        /*! \deprecated Use the constructor without formatString.
+                        Deprecated in version 1.33.
+        */
+        QL_DEPRECATED
+        Currency(const std::string& name,
+                 const std::string& code,
+                 Integer numericCode,
+                 const std::string& symbol,
+                 const std::string& fractionSymbol,
+                 Integer fractionsPerUnit,
+                 const Rounding& rounding,
                  const std::string& formatString,
                  const Currency& triangulationCurrency = Currency(),
                  const std::set<std::string>& minorUnitCodes = {});
@@ -75,6 +88,10 @@ namespace QuantLib {
         /*! The format will be fed three positional parameters,
             namely, value, code, and symbol, in this order.
         */
+        /*! \deprecated Copy the formatting into your project if you need it.
+                        Deprecated in version 1.33.
+        */
+        [[deprecated("Copy the formatting into your project if you need it.")]]
         std::string format() const;
         //@}
         //! \name Other information
@@ -93,6 +110,8 @@ namespace QuantLib {
         void checkNonEmpty() const;
     };
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     struct Currency::Data {
         std::string name, code;
         Integer numeric;
@@ -100,8 +119,23 @@ namespace QuantLib {
         Integer fractionsPerUnit;
         Rounding rounding;
         Currency triangulated;
+        QL_DEPRECATED
         std::string formatString;
         std::set<std::string> minorUnitCodes;
+
+        /*! \deprecated Use the constructor without formatString.
+                        Deprecated in version 1.33.
+        */
+        QL_DEPRECATED
+        Data(std::string name,
+             std::string code,
+             Integer numericCode,
+             std::string symbol,
+             std::string fractionSymbol,
+             Integer fractionsPerUnit,
+             const Rounding& rounding,
+             Currency triangulationCurrency = Currency(),
+             std::set<std::string> minorUnitCodes = {});
 
         Data(std::string name,
              std::string code,
@@ -114,6 +148,8 @@ namespace QuantLib {
              Currency triangulationCurrency = Currency(),
              std::set<std::string> minorUnitCodes = {});
     };
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     /*! \relates Currency */
     bool operator==(const Currency&,
@@ -169,10 +205,14 @@ namespace QuantLib {
         return data_->rounding;
     }
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     inline std::string Currency::format() const {
         checkNonEmpty();
         return data_->formatString;
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
 
     inline bool Currency::empty() const {
         return !data_;

--- a/ql/money.cpp
+++ b/ql/money.cpp
@@ -22,8 +22,6 @@
 #include <ql/currencies/exchangeratemanager.hpp>
 #include <ql/math/comparison.hpp>
 
-#include <boost/format.hpp>
-
 namespace QuantLib {
 
     namespace {
@@ -204,16 +202,9 @@ namespace QuantLib {
         }
     }
 
-
     std::ostream& operator<<(std::ostream& out, const Money& m) {
-        boost::format fmt(m.currency().format());
-        fmt.exceptions(boost::io::all_error_bits ^
-                       boost::io::too_many_args_bit);
-        return out << fmt % m.rounded().value()
-                          % m.currency().code()
-                          % m.currency().symbol();
+        return out << m.rounded().value() << " " << m.currency().code();
     }
-
 
     const Money::ConversionType & Money::Settings::conversionType() const
     {

--- a/test-suite/currency.cpp
+++ b/test-suite/currency.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(testBespokeConstructor) {
     std::string code("CCY");
     std::string symbol("#");
 
-    Currency customCcy(name, code, 100, symbol, "", 100, Rounding(), "");
+    Currency customCcy(name, code, 100, symbol, "", 100, Rounding());
 
     if (customCcy.empty())
         BOOST_ERROR("Failed to create bespoke currency.");


### PR DESCRIPTION
Closes #1801 

Let me know if there are any other arguments to the constructors of `Currency` or `Currency::Data` that you think should be deprecated at the same time.