### PR TITLE
Deprecate a few specific indexes no longer fixed.

### DIFF
--- a/ql/indexes/ibor/bibor.hpp
+++ b/ql/indexes/ibor/bibor.hpp
@@ -45,14 +45,14 @@ namespace QuantLib {
     };
 
 
-    //! 1-month %Euribor index
+    //! 1-month %Bibor index
     class Bibor1M : public Bibor {
       public:
         explicit Bibor1M(Handle<YieldTermStructure> h = {})
         : Bibor(Period(1, Months), std::move(h)) {}
     };
 
-    //! 2-months %Euribor index
+    //! 2-months %Bibor index
     class Bibor2M : public Bibor {
       public:
         explicit Bibor2M(Handle<YieldTermStructure> h = {})
@@ -73,8 +73,10 @@ namespace QuantLib {
         : Bibor(Period(6, Months), std::move(h)) {}
     };
 
-    //! 9-months %Bibor index
-    class Bibor9M : public Bibor {
+    /*! \deprecated If needed, use the Bibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Bibor class with an explicit tenor instead")]] Bibor9M : public Bibor {
       public:
         explicit Bibor9M(Handle<YieldTermStructure> h = {})
         : Bibor(Period(9, Months), std::move(h)) {}

--- a/ql/indexes/ibor/euribor.hpp
+++ b/ql/indexes/ibor/euribor.hpp
@@ -57,21 +57,31 @@ namespace QuantLib {
     };
 
     //! 1-week %Euribor index
-    class EuriborSW : public Euribor {
+    class Euribor1W : public Euribor {
       public:
-        explicit EuriborSW(Handle<YieldTermStructure> h = {})
+        explicit Euribor1W(Handle<YieldTermStructure> h = {})
         : Euribor(Period(1, Weeks), std::move(h)) {}
     };
 
-    //! 2-weeks %Euribor index
-    class Euribor2W : public Euribor {
+    /*! \deprecated Renamed to Euribor1W.
+         Deprecated in version 1.35.
+    */
+    [[deprecated("Renamed to Euribor1W")]]
+    typedef Euribor1W EuriborSW;
+    
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor2W : public Euribor {
       public:
         explicit Euribor2W(Handle<YieldTermStructure> h = {})
         : Euribor(Period(2, Weeks), std::move(h)) {}
     };
 
-    //! 3-weeks %Euribor index
-    class Euribor3W : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor3W : public Euribor {
       public:
         explicit Euribor3W(Handle<YieldTermStructure> h = {})
         : Euribor(Period(3, Weeks), std::move(h)) {}
@@ -84,8 +94,10 @@ namespace QuantLib {
         : Euribor(Period(1, Months), std::move(h)) {}
     };
 
-    //! 2-months %Euribor index
-    class Euribor2M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor2M : public Euribor {
       public:
         explicit Euribor2M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(2, Months), std::move(h)) {}
@@ -98,15 +110,19 @@ namespace QuantLib {
         : Euribor(Period(3, Months), std::move(h)) {}
     };
 
-    //! 4-months %Euribor index
-    class Euribor4M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor4M : public Euribor {
       public:
         explicit Euribor4M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(4, Months), std::move(h)) {}
     };
 
-    //! 5-months %Euribor index
-    class Euribor5M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor5M : public Euribor {
       public:
         explicit Euribor5M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(5, Months), std::move(h)) {}
@@ -119,36 +135,46 @@ namespace QuantLib {
         : Euribor(Period(6, Months), std::move(h)) {}
     };
 
-    //! 7-months %Euribor index
-    class Euribor7M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor7M : public Euribor {
       public:
         explicit Euribor7M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(7, Months), std::move(h)) {}
     };
 
-    //! 8-months %Euribor index
-    class Euribor8M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor8M : public Euribor {
       public:
         explicit Euribor8M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(8, Months), std::move(h)) {}
     };
 
-    //! 9-months %Euribor index
-    class Euribor9M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor9M : public Euribor {
       public:
         explicit Euribor9M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(9, Months), std::move(h)) {}
     };
 
-    //! 10-months %Euribor index
-    class Euribor10M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor10M : public Euribor {
       public:
         explicit Euribor10M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(10, Months), std::move(h)) {}
     };
 
-    //! 11-months %Euribor index
-    class Euribor11M : public Euribor {
+    /*! \deprecated If really needed, use the Euribor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If really needed, use the Euribor class with an explicit tenor instead")]] Euribor11M : public Euribor {
       public:
         explicit Euribor11M(Handle<YieldTermStructure> h = {})
         : Euribor(Period(11, Months), std::move(h)) {}
@@ -162,106 +188,136 @@ namespace QuantLib {
     };
 
 
-    //! 1-week %Euribor365 index
-    class Euribor365_SW : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_SW : public Euribor365 {
       public:
         explicit Euribor365_SW(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(1, Weeks), std::move(h)) {}
     };
 
-    //! 2-weeks %Euribor365 index
-    class Euribor365_2W : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_2W : public Euribor365 {
       public:
         explicit Euribor365_2W(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(2, Weeks), std::move(h)) {}
     };
 
-    //! 3-weeks %Euribor365 index
-    class Euribor365_3W : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_3W : public Euribor365 {
       public:
         explicit Euribor365_3W(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(3, Weeks), std::move(h)) {}
     };
 
-    //! 1-month %Euribor365 index
-    class Euribor365_1M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_1M : public Euribor365 {
       public:
         explicit Euribor365_1M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(1, Months), std::move(h)) {}
     };
 
-    //! 2-months %Euribor365 index
-    class Euribor365_2M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_2M : public Euribor365 {
       public:
         explicit Euribor365_2M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(2, Months), std::move(h)) {}
     };
 
-    //! 3-months %Euribor365 index
-    class Euribor365_3M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_3M : public Euribor365 {
       public:
         explicit Euribor365_3M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(3, Months), std::move(h)) {}
     };
 
-    //! 4-months %Euribor365 index
-    class Euribor365_4M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_4M : public Euribor365 {
       public:
         explicit Euribor365_4M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(4, Months), std::move(h)) {}
     };
 
-    //! 5-months %Euribor365 index
-    class Euribor365_5M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_5M : public Euribor365 {
       public:
         explicit Euribor365_5M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(5, Months), std::move(h)) {}
     };
 
-    //! 6-months %Euribor365 index
-    class Euribor365_6M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_6M : public Euribor365 {
       public:
         explicit Euribor365_6M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(6, Months), std::move(h)) {}
     };
 
-    //! 7-months %Euribor365 index
-    class Euribor365_7M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_7M : public Euribor365 {
       public:
         explicit Euribor365_7M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(7, Months), std::move(h)) {}
     };
 
-    //! 8-months %Euribor365 index
-    class Euribor365_8M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_8M : public Euribor365 {
       public:
         explicit Euribor365_8M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(8, Months), std::move(h)) {}
     };
 
-    //! 9-months %Euribor365 index
-    class Euribor365_9M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_9M : public Euribor365 {
       public:
         explicit Euribor365_9M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(9, Months), std::move(h)) {}
     };
 
-    //! 10-months %Euribor365 index
-    class Euribor365_10M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_10M : public Euribor365 {
       public:
         explicit Euribor365_10M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(10, Months), std::move(h)) {}
     };
 
-    //! 11-months %Euribor365 index
-    class Euribor365_11M : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_11M : public Euribor365 {
       public:
         explicit Euribor365_11M(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(11, Months), std::move(h)) {}
     };
 
-    //! 1-year %Euribor365 index
-    class Euribor365_1Y : public Euribor365 {
+    /*! \deprecated If needed, use the Euribor365 class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the Euribor365 class with an explicit tenor instead")]] Euribor365_1Y : public Euribor365 {
       public:
         explicit Euribor365_1Y(Handle<YieldTermStructure> h = {})
         : Euribor365(Period(1, Years), std::move(h)) {}

--- a/ql/indexes/ibor/eurlibor.hpp
+++ b/ql/indexes/ibor/eurlibor.hpp
@@ -77,20 +77,23 @@ namespace QuantLib {
         : DailyTenorEURLibor(0, std::move(h)) {}
     };
 
-    //! 1-week %EUR %Libor index
-    class EURLiborSW : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLiborSW : public EURLibor {
       public:
         explicit EURLiborSW(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(1, Weeks), std::move(h)) {}
     };
 
-    //! 2-weeks %EUR %Libor index
-    class EURLibor2W : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor2W : public EURLibor {
       public:
         explicit EURLibor2W(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(2, Weeks), std::move(h)) {}
     };
-
 
     //! 1-month %EUR %Libor index
     class EURLibor1M : public EURLibor {
@@ -99,8 +102,10 @@ namespace QuantLib {
         : EURLibor(Period(1, Months), std::move(h)) {}
     };
 
-    //! 2-months %EUR %Libor index
-    class EURLibor2M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor2M : public EURLibor {
       public:
         explicit EURLibor2M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(2, Months), std::move(h)) {}
@@ -113,15 +118,19 @@ namespace QuantLib {
         : EURLibor(Period(3, Months), std::move(h)) {}
     };
 
-    //! 4-months %EUR %Libor index
-    class EURLibor4M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor4M : public EURLibor {
       public:
         explicit EURLibor4M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(4, Months), std::move(h)) {}
     };
 
-    //! 5-months %EUR %Libor index
-    class EURLibor5M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor5M : public EURLibor {
       public:
         explicit EURLibor5M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(5, Months), std::move(h)) {}
@@ -134,36 +143,46 @@ namespace QuantLib {
         : EURLibor(Period(6, Months), std::move(h)) {}
     };
 
-    //! 7-months %EUR %Libor index
-    class EURLibor7M : public EURLibor{
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor7M : public EURLibor{
       public:
         explicit EURLibor7M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(7, Months), std::move(h)) {}
     };
 
-    //! 8-months %EUR %Libor index
-    class EURLibor8M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor8M : public EURLibor {
       public:
         explicit EURLibor8M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(8, Months), std::move(h)) {}
     };
 
-    //! 9-months %EUR %Libor index
-    class EURLibor9M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor9M : public EURLibor {
       public:
         explicit EURLibor9M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(9, Months), std::move(h)) {}
     };
 
-    //! 10-months %EUR %Libor index
-    class EURLibor10M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor10M : public EURLibor {
       public:
         explicit EURLibor10M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(10, Months), std::move(h)) {}
     };
 
-    //! 11-months %EUR %Libor index
-    class EURLibor11M : public EURLibor {
+    /*! \deprecated If needed, use the EURLibor class with an explicit tenor instead.
+                    Deprecated in version 1.35.
+    */
+    class [[deprecated("If needed, use the EURLibor class with an explicit tenor instead")]] EURLibor11M : public EURLibor {
       public:
         explicit EURLibor11M(Handle<YieldTermStructure> h = {})
         : EURLibor(Period(11, Months), std::move(h)) {}


### PR DESCRIPTION
They can be still instantiated by means of a generic constructor anyway.