### PR TITLE
Remove forwardStart from DatedOISRateHelper

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -215,6 +215,26 @@ namespace QuantLib {
         latestDate_ = std::max(swap_->maturityDate(), lastPaymentDate);
     }
 
+    DatedOISRateHelper::DatedOISRateHelper(const Date& startDate,
+                                           const Date& endDate,
+                                           const Handle<Quote>& fixedRate,
+                                           const ext::shared_ptr<OvernightIndex>& overnightIndex,
+                                           Handle<YieldTermStructure> discount,
+                                           bool telescopicValueDates,
+                                           RateAveraging::Type averagingMethod,
+                                           Integer paymentLag,
+                                           BusinessDayConvention paymentConvention,
+                                           Frequency paymentFrequency,
+                                           const Calendar& paymentCalendar,
+                                           const Period&,
+                                           Spread overnightSpread,
+                                           ext::optional<bool> endOfMonth,
+                                           ext::optional<Frequency> fixedPaymentFrequency,
+                                           const Calendar& fixedCalendar)
+    : DatedOISRateHelper(startDate, endDate, fixedRate, overnightIndex, discount, telescopicValueDates,
+                         averagingMethod, paymentLag, paymentConvention, paymentFrequency, paymentCalendar,
+                         overnightSpread, endOfMonth, fixedPaymentFrequency, fixedCalendar) {}
+    
     void DatedOISRateHelper::setTermStructure(YieldTermStructure* t) {
         // do not set the relinkable handle as an observer -
         // force recalculation when needed

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -168,7 +168,6 @@ namespace QuantLib {
                                            BusinessDayConvention paymentConvention,
                                            Frequency paymentFrequency,
                                            const Calendar& paymentCalendar,
-                                           const Period& forwardStart,
                                            Spread overnightSpread,
                                            ext::optional<bool> endOfMonth,
                                            ext::optional<Frequency> fixedPaymentFrequency,
@@ -188,7 +187,7 @@ namespace QuantLib {
 
         // input discount curve Handle might be empty now but it could
         //    be assigned a curve later; use a RelinkableHandle here
-        auto tmp = MakeOIS(Period(), clonedOvernightIndex, 0.0, forwardStart)
+        auto tmp = MakeOIS(Period(), clonedOvernightIndex, 0.0)
             .withDiscountingTermStructure(discountRelinkableHandle_)
             .withEffectiveDate(startDate)
             .withTerminationDate(endDate)

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -113,6 +113,29 @@ namespace QuantLib {
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
                            const Calendar& fixedCalendar = Calendar());
+        
+        /*! \deprecated Use the overload without forward start.
+                        Deprecated in version 1.35.
+        */
+        QL_DEPRECATED
+        DatedOISRateHelper(const Date& startDate,
+                           const Date& endDate,
+                           const Handle<Quote>& fixedRate,
+                           const ext::shared_ptr<OvernightIndex>& overnightIndex,
+                           // exogenous discounting curve
+                           Handle<YieldTermStructure> discountingCurve,
+                           bool telescopicValueDates,
+                           RateAveraging::Type averagingMethod,
+                           Integer paymentLag,
+                           BusinessDayConvention paymentConvention,
+                           Frequency paymentFrequency,
+                           const Calendar& paymentCalendar,
+                           const Period& forwardStart,
+                           Spread overnightSpread = 0.0,
+                           ext::optional<bool> endOfMonth = ext::nullopt,
+                           ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+                           const Calendar& fixedCalendar = Calendar());
+
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -109,7 +109,6 @@ namespace QuantLib {
                            BusinessDayConvention paymentConvention = Following,
                            Frequency paymentFrequency = Annual,
                            const Calendar& paymentCalendar = Calendar(),
-                           const Period& forwardStart = 0 * Days,
                            Spread overnightSpread = 0.0,
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,


### PR DESCRIPTION
I added it recently, but this was a mistake: forwardStart has no effect when both start and end dates are specified.