### PR TITLE
Return cached fixingDate in IborCoupon

### DIFF
--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -50,7 +50,7 @@ namespace QuantLib {
                          refPeriodStart, refPeriodEnd,
                          dayCounter, isInArrears, exCouponDate),
       iborIndex_(iborIndex) {
-        fixingDate_ = fixingDate();
+        fixingDate_ = FloatingRateCoupon::fixingDate();
     }
 
     void IborCoupon::initializeCachedData() const {
@@ -82,6 +82,10 @@ namespace QuantLib {
     Time IborCoupon::spanningTimeIndexMaturity() const {
         initializeCachedData();
         return spanningTimeIndexMaturity_;
+    }
+
+    Date IborCoupon::fixingDate() const {
+        return fixingDate_;
     }
 
     Rate IborCoupon::indexFixing() const {

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -59,6 +59,7 @@ namespace QuantLib {
         //@}
         //! \name FloatingRateCoupon interface
         //@{
+        Date fixingDate() const override;
         // implemented in order to manage the case of par coupon
         Rate indexFixing() const override;
         void setPricer(const ext::shared_ptr<FloatingRateCouponPricer>&) override;


### PR DESCRIPTION
Return the cached date from fixingDate() method since it is used internally in indexFixing().