### PR TITLE
Uses Real in GeometricBrownianMotionProcess instead of double

### DIFF
--- a/ql/processes/geometricbrownianprocess.cpp
+++ b/ql/processes/geometricbrownianprocess.cpp
@@ -25,9 +25,9 @@
 namespace QuantLib {
 
     GeometricBrownianMotionProcess::GeometricBrownianMotionProcess(
-                                                          double initialValue,
-                                                          double mue,
-                                                          double sigma)
+                                                          Real initialValue,
+                                                          Real mue,
+                                                          Real sigma)
     : StochasticProcess1D(ext::shared_ptr<discretization>(
                                                     new EulerDiscretization)),
       initialValue_(initialValue), mue_(mue), sigma_(sigma) {}

--- a/ql/processes/geometricbrownianprocess.hpp
+++ b/ql/processes/geometricbrownianprocess.hpp
@@ -40,17 +40,17 @@ namespace QuantLib {
     */
     class GeometricBrownianMotionProcess : public StochasticProcess1D {
       public:
-        GeometricBrownianMotionProcess(double initialValue,
-                                       double mue,
-                                       double sigma);
+        GeometricBrownianMotionProcess(Real initialValue,
+                                       Real mue,
+                                       Real sigma);
         Real x0() const override;
         Real drift(Time t, Real x) const override;
         Real diffusion(Time t, Real x) const override;
 
       protected:
-        double initialValue_;
-        double mue_;
-        double sigma_;
+        Real initialValue_;
+        Real mue_;
+        Real sigma_;
     };
 
 }


### PR DESCRIPTION
This fixes some stray usages of `double` instead of `Real`. 