### PR TITLE
Fix building parallel test runner

### DIFF
--- a/test-suite/quantlibtestsuite.cpp
+++ b/test-suite/quantlibtestsuite.cpp
@@ -18,6 +18,8 @@
  FOR A PARTICULAR PURPOSE.  See the license for more details.
 */
 
+#include <ql/qldefines.hpp>
+
 #define BOOST_TEST_MODULE QuantLibTests
 
 #ifdef QL_ENABLE_PARALLEL_UNIT_TEST_RUNNER


### PR DESCRIPTION
We are missing #include of the config option to select parallel test runner, so we always end up with the standard one.