### PR TITLE
More functions to support both clean and dirty prices as input parameter

### DIFF
--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -541,13 +541,9 @@ int main(int, char* []) {
          << floatingRateBond.cleanPrice(floatingRateBond.yield(Actual360(),Compounded,Annual),Actual360(),Compounded,Annual,settlementDate) << std::endl;
 
          std::cout << "Clean Price to Yield: "
-                   << io::rate(floatingRateBond.yield(
-                          Bond::Price(floatingRateBond.cleanPrice(), Bond::Price::Clean),
-                          Actual360(), Compounded, Annual, settlementDate))
+                   << io::rate(floatingRateBond.yield({floatingRateBond.cleanPrice(), Bond::Price::Clean},
+                                                      Actual360(), Compounded, Annual, settlementDate))
                    << std::endl;
-
-         /* "Yield to Price"
-            "Price to Yield" */
 
          return 0;
 

--- a/Examples/Bonds/Bonds.cpp
+++ b/Examples/Bonds/Bonds.cpp
@@ -541,7 +541,10 @@ int main(int, char* []) {
          << floatingRateBond.cleanPrice(floatingRateBond.yield(Actual360(),Compounded,Annual),Actual360(),Compounded,Annual,settlementDate) << std::endl;
 
          std::cout << "Clean Price to Yield: "
-         << io::rate(floatingRateBond.yield(floatingRateBond.cleanPrice(),Actual360(),Compounded,Annual,settlementDate)) << std::endl;
+                   << io::rate(floatingRateBond.yield(
+                          Bond::Price(floatingRateBond.cleanPrice(), Bond::Price::Clean),
+                          Actual360(), Compounded, Annual, settlementDate))
+                   << std::endl;
 
          /* "Yield to Price"
             "Price to Yield" */

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -592,7 +592,7 @@ int main(int, char* []) {
 
             Real P = instrumentsA[k]->quote()->value();
             const Bond& b = *instrumentsA[k]->bond();
-            Rate ytm = BondFunctions::yield(b, Bond::Price(P, Bond::Price::Clean),
+            Rate ytm = BondFunctions::yield(b, {P, Bond::Price::Clean},
                                             dc, Compounded, frequency,
                                             today);
             Time dur = BondFunctions::duration(b, ytm,

--- a/Examples/FittedBondCurve/FittedBondCurve.cpp
+++ b/Examples/FittedBondCurve/FittedBondCurve.cpp
@@ -592,7 +592,7 @@ int main(int, char* []) {
 
             Real P = instrumentsA[k]->quote()->value();
             const Bond& b = *instrumentsA[k]->bond();
-            Rate ytm = BondFunctions::yield(b, P,
+            Rate ytm = BondFunctions::yield(b, Bond::Price(P, Bond::Price::Clean),
                                             dc, Compounded, frequency,
                                             today);
             Time dur = BondFunctions::duration(b, ytm,

--- a/Examples/Repo/Repo.cpp
+++ b/Examples/Repo/Repo.cpp
@@ -73,7 +73,7 @@ int main(int, char* []) {
         // unknown what fincad is using. this may affect accrued calculation
         Integer bondSettlementDays = 0;
         BusinessDayConvention bondBusinessDayConvention = Unadjusted;
-        Real bondCleanPrice = 89.97693786;
+        Bond::Price bondCleanPrice(89.97693786, Bond::Price::Clean);
         Real bondRedemption = 100.0;
         Real faceAmount = 100.0;
 

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -414,12 +414,4 @@ namespace QuantLib {
             QL_REQUIRE(cf, "null cash flow provided");
     }
 
-    bool operator==(const Bond::Price& p1, const Bond::Price& p2) {
-        return (p1.amount() == p2.amount()) && ((p1.type() == p2.type()));
-    }
-
-    bool operator!=(const Bond::Price& p1, const Bond::Price& p2) {
-        return (p1.amount() != p2.amount()) || ((p1.type() != p2.type()));
-    }
-
 }

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -414,4 +414,12 @@ namespace QuantLib {
             QL_REQUIRE(cf, "null cash flow provided");
     }
 
+    bool operator==(const Bond::Price& p1, const Bond::Price& p2) {
+        return (p1.amount() == p2.amount()) && ((p1.type() == p2.type()));
+    }
+
+    bool operator!=(const Bond::Price& p1, const Bond::Price& p2) {
+        return (p1.amount() != p2.amount()) || ((p1.type() != p2.type()));
+    }
+
 }

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -206,12 +206,12 @@ namespace QuantLib {
         if (currentNotional == 0.0)
             return 0.0;
 
-        Real price = priceType == Bond::Price::Clean ? cleanPrice() : dirtyPrice();
+        Bond::Price price(priceType == Bond::Price::Clean ? cleanPrice() : dirtyPrice(), priceType);
 
         return BondFunctions::yield(*this, price, dc, comp, freq,
                                     settlementDate(),
                                     accuracy, maxEvaluations,
-                                    guess, priceType);
+                                    guess);
     }
 
     Real Bond::cleanPrice(Rate y,
@@ -244,13 +244,24 @@ namespace QuantLib {
                      Size maxEvaluations,
                      Real guess,
                      Bond::Price::Type priceType) const {
+        return yield(Bond::Price(price, priceType), dc, comp, freq, settlement, accuracy,
+                     maxEvaluations, guess);
+    }
+    Rate Bond::yield(Bond::Price price,
+                     const DayCounter& dc,
+                     Compounding comp,
+                     Frequency freq,
+                     Date settlement,
+                     Real accuracy,
+                     Size maxEvaluations,
+                     Real guess) const {
         Real currentNotional = notional(settlement);
         if (currentNotional == 0.0)
             return 0.0;
 
         return BondFunctions::yield(*this, price, dc, comp, freq,
                                     settlement, accuracy, maxEvaluations,
-                                    guess, priceType);
+                                    guess);
     }
 
     Real Bond::accruedAmount(Date settlement) const {

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -244,7 +244,7 @@ namespace QuantLib {
                      Size maxEvaluations,
                      Real guess,
                      Bond::Price::Type priceType) const {
-        return yield(Bond::Price(price, priceType), dc, comp, freq, settlement, accuracy,
+        return yield({price, priceType}, dc, comp, freq, settlement, accuracy,
                      maxEvaluations, guess);
     }
     Rate Bond::yield(Bond::Price price,

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -62,7 +62,8 @@ namespace QuantLib {
         class Price {
           public:
             enum Type { Dirty, Clean };
-            Price() : amount_(Null<Real>()) {}
+            Price() : amount_(Null<Real>()), type_(Bond::Price::Clean) {}
+            Price(Real amount) : amount_(amount), type_(Bond::Price::Clean) {}
             Price(Real amount, Type type) : amount_(amount), type_(type) {}
             Real amount() const {
                 QL_REQUIRE(amount_ != Null<Real>(), "no amount given");
@@ -350,6 +351,14 @@ namespace QuantLib {
         return issueDate_;
     }
 
+/*! Returns <tt>true</tt> iff the two bond prices belong to the same
+    derived class.
+    \relates Bond::Price
+*/
+    bool operator==(const Bond::Price&, const Bond::Price&);
+
+    /*! \relates Bond::Price */
+    bool operator!=(const Bond::Price&, const Bond::Price&);
 }
 
 #endif

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -70,6 +70,7 @@ namespace QuantLib {
                 return amount_;
             }
             Type type() const { return type_; }
+            bool isValid() const { return amount_ != Null<Real>(); }
           private:
             Real amount_;
             Type type_;
@@ -351,14 +352,6 @@ namespace QuantLib {
         return issueDate_;
     }
 
-/*! Returns <tt>true</tt> iff the two bond prices belong to the same
-    derived class.
-    \relates Bond::Price
-*/
-    bool operator==(const Bond::Price&, const Bond::Price&);
-
-    /*! \relates Bond::Price */
-    bool operator!=(const Bond::Price&, const Bond::Price&);
 }
 
 #endif

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -195,9 +195,10 @@ namespace QuantLib {
         /*! The default bond settlement date is used for calculation. */
         Real settlementValue(Real cleanPrice) const;
 
-        //! yield given a price and settlement date
-        /*! The default bond settlement is used if no date is given. */
-        [[deprecated("Use the version with the Bond::Price argument")]]
+        /*! \deprecated Use the overload taking a Bond::Price argument instead.
+                        Deprecated in version 1.34.
+        */
+        [[deprecated("Use the overload taking a Bond::Price argument instead")]]
         Rate yield(Real price,
                    const DayCounter& dc,
                    Compounding comp,
@@ -207,6 +208,7 @@ namespace QuantLib {
                    Size maxEvaluations = 100,
                    Real guess = 0.05,
                    Bond::Price::Type priceType = Bond::Price::Clean) const;
+
         //! yield given a price and settlement date
         /*! The default bond settlement is used if no date is given. */
         Rate yield(Bond::Price price,

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -196,6 +196,7 @@ namespace QuantLib {
 
         //! yield given a price and settlement date
         /*! The default bond settlement is used if no date is given. */
+        [[deprecated("Use the version with the Bond::Price argument")]]
         Rate yield(Real price,
                    const DayCounter& dc,
                    Compounding comp,
@@ -205,6 +206,16 @@ namespace QuantLib {
                    Size maxEvaluations = 100,
                    Real guess = 0.05,
                    Bond::Price::Type priceType = Bond::Price::Clean) const;
+        //! yield given a price and settlement date
+        /*! The default bond settlement is used if no date is given. */
+        Rate yield(Bond::Price price,
+                   const DayCounter& dc,
+                   Compounding comp,
+                   Frequency freq,
+                   Date settlementDate = Date(),
+                   Real accuracy = 1.0e-8,
+                   Size maxEvaluations = 100,
+                   Real guess = 0.05) const;
 
         //! accrued amount at a given date
         /*! The default bond settlement is used if no date is given. */

--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -63,7 +63,6 @@ namespace QuantLib {
           public:
             enum Type { Dirty, Clean };
             Price() : amount_(Null<Real>()), type_(Bond::Price::Clean) {}
-            Price(Real amount) : amount_(amount), type_(Bond::Price::Clean) {}
             Price(Real amount, Type type) : amount_(amount), type_(type) {}
             Real amount() const {
                 QL_REQUIRE(amount_ != Null<Real>(), "no amount given");

--- a/ql/instruments/bonds/btp.cpp
+++ b/ql/instruments/bonds/btp.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
                     Date settlementDate,
                     Real accuracy,
                     Size maxEvaluations) const {
-        return Bond::yield(Bond::Price(cleanPrice, Bond::Price::Clean),
+        return Bond::yield({cleanPrice, Bond::Price::Clean},
                            ActualActual(ActualActual::ISMA), Compounded, Annual, settlementDate,
                            accuracy, maxEvaluations);
     }
@@ -160,7 +160,7 @@ namespace QuantLib {
         Date bondSettlementDate = btps[0]->settlementDate();
         for (Size i=0; i<basket_->size(); ++i) {
             yields_[i] = BondFunctions::yield(
-                *btps[i], Bond::Price(quotes[i]->value(), Bond::Price::Clean),
+                *btps[i], {quotes[i]->value(), Bond::Price::Clean},
                 ActualActual(ActualActual::ISMA), Compounded, Annual, bondSettlementDate,
                 // accuracy, maxIterations, guess
                 1.0e-10, 100, yields_[i]);
@@ -185,7 +185,7 @@ namespace QuantLib {
                                Following, // paymentConvention
                                100.0);    // redemption
         swapBondYields_[0] = BondFunctions::yield(swapBond,
-            Bond::Price(100.0, Bond::Price::Clean), // floating leg NPV including end payment
+            {100.0, Bond::Price::Clean}, // floating leg NPV including end payment
             ActualActual(ActualActual::ISMA), Compounded, Annual,
             bondSettlementDate,
             // accuracy, maxIterations, guess
@@ -204,7 +204,7 @@ namespace QuantLib {
                                    Following, // paymentConvention
                                    100.0);    // redemption
             swapBondYields_[i] = BondFunctions::yield(swapBond,
-                Bond::Price(100.0, Bond::Price::Clean), // floating leg NPV including end payment
+                {100.0, Bond::Price::Clean}, // floating leg NPV including end payment
                 ActualActual(ActualActual::ISMA), Compounded, Annual,
                 bondSettlementDate,
                 // accuracy, maxIterations, guess

--- a/ql/instruments/bonds/btp.cpp
+++ b/ql/instruments/bonds/btp.cpp
@@ -83,9 +83,9 @@ namespace QuantLib {
                     Date settlementDate,
                     Real accuracy,
                     Size maxEvaluations) const {
-        return Bond::yield(cleanPrice, ActualActual(ActualActual::ISMA),
-                           Compounded, Annual,
-                           settlementDate, accuracy, maxEvaluations);
+        return Bond::yield(Bond::Price(cleanPrice, Bond::Price::Clean),
+                           ActualActual(ActualActual::ISMA), Compounded, Annual, settlementDate,
+                           accuracy, maxEvaluations);
     }
 
 
@@ -160,9 +160,8 @@ namespace QuantLib {
         Date bondSettlementDate = btps[0]->settlementDate();
         for (Size i=0; i<basket_->size(); ++i) {
             yields_[i] = BondFunctions::yield(
-                *btps[i], quotes[i]->value(),
-                ActualActual(ActualActual::ISMA), Compounded, Annual,
-                bondSettlementDate,
+                *btps[i], Bond::Price(quotes[i]->value(), Bond::Price::Clean),
+                ActualActual(ActualActual::ISMA), Compounded, Annual, bondSettlementDate,
                 // accuracy, maxIterations, guess
                 1.0e-10, 100, yields_[i]);
             durations_[i] = BondFunctions::duration(
@@ -186,7 +185,7 @@ namespace QuantLib {
                                Following, // paymentConvention
                                100.0);    // redemption
         swapBondYields_[0] = BondFunctions::yield(swapBond,
-            100.0, // floating leg NPV including end payment
+            Bond::Price(100.0, Bond::Price::Clean), // floating leg NPV including end payment
             ActualActual(ActualActual::ISMA), Compounded, Annual,
             bondSettlementDate,
             // accuracy, maxIterations, guess
@@ -205,7 +204,7 @@ namespace QuantLib {
                                    Following, // paymentConvention
                                    100.0);    // redemption
             swapBondYields_[i] = BondFunctions::yield(swapBond,
-                100.0, // floating leg NPV including end payment
+                Bond::Price(100.0, Bond::Price::Clean), // floating leg NPV including end payment
                 ActualActual(ActualActual::ISMA), Compounded, Annual,
                 bondSettlementDate,
                 // accuracy, maxIterations, guess

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -367,11 +367,23 @@ namespace QuantLib {
                               Size maxIterations,
                               Rate guess,
                               Bond::Price::Type priceType) {
+        return yield(bond, Bond::Price(price, priceType), dayCounter, compounding, frequency,
+                     settlement, accuracy, maxIterations, guess);
+    }
+    Rate BondFunctions::yield(const Bond& bond,
+                              Bond::Price price,
+                              const DayCounter& dayCounter,
+                              Compounding compounding,
+                              Frequency frequency,
+                              Date settlement,
+                              Real accuracy,
+                              Size maxIterations,
+                              Rate guess) {
         NewtonSafe solver;
         solver.setMaxEvaluations(maxIterations);
         return yield<NewtonSafe>(solver, bond, price, dayCounter,
                                  compounding, frequency, settlement,
-                                 accuracy, guess, priceType);
+                                 accuracy, guess);
     }
 
     Time BondFunctions::duration(const Bond& bond,

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -242,6 +242,15 @@ namespace QuantLib {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
+        return dirtyPrice(bond, discountCurve, settlement) - bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const YieldTermStructure& discountCurve,
+                                   Date settlement) {
+        if (settlement == Date())
+            settlement = bond.settlementDate();
+
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
                    "non tradable at " << settlement <<
                    " settlement date (maturity being " <<
@@ -250,7 +259,7 @@ namespace QuantLib {
         Real dirtyPrice = CashFlows::npv(bond.cashflows(), discountCurve,
                                          false, settlement) *
             100.0 / bond.notional(settlement);
-        return dirtyPrice - bond.accruedAmount(settlement);
+        return dirtyPrice;
     }
 
     Real BondFunctions::bps(const Bond& bond,
@@ -508,6 +517,19 @@ namespace QuantLib {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
+        return dirtyPrice(bond, d, zSpread, dc, comp, freq, settlement) - bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter& dc,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        if (settlement == Date())
+            settlement = bond.settlementDate();
+
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
                    "non tradable at " << settlement <<
                    " (maturity being " << bond.maturityDate() << ")");
@@ -516,7 +538,7 @@ namespace QuantLib {
                                          zSpread, dc, comp, freq,
                                          false, settlement) *
             100.0 / bond.notional(settlement);
-        return dirtyPrice - bond.accruedAmount(settlement);
+        return dirtyPrice;
     }
 
     Spread BondFunctions::zSpread(const Bond& bond,

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -283,6 +283,7 @@ namespace QuantLib {
                                 Real cleanPrice) {
         return atmRate(bond, discountCurve, settlement, Bond::Price(cleanPrice, Bond::Price::Clean));
     }
+
     Rate BondFunctions::atmRate(const Bond& bond,
                                 const YieldTermStructure& discountCurve,
                                 Date settlement,
@@ -294,22 +295,19 @@ namespace QuantLib {
                    "non tradable at " << settlement <<
                    " (maturity being " << bond.maturityDate() << ")");
 
-        if (price == Null<Bond::Price>())
-            return CashFlows::atmRate(bond.cashflows(), discountCurve,
-                                      false, settlement, settlement,
-                                      Null<Real>());
-        else {
+        Real npv = Null<Real>();
+        if (price.isValid()) {
             Real dirtyPrice =
                 price.amount() +
                 (price.type() == Bond::Price::Clean ? bond.accruedAmount(settlement) : 0);
 
             Real currentNotional = bond.notional(settlement);
-            Real npv = dirtyPrice / 100.0 * currentNotional;
+            npv = dirtyPrice / 100.0 * currentNotional;
 
-            return CashFlows::atmRate(bond.cashflows(), discountCurve,
-                                      false, settlement, settlement,
-                                      npv);
         }
+        return CashFlows::atmRate(bond.cashflows(), discountCurve,
+                                  false, settlement, settlement,
+                                  npv);
     }
 
     Real BondFunctions::cleanPrice(const Bond& bond,

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -281,7 +281,7 @@ namespace QuantLib {
                                 const YieldTermStructure& discountCurve,
                                 Date settlement,
                                 Real cleanPrice) {
-        return atmRate(bond, discountCurve, settlement, Bond::Price(cleanPrice, Bond::Price::Clean));
+        return atmRate(bond, discountCurve, settlement, {cleanPrice, Bond::Price::Clean});
     }
 
     Rate BondFunctions::atmRate(const Bond& bond,
@@ -387,9 +387,10 @@ namespace QuantLib {
                               Size maxIterations,
                               Rate guess,
                               Bond::Price::Type priceType) {
-        return yield(bond, Bond::Price(price, priceType), dayCounter, compounding, frequency,
+        return yield(bond, {price, priceType}, dayCounter, compounding, frequency,
                      settlement, accuracy, maxIterations, guess);
     }
+
     Rate BondFunctions::yield(const Bond& bond,
                               Bond::Price price,
                               const DayCounter& dayCounter,
@@ -549,9 +550,10 @@ namespace QuantLib {
                                   Real accuracy,
                                   Size maxIterations,
                                   Rate guess) {
-        return zSpread(bond, Bond::Price(cleanPrice, Bond::Price::Clean), d, dayCounter,
+        return zSpread(bond, {cleanPrice, Bond::Price::Clean}, d, dayCounter,
                        compounding, frequency, settlement, accuracy, maxIterations, guess);
     }
+
     Spread BondFunctions::zSpread(const Bond& bond,
                                   Bond::Price price,
                                   const ext::shared_ptr<YieldTermStructure>& d,

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -108,6 +108,9 @@ namespace QuantLib {
         static Real cleanPrice(const Bond& bond,
                                const YieldTermStructure& discountCurve,
                                Date settlementDate = Date());
+        static Real dirtyPrice(const Bond& bond,
+                               const YieldTermStructure& discountCurve,
+                               Date settlementDate = Date());
         static Real bps(const Bond& bond,
                         const YieldTermStructure& discountCurve,
                         Date settlementDate = Date());
@@ -258,6 +261,13 @@ namespace QuantLib {
         //! \name Z-spread functions
         //@{
         static Real cleanPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
+                               const DayCounter& dayCounter,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+        static Real dirtyPrice(const Bond& bond,
                                const ext::shared_ptr<YieldTermStructure>& discount,
                                Spread zSpread,
                                const DayCounter& dayCounter,

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -111,10 +111,15 @@ namespace QuantLib {
         static Real bps(const Bond& bond,
                         const YieldTermStructure& discountCurve,
                         Date settlementDate = Date());
+        [[deprecated("Use the version with the Bond::Price argument")]]
         static Rate atmRate(const Bond& bond,
                             const YieldTermStructure& discountCurve,
                             Date settlementDate = Date(),
                             Real cleanPrice = Null<Real>());
+        static Rate atmRate(const Bond& bond,
+                            const YieldTermStructure& discountCurve,
+                            Date settlementDate = Date(),
+                            Bond::Price price = Null<Bond::Price>());
         //@}
 
         //! \name Yield (a.k.a. Internal Rate of Return, i.e. IRR) functions
@@ -259,8 +264,19 @@ namespace QuantLib {
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
+        [[deprecated("Use the version with the Bond::Price argument")]]
         static Spread zSpread(const Bond& bond,
                               Real cleanPrice,
+                              const ext::shared_ptr<YieldTermStructure>&,
+                              const DayCounter& dayCounter,
+                              Compounding compounding,
+                              Frequency frequency,
+                              Date settlementDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+        static Spread zSpread(const Bond& bond,
+                              Bond::Price price,
                               const ext::shared_ptr<YieldTermStructure>&,
                               const DayCounter& dayCounter,
                               Compounding compounding,

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -126,7 +126,7 @@ namespace QuantLib {
         static Rate atmRate(const Bond& bond,
                             const YieldTermStructure& discountCurve,
                             Date settlementDate = Date(),
-                            Bond::Price price = Null<Bond::Price>());
+                            Bond::Price price = {});
         //@}
 
         //! \name Yield (a.k.a. Internal Rate of Return, i.e. IRR) functions

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -114,7 +114,11 @@ namespace QuantLib {
         static Real bps(const Bond& bond,
                         const YieldTermStructure& discountCurve,
                         Date settlementDate = Date());
-        [[deprecated("Use the version with the Bond::Price argument")]]
+
+        /*! \deprecated Use the overload taking a Bond::Price argument instead.
+                        Deprecated in version 1.34.
+        */
+        [[deprecated("Use the overload taking a Bond::Price argument instead")]]
         static Rate atmRate(const Bond& bond,
                             const YieldTermStructure& discountCurve,
                             Date settlementDate = Date(),
@@ -154,7 +158,10 @@ namespace QuantLib {
                         Compounding compounding,
                         Frequency frequency,
                         Date settlementDate = Date());
-        [[deprecated("Use the version with the Bond::Price argument")]]
+        /*! \deprecated Use the overload taking a Bond::Price argument instead.
+                        Deprecated in version 1.34.
+        */
+        [[deprecated("Use the overload taking a Bond::Price argument instead")]]
         static Rate yield(const Bond& bond,
                           Real price,
                           const DayCounter& dayCounter,
@@ -174,8 +181,11 @@ namespace QuantLib {
                           Real accuracy = 1.0e-10,
                           Size maxIterations = 100,
                           Rate guess = 0.05);
+        /*! \deprecated Use the overload taking a Bond::Price argument instead.
+                        Deprecated in version 1.34.
+        */
         template <typename Solver>
-        [[deprecated("Use the version with the Bond::Price argument")]]
+        [[deprecated("Use the overload taking a Bond::Price argument instead")]]
         static Rate yield(const Solver& solver,
                           const Bond& bond,
                           Real price,
@@ -274,7 +284,10 @@ namespace QuantLib {
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
-        [[deprecated("Use the version with the Bond::Price argument")]]
+        /*! \deprecated Use the overload taking a Bond::Price argument instead.
+                        Deprecated in version 1.34.
+        */
+        [[deprecated("Use the overload taking a Bond::Price argument instead")]]
         static Spread zSpread(const Bond& bond,
                               Real cleanPrice,
                               const ext::shared_ptr<YieldTermStructure>&,

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -146,6 +146,7 @@ namespace QuantLib {
                         Compounding compounding,
                         Frequency frequency,
                         Date settlementDate = Date());
+        [[deprecated("Use the version with the Bond::Price argument")]]
         static Rate yield(const Bond& bond,
                           Real price,
                           const DayCounter& dayCounter,
@@ -156,7 +157,17 @@ namespace QuantLib {
                           Size maxIterations = 100,
                           Rate guess = 0.05,
                           Bond::Price::Type priceType = Bond::Price::Clean);
+        static Rate yield(const Bond& bond,
+                          Bond::Price price,
+                          const DayCounter& dayCounter,
+                          Compounding compounding,
+                          Frequency frequency,
+                          Date settlementDate = Date(),
+                          Real accuracy = 1.0e-10,
+                          Size maxIterations = 100,
+                          Rate guess = 0.05);
         template <typename Solver>
+        [[deprecated("Use the version with the Bond::Price argument")]]
         static Rate yield(const Solver& solver,
                           const Bond& bond,
                           Real price,
@@ -167,6 +178,19 @@ namespace QuantLib {
                           Real accuracy = 1.0e-10,
                           Rate guess = 0.05,
                           Bond::Price::Type priceType = Bond::Price::Clean) {
+            return yield(solver, Bond::Price(price, priceType), dayCounter, compounding, frequency,
+                         settlementDate, accuracy, guess);
+        }
+        template <typename Solver>
+        static Rate yield(const Solver& solver,
+                          const Bond& bond,
+                          Bond::Price price,
+                          const DayCounter& dayCounter,
+                          Compounding compounding,
+                          Frequency frequency,
+                          Date settlementDate = Date(),
+                          Real accuracy = 1.0e-10,
+                          Rate guess = 0.05) {
             if (settlementDate == Date())
                 settlementDate = bond.settlementDate();
 
@@ -174,15 +198,15 @@ namespace QuantLib {
                        "non tradable at " << settlementDate <<
                        " (maturity being " << bond.maturityDate() << ")");
 
-            Real dirtyPrice = price;
+            Real amount = price.amount();
 
-            if (priceType == Bond::Price::Clean)
-                dirtyPrice += bond.accruedAmount(settlementDate);
+            if (price.type() == Bond::Price::Clean)
+                amount += bond.accruedAmount(settlementDate);
 
-            dirtyPrice /= 100.0 / bond.notional(settlementDate);
+            amount /= 100.0 / bond.notional(settlementDate);
 
-            return CashFlows::yield<Solver>(solver, bond.cashflows(),
-                                            dirtyPrice, dayCounter, compounding,
+            return CashFlows::yield<Solver>(solver, bond.cashflows(), amount, dayCounter,
+                                            compounding,
                                             frequency, false, settlementDate,
                                             settlementDate, accuracy, guess);
         }

--- a/ql/termstructures/yield/fittedbonddiscountcurve.cpp
+++ b/ql/termstructures/yield/fittedbonddiscountcurve.cpp
@@ -149,10 +149,11 @@ namespace QuantLib {
             for (Size i=0; i<curve_->bondHelpers_.size(); ++i) {
                 ext::shared_ptr<Bond> bond = curve_->bondHelpers_[i]->bond();
 
-                Real cleanPrice = curve_->bondHelpers_[i]->quote()->value();
+                Real amount = curve_->bondHelpers_[i]->quote()->value();
+                Bond::Price price(amount, curve_->bondHelpers_[i]->priceType());
 
                 Date bondSettlement = bond->settlementDate();
-                Rate ytm = BondFunctions::yield(*bond, cleanPrice,
+                Rate ytm = BondFunctions::yield(*bond, price,
                                                 yieldDC, yieldComp, yieldFreq,
                                                 bondSettlement);
 

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -134,9 +134,10 @@ BOOST_AUTO_TEST_CASE(testYield) {
 
                         for (Real m : yields) {
 
-                            Bond::Price price(
+                            Bond::Price price = {
                                 BondFunctions::cleanPrice(bond, m, bondDayCount, n, frequency),
-                                Bond::Price::Clean);
+                                Bond::Price::Clean
+                            };
 
                             Rate calculated = BondFunctions::yield(
                                 bond, price, bondDayCount, n, frequency, Date(), tolerance,
@@ -162,9 +163,10 @@ BOOST_AUTO_TEST_CASE(testYield) {
                                 }
                             }
 
-                            price = Bond::Price(
+                            price = {
                                 BondFunctions::dirtyPrice(bond, m, bondDayCount, n, frequency),
-                                Bond::Price::Dirty);
+                                Bond::Price::Dirty
+                            };
 
                             calculated = BondFunctions::yield(
                                 bond, price, bondDayCount, n, frequency, Date(), tolerance,
@@ -233,7 +235,7 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
                                        paymentConvention, redemption, issue);
 
                     bond.setPricingEngine(bondEngine);
-                    Bond::Price price(bond.cleanPrice(), Bond::Price::Clean);
+                    Bond::Price price = {bond.cleanPrice(), Bond::Price::Clean};
                     Rate calculated =
                         BondFunctions::atmRate(bond, **disc, bond.settlementDate(), price);
 
@@ -249,7 +251,7 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
                                     "\n atm rate:        " << io::rate(calculated));
                     }
 
-                    price = Bond::Price(bond.dirtyPrice(), Bond::Price::Dirty);
+                    price = {bond.dirtyPrice(), Bond::Price::Dirty};
                     calculated =
                         BondFunctions::atmRate(bond, **disc, bond.settlementDate(), price);
 
@@ -316,10 +318,12 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                         for (Real spread : spreads) {
 
                             // Clean price
-                            Bond::Price price(BondFunctions::cleanPrice(bond, *discountCurve,
-                                                                        spread, bondDayCount, n,
-                                                                        frequency),
-                                              Bond::Price::Clean);
+                            Bond::Price price = {
+                                BondFunctions::cleanPrice(bond, *discountCurve,
+                                                          spread, bondDayCount, n,
+                                                          frequency),
+                                Bond::Price::Clean
+                            };
                             Spread calculated = BondFunctions::zSpread(
                                 bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
                                 tolerance, maxEvaluations);
@@ -344,10 +348,11 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                             }
 
                             // Dirty price
-                            price =
-                                Bond::Price(BondFunctions::dirtyPrice(bond, *discountCurve, spread,
-                                                                      bondDayCount, n, frequency),
-                                            Bond::Price::Dirty);
+                            price = {
+                                BondFunctions::dirtyPrice(bond, *discountCurve, spread,
+                                                          bondDayCount, n, frequency),
+                                Bond::Price::Dirty
+                            };
 
                             calculated = BondFunctions::zSpread(
                                 bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
@@ -444,7 +449,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                     }
 
                     Rate calculatedYield = BondFunctions::yield(
-                        bond, Bond::Price(calculatedPrice, Bond::Price::Clean), bondDayCount,
+                        bond, {calculatedPrice, Bond::Price::Clean}, bondDayCount,
                         Continuous, frequency, bond.settlementDate(), tolerance, maxEvaluations);
                     if (std::fabs(m - calculatedYield) > tolerance) {
                         BOOST_ERROR("yield calculation failed:" <<
@@ -477,7 +482,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                     }
 
                     calculatedYield = BondFunctions::yield(
-                        bond, Bond::Price(calculatedPrice, Bond::Price::Dirty), bondDayCount,
+                        bond, {calculatedPrice, Bond::Price::Dirty}, bondDayCount,
                         Continuous, frequency, bond.settlementDate(), tolerance, maxEvaluations, 0.05);
                     if (std::fabs(m - calculatedYield) > tolerance) {
                         BOOST_ERROR("yield calculation failed:" <<
@@ -605,28 +610,28 @@ BOOST_AUTO_TEST_CASE(testCached) {
         tolerance,
         "failed to reproduce cached clean price with no schdule for bond 1:"
     );
-    checkValue(BondFunctions::yield(bond1, Bond::Price(marketPrice1, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond1, {marketPrice1, Bond::Price::Clean},
                                     bondDayCount1, Compounded, freq),
                cachedYield1a, tolerance,
                "failed to reproduce cached compounded yield with schedule for bond 1:");
-    checkValue(BondFunctions::yield(bond1NoSchedule, Bond::Price(marketPrice1, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond1NoSchedule, {marketPrice1, Bond::Price::Clean},
                                     bondDayCount1NoSchedule, Compounded, freq),
                cachedYield1a, tolerance,
                "failed to reproduce cached compounded yield with no schedule for bond 1:");
-    checkValue(BondFunctions::yield(bond1, Bond::Price(marketPrice1, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond1, {marketPrice1, Bond::Price::Clean},
                                     bondDayCount1, Continuous, freq),
                cachedYield1b, tolerance,
                "failed to reproduce cached continuous yield with schedule for bond 1:");
-    checkValue(BondFunctions::yield(bond1NoSchedule, Bond::Price(marketPrice1, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond1NoSchedule, {marketPrice1, Bond::Price::Clean},
                                     bondDayCount1NoSchedule, Continuous, freq),
                cachedYield1b, tolerance,
                "failed to reproduce cached continuous yield with no schedule for bond 1:");
-    checkValue(BondFunctions::yield(bond1, Bond::Price(bond1.cleanPrice(), Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond1, {bond1.cleanPrice(), Bond::Price::Clean},
                                     bondDayCount1, Continuous, freq, bond1.settlementDate()),
                cachedYield1c, tolerance,
                "failed to reproduce cached continuous yield with schedule for bond 1:");
     checkValue(BondFunctions::yield(
-                   bond1NoSchedule, Bond::Price(bond1NoSchedule.cleanPrice(), Bond::Price::Clean),
+                   bond1NoSchedule, {bond1NoSchedule.cleanPrice(), Bond::Price::Clean},
                    bondDayCount1NoSchedule, Continuous, freq, bond1.settlementDate()),
                cachedYield1c, tolerance,
                "failed to reproduce cached continuous yield with no schedule for bond 1:");
@@ -657,28 +662,28 @@ BOOST_AUTO_TEST_CASE(testCached) {
         tolerance,
         "failed to reproduce cached clean price with no schedule for bond 2:"
     );
-    checkValue(BondFunctions::yield(bond2, Bond::Price(marketPrice2, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond2, {marketPrice2, Bond::Price::Clean},
                                     bondDayCount2, Compounded, freq),
                cachedYield2a, tolerance,
                "failed to reproduce cached compounded yield with schedule for bond 2:");
-    checkValue(BondFunctions::yield(bond2NoSchedule, Bond::Price(marketPrice2, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond2NoSchedule, {marketPrice2, Bond::Price::Clean},
                                     bondDayCount2NoSchedule, Compounded, freq),
                cachedYield2a, tolerance,
                "failed to reproduce cached compounded yield with no schedule for bond 2:");
-    checkValue(BondFunctions::yield(bond2, Bond::Price(marketPrice2, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond2, {marketPrice2, Bond::Price::Clean},
                                     bondDayCount2, Continuous, freq),
                cachedYield2b, tolerance,
                "failed to reproduce chached continuous yield with schedule for bond 2:");
-    checkValue(BondFunctions::yield(bond2NoSchedule, Bond::Price(marketPrice2, Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond2NoSchedule, {marketPrice2, Bond::Price::Clean},
                                     bondDayCount2NoSchedule, Continuous, freq),
                cachedYield2b, tolerance,
                "failed to reproduce cached continuous yield with schedule for bond 2:");
-    checkValue(BondFunctions::yield(bond2, Bond::Price(bond2.cleanPrice(), Bond::Price::Clean),
+    checkValue(BondFunctions::yield(bond2, {bond2.cleanPrice(), Bond::Price::Clean},
                                     bondDayCount2, Continuous, freq, bond2.settlementDate()),
                cachedYield2c, tolerance,
                "failed to reproduce cached continuous yield for bond 2 with schedule:");
     checkValue(BondFunctions::yield(
-                   bond2NoSchedule, Bond::Price(bond2NoSchedule.cleanPrice(), Bond::Price::Clean),
+                   bond2NoSchedule, {bond2NoSchedule.cleanPrice(), Bond::Price::Clean},
                    bondDayCount2NoSchedule, Continuous, freq, bond2NoSchedule.settlementDate()),
                cachedYield2c, tolerance,
                "failed to reproduce cached continuous yield for bond 2 with no schedule:");

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -315,6 +315,7 @@ BOOST_AUTO_TEST_CASE(testZspread) {
 
                         for (Real spread : spreads) {
 
+                            // Clean price
                             Bond::Price price(BondFunctions::cleanPrice(bond, *discountCurve,
                                                                         spread, bondDayCount, n,
                                                                         frequency),
@@ -339,6 +340,36 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                                                 "\n    clean price:  " << price.amount() <<
                                                 "\n    Z-spread': " << io::rate(calculated) <<
                                                 "\n    clean price': " << price2);
+                                }
+                            }
+
+                            // Dirty price
+                            price =
+                                Bond::Price(BondFunctions::dirtyPrice(bond, *discountCurve, spread,
+                                                                      bondDayCount, n, frequency),
+                                            Bond::Price::Dirty);
+
+                            calculated = BondFunctions::zSpread(
+                                bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
+                                tolerance, maxEvaluations);
+
+                            if (std::fabs(spread - calculated) > tolerance) {
+                                // the difference might not matter
+                                Real price2 = BondFunctions::dirtyPrice(
+                                    bond, *discountCurve, calculated, bondDayCount, n, frequency);
+                                if (std::fabs(price.amount() - price2) / price.amount() > tolerance) {
+                                    BOOST_ERROR("\nZ-spread recalculation failed:"
+                                                "\n    issue:        " << issue <<
+                                                "\n    maturity:     " << maturity <<
+                                                "\n    coupon:       " << io::rate(coupon) <<
+                                                "\n    frequency:    " << frequency <<
+                                                "\n    Z-spread:     " << io::rate(spread) <<
+                                                (compounding[n] == Compounded ?
+                                                    " compounded" : " continuous") <<
+                                                std::setprecision(7) <<
+                                                "\n    dirty price:  " << price.amount() <<
+                                                "\n    Z-spread':    " << io::rate(calculated) <<
+                                                "\n    dirty price': " << price2);
                                 }
                             }
                         }

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -117,14 +117,14 @@ BOOST_AUTO_TEST_CASE(testYield) {
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
             for (Real& coupon : coupons) {
-                for (auto& frequencie : frequencies) {
+                for (auto& frequency : frequencies) {
                     for (auto& n : compounding) {
 
                         Date dated = vars.calendar.advance(vars.today, issueMonth, Months);
                         Date issue = dated;
                         Date maturity = vars.calendar.advance(issue, length, Years);
 
-                        Schedule sch(dated, maturity, Period(frequencie), vars.calendar,
+                        Schedule sch(dated, maturity, Period(frequency), vars.calendar,
                                      accrualConvention, accrualConvention, DateGeneration::Backward,
                                      false);
 
@@ -135,22 +135,22 @@ BOOST_AUTO_TEST_CASE(testYield) {
                         for (Real m : yields) {
 
                             Real price =
-                                BondFunctions::cleanPrice(bond, m, bondDayCount, n, frequencie);
+                                BondFunctions::cleanPrice(bond, m, bondDayCount, n, frequency);
 
                             Rate calculated = BondFunctions::yield(
-                                bond, price, bondDayCount, n, frequencie, Date(), tolerance,
+                                bond, price, bondDayCount, n, frequency, Date(), tolerance,
                                 maxEvaluations, 0.05, Bond::Price::Clean);
 
                             if (std::fabs(m - calculated) > tolerance) {
                                 // the difference might not matter
                                 Real price2 = BondFunctions::cleanPrice(
-                                    bond, calculated, bondDayCount, n, frequencie);
+                                    bond, calculated, bondDayCount, n, frequency);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nyield recalculation failed:"
                                                 "\n    issue:        " << issue <<
                                                 "\n    maturity:     " << maturity <<
                                                 "\n    coupon:       " << io::rate(coupon) <<
-                                                "\n    frequency:    " << frequencie <<
+                                                "\n    frequency:    " << frequency <<
                                                 "\n    yield:        " << io::rate(m) <<
                                                     (n == Compounded ? " compounded" : " continuous") <<
                                                 std::setprecision(7) <<
@@ -160,22 +160,22 @@ BOOST_AUTO_TEST_CASE(testYield) {
                                 }
                             }
 
-                            price = BondFunctions::dirtyPrice(bond, m, bondDayCount, n, frequencie);
+                            price = BondFunctions::dirtyPrice(bond, m, bondDayCount, n, frequency);
 
                             calculated = BondFunctions::yield(
-                                bond, price, bondDayCount, n, frequencie, Date(), tolerance,
+                                bond, price, bondDayCount, n, frequency, Date(), tolerance,
                                 maxEvaluations, 0.05, Bond::Price::Dirty);
 
                             if (std::fabs(m - calculated) > tolerance) {
                                 // the difference might not matter
                                 Real price2 = BondFunctions::dirtyPrice(
-                                    bond, calculated, bondDayCount, n, frequencie);
+                                    bond, calculated, bondDayCount, n, frequency);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nyield recalculation failed:"
                                                 "\n    issue:        " << issue <<
                                                 "\n    maturity:     " << maturity <<
                                                 "\n    coupon:       " << io::rate(coupon) <<
-                                                "\n    frequency:    " << frequencie <<
+                                                "\n    frequency:    " << frequency <<
                                                 "\n    yield:        " << io::rate(m) <<
                                                     (n == Compounded ? " compounded" : " continuous") <<
                                                 std::setprecision(7) <<
@@ -215,12 +215,12 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
             for (Real& coupon : coupons) {
-                for (auto& frequencie : frequencies) {
+                for (auto& frequency : frequencies) {
                     Date dated = vars.calendar.advance(vars.today, issueMonth, Months);
                     Date issue = dated;
                     Date maturity = vars.calendar.advance(issue, length, Years);
 
-                    Schedule sch(dated, maturity, Period(frequencie), vars.calendar,
+                    Schedule sch(dated, maturity, Period(frequency), vars.calendar,
                                  accrualConvention, accrualConvention, DateGeneration::Backward,
                                  false);
 
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
                                     "\n issue:           " << issue <<
                                     "\n maturity:        " << maturity <<
                                     "\n coupon:          " << io::rate(coupon) <<
-                                    "\n frequency:       " << frequencie <<
+                                    "\n frequency:       " << frequency <<
                                     "\n clean price:     " << price <<
                                     "\n dirty price:     " << price + bond.accruedAmount() <<
                                     "\n atm rate:        " << io::rate(calculated));
@@ -279,14 +279,14 @@ BOOST_AUTO_TEST_CASE(testZspread) {
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
             for (Real& coupon : coupons) {
-                for (auto& frequencie : frequencies) {
+                for (auto& frequency : frequencies) {
                     for (auto& n : compounding) {
 
                         Date dated = vars.calendar.advance(vars.today, issueMonth, Months);
                         Date issue = dated;
                         Date maturity = vars.calendar.advance(issue, length, Years);
 
-                        Schedule sch(dated, maturity, Period(frequencie), vars.calendar,
+                        Schedule sch(dated, maturity, Period(frequency), vars.calendar,
                                      accrualConvention, accrualConvention, DateGeneration::Backward,
                                      false);
 
@@ -297,21 +297,21 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                         for (Real spread : spreads) {
 
                             Real price = BondFunctions::cleanPrice(bond, *discountCurve, spread,
-                                                                   bondDayCount, n, frequencie);
+                                                                   bondDayCount, n, frequency);
                             Spread calculated = BondFunctions::zSpread(
-                                bond, price, *discountCurve, bondDayCount, n, frequencie, Date(),
+                                bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
                                 tolerance, maxEvaluations);
 
                             if (std::fabs(spread - calculated) > tolerance) {
                                 // the difference might not matter
                                 Real price2 = BondFunctions::cleanPrice(
-                                    bond, *discountCurve, calculated, bondDayCount, n, frequencie);
+                                    bond, *discountCurve, calculated, bondDayCount, n, frequency);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nZ-spread recalculation failed:"
                                                 "\n    issue:     " << issue <<
                                                 "\n    maturity:  " << maturity <<
                                                 "\n    coupon:    " << io::rate(coupon) <<
-                                                "\n    frequency: " << frequencie <<
+                                                "\n    frequency: " << frequency <<
                                                 "\n    Z-spread:  " << io::rate(spread) <<
                                                     (n == Compounded ? " compounded" : " continuous") <<
                                                 std::setprecision(7) <<
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
 
     for (unsigned long length : lengths) {
         for (Real& coupon : coupons) {
-            for (auto& frequencie : frequencies) {
+            for (auto& frequency : frequencies) {
 
                 Date dated = vars.today;
                 Date issue = dated;
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                 ext::shared_ptr<SimpleQuote> rate(new SimpleQuote(0.0));
                 Handle<YieldTermStructure> discountCurve(flatRate(vars.today, rate, bondDayCount));
 
-                Schedule sch(dated, maturity, Period(frequencie), vars.calendar, accrualConvention,
+                Schedule sch(dated, maturity, Period(frequency), vars.calendar, accrualConvention,
                              accrualConvention, DateGeneration::Backward, false);
 
                 FixedRateBond bond(settlementDays, vars.faceAmount, sch,
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                     rate->setValue(m);
 
                     Real price =
-                        BondFunctions::cleanPrice(bond, m, bondDayCount, Continuous, frequencie);
+                        BondFunctions::cleanPrice(bond, m, bondDayCount, Continuous, frequency);
                     Real calculatedPrice = bond.cleanPrice();
 
                     if (std::fabs(price - calculatedPrice) > tolerance) {
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                                     "\n    issue:       " << issue <<
                                     "\n    maturity:    " << maturity <<
                                     "\n    coupon:      " << io::rate(coupon) <<
-                                    "\n    frequency:   " << frequencie <<
+                                    "\n    frequency:   " << frequency <<
                                     "\n    yield:       " << io::rate(m) <<
                                     std::setprecision(7) <<
                                     "\n    expected:    " << price <<
@@ -391,14 +391,14 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                     }
 
                     Rate calculatedYield = BondFunctions::yield(
-                        bond, calculatedPrice, bondDayCount, Continuous, frequencie,
+                        bond, calculatedPrice, bondDayCount, Continuous, frequency,
                         bond.settlementDate(), tolerance, maxEvaluations);
                     if (std::fabs(m - calculatedYield) > tolerance) {
                         BOOST_ERROR("yield calculation failed:" <<
                                     "\n    issue:     " << issue <<
                                     "\n    maturity:  " << maturity <<
                                     "\n    coupon:    " << io::rate(coupon) <<
-                                    "\n    frequency: " << frequencie <<
+                                    "\n    frequency: " << frequency <<
                                     "\n    yield:     " << io::rate(m) <<
                                     std::setprecision(7) <<
                                     "\n    price:     " << price <<

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -147,15 +147,16 @@ BOOST_AUTO_TEST_CASE(testYield) {
                                     bond, calculated, bondDayCount, n, frequencie);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nyield recalculation failed:"
-                                                "\n    issue:     "
-                                                << issue << "\n    maturity:  " << maturity
-                                                << "\n    coupon:    " << io::rate(coupon)
-                                                << "\n    frequency: " << frequencie
-                                                << "\n    yield:   " << io::rate(m)
-                                                << (n == Compounded ? " compounded" : " continuous")
-                                                << std::setprecision(7) << "\n    clean price:   "
-                                                << price << "\n    yield': " << io::rate(calculated)
-                                                << "\n    clean price': " << price2);
+                                                "\n    issue:        " << issue <<
+                                                "\n    maturity:     " << maturity <<
+                                                "\n    coupon:       " << io::rate(coupon) <<
+                                                "\n    frequency:    " << frequencie <<
+                                                "\n    yield:        " << io::rate(m) <<
+                                                    (n == Compounded ? " compounded" : " continuous") <<
+                                                std::setprecision(7) <<
+                                                "\n    clean price:  " << price <<
+                                                "\n    yield':       " << io::rate(calculated) <<
+                                                "\n    clean price': " << price2);
                                 }
                             }
 
@@ -171,15 +172,16 @@ BOOST_AUTO_TEST_CASE(testYield) {
                                     bond, calculated, bondDayCount, n, frequencie);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nyield recalculation failed:"
-                                                "\n    issue:     "
-                                                << issue << "\n    maturity:  " << maturity
-                                                << "\n    coupon:    " << io::rate(coupon)
-                                                << "\n    frequency: " << frequencie
-                                                << "\n    yield:   " << io::rate(m)
-                                                << (n == Compounded ? " compounded" : " continuous")
-                                                << std::setprecision(7) << "\n    dirty price:   "
-                                                << price << "\n    yield': " << io::rate(calculated)
-                                                << "\n    dirty price': " << price2);
+                                                "\n    issue:        " << issue <<
+                                                "\n    maturity:     " << maturity <<
+                                                "\n    coupon:       " << io::rate(coupon) <<
+                                                "\n    frequency:    " << frequencie <<
+                                                "\n    yield:        " << io::rate(m) <<
+                                                    (n == Compounded ? " compounded" : " continuous") <<
+                                                std::setprecision(7) <<
+                                                "\n    dirty price:  " << price <<
+                                                "\n    yield':       " << io::rate(calculated) <<
+                                                "\n    dirty price': " << price2);
                                 }
                             }
                         }
@@ -233,14 +235,15 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
 
                     if (std::fabs(coupon - calculated) > tolerance) {
                         BOOST_ERROR("\natm rate recalculation failed:"
-                                    "\n today:           "
-                                    << vars.today << "\n settlement date: " << bond.settlementDate()
-                                    << "\n issue:           " << issue << "\n maturity:        "
-                                    << maturity << "\n coupon:          " << io::rate(coupon)
-                                    << "\n frequency:       " << frequencie
-                                    << "\n clean price:     " << price
-                                    << "\n dirty price:     " << price + bond.accruedAmount()
-                                    << "\n atm rate:        " << io::rate(calculated));
+                                    "\n today:           " << vars.today <<
+                                    "\n settlement date: " << bond.settlementDate() <<
+                                    "\n issue:           " << issue <<
+                                    "\n maturity:        " << maturity <<
+                                    "\n coupon:          " << io::rate(coupon) <<
+                                    "\n frequency:       " << frequencie <<
+                                    "\n clean price:     " << price <<
+                                    "\n dirty price:     " << price + bond.accruedAmount() <<
+                                    "\n atm rate:        " << io::rate(calculated));
                     }
                 }
             }
@@ -305,16 +308,16 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                                     bond, *discountCurve, calculated, bondDayCount, n, frequencie);
                                 if (std::fabs(price - price2) / price > tolerance) {
                                     BOOST_ERROR("\nZ-spread recalculation failed:"
-                                                "\n    issue:     "
-                                                << issue << "\n    maturity:  " << maturity
-                                                << "\n    coupon:    " << io::rate(coupon)
-                                                << "\n    frequency: " << frequencie
-                                                << "\n    Z-spread:  " << io::rate(spread)
-                                                << (n == Compounded ? " compounded" : " continuous")
-                                                << std::setprecision(7)
-                                                << "\n    price:     " << price
-                                                << "\n    Z-spread': " << io::rate(calculated)
-                                                << "\n    price':    " << price2);
+                                                "\n    issue:     " << issue <<
+                                                "\n    maturity:  " << maturity <<
+                                                "\n    coupon:    " << io::rate(coupon) <<
+                                                "\n    frequency: " << frequencie <<
+                                                "\n    Z-spread:  " << io::rate(spread) <<
+                                                    (n == Compounded ? " compounded" : " continuous") <<
+                                                std::setprecision(7) <<
+                                                "\n    price:     " << price <<
+                                                "\n    Z-spread': " << io::rate(calculated) <<
+                                                "\n    price':    " << price2);
                                 }
                             }
                         }
@@ -375,27 +378,31 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                     Real calculatedPrice = bond.cleanPrice();
 
                     if (std::fabs(price - calculatedPrice) > tolerance) {
-                        BOOST_ERROR("price calculation failed:"
-                                    << "\n    issue:     " << issue << "\n    maturity:  "
-                                    << maturity << "\n    coupon:    " << io::rate(coupon)
-                                    << "\n    frequency: " << frequencie
-                                    << "\n    yield:  " << io::rate(m) << std::setprecision(7)
-                                    << "\n    expected:    " << price
-                                    << "\n    calculated': " << calculatedPrice
-                                    << "\n    error':      " << price - calculatedPrice);
+                        BOOST_ERROR("price calculation failed:" <<
+                                    "\n    issue:       " << issue <<
+                                    "\n    maturity:    " << maturity <<
+                                    "\n    coupon:      " << io::rate(coupon) <<
+                                    "\n    frequency:   " << frequencie <<
+                                    "\n    yield:       " << io::rate(m) <<
+                                    std::setprecision(7) <<
+                                    "\n    expected:    " << price <<
+                                    "\n    calculated': " << calculatedPrice <<
+                                    "\n    error':      " << price - calculatedPrice);
                     }
 
                     Rate calculatedYield = BondFunctions::yield(
                         bond, calculatedPrice, bondDayCount, Continuous, frequencie,
                         bond.settlementDate(), tolerance, maxEvaluations);
                     if (std::fabs(m - calculatedYield) > tolerance) {
-                        BOOST_ERROR("yield calculation failed:"
-                                    << "\n    issue:     " << issue << "\n    maturity:  "
-                                    << maturity << "\n    coupon:    " << io::rate(coupon)
-                                    << "\n    frequency: " << frequencie
-                                    << "\n    yield:  " << io::rate(m) << std::setprecision(7)
-                                    << "\n    price:  " << price
-                                    << "\n    yield': " << io::rate(calculatedYield));
+                        BOOST_ERROR("yield calculation failed:" <<
+                                    "\n    issue:     " << issue <<
+                                    "\n    maturity:  " << maturity <<
+                                    "\n    coupon:    " << io::rate(coupon) <<
+                                    "\n    frequency: " << frequencie <<
+                                    "\n    yield:     " << io::rate(m) <<
+                                    std::setprecision(7) <<
+                                    "\n    price:     " << price <<
+                                    "\n    yield':    " << io::rate(calculatedYield));
                     }
                 }
             }

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(testFlatExtrapolation) {
 
     // extract the model prices using the two curves
 
-    std::vector<Real> modelPrices1, modelPrices2;
+    std::vector<Bond::Price> modelPrices1, modelPrices2;
 
     ext::shared_ptr<PricingEngine> engine1 =
         ext::make_shared<DiscountingBondEngine>(Handle<YieldTermStructure>(curve1));
@@ -153,9 +153,9 @@ BOOST_AUTO_TEST_CASE(testFlatExtrapolation) {
 
     for (auto& bond : bonds) {
         bond->setPricingEngine(engine1);
-        modelPrices1.push_back(bond->cleanPrice());
+        modelPrices1.push_back(Bond::Price(bond->cleanPrice(), Bond::Price::Clean));
         bond->setPricingEngine(engine2);
-        modelPrices2.push_back(bond->cleanPrice());
+        modelPrices2.push_back(Bond::Price(bond->cleanPrice(), Bond::Price::Clean));
     }
     BOOST_CHECK_EQUAL(curve1->fitResults().errorCode(), EndCriteria::MaxIterations);
     BOOST_CHECK_EQUAL(curve2->fitResults().errorCode(), EndCriteria::MaxIterations);

--- a/test-suite/fittedbonddiscountcurve.cpp
+++ b/test-suite/fittedbonddiscountcurve.cpp
@@ -153,9 +153,9 @@ BOOST_AUTO_TEST_CASE(testFlatExtrapolation) {
 
     for (auto& bond : bonds) {
         bond->setPricingEngine(engine1);
-        modelPrices1.push_back(Bond::Price(bond->cleanPrice(), Bond::Price::Clean));
+        modelPrices1.emplace_back(bond->cleanPrice(), Bond::Price::Clean);
         bond->setPricingEngine(engine2);
-        modelPrices2.push_back(Bond::Price(bond->cleanPrice(), Bond::Price::Clean));
+        modelPrices2.emplace_back(bond->cleanPrice(), Bond::Price::Clean);
     }
     BOOST_CHECK_EQUAL(curve1->fitResults().errorCode(), EndCriteria::MaxIterations);
     BOOST_CHECK_EQUAL(curve2->fitResults().errorCode(), EndCriteria::MaxIterations);


### PR DESCRIPTION
I noticed some more bond functions that currently accept only a clean price. This PR extends them to accept either dirty or clean price and adds the relevant priceType parameter.

Previous attempt at #939