### PR TITLE
Add Inauguration Day to Mexican calendar

### DIFF
--- a/ql/time/calendars/mexico.cpp
+++ b/ql/time/calendars/mexico.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2005 StatPro Italia srl
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -50,6 +51,8 @@ namespace QuantLib {
             || (d == 1 && m == May)
             // National Day
             || (d == 16 && m == September)
+            // Inauguration Day
+            || (d == 1 && m == October && y >= 2024 && (y - 2024) % 6 == 0)
             // All Souls Day
             || (d == 2 && m == November)
             // Revolution Day

--- a/ql/time/calendars/mexico.hpp
+++ b/ql/time/calendars/mexico.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2005 StatPro Italia srl
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -43,6 +44,7 @@ namespace QuantLib {
         <li>Good Friday</li>
         <li>Labour Day, May 1st</li>
         <li>National Day, September 16th</li>
+        <li>Inauguration Day, October 1st, every sixth year starting 2024</li>
         <li>All Souls Day, November 2nd (bank holiday, not a public one)</li>
         <li>Revolution Day, third Monday in November
             (November 20th before 2006)</li>

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -9,7 +9,7 @@
  Copyright (C) 2020 Piotr Siejda
  Copyright (C) 2020 Leonardo Arcari
  Copyright (C) 2020 Kline s.r.l.
- Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
+ Copyright (C) 2022, 2024 Skandinaviska Enskilda Banken AB (publ)
  Copyright (C) 2023 Jonghee Lee
 
  This file is part of QuantLib, a free-software/open-source library
@@ -38,6 +38,7 @@
 #include <ql/time/calendars/italy.hpp>
 #include <ql/time/calendars/japan.hpp>
 #include <ql/time/calendars/jointcalendar.hpp>
+#include <ql/time/calendars/mexico.hpp>
 #include <ql/time/calendars/russia.hpp>
 #include <ql/time/calendars/southkorea.hpp>
 #include <ql/time/calendars/target.hpp>
@@ -3330,6 +3331,45 @@ BOOST_AUTO_TEST_CASE(testChinaIB) {
                                  << " expected working weekends, while there are " << k
                                  << " calculated working weekends");
 }
+
+BOOST_AUTO_TEST_CASE(testMexicoInaugurationDay) {
+    BOOST_TEST_MESSAGE("Testing Mexican Inauguration Day holiday...");
+
+    // The first five Inauguration Days 2024 and later
+    std::vector<Date> expectedHol;
+    expectedHol.emplace_back(1, Oct, 2024);
+    expectedHol.emplace_back(1, Oct, 2030);
+    expectedHol.emplace_back(1, Oct, 2036);
+    expectedHol.emplace_back(1, Oct, 2042);
+    expectedHol.emplace_back(1, Oct, 2048);
+
+    // Some years of non-Inaugurations
+    std::vector<Date> expectedWorkingDays;
+    expectedWorkingDays.emplace_back(1, Oct, 2018);
+    expectedWorkingDays.emplace_back(1, Oct, 2025);
+    expectedWorkingDays.emplace_back(1, Oct, 2026);
+    expectedWorkingDays.emplace_back(1, Oct, 2027);
+    // 2028 falls on a weekend
+    expectedWorkingDays.emplace_back(1, Oct, 2029);
+    expectedWorkingDays.emplace_back(1, Oct, 2031);
+    expectedWorkingDays.emplace_back(1, Oct, 2032);
+    // 2033 and 2034 fall on weekends
+    expectedWorkingDays.emplace_back(1, Oct, 2035);
+
+    Calendar mexico = Mexico();
+    for (auto holiday : expectedHol) {
+        if (!mexico.isHoliday(holiday)) {
+            BOOST_FAIL("Expected to have an Inauguration Day holiday in the Mexican calendar for date " << holiday);
+        }
+    }
+    for (auto workingDay : expectedWorkingDays) {
+        if (!mexico.isBusinessDay(workingDay)) {
+            BOOST_FAIL("Did not expect to have a holiday in the Mexican calendar for date "
+                       << workingDay);
+        }
+    }
+}
+
 
 BOOST_AUTO_TEST_CASE(testEndOfMonth) {
     BOOST_TEST_MESSAGE("Testing end-of-month calculation...");


### PR DESCRIPTION
Hi,

This new holiday is mentioned in this article (https://bnnbreaking.com/world/mexico/mexicos-new-holiday-a-day-of-celebration-and-reflection/) and also listed on the website of BMV from the current docstring. Includes a minimal test to verify the logic.