### PR TITLE
Pass an explicit base date to inflation curves instead of an observation lag

### DIFF
--- a/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.cpp
@@ -39,10 +39,11 @@ namespace QuantLib {
         const std::vector<Period>& cfMaturities,
         const Matrix& cPrice,
         const Matrix& fPrice)
-    : InflationTermStructure(0, cal, baseRate, observationLag, zii->frequency(), dc),
+    : TermStructure(0, cal, dc),
       zii_(zii), interpolationType_(interpolationType), nominalTS_(std::move(yts)),
       cStrikes_(cStrikes), fStrikes_(fStrikes), cfMaturities_(cfMaturities),
-      cPrice_(cPrice), fPrice_(fPrice), nominal_(nominal), bdc_(bdc) {
+      cPrice_(cPrice), fPrice_(fPrice), nominal_(nominal), bdc_(bdc),
+      observationLag_(observationLag), baseRate_(baseRate) {
 
         // does the index have a TS?
         QL_REQUIRE(!zii_->zeroInflationTermStructure().empty(), "ZITS missing from index");

--- a/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/cpicapfloortermpricesurface.hpp
@@ -51,7 +51,7 @@ namespace QuantLib {
         The observationLag is that for the referenced instrument prices.
         Strikes are as-quoted not as-used.
     */
-    class CPICapFloorTermPriceSurface : public InflationTermStructure {
+    class CPICapFloorTermPriceSurface : public TermStructure {
       public:
         CPICapFloorTermPriceSurface(
             Real nominal,
@@ -71,8 +71,10 @@ namespace QuantLib {
 
         //! \name InflationTermStructure interface
         //@{
-        Period observationLag() const override;
-        Date baseDate() const override;
+        virtual Period observationLag() const;
+        virtual Frequency frequency() const;
+        virtual Date baseDate() const;
+        virtual Rate baseRate() const;
         //@}
 
         //! inspectors
@@ -138,6 +140,8 @@ namespace QuantLib {
       private:
         Real nominal_;
         BusinessDayConvention bdc_;
+        Period observationLag_;
+        Rate baseRate_;
     };
 
 
@@ -326,11 +330,19 @@ namespace QuantLib {
     // inline definitions
 
     inline Period CPICapFloorTermPriceSurface::observationLag() const {
-        return zeroInflationIndex()->zeroInflationTermStructure()->observationLag();
+        return observationLag_;
+    }
+
+    inline Frequency CPICapFloorTermPriceSurface::frequency() const {
+        return zeroInflationIndex()->frequency();
     }
 
     inline Date CPICapFloorTermPriceSurface::baseDate() const {
         return zeroInflationIndex()->zeroInflationTermStructure()->baseDate();
+    }
+
+    inline Rate CPICapFloorTermPriceSurface::baseRate() const {
+        return baseRate_;
     }
 
     inline Real CPICapFloorTermPriceSurface::nominal() const {

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.cpp
@@ -36,8 +36,8 @@ namespace QuantLib {
         const std::vector<Period>& cfMaturities,
         const Matrix& cPrice,
         const Matrix& fPrice)
-    : InflationTermStructure(0, cal, baseRate, lag, yii->frequency(), dc),
-      fixingDays_(fixingDays), bdc_(bdc), yoyIndex_(yii), nominalTS_(std::move(nominal)),
+    : TermStructure(0, cal, dc),
+      fixingDays_(fixingDays), bdc_(bdc), yoyIndex_(yii), observationLag_(lag), nominalTS_(std::move(nominal)),
       cStrikes_(cStrikes), fStrikes_(fStrikes), cfMaturities_(cfMaturities), cPrice_(cPrice),
       fPrice_(fPrice), indexIsInterpolated_(yii->interpolated()) {
 
@@ -127,8 +127,6 @@ namespace QuantLib {
                     bool extrapolate) const {
         return atmYoYRate(yoyOptionDateFromTenor(d), obsLag, extrapolate);
     }
-
-
 
 }
 

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
 
         \todo deal with index interpolation.
     */
-    class YoYCapFloorTermPriceSurface : public InflationTermStructure {
+    class YoYCapFloorTermPriceSurface : public TermStructure {
       public:
         YoYCapFloorTermPriceSurface(Natural fixingDays,
                                     const Period& yyLag,
@@ -56,6 +56,8 @@ namespace QuantLib {
                                     const Matrix& fPrice);
 
         bool indexIsInterpolated() const;
+        virtual Period observationLag() const;
+        virtual Frequency frequency() const;
 
         //! atm yoy swaps from put-call parity on cap/floor data
         /*! uses interpolation (on surface price data), yearly maturities. */
@@ -79,6 +81,7 @@ namespace QuantLib {
         //@{
         virtual BusinessDayConvention businessDayConvention() const {return bdc_;}
         virtual Natural fixingDays() const {return fixingDays_;}
+        virtual Date baseDate() const = 0;
         virtual Real price(const Date& d, Rate k) const = 0;
         virtual Real capPrice(const Date& d, Rate k) const = 0;
         virtual Real floorPrice(const Date& d, Rate k) const = 0;
@@ -124,6 +127,7 @@ namespace QuantLib {
         Natural fixingDays_;
         BusinessDayConvention bdc_;
         ext::shared_ptr<YoYInflationIndex> yoyIndex_;
+        Period observationLag_;
         Handle<YieldTermStructure> nominalTS_;
         // data
         std::vector<Rate> cStrikes_;
@@ -232,6 +236,14 @@ namespace QuantLib {
 
     inline bool YoYCapFloorTermPriceSurface::indexIsInterpolated() const {
         return indexIsInterpolated_;
+    }
+
+    inline Period YoYCapFloorTermPriceSurface::observationLag() const {
+        return observationLag_;
+    }
+
+    inline Frequency YoYCapFloorTermPriceSurface::frequency() const {
+        return yoyIndex_->frequency();
     }
 
     // template definitions

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -126,6 +126,12 @@ namespace QuantLib {
         }
     }
 
+    Date ZeroInflationIndex::lastFixingDate() const {
+        const auto& fixings = timeSeries();
+        QL_REQUIRE(!fixings.empty(), "no fixings stored for " << name());
+        // attribute fixing to first day of the underlying period
+        return inflationPeriod(fixings.lastDate(), frequency_).first;
+    }
 
     bool ZeroInflationIndex::needsForecast(const Date& fixingDate) const {
 

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -167,6 +167,7 @@ namespace QuantLib {
         //@}
         //! \name Other methods
         //@{
+        Date lastFixingDate() const;
         Handle<ZeroInflationTermStructure> zeroInflationTermStructure() const;
         ext::shared_ptr<ZeroInflationIndex> clone(const Handle<ZeroInflationTermStructure>& h) const;
         //@}

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -126,6 +126,7 @@ namespace QuantLib {
                                        t->frequency()).first;
             }
         }
+
         // value at reference date
         static Rate initialValue(const YoYInflationTermStructure* t) {
             return t->baseRate();

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -50,8 +50,9 @@ namespace QuantLib {
                 return inflationPeriod(t->referenceDate() - t->observationLag(), t->frequency()).first;
         }
         // value at reference date
-        static Rate initialValue(const ZeroInflationTermStructure* t) {
-            return t->baseRate();
+        static Rate initialValue(const ZeroInflationTermStructure*) {
+            // this will be overwritten during bootstrap
+            return detail::avgInflation;
         }
 
         // guesses
@@ -64,10 +65,6 @@ namespace QuantLib {
             if (validData) // previous iteration value
                 return c->data()[i];
 
-            if (i==1) // first pillar
-                return detail::avgInflation;
-
-            // could/should extrapolate
             return detail::avgInflation;
         }
 
@@ -104,6 +101,8 @@ namespace QuantLib {
                                 Rate level,
                                 Size i) {
             data[i] = level;
+            if (i==1)
+                data[0] = level; // the first point is updated as well
         }
         // upper bound for convergence loop
         // calibration is trivial, should be immediate
@@ -142,10 +141,6 @@ namespace QuantLib {
             if (validData) // previous iteration value
                 return c->data()[i];
 
-            if (i==1) // first pillar
-                return detail::avgInflation;
-        
-            // could/should extrapolate
             return detail::avgInflation;
         }
 

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -44,7 +44,10 @@ namespace QuantLib {
 
         // start of curve data
         static Date initialDate(const ZeroInflationTermStructure* t) {
-            return inflationPeriod(t->referenceDate() - t->observationLag(), t->frequency()).first;
+            if (t->hasExplicitBaseDate())
+                return t->baseDate();
+            else
+                return inflationPeriod(t->referenceDate() - t->observationLag(), t->frequency()).first;
         }
         // value at reference date
         static Rate initialValue(const ZeroInflationTermStructure* t) {
@@ -115,7 +118,9 @@ namespace QuantLib {
 
         // start of curve data
         static Date initialDate(const YoYInflationTermStructure* t) {
-            if (t->indexIsInterpolated()) {
+            if (t->hasExplicitBaseDate()) {
+                return t->baseDate();
+            } else if (t->indexIsInterpolated()) {
                 return t->referenceDate() - t->observationLag();
             } else {
                 return inflationPeriod(t->referenceDate() - t->observationLag(),

--- a/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
@@ -45,6 +45,20 @@ namespace QuantLib {
           protected InterpolatedCurve<Interpolator> {
       public:
         InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                      std::vector<Date> dates,
+                                      const std::vector<Rate>& rates,
+                                      Frequency frequency,
+                                      bool indexIsInterpolated,
+                                      const DayCounter& dayCounter,
+                                      const ext::shared_ptr<Seasonality>& seasonality = {},
+                                      const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        as the first date in the vector instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        InterpolatedYoYInflationCurve(const Date& referenceDate,
                                       const Calendar& calendar,
                                       const DayCounter& dayCounter,
                                       const Period& lag,
@@ -81,14 +95,27 @@ namespace QuantLib {
             construction.
         */
         InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                      Date baseDate,
+                                      Rate baseYoYRate,
+                                      Frequency frequency,
+                                      bool indexIsInterpolated,
+                                      const DayCounter& dayCounter,
+                                      const ext::shared_ptr<Seasonality>& seasonality = {},
+                                      const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        InterpolatedYoYInflationCurve(const Date& referenceDate,
                                       const Calendar& calendar,
                                       const DayCounter& dayCounter,
                                       Rate baseYoYRate,
                                       const Period& lag,
                                       Frequency frequency,
                                       bool indexIsInterpolated,
-                                      const Interpolator& interpolator
-                                                            = Interpolator());
+                                      const Interpolator& interpolator = Interpolator());
     };
 
     typedef InterpolatedYoYInflationCurve<Linear> YoYInflationCurve;
@@ -96,6 +123,56 @@ namespace QuantLib {
 
 
     // template definitions
+
+    template <class Interpolator>
+    InterpolatedYoYInflationCurve<Interpolator>::InterpolatedYoYInflationCurve(
+        const Date& referenceDate,
+        std::vector<Date> dates,
+        const std::vector<Rate>& rates,
+        Frequency frequency,
+        bool indexIsInterpolated,
+        const DayCounter& dayCounter,
+        const ext::shared_ptr<Seasonality>& seasonality,
+        const Interpolator& interpolator)
+    : YoYInflationTermStructure(referenceDate, dates.at(0), rates[0], frequency,
+                                indexIsInterpolated, dayCounter, seasonality),
+      InterpolatedCurve<Interpolator>(std::vector<Time>(), rates, interpolator),
+      dates_(std::move(dates)) {
+
+        QL_REQUIRE(dates_.size()>1, "too few dates: " << dates_.size());
+
+        QL_REQUIRE(this->data_.size() == dates_.size(),
+                   "indices/dates count mismatch: "
+                   << this->data_.size() << " vs " << dates_.size());
+
+        for (Size i = 1; i < dates_.size(); i++) {
+            // YoY inflation data may be positive or negative
+            // but must be greater than -1
+            QL_REQUIRE(this->data_[i] > -1.0,
+                       "year-on-year inflation data < -100 %");
+        }
+
+        this->setupTimes(dates_, referenceDate, dayCounter);
+        this->setupInterpolation();
+        this->interpolation_.update();
+    }
+
+    template <class Interpolator>
+    InterpolatedYoYInflationCurve<Interpolator>::
+    InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality,
+                                  const Interpolator& interpolator)
+    : YoYInflationTermStructure(referenceDate, baseDate, baseYoYRate, frequency,
+                                indexIsInterpolated, dayCounter, seasonality),
+      InterpolatedCurve<Interpolator>(interpolator) {}
+
+
+    QL_DEPRECATED_DISABLE_WARNING
 
     template <class Interpolator>
     InterpolatedYoYInflationCurve<Interpolator>::InterpolatedYoYInflationCurve(
@@ -154,10 +231,15 @@ namespace QuantLib {
                                 lag, frequency, indexIsInterpolated),
       InterpolatedCurve<Interpolator>(interpolator) {}
 
+    QL_DEPRECATED_ENABLE_WARNING
+
 
     template <class T>
-    Date InterpolatedYoYInflationCurve<T>::baseDate() const{
-        return dates_.front();
+    Date InterpolatedYoYInflationCurve<T>::baseDate() const {
+        if (hasExplicitBaseDate())
+            return YoYInflationTermStructure::baseDate();
+        else
+            return dates_.front();
     }
 
     template <class T>

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -41,6 +41,19 @@ namespace QuantLib {
           protected InterpolatedCurve<Interpolator> {
       public:
         InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       std::vector<Date> dates,
+                                       const std::vector<Rate>& rates,
+                                       Frequency frequency,
+                                       const DayCounter& dayCounter,
+                                       const ext::shared_ptr<Seasonality>& seasonality = {},
+                                       const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        as the first date in the vector instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
                                        const Calendar& calendar,
                                        const DayCounter& dayCounter,
                                        const Period& lag,
@@ -76,6 +89,19 @@ namespace QuantLib {
             construction.
         */
         InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                       Date baseDate,
+                                       Frequency frequency,
+                                       const DayCounter& dayCounter,
+                                       const ext::shared_ptr<Seasonality>& seasonality = {},
+                                       Rate baseRate = Null<Rate>(),
+                                       const Interpolator &interpolator = Interpolator());
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        InterpolatedZeroInflationCurve(const Date& referenceDate,
                                        const Calendar& calendar,
                                        const DayCounter& dayCounter,
                                        const Period& lag,
@@ -89,6 +115,49 @@ namespace QuantLib {
 
 
     // template definitions
+
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::InterpolatedZeroInflationCurve(
+        const Date& referenceDate,
+        std::vector<Date> dates,
+        const std::vector<Rate>& rates,
+        Frequency frequency,
+        const DayCounter& dayCounter,
+        const ext::shared_ptr<Seasonality>& seasonality,
+        const Interpolator& interpolator)
+    : ZeroInflationTermStructure(referenceDate, dates.at(0), frequency, dayCounter, seasonality),
+      InterpolatedCurve<Interpolator>(std::vector<Time>(), rates, interpolator),
+      dates_(std::move(dates)) {
+
+        QL_REQUIRE(dates_.size() > 1, "too few dates: " << dates_.size());
+
+        QL_REQUIRE(this->data_.size() == dates_.size(),
+                   "indices/dates count mismatch: " << this->data_.size() << " vs "
+                                                    << dates_.size());
+        for (Size i = 1; i < dates_.size(); i++) {
+            // must be greater than -1
+            QL_REQUIRE(this->data_[i] > -1.0, "zero inflation data < -100 %");
+        }
+
+        this->setupTimes(dates_, referenceDate, dayCounter);
+        this->setupInterpolation();
+        this->interpolation_.update();
+    }
+
+    template <class Interpolator>
+    InterpolatedZeroInflationCurve<Interpolator>::
+    InterpolatedZeroInflationCurve(const Date& referenceDate,
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality,
+                                   Rate baseRate,
+                                   const Interpolator& interpolator)
+    :  ZeroInflationTermStructure(referenceDate, baseDate, frequency, dayCounter, seasonality, baseRate),
+       InterpolatedCurve<Interpolator>(interpolator) {
+    }
+
+    QL_DEPRECATED_DISABLE_WARNING
 
     template <class Interpolator>
     InterpolatedZeroInflationCurve<Interpolator>::InterpolatedZeroInflationCurve(
@@ -142,14 +211,22 @@ namespace QuantLib {
        InterpolatedCurve<Interpolator>(interpolator) {
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
+
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::baseDate() const {
-        return dates_.front();
+        if (hasExplicitBaseDate())
+            return ZeroInflationTermStructure::baseDate();
+        else
+            return dates_.front();
     }
 
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::maxDate() const {
-        return inflationPeriod(dates_.back(), frequency()).second;
+        if (hasExplicitBaseDate())
+            return dates_.back();
+        else
+            return inflationPeriod(dates_.back(), frequency()).second;
     }
 
     template <class T>

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -93,11 +93,10 @@ namespace QuantLib {
                                        Frequency frequency,
                                        const DayCounter& dayCounter,
                                        const ext::shared_ptr<Seasonality>& seasonality = {},
-                                       Rate baseRate = Null<Rate>(),
                                        const Interpolator &interpolator = Interpolator());
 
         /*! \deprecated Use the other overload and pass the base date directly
-                        instead of using a lag.
+                        instead of using a lag. A base rate should not be needed.
                         Deprecated in version 1.34.
         */
         QL_DEPRECATED
@@ -151,9 +150,8 @@ namespace QuantLib {
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
                                    const ext::shared_ptr<Seasonality>& seasonality,
-                                   Rate baseRate,
                                    const Interpolator& interpolator)
-    :  ZeroInflationTermStructure(referenceDate, baseDate, frequency, dayCounter, seasonality, baseRate),
+    :  ZeroInflationTermStructure(referenceDate, baseDate, frequency, dayCounter, seasonality),
        InterpolatedCurve<Interpolator>(interpolator) {
     }
 

--- a/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
@@ -51,6 +51,37 @@ namespace QuantLib {
         //@{
         PiecewiseYoYInflationCurve(
             const Date& referenceDate,
+            Date baseDate,
+            Rate baseYoYRate,
+            Frequency frequency,
+            bool indexIsInterpolated,
+            const DayCounter& dayCounter,
+            std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
+            const ext::shared_ptr<Seasonality>& seasonality = {},
+            Real accuracy = 1.0e-12,
+            const Interpolator& i = Interpolator())
+        : base_curve(referenceDate,
+                     baseDate,
+                     baseYoYRate,
+                     frequency,
+                     indexIsInterpolated,
+                     dayCounter,
+                     seasonality,
+                     i),
+          instruments_(std::move(instruments)), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        PiecewiseYoYInflationCurve(
+            const Date& referenceDate,
             const Calendar& calendar,
             const DayCounter& dayCounter,
             const Period& lag,
@@ -71,6 +102,8 @@ namespace QuantLib {
           instruments_(std::move(instruments)), accuracy_(accuracy) {
             bootstrap_.setup(this);
         }
+
+        QL_DEPRECATED_ENABLE_WARNING
         //@}
 
         //! \name Inflation interface
@@ -106,7 +139,8 @@ namespace QuantLib {
 
     template <class I, template <class> class B, class T>
     inline Date PiecewiseYoYInflationCurve<I,B,T>::baseDate() const {
-        this->calculate();
+        if (!this->hasExplicitBaseDate())
+            this->calculate();
         return base_curve::baseDate();
     }
 

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -56,7 +56,6 @@ namespace QuantLib {
             Frequency frequency,
             const DayCounter& dayCounter,
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
-            Rate baseRate,
             const ext::shared_ptr<Seasonality>& seasonality = {},
             Real accuracy = 1.0e-14,
             const Interpolator& i = Interpolator())
@@ -65,14 +64,13 @@ namespace QuantLib {
                      frequency,
                      dayCounter,
                      seasonality,
-                     baseRate,
                      i),
           instruments_(std::move(instruments)), accuracy_(accuracy) {
             bootstrap_.setup(this);
         }
 
         /*! \deprecated Use the other overload and pass the base date directly
-                        instead of using a lag.
+                        instead of using a lag. A base rate is not needed.
                         Deprecated in version 1.34.
         */
         QL_DEPRECATED

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -69,6 +69,8 @@ namespace QuantLib {
             bootstrap_.setup(this);
         }
 
+        QL_DEPRECATED_DISABLE_WARNING
+
         /*! \deprecated Use the other overload and pass the base date directly
                         instead of using a lag. A base rate is not needed.
                         Deprecated in version 1.34.
@@ -84,7 +86,6 @@ namespace QuantLib {
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             Real accuracy = 1.0e-12,
             const Interpolator& i = Interpolator())
-        QL_DEPRECATED_DISABLE_WARNING
         : base_curve(referenceDate,
                      calendar,
                      dayCounter,
@@ -95,6 +96,7 @@ namespace QuantLib {
           instruments_(std::move(instruments)), accuracy_(accuracy) {
             bootstrap_.setup(this);
         }
+
         QL_DEPRECATED_ENABLE_WARNING
         //@}
 

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -52,6 +52,32 @@ namespace QuantLib {
         //@{
         PiecewiseZeroInflationCurve(
             const Date& referenceDate,
+            Date baseDate,
+            Frequency frequency,
+            const DayCounter& dayCounter,
+            std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
+            Rate baseRate,
+            const ext::shared_ptr<Seasonality>& seasonality = {},
+            Real accuracy = 1.0e-14,
+            const Interpolator& i = Interpolator())
+        : base_curve(referenceDate,
+                     baseDate,
+                     frequency,
+                     dayCounter,
+                     seasonality,
+                     baseRate,
+                     i),
+          instruments_(std::move(instruments)), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+        /*! \deprecated Use the other overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
+        PiecewiseZeroInflationCurve(
+            const Date& referenceDate,
             const Calendar& calendar,
             const DayCounter& dayCounter,
             const Period& lag,
@@ -60,6 +86,7 @@ namespace QuantLib {
             std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
             Real accuracy = 1.0e-12,
             const Interpolator& i = Interpolator())
+        QL_DEPRECATED_DISABLE_WARNING
         : base_curve(referenceDate,
                      calendar,
                      dayCounter,
@@ -70,6 +97,7 @@ namespace QuantLib {
           instruments_(std::move(instruments)), accuracy_(accuracy) {
             bootstrap_.setup(this);
         }
+        QL_DEPRECATED_ENABLE_WARNING
         //@}
 
         //! \name Inflation interface
@@ -105,7 +133,8 @@ namespace QuantLib {
 
     template <class I, template <class> class B, class T>
     inline Date PiecewiseZeroInflationCurve<I,B,T>::baseDate() const {
-        this->calculate();
+        if (!this->hasExplicitBaseDate())
+            this->calculate();
         return base_curve::baseDate();
     }
 

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -24,6 +24,54 @@
 namespace QuantLib {
 
     InflationTermStructure::InflationTermStructure(
+                                        Date baseDate,
+                                        Frequency frequency,
+                                        const DayCounter& dayCounter,
+                                        ext::shared_ptr<Seasonality> seasonality,
+                                        Rate baseRate)
+    : TermStructure(dayCounter), seasonality_(std::move(seasonality)),
+      frequency_(frequency), baseRate_(baseRate), baseDate_(baseDate),
+      hasExplicitBaseDate_(true) {
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+        }
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        const Date& referenceDate,
+                                        Date baseDate,
+                                        Frequency frequency,
+                                        const DayCounter& dayCounter,
+                                        ext::shared_ptr<Seasonality> seasonality,
+                                        Rate baseRate)
+    : TermStructure(referenceDate, Calendar(), dayCounter), seasonality_(std::move(seasonality)),
+      frequency_(frequency), baseRate_(baseRate), baseDate_(baseDate),
+      hasExplicitBaseDate_(true) {
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+        }
+    }
+
+    InflationTermStructure::InflationTermStructure(
+                                        Natural settlementDays,
+                                        const Calendar& calendar,
+                                        Date baseDate,
+                                        Frequency frequency,
+                                        const DayCounter& dayCounter,
+                                        ext::shared_ptr<Seasonality> seasonality,
+                                        Rate baseRate)
+    : TermStructure(settlementDays, calendar, dayCounter), seasonality_(std::move(seasonality)),
+      frequency_(frequency), baseRate_(baseRate), baseDate_(baseDate),
+      hasExplicitBaseDate_(true) {
+        if (seasonality_ != nullptr) {
+            QL_REQUIRE(seasonality_->isConsistent(*this),
+                       "Seasonality inconsistent with inflation term structure");
+        }
+    }
+
+    InflationTermStructure::InflationTermStructure(
                                         Rate baseRate,
                                         const Period& observationLag,
                                         Frequency frequency,
@@ -31,7 +79,8 @@ namespace QuantLib {
                                         ext::shared_ptr<Seasonality> seasonality)
     : TermStructure(dayCounter), seasonality_(std::move(seasonality)),
       observationLag_(observationLag), frequency_(frequency),
-      baseRate_(baseRate) {
+      baseRate_(baseRate),
+      hasExplicitBaseDate_(false) {
         if (seasonality_ != nullptr) {
             QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
@@ -47,7 +96,8 @@ namespace QuantLib {
                                         const DayCounter& dayCounter,
                                         ext::shared_ptr<Seasonality> seasonality)
     : TermStructure(referenceDate, calendar, dayCounter), seasonality_(std::move(seasonality)),
-      observationLag_(observationLag), frequency_(frequency), baseRate_(baseRate) {
+      observationLag_(observationLag), frequency_(frequency), baseRate_(baseRate),
+      hasExplicitBaseDate_(false) {
         if (seasonality_ != nullptr) {
             QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
@@ -64,10 +114,19 @@ namespace QuantLib {
                                         ext::shared_ptr<Seasonality> seasonality)
     : TermStructure(settlementDays, calendar, dayCounter), seasonality_(std::move(seasonality)),
       observationLag_(observationLag), frequency_(frequency),
-      baseRate_(baseRate) {
+      baseRate_(baseRate),
+      hasExplicitBaseDate_(false) {
         if (seasonality_ != nullptr) {
             QL_REQUIRE(seasonality_->isConsistent(*this),
                        "Seasonality inconsistent with inflation term structure");
+        }
+    }
+
+    Date InflationTermStructure::baseDate() const {
+        if (hasExplicitBaseDate()) {
+            return baseDate_;
+        } else {
+            return inflationPeriod(referenceDate() - observationLag(), frequency()).first;
         }
     }
 
@@ -102,6 +161,36 @@ namespace QuantLib {
     }
 
 
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality,
+                                   Rate baseRate)
+    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality, baseRate) {}
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                   const Date& referenceDate,
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality,
+                                   Rate baseRate)
+    : InflationTermStructure(referenceDate, baseDate, frequency,
+                             dayCounter, seasonality, baseRate) {}
+
+    ZeroInflationTermStructure::ZeroInflationTermStructure(
+                                   Natural settlementDays,
+                                   const Calendar& calendar,
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality,
+                                   Rate baseRate)
+    : InflationTermStructure(settlementDays, calendar, baseDate, frequency,
+                             dayCounter, seasonality, baseRate) {}
+
+    QL_DEPRECATED_DISABLE_WARNING
 
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                     const DayCounter& dayCounter,
@@ -134,13 +223,15 @@ namespace QuantLib {
     : InflationTermStructure(settlementDays, calendar, baseZeroRate, observationLag, frequency,
                              dayCounter, seasonality) {}
 
+    QL_DEPRECATED_ENABLE_WARNING
+
     Rate ZeroInflationTermStructure::zeroRate(const Date &d, const Period& instObsLag,
                                               bool forceLinearInterpolation,
                                               bool extrapolate) const {
 
         Period useLag = instObsLag;
         if (instObsLag == Period(-1,Days)) {
-            useLag = observationLag();
+            useLag = hasExplicitBaseDate() ? Period(0, Days) : observationLag();
         }
 
         Rate zeroRate;
@@ -176,6 +267,8 @@ namespace QuantLib {
         return zeroRateImpl(t);
     }
 
+
+    QL_DEPRECATED_DISABLE_WARNING
 
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     const DayCounter& dayCounter,
@@ -214,6 +307,8 @@ namespace QuantLib {
                              frequency, dayCounter, seasonality),
       indexIsInterpolated_(indexIsInterpolated) {}
 
+    QL_DEPRECATED_ENABLE_WARNING
+
 
     Rate YoYInflationTermStructure::yoyRate(const Date &d, const Period& instObsLag,
                                               bool forceLinearInterpolation,
@@ -221,7 +316,7 @@ namespace QuantLib {
 
         Period useLag = instObsLag;
         if (instObsLag == Period(-1,Days)) {
-            useLag = observationLag();
+            useLag = hasExplicitBaseDate() ? Period(0, Days) : observationLag();
         }
 
         Rate yoyRate;

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -263,6 +263,41 @@ namespace QuantLib {
     }
 
 
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality, baseYoYRate),
+      indexIsInterpolated_(indexIsInterpolated) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    const Date& referenceDate,
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(referenceDate, baseDate, frequency,
+                             dayCounter, seasonality, baseYoYRate),
+      indexIsInterpolated_(indexIsInterpolated) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    Natural settlementDays,
+                                    const Calendar& calendar,
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    bool indexIsInterpolated,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseDate, frequency,
+                             dayCounter, seasonality, baseYoYRate),
+      indexIsInterpolated_(indexIsInterpolated) {}
+
     QL_DEPRECATED_DISABLE_WARNING
 
     YoYInflationTermStructure::YoYInflationTermStructure(

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -165,19 +165,16 @@ namespace QuantLib {
                                    Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality,
-                                   Rate baseRate)
-    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality, baseRate) {}
+                                   const ext::shared_ptr<Seasonality>& seasonality)
+    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality) {}
 
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                    const Date& referenceDate,
                                    Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality,
-                                   Rate baseRate)
-    : InflationTermStructure(referenceDate, baseDate, frequency,
-                             dayCounter, seasonality, baseRate) {}
+                                   const ext::shared_ptr<Seasonality>& seasonality)
+    : InflationTermStructure(referenceDate, baseDate, frequency, dayCounter, seasonality) {}
 
     ZeroInflationTermStructure::ZeroInflationTermStructure(
                                    Natural settlementDays,
@@ -185,10 +182,8 @@ namespace QuantLib {
                                    Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality,
-                                   Rate baseRate)
-    : InflationTermStructure(settlementDays, calendar, baseDate, frequency,
-                             dayCounter, seasonality, baseRate) {}
+                                   const ext::shared_ptr<Seasonality>& seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseDate, frequency, dayCounter, seasonality) {}
 
     QL_DEPRECATED_DISABLE_WARNING
 

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -42,12 +42,14 @@ namespace QuantLib {
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {},
                                Rate baseRate = Null<Rate>());
+
         InflationTermStructure(const Date& referenceDate,
                                Date baseDate,
                                Frequency frequency,
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {},
                                Rate baseRate = Null<Rate>());
+
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Date baseDate,
@@ -55,6 +57,7 @@ namespace QuantLib {
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {},
                                Rate baseRate = Null<Rate>());
+
         /*! \deprecated Use another overload and pass the base date directly
                         instead of using a lag.
                         Deprecated in version 1.34.
@@ -65,6 +68,7 @@ namespace QuantLib {
                                Frequency frequency,
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {});
+
         /*! \deprecated Use another overload and pass the base date directly
                         instead of using a lag.
                         Deprecated in version 1.34.
@@ -77,6 +81,7 @@ namespace QuantLib {
                                const Calendar& calendar = Calendar(),
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {});
+
         /*! \deprecated Use another overload and pass the base date directly
                         instead of using a lag.
                         Deprecated in version 1.34.
@@ -131,7 +136,7 @@ namespace QuantLib {
                         Deprecated in version 1.34.
         */
         [[deprecated("Do not use; set baseRate_ directly if needed.")]]
-        virtual void setBaseRate(const Rate &r) { baseRate_ = r; }
+        virtual void setBaseRate(const Rate& r) { baseRate_ = r; }
 
         // range-checking
         void checkRange(const Date&,
@@ -181,7 +186,7 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
-                                   const ext::shared_ptr<Seasonality> &seasonality = {});
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
         /*! \deprecated Use another overload and pass the base date directly
                         instead of using a lag. A base rate should not be needed.
@@ -207,7 +212,7 @@ namespace QuantLib {
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
-                                   const ext::shared_ptr<Seasonality> &seasonality = {});
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
         //@}
 
         //! \name Inspectors
@@ -222,7 +227,7 @@ namespace QuantLib {
             If you want to get predictions of RPI/CPI/etc then use an
             index.
         */
-        Rate zeroRate(const Date &d, const Period& instObsLag = Period(-1,Days),
+        Rate zeroRate(const Date& d, const Period& instObsLag = Period(-1,Days),
                       bool forceLinearInterpolation = false,
                       bool extrapolate = false) const;
         //! zero-coupon inflation rate.
@@ -246,13 +251,47 @@ namespace QuantLib {
       public:
         //! \name Constructors
         //@{
+        YoYInflationTermStructure(Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        YoYInflationTermStructure(const Date& referenceDate,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        YoYInflationTermStructure(Natural settlementDays,
+                                  const Calendar& calendar,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  bool indexIsInterpolated,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         YoYInflationTermStructure(const DayCounter& dayCounter,
                                   Rate baseYoYRate,
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = {});
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
 
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         YoYInflationTermStructure(const Date& referenceDate,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,
@@ -260,8 +299,13 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = {});
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
 
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         YoYInflationTermStructure(Natural settlementDays,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,
@@ -269,7 +313,7 @@ namespace QuantLib {
                                   const Period& lag,
                                   Frequency frequency,
                                   bool indexIsInterpolated,
-                                  const ext::shared_ptr<Seasonality> &seasonality = {});
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
         //@}
 
         //! \name Inspectors
@@ -280,7 +324,7 @@ namespace QuantLib {
 
             \note this is not the year-on-year swap (YYIIS) rate.
         */
-        Rate yoyRate(const Date &d, const Period& instObsLag = Period(-1,Days),
+        Rate yoyRate(const Date& d, const Period& instObsLag = Period(-1,Days),
                      bool forceLinearInterpolation = false,
                      bool extrapolate = false) const;
         //! year-on-year inflation rate.
@@ -304,15 +348,15 @@ namespace QuantLib {
 
 
     //! utility function giving the inflation period for a given date
-    std::pair<Date,Date> inflationPeriod(const Date &,
+    std::pair<Date,Date> inflationPeriod(const Date&,
                                          Frequency);
 
     //! utility function giving the time between two dates depending on
     //! index frequency and interpolation, and a day counter
     Time inflationYearFraction(Frequency ,
                                bool indexIsInterpolated,
-                               const DayCounter &,
-                               const Date &, const Date &);
+                               const DayCounter&,
+                               const Date&, const Date&);
 
 
     // inline

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -157,26 +157,23 @@ namespace QuantLib {
         ZeroInflationTermStructure(Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality = {},
-                                   Rate baseRate = Null<Rate>());
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
         ZeroInflationTermStructure(const Date& referenceDate,
                                    Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality = {},
-                                   Rate baseRate = Null<Rate>());
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
                                    Date baseDate,
                                    Frequency frequency,
                                    const DayCounter& dayCounter,
-                                   const ext::shared_ptr<Seasonality>& seasonality = {},
-                                   Rate baseRate = Null<Rate>());
+                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
         /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+                        instead of using a lag. A base rate should not be needed.
                         Deprecated in version 1.34.
         */
         QL_DEPRECATED
@@ -187,7 +184,7 @@ namespace QuantLib {
                                    const ext::shared_ptr<Seasonality> &seasonality = {});
 
         /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+                        instead of using a lag. A base rate should not be needed.
                         Deprecated in version 1.34.
         */
         QL_DEPRECATED
@@ -200,7 +197,7 @@ namespace QuantLib {
                                    const ext::shared_ptr<Seasonality>& seasonality = {});
 
         /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+                        instead of using a lag. A base rate should not be needed.
                         Deprecated in version 1.34.
         */
         QL_DEPRECATED

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -60,9 +60,6 @@ namespace QuantLib {
 
         //! \name Inflation interface
         //@{
-        //! The TS observes with a lag that is usually different from the
-        //! availability lag of the index.  An inflation rate is given,
-        //! by default, for the maturity requested assuming this lag.
         virtual Period observationLag() const;
         virtual Frequency frequency() const;
         virtual Rate baseRate() const;
@@ -80,23 +77,24 @@ namespace QuantLib {
         virtual Date baseDate() const = 0;
         //@}
 
-        //! Functions to set and get seasonality.
-        /*! Calling setSeasonality with no arguments means unsetting
-            as the default is used to choose unsetting.
+        //! \name Seasonality
+        //@{
+        /*! \deprecated Use the overload taking a pointer and pass an empty one to remove seasonality.
+                        Deprecated in version 1.34.
         */
-        void setSeasonality(const ext::shared_ptr<Seasonality>& seasonality = {});
+        [[deprecated("Use the overload taking a pointer and pass an empty one to remove seasonality.")]]
+        void setSeasonality() { setSeasonality({}); }
+        void setSeasonality(const ext::shared_ptr<Seasonality>& seasonality);
         ext::shared_ptr<Seasonality> seasonality() const;
         bool hasSeasonality() const;
+        //@}
 
       protected:
-
-        // This next part is required for piecewise- constructors
-        // because, for inflation, they need more than just the
-        // instruments to build the term structure, since the rate at
-        // time 0-lag is non-zero, since we deal (effectively) with
-        // "forwards".
+        /*! \deprecated Do not use; set baseRate_ directly if needed.
+                        Deprecated in version 1.34.
+        */
+        [[deprecated("Do not use; set baseRate_ directly if needed.")]]
         virtual void setBaseRate(const Rate &r) { baseRate_ = r; }
-
 
         // range-checking
         void checkRange(const Date&,

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -37,11 +37,39 @@ namespace QuantLib {
       public:
         //! \name Constructors
         //@{
+        InflationTermStructure(Date baseDate,
+                               Frequency frequency,
+                               const DayCounter& dayCounter = DayCounter(),
+                               ext::shared_ptr<Seasonality> seasonality = {},
+                               Rate baseRate = Null<Rate>());
+        InflationTermStructure(const Date& referenceDate,
+                               Date baseDate,
+                               Frequency frequency,
+                               const DayCounter& dayCounter = DayCounter(),
+                               ext::shared_ptr<Seasonality> seasonality = {},
+                               Rate baseRate = Null<Rate>());
+        InflationTermStructure(Natural settlementDays,
+                               const Calendar& calendar,
+                               Date baseDate,
+                               Frequency frequency,
+                               const DayCounter& dayCounter = DayCounter(),
+                               ext::shared_ptr<Seasonality> seasonality = {},
+                               Rate baseRate = Null<Rate>());
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         InflationTermStructure(Rate baseRate,
                                const Period& observationLag,
                                Frequency frequency,
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {});
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         InflationTermStructure(const Date& referenceDate,
                                Rate baseRate,
                                const Period& observationLag,
@@ -49,6 +77,11 @@ namespace QuantLib {
                                const Calendar& calendar = Calendar(),
                                const DayCounter& dayCounter = DayCounter(),
                                ext::shared_ptr<Seasonality> seasonality = {});
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         InflationTermStructure(Natural settlementDays,
                                const Calendar& calendar,
                                Rate baseRate,
@@ -65,16 +98,20 @@ namespace QuantLib {
         virtual Rate baseRate() const;
 
         //! minimum (base) date
-        /*! Important in inflation since it starts before nominal
-            reference date.  Changes depending whether index is
-            interpolated or not.  When interpolated the base date
-            is just observation lag before nominal.  When not
-            interpolated it is the beginning of the relevant period
-            (hence it is easy to create interpolated fixings from
-             a not-interpolated curve because interpolation, usually,
-             of fixings is forward looking).
+        /*! The last date for which we have information.
+
+            When not set directly (the recommended option), it is
+            calculated base on an observation lag relative to today.
         */
-        virtual Date baseDate() const = 0;
+        virtual Date baseDate() const;
+
+        /*! This can be used temporarily to check whether the term structure
+            was created using one of the new constructors taking a base date
+            or one of the deprecated ones taking an observation lag.
+        */
+        bool hasExplicitBaseDate() const {
+            return hasExplicitBaseDate_;
+        }
         //@}
 
         //! \name Seasonality
@@ -106,21 +143,54 @@ namespace QuantLib {
         Period observationLag_;
         Frequency frequency_;
         mutable Rate baseRate_;
+
+      private:
+        Date baseDate_;
+        bool hasExplicitBaseDate_;
     };
 
     //! Interface for zero inflation term structures.
-    // Child classes use templates but do not want that exposed to
-    // general users.
     class ZeroInflationTermStructure : public InflationTermStructure {
       public:
         //! \name Constructors
         //@{
+        ZeroInflationTermStructure(Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality = {},
+                                   Rate baseRate = Null<Rate>());
+
+        ZeroInflationTermStructure(const Date& referenceDate,
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality = {},
+                                   Rate baseRate = Null<Rate>());
+
+        ZeroInflationTermStructure(Natural settlementDays,
+                                   const Calendar& calendar,
+                                   Date baseDate,
+                                   Frequency frequency,
+                                   const DayCounter& dayCounter,
+                                   const ext::shared_ptr<Seasonality>& seasonality = {},
+                                   Rate baseRate = Null<Rate>());
+
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(const DayCounter& dayCounter,
                                    Rate baseZeroRate,
                                    const Period& lag,
                                    Frequency frequency,
                                    const ext::shared_ptr<Seasonality> &seasonality = {});
 
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(const Date& referenceDate,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,
@@ -129,6 +199,11 @@ namespace QuantLib {
                                    Frequency frequency,
                                    const ext::shared_ptr<Seasonality>& seasonality = {});
 
+        /*! \deprecated Use another overload and pass the base date directly
+                        instead of using a lag.
+                        Deprecated in version 1.34.
+        */
+        QL_DEPRECATED
         ZeroInflationTermStructure(Natural settlementDays,
                                    const Calendar& calendar,
                                    const DayCounter& dayCounter,
@@ -254,6 +329,7 @@ namespace QuantLib {
     }
 
     inline Rate InflationTermStructure::baseRate() const {
+        QL_REQUIRE(baseRate_ != Null<Real>(), "base rate not available");
         return baseRate_;
     }
 

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -359,12 +359,14 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
             quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, nominalTS);
     };
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
-    Rate baseZeroRate = zcData[0].rate/100.0;
 
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS =
         ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
-            evaluationDate, baseDate, frequency, dc, helpers, baseZeroRate);
+            evaluationDate, baseDate, frequency, dc, helpers);
     hz.linkTo(pZITS);
+
+    for (auto n : pZITS->nodes())
+        std::cout << n.first << "\t" << n.second << std::endl;
 
     //===========================================================================================
     // first check that the quoted swaps are repriced correctly
@@ -442,6 +444,10 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
         ext::make_shared<MultiplicativePriceSeasonality>(seasonalityBaseDate, Monthly, seasonalityFactors);
 
     pZITS->setSeasonality(nonUnitSeasonality);
+
+    std::cout << "setting seasonality" << std::endl;
+    for (auto n : pZITS->nodes())
+        std::cout << n.first << "\t" << n.second << std::endl;
 
     for (const auto& datum: zcData) {
         ZeroCouponInflationSwap nzcis(Swap::Payer,

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -185,7 +185,7 @@ void checkSeasonality(const Handle<ZeroInflationTermStructure>& hz,
     }
 
     // Testing that unsetting seasonality works also
-    hz->setSeasonality();
+    hz->setSeasonality({});
     vector<Rate> unsetSeasonalityFixings(12, 1.0);
     for (Size i = 0; i < fixingDates.size(); ++i) {
         unsetSeasonalityFixings[i] = ii->fixing(fixingDates[i], true);

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -305,6 +305,176 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     evaluationDate = calendar.adjust(evaluationDate);
     Settings::instance().evaluationDate() = evaluationDate;
 
+    Date baseDate(1, July, 2007);
+
+    // fixing data
+    Date from(1, January, 2005);
+    Date to(13, August, 2007);
+    Schedule rpiSchedule = MakeSchedule().from(from).to(to)
+        .withTenor(1*Months)
+        .withCalendar(NullCalendar())
+        .withConvention(ModifiedFollowing)
+        .forwards();
+
+    Real fixData[] = {
+        189.9, 189.9, 189.6, 190.5, 191.6, 192.0,
+        192.2, 192.2, 192.6, 193.1, 193.3, 193.6,
+        194.1, 193.4, 194.2, 195.0, 196.5, 197.7,
+        198.5, 198.5, 199.2, 200.1, 200.4, 201.1,
+        202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+        207.3};
+
+    RelinkableHandle<ZeroInflationTermStructure> hz;
+    auto ii = ext::make_shared<UKRPI>(hz);
+    for (Size i=0; i<LENGTH(fixData); i++) {
+        ii->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    Handle<YieldTermStructure> nominalTS(nominalTermStructure());
+
+    // now build the zero inflation curve
+    std::vector<Datum> zcData = {
+        { Date(13, August, 2008), 2.93 },
+        { Date(13, August, 2009), 2.95 },
+        { Date(13, August, 2010), 2.965 },
+        { Date(15, August, 2011), 2.98 },
+        { Date(13, August, 2012), 3.0 },
+        { Date(13, August, 2014), 3.06 },
+        { Date(13, August, 2017), 3.175 },
+        { Date(13, August, 2019), 3.243 },
+        { Date(15, August, 2022), 3.293 },
+        { Date(14, August, 2027), 3.338 },
+        { Date(13, August, 2032), 3.348 },
+        { Date(15, August, 2037), 3.348 },
+        { Date(13, August, 2047), 3.308 },
+        { Date(13, August, 2057), 3.228 }
+    };
+
+    Period observationLag = Period(3, Months);
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
+    Frequency frequency = Monthly;
+
+    auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
+        return ext::make_shared<ZeroCouponInflationSwapHelper>(
+            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, nominalTS);
+    };
+    auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
+    Rate baseZeroRate = zcData[0].rate/100.0;
+
+    ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS =
+        ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
+            evaluationDate, baseDate, frequency, dc, helpers, baseZeroRate);
+    hz.linkTo(pZITS);
+
+    //===========================================================================================
+    // first check that the quoted swaps are repriced correctly
+
+    const Real eps = 1.0e-7;
+    auto engine = ext::make_shared<DiscountingSwapEngine>(nominalTS);
+
+    for (const auto& datum: zcData) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      datum.date,
+                                      calendar, bdc, dc,
+                                      datum.rate/100.0,
+                                      ii, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << datum.rate/100.0);
+    }
+
+    //===========================================================================================
+    // now test the forecasting capability of the index.
+
+    from = hz->referenceDate();
+    to = hz->maxDate()-1*Months; // a bit of margin for adjustments
+    Schedule testIndex = MakeSchedule().from(from).to(to)
+                            .withTenor(1*Months)
+                            .withCalendar(UnitedKingdom())
+                            .withConvention(ModifiedFollowing);
+
+    // we are testing UKRPI which is not interpolated
+    Date bd = hz->baseDate();
+    Real bf = ii->fixing(bd);
+    for (const auto& d : testIndex) {
+        Real z = hz->zeroRate(d, Period(0, Days));
+        Real t = hz->dayCounter().yearFraction(bd, inflationPeriod(d, ii->frequency()).first);
+        Real calc = bf * std::pow(1+z, t);
+        if (t<=0)
+            calc = ii->fixing(d,false); // still historical
+        if (std::fabs(calc - ii->fixing(d,true)) > eps)
+            BOOST_ERROR("inflation index does not forecast correctly"
+                        << "\n    date:        " << d
+                        << "\n    base date:   " << bd
+                        << "\n    base fixing: " << bf
+                        << "\n    expected:    " << calc
+                        << "\n    forecast:    " << ii->fixing(d,true));
+    }
+
+    //===========================================================================================
+    // Add a seasonality correction.  The curve should recalculate and still reprice the swaps.
+
+    Date nextBaseDate = inflationPeriod(hz->baseDate(), ii->frequency()).second;
+    Date seasonalityBaseDate(31, January, nextBaseDate.year());
+    vector<Rate> seasonalityFactors = {
+        1.003245,
+        1.000000,
+        0.999715,
+        1.000495,
+        1.000929,
+        0.998687,
+        0.995949,
+        0.994682,
+        0.995949,
+        1.000519,
+        1.003705,
+        1.004186
+    };
+
+    ext::shared_ptr<MultiplicativePriceSeasonality> nonUnitSeasonality =
+        ext::make_shared<MultiplicativePriceSeasonality>(seasonalityBaseDate, Monthly, seasonalityFactors);
+
+    pZITS->setSeasonality(nonUnitSeasonality);
+
+    for (const auto& datum: zcData) {
+        ZeroCouponInflationSwap nzcis(Swap::Payer,
+                                      1000000.0,
+                                      evaluationDate,
+                                      datum.date,
+                                      calendar, bdc, dc,
+                                      datum.rate/100.0,
+                                      ii, observationLag,
+                                      CPI::AsIndex);
+        nzcis.setPricingEngine(engine);
+
+        BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
+                            "zero-coupon inflation swap does not reprice to zero"
+                            << "\n    NPV:      " << nzcis.NPV()
+                            << "\n    maturity: " << nzcis.maturityDate()
+                            << "\n    rate:     " << datum.rate);
+    }
+
+    // remove circular refernce
+    hz.linkTo(ext::shared_ptr<ZeroInflationTermStructure>());
+}
+
+BOOST_AUTO_TEST_CASE(testZeroTermStructureWithLag) {
+    BOOST_TEST_MESSAGE("Testing old-style zero inflation term structure with observation lag...");
+
+    // try the Zero UK
+    Calendar calendar = UnitedKingdom();
+    BusinessDayConvention bdc = ModifiedFollowing;
+    Date evaluationDate(13, August, 2007);
+    evaluationDate = calendar.adjust(evaluationDate);
+    Settings::instance().evaluationDate() = evaluationDate;
+
     // fixing data
     Date from(1, January, 2005);
     Date to(13, August, 2007);
@@ -358,10 +528,12 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
 
     Rate baseZeroRate = zcData[0].rate/100.0;
+    QL_DEPRECATED_DISABLE_WARNING
     ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pZITS(
                         new PiecewiseZeroInflationCurve<Linear>(
                         evaluationDate, calendar, dc, observationLag,
                         frequency, baseZeroRate, helpers));
+    QL_DEPRECATED_ENABLE_WARNING
     hz.linkTo(pZITS);
 
     //===========================================================================================
@@ -531,13 +703,11 @@ BOOST_AUTO_TEST_CASE(testSeasonalityCorrection) {
         0.03228
     };
 
-    Period observationLag = Period(2,Months);
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
 
     auto zeroCurve = ext::make_shared<InterpolatedZeroInflationCurve<Linear>>(
-                                 evaluationDate, calendar, dc, observationLag,
-                                 frequency, nodes, rates);
+                                 evaluationDate, nodes, rates, frequency, dc);
     hz.linkTo(zeroCurve);
 
     // Perform checks on the seasonality for this non-interpolated index
@@ -584,10 +754,10 @@ BOOST_AUTO_TEST_CASE(testInterpolatedZeroTermStructure) {
     Date today = Date(27, January, 2022);
     Settings::instance().evaluationDate() = today;
 
-    Period lag = 3 * Months;
+    Date baseDate = Date(1, December, 2021);
 
     std::vector<Date> dates = {
-        today - lag,
+        baseDate,
         today + 7 * Days,
         today + 14 * Days,
         today + 1 * Months,
@@ -602,7 +772,7 @@ BOOST_AUTO_TEST_CASE(testInterpolatedZeroTermStructure) {
     std::vector<Rate> rates = { 0.01, 0.01, 0.011, 0.012, 0.013, 0.015, 0.018, 0.02, 0.025, 0.03, 0.03 };
 
     auto curve = ext::make_shared<InterpolatedZeroInflationCurve<Linear>>(
-        today, TARGET(), Actual360(), lag, Monthly, dates, rates);
+        today, dates, rates, Monthly, Actual360());
 
     auto nodes = curve->nodes();
 
@@ -1228,9 +1398,7 @@ BOOST_AUTO_TEST_CASE(testCpiAsIndexInterpolation) {
     std::vector<Date> dates = { today - 3*Months, today + 5*Years };
     std::vector<Rate> rates = { 0.02, 0.02 };
     Handle<ZeroInflationTermStructure> mock_curve(
-            ext::make_shared<ZeroInflationCurve>(today, TARGET(), Actual360(),
-                                                 3 * Months, Monthly, dates, rates));
-
+            ext::make_shared<ZeroInflationCurve>(today, dates, rates, Monthly, Actual360()));
     auto testIndex = ext::make_shared<UKRPI>(mock_curve);
 
     testIndex->addFixing(Date(1, November, 2020), 293.5);

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -365,9 +365,6 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
             evaluationDate, baseDate, frequency, dc, helpers);
     hz.linkTo(pZITS);
 
-    for (auto n : pZITS->nodes())
-        std::cout << n.first << "\t" << n.second << std::endl;
-
     //===========================================================================================
     // first check that the quoted swaps are repriced correctly
 
@@ -444,10 +441,6 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
         ext::make_shared<MultiplicativePriceSeasonality>(seasonalityBaseDate, Monthly, seasonalityFactors);
 
     pZITS->setSeasonality(nonUnitSeasonality);
-
-    std::cout << "setting seasonality" << std::endl;
-    for (auto n : pZITS->nodes())
-        std::cout << n.first << "\t" << n.second << std::endl;
 
     for (const auto& datum: zcData) {
         ZeroCouponInflationSwap nzcis(Swap::Payer,

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -175,15 +175,13 @@ struct CommonVars {
                                calendar, convention, dc,
                                Handle<YieldTermStructure>(nominalTS));
 
+        Date baseDate = rpi->lastFixingDate();
         Rate baseYYRate = yyData[0].rate/100.0;
-        ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> > pYYTS(
-                new PiecewiseYoYInflationCurve<Linear>(
-                        evaluationDate, calendar, dc, observationLag,
-                        iir->frequency(),iir->interpolated(), baseYYRate,
-                        helpers));
-        pYYTS->recalculate();
+        auto pYYTS =
+            ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
+                        evaluationDate, baseDate, baseYYRate, iir->frequency(),
+                        iir->interpolated(), dc, helpers);
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
-
 
         // make sure that the index has the latest yoy term structure
         hy.linkTo(pYYTS);

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -183,15 +183,13 @@ struct CommonVars {
                                calendar, convention, dc,
                                Handle<YieldTermStructure>(nominalTS));
 
+        Date baseDate = rpi->lastFixingDate();
         Rate baseYYRate = yyData[0].rate/100.0;
-        ext::shared_ptr<PiecewiseYoYInflationCurve<Linear> > pYYTS(
-                            new PiecewiseYoYInflationCurve<Linear>(
-                                evaluationDate, calendar, dc, observationLag,
-                                iir->frequency(),iir->interpolated(), baseYYRate,
-                                helpers));
-        pYYTS->recalculate();
+        auto pYYTS =
+            ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
+                        evaluationDate, baseDate, baseYYRate, iir->frequency(),
+                        iir->interpolated(), dc, helpers);
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
-
 
         // make sure that the index has the latest yoy term structure
         hy.linkTo(pYYTS);

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -146,7 +146,8 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
             makeHelpers(zciisData, ii,
                         observationLag, calendar, convention, dayCounter, yTS);
 
-        Date baseDate(1, September, 2009);
+        Date baseDate = ii->lastFixingDate();
+
         cpiTS.linkTo(ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                          evaluationDate, baseDate, ii->frequency(), dayCounter, helpers));
     }

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -146,11 +146,9 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
             makeHelpers(zciisData, ii,
                         observationLag, calendar, convention, dayCounter, yTS);
 
-        Rate baseZeroRate = zciisData[0].rate/100.0;
         Date baseDate(1, September, 2009);
         cpiTS.linkTo(ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
-                         evaluationDate, baseDate, ii->frequency(), dayCounter,
-                         helpers, baseZeroRate));
+                         evaluationDate, baseDate, ii->frequency(), dayCounter, helpers));
     }
 
     // teardown

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -97,22 +97,20 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
         Settings::instance().evaluationDate() = evaluationDate;
         dayCounter = ActualActual(ActualActual::ISDA);
 
-        Date from(20, July, 2007);
-        Date to(20, November, 2009);
-        Schedule rpiSchedule =
-            MakeSchedule().from(from).to(to)
-            .withTenor(1*Months)
-            .withCalendar(UnitedKingdom())
-            .withConvention(ModifiedFollowing);
-
         ii = ext::make_shared<UKRPI>(cpiTS);
+
+        Schedule rpiSchedule =
+            MakeSchedule()
+            .from(Date(1, July, 2007))
+            .to(Date(1, September, 2009))
+            .withFrequency(Monthly);
 
         Real fixData[] = {
             206.1, 207.3, 208.0, 208.9, 209.7, 210.9,
             209.8, 211.4, 212.1, 214.0, 215.1, 216.8,
-            216.5, 217.2, 218.4, 217.7, 216,
-            212.9, 210.1, 211.4, 211.3, 211.5,
-            212.8, 213.4, 213.4, 213.4, 214.4
+            216.5, 217.2, 218.4, 217.7, 216.0, 212.9,
+            210.1, 211.4, 211.3, 211.5, 212.8, 213.4,
+            213.4, 213.4, 214.4
         };
         for (Size i=0; i<LENGTH(fixData); ++i) {
             ii->addFixing(rpiSchedule[i], fixData[i]);
@@ -149,10 +147,10 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
                         observationLag, calendar, convention, dayCounter, yTS);
 
         Rate baseZeroRate = zciisData[0].rate/100.0;
-        cpiTS.linkTo(ext::shared_ptr<ZeroInflationTermStructure>(
-                  new PiecewiseZeroInflationCurve<Linear>(
-                         evaluationDate, calendar, dayCounter, observationLag,
-                         ii->frequency(), baseZeroRate, helpers)));
+        Date baseDate(1, September, 2009);
+        cpiTS.linkTo(ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
+                         evaluationDate, baseDate, ii->frequency(), dayCounter,
+                         helpers, baseZeroRate));
     }
 
     // teardown

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -249,7 +249,7 @@ struct CommonVars {
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.
         baseZeroRate = zciisData[0].rate/100.0;
-        Date baseDate(1, April, 2010);
+        Date baseDate = ii->lastFixingDate();
         auto pCPIts = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                                     evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);
         pCPIts->recalculate();

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -138,22 +138,20 @@ struct CommonVars {
         dcZCIIS = ActualActual(ActualActual::ISDA);
         dcNominal = ActualActual(ActualActual::ISDA);
 
-        // uk rpi index
-        //      fixing data
-        Date from(1, July, 2007);
-        Date to(1, June, 2010);
-        Schedule rpiSchedule = MakeSchedule().from(from).to(to)
-            .withTenor(1*Months)
-            .withCalendar(UnitedKingdom())
-            .withConvention(ModifiedFollowing);
+        // UK RPI index fixing data
+        Schedule rpiSchedule =
+            MakeSchedule()
+            .from(Date(1, July, 2007))
+            .to(Date(1, April, 2010))
+            .withFrequency(Monthly);
         Real fixData[] = {
             206.1, 207.3, 208.0, 208.9, 209.7, 210.9,
             209.8, 211.4, 212.1, 214.0, 215.1, 216.8,   //  2008
             216.5, 217.2, 218.4, 217.7, 216.0, 212.9,
             210.1, 211.4, 211.3, 211.5, 212.8, 213.4,   //  2009
             213.4, 214.4, 215.3, 216.0, 216.6, 218.0,
-            217.9, 219.2, 220.7, 222.8, -999, -999,     //  2010
-            -999};
+            217.9, 219.2, 220.7, 222.8                  //  2010
+        };
 
         // link from cpi index to cpi TS
         ii = ext::make_shared<UKRPI>(hcpi);
@@ -251,10 +249,10 @@ struct CommonVars {
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.
         baseZeroRate = zciisData[0].rate/100.0;
-        ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pCPIts(
-                                new PiecewiseZeroInflationCurve<Linear>(
-                                    evaluationDate, calendar, dcZCIIS, observationLag,
-                                    ii->frequency(), baseZeroRate, helpers));
+        Date baseDate(1, April, 2010);
+        auto pCPIts = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
+                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS,
+                                    helpers, baseZeroRate);
         pCPIts->recalculate();
         cpiUK.linkTo(pCPIts);
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -251,8 +251,7 @@ struct CommonVars {
         baseZeroRate = zciisData[0].rate/100.0;
         Date baseDate(1, April, 2010);
         auto pCPIts = ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
-                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS,
-                                    helpers, baseZeroRate);
+                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);
         pCPIts->recalculate();
         cpiUK.linkTo(pCPIts);
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -229,12 +229,10 @@ struct CommonVars {
 
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.
-        Rate baseZeroRate = zciisData[0].rate/100.0;
         Date baseDate(1, September, 2009);
         auto pCPIts =
             ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
-                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS,
-                                    helpers, baseZeroRate);
+                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);
         pCPIts->recalculate();
         cpiTS = ext::dynamic_pointer_cast<ZeroInflationTermStructure>(pCPIts);
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -229,7 +229,7 @@ struct CommonVars {
 
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.
-        Date baseDate(1, September, 2009);
+        Date baseDate = ii->lastFixingDate();
         auto pCPIts =
             ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
                                     evaluationDate, baseDate, ii->frequency(), dcZCIIS, helpers);

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -124,22 +124,19 @@ struct CommonVars {
         dcZCIIS = ActualActual(ActualActual::ISDA);
         dcNominal = ActualActual(ActualActual::ISDA);
 
-        // uk rpi index
-        //      fixing data
-        Date from(20, July, 2007);
-        //Date from(20, July, 2008);
-        Date to(20, November, 2009);
-        Schedule rpiSchedule = MakeSchedule().from(from).to(to)
-            .withTenor(1*Months)
-            .withCalendar(UnitedKingdom())
-            .withConvention(ModifiedFollowing);
+        // UK RPI index fixing data
+        Schedule rpiSchedule =
+            MakeSchedule()
+            .from(Date(1, July, 2007))
+            .to(Date(1, September, 2009))
+            .withFrequency(Monthly);
         Real fixData[] = {
             206.1, 207.3, 208.0, 208.9, 209.7, 210.9,
             209.8, 211.4, 212.1, 214.0, 215.1, 216.8,
-            216.5, 217.2, 218.4, 217.7, 216,
-            212.9, 210.1, 211.4, 211.3, 211.5,
-            212.8, 213.4, 213.4, 213.4, 214.4,
-            -999.0, -999.0 };
+            216.5, 217.2, 218.4, 217.7, 216.0, 212.9,
+            210.1, 211.4, 211.3, 211.5, 212.8, 213.4,
+            213.4, 213.4, 214.4
+        };
 
         // link from cpi index to cpi TS
         ii = ext::make_shared<UKRPI>(hcpi);
@@ -233,13 +230,13 @@ struct CommonVars {
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.
         Rate baseZeroRate = zciisData[0].rate/100.0;
-        ext::shared_ptr<PiecewiseZeroInflationCurve<Linear> > pCPIts(
-                                new PiecewiseZeroInflationCurve<Linear>(
-                                    evaluationDate, calendar, dcZCIIS, observationLag,
-                                    ii->frequency(), baseZeroRate, helpers));
+        Date baseDate(1, September, 2009);
+        auto pCPIts =
+            ext::make_shared<PiecewiseZeroInflationCurve<Linear>>(
+                                    evaluationDate, baseDate, ii->frequency(), dcZCIIS,
+                                    helpers, baseZeroRate);
         pCPIts->recalculate();
         cpiTS = ext::dynamic_pointer_cast<ZeroInflationTermStructure>(pCPIts);
-
 
         // make sure that the index has the latest zero inflation term structure
         hcpi.linkTo(pCPIts);

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -181,10 +181,9 @@ void setup() {
     bool indexIsInterpolated = true;    // actually false for UKRPI but smooth surfaces are
                                         // better for finding intersections etc
 
-    ext::shared_ptr<InterpolatedYoYInflationCurve<Linear> >
-        pYTSEU( new InterpolatedYoYInflationCurve<Linear>(
-                    eval, TARGET(), Actual365Fixed(), Period(2,Months), Monthly,
-                    indexIsInterpolated, d, r) );
+    auto pYTSEU =
+        ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
+                    eval, d, r, Monthly, indexIsInterpolated, Actual365Fixed());
     yoyEU.linkTo(pYTSEU);
 
     // price data


### PR DESCRIPTION
The base date of an inflation curve should correspond to the latest published inflation fixing, because that's the boundary between what we already know and what we need to forecast.

This is awkward to specify by means of an observation lag, which is probably the wrong concept anyway—it's tied to instruments T&Cs.  With these changes, it's possible to pass the base date directly.  Constructors taking the observation lag are now deprecated.