### PR TITLE
CMake presets: Obey ordering rule

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -174,43 +174,43 @@
     {
       "name": "linux-clang-ninja-debug",
       "inherits": [
-        "linux-clang-debug",
-        "ninja"
+        "ninja",
+        "linux-clang-debug"
       ]
     },
     {
       "name": "linux-clang-ninja-release",
       "inherits": [
-        "linux-clang-release",
-        "ninja"
+        "ninja",
+        "linux-clang-release"
       ]
     },
     {
       "name": "linux-clang-ninja-relwithdebinfo",
       "inherits": [
-        "linux-clang-relwithdebinfo",
-        "ninja"
+        "ninja",
+        "linux-clang-relwithdebinfo"
       ]
     },
     {
       "name": "linux-gcc-ninja-debug",
       "inherits": [
-        "linux-gcc-debug",
-        "ninja"
+        "ninja",
+        "linux-gcc-debug"
       ]
     },
     {
       "name": "linux-gcc-ninja-release",
       "inherits": [
-        "linux-gcc-release",
-        "ninja"
+        "ninja",
+        "linux-gcc-release"
       ]
     },
     {
       "name": "linux-gcc-ninja-relwithdebinfo",
       "inherits": [
-        "linux-gcc-relwithdebinfo",
-        "ninja"
+        "ninja",
+        "linux-gcc-relwithdebinfo"
       ]
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -216,9 +216,7 @@
     {
       "name": "linux-gcc-debug-with-clang-tidy",
       "inherits": [
-        "linux-gcc-base",
-        "make",
-        "_debug"
+        "linux-gcc-debug"
       ],
       "cacheVariables": {
         "QL_CLANG_TIDY_OPTIONS": "-warnings-as-errors=*",
@@ -276,9 +274,7 @@
     {
       "name": "linux-ci-build-with-clang-tidy",
       "inherits": [
-        "linux-gcc-base",
-        "make",
-        "_debug"
+        "linux-gcc-debug"
       ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
@@ -292,9 +288,7 @@
     {
       "name": "linux-ci-build-with-nonstandard-options",
       "inherits": [
-        "linux-gcc-base",
-        "ninja",
-        "_release"
+        "linux-gcc-ninja-release"
       ],
       "cacheVariables": {
         "BOOST_ROOT": "/usr",
@@ -319,9 +313,7 @@
     {
       "name": "windows-ci-build-with-nonstandard-options",
       "inherits": [
-        "windows-msvc-base",
-        "ninja",
-        "_release"
+        "windows-msvc-release"
       ],
       "cacheVariables": {
         "CMAKE_CXX_STANDARD": "17",


### PR DESCRIPTION
Closes #1824 .

The first commit fixes the original issue.

The second commit cleans some presets up by making use of previously defined presets.