### PR TITLE
Fixes data type used for test tolerances in boost

### DIFF
--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfCalendarMonth)
         BOOST_ERROR("Expected reference start date at end of calendar day of the month, "
                     "got " << firstCoupon->referencePeriodStart());
     // Expect first cashflow to be 0.9375
-    BOOST_TEST(firstCoupon->amount() == 0.9375, boost::test_tools::tolerance(0.0001));
+    BOOST_TEST(firstCoupon->amount() == 0.9375, boost::test_tools::tolerance<Real>(0.0001));
 }
 
 BOOST_AUTO_TEST_CASE(testIrregularLastCouponReferenceDatesAtEndOfMonth) {

--- a/test-suite/period.cpp
+++ b/test-suite/period.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(testConvertToYears) {
     BOOST_TEST(years(Period(1, Years)) == 1);
     BOOST_TEST(years(Period(5, Years)) == 5);
 
-    const auto tol = boost::test_tools::tolerance(1e-15);
+    const auto tol = boost::test_tools::tolerance<Real>(1e-15);
     BOOST_TEST(years(Period(1, Months)) == 1.0/12.0, tol);
     BOOST_TEST(years(Period(8, Months)) == 8.0/12.0, tol);
     BOOST_TEST(years(Period(12, Months)) == 1);
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(testConvertToWeeks) {
     BOOST_TEST(weeks(Period(1, Weeks)) == 1);
     BOOST_TEST(weeks(Period(5, Weeks)) == 5);
 
-    const auto tol = boost::test_tools::tolerance(1e-15);
+    const auto tol = boost::test_tools::tolerance<Real>(1e-15);
     BOOST_TEST(weeks(Period(1, Days)) == 1.0/7.0, tol);
     BOOST_TEST(weeks(Period(3, Days)) == 3.0/7.0, tol);
     BOOST_TEST(weeks(Period(11, Days)) == 11.0/7.0, tol);

--- a/test-suite/prices.cpp
+++ b/test-suite/prices.cpp
@@ -35,10 +35,10 @@ BOOST_AUTO_TEST_CASE(testMidEquivalent) {
 
     using boost::test_tools::tolerance;
 
-    BOOST_TEST(1.5 == midEquivalent(1, 2, 3, 4), tolerance(1e-14));
-    BOOST_TEST(1.5 == midEquivalent(1, 2, 0, 4), tolerance(1e-14));
-    BOOST_TEST(1.5 == midEquivalent(1, 2, 3, 0), tolerance(1e-14));
-    BOOST_TEST(1.5 == midEquivalent(1, 2, 0, 0), tolerance(1e-14));
+    BOOST_TEST(1.5 == midEquivalent(1, 2, 3, 4), tolerance<Real>(1e-14));
+    BOOST_TEST(1.5 == midEquivalent(1, 2, 0, 4), tolerance<Real>(1e-14));
+    BOOST_TEST(1.5 == midEquivalent(1, 2, 3, 0), tolerance<Real>(1e-14));
+    BOOST_TEST(1.5 == midEquivalent(1, 2, 0, 0), tolerance<Real>(1e-14));
 
     BOOST_TEST(1 == midEquivalent(1, 0, 3, 4));
     BOOST_TEST(1 == midEquivalent(1, 0, 0, 4));
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(testMidSafe) {
 
     using boost::test_tools::tolerance;
 
-    BOOST_TEST(1.5 == midSafe(1, 2), tolerance(1e-14));
+    BOOST_TEST(1.5 == midSafe(1, 2), tolerance<Real>(1e-14));
 
     BOOST_CHECK_THROW(midSafe(0, 0), QuantLib::Error);
     BOOST_CHECK_THROW(midSafe(1, 0), QuantLib::Error);


### PR DESCRIPTION
I appears that comparison tolerances set with the `boost::test_tools::tolerance` template are ignored if their data type is different to the type of the expression. This PR explicitly sets the type to `Real`, which avoids this problem.

An illustration of this problem can be seen in the [QuantLib build with AAD here](https://github.com/auto-differentiation/quantlib-xad/actions/runs/8106892201/job/22157556873#step:9:249), where `Real` is different from `double`. 