### PR TITLE
Capfloor enhancement for risk free rate

### DIFF
--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -146,6 +146,15 @@ namespace QuantLib {
         registerWith(Settings::instance().evaluationDate());
     }
 
+    CapFloor::CapFloor(CapFloor::Type type,
+        Leg floatingLeg,
+        std::vector<Rate> capRates,
+        std::vector<Rate> floorRates,
+        bool backwardLooking)
+        : CapFloor(type, floatingLeg, capRates, floorRates) {
+        backwardLooking_ = backwardLooking;
+    }
+
     CapFloor::CapFloor(CapFloor::Type type, Leg floatingLeg, const std::vector<Rate>& strikes)
     : type_(type), floatingLeg_(std::move(floatingLeg)) {
         QL_REQUIRE(!strikes.empty(), "no strikes given");
@@ -167,6 +176,14 @@ namespace QuantLib {
             registerWith(*i);
 
         registerWith(Settings::instance().evaluationDate());
+    }
+
+       CapFloor::CapFloor(CapFloor::Type type,
+                       Leg floatingLeg,
+                       const std::vector<Rate>& strikes,
+                       bool backwardLooking)
+    : CapFloor(type, floatingLeg, strikes) {
+        backwardLooking_ = backwardLooking;
     }
 
     bool CapFloor::isExpired() const {

--- a/ql/instruments/capfloor.hpp
+++ b/ql/instruments/capfloor.hpp
@@ -62,6 +62,15 @@ namespace QuantLib {
                  std::vector<Rate> capRates,
                  std::vector<Rate> floorRates);
         CapFloor(Type type, Leg floatingLeg, const std::vector<Rate>& strikes);
+        CapFloor(Type type,
+                 Leg floatingLeg,
+                 std::vector<Rate> capRates,
+                 std::vector<Rate> floorRates,
+                 bool backwardLooking);
+        CapFloor(Type type,
+                 Leg floatingLeg,
+                 const std::vector<Rate>& strikes,
+                 bool backwardLooking);
         //! \name Observable interface
         //@{
         void deepUpdate() override;
@@ -101,6 +110,7 @@ namespace QuantLib {
         Leg floatingLeg_;
         std::vector<Rate> capRates_;
         std::vector<Rate> floorRates_;
+        bool backwardLooking_;
     };
 
     //! Concrete cap class

--- a/ql/instruments/makecapfloor.cpp
+++ b/ql/instruments/makecapfloor.cpp
@@ -73,7 +73,7 @@ namespace QuantLib {
         }
 
         ext::shared_ptr<CapFloor> capFloor(new
-            CapFloor(capFloorType_, leg, strikeVector));
+            CapFloor(capFloorType_, leg, strikeVector, backwardLooking_));
         capFloor->setPricingEngine(engine_);
         return capFloor;
     }
@@ -149,6 +149,11 @@ namespace QuantLib {
     MakeCapFloor& MakeCapFloor::withPricingEngine(
                              const ext::shared_ptr<PricingEngine>& engine) {
         engine_ = engine;
+        return *this;
+    }
+
+    MakeCapFloor& MakeCapFloor::backwardLooking(bool backwardLooking) {
+        backwardLooking_ = backwardLooking;
         return *this;
     }
 

--- a/ql/instruments/makecapfloor.hpp
+++ b/ql/instruments/makecapfloor.hpp
@@ -63,10 +63,13 @@ namespace QuantLib {
 
         MakeCapFloor& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
+        MakeCapFloor& backwardLooking(bool backwardLooking);
+
       private:
         CapFloor::Type capFloorType_;
         Rate strike_;
         bool firstCapletExcluded_, asOptionlet_ = false;
+        bool backwardLooking_;
 
         MakeVanillaSwap makeVanillaSwap_;
 

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.hpp
@@ -52,7 +52,8 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& discount = {},
             VolatilityType type = ShiftedLognormal,
             Real displacement = 0.0,
-            bool dontThrow = false);
+            bool dontThrow = false,
+            bool backwardLooking = false);
 
         const Matrix& capFloorPrices() const;
         const Matrix &capletVols() const;
@@ -75,6 +76,7 @@ namespace QuantLib {
         Real accuracy_;
         Natural maxIter_;
         bool dontThrow_;
+        bool backwardLooking_;
     };
 
 }


### PR DESCRIPTION
A straightforward approach for valuing backward-looking cap floors, such as those based on SOFR, SONIA, etc., involves utilizing the accrual period's end date to derive volatility from the volatility surface. This method aligns with the practices of numerous vendors, including ICAP, in the valuation of risk-free cap floors. My proposed solution offers a rapid means to adapt IBOR-type floating coupon mechanisms for pricing products with daily compounding and backward-looking cap floors. While it may not be the ultimate solution, it effectively conforms to industry standards.