### PR TITLE
Fix Thailand, Singapore, South African calendars for 2023, 2024

### DIFF
--- a/ql/time/calendars/singapore.cpp
+++ b/ql/time/calendars/singapore.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004 FIMAT Group
  Copyright (C) 2007, 2008, 2009, 2010 StatPro Italia srl
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -195,8 +196,25 @@ namespace QuantLib {
                 || (d == 2 && m == June)
                 // Hari Raya Haji
                 || (d == 29 && m == June)
+                // Public holiday on polling day
+                || (d == 1 && m == September)
                 // Deepavali
                 || (d == 13 && m == November))
+                return false;
+        }
+        // https://api2.sgx.com/sites/default/files/2024-01/SGX%20Calendar%202024_2.pdf
+        if (y == 2024)
+        {
+            if (// Chinese New Year
+                (d == 12 && m == February)
+                // Hari Raya Puasa
+                || (d == 10 && m == April)
+                // Vesak Poya Day
+                || (d == 22 && m == May)
+                // Hari Raya Haji
+                || (d == 17 && m == June)
+                // Deepavali
+                || (d == 31 && m == October))
                 return false;
         }
         return true;

--- a/ql/time/calendars/singapore.hpp
+++ b/ql/time/calendars/singapore.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2004 FIMAT Group
  Copyright (C) 2007, 2008, 2009, 2010 StatPro Italia srl
+ Copyright (C) 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -44,7 +45,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2004-2010, 2012-2014, 2019-2023 only:)
+        (data available for 2004-2010, 2012-2014, 2019-2024 only:)
         <ul>
         <li>Chinese New Year</li>
         <li>Hari Raya Haji</li>

--- a/ql/time/calendars/southafrica.cpp
+++ b/ql/time/calendars/southafrica.cpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
- Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
+ Copyright (C) 2023, 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -80,6 +80,8 @@ namespace QuantLib {
             || (d == 27 && m == December && y == 2022)
             // one-shot: Special holiday to celebrate winning of Rugby World Cup 2023
             || (d == 15 && m == December && y == 2023)
+            // one-shot: Election day 2024
+            || (d == 29 && m == May && y == 2024)
             )
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;

--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -2,7 +2,7 @@
 
 /*
  Copyright (C) 2018 Matthias Groncki
- Copyright (C) 2023 Skandinaviska Enskilda Banken AB (publ)
+ Copyright (C) 2023, 2024 Skandinaviska Enskilda Banken AB (publ)
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -288,6 +288,7 @@ namespace QuantLib {
 
         if ((y == 2024) && ((d == 26 && m == February)    // Substitution for Makha Bucha Day (Saturday 24th February 2024)
                             || (d == 8 && m == April)     // Substitution for Chakri Memorial Day (Saturday 6th April 2024)
+                            || (d == 12 && m == April)    // Additional holiday in relation to the Songkran festival
                             || (d == 6 && m == May)       // Substitution for Coronation Day (Saturday 4th May 2024)
                             || (d == 22 && m == May)      // Wisakha Bucha Day
                             || (d == 22 && m == July)     // Substitution for Asarnha Bucha Day (Saturday 20th July 2024)


### PR DESCRIPTION
Hello,
Minor additions with new data.

Singapore:
* https://www.kensington-trust.com/public-holiday-on-polling-day-1-september-2023/
* https://api2.sgx.com/sites/default/files/2024-01/SGX%20Calendar%202024_2.pdf

Thailand:
* https://www.bot.or.th/en/news-and-media/news/news-20240221.html

South Africa:
* https://www.gov.za/news/media-statements/president-cyril-ramaphosa-announces-2024-general-elections-date-20-feb-2024