### PR TITLE
Add TWSE holidays for 2024 to Taiwan calendar

### DIFF
--- a/ql/time/calendars/taiwan.cpp
+++ b/ql/time/calendars/taiwan.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004 FIMAT Group
  Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011 StatPro Italia srl
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -437,6 +438,25 @@ namespace QuantLib {
                 // adjusted holiday
                 || (d == 9 && m == October)
                 )
+                return false;
+        }
+
+        if (y == 2024) {
+            if ( // adjusted holiday
+                (d == 8 && m == February)
+                // Lunar New Year
+                || (d >= 9 && d <= 12 && m == February)
+                // adjusted holiday
+                || (d >= 13 && d <= 14 && m == February)
+                // Children's Day
+                || (d == 4 && m == April)
+                // Tomb-sweeping Day
+                || (d == 5 && m == April)
+                // Dragon Boat Festival
+                || (d == 10 && m == June)
+                // Mid-autumn/Moon Festival
+                || (d == 17 && m == September)
+            )
                 return false;
         }
 

--- a/ql/time/calendars/taiwan.hpp
+++ b/ql/time/calendars/taiwan.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004 FIMAT Group
  Copyright (C) 2005, 2006, 2007, 2008, 2009, 2011 StatPro Italia srl
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -42,7 +43,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2002-2023 only:)
+        (data available for 2002-2024 only:)
         <ul>
         <li>Chinese Lunar New Year</li>
         <li>Tomb Sweeping Day</li>


### PR DESCRIPTION
Hi,
Small additions sourced from the link in the docstring.

Not sure whether to also add 2023-08-03 as a past holiday, when the markets closed in the afternoon due to a typhoon. Reference: https://www.reuters.com/world/asia-pacific/typhoon-khanun-shuts-markets-grounds-flights-taiwan-2023-08-03/. 

/Fredrik