### PR TITLE
Make BondFunctions BPV and YVBP consistent

### DIFF
--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -446,8 +446,7 @@ namespace QuantLib {
                               Frequency frequency,
                                         Date settlement) {
         InterestRate y(yield, dayCounter, compounding, frequency);
-        return CashFlows::basisPointValue(bond.cashflows(), y,
-                                          false, settlement);
+        return basisPointValue(bond, y, settlement);
     }
 
     Real BondFunctions::yieldValueBasisPoint(const Bond& bond,
@@ -471,8 +470,7 @@ namespace QuantLib {
                                              Frequency frequency,
                                              Date settlement) {
         InterestRate y(yield, dayCounter, compounding, frequency);
-        return CashFlows::yieldValueBasisPoint(bond.cashflows(), y,
-                                               false, settlement);
+        return yieldValueBasisPoint(bond, y, settlement);
     }
 
     Real BondFunctions::cleanPrice(const Bond& bond,


### PR DESCRIPTION
Most `BondFunctions` methods are overloaded, with one version converting its arguments and chaining to a different overload where defaults are handled and then a call made to static [CashFlows](https://www.quantlib.org/reference/class_quant_lib_1_1_cash_flows.html) methods to do the actual calculations -- e.g. [`BondFunctions::duration()`](https://github.com/lballabio/QuantLib/blob/9b052b1fe3a1455aa56cc89d34d70e4732eb1191/ql/pricingengines/bond/bondfunctions.cpp#L377) and [`BondFunctions::duration()`](https://github.com/lballabio/QuantLib/blob/9b052b1fe3a1455aa56cc89d34d70e4732eb1191/ql/pricingengines/bond/bondfunctions.cpp#L393) (v1.33).

[`basisPointValue()`](https://github.com/lballabio/QuantLib/blob/9b052b1fe3a1455aa56cc89d34d70e4732eb1191/ql/pricingengines/bond/bondfunctions.cpp#L428) and [`yieldValueBasisPoint()`](https://github.com/lballabio/QuantLib/blob/9b052b1fe3a1455aa56cc89d34d70e4732eb1191/ql/pricingengines/bond/bondfunctions.cpp#L453) have similarly paired overloads, however do not follow the same trampolining pattern: both methods instead directly call upstream `CashFlows` methods. 
 This results in the settlement date not being set correctly -- unless explicitly passed in -- in the overloads _not_ taking an `InterestRate` object when passed to the underlying calculations (`settlement` is defaulted in these methods’ declarations).

Make these two methods' behavior consistent with other `BondFunctions` methods and add tests to assert parity.