### PR TITLE
Fix - São Paulo city holiday just for years before 2022 

### DIFF
--- a/ql/time/calendars/brazil.cpp
+++ b/ql/time/calendars/brazil.cpp
@@ -92,7 +92,7 @@ namespace QuantLib {
             // New Year's Day
             || (d == 1 && m == January)
             // Sao Paulo City Day
-            || (d == 25 && m == January)
+            || (d == 25 && m == January && y < 2022)
             // Tiradentes Day
             || (d == 21 && m == April)
             // Labor Day

--- a/ql/time/calendars/brazil.hpp
+++ b/ql/time/calendars/brazil.hpp
@@ -53,7 +53,7 @@ namespace QuantLib {
         <li>Saturdays</li>
         <li>Sundays</li>
         <li>New Year's Day, January 1st</li>
-        <li>Sao Paulo City Day, January 25th</li>
+        <li>Sao Paulo City Day, January 25th (up to 2021 included)</li>
         <li>Tiradentes's Day, April 21th</li>
         <li>Labour Day, May 1st</li>
         <li>Revolution Day, July 9th</li>


### PR DESCRIPTION
Fix - São Paulo city holiday just for years before 2022 for Brazilian exchange holidays. 

Official statement:
[B3 News](https://www.b3.com.br/pt_br/noticias/b3-tera-pregao-nos-feriados-municipais-de-sao-paulo-em-2023.htm)

Current rule for holidays:
[B3 trading calendar](https://www.b3.com.br/en_us/solutions/platforms/puma-trading-system/for-members-and-traders/trading-calendar/holidays/)