### PR TITLE
Fixes to maintain AAD compatibility

### DIFF
--- a/ql/math/integrals/exponentialintegrals.cpp
+++ b/ql/math/integrals/exponentialintegrals.cpp
@@ -129,8 +129,8 @@ namespace QuantLib {
             }
 
 
-            constexpr Real DIST = 4.5;
-            constexpr Real MAX_ERROR = 5*QL_EPSILON;
+            constexpr double DIST = 4.5;
+            constexpr double MAX_ERROR = 5.0 * QL_EPSILON;
 
             const Real z_inf = std::log(0.01*QL_MAX_REAL) + std::log(100.0);
             QL_REQUIRE(z.real() < z_inf, "argument error " << z);

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -511,7 +511,7 @@ namespace QuantLib {
                         == std::complex<Real>(0.0),
                    "only Heston model is supported");
 
-        constexpr std::complex<Real> i(0, 1);
+        constexpr std::complex<double> i(0, 1);
 
         if (cpxLog_ == AngledContour || cpxLog_ == AngledContourNoCV || cpxLog_ == AsymptoticChF) {
             const std::complex<Real> h_u(u, u*tanPhi_ - alpha_);

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -1944,15 +1944,15 @@ BOOST_AUTO_TEST_CASE(testBjerksundStenslandEuropeanGreeks) {
 
         constexpr double tol = 1000*QL_EPSILON;
 
-        BOOST_CHECK_CLOSE(europeanOption.NPV(), americanOption.NPV(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.delta(), americanOption.delta(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.strikeSensitivity(), americanOption.strikeSensitivity(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.gamma(), americanOption.gamma(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.vega(), americanOption.vega(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.theta(), americanOption.theta(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.thetaPerDay(), americanOption.thetaPerDay(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.rho(), americanOption.rho(), tol);
-        BOOST_CHECK_CLOSE(europeanOption.dividendRho(), americanOption.dividendRho(), tol);
+        QL_CHECK_CLOSE(europeanOption.NPV(), americanOption.NPV(), tol);
+        QL_CHECK_CLOSE(europeanOption.delta(), americanOption.delta(), tol);
+        QL_CHECK_CLOSE(europeanOption.strikeSensitivity(), americanOption.strikeSensitivity(), tol);
+        QL_CHECK_CLOSE(europeanOption.gamma(), americanOption.gamma(), tol);
+        QL_CHECK_CLOSE(europeanOption.vega(), americanOption.vega(), tol);
+        QL_CHECK_CLOSE(europeanOption.theta(), americanOption.theta(), tol);
+        QL_CHECK_CLOSE(europeanOption.thetaPerDay(), americanOption.thetaPerDay(), tol);
+        QL_CHECK_CLOSE(europeanOption.rho(), americanOption.rho(), tol);
+        QL_CHECK_CLOSE(europeanOption.dividendRho(), americanOption.dividendRho(), tol);
     }
 }
 

--- a/test-suite/functions.cpp
+++ b/test-suite/functions.cpp
@@ -299,28 +299,28 @@ BOOST_AUTO_TEST_CASE(testExpm1) {
     BOOST_TEST_MESSAGE("Testing complex valued expm1...");
 
     const std::complex<Real> z = std::complex<Real>(1.2, 0.5);
-    BOOST_CHECK_SMALL(std::abs(std::exp(z) - 1.0 - expm1(z)), 10*QL_EPSILON);
+    QL_CHECK_SMALL(std::abs(std::exp(z) - 1.0 - expm1(z)), 10*QL_EPSILON);
 
     const std::complex<Real> calculated = expm1(std::complex<Real>(5e-6, 5e-5));
     //scipy reference value
     const std::complex<Real> expected(4.998762493771078e-06,5.000024997979157e-05);
     const Real tol = std::max(2.2e-14, 100*QL_EPSILON);
-    BOOST_CHECK_CLOSE_FRACTION(calculated.real(), expected.real(), tol);
-    BOOST_CHECK_CLOSE_FRACTION(calculated.imag(), expected.imag(), tol);
+    QL_CHECK_CLOSE_FRACTION(calculated.real(), expected.real(), tol);
+    QL_CHECK_CLOSE_FRACTION(calculated.imag(), expected.imag(), tol);
 }
 
 BOOST_AUTO_TEST_CASE(testLog1p) {
     BOOST_TEST_MESSAGE("Testing complex valued log1p...");
 
     const std::complex<Real> z = std::complex<Real>(1.2, 0.57);
-    BOOST_CHECK_SMALL(std::abs(std::log(1.0+z) - log1p(z)), 10*QL_EPSILON);
+    QL_CHECK_SMALL(std::abs(std::log(1.0+z) - log1p(z)), 10*QL_EPSILON);
 
     const std::complex<Real> calculated = log1p(std::complex<Real>(5e-6, 5e-5));
     //scipy reference value
     const std::complex<Real> expected(5.0012374875401984e-06, 4.999974995958395e-05);
     const Real tol = std::max(2.2e-14, 100*QL_EPSILON);
-    BOOST_CHECK_CLOSE_FRACTION(calculated.real(), expected.real(), tol);
-    BOOST_CHECK_CLOSE_FRACTION(calculated.imag(), expected.imag(), tol);
+    QL_CHECK_CLOSE_FRACTION(calculated.real(), expected.real(), tol);
+    QL_CHECK_CLOSE_FRACTION(calculated.imag(), expected.imag(), tol);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3288,7 +3288,7 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmin) {
     const Real alphaStar = AnalyticHestonEngine::OptimalAlpha(1.0, engine.get())
                                .alphaSmallerMinusOne(strike).first;
 
-    BOOST_CHECK_SMALL(alphaStar+3.71, 0.0051);
+    QL_CHECK_SMALL(alphaStar+3.71, 0.0051);
 
     const Date maturityDate = todaysDate + Period(15, Months);
 
@@ -3345,7 +3345,7 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmax) {
     auto engine = ext::make_shared<AnalyticHestonEngine>(model);
     Real alphaStar = AnalyticHestonEngine::OptimalAlpha(T, engine.get())
             .alphaGreaterZero(strike).first;
-    BOOST_CHECK_SMALL(alphaStar - 3.22615, 1e-4);
+    QL_CHECK_SMALL(alphaStar - 3.22615, 1e-4);
 
     // case 2: kappa - sigma*rho < 0, T < t_cut
     model = ext::make_shared<HestonModel>(
@@ -3353,7 +3353,7 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmax) {
     engine = ext::make_shared<AnalyticHestonEngine>(model);
     alphaStar = AnalyticHestonEngine::OptimalAlpha(T, engine.get())
             .alphaGreaterZero(strike).first;
-    BOOST_CHECK_SMALL(alphaStar - 0.31137, 1e-4);
+    QL_CHECK_SMALL(alphaStar - 0.31137, 1e-4);
 
     // case 3: kappa - sigma*rho < 0, T >= t_cut
     model = ext::make_shared<HestonModel>(
@@ -3361,7 +3361,7 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmax) {
     engine = ext::make_shared<AnalyticHestonEngine>(model);
     alphaStar = AnalyticHestonEngine::OptimalAlpha(T, engine.get())
             .alphaGreaterZero(strike).first;
-    BOOST_CHECK_SMALL(alphaStar - 0.11940, 1e-4);
+    QL_CHECK_SMALL(alphaStar - 0.11940, 1e-4);
 
     // case 4: kappa - sigma*rho == 0
     model = ext::make_shared<HestonModel>(
@@ -3369,7 +3369,7 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmax) {
     engine = ext::make_shared<AnalyticHestonEngine>(model);
     alphaStar = AnalyticHestonEngine::OptimalAlpha(T, engine.get())
             .alphaGreaterZero(strike).first;
-    BOOST_CHECK_SMALL(alphaStar - 0.28006, 1e-4);
+    QL_CHECK_SMALL(alphaStar - 0.28006, 1e-4);
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -588,16 +588,16 @@ BOOST_AUTO_TEST_CASE(testExponentialIntegralLimits) {
 
     const Real tol = 1000*QL_EPSILON;
 
-    BOOST_CHECK_CLOSE(largeValuePosImag.imag(), M_PI, tol);
+    QL_CHECK_CLOSE(largeValuePosImag.imag(), M_PI, tol);
 
-    BOOST_CHECK_CLOSE(
+    QL_CHECK_CLOSE(
         largeValuePosImag.real(), std::exp(largeValue)/largeValue, 1e3/largeValue);
 
     const std::complex<Real> largeValueNegImag =
         Ei(std::complex<Real>(largeValue, -std::numeric_limits<Real>::min()));
 
-    BOOST_CHECK_CLOSE(largeValueNegImag.imag(), -M_PI, tol);
-    BOOST_CHECK_CLOSE(
+    QL_CHECK_CLOSE(largeValueNegImag.imag(), -M_PI, tol);
+    QL_CHECK_CLOSE(
         largeValueNegImag.real(), std::exp(largeValue)/largeValue, 1e3/largeValue);
 
     const std::complex<Real> largeValueZeroImag =
@@ -619,8 +619,8 @@ BOOST_AUTO_TEST_CASE(testExponentialIntegralLimits) {
         // principal branch
         const std::complex<Real> limit_ei = M_EULER_MASCHERONI + std::log(z);
 
-        BOOST_CHECK_CLOSE(ei.real(), limit_ei.real(), tol);
-        BOOST_CHECK_CLOSE(ei.imag(), limit_ei.imag(), tol);
+        QL_CHECK_CLOSE(ei.real(), limit_ei.real(), tol);
+        QL_CHECK_CLOSE(ei.imag(), limit_ei.imag(), tol);
     }
 
     const Real largeR = largeValue;
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE(testExponentialIntegralLimits) {
 
             const Real limit_ei_imag = boost::math::sign(z.imag())*M_PI;
             BOOST_CHECK(close_enough(ei.real(), 0.0));
-            BOOST_CHECK_CLOSE(ei.imag(), limit_ei_imag, tol);
+            QL_CHECK_CLOSE(ei.imag(), limit_ei_imag, tol);
         }
     }
 }

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -61,6 +61,7 @@ using QuantLib::value;
 
 #define QL_CHECK_SMALL(FPV, T)  BOOST_CHECK_SMALL(value(FPV), value(T))
 #define QL_CHECK_CLOSE(L, R, T) BOOST_CHECK_CLOSE(value(L), value(R), value(T))
+#define QL_CHECK_CLOSE_FRACTION(L, R, T) BOOST_CHECK_CLOSE_FRACTION(value(L), value(R), value(T))
 
 
 // This makes it easier to use array literals (for new code, use std::vector though)


### PR DESCRIPTION
This fixes consistent usage of `Real` and the QL test macros, in order to allow defining `Real` as an AAD type. 

The fixed version has been tested against [XAD](https://auto-differentiation.github.io).