### PR TITLE
Pass Handle by value and move (part 1)

### DIFF
--- a/ql/indexes/bmaindex.cpp
+++ b/ql/indexes/bmaindex.cpp
@@ -40,15 +40,15 @@ namespace QuantLib {
 
     }
 
-    BMAIndex::BMAIndex(const Handle<YieldTermStructure>& h)
+    BMAIndex::BMAIndex(Handle<YieldTermStructure> h)
     : InterestRateIndex("BMA",
                         1 * Weeks,
                         1,
                         USDCurrency(),
                         UnitedStates(UnitedStates::GovernmentBond),
                         ActualActual(ActualActual::ISDA)),
-      termStructure_(h) {
-        registerWith (h);
+      termStructure_(std::move(h)) {
+        registerWith(termStructure_);
     }
 
     bool BMAIndex::isValidFixingDate(const Date& date) const {

--- a/ql/indexes/bmaindex.hpp
+++ b/ql/indexes/bmaindex.hpp
@@ -39,7 +39,7 @@ namespace QuantLib {
     */
     class BMAIndex : public InterestRateIndex {
       public:
-        explicit BMAIndex(const Handle<YieldTermStructure>& h = {});
+        explicit BMAIndex(Handle<YieldTermStructure> h = {});
         //! \name Index interface
         //@{
         /*! BMA is fixed weekly on Wednesdays.

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -60,12 +60,12 @@ namespace QuantLib {
         if (result != Null<Real>())
             // if historical fixing is present use it
             return result;
-        
+
         if (fixingDate == today && !spot_.empty())
             // Today's fixing is missing, but spot is
             // provided, so use it as proxy
             return spot_->value();
-        
+
         QL_FAIL("Missing " << name() << " fixing for " << fixingDate);
     }
 
@@ -92,9 +92,9 @@ namespace QuantLib {
         return forward;
     }
 
-    ext::shared_ptr<EquityIndex> EquityIndex::clone(const Handle<YieldTermStructure>& interest,
-                                                    const Handle<YieldTermStructure>& dividend,
-                                                    const Handle<Quote>& spot) const {
-        return ext::make_shared<EquityIndex>(name(), fixingCalendar(), interest, dividend, spot);
+    ext::shared_ptr<EquityIndex> EquityIndex::clone(Handle<YieldTermStructure> interest,
+                                                    Handle<YieldTermStructure> dividend,
+                                                    Handle<Quote> spot) const {
+        return ext::make_shared<EquityIndex>(name(), fixingCalendar(), std::move(interest), std::move(dividend), std::move(spot));
     }
 }

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -38,7 +38,7 @@ namespace QuantLib {
         term structure, or just the interest rate term structure
         in which case one can provide a term structure of equity
         forwards implied from, e.g. option prices.
-        
+
         In case of the first method, the forward is calculated as:
         \f[
         I(t, T) = I(t, t) \frac{P_{D}(t, T)}{P_{R}(t, T)},
@@ -98,9 +98,9 @@ namespace QuantLib {
         //@{
         //! returns a copy of itself linked to different interest, dividend curves
         //! or spot quote
-        virtual ext::shared_ptr<EquityIndex> clone(const Handle<YieldTermStructure>& interest,
-                                                   const Handle<YieldTermStructure>& dividend,
-                                                   const Handle<Quote>& spot) const;
+        virtual ext::shared_ptr<EquityIndex> clone(Handle<YieldTermStructure> interest,
+                                                   Handle<YieldTermStructure> dividend,
+                                                   Handle<Quote> spot) const;
         // @}
       private:
         std::string name_;

--- a/ql/indexes/ibor/aonia.hpp
+++ b/ql/indexes/ibor/aonia.hpp
@@ -38,10 +38,10 @@ namespace QuantLib {
     */
     class Aonia : public OvernightIndex {
       public:
-        explicit Aonia(const Handle<YieldTermStructure>& h = {})
+        explicit Aonia(Handle<YieldTermStructure> h = {})
         : OvernightIndex("Aonia", 0, AUDCurrency(),
                          Australia(),
-                         Actual365Fixed(), h) {}
+                         Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/audlibor.hpp
+++ b/ql/indexes/ibor/audlibor.hpp
@@ -38,12 +38,12 @@ namespace QuantLib {
     class AUDLibor : public Libor {
       public:
         AUDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("AUDLibor", tenor,
                 2,
                 AUDCurrency(),
                 Australia(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/bbsw.hpp
+++ b/ql/indexes/ibor/bbsw.hpp
@@ -39,12 +39,12 @@ namespace QuantLib {
     class Bbsw : public IborIndex {
       public:
         Bbsw(const Period& tenor,
-             const Handle<YieldTermStructure>& h = {})
+             Handle<YieldTermStructure> h = {})
         : IborIndex("Bbsw", tenor,
                     0, // settlement days
                     AUDCurrency(), Australia(),
                     HalfMonthModifiedFollowing, true,
-                    Actual365Fixed(), h) {
+                    Actual365Fixed(), std::move(h)) {
             QL_REQUIRE(this->tenor().units() != Days,
                        "for daily tenors (" << this->tenor() <<
                        ") dedicated DailyTenor constructor must be used");
@@ -54,43 +54,43 @@ namespace QuantLib {
     //! 1-month %Bbsw index
     class Bbsw1M : public Bbsw {
       public:
-        explicit Bbsw1M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(1, Months), h) {}
+        explicit Bbsw1M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %Bbsw index
     class Bbsw2M : public Bbsw {
       public:
-        explicit Bbsw2M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(2, Months), h) {}
+        explicit Bbsw2M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %Bbsw index
     class Bbsw3M : public Bbsw {
       public:
-        explicit Bbsw3M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(3, Months), h) {}
+        explicit Bbsw3M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(3, Months), std::move(h)) {}
     };
 
     //! 4-months %Bbsw index
     class Bbsw4M : public Bbsw {
       public:
-        explicit Bbsw4M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(4, Months), h) {}
+        explicit Bbsw4M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(4, Months), std::move(h)) {}
     };
 
     //! 5-months %Bbsw index
     class Bbsw5M : public Bbsw {
       public:
-        explicit Bbsw5M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(5, Months), h) {}
+        explicit Bbsw5M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(5, Months), std::move(h)) {}
     };
 
     //! 6-months %Bbsw index
     class Bbsw6M : public Bbsw {
       public:
-        explicit Bbsw6M(const Handle<YieldTermStructure>& h = {})
-        : Bbsw(Period(6, Months), h) {}
+        explicit Bbsw6M(Handle<YieldTermStructure> h = {})
+        : Bbsw(Period(6, Months), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/bibor.cpp
+++ b/ql/indexes/ibor/bibor.cpp
@@ -55,13 +55,12 @@ namespace QuantLib {
 
     }
 
-    Bibor::Bibor(const Period& tenor,
-                     const Handle<YieldTermStructure>& h)
+    Bibor::Bibor(const Period& tenor, Handle<YieldTermStructure> h)
     : IborIndex("Bibor", tenor,
                 2, // settlement days
                 THBCurrency(), Thailand(),
                 BiborConvention(tenor), BiborEOM(tenor),
-                Actual365Fixed(), h) {
+                Actual365Fixed(), std::move(h)) {
         QL_REQUIRE(this->tenor().units()!=Days,
                    "for daily tenors (" << this->tenor() <<
                    ") dedicated DailyTenor constructor must be used");

--- a/ql/indexes/ibor/bibor.hpp
+++ b/ql/indexes/ibor/bibor.hpp
@@ -33,59 +33,58 @@ namespace QuantLib {
     */
     class Bibor : public IborIndex {
       public:
-        Bibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {});
+        Bibor(const Period& tenor, Handle<YieldTermStructure> h = {});
     };
 
 
     //! 1-week %Bibor index
     class BiborSW : public Bibor {
       public:
-        explicit BiborSW(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(1, Weeks), h) {}
+        explicit BiborSW(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(1, Weeks), std::move(h)) {}
     };
 
 
     //! 1-month %Euribor index
     class Bibor1M : public Bibor {
       public:
-        explicit Bibor1M(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(1, Months), h) {}
+        explicit Bibor1M(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %Euribor index
     class Bibor2M : public Bibor {
       public:
-        explicit Bibor2M(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(2, Months), h) {}
+        explicit Bibor2M(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %Bibor index
     class Bibor3M : public Bibor {
       public:
-        explicit Bibor3M(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(3, Months), h) {}
+        explicit Bibor3M(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(3, Months), std::move(h)) {}
     };
 
     //! 6-months %Bibor index
     class Bibor6M : public Bibor {
       public:
-        explicit Bibor6M(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(6, Months), h) {}
+        explicit Bibor6M(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(6, Months), std::move(h)) {}
     };
 
     //! 9-months %Bibor index
     class Bibor9M : public Bibor {
       public:
-        explicit Bibor9M(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(9, Months), h) {}
+        explicit Bibor9M(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(9, Months), std::move(h)) {}
     };
 
     //! 1-year %Bibor index
     class Bibor1Y : public Bibor {
       public:
-        explicit Bibor1Y(const Handle<YieldTermStructure>& h = {})
-        : Bibor(Period(1, Years), h) {}
+        explicit Bibor1Y(Handle<YieldTermStructure> h = {})
+        : Bibor(Period(1, Years), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/bkbm.hpp
+++ b/ql/indexes/ibor/bkbm.hpp
@@ -38,13 +38,12 @@ namespace QuantLib {
     */
     class Bkbm : public IborIndex {
       public:
-        Bkbm(const Period& tenor,
-             const Handle<YieldTermStructure>& h = {})
+        Bkbm(const Period& tenor, Handle<YieldTermStructure> h = {})
         : IborIndex("Bkbm", tenor,
                     0, // settlement days
                     NZDCurrency(), NewZealand(),
                     ModifiedFollowing, true,
-                    Actual365Fixed(), h) {
+                    Actual365Fixed(), std::move(h)) {
             QL_REQUIRE(this->tenor().units() != Days,
                        "for daily tenors (" << this->tenor() <<
                        ") dedicated DailyTenor constructor must be used");
@@ -54,43 +53,43 @@ namespace QuantLib {
     //! 1-month %Bkbm index
     class Bkbm1M : public Bkbm {
       public:
-        explicit Bkbm1M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(1, Months), h) {}
+        explicit Bkbm1M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %Bkbm index
     class Bkbm2M : public Bkbm {
       public:
-        explicit Bkbm2M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(2, Months), h) {}
+        explicit Bkbm2M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %Bkbm index
     class Bkbm3M : public Bkbm {
       public:
-        explicit Bkbm3M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(3, Months), h) {}
+        explicit Bkbm3M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(3, Months), std::move(h)) {}
     };
 
     //! 4-months %Bkbm index
     class Bkbm4M : public Bkbm {
       public:
-        explicit Bkbm4M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(4, Months), h) {}
+        explicit Bkbm4M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(4, Months), std::move(h)) {}
     };
 
     //! 5-months %Bkbm index
     class Bkbm5M : public Bkbm {
       public:
-        explicit Bkbm5M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(5, Months), h) {}
+        explicit Bkbm5M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(5, Months), std::move(h)) {}
     };
 
     //! 6-months %Bkbm index
     class Bkbm6M : public Bkbm {
       public:
-        explicit Bkbm6M(const Handle<YieldTermStructure>& h = {})
-        : Bkbm(Period(6, Months), h) {}
+        explicit Bkbm6M(Handle<YieldTermStructure> h = {})
+        : Bkbm(Period(6, Months), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/cadlibor.hpp
+++ b/ql/indexes/ibor/cadlibor.hpp
@@ -45,23 +45,23 @@ namespace QuantLib {
     class CADLibor : public Libor {
       public:
         CADLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("CADLibor", tenor,
                 0,
                 CADCurrency(),
                 Canada(),
-                Actual365Fixed(), h) {}
+                Actual365Fixed(), std::move(h)) {}
     };
 
     //! Overnight %CAD %Libor index
     class CADLiborON : public DailyTenorLibor {
       public:
-        explicit CADLiborON(const Handle<YieldTermStructure>& h = {})
+        explicit CADLiborON(Handle<YieldTermStructure> h = {})
         : DailyTenorLibor("CADLibor",
                           0,
                           CADCurrency(),
                           Canada(),
-                          Actual365Fixed(), h) {}
+                          Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/cdor.hpp
+++ b/ql/indexes/ibor/cdor.hpp
@@ -44,10 +44,10 @@ namespace QuantLib {
     class Cdor : public IborIndex {
       public:
         Cdor(const Period& tenor,
-             const Handle<YieldTermStructure>& h = {})
+             Handle<YieldTermStructure> h = {})
         : IborIndex("CDOR", tenor, 0, CADCurrency(),
                     Canada(), ModifiedFollowing, false,
-                    Actual365Fixed(), h) {}
+                    Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/chflibor.hpp
+++ b/ql/indexes/ibor/chflibor.hpp
@@ -43,23 +43,23 @@ namespace QuantLib {
     class CHFLibor : public Libor {
       public:
         CHFLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("CHFLibor", tenor,
                 2,
                 CHFCurrency(),
                 Switzerland(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
     //! base class for the one day deposit BBA %CHF %LIBOR indexes
     class DailyTenorCHFLibor : public DailyTenorLibor {
       public:
         DailyTenorCHFLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h = {})
+                           Handle<YieldTermStructure> h = {})
         : DailyTenorLibor("CHFLibor", settlementDays,
                           CHFCurrency(),
                           Switzerland(),
-                          Actual360(), h) {}
+                          Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/corra.cpp
+++ b/ql/indexes/ibor/corra.cpp
@@ -22,6 +22,6 @@
 #include <ql/time/calendars/canada.hpp>
 
 namespace QuantLib {
-    Corra::Corra(const Handle<YieldTermStructure>& h)
-    : OvernightIndex("CORRA", 0, CADCurrency(), Canada(), Actual365Fixed(), h) {}
+    Corra::Corra(Handle<YieldTermStructure> h)
+    : OvernightIndex("CORRA", 0, CADCurrency(), Canada(), Actual365Fixed(), std::move(h)) {}
 }

--- a/ql/indexes/ibor/corra.hpp
+++ b/ql/indexes/ibor/corra.hpp
@@ -25,7 +25,7 @@
 namespace QuantLib {
     class Corra : public OvernightIndex {
       public:
-        explicit Corra(const Handle<YieldTermStructure>& h = {});
+        explicit Corra(Handle<YieldTermStructure> h = {});
     };
 }
 

--- a/ql/indexes/ibor/destr.hpp
+++ b/ql/indexes/ibor/destr.hpp
@@ -34,8 +34,8 @@ namespace QuantLib {
     //! %Destr (Denmark Short-Term Rate) index.
     class Destr : public OvernightIndex {
       public:
-        explicit Destr(const Handle<YieldTermStructure>& h = {})
-        : OvernightIndex("DESTR", 0, DKKCurrency(), Denmark(), Actual360(), h) {}
+        explicit Destr(Handle<YieldTermStructure> h = {})
+        : OvernightIndex("DESTR", 0, DKKCurrency(), Denmark(), Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/dkklibor.hpp
+++ b/ql/indexes/ibor/dkklibor.hpp
@@ -38,12 +38,12 @@ namespace QuantLib {
     class DKKLibor : public Libor {
       public:
         DKKLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("DKKLibor", tenor,
                 2,
                 DKKCurrency(),
                 Denmark(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/eonia.cpp
+++ b/ql/indexes/ibor/eonia.cpp
@@ -24,7 +24,7 @@
 
 namespace QuantLib {
 
-    Eonia::Eonia(const Handle<YieldTermStructure>& h)
-    : OvernightIndex("Eonia", 0, EURCurrency(), TARGET(), Actual360(), h) {}
+    Eonia::Eonia(Handle<YieldTermStructure> h)
+    : OvernightIndex("Eonia", 0, EURCurrency(), TARGET(), Actual360(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/eonia.hpp
+++ b/ql/indexes/ibor/eonia.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
     //! %Eonia (Euro Overnight Index Average) rate fixed by the ECB.
     class Eonia : public OvernightIndex {
       public:
-        explicit Eonia(const Handle<YieldTermStructure>& h = {});
+        explicit Eonia(Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/estr.cpp
+++ b/ql/indexes/ibor/estr.cpp
@@ -24,7 +24,7 @@
 
 namespace QuantLib {
 
-    Estr::Estr(const Handle<YieldTermStructure>& h)
-    : OvernightIndex("ESTR", 0, EURCurrency(), TARGET(), Actual360(), h) {}
+    Estr::Estr(Handle<YieldTermStructure> h)
+    : OvernightIndex("ESTR", 0, EURCurrency(), TARGET(), Actual360(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/estr.hpp
+++ b/ql/indexes/ibor/estr.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
     //! %ESTR (Euro Short-Term Rate) rate fixed by the ECB.
     class Estr : public OvernightIndex {
       public:
-        explicit Estr(const Handle<YieldTermStructure>& h = {});
+        explicit Estr(Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/euribor.cpp
+++ b/ql/indexes/ibor/euribor.cpp
@@ -57,24 +57,24 @@ namespace QuantLib {
     }
 
     Euribor::Euribor(const Period& tenor,
-                     const Handle<YieldTermStructure>& h)
+                     Handle<YieldTermStructure> h)
     : IborIndex("Euribor", tenor,
                 2, // settlement days
                 EURCurrency(), TARGET(),
                 euriborConvention(tenor), euriborEOM(tenor),
-                Actual360(), h) {
+                Actual360(), std::move(h)) {
         QL_REQUIRE(this->tenor().units()!=Days,
                    "for daily tenors (" << this->tenor() <<
                    ") dedicated DailyTenor constructor must be used");
     }
 
     Euribor365::Euribor365(const Period& tenor,
-                           const Handle<YieldTermStructure>& h)
+                           Handle<YieldTermStructure> h)
     : IborIndex("Euribor365", tenor,
                 2, // settlement days
                 EURCurrency(), TARGET(),
                 euriborConvention(tenor), euriborEOM(tenor),
-                Actual365Fixed(), h) {
+                Actual365Fixed(), std::move(h)) {
         QL_REQUIRE(this->tenor().units()!=Days,
                    "for daily tenors (" << this->tenor() <<
                    ") dedicated DailyTenor constructor must be used");

--- a/ql/indexes/ibor/euribor.hpp
+++ b/ql/indexes/ibor/euribor.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
     class Euribor : public IborIndex {
       public:
         Euribor(const Period& tenor,
-                const Handle<YieldTermStructure>& h = {});
+                Handle<YieldTermStructure> h = {});
     };
 
     //! Actual/365 %Euribor index
@@ -53,218 +53,218 @@ namespace QuantLib {
     class Euribor365 : public IborIndex {
       public:
         Euribor365(const Period& tenor,
-                   const Handle<YieldTermStructure>& h = {});
+                   Handle<YieldTermStructure> h = {});
     };
 
     //! 1-week %Euribor index
     class EuriborSW : public Euribor {
       public:
-        explicit EuriborSW(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(1, Weeks), h) {}
+        explicit EuriborSW(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(1, Weeks), std::move(h)) {}
     };
 
     //! 2-weeks %Euribor index
     class Euribor2W : public Euribor {
       public:
-        explicit Euribor2W(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(2, Weeks), h) {}
+        explicit Euribor2W(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(2, Weeks), std::move(h)) {}
     };
 
     //! 3-weeks %Euribor index
     class Euribor3W : public Euribor {
       public:
-        explicit Euribor3W(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(3, Weeks), h) {}
+        explicit Euribor3W(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(3, Weeks), std::move(h)) {}
     };
 
     //! 1-month %Euribor index
     class Euribor1M : public Euribor {
       public:
-        explicit Euribor1M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(1, Months), h) {}
+        explicit Euribor1M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %Euribor index
     class Euribor2M : public Euribor {
       public:
-        explicit Euribor2M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(2, Months), h) {}
+        explicit Euribor2M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %Euribor index
     class Euribor3M : public Euribor {
       public:
-        explicit Euribor3M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(3, Months), h) {}
+        explicit Euribor3M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(3, Months), std::move(h)) {}
     };
 
     //! 4-months %Euribor index
     class Euribor4M : public Euribor {
       public:
-        explicit Euribor4M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(4, Months), h) {}
+        explicit Euribor4M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(4, Months), std::move(h)) {}
     };
 
     //! 5-months %Euribor index
     class Euribor5M : public Euribor {
       public:
-        explicit Euribor5M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(5, Months), h) {}
+        explicit Euribor5M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(5, Months), std::move(h)) {}
     };
 
     //! 6-months %Euribor index
     class Euribor6M : public Euribor {
       public:
-        explicit Euribor6M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(6, Months), h) {}
+        explicit Euribor6M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(6, Months), std::move(h)) {}
     };
 
     //! 7-months %Euribor index
     class Euribor7M : public Euribor {
       public:
-        explicit Euribor7M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(7, Months), h) {}
+        explicit Euribor7M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(7, Months), std::move(h)) {}
     };
 
     //! 8-months %Euribor index
     class Euribor8M : public Euribor {
       public:
-        explicit Euribor8M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(8, Months), h) {}
+        explicit Euribor8M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(8, Months), std::move(h)) {}
     };
 
     //! 9-months %Euribor index
     class Euribor9M : public Euribor {
       public:
-        explicit Euribor9M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(9, Months), h) {}
+        explicit Euribor9M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(9, Months), std::move(h)) {}
     };
 
     //! 10-months %Euribor index
     class Euribor10M : public Euribor {
       public:
-        explicit Euribor10M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(10, Months), h) {}
+        explicit Euribor10M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(10, Months), std::move(h)) {}
     };
 
     //! 11-months %Euribor index
     class Euribor11M : public Euribor {
       public:
-        explicit Euribor11M(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(11, Months), h) {}
+        explicit Euribor11M(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(11, Months), std::move(h)) {}
     };
 
     //! 1-year %Euribor index
     class Euribor1Y : public Euribor {
       public:
-        explicit Euribor1Y(const Handle<YieldTermStructure>& h = {})
-        : Euribor(Period(1, Years), h) {}
+        explicit Euribor1Y(Handle<YieldTermStructure> h = {})
+        : Euribor(Period(1, Years), std::move(h)) {}
     };
 
 
     //! 1-week %Euribor365 index
     class Euribor365_SW : public Euribor365 {
       public:
-        explicit Euribor365_SW(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(1, Weeks), h) {}
+        explicit Euribor365_SW(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(1, Weeks), std::move(h)) {}
     };
 
     //! 2-weeks %Euribor365 index
     class Euribor365_2W : public Euribor365 {
       public:
-        explicit Euribor365_2W(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(2, Weeks), h) {}
+        explicit Euribor365_2W(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(2, Weeks), std::move(h)) {}
     };
 
     //! 3-weeks %Euribor365 index
     class Euribor365_3W : public Euribor365 {
       public:
-        explicit Euribor365_3W(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(3, Weeks), h) {}
+        explicit Euribor365_3W(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(3, Weeks), std::move(h)) {}
     };
 
     //! 1-month %Euribor365 index
     class Euribor365_1M : public Euribor365 {
       public:
-        explicit Euribor365_1M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(1, Months), h) {}
+        explicit Euribor365_1M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %Euribor365 index
     class Euribor365_2M : public Euribor365 {
       public:
-        explicit Euribor365_2M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(2, Months), h) {}
+        explicit Euribor365_2M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %Euribor365 index
     class Euribor365_3M : public Euribor365 {
       public:
-        explicit Euribor365_3M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(3, Months), h) {}
+        explicit Euribor365_3M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(3, Months), std::move(h)) {}
     };
 
     //! 4-months %Euribor365 index
     class Euribor365_4M : public Euribor365 {
       public:
-        explicit Euribor365_4M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(4, Months), h) {}
+        explicit Euribor365_4M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(4, Months), std::move(h)) {}
     };
 
     //! 5-months %Euribor365 index
     class Euribor365_5M : public Euribor365 {
       public:
-        explicit Euribor365_5M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(5, Months), h) {}
+        explicit Euribor365_5M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(5, Months), std::move(h)) {}
     };
 
     //! 6-months %Euribor365 index
     class Euribor365_6M : public Euribor365 {
       public:
-        explicit Euribor365_6M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(6, Months), h) {}
+        explicit Euribor365_6M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(6, Months), std::move(h)) {}
     };
 
     //! 7-months %Euribor365 index
     class Euribor365_7M : public Euribor365 {
       public:
-        explicit Euribor365_7M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(7, Months), h) {}
+        explicit Euribor365_7M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(7, Months), std::move(h)) {}
     };
 
     //! 8-months %Euribor365 index
     class Euribor365_8M : public Euribor365 {
       public:
-        explicit Euribor365_8M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(8, Months), h) {}
+        explicit Euribor365_8M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(8, Months), std::move(h)) {}
     };
 
     //! 9-months %Euribor365 index
     class Euribor365_9M : public Euribor365 {
       public:
-        explicit Euribor365_9M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(9, Months), h) {}
+        explicit Euribor365_9M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(9, Months), std::move(h)) {}
     };
 
     //! 10-months %Euribor365 index
     class Euribor365_10M : public Euribor365 {
       public:
-        explicit Euribor365_10M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(10, Months), h) {}
+        explicit Euribor365_10M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(10, Months), std::move(h)) {}
     };
 
     //! 11-months %Euribor365 index
     class Euribor365_11M : public Euribor365 {
       public:
-        explicit Euribor365_11M(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(11, Months), h) {}
+        explicit Euribor365_11M(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(11, Months), std::move(h)) {}
     };
 
     //! 1-year %Euribor365 index
     class Euribor365_1Y : public Euribor365 {
       public:
-        explicit Euribor365_1Y(const Handle<YieldTermStructure>& h = {})
-        : Euribor365(Period(1, Years), h) {}
+        explicit Euribor365_1Y(Handle<YieldTermStructure> h = {})
+        : Euribor365(Period(1, Years), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/eurlibor.cpp
+++ b/ql/indexes/ibor/eurlibor.cpp
@@ -58,7 +58,7 @@ namespace QuantLib {
     }
 
     EURLibor::EURLibor(const Period& tenor,
-                       const Handle<YieldTermStructure>& h)
+                       Handle<YieldTermStructure> h)
     : IborIndex("EURLibor", tenor,
                 2,
                 EURCurrency(),
@@ -69,7 +69,7 @@ namespace QuantLib {
                               TARGET(),
                               JoinBusinessDays),
                 eurliborConvention(tenor), eurliborEOM(tenor),
-                Actual360(), h),
+                Actual360(), std::move(h)),
       target_(TARGET()) {
         QL_REQUIRE(this->tenor().units()!=Days,
                    "for daily tenors (" << this->tenor() <<
@@ -95,7 +95,7 @@ namespace QuantLib {
     }
 
     DailyTenorEURLibor::DailyTenorEURLibor(Natural settlementDays,
-                                           const Handle<YieldTermStructure>& h)
+                                           Handle<YieldTermStructure> h)
     : IborIndex("EURLibor", 1*Days,
                 settlementDays,
                 EURCurrency(),
@@ -105,6 +105,6 @@ namespace QuantLib {
                 // closed but London is open on the fixing day.
                 TARGET(),
                 eurliborConvention(1*Days), eurliborEOM(1*Days),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/eurlibor.hpp
+++ b/ql/indexes/ibor/eurlibor.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
     class EURLibor : public IborIndex {
       public:
         EURLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {});
+                 Handle<YieldTermStructure> h = {});
         /*! \name Date calculations
 
             See <https://www.theice.com/marketdata/reports/170>.
@@ -67,113 +67,113 @@ namespace QuantLib {
     class DailyTenorEURLibor : public IborIndex {
       public:
         DailyTenorEURLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h = {});
+                           Handle<YieldTermStructure> h = {});
     };
 
     //! Overnight %EUR %Libor index
     class EURLiborON : public DailyTenorEURLibor {
       public:
-        explicit EURLiborON(const Handle<YieldTermStructure>& h = {})
-        : DailyTenorEURLibor(0, h) {}
+        explicit EURLiborON(Handle<YieldTermStructure> h = {})
+        : DailyTenorEURLibor(0, std::move(h)) {}
     };
 
     //! 1-week %EUR %Libor index
     class EURLiborSW : public EURLibor {
       public:
-        explicit EURLiborSW(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(1, Weeks), h) {}
+        explicit EURLiborSW(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(1, Weeks), std::move(h)) {}
     };
 
     //! 2-weeks %EUR %Libor index
     class EURLibor2W : public EURLibor {
       public:
-        explicit EURLibor2W(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(2, Weeks), h) {}
+        explicit EURLibor2W(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(2, Weeks), std::move(h)) {}
     };
 
 
     //! 1-month %EUR %Libor index
     class EURLibor1M : public EURLibor {
       public:
-        explicit EURLibor1M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(1, Months), h) {}
+        explicit EURLibor1M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(1, Months), std::move(h)) {}
     };
 
     //! 2-months %EUR %Libor index
     class EURLibor2M : public EURLibor {
       public:
-        explicit EURLibor2M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(2, Months), h) {}
+        explicit EURLibor2M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(2, Months), std::move(h)) {}
     };
 
     //! 3-months %EUR %Libor index
     class EURLibor3M : public EURLibor {
       public:
-        explicit EURLibor3M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(3, Months), h) {}
+        explicit EURLibor3M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(3, Months), std::move(h)) {}
     };
 
     //! 4-months %EUR %Libor index
     class EURLibor4M : public EURLibor {
       public:
-        explicit EURLibor4M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(4, Months), h) {}
+        explicit EURLibor4M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(4, Months), std::move(h)) {}
     };
 
     //! 5-months %EUR %Libor index
     class EURLibor5M : public EURLibor {
       public:
-        explicit EURLibor5M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(5, Months), h) {}
+        explicit EURLibor5M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(5, Months), std::move(h)) {}
     };
 
     //! 6-months %EUR %Libor index
     class EURLibor6M : public EURLibor {
       public:
-        explicit EURLibor6M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(6, Months), h) {}
+        explicit EURLibor6M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(6, Months), std::move(h)) {}
     };
 
     //! 7-months %EUR %Libor index
     class EURLibor7M : public EURLibor{
       public:
-        explicit EURLibor7M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(7, Months), h) {}
+        explicit EURLibor7M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(7, Months), std::move(h)) {}
     };
 
     //! 8-months %EUR %Libor index
     class EURLibor8M : public EURLibor {
       public:
-        explicit EURLibor8M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(8, Months), h) {}
+        explicit EURLibor8M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(8, Months), std::move(h)) {}
     };
 
     //! 9-months %EUR %Libor index
     class EURLibor9M : public EURLibor {
       public:
-        explicit EURLibor9M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(9, Months), h) {}
+        explicit EURLibor9M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(9, Months), std::move(h)) {}
     };
 
     //! 10-months %EUR %Libor index
     class EURLibor10M : public EURLibor {
       public:
-        explicit EURLibor10M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(10, Months), h) {}
+        explicit EURLibor10M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(10, Months), std::move(h)) {}
     };
 
     //! 11-months %EUR %Libor index
     class EURLibor11M : public EURLibor {
       public:
-        explicit EURLibor11M(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(11, Months), h) {}
+        explicit EURLibor11M(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(11, Months), std::move(h)) {}
     };
 
     //! 1-year %EUR %Libor index
     class EURLibor1Y : public EURLibor {
       public:
-        explicit EURLibor1Y(const Handle<YieldTermStructure>& h = {})
-        : EURLibor(Period(1, Years), h) {}
+        explicit EURLibor1Y(Handle<YieldTermStructure> h = {})
+        : EURLibor(Period(1, Years), std::move(h)) {}
     };
 
 

--- a/ql/indexes/ibor/fedfunds.cpp
+++ b/ql/indexes/ibor/fedfunds.cpp
@@ -24,10 +24,10 @@
 
 namespace QuantLib {
 
-    FedFunds::FedFunds(const Handle<YieldTermStructure>& h)
+    FedFunds::FedFunds(Handle<YieldTermStructure> h)
     : OvernightIndex("FedFunds", 0,
                      USDCurrency(),
                      UnitedStates(UnitedStates::FederalReserve),
-                     Actual360(), h) {}
+                     Actual360(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/fedfunds.hpp
+++ b/ql/indexes/ibor/fedfunds.hpp
@@ -32,7 +32,7 @@ namespace QuantLib {
     /*! (for balances held at the Federal Reserve) */
     class FedFunds : public OvernightIndex {
       public:
-        explicit FedFunds(const Handle<YieldTermStructure>& h = {});
+        explicit FedFunds(Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/gbplibor.hpp
+++ b/ql/indexes/ibor/gbplibor.hpp
@@ -40,30 +40,30 @@ namespace QuantLib {
     class GBPLibor : public Libor {
       public:
         GBPLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("GBPLibor", tenor,
                 0,
                 GBPCurrency(),
                 UnitedKingdom(UnitedKingdom::Exchange),
-                Actual365Fixed(), h) {}
+                Actual365Fixed(), std::move(h)) {}
     };
 
     //! Base class for the one day deposit ICE %GBP %LIBOR indexes
     class DailyTenorGBPLibor : public DailyTenorLibor {
       public:
         DailyTenorGBPLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h = {})
+                           Handle<YieldTermStructure> h = {})
         : DailyTenorLibor("GBPLibor", settlementDays,
                           GBPCurrency(),
                           UnitedKingdom(UnitedKingdom::Exchange),
-                          Actual365Fixed(), h) {}
+                          Actual365Fixed(), std::move(h)) {}
     };
 
     //! Overnight %GBP %Libor index
     class GBPLiborON : public DailyTenorGBPLibor {
       public:
-        explicit GBPLiborON(const Handle<YieldTermStructure>& h = {})
-        : DailyTenorGBPLibor(0, h) {}
+        explicit GBPLiborON(Handle<YieldTermStructure> h = {})
+        : DailyTenorGBPLibor(0, std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/jibar.hpp
+++ b/ql/indexes/ibor/jibar.hpp
@@ -40,10 +40,10 @@ namespace QuantLib {
     class Jibar : public IborIndex {
       public:
         Jibar(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {})
+              Handle<YieldTermStructure> h = {})
         : IborIndex("Jibar", tenor, 0, ZARCurrency(),
                 SouthAfrica(), ModifiedFollowing, false,
-                Actual365Fixed(), h) {}
+                Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/jpylibor.hpp
+++ b/ql/indexes/ibor/jpylibor.hpp
@@ -44,23 +44,23 @@ namespace QuantLib {
     class JPYLibor : public Libor {
       public:
         JPYLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("JPYLibor", tenor,
                 2,
                 JPYCurrency(),
                 Japan(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
     //! base class for the one day deposit ICE %JPY %LIBOR indexes
     class DailyTenorJPYLibor : public DailyTenorLibor {
       public:
         DailyTenorJPYLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h = {})
+                           Handle<YieldTermStructure> h = {})
         : DailyTenorLibor("JPYLibor", settlementDays,
                           JPYCurrency(),
                           Japan(),
-                          Actual360(), h) {}
+                          Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/libor.cpp
+++ b/ql/indexes/ibor/libor.cpp
@@ -57,21 +57,21 @@ namespace QuantLib {
     }
 
 
-    Libor::Libor(const std::string& familyName,
+    Libor::Libor(std::string familyName,
                  const Period& tenor,
                  Natural settlementDays,
                  const Currency& currency,
                  const Calendar& financialCenterCalendar,
                  const DayCounter& dayCounter,
-                 const Handle<YieldTermStructure>& h)
-    : IborIndex(familyName, tenor, settlementDays, currency,
+                 Handle<YieldTermStructure> h)
+    : IborIndex(std::move(familyName), tenor, settlementDays, currency,
                 // http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1412 :
                 // UnitedKingdom::Exchange is the fixing calendar for
                 // a) all currencies but EUR
                 // b) all indexes but o/n and s/n
                 UnitedKingdom(UnitedKingdom::Exchange),
                 liborConvention(tenor), liborEOM(tenor),
-                dayCounter, h),
+                dayCounter, std::move(h)),
       financialCenterCalendar_(financialCenterCalendar),
       jointCalendar_(JointCalendar(UnitedKingdom(UnitedKingdom::Exchange),
                                    financialCenterCalendar,
@@ -116,26 +116,25 @@ namespace QuantLib {
         return jointCalendar_;
     }
 
-    ext::shared_ptr<IborIndex> Libor::clone(
-                                  const Handle<YieldTermStructure>& h) const {
+    ext::shared_ptr<IborIndex> Libor::clone(Handle<YieldTermStructure> h) const {
         return ext::shared_ptr<IborIndex>(new Libor(familyName(),
                                                       tenor(),
                                                       fixingDays(),
                                                       currency(),
                                                       financialCenterCalendar_,
                                                       dayCounter(),
-                                                      h));
+                                                      std::move(h)));
     }
 
 
     DailyTenorLibor::DailyTenorLibor(
-                 const std::string& familyName,
+                 std::string familyName,
                  Natural settlementDays,
                  const Currency& currency,
                  const Calendar& financialCenterCalendar,
                  const DayCounter& dayCounter,
-                 const Handle<YieldTermStructure>& h)
-    : IborIndex(familyName, 1*Days, settlementDays, currency,
+                 Handle<YieldTermStructure> h)
+    : IborIndex(std::move(familyName), 1*Days, settlementDays, currency,
                 // http://www.bba.org.uk/bba/jsp/polopoly.jsp?d=225&a=1412 :
                 // no o/n or s/n fixings (as the case may be) will take place
                 // when the principal centre of the currency concerned is
@@ -144,7 +143,7 @@ namespace QuantLib {
                               financialCenterCalendar,
                               JoinHolidays),
                 liborConvention(1*Days), liborEOM(1*Days),
-                dayCounter, h) {
+                dayCounter, std::move(h)) {
         QL_REQUIRE(currency!=EURCurrency(),
                    "for EUR Libor dedicated EurLibor constructor must be used");
     }

--- a/ql/indexes/ibor/libor.hpp
+++ b/ql/indexes/ibor/libor.hpp
@@ -37,13 +37,13 @@ namespace QuantLib {
     */
     class Libor : public IborIndex {
       public:
-        Libor(const std::string& familyName,
+        Libor(std::string familyName,
               const Period& tenor,
               Natural settlementDays,
               const Currency& currency,
               const Calendar& financialCenterCalendar,
               const DayCounter& dayCounter,
-              const Handle<YieldTermStructure>& h = {});
+              Handle<YieldTermStructure> h = {});
         /*! \name Date calculations
 
             See <https://www.theice.com/marketdata/reports/170>.
@@ -54,7 +54,7 @@ namespace QuantLib {
         // @}
         //! \name Other methods
         //@{
-        ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        ext::shared_ptr<IborIndex> clone(Handle<YieldTermStructure> h) const override;
         // @}
         //! \name Other inspectors
         //@{
@@ -72,12 +72,12 @@ namespace QuantLib {
     */
     class DailyTenorLibor : public IborIndex {
       public:
-        DailyTenorLibor(const std::string& familyName,
+        DailyTenorLibor(std::string familyName,
                         Natural settlementDays,
                         const Currency& currency,
                         const Calendar& financialCenterCalendar,
                         const DayCounter& dayCounter,
-                        const Handle<YieldTermStructure>& h = {});
+                        Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/mosprime.hpp
+++ b/ql/indexes/ibor/mosprime.hpp
@@ -42,10 +42,10 @@ namespace QuantLib {
 	class Mosprime : public IborIndex {
 	public:
 		Mosprime(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
 			: IborIndex("MOSPRIME", tenor, (tenor == 1 * Days ? 0 : 1), RUBCurrency(),
 				Russia(), ModifiedFollowing, false,
-				ActualActual(ActualActual::ISDA), h) {}
+				ActualActual(ActualActual::ISDA), std::move(h)) {}
 	};
 
 }

--- a/ql/indexes/ibor/nzdlibor.hpp
+++ b/ql/indexes/ibor/nzdlibor.hpp
@@ -38,12 +38,12 @@ namespace QuantLib {
     class NZDLibor : public Libor {
       public:
         NZDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("NZDLibor", tenor,
                 2,
                 NZDCurrency(),
                 NewZealand(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/nzocr.hpp
+++ b/ql/indexes/ibor/nzocr.hpp
@@ -38,10 +38,10 @@ namespace QuantLib {
     */
     class Nzocr : public OvernightIndex {
       public:
-        explicit Nzocr(const Handle<YieldTermStructure>& h = {})
+        explicit Nzocr(Handle<YieldTermStructure> h = {})
         : OvernightIndex("Nzocr", 0, NZDCurrency(),
                          NewZealand(),
-                         Actual365Fixed(), h) {}
+                         Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/pribor.hpp
+++ b/ql/indexes/ibor/pribor.hpp
@@ -44,10 +44,10 @@ namespace QuantLib {
 	class Pribor : public IborIndex {
 	public:
 		Pribor(const Period& tenor,
-               const Handle<YieldTermStructure>& h = {})
+               Handle<YieldTermStructure> h = {})
 			: IborIndex("PRIBOR", tenor, (tenor == 1 * Days ? 0 : 2), CZKCurrency(),
 				CzechRepublic(), ModifiedFollowing, false,
-				Actual360(), h) {}
+				Actual360(), std::move(h)) {}
 	};
 
 }

--- a/ql/indexes/ibor/robor.hpp
+++ b/ql/indexes/ibor/robor.hpp
@@ -42,10 +42,10 @@ namespace QuantLib {
 	class Robor : public IborIndex {
 	public:
 		Robor(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {})
+              Handle<YieldTermStructure> h = {})
 			: IborIndex("ROBOR", tenor, (tenor == 1 * Days ? 0 : 2), RONCurrency(),
 				Romania(), ModifiedFollowing, false,
-				Actual360(), h) {}
+				Actual360(), std::move(h)) {}
 	};
 
 }

--- a/ql/indexes/ibor/seklibor.hpp
+++ b/ql/indexes/ibor/seklibor.hpp
@@ -39,12 +39,12 @@ namespace QuantLib {
     class SEKLibor : public Libor {
       public:
         SEKLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("SEKLibor", tenor,
                 2,
                 SEKCurrency(),
                 Sweden(),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/shibor.cpp
+++ b/ql/indexes/ibor/shibor.cpp
@@ -42,13 +42,13 @@ namespace QuantLib {
     }
 
     Shibor::Shibor(const Period& tenor,
-                   const Handle<YieldTermStructure>& h)
+                   Handle<YieldTermStructure> h)
     : IborIndex("Shibor", tenor, (tenor == 1*Days? 0 : 1), CNYCurrency(),
                 China(China::IB), shiborConvention(tenor), false,
-                Actual360(), h) {}
-    
+                Actual360(), std::move(h)) {}
+
     ext::shared_ptr<IborIndex> Shibor::clone(
-                                  const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(new Shibor(tenor(), h));
+                                  Handle<YieldTermStructure> h) const {
+        return ext::shared_ptr<IborIndex>(new Shibor(tenor(), std::move(h)));
     }
 }

--- a/ql/indexes/ibor/shibor.hpp
+++ b/ql/indexes/ibor/shibor.hpp
@@ -32,10 +32,10 @@ namespace QuantLib {
       public:
         Shibor(
             const Period& tenor,
-            const Handle<YieldTermStructure>& h = {});
+            Handle<YieldTermStructure> h = {});
 
         ext::shared_ptr<IborIndex>
-        clone(const Handle<YieldTermStructure>& forwarding) const override;
+        clone(Handle<YieldTermStructure> forwarding) const override;
     };
 
 }

--- a/ql/indexes/ibor/sofr.cpp
+++ b/ql/indexes/ibor/sofr.cpp
@@ -24,9 +24,9 @@
 
 namespace QuantLib {
 
-    Sofr::Sofr(const Handle<YieldTermStructure>& h)
+    Sofr::Sofr(Handle<YieldTermStructure> h)
     : OvernightIndex("SOFR", 0, USDCurrency(),
                      UnitedStates(UnitedStates::SOFR),
-                     Actual360(), h) {}
+                     Actual360(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/sofr.hpp
+++ b/ql/indexes/ibor/sofr.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
     //! %Sofr (Secured Overnight Financing Rate) index.
     class Sofr : public OvernightIndex {
       public:
-        explicit Sofr(const Handle<YieldTermStructure>& h = {});
+        explicit Sofr(Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/sonia.cpp
+++ b/ql/indexes/ibor/sonia.cpp
@@ -24,9 +24,9 @@
 
 namespace QuantLib {
 
-    Sonia::Sonia(const Handle<YieldTermStructure>& h)
+    Sonia::Sonia(Handle<YieldTermStructure> h)
     : OvernightIndex("Sonia", 0, GBPCurrency(),
                      UnitedKingdom(UnitedKingdom::Exchange),
-                     Actual365Fixed(), h) {}
+                     Actual365Fixed(), std::move(h)) {}
 
 }

--- a/ql/indexes/ibor/sonia.hpp
+++ b/ql/indexes/ibor/sonia.hpp
@@ -31,7 +31,7 @@ namespace QuantLib {
     //! %Sonia (Sterling Overnight Index Average) rate.
     class Sonia : public OvernightIndex {
       public:
-        explicit Sonia(const Handle<YieldTermStructure>& h = {});
+        explicit Sonia(Handle<YieldTermStructure> h = {});
     };
 
 }

--- a/ql/indexes/ibor/swestr.hpp
+++ b/ql/indexes/ibor/swestr.hpp
@@ -34,8 +34,8 @@ namespace QuantLib {
     //! %Swestr (Swedish krona Short Term Rate) index.
     class Swestr : public OvernightIndex {
       public:
-        explicit Swestr(const Handle<YieldTermStructure>& h = {})
-        : OvernightIndex("SWESTR", 0, SEKCurrency(), Sweden(), Actual360(), h) {}
+        explicit Swestr(Handle<YieldTermStructure> h = {})
+        : OvernightIndex("SWESTR", 0, SEKCurrency(), Sweden(), Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/thbfix.hpp
+++ b/ql/indexes/ibor/thbfix.hpp
@@ -50,13 +50,13 @@ namespace QuantLib {
     class THBFIX : public IborIndex {
       public:
         THBFIX(const Period& tenor,
-               const Handle<YieldTermStructure>& h = {})
+               Handle<YieldTermStructure> h = {})
         : IborIndex("THBFIX", tenor,
                     2,
                     THBCurrency(),
                     Thailand(),
                     ModifiedFollowing, true,
-                    Actual365Fixed(), h) {}
+                    Actual365Fixed(), std::move(h)) {}
     };
 }
 

--- a/ql/indexes/ibor/tibor.hpp
+++ b/ql/indexes/ibor/tibor.hpp
@@ -42,10 +42,10 @@ namespace QuantLib {
     class Tibor : public IborIndex {
       public:
         Tibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {})
+              Handle<YieldTermStructure> h = {})
         : IborIndex("Tibor", tenor, 2, JPYCurrency(),
                     Japan(), ModifiedFollowing,
-                    false, Actual365Fixed(), h) {}
+                    false, Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/tona.hpp
+++ b/ql/indexes/ibor/tona.hpp
@@ -38,10 +38,10 @@ namespace QuantLib {
     */
     class Tona : public OvernightIndex {
       public:
-        explicit Tona(const Handle<YieldTermStructure>& h = {})
+        explicit Tona(Handle<YieldTermStructure> h = {})
         : OvernightIndex("Tona", 0, JPYCurrency(),
                          Japan(),
-                         Actual365Fixed(), h) {}
+                         Actual365Fixed(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/ibor/trlibor.hpp
+++ b/ql/indexes/ibor/trlibor.hpp
@@ -41,14 +41,13 @@ namespace QuantLib {
     class TRLibor : public IborIndex {
       public:
         TRLibor(const Period& tenor,
-                const Handle<YieldTermStructure>& h = {})
+                Handle<YieldTermStructure> h = {})
         : IborIndex("TRLibor", tenor, 0, TRYCurrency(),
                     Turkey(), ModifiedFollowing, false,
-                    Actual360(), h) {}
+                    Actual360(), std::move(h)) {}
     };
 
 }
 
 
 #endif
-

--- a/ql/indexes/ibor/usdlibor.hpp
+++ b/ql/indexes/ibor/usdlibor.hpp
@@ -42,30 +42,30 @@ namespace QuantLib {
     class USDLibor : public Libor {
       public:
         USDLibor(const Period& tenor,
-                 const Handle<YieldTermStructure>& h = {})
+                 Handle<YieldTermStructure> h = {})
         : Libor("USDLibor", tenor,
                 2,
                 USDCurrency(),
                 UnitedStates(UnitedStates::LiborImpact),
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
     //! base class for the one day deposit ICE %USD %LIBOR indexes
     class DailyTenorUSDLibor : public DailyTenorLibor {
       public:
         DailyTenorUSDLibor(Natural settlementDays,
-                           const Handle<YieldTermStructure>& h = {})
+                           Handle<YieldTermStructure> h = {})
         : DailyTenorLibor("USDLibor", settlementDays,
                           USDCurrency(),
                           UnitedStates(UnitedStates::LiborImpact),
-                          Actual360(), h) {}
+                          Actual360(), std::move(h)) {}
     };
 
     //! Overnight %USD %Libor index
     class USDLiborON : public DailyTenorUSDLibor {
       public:
-        explicit USDLiborON(const Handle<YieldTermStructure>& h = {})
-        : DailyTenorUSDLibor(0, h) {}
+        explicit USDLiborON(Handle<YieldTermStructure> h = {})
+        : DailyTenorUSDLibor(0, std::move(h)) {}
     };
 }
 

--- a/ql/indexes/ibor/wibor.hpp
+++ b/ql/indexes/ibor/wibor.hpp
@@ -42,10 +42,10 @@ namespace QuantLib {
 	class Wibor : public IborIndex {
 	public:
 		Wibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {})
+              Handle<YieldTermStructure> h = {})
 			: IborIndex("WIBOR", tenor, (tenor == 1 * Days ? 0 : 2), PLNCurrency(),
 				Poland(), ModifiedFollowing, false,
-				Actual365Fixed(), h) {}
+				Actual365Fixed(), std::move(h)) {}
 	};
 
 }

--- a/ql/indexes/ibor/zibor.hpp
+++ b/ql/indexes/ibor/zibor.hpp
@@ -43,10 +43,10 @@ namespace QuantLib {
     class Zibor : public IborIndex {
       public:
         Zibor(const Period& tenor,
-              const Handle<YieldTermStructure>& h = {})
+              Handle<YieldTermStructure> h = {})
         : IborIndex("Zibor", tenor, 2, CHFCurrency(),
                 Switzerland(), ModifiedFollowing, false,
-                Actual360(), h) {}
+                Actual360(), std::move(h)) {}
     };
 
 }

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -25,7 +25,7 @@
 
 namespace QuantLib {
 
-    IborIndex::IborIndex(const std::string& familyName,
+    IborIndex::IborIndex(std::string familyName,
                          const Period& tenor,
                          Natural settlementDays,
                          const Currency& currency,
@@ -34,7 +34,7 @@ namespace QuantLib {
                          bool endOfMonth,
                          const DayCounter& dayCounter,
                          Handle<YieldTermStructure> h)
-    : InterestRateIndex(familyName, tenor, settlementDays, currency, fixingCalendar, dayCounter),
+    : InterestRateIndex(std::move(familyName), tenor, settlementDays, currency, fixingCalendar, dayCounter),
       convention_(convention), termStructure_(std::move(h)), endOfMonth_(endOfMonth) {
         registerWith(termStructure_);
     }
@@ -58,8 +58,7 @@ namespace QuantLib {
                                         endOfMonth_);
     }
 
-    ext::shared_ptr<IborIndex> IborIndex::clone(
-                               const Handle<YieldTermStructure>& h) const {
+    ext::shared_ptr<IborIndex> IborIndex::clone(Handle<YieldTermStructure> h) const {
         return ext::make_shared<IborIndex>(
                                         familyName(),
                                                       tenor(),
@@ -69,28 +68,27 @@ namespace QuantLib {
                                                       businessDayConvention(),
                                                       endOfMonth(),
                                                       dayCounter(),
-                                                      h);
+                                                      std::move(h));
     }
 
 
-    OvernightIndex::OvernightIndex(const std::string& familyName,
+    OvernightIndex::OvernightIndex(std::string familyName,
                                    Natural settlementDays,
                                    const Currency& curr,
                                    const Calendar& fixCal,
                                    const DayCounter& dc,
-                                   const Handle<YieldTermStructure>& h)
-   : IborIndex(familyName, 1*Days, settlementDays, curr,
-               fixCal, Following, false, dc, h) {}
+                                   Handle<YieldTermStructure> h)
+   : IborIndex(std::move(familyName), 1*Days, settlementDays, curr,
+               fixCal, Following, false, dc, std::move(h)) {}
 
-    ext::shared_ptr<IborIndex> OvernightIndex::clone(
-                               const Handle<YieldTermStructure>& h) const {
+    ext::shared_ptr<IborIndex> OvernightIndex::clone(Handle<YieldTermStructure> h) const {
         return ext::shared_ptr<IborIndex>(
                                         new OvernightIndex(familyName(),
                                                            fixingDays(),
                                                            currency(),
                                                            fixingCalendar(),
                                                            dayCounter(),
-                                                           h));
+                                                           std::move(h)));
     }
 
 }

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     //! base class for Inter-Bank-Offered-Rate indexes (e.g. %Libor, etc.)
     class IborIndex : public InterestRateIndex {
       public:
-        IborIndex(const std::string& familyName,
+        IborIndex(std::string familyName,
                   const Period& tenor,
                   Natural settlementDays,
                   const Currency& currency,
@@ -58,8 +58,7 @@ namespace QuantLib {
         //! \name Other methods
         //@{
         //! returns a copy of itself linked to a different forwarding curve
-        virtual ext::shared_ptr<IborIndex> clone(
-                        const Handle<YieldTermStructure>& forwarding) const;
+        virtual ext::shared_ptr<IborIndex> clone(Handle<YieldTermStructure> forwarding) const;
         // @}
       protected:
         BusinessDayConvention convention_;
@@ -87,14 +86,14 @@ namespace QuantLib {
 
     class OvernightIndex : public IborIndex {
       public:
-        OvernightIndex(const std::string& familyName,
+        OvernightIndex(std::string familyName,
                        Natural settlementDays,
                        const Currency& currency,
                        const Calendar& fixingCalendar,
                        const DayCounter& dayCounter,
-                       const Handle<YieldTermStructure>& h = {});
+                       Handle<YieldTermStructure> h = {});
         //! returns a copy of itself linked to a different forwarding curve
-        ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        ext::shared_ptr<IborIndex> clone(Handle<YieldTermStructure> h) const override;
     };
 
 

--- a/ql/indexes/inflation/aucpi.hpp
+++ b/ql/indexes/inflation/aucpi.hpp
@@ -35,9 +35,9 @@ namespace QuantLib {
       public:
         AUCPI(Frequency frequency,
               bool revised,
-              const Handle<ZeroInflationTermStructure>& ts = {})
+              Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex(
-              "CPI", AustraliaRegion(), revised, frequency, Period(2, Months), AUDCurrency(), ts) {}
+              "CPI", AustraliaRegion(), revised, frequency, Period(2, Months), AUDCurrency(), std::move(ts)) {}
     };
 
 
@@ -47,7 +47,7 @@ namespace QuantLib {
         YYAUCPI(Frequency frequency,
                 bool revised,
                 bool interpolated,
-                const Handle<YoYInflationTermStructure>& ts = {})
+                Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_CPI",
                             AustraliaRegion(),
                             revised,
@@ -55,7 +55,7 @@ namespace QuantLib {
                             frequency,
                             Period(2, Months),
                             AUDCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -70,7 +70,7 @@ namespace QuantLib {
         YYAUCPIr(Frequency frequency,
                  bool revised,
                  bool interpolated,
-                 const Handle<YoYInflationTermStructure>& ts = {})
+                 Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_CPI",
                             AustraliaRegion(),
                             revised,
@@ -79,7 +79,7 @@ namespace QuantLib {
                             frequency,
                             Period(2, Months),
                             AUDCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflation/euhicp.hpp
+++ b/ql/indexes/inflation/euhicp.hpp
@@ -34,27 +34,27 @@ namespace QuantLib {
     //! EU HICP index
     class EUHICP : public ZeroInflationIndex {
       public:
-        explicit EUHICP(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit EUHICP(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex("HICP",
                              EURegion(),
                              false,
                              Monthly,
                              Period(1, Months), // availability
                              EURCurrency(),
-                             ts) {}
+                             std::move(ts)) {}
     };
 
     //! EU HICPXT index
     class EUHICPXT : public ZeroInflationIndex {
       public:
-        explicit EUHICPXT(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit EUHICPXT(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex("HICPXT",
                              EURegion(),
                              false,
                              Monthly,
                              Period(1, Months), // availability
                              EURCurrency(),
-                             ts) {}
+                             std::move(ts)) {}
     };
 
 
@@ -63,7 +63,7 @@ namespace QuantLib {
       public:
         explicit YYEUHICP(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_HICP",
                             EURegion(),
                             false,
@@ -71,7 +71,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             EURCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     //! Quoted year-on-year EU HICPXT
@@ -79,7 +79,7 @@ namespace QuantLib {
       public:
         explicit YYEUHICPXT(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_HICPXT",
                             EURegion(),
                             false,
@@ -87,7 +87,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             EURCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -101,7 +101,7 @@ namespace QuantLib {
       public:
         explicit YYEUHICPr(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_HICP",
                             EURegion(),
                             false,
@@ -110,7 +110,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             EURCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflation/frhicp.hpp
+++ b/ql/indexes/inflation/frhicp.hpp
@@ -33,9 +33,9 @@ namespace QuantLib {
     //! FR HICP index
     class FRHICP : public ZeroInflationIndex {
       public:
-        explicit FRHICP(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit FRHICP(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex(
-              "HICP", FranceRegion(), false, Monthly, Period(1, Months), EURCurrency(), ts) {}
+              "HICP", FranceRegion(), false, Monthly, Period(1, Months), EURCurrency(), std::move(ts)) {}
     };
 
 
@@ -44,7 +44,7 @@ namespace QuantLib {
       public:
         explicit YYFRHICP(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_HICP",
                             FranceRegion(),
                             false,
@@ -52,7 +52,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             EURCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -66,7 +66,7 @@ namespace QuantLib {
       public:
         explicit YYFRHICPr(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_HICP",
                             FranceRegion(),
                             false,
@@ -75,7 +75,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             EURCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflation/ukhicp.hpp
+++ b/ql/indexes/inflation/ukhicp.hpp
@@ -32,9 +32,9 @@ namespace QuantLib {
     //! UK HICP index
     class UKHICP : public ZeroInflationIndex {
       public:
-        explicit UKHICP(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit UKHICP(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex(
-              "HICP", UKRegion(), false, Monthly, Period(1, Months), GBPCurrency(), ts) {}
+              "HICP", UKRegion(), false, Monthly, Period(1, Months), GBPCurrency(), std::move(ts)) {}
     };
 }
 

--- a/ql/indexes/inflation/ukrpi.hpp
+++ b/ql/indexes/inflation/ukrpi.hpp
@@ -33,9 +33,9 @@ namespace QuantLib {
     //! UK Retail Price Inflation Index
     class UKRPI : public ZeroInflationIndex {
       public:
-        explicit UKRPI(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit UKRPI(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex(
-              "RPI", UKRegion(), false, Monthly, Period(1, Months), GBPCurrency(), ts) {}
+              "RPI", UKRegion(), false, Monthly, Period(1, Months), GBPCurrency(), std::move(ts)) {}
     };
 
 
@@ -44,7 +44,7 @@ namespace QuantLib {
       public:
         explicit YYUKRPI(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_RPI",
                             UKRegion(),
                             false,
@@ -52,7 +52,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             GBPCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -66,7 +66,7 @@ namespace QuantLib {
       public:
         explicit YYUKRPIr(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_RPI",
                             UKRegion(),
                             false,
@@ -75,7 +75,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             GBPCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflation/uscpi.hpp
+++ b/ql/indexes/inflation/uscpi.hpp
@@ -33,14 +33,14 @@ namespace QuantLib {
     //! US CPI index
     class USCPI : public ZeroInflationIndex {
       public:
-        explicit USCPI(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit USCPI(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex("CPI",
                              USRegion(),
                              false,
                              Monthly,
                              Period(1, Months), // availability
                              USDCurrency(),
-                             ts) {}
+                             std::move(ts)) {}
     };
 
 
@@ -49,7 +49,7 @@ namespace QuantLib {
       public:
         explicit YYUSCPI(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_CPI",
                             USRegion(),
                             false,
@@ -57,7 +57,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             USDCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -71,7 +71,7 @@ namespace QuantLib {
       public:
         explicit YYUSCPIr(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_CPI",
                             USRegion(),
                             false,
@@ -80,7 +80,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             USDCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflation/zacpi.hpp
+++ b/ql/indexes/inflation/zacpi.hpp
@@ -33,9 +33,9 @@ namespace QuantLib {
     //! South African Consumer Price Inflation Index
     class ZACPI : public ZeroInflationIndex {
       public:
-        explicit ZACPI(const Handle<ZeroInflationTermStructure>& ts = {})
+        explicit ZACPI(Handle<ZeroInflationTermStructure> ts = {})
         : ZeroInflationIndex(
-              "CPI", ZARegion(), false, Monthly, Period(1, Months), ZARCurrency(), ts) {}
+              "CPI", ZARegion(), false, Monthly, Period(1, Months), ZARCurrency(), std::move(ts)) {}
     };
 
 
@@ -44,7 +44,7 @@ namespace QuantLib {
       public:
         explicit YYZACPI(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YY_CPI",
                             ZARegion(),
                             false,
@@ -52,7 +52,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             ZARCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
 
@@ -66,7 +66,7 @@ namespace QuantLib {
       public:
         explicit YYZACPIr(
             bool interpolated,
-            const Handle<YoYInflationTermStructure>& ts = {})
+            Handle<YoYInflationTermStructure> ts = {})
         : YoYInflationIndex("YYR_CPI",
                             ZARegion(),
                             false,
@@ -75,7 +75,7 @@ namespace QuantLib {
                             Monthly,
                             Period(1, Months),
                             ZARCurrency(),
-                            ts) {}
+                            std::move(ts)) {}
     };
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -98,14 +98,14 @@ namespace QuantLib {
                           rates.begin(), forceOverwrite);
     }
 
-    ZeroInflationIndex::ZeroInflationIndex(const std::string& familyName,
+    ZeroInflationIndex::ZeroInflationIndex(std::string familyName,
                                            const Region& region,
                                            bool revised,
                                            Frequency frequency,
                                            const Period& availabilityLag,
                                            const Currency& currency,
                                            Handle<ZeroInflationTermStructure> zeroInflation)
-    : InflationIndex(familyName, region, revised, frequency, availabilityLag, currency),
+    : InflationIndex(std::move(familyName), region, revised, frequency, availabilityLag, currency),
       zeroInflation_(std::move(zeroInflation)) {
         registerWith(zeroInflation_);
     }
@@ -185,10 +185,9 @@ namespace QuantLib {
     }
 
 
-    ext::shared_ptr<ZeroInflationIndex> ZeroInflationIndex::clone(
-                          const Handle<ZeroInflationTermStructure>& h) const {
+    ext::shared_ptr<ZeroInflationIndex> ZeroInflationIndex::clone(Handle<ZeroInflationTermStructure> h) const {
         return ext::make_shared<ZeroInflationIndex>(
-            familyName_, region_, revised_, frequency_, availabilityLag_, currency_, h);
+            familyName_, region_, revised_, frequency_, availabilityLag_, currency_, std::move(h));
     }
 
 
@@ -206,7 +205,7 @@ namespace QuantLib {
 
     QL_DEPRECATED_DISABLE_WARNING
 
-    YoYInflationIndex::YoYInflationIndex(const std::string& familyName,
+    YoYInflationIndex::YoYInflationIndex(std::string familyName,
                                          const Region& region,
                                          bool revised,
                                          bool interpolated,
@@ -214,12 +213,12 @@ namespace QuantLib {
                                          const Period& availabilityLag,
                                          const Currency& currency,
                                          Handle<YoYInflationTermStructure> yoyInflation)
-    : YoYInflationIndex(familyName, region, revised, interpolated, false,
+    : YoYInflationIndex(std::move(familyName), region, revised, interpolated, false,
                         frequency, availabilityLag, currency, std::move(yoyInflation)) {}
 
     QL_DEPRECATED_ENABLE_WARNING
 
-    YoYInflationIndex::YoYInflationIndex(const std::string& familyName,
+    YoYInflationIndex::YoYInflationIndex(std::string familyName,
                                          const Region& region,
                                          bool revised,
                                          bool interpolated,
@@ -228,10 +227,10 @@ namespace QuantLib {
                                          const Period& availabilityLag,
                                          const Currency& currency,
                                          Handle<YoYInflationTermStructure> yoyInflation)
-    : InflationIndex(familyName, region, revised, frequency, availabilityLag, currency),
+    : InflationIndex(std::move(familyName), region, revised, frequency, availabilityLag, currency),
       interpolated_(interpolated), ratio_(ratio), yoyInflation_(std::move(yoyInflation)) {
         if (ratio)
-            underlyingIndex_ = ext::make_shared<ZeroInflationIndex>(familyName, region, revised,
+            underlyingIndex_ = ext::make_shared<ZeroInflationIndex>(familyName_, region, revised,
                                                                     frequency, availabilityLag, currency);
         registerWith(yoyInflation_);
     }
@@ -313,14 +312,13 @@ namespace QuantLib {
         return yoyInflation_->yoyRate(d,0*Days);
     }
 
-    ext::shared_ptr<YoYInflationIndex> YoYInflationIndex::clone(
-                           const Handle<YoYInflationTermStructure>& h) const {
+    ext::shared_ptr<YoYInflationIndex> YoYInflationIndex::clone(Handle<YoYInflationTermStructure> h) const {
         if (ratio_) {
-            return ext::make_shared<YoYInflationIndex>(underlyingIndex_, interpolated_, h);
+            return ext::make_shared<YoYInflationIndex>(underlyingIndex_, interpolated_, std::move(h));
         } else {
             return ext::make_shared<YoYInflationIndex>(familyName_, region_, revised_,
                                                        interpolated_, frequency_,
-                                                       availabilityLag_, currency_, h);
+                                                       availabilityLag_, currency_, std::move(h));
         }
     }
 

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -150,7 +150,7 @@ namespace QuantLib {
     class ZeroInflationIndex : public InflationIndex {
       public:
         ZeroInflationIndex(
-            const std::string& familyName,
+            std::string familyName,
             const Region& region,
             bool revised,
             Frequency frequency,
@@ -169,7 +169,7 @@ namespace QuantLib {
         //@{
         Date lastFixingDate() const;
         Handle<ZeroInflationTermStructure> zeroInflationTermStructure() const;
-        ext::shared_ptr<ZeroInflationIndex> clone(const Handle<ZeroInflationTermStructure>& h) const;
+        ext::shared_ptr<ZeroInflationIndex> clone(Handle<ZeroInflationTermStructure> h) const;
         //@}
       private:
         bool needsForecast(const Date& fixingDate) const;
@@ -202,7 +202,7 @@ namespace QuantLib {
             via the `addFixing` or `addFixings` method.
         */
         YoYInflationIndex(
-            const std::string& familyName,
+            std::string familyName,
             const Region& region,
             bool revised,
             bool interpolated,
@@ -224,7 +224,7 @@ namespace QuantLib {
         */
         QL_DEPRECATED
         YoYInflationIndex(
-            const std::string& familyName,
+            std::string familyName,
             const Region& region,
             bool revised,
             bool interpolated,
@@ -251,7 +251,7 @@ namespace QuantLib {
         ext::shared_ptr<ZeroInflationIndex> underlyingIndex() const;
         Handle<YoYInflationTermStructure> yoyInflationTermStructure() const;
 
-        ext::shared_ptr<YoYInflationIndex> clone(const Handle<YoYInflationTermStructure>& h) const;
+        ext::shared_ptr<YoYInflationIndex> clone(Handle<YoYInflationTermStructure> h) const;
         //@}
 
       protected:

--- a/ql/indexes/swap/chfliborswap.cpp
+++ b/ql/indexes/swap/chfliborswap.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
 
     ChfLiborSwapIsdaFix::ChfLiborSwapIsdaFix(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& h)
+                                Handle<YieldTermStructure> h)
     : SwapIndex("ChfLiborSwapIsdaFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -38,13 +38,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, std::move(h)))) {}
 
     ChfLiborSwapIsdaFix::ChfLiborSwapIsdaFix(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("ChfLiborSwapIsdaFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 }

--- a/ql/indexes/swap/chfliborswap.hpp
+++ b/ql/indexes/swap/chfliborswap.hpp
@@ -41,10 +41,10 @@ namespace QuantLib {
     class ChfLiborSwapIsdaFix : public SwapIndex {
       public:
         ChfLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& h = {});
+                            Handle<YieldTermStructure> h = {});
         ChfLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& forwarding,
-                            const Handle<YieldTermStructure>& discounting);
+                            Handle<YieldTermStructure> forwarding,
+                            Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swap/euriborswap.cpp
+++ b/ql/indexes/swap/euriborswap.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
 
     EuriborSwapIsdaFixA::EuriborSwapIsdaFixA(
                                         const Period& tenor,
-                                        const Handle<YieldTermStructure>& h)
+                                        Handle<YieldTermStructure> h)
     : SwapIndex("EuriborSwapIsdaFixA", // familyName
                 tenor,
                 2, // settlementDays
@@ -38,13 +38,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(h)))) {}
 
     EuriborSwapIsdaFixA::EuriborSwapIsdaFixA(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EuriborSwapIsdaFixA", // familyName
                 tenor,
                 2, // settlementDays
@@ -54,13 +54,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
                                         const Period& tenor,
-                                        const Handle<YieldTermStructure>& h)
+                                        Handle<YieldTermStructure> h)
     : SwapIndex("EuriborSwapIsdaFixB", // familyName
                 tenor,
                 2, // settlementDays
@@ -70,13 +70,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(h)))) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EuriborSwapIsdaFixB", // familyName
                 tenor,
                 2, // settlementDays
@@ -86,13 +86,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 
     EuriborSwapIfrFix::EuriborSwapIfrFix(const Period& tenor,
-                                         const Handle<YieldTermStructure>& h)
+                                         Handle<YieldTermStructure> h)
     : SwapIndex("EuriborSwapIfrFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -102,13 +102,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(h)))) {}
 
     EuriborSwapIfrFix::EuriborSwapIfrFix(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EuriborSwapIfrFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -118,9 +118,9 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 
 }

--- a/ql/indexes/swap/euriborswap.hpp
+++ b/ql/indexes/swap/euriborswap.hpp
@@ -41,10 +41,10 @@ namespace QuantLib {
     class EuriborSwapIsdaFixA : public SwapIndex {
       public:
         EuriborSwapIsdaFixA(const Period& tenor,
-                            const Handle<YieldTermStructure>& h = {});
+                            Handle<YieldTermStructure> h = {});
         EuriborSwapIsdaFixA(const Period& tenor,
-                            const Handle<YieldTermStructure>& forwarding,
-                            const Handle<YieldTermStructure>& discounting);
+                            Handle<YieldTermStructure> forwarding,
+                            Handle<YieldTermStructure> discounting);
     };
 
     //! %EuriborSwapIsdaFixB index base class
@@ -60,10 +60,10 @@ namespace QuantLib {
     class EuriborSwapIsdaFixB : public SwapIndex {
       public:
         EuriborSwapIsdaFixB(const Period& tenor,
-                            const Handle<YieldTermStructure>& h = {});
+                            Handle<YieldTermStructure> h = {});
         EuriborSwapIsdaFixB(const Period& tenor,
-                            const Handle<YieldTermStructure>& forwarding,
-                            const Handle<YieldTermStructure>& discounting);
+                            Handle<YieldTermStructure> forwarding,
+                            Handle<YieldTermStructure> discounting);
     };
 
     //! %EuriborSwapIfrFix index base class
@@ -76,10 +76,10 @@ namespace QuantLib {
     class EuriborSwapIfrFix : public SwapIndex {
       public:
         EuriborSwapIfrFix(const Period& tenor,
-                          const Handle<YieldTermStructure>& h = {});
+                          Handle<YieldTermStructure> h = {});
         EuriborSwapIfrFix(const Period& tenor,
-                          const Handle<YieldTermStructure>& forwarding,
-                          const Handle<YieldTermStructure>& discounting);
+                          Handle<YieldTermStructure> forwarding,
+                          Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swap/eurliborswap.cpp
+++ b/ql/indexes/swap/eurliborswap.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
 
     EurLiborSwapIsdaFixA::EurLiborSwapIsdaFixA(
                                         const Period& tenor,
-                                        const Handle<YieldTermStructure>& h)
+                                        Handle<YieldTermStructure> h)
     : SwapIndex("EurLiborSwapIsdaFixA", // familyName
                 tenor,
                 2, // settlementDays
@@ -38,13 +38,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(h)))) {}
 
     EurLiborSwapIsdaFixA::EurLiborSwapIsdaFixA(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EurLiborSwapIsdaFixA", // familyName
                 tenor,
                 2, // settlementDays
@@ -54,13 +54,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
                                         const Period& tenor,
-                                        const Handle<YieldTermStructure>& h)
+                                        Handle<YieldTermStructure> h)
     : SwapIndex("EurLiborSwapIsdaFixB", // familyName
                 tenor,
                 2, // settlementDays
@@ -70,13 +70,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(h)))) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EurLiborSwapIsdaFixB", // familyName
                 tenor,
                 2, // settlementDays
@@ -86,13 +86,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
                                         const Period& tenor,
-                                        const Handle<YieldTermStructure>& h)
+                                        Handle<YieldTermStructure> h)
     : SwapIndex("EurLiborSwapIfrFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -102,13 +102,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(h)))) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("EurLiborSwapIfrFix", // familyName
                 tenor,
                 2, // settlementDays
@@ -118,8 +118,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 }

--- a/ql/indexes/swap/eurliborswap.hpp
+++ b/ql/indexes/swap/eurliborswap.hpp
@@ -41,10 +41,10 @@ namespace QuantLib {
     class EurLiborSwapIsdaFixA : public SwapIndex {
       public:
         EurLiborSwapIsdaFixA(const Period& tenor,
-                             const Handle<YieldTermStructure>& h = {});
+                             Handle<YieldTermStructure> h = {});
         EurLiborSwapIsdaFixA(const Period& tenor,
-                             const Handle<YieldTermStructure>& forwarding,
-                             const Handle<YieldTermStructure>& discounting);
+                             Handle<YieldTermStructure> forwarding,
+                             Handle<YieldTermStructure> discounting);
     };
 
     //! %EurLiborSwapIsdaFixB index base class
@@ -60,10 +60,10 @@ namespace QuantLib {
     class EurLiborSwapIsdaFixB : public SwapIndex {
       public:
         EurLiborSwapIsdaFixB(const Period& tenor,
-                             const Handle<YieldTermStructure>& h = {});
+                             Handle<YieldTermStructure> h = {});
         EurLiborSwapIsdaFixB(const Period& tenor,
-                             const Handle<YieldTermStructure>& forwarding,
-                             const Handle<YieldTermStructure>& discounting);
+                             Handle<YieldTermStructure> forwarding,
+                             Handle<YieldTermStructure> discounting);
     };
 
 
@@ -77,10 +77,10 @@ namespace QuantLib {
     class EurLiborSwapIfrFix : public SwapIndex {
       public:
         EurLiborSwapIfrFix(const Period& tenor,
-                           const Handle<YieldTermStructure>& h = {});
+                           Handle<YieldTermStructure> h = {});
         EurLiborSwapIfrFix(const Period& tenor,
-                           const Handle<YieldTermStructure>& forwarding,
-                           const Handle<YieldTermStructure>& discounting);
+                           Handle<YieldTermStructure> forwarding,
+                           Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swap/gbpliborswap.cpp
+++ b/ql/indexes/swap/gbpliborswap.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
 
     GbpLiborSwapIsdaFix::GbpLiborSwapIsdaFix(
                             const Period& tenor,
-                            const Handle<YieldTermStructure>& h)
+                            Handle<YieldTermStructure> h)
     : SwapIndex("GbpLiborSwapIsdaFix", // familyName
                 tenor,
                 0, // settlementDays
@@ -39,13 +39,13 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, h))) {}
+                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, std::move(h))) :
+                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, std::move(h)))) {}
 
     GbpLiborSwapIsdaFix::GbpLiborSwapIsdaFix(
                             const Period& tenor,
-                            const Handle<YieldTermStructure>& forwarding,
-                            const Handle<YieldTermStructure>& discounting)
+                            Handle<YieldTermStructure> forwarding,
+                            Handle<YieldTermStructure> discounting)
     : SwapIndex("GbpLiborSwapIsdaFix", // familyName
                 tenor,
                 0, // settlementDays
@@ -56,8 +56,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, forwarding)),
-                discounting) {}
+                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, std::move(forwarding))) :
+                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 }

--- a/ql/indexes/swap/gbpliborswap.hpp
+++ b/ql/indexes/swap/gbpliborswap.hpp
@@ -41,10 +41,10 @@ namespace QuantLib {
     class GbpLiborSwapIsdaFix : public SwapIndex {
       public:
         GbpLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& h = {});
+                            Handle<YieldTermStructure> h = {});
         GbpLiborSwapIsdaFix(const Period& tenor,
-                            const Handle<YieldTermStructure>& forwarding,
-                            const Handle<YieldTermStructure>& discounting);
+                            Handle<YieldTermStructure> forwarding,
+                            Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swap/jpyliborswap.cpp
+++ b/ql/indexes/swap/jpyliborswap.cpp
@@ -27,7 +27,7 @@ namespace QuantLib {
 
     JpyLiborSwapIsdaFixAm::JpyLiborSwapIsdaFixAm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& h)
+                                Handle<YieldTermStructure> h)
     : SwapIndex("JpyLiborSwapIsdaFixAm", // familyName
                 tenor,
                 2, // settlementDays
@@ -36,12 +36,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, std::move(h)))) {}
 
     JpyLiborSwapIsdaFixAm::JpyLiborSwapIsdaFixAm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("JpyLiborSwapIsdaFixAm", // familyName
                 tenor,
                 2, // settlementDays
@@ -50,12 +50,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
-                discounting) {}
+                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& h)
+                                Handle<YieldTermStructure> h)
     : SwapIndex("JpyLiborSwapIsdaFixPm", // familyName
                 tenor,
                 2, // settlementDays
@@ -64,12 +64,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, std::move(h)))) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("JpyLiborSwapIsdaFixPm", // familyName
                 tenor,
                 2, // settlementDays
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
-                discounting) {}
+                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 }

--- a/ql/indexes/swap/jpyliborswap.hpp
+++ b/ql/indexes/swap/jpyliborswap.hpp
@@ -40,10 +40,10 @@ namespace QuantLib {
     class JpyLiborSwapIsdaFixAm : public SwapIndex {
       public:
         JpyLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h = {});
+                              Handle<YieldTermStructure> h = {});
         JpyLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& forwarding,
-                              const Handle<YieldTermStructure>& discounting);
+                              Handle<YieldTermStructure> forwarding,
+                              Handle<YieldTermStructure> discounting);
     };
 
     //! %JpyLiborSwapIsdaFixPm index base class
@@ -58,10 +58,10 @@ namespace QuantLib {
     class JpyLiborSwapIsdaFixPm : public SwapIndex {
       public:
         JpyLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h = {});
+                              Handle<YieldTermStructure> h = {});
         JpyLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& forwarding,
-                              const Handle<YieldTermStructure>& discounting);
+                              Handle<YieldTermStructure> forwarding,
+                              Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swap/usdliborswap.cpp
+++ b/ql/indexes/swap/usdliborswap.cpp
@@ -27,7 +27,7 @@ namespace QuantLib {
 
     UsdLiborSwapIsdaFixAm::UsdLiborSwapIsdaFixAm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& h)
+                                Handle<YieldTermStructure> h)
     : SwapIndex("UsdLiborSwapIsdaFixAm", // familyName
                 tenor,
                 2, // settlementDays
@@ -36,12 +36,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, std::move(h)))) {}
 
     UsdLiborSwapIsdaFixAm::UsdLiborSwapIsdaFixAm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("UsdLiborSwapIsdaFixAm", // familyName
                 tenor,
                 2, // settlementDays
@@ -50,12 +50,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
-                discounting) {}
+                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& h)
+                                Handle<YieldTermStructure> h)
     : SwapIndex("UsdLiborSwapIsdaFixPm", // familyName
                 tenor,
                 2, // settlementDays
@@ -64,12 +64,12 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, std::move(h)))) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
                                 const Period& tenor,
-                                const Handle<YieldTermStructure>& forwarding,
-                                const Handle<YieldTermStructure>& discounting)
+                                Handle<YieldTermStructure> forwarding,
+                                Handle<YieldTermStructure> discounting)
     : SwapIndex("UsdLiborSwapIsdaFixPm", // familyName
                 tenor,
                 2, // settlementDays
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
-                discounting) {}
+                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, std::move(forwarding))),
+                std::move(discounting)) {}
 
 }

--- a/ql/indexes/swap/usdliborswap.hpp
+++ b/ql/indexes/swap/usdliborswap.hpp
@@ -40,10 +40,10 @@ namespace QuantLib {
     class UsdLiborSwapIsdaFixAm : public SwapIndex {
       public:
         UsdLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h = {});
+                              Handle<YieldTermStructure> h = {});
         UsdLiborSwapIsdaFixAm(const Period& tenor,
-                              const Handle<YieldTermStructure>& forwarding,
-                              const Handle<YieldTermStructure>& discounting);
+                              Handle<YieldTermStructure> forwarding,
+                              Handle<YieldTermStructure> discounting);
     };
 
     //! %UsdLiborSwapIsdaFixPm index base class
@@ -58,10 +58,10 @@ namespace QuantLib {
     class UsdLiborSwapIsdaFixPm : public SwapIndex {
       public:
         UsdLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& h = {});
+                              Handle<YieldTermStructure> h = {});
         UsdLiborSwapIsdaFixPm(const Period& tenor,
-                              const Handle<YieldTermStructure>& forwarding,
-                              const Handle<YieldTermStructure>& discounting);
+                              Handle<YieldTermStructure> forwarding,
+                              Handle<YieldTermStructure> discounting);
     };
 
 }

--- a/ql/indexes/swapindex.cpp
+++ b/ql/indexes/swapindex.cpp
@@ -26,7 +26,7 @@
 
 namespace QuantLib {
 
-    SwapIndex::SwapIndex(const std::string& familyName,
+    SwapIndex::SwapIndex(std::string familyName,
                          const Period& tenor,
                          Natural settlementDays,
                          const Currency& currency,
@@ -36,13 +36,13 @@ namespace QuantLib {
                          const DayCounter& fixedLegDayCounter,
                          ext::shared_ptr<IborIndex> iborIndex)
     : InterestRateIndex(
-          familyName, tenor, settlementDays, currency, fixingCalendar, fixedLegDayCounter),
+          std::move(familyName), tenor, settlementDays, currency, fixingCalendar, fixedLegDayCounter),
       tenor_(tenor), iborIndex_(std::move(iborIndex)), fixedLegTenor_(fixedLegTenor),
       fixedLegConvention_(fixedLegConvention), exogenousDiscount_(false) {
         registerWith(iborIndex_);
     }
 
-    SwapIndex::SwapIndex(const std::string& familyName,
+    SwapIndex::SwapIndex(std::string familyName,
                          const Period& tenor,
                          Natural settlementDays,
                          const Currency& currency,
@@ -53,7 +53,7 @@ namespace QuantLib {
                          ext::shared_ptr<IborIndex> iborIndex,
                          Handle<YieldTermStructure> discount)
     : InterestRateIndex(
-          familyName, tenor, settlementDays, currency, fixingCalendar, fixedLegDayCounter),
+          std::move(familyName), tenor, settlementDays, currency, fixingCalendar, fixedLegDayCounter),
       tenor_(tenor), iborIndex_(std::move(iborIndex)), fixedLegTenor_(fixedLegTenor),
       fixedLegConvention_(fixedLegConvention), exogenousDiscount_(true),
       discount_(std::move(discount)) {
@@ -109,7 +109,7 @@ namespace QuantLib {
     }
 
     ext::shared_ptr<SwapIndex>
-    SwapIndex::clone(const Handle<YieldTermStructure>& forwarding) const {
+    SwapIndex::clone(Handle<YieldTermStructure> forwarding) const {
 
         if (exogenousDiscount_)
             return ext::make_shared<SwapIndex>(familyName(),
@@ -120,7 +120,7 @@ namespace QuantLib {
                           fixedLegTenor(),
                           fixedLegConvention(),
                           dayCounter(),
-                          iborIndex_->clone(forwarding),
+                          iborIndex_->clone(std::move(forwarding)),
                           discount_);
         else
             return ext::make_shared<SwapIndex>(familyName(),
@@ -131,12 +131,12 @@ namespace QuantLib {
                           fixedLegTenor(),
                           fixedLegConvention(),
                           dayCounter(),
-                          iborIndex_->clone(forwarding));
+                          iborIndex_->clone(std::move(forwarding)));
     }
 
     ext::shared_ptr<SwapIndex>
-    SwapIndex::clone(const Handle<YieldTermStructure>& forwarding,
-                     const Handle<YieldTermStructure>& discounting) const {
+    SwapIndex::clone(Handle<YieldTermStructure> forwarding,
+                     Handle<YieldTermStructure> discounting) const {
         return ext::make_shared<SwapIndex>(familyName(),
                        tenor(),
                        fixingDays(),
@@ -145,8 +145,8 @@ namespace QuantLib {
                        fixedLegTenor(),
                        fixedLegConvention(),
                        dayCounter(),
-                       iborIndex_->clone(forwarding),
-                       discounting);
+                       iborIndex_->clone(std::move(forwarding)),
+                       std::move(discounting));
     }
 
     ext::shared_ptr<SwapIndex>
@@ -177,14 +177,14 @@ namespace QuantLib {
     }
 
     OvernightIndexedSwapIndex::OvernightIndexedSwapIndex(
-        const std::string& familyName,
+        std::string familyName,
         const Period& tenor,
         Natural settlementDays,
         const Currency& currency,
         const ext::shared_ptr<OvernightIndex>& overnightIndex,
         bool telescopicValueDates,
         RateAveraging::Type averagingMethod)
-    : SwapIndex(familyName,
+    : SwapIndex(std::move(familyName),
                 tenor,
                 settlementDays,
                 currency,
@@ -193,8 +193,8 @@ namespace QuantLib {
                 ModifiedFollowing,
                 overnightIndex->dayCounter(),
                 overnightIndex),
-      overnightIndex_(overnightIndex), 
-      telescopicValueDates_(telescopicValueDates), 
+      overnightIndex_(overnightIndex),
+      telescopicValueDates_(telescopicValueDates),
       averagingMethod_(averagingMethod) {}
 
 

--- a/ql/indexes/swapindex.hpp
+++ b/ql/indexes/swapindex.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
     //! base class for swap-rate indexes
     class SwapIndex : public InterestRateIndex {
       public:
-        SwapIndex(const std::string& familyName,
+        SwapIndex(std::string familyName,
                   const Period& tenor,
                   Natural settlementDays,
                   const Currency& currency,
@@ -49,7 +49,7 @@ namespace QuantLib {
                   BusinessDayConvention fixedLegConvention,
                   const DayCounter& fixedLegDayCounter,
                   ext::shared_ptr<IborIndex> iborIndex);
-        SwapIndex(const std::string& familyName,
+        SwapIndex(std::string familyName,
                   const Period& tenor,
                   Natural settlementDays,
                   const Currency& currency,
@@ -81,11 +81,11 @@ namespace QuantLib {
         //@{
         //! returns a copy of itself linked to a different forwarding curve
         virtual ext::shared_ptr<SwapIndex> clone(
-                        const Handle<YieldTermStructure>& forwarding) const;
+                        Handle<YieldTermStructure> forwarding) const;
         //! returns a copy of itself linked to different curves
         virtual ext::shared_ptr<SwapIndex> clone(
-                        const Handle<YieldTermStructure>& forwarding,
-                        const Handle<YieldTermStructure>& discounting) const;
+                        Handle<YieldTermStructure> forwarding,
+                        Handle<YieldTermStructure> discounting) const;
         //! returns a copy of itself with different tenor
         virtual ext::shared_ptr<SwapIndex> clone(
                         const Period& tenor) const;
@@ -109,7 +109,7 @@ namespace QuantLib {
     class OvernightIndexedSwapIndex : public SwapIndex {
       public:
         OvernightIndexedSwapIndex(
-                  const std::string& familyName,
+                  std::string familyName,
                   const Period& tenor,
                   Natural settlementDays,
                   const Currency& currency,


### PR DESCRIPTION
To limit the size of this PR I have started with the `ql/indexes` directory. Once it is merged I will submit another PR for other directories.

Besides `Handle`, I fixed a few `std::string` that were not being passed by value and moved.