### PR TITLE
Correct Thailand calendar for 2019-2024

### DIFF
--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -35,30 +35,36 @@ namespace QuantLib {
 
         if (isWeekend(w)
             // New Year's Day
-            || ((d == 1 || (d==3 && w==Monday)) && m == January)
+            || ((d == 1 || (d == 3 && w == Monday)) && m == January)
             // Chakri Memorial Day
-            || ((d == 6 || ((d==7 || d==8) && w==Monday)) && m == April)
-            // Songkran Festival
-            || ((d == 13 || d == 14 || d == 15) && m == April)
-            // Songkran Festival obersvence (usually not more then 1 holiday will be replaced)
-            || (d == 16 && (w == Monday || w == Tuesday) && m == April)
+            || ((d == 6 || ((d == 7 || d == 8) && w == Monday)) && m == April)
+            // Songkran Festival (was cancelled in 2020 due to the Covid-19 Pandamic)
+            || ((d == 13 || d == 14 || d == 15) && m == April && y != 2020)
+            // Substitution Songkran Festival, usually not more than 5 days in total (was cancelled
+            // in 2020 due to the Covid-19 Pandamic)
+            || (d == 16 && (w == Monday || w == Tuesday) && m == April && y != 2020)
             // Labor Day
-            || ((d == 1 || ((d==2 || d==3) && w==Monday)) && m == May)
-            // H.M. the King's Birthday
-            || ((d == 28 || ((d==29 || d==30) && w==Monday)) && m == July && y >= 2017)
-            // H.M. the Queen's Birthday
-            || ((d == 12 || ((d==13 || d==14) && w==Monday)) && m == August)
-            // H.M. King Bhumibol Adulyadej Memorial Day
-            || ((d == 13 || ((d==14 || d==15) && w==Monday)) && m == October && y >= 2017)
-            // H.M. King Bhumibol Adulyadej's Birthday
-            || ((d == 5 || ((d==6 || d==7) && w==Monday)) && m == December)
+            || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == May)
+            // Coronation Day
+            || ((d == 4 || ((d == 5 || d == 6) && w == Monday)) && m == May && y >= 2019)
+            // H.M.Queen Suthida Bajrasudhabimalalakshana’s Birthday
+            || ((d == 02 || ((d == 03 || d == 04) && w == Monday)) && m == June && y >= 2019)
+            // H.M. King Maha Vajiralongkorn Phra Vajiraklaochaoyuhua’s Birthday
+            || ((d == 28 || ((d == 29 || d == 30) && w == Monday)) && m == July && y >= 2017)
+            // 	​H.M. Queen Sirikit The Queen Mother’s Birthday / Mother’s Day
+            || ((d == 12 || ((d == 13 || d == 14) && w == Monday)) && m == August)
+            // H.M. King Bhumibol Adulyadej The Great Memorial Day
+            || ((d == 13 || ((d == 14 || d == 15) && w == Monday)) && m == October && y >= 2017)
+            // Chulalongkorn Day
+            || ((d == 23 || ((d == 24 || d == 25) && w == Monday)) && m == October)
+            // H.M. King Bhumibol Adulyadej The Great’s Birthday/ National Day / Father’s Day
+            || ((d == 5 || ((d == 6 || d == 7) && w == Monday)) && m == December)
             // Constitution Day
-            || ((d == 10 || ((d==11 || d==12) && w==Monday)) && m == December)
+            || ((d == 10 || ((d == 11 || d == 12) && w == Monday)) && m == December)
             // New Year’s Eve
             || (d == 31 && m == December)
             // New Year’s Eve Observence
-            || ((d == 1 || d==2) && w == Monday && m == January)
-            )
+            || ((d == 1 || d == 2) && w == Monday && m == January))
             return false;
 
         if ((y == 2000) &&
@@ -234,6 +240,33 @@ namespace QuantLib {
              || (d==27 && m==July)    // Asarnha Bucha Day1
              || (d==23 && m==October) // Chulalongkorn Day
                 ))
+            return false;
+
+        if ((y == 2019) && ((d == 19 && m == February) // Makha Bucha Day
+                            || (d == 6 && m == May)    // Special Holiday
+                            || (d == 20 && m == May)   // Wisakha Bucha Day
+                            || (d == 16 && m == July)  // Asarnha Bucha Day
+                            ))
+            return false;
+
+        if ((y == 2020) && ((d == 10 && m == February)    // Makha Bucha Day
+                            || (d == 6 && m == May)       // Wisakha Bucha Day
+                            || (d == 6 && m == July)      // Asarnha Bucha Day
+                            || (d == 27 && m == July)     // Substitution for Songkran Festival
+                            || (d == 4 && m == September) // Substitution for Songkran Festival
+                            || (d == 7 && m == September) // Substitution for Songkran Festival
+                            || (d == 11 && m == December) // Special Holiday
+                            ))
+            return false;
+
+        if ((y == 2021) && ((d == 12 && m == February)     // Special Holiday
+                            || (d == 26 && m == February)  // Makha Bucha Day
+                            || (d == 26 && m == May)       // Wisakha Bucha Day
+                            || (d == 26 && m == July)      // Asarnha Bucha Day
+                            || (d == 27 && m == July)      // Substitution for Songkran Festival
+                            || (d == 24 && m == September) // Special Holiday
+                            || (d == 22 && m == October)   // ​Substitution for Chulalongkorn Day
+                            ))
             return false;
 
         return true;

--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -268,6 +268,33 @@ namespace QuantLib {
                             ))
             return false;
 
+        if ((y == 2022) && ((d == 16 && m == February)   // Makha Bucha Day
+                            || (d == 16 && m == May)     // Substitution for Wisakha Bucha Day (Sunday 15th May 2022)
+                            || (d == 13 && m == July)    // Asarnha Bucha Day
+                            || (d == 29 && m == July)    // Additional special holiday (added)
+                            || (d == 14 && m == October) // Additional special holiday (added)
+                            || (d == 24 && m == October) // ​Substitution for Chulalongkorn Day (Sunday 23rd October 2022)
+            ))
+            return false;
+
+        if ((y == 2023) && ((d == 6 && m == March)        // Makha Bucha Day
+                            || (d == 5 && m == May)       // Additional special holiday (added)
+                            || (d == 5 && m == June)      // Substitution for H.M. Queen's birthday and Wisakha Bucha Day (Saturday 3rd June 2022)
+                            || (d == 1 && m == August)    // Asarnha Bucha Day
+                            || (d == 23 && m == October)  // Chulalongkorn Day
+                            || (d == 29 && m == December) // Substitution for New Year’s Eve (Sunday 31st December 2023) (added)
+            ))
+            return false;
+
+        if ((y == 2024) && ((d == 26 && m == February)    // Substitution for Makha Bucha Day (Saturday 24th February 2024)
+                            || (d == 8 && m == April)     // Substitution for Chakri Memorial Day (Saturday 6th April 2024)
+                            || (d == 6 && m == May)       // Substitution for Coronation Day (Saturday 4th May 2024)
+                            || (d == 22 && m == May)      // Wisakha Bucha Day
+                            || (d == 22 && m == July)     // Substitution for Asarnha Bucha Day (Saturday 20th July 2024)
+                            || (d == 23 && m == October)  // Chulalongkorn Day
+            ))
+            return false;
+
         return true;
     }
 

--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2018 Matthias Groncki
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -48,7 +49,7 @@ namespace QuantLib {
             // Coronation Day
             || ((d == 4 || ((d == 5 || d == 6) && w == Monday)) && m == May && y >= 2019)
             // H.M.Queen Suthida Bajrasudhabimalalakshana’s Birthday
-            || ((d == 02 || ((d == 03 || d == 04) && w == Monday)) && m == June && y >= 2019)
+            || ((d == 03 || ((d == 04 || d == 05) && w == Monday)) && m == June && y >= 2019)
             // H.M. King Maha Vajiralongkorn Phra Vajiraklaochaoyuhua’s Birthday
             || ((d == 28 || ((d == 29 || d == 30) && w == Monday)) && m == July && y >= 2017)
             // 	​H.M. Queen Sirikit The Queen Mother’s Birthday / Mother’s Day
@@ -56,15 +57,14 @@ namespace QuantLib {
             // H.M. King Bhumibol Adulyadej The Great Memorial Day
             || ((d == 13 || ((d == 14 || d == 15) && w == Monday)) && m == October && y >= 2017)
             // Chulalongkorn Day
-            || ((d == 23 || ((d == 24 || d == 25) && w == Monday)) && m == October)
+            || ((d == 23 || ((d == 24 || d == 25) && w == Monday)) && m == October && y != 2021)  // Moved 2021, see below
             // H.M. King Bhumibol Adulyadej The Great’s Birthday/ National Day / Father’s Day
             || ((d == 5 || ((d == 6 || d == 7) && w == Monday)) && m == December)
             // Constitution Day
             || ((d == 10 || ((d == 11 || d == 12) && w == Monday)) && m == December)
             // New Year’s Eve
-            || (d == 31 && m == December)
-            // New Year’s Eve Observence
-            || ((d == 1 || d == 2) && w == Monday && m == January))
+            || ((d == 31 && m == December) || (d == 2 && w == Monday && m == January && y != 2024))  // Moved 2024
+            )
             return false;
 
         if ((y == 2000) &&
@@ -262,8 +262,7 @@ namespace QuantLib {
         if ((y == 2021) && ((d == 12 && m == February)     // Special Holiday
                             || (d == 26 && m == February)  // Makha Bucha Day
                             || (d == 26 && m == May)       // Wisakha Bucha Day
-                            || (d == 26 && m == July)      // Asarnha Bucha Day
-                            || (d == 27 && m == July)      // Substitution for Songkran Festival
+                            || (d == 26 && m == July)      // Substitution for Asarnha Bucha Day (Saturday 24th July 2021)
                             || (d == 24 && m == September) // Special Holiday
                             || (d == 22 && m == October)   // ​Substitution for Chulalongkorn Day
                             ))

--- a/ql/time/calendars/thailand.hpp
+++ b/ql/time/calendars/thailand.hpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2000-2018 with some years missing)
+        (data available for 2000-2024 with some years missing)
         <ul>
         <li>Makha Bucha Day</li>
         <li>Wisakha Bucha Day</li>

--- a/ql/time/calendars/thailand.hpp
+++ b/ql/time/calendars/thailand.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2018 Matthias Groncki
+ Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -31,12 +32,12 @@ namespace QuantLib {
     //! %Thailand calendars
     /*! Holidays for the Thailand exchange
         Holidays observed by financial institutions (not to be confused with bank holidays in the United Kingdom) are regulated by the Bank of Thailand.
-        If a holiday fall on a weekend the government will annouce a replacement day (usally the following monday).
+        If a holiday fall on a weekend the government will announce a replacement day (usually the following Monday).
 
         Sometimes the government add one or two extra holidays in a year.
 
         (data from
-         https://www.bot.or.th/English/FinancialInstitutions/FIholiday/Pages/2018.aspx:
+         https://www.bot.or.th/en/financial-institutions-holiday.html:
         Fixed holidays
         <ul>
         <li>Saturdays</li>


### PR DESCRIPTION
Hi,

Building on @mgroncki's work (cherry-picked for attribution) from their [fork](https://github.com/OpenSourceRisk/QuantLib/blob/master/ql/time/calendars/thailand.cpp), I've extended the Thai holidays until 2024. The calendar now matches our expectations for 2019 through 2024. 

Updated based on a few references:
- [Holidays 2019](https://www.bot.or.th/content/dam/bot/fipcs/documents/FPG/2561/EngPDF/25610226.pdf)
- [Holidays 2020](https://www.bot.or.th/content/dam/bot/fipcs/documents/FPG/2562/EngPDF/25620179.pdf)
- [Holidays 2021](https://www.bot.or.th/content/dam/bot/fipcs/documents/FPG/2563/EngPDF/25630233.pdf)
- [Substitutions 2023](https://www.bot.or.th/en/news-and-media/news/news-20231102.html)
- And: https://www.bot.or.th/en/financial-institutions-holiday.html