### PR TITLE
New Brazilian holiday

### DIFF
--- a/ql/time/calendars/brazil.cpp
+++ b/ql/time/calendars/brazil.cpp
@@ -65,6 +65,8 @@ namespace QuantLib {
             || (d == 2 && m == November)
             // Republic Day
             || (d == 15 && m == November)
+            // Black Awareness Day
+            || (d == 20 && m == November && y >= 2024)
             // Christmas
             || (d == 25 && m == December)
             // Passion of Christ

--- a/ql/time/calendars/brazil.hpp
+++ b/ql/time/calendars/brazil.hpp
@@ -41,6 +41,7 @@ namespace QuantLib {
         <li>Nossa Sra. Aparecida Day, October 12th</li>
         <li>All Souls Day, November 2nd</li>
         <li>Republic Day, November 15th</li>
+        <li>Black Awareness Day, November 20th (since 2024)</li>
         <li>Christmas, December 25th</li>
         <li>Passion of Christ</li>
         <li>Carnival</li>

--- a/test-suite/amortizingbond.cpp
+++ b/test-suite/amortizingbond.cpp
@@ -159,7 +159,10 @@ BOOST_AUTO_TEST_CASE(testBrazilianAmortizingFixedRateBond) {
         1.38600825, 1.23425366, 1.39521333, 1.06968563,
         1.03950542, 1.00065409, 0.90968563, 0.81871706,
         0.79726493, 0.63678002, 0.57187676, 0.49829046,
-        0.32913418, 0.27290565, 0.19062560, 0.08662552
+        // data changed as source (pentagonotrustee.com.br) does not include newly introduced
+        // "Black Awareness Day" holiday
+        0.31177086,
+                    0.27290565, 0.19062560, 0.08662552
     };
 
     Natural settlementDays = 0;


### PR DESCRIPTION
Closes #1870.

This adds the newly introduced "Black Awareness Day" holiday on 20th November starting in 2024.

The data for the unit test had to be modified to incorporate the holiday, even though it is not currently included in the data source.