### PR TITLE
fixing compilation issue: value usage of fwd declared struct

### DIFF
--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -42,7 +42,10 @@ using std::cos;
 
 namespace {
 
-    struct NamedOptimizationMethod;
+    struct NamedOptimizationMethod {
+        ext::shared_ptr<OptimizationMethod> optimizationMethod;
+        std::string name;
+    };
 
     std::vector<ext::shared_ptr<CostFunction> > costFunctions_;
     std::vector<ext::shared_ptr<Constraint> > constraints_;
@@ -138,11 +141,6 @@ namespace {
             QL_FAIL("unknown OptimizationMethod type");
         }
     }
-
-    struct NamedOptimizationMethod {
-        ext::shared_ptr<OptimizationMethod> optimizationMethod;
-        std::string name;
-    };
 
 
     ext::shared_ptr<OptimizationMethod> makeOptimizationMethod(


### PR DESCRIPTION
This addresses issue #1822.

The issue has been using a vector where the underlying value type has only been forward declared and defined later on, e.g.
```c++
struct NamedOptimizationMethod;
std::vector<std::vector<NamedOptimizationMethod> > optimizationMethods_;
struct NamedOptimizationMethod {
        ext::shared_ptr<OptimizationMethod> optimizationMethod;
        std::string name;
};
```
Minimal (non-)working example: [godbolt](https://godbolt.org/z/P7jGPWvEo)