### PR TITLE
Initialize bounds in Solver1D

### DIFF
--- a/ql/math/solver1d.hpp
+++ b/ql/math/solver1d.hpp
@@ -227,7 +227,7 @@ namespace QuantLib {
         mutable Size evaluationNumber_;
       private:
         Real enforceBounds_(Real x) const;
-        Real lowerBound_, upperBound_;
+        Real lowerBound_{}, upperBound_{};
         bool lowerBoundEnforced_ = false, upperBoundEnforced_ = false;
     };
 


### PR DESCRIPTION
Resolves compilation failure in https://github.com/lballabio/QuantLib/actions/runs/7073435454/job/19253354984.

It doesn't look like the uninitialized value would ever be used in the code, so it could be a false positive, but anyway it's best practice to always initialize member variables.