### PR TITLE
Add DatedSwapRateHelper

### DIFF
--- a/ql/instruments/fixedvsfloatingswap.hpp
+++ b/ql/instruments/fixedvsfloatingswap.hpp
@@ -90,6 +90,7 @@ namespace QuantLib {
 
         const Leg& fixedLeg() const;
         const Leg& floatingLeg() const;
+        virtual Date latestRelevantDate() const = 0;
         //@}
 
         //! \name Results

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -103,6 +103,12 @@ namespace QuantLib {
                             floatingSchedule().tenor().frequency());
         }
 
+        Date latestRelevantDate() const override {
+            Date lastPaymentDate = std::max(overnightLeg().back()->date(),
+                                            fixedLeg().back()->date());
+            return std::max(maturityDate(), lastPaymentDate);
+        }
+
         const std::vector<Real>& overnightNominals() const { return floatingNominals(); }
         const Schedule& overnightSchedule() const { return floatingSchedule(); }
         const ext::shared_ptr<OvernightIndex>& overnightIndex() const { return overnightIndex_; }

--- a/ql/instruments/vanillaswap.cpp
+++ b/ql/instruments/vanillaswap.cpp
@@ -79,4 +79,8 @@ namespace QuantLib {
         }
     }
 
+    Date VanillaSwap::latestRelevantDate() const {
+        auto lastCoupon = ext::dynamic_pointer_cast<IborCoupon>(floatingLeg().back());
+        return std::max(maturityDate(), lastCoupon->fixingEndDate());
+    }
 }

--- a/ql/instruments/vanillaswap.hpp
+++ b/ql/instruments/vanillaswap.hpp
@@ -76,6 +76,7 @@ namespace QuantLib {
                     ext::optional<BusinessDayConvention> paymentConvention = ext::nullopt,
                     ext::optional<bool> useIndexedCoupons = ext::nullopt);
 
+        Date latestRelevantDate() const override;
       private:
         void setupFloatingArguments(arguments* args) const override;
     };

--- a/ql/termstructures/bootstraphelper.hpp
+++ b/ql/termstructures/bootstraphelper.hpp
@@ -125,11 +125,11 @@ namespace QuantLib {
     /*! Derived classes must takes care of rebuilding the date schedule when
         the global evaluation date changes
     */
-    template <class TS>
-    class RelativeDateBootstrapHelper : public BootstrapHelper<TS> {
+    template <class TS, class Base = BootstrapHelper<TS>>
+    class RelativeDateBootstrapHelper : public Base {
       public:
-        explicit RelativeDateBootstrapHelper(const Handle<Quote>& quote);
-        explicit RelativeDateBootstrapHelper(Real quote);
+        template <class... Args>
+        explicit RelativeDateBootstrapHelper(Args&&... args);
         //! \name Observer interface
         //@{
         void update() override {
@@ -137,7 +137,7 @@ namespace QuantLib {
                 evaluationDate_ = Settings::instance().evaluationDate();
                 initializeDates();
             }
-            BootstrapHelper<TS>::update();
+            Base::update();
         }
         //@}
       protected:
@@ -210,17 +210,10 @@ namespace QuantLib {
             QL_FAIL("not a bootstrap-helper visitor");
     }
 
-    template <class TS>
-    RelativeDateBootstrapHelper<TS>::RelativeDateBootstrapHelper(
-                                                    const Handle<Quote>& quote)
-    : BootstrapHelper<TS>(quote) {
-        this->registerWith(Settings::instance().evaluationDate());
-        evaluationDate_ = Settings::instance().evaluationDate();
-    }
-
-    template <class TS>
-    RelativeDateBootstrapHelper<TS>::RelativeDateBootstrapHelper(Real quote)
-    : BootstrapHelper<TS>(quote) {
+    template <class TS, class Base>
+    template <class... Args>
+    RelativeDateBootstrapHelper<TS, Base>::RelativeDateBootstrapHelper(Args&&... args)
+    : Base(std::forward<Args>(args)...) {
         this->registerWith(Settings::instance().evaluationDate());
         evaluationDate_ = Settings::instance().evaluationDate();
     }


### PR DESCRIPTION
Also, move common functionality into SwapRateHelperBase to avoid
duplication. Reuse it between vanilla and overnight swaps.