### PR TITLE
Allow different frequencies in MakeOIS and OISRateHelper

### DIFF
--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -34,9 +34,8 @@ namespace QuantLib {
                      const Period& forwardStart)
     : swapTenor_(swapTenor), overnightIndex_(overnightIndex), fixedRate_(fixedRate),
       forwardStart_(forwardStart),
-
-      calendar_(overnightIndex->fixingCalendar()),
-
+      fixedCalendar_(overnightIndex->fixingCalendar()),
+      overnightCalendar_(overnightIndex->fixingCalendar()),
       fixedDayCount_(overnightIndex->dayCounter()) {}
 
     MakeOIS::operator OvernightIndexedSwap() const {
@@ -53,27 +52,27 @@ namespace QuantLib {
             Date refDate = Settings::instance().evaluationDate();
             // if the evaluation date is not a business day
             // then move to the next business day
-            refDate = calendar_.adjust(refDate);
-            Date spotDate = calendar_.advance(refDate,
-                                              settlementDays_*Days);
+            refDate = overnightCalendar_.adjust(refDate);
+            Date spotDate = overnightCalendar_.advance(refDate,
+                                                       settlementDays_*Days);
             startDate = spotDate+forwardStart_;
             if (forwardStart_.length()<0)
-                startDate = calendar_.adjust(startDate, Preceding);
+                startDate = overnightCalendar_.adjust(startDate, Preceding);
             else
-                startDate = calendar_.adjust(startDate, Following);
+                startDate = overnightCalendar_.adjust(startDate, Following);
         }
 
         // OIS end of month default
         bool usedEndOfMonth =
-            isDefaultEOM_ ? calendar_.isEndOfMonth(startDate) : endOfMonth_;
+            isDefaultEOM_ ? overnightCalendar_.isEndOfMonth(startDate) : endOfMonth_;
 
         Date endDate = terminationDate_;
         if (endDate == Date()) {
             if (usedEndOfMonth)
-                endDate = calendar_.advance(startDate,
-                                            swapTenor_,
-                                            ModifiedFollowing,
-                                            usedEndOfMonth);
+                endDate = overnightCalendar_.advance(startDate,
+                                                     swapTenor_,
+                                                     ModifiedFollowing,
+                                                     usedEndOfMonth);
             else
                 endDate = startDate + swapTenor_;
         }
@@ -97,16 +96,17 @@ namespace QuantLib {
 
         Schedule fixedSchedule(startDate, endDate,
                                Period(fixedPaymentFrequency),
-                               calendar_,
+                               fixedCalendar_,
                                ModifiedFollowing,
                                ModifiedFollowing,
                                fixedRule,
                                usedEndOfMonth);
         ext::optional<Schedule> overnightSchedule;
-        if (fixedPaymentFrequency != overnightPaymentFrequency || fixedRule != overnightRule) {
+        if (fixedPaymentFrequency != overnightPaymentFrequency || fixedRule != overnightRule ||
+            fixedCalendar_ != overnightCalendar_) {
             overnightSchedule.emplace(startDate, endDate,
                                       Period(overnightPaymentFrequency),
-                                      calendar_,
+                                      overnightCalendar_,
                                       ModifiedFollowing,
                                       ModifiedFollowing,
                                       overnightRule,
@@ -220,6 +220,16 @@ namespace QuantLib {
 
     MakeOIS& MakeOIS::withPaymentCalendar(const Calendar& cal) {
         paymentCalendar_ = cal;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withFixedLegCalendar(const Calendar& cal) {
+        fixedCalendar_ = cal;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withOvernightLegCalendar(const Calendar& cal) {
+        overnightCalendar_ = cal;
         return *this;
     }
 

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -54,8 +54,12 @@ namespace QuantLib {
         MakeOIS& withEffectiveDate(const Date&);
         MakeOIS& withTerminationDate(const Date&);
         MakeOIS& withRule(DateGeneration::Rule r);
+        MakeOIS& withFixedLegRule(DateGeneration::Rule r);
+        MakeOIS& withOvernightLegRule(DateGeneration::Rule r);
 
         MakeOIS& withPaymentFrequency(Frequency f);
+        MakeOIS& withFixedLegPaymentFrequency(Frequency f);
+        MakeOIS& withOvernightLegPaymentFrequency(Frequency f);
         MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
         MakeOIS& withPaymentLag(Integer lag);
         MakeOIS& withPaymentCalendar(const Calendar& cal);
@@ -85,12 +89,14 @@ namespace QuantLib {
         Date effectiveDate_, terminationDate_;
         Calendar calendar_;
 
-        Frequency paymentFrequency_ = Annual;
+        Frequency fixedPaymentFrequency_ = Annual;
+        Frequency overnightPaymentFrequency_ = Annual;
         Calendar paymentCalendar_;
         BusinessDayConvention paymentAdjustment_ = Following;
         Integer paymentLag_ = 0;
 
-        DateGeneration::Rule rule_ = DateGeneration::Backward;
+        DateGeneration::Rule fixedRule_ = DateGeneration::Backward;
+        DateGeneration::Rule overnightRule_ = DateGeneration::Backward;
         bool endOfMonth_ = false, isDefaultEOM_ = true;
 
         Swap::Type type_ = Swap::Payer;

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -63,6 +63,8 @@ namespace QuantLib {
         MakeOIS& withPaymentAdjustment(BusinessDayConvention convention);
         MakeOIS& withPaymentLag(Integer lag);
         MakeOIS& withPaymentCalendar(const Calendar& cal);
+        MakeOIS& withFixedLegCalendar(const Calendar& cal);
+        MakeOIS& withOvernightLegCalendar(const Calendar& cal);
 
         MakeOIS& withEndOfMonth(bool flag = true);
 
@@ -87,7 +89,7 @@ namespace QuantLib {
 
         Natural settlementDays_ = 2;
         Date effectiveDate_, terminationDate_;
-        Calendar calendar_;
+        Calendar fixedCalendar_, overnightCalendar_;
 
         Frequency fixedPaymentFrequency_ = Annual;
         Frequency overnightPaymentFrequency_ = Annual;

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -43,14 +43,15 @@ namespace QuantLib {
                                  Date customPillarDate,
                                  RateAveraging::Type averagingMethod,
                                  ext::optional<bool> endOfMonth,
-                                 ext::optional<Frequency> fixedPaymentFrequency)
+                                 ext::optional<Frequency> fixedPaymentFrequency,
+                                 Calendar fixedCalendar)
     : RelativeDateRateHelper(fixedRate), pillarChoice_(pillar), settlementDays_(settlementDays), tenor_(tenor),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
       paymentLag_(paymentLag), paymentConvention_(paymentConvention),
       paymentFrequency_(paymentFrequency), paymentCalendar_(std::move(paymentCalendar)),
       forwardStart_(forwardStart), overnightSpread_(overnightSpread),
       averagingMethod_(averagingMethod), endOfMonth_(endOfMonth),
-      fixedPaymentFrequency_(fixedPaymentFrequency) {
+      fixedPaymentFrequency_(fixedPaymentFrequency), fixedCalendar_(std::move(fixedCalendar)) {
 
         overnightIndex_ =
             ext::dynamic_pointer_cast<OvernightIndex>(overnightIndex->clone(termStructureHandle_));
@@ -85,6 +86,9 @@ namespace QuantLib {
         }
         if (fixedPaymentFrequency_) {
             tmp.withFixedLegPaymentFrequency(*fixedPaymentFrequency_);
+        }
+        if (!fixedCalendar_.empty()) {
+            tmp.withFixedLegCalendar(fixedCalendar_);
         }
         swap_ = tmp;
 
@@ -167,7 +171,8 @@ namespace QuantLib {
                                            const Period& forwardStart,
                                            Spread overnightSpread,
                                            ext::optional<bool> endOfMonth,
-                                           ext::optional<Frequency> fixedPaymentFrequency)
+                                           ext::optional<Frequency> fixedPaymentFrequency,
+                                           const Calendar& fixedCalendar)
     : RateHelper(fixedRate), discountHandle_(std::move(discount)),
       telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
 
@@ -199,6 +204,9 @@ namespace QuantLib {
         }
         if (fixedPaymentFrequency) {
             tmp.withFixedLegPaymentFrequency(*fixedPaymentFrequency);
+        }
+        if (!fixedCalendar.empty()) {
+            tmp.withFixedLegCalendar(fixedCalendar);
         }
         swap_ = tmp;
 

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -42,13 +42,15 @@ namespace QuantLib {
                                  Pillar::Choice pillar,
                                  Date customPillarDate,
                                  RateAveraging::Type averagingMethod,
-                                 ext::optional<bool> endOfMonth)
+                                 ext::optional<bool> endOfMonth,
+                                 ext::optional<Frequency> fixedPaymentFrequency)
     : RelativeDateRateHelper(fixedRate), pillarChoice_(pillar), settlementDays_(settlementDays), tenor_(tenor),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
       paymentLag_(paymentLag), paymentConvention_(paymentConvention),
       paymentFrequency_(paymentFrequency), paymentCalendar_(std::move(paymentCalendar)),
       forwardStart_(forwardStart), overnightSpread_(overnightSpread),
-      averagingMethod_(averagingMethod), endOfMonth_(endOfMonth) {
+      averagingMethod_(averagingMethod), endOfMonth_(endOfMonth),
+      fixedPaymentFrequency_(fixedPaymentFrequency) {
 
         overnightIndex_ =
             ext::dynamic_pointer_cast<OvernightIndex>(overnightIndex->clone(termStructureHandle_));
@@ -79,10 +81,12 @@ namespace QuantLib {
             .withOvernightLegSpread(overnightSpread_)
             .withAveragingMethod(averagingMethod_);
         if (endOfMonth_) {
-            swap_ = tmp.withEndOfMonth(*endOfMonth_);
-        } else {
-            swap_ = tmp;
+            tmp.withEndOfMonth(*endOfMonth_);
         }
+        if (fixedPaymentFrequency_) {
+            tmp.withFixedLegPaymentFrequency(*fixedPaymentFrequency_);
+        }
+        swap_ = tmp;
 
         simplifyNotificationGraph(*swap_, true);
 
@@ -162,7 +166,8 @@ namespace QuantLib {
                                            const Calendar& paymentCalendar,
                                            const Period& forwardStart,
                                            Spread overnightSpread,
-                                           ext::optional<bool> endOfMonth)
+                                           ext::optional<bool> endOfMonth,
+                                           ext::optional<Frequency> fixedPaymentFrequency)
     : RateHelper(fixedRate), discountHandle_(std::move(discount)),
       telescopicValueDates_(telescopicValueDates), averagingMethod_(averagingMethod) {
 
@@ -190,10 +195,12 @@ namespace QuantLib {
             .withOvernightLegSpread(overnightSpread)
             .withAveragingMethod(averagingMethod_);
         if (endOfMonth) {
-            swap_ = tmp.withEndOfMonth(*endOfMonth);
-        } else {
-            swap_ = tmp;
+            tmp.withEndOfMonth(*endOfMonth);
         }
+        if (fixedPaymentFrequency) {
+            tmp.withFixedLegPaymentFrequency(*fixedPaymentFrequency);
+        }
+        swap_ = tmp;
 
         earliestDate_ = swap_->startDate();
         Date lastPaymentDate = std::max(swap_->overnightLeg().back()->date(),

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -51,7 +51,8 @@ namespace QuantLib {
                       Date customPillarDate = Date(),
                       RateAveraging::Type averagingMethod = RateAveraging::Compound,
                       ext::optional<bool> endOfMonth = ext::nullopt,
-                      ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt);
+                      ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+                      Calendar fixedCalendar = Calendar());
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -90,6 +91,7 @@ namespace QuantLib {
       RateAveraging::Type averagingMethod_;
       ext::optional<bool> endOfMonth_;
       ext::optional<Frequency> fixedPaymentFrequency_;
+      Calendar fixedCalendar_;
     };
 
     //! Rate helper for bootstrapping over Overnight Indexed Swap rates
@@ -110,7 +112,8 @@ namespace QuantLib {
                            const Period& forwardStart = 0 * Days,
                            Spread overnightSpread = 0.0,
                            ext::optional<bool> endOfMonth = ext::nullopt,
-                           ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt);
+                           ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+                           const Calendar& fixedCalendar = Calendar());
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -50,7 +50,8 @@ namespace QuantLib {
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(),
                       RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                      ext::optional<bool> endOfMonth = ext::nullopt);
+                      ext::optional<bool> endOfMonth = ext::nullopt,
+                      ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -88,6 +89,7 @@ namespace QuantLib {
       Spread overnightSpread_;
       RateAveraging::Type averagingMethod_;
       ext::optional<bool> endOfMonth_;
+      ext::optional<Frequency> fixedPaymentFrequency_;
     };
 
     //! Rate helper for bootstrapping over Overnight Indexed Swap rates
@@ -107,7 +109,8 @@ namespace QuantLib {
                            const Calendar& paymentCalendar = Calendar(),
                            const Period& forwardStart = 0 * Days,
                            Spread overnightSpread = 0.0,
-                           ext::optional<bool> endOfMonth = ext::nullopt);
+                           ext::optional<bool> endOfMonth = ext::nullopt,
+                           ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;


### PR DESCRIPTION
Allow setting different payment frequencies for fixed and overnight legs.