### PR TITLE
Stop moving Juneteenth to Friday if Saturday for US-Fed calendar

### DIFF
--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -6,6 +6,7 @@
  Copyright (C) 2003, 2004, 2005, 2006 StatPro Italia srl
  Copyright (C) 2017 Peter Caspers
  Copyright (C) 2017 Oleg Kulkov
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -35,7 +36,7 @@ namespace QuantLib {
                 // third Monday in February
                 return (d >= 15 && d <= 21) && w == Monday && m == February;
             } else {
-                // February 22nd, possily adjusted
+                // February 22nd, possibly adjusted
                 return (d == 22 || (d == 23 && w == Monday)
                         || (d == 21 && w == Friday)) && m == February;
             }

--- a/ql/time/calendars/unitedstates.cpp
+++ b/ql/time/calendars/unitedstates.cpp
@@ -84,9 +84,9 @@ namespace QuantLib {
             }
         }
 
-        bool isJuneteenth(Day d, Month m, Year y, Weekday w) {
+        bool isJuneteenth(Day d, Month m, Year y, Weekday w, bool moveToFriday = true) {
             // declared in 2021, but only observed by exchanges since 2022
-            return (d == 19 || (d == 20 && w == Monday) || (d == 18 && w == Friday))
+            return (d == 19 || (d == 20 && w == Monday) || ((d == 18 && w == Friday) && moveToFriday))
                 && m == June && y >= 2022;
         }
     }
@@ -363,8 +363,8 @@ namespace QuantLib {
             || isWashingtonBirthday(d, m, y, w)
             // Memorial Day (last Monday in May)
             || isMemorialDay(d, m, y, w)
-            // Juneteenth (Monday if Sunday or Friday if Saturday)
-            || isJuneteenth(d, m, y, w)
+            // Juneteenth (Monday if Sunday)
+            || isJuneteenth(d, m, y, w, false)
             // Independence Day (Monday if Sunday)
             || ((d == 4 || (d == 5 && w == Monday)) && m == July)
             // Labor Day (first Monday in September)

--- a/ql/time/calendars/unitedstates.hpp
+++ b/ql/time/calendars/unitedstates.hpp
@@ -6,6 +6,7 @@
  Copyright (C) 2004 Ferdinando Ametrano
  Copyright (C) 2017 Peter Caspers
  Copyright (C) 2017 Oleg Kulkov
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -121,6 +122,28 @@ namespace QuantLib {
         <li>Memorial Day, last Monday in May</li>
         <li>Independence Day, July 4th (moved to Monday if Sunday)</li>
         <li>Labor Day, first Monday in September</li>
+        <li>Thanksgiving Day, fourth Thursday in November</li>
+        <li>Christmas, December 25th (moved to Monday if Sunday)</li>
+        </ul>
+
+        Holidays for the Federal Reserve Bankwire System
+        (data from https://www.federalreserve.gov/aboutthefed/k8.htm
+        and https://www.frbservices.org/about/holiday-schedules):
+         <ul>
+        <li>Saturdays</li>
+        <li>Sundays</li>
+        <li>New Year's Day, January 1st (possibly moved to Monday if
+            actually on Sunday)</li>
+        <li>Martin Luther King's birthday, third Monday in January (since
+            1983)</li>
+        <li>Presidents' Day (a.k.a. Washington's birthday),
+            third Monday in February</li>
+        <li>Memorial Day, last Monday in May</li>
+        <li>Juneteenth, June 19th (moved to Monday if Sunday)</li>
+        <li>Independence Day, July 4th (moved to Monday if Sunday)</li>
+        <li>Labor Day, first Monday in September</li>
+        <li>Columbus Day, second Monday in October</li>
+        <li>Veterans' Day, November 11th (moved to Monday if Sunday)</li>
         <li>Thanksgiving Day, fourth Thursday in November</li>
         <li>Christmas, December 25th (moved to Monday if Sunday)</li>
         </ul>

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -387,6 +387,36 @@ BOOST_AUTO_TEST_CASE(testSOFR) {
         BOOST_ERROR(testDate << " should not be a fixing date for " << sofr.name());
 }
 
+BOOST_AUTO_TEST_CASE(testUSFederalReserveJuneteenth) {
+    BOOST_TEST_MESSAGE("Testing holiday occurrence of Juneteenth for US Federal Reserve calendar...");
+
+    auto fedCalendar = UnitedStates(UnitedStates::FederalReserve);
+
+    std::vector<Date> expectedHol;
+    // Sunday, moved to Monday 20th: expectedHol.emplace_back(19, June, 2022);
+    expectedHol.emplace_back(20, June, 2022);
+    expectedHol.emplace_back(19, June, 2023);
+    expectedHol.emplace_back(19, June, 2024);
+    expectedHol.emplace_back(19, June, 2025);
+    // Saturday: expectedHol.emplace_back(19, June, 2026);
+    expectedHol.emplace_back(19, June, 2027);
+    expectedHol.emplace_back(19, June, 2028);
+    expectedHol.emplace_back(19, June, 2029);
+    expectedHol.emplace_back(19, June, 2030);
+    expectedHol.emplace_back(19, June, 2031);
+    // Saturday: expectedHol.emplace_back(19, June, 2032);
+    // Sunday, moved to Monday 20th: expectedHol.emplace_back(19, June, 2033);
+    expectedHol.emplace_back(20, June, 2033);
+    for (Date holiday : expectedHol) {
+        if (!fedCalendar.isHoliday(holiday))
+            BOOST_ERROR(holiday << " should be a holiday for " << fedCalendar.name());
+    }
+
+    Date notMovedToFriday(18, June, 2027);
+    if (fedCalendar.isHoliday(notMovedToFriday))
+        BOOST_ERROR(notMovedToFriday << " should not be a holiday for " << fedCalendar.name());
+}
+
 BOOST_AUTO_TEST_CASE(testTARGET) {
     BOOST_TEST_MESSAGE("Testing TARGET holiday list...");
 


### PR DESCRIPTION
Hi,
These two links suggest the moving of Juneteenth to Fridays is incorrect for the Federal Reserve implementation: 

- https://www.federalreserve.gov/aboutthefed/k8.htm
- https://www.frbservices.org/about/holiday-schedules

This currently leads to issues during 2027, 2032, etc. I've added a boolean to `isJuneteenth` to preserve the behavior for other calendar implementations.