### PR TITLE
apply the paymentLag and paymentCalendar to the fixed leg

### DIFF
--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -123,7 +123,7 @@ namespace QuantLib {
                                                RateAveraging::Type averagingMethod)
     : FixedVsFloatingSwap(type, std::move(fixedNominals), std::move(fixedSchedule), fixedRate, std::move(fixedDC),
                           overnightNominals, overnightSchedule, overnightIndex,
-                          spread, DayCounter(), ext::nullopt),
+                          spread, DayCounter(), ext::nullopt, paymentLag, paymentCalendar),
       overnightIndex_(overnightIndex), averagingMethod_(averagingMethod) {
 
         legs_[1] =


### PR DESCRIPTION
Since the big refactor #1789 which made OvernightIndexedSwap derive from FixedVsFloatingSwap, the payment lag and payment calendar were not applied to the fixed leg.