### PR TITLE
Add lookback and lockout to the overnight coupon

### DIFF
--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -115,10 +115,6 @@ namespace QuantLib {
                     QL_REQUIRE(!curve.empty(),
                                "null term structure set to this instance of " << index->name());
 
-                    const bool isLookbackApplied = coupon_->fixingDays() != index->fixingDays();
-                    const bool isObservationShiftWithNoIntrinsicIndexFixingDelay =
-                        applyObservationShift && index->fixingDays() == 0;
-
                     const auto effectiveRate = [&index, &fixingDates, &date, &interestDates,
                                                 &dt](Size position) {
                         Rate fixing = index->fixing(fixingDates[position]);

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -129,7 +129,7 @@ namespace QuantLib {
                         return span * fixing;
                     };
 
-                    if (isLookbackApplied && !isObservationShiftWithNoIntrinsicIndexFixingDelay) {
+                    if (!coupon_->canApplyTelescopicFormula()) {
                         // With lookback applied, the telescopic formula cannot be used,
                         // we need to project each fixing in the coupon.
                         // Only in one particular case when observation shift is used and
@@ -245,8 +245,7 @@ namespace QuantLib {
            a grace period of 7 business after the evaluation date). This will
            lead to false coupon projections (see the warning the class header). */
 
-        QL_REQUIRE(!(fixingDays_ != overnightIndex->fixingDays() && telescopicValueDates &&
-                     !(applyObservationShift_ && overnightIndex->fixingDays() == 0)),
+        QL_REQUIRE(canApplyTelescopicFormula() || !telescopicValueDates,
                    "Telescopic formula cannot be applied for a coupon with lookback.");
 
         if (telescopicValueDates) {

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -137,9 +137,8 @@ namespace QuantLib {
         Date getFixingDate(const ext::shared_ptr<InterestRateIndex>& index,
                            const Date& valueDate,
                            Natural fixingDays) {
-            Date fixingDate =
-                index->fixingCalendar().advance(valueDate, -static_cast<Integer>(fixingDays), Days);
-            return fixingDate;
+            return index->fixingCalendar().advance(valueDate, -static_cast<Integer>(fixingDays),
+                                                   Days);
         }
     }
 
@@ -156,11 +155,11 @@ namespace QuantLib {
                     const DayCounter& dayCounter,
                     bool telescopicValueDates,
                     RateAveraging::Type averagingMethod,
-                    ext::optional<Natural> fixingDays,
+                    Natural fixingDays,
                     Natural lockoutDays,
                     bool applyObservationShift)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
-                         fixingDays ? *fixingDays : overnightIndex ? overnightIndex->fixingDays() : 0,
+                         fixingDays,
                          overnightIndex,
                          gearing, spread,
                          refPeriodStart, refPeriodEnd,

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -463,7 +463,7 @@ namespace QuantLib {
         lockoutDays_ = lockoutDays;
         return *this;
     }
-    OvernightLeg& OvernightLeg::withApplyObservationShift(bool applyObservationShift) {
+    OvernightLeg& OvernightLeg::withObservationShift(bool applyObservationShift) {
         applyObservationShift_ = applyObservationShift;
         return *this;
     }

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -159,11 +159,14 @@ namespace QuantLib {
                             // interest over that fixing is accrued) are not fixed at lockout,
                             // hence they do not cancel out.
                             i = std::max(nLockout, i);
+                            
+                            // With no lockout, the loop is skipped because i = n.
                             while (i < n) {
                                 compoundFactor *= (1.0 + effectiveRate(i));
                                 ++i;
                             }
                         } else {
+                            // No lockout and date is different than last interest date.
                             // The last fixing is not used for its full period (the date is between
                             // its start and end date).  We can use the telescopic formula until the
                             // previous date, then we'll add the missing bit.
@@ -307,7 +310,7 @@ namespace QuantLib {
                     // corresponding to a deposit instrument linked to the index.
                     // This is to ensure that future projections (which are computed 
                     // based on the value dates) of the index do not
-                    // yield any additional convexity corrections. 
+                    // yield any convexity corrections. 
                     valueDates_[i] = overnightIndex->valueDate(tmp);
             }
         }

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -117,7 +117,7 @@ namespace QuantLib {
 
                     const bool isLookbackApplied = coupon_->fixingDays() != index->fixingDays();
                     const bool isObservationShiftWithNoIntrinsicIndexFixingDelay =
-                        coupon_->applyObservationShift() && index->fixingDays() == 0;
+                        applyObservationShift && index->fixingDays() == 0;
 
                     const auto effectiveRate = [&index, &fixingDates, &date, &interestDates,
                                                 &dt](Size position) {
@@ -245,7 +245,8 @@ namespace QuantLib {
            a grace period of 7 business after the evaluation date). This will
            lead to false coupon projections (see the warning the class header). */
 
-        QL_REQUIRE(!(fixingDays_ != overnightIndex->fixingDays() && telescopicValueDates),
+        QL_REQUIRE(!(fixingDays_ != overnightIndex->fixingDays() && telescopicValueDates &&
+                     !(applyObservationShift_ && overnightIndex->fixingDays() == 0)),
                    "Telescopic formula cannot be applied for a coupon with lookback.");
 
         if (telescopicValueDates) {

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -60,7 +60,10 @@ namespace QuantLib {
                     const Date& refPeriodEnd = Date(),
                     const DayCounter& dayCounter = DayCounter(),
                     bool telescopicValueDates = false,
-                    RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                    RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                    ext::optional<Natural> fixingDays = ext::nullopt,
+                    Natural lockoutDays = 0,
+                    bool applyObservationShift = false);
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded
@@ -90,6 +93,8 @@ namespace QuantLib {
         Size n_;
         std::vector<Time> dt_;
         RateAveraging::Type averagingMethod_;
+        Natural lockoutDays_;
+        bool applyObservationShift_;
 
         Rate averageRate(const Date& date) const;
     };

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -137,7 +137,7 @@ namespace QuantLib {
         OvernightLeg& withAveragingMethod(RateAveraging::Type averagingMethod);
         OvernightLeg& withLookbackDays(Natural lookbackDays);
         OvernightLeg& withLockoutDays(Natural lockoutDays);
-        OvernightLeg& withApplyObservationShift(bool applyObservationShift);
+        OvernightLeg& withObservationShift(bool applyObservationShift = true);
         operator Leg() const;
       private:
         Schedule schedule_;

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -74,6 +74,8 @@ namespace QuantLib {
         const std::vector<Rate>& indexFixings() const;
         //! value dates for the rates to be compounded
         const std::vector<Date>& valueDates() const { return valueDates_; }
+        //! value dates for the rates to be compounded
+        const std::vector<Date>& interestDates() const { return interestDates_; }
         //! averaging method
         const RateAveraging::Type averagingMethod() const { return averagingMethod_; }
         //! lockout days
@@ -92,7 +94,7 @@ namespace QuantLib {
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-        std::vector<Date> valueDates_, fixingDates_;
+        std::vector<Date> valueDates_, interestDates_, fixingDates_;
         mutable std::vector<Rate> fixings_;
         Size n_;
         std::vector<Time> dt_;

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -93,6 +93,14 @@ namespace QuantLib {
         //@{
         void accept(AcyclicVisitor&) override;
         //@}
+        //! \name Telescopic property
+        //! Telescopic formula cannot be used with lookback days
+        //! being different than intrinsic index fixing delay.
+        //! Only when index fixing delay is 0 and observation shift is used,
+        //! we can apply telescopic formula, when applying lookback period.
+        //@{
+        const bool canApplyTelescopicFormula() const;
+        //@}
       private:
         std::vector<Date> valueDates_, interestDates_, fixingDates_;
         mutable std::vector<Rate> fixings_;
@@ -104,6 +112,11 @@ namespace QuantLib {
 
         Rate averageRate(const Date& date) const;
     };
+
+    inline const bool OvernightIndexedCoupon::canApplyTelescopicFormula() const {
+        return fixingDays_ == index_->fixingDays() ||
+               (applyObservationShift_ && index_->fixingDays() == 0);
+    }
 
 
     //! helper class building a sequence of overnight coupons

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -76,6 +76,10 @@ namespace QuantLib {
         const std::vector<Date>& valueDates() const { return valueDates_; }
         //! averaging method
         const RateAveraging::Type averagingMethod() const { return averagingMethod_; }
+        //! lockout days
+        const Natural lockoutDays() const { return lockoutDays_; }
+        //! apply observation shift
+        const bool applyObservationShift() const { return applyObservationShift_; }
         //@}
         //! \name FloatingRateCoupon interface
         //@{

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -61,7 +61,7 @@ namespace QuantLib {
                     const DayCounter& dayCounter = DayCounter(),
                     bool telescopicValueDates = false,
                     RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                    ext::optional<Natural> fixingDays = ext::nullopt,
+                    Natural fixingDays = Null<Natural>(),
                     Natural lockoutDays = 0,
                     bool applyObservationShift = false);
         //! \name Inspectors

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -74,7 +74,7 @@ namespace QuantLib {
         const std::vector<Rate>& indexFixings() const;
         //! value dates for the rates to be compounded
         const std::vector<Date>& valueDates() const { return valueDates_; }
-        //! value dates for the rates to be compounded
+        //! interest dates for the rates to be compounded
         const std::vector<Date>& interestDates() const { return interestDates_; }
         //! averaging method
         const RateAveraging::Type averagingMethod() const { return averagingMethod_; }

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -61,7 +61,7 @@ namespace QuantLib {
                     const DayCounter& dayCounter = DayCounter(),
                     bool telescopicValueDates = false,
                     RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                    Natural fixingDays = Null<Natural>(),
+                    Natural lookbackDays = Null<Natural>(),
                     Natural lockoutDays = 0,
                     bool applyObservationShift = false);
         //! \name Inspectors
@@ -122,6 +122,9 @@ namespace QuantLib {
         OvernightLeg& withSpreads(const std::vector<Spread>& spreads);
         OvernightLeg& withTelescopicValueDates(bool telescopicValueDates);
         OvernightLeg& withAveragingMethod(RateAveraging::Type averagingMethod);
+        OvernightLeg& withLookbackDays(Natural lookbackDays);
+        OvernightLeg& withLockoutDays(Natural lockoutDays);
+        OvernightLeg& withApplyObservationShift(bool applyObservationShift);
         operator Leg() const;
       private:
         Schedule schedule_;
@@ -135,6 +138,9 @@ namespace QuantLib {
         std::vector<Spread> spreads_;
         bool telescopicValueDates_ = false;
         RateAveraging::Type averagingMethod_ = RateAveraging::Compound;
+        Natural lookbackDays_ = Null<Natural>();
+        Natural lockoutDays_ = 0;
+        bool applyObservationShift_ = false;
     };
 
 }

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -148,7 +148,8 @@ namespace QuantLib {
                                  overnightIndex_, overnightSpread_,
                                  paymentLag_, paymentAdjustment_,
                                  paymentCalendar_, telescopicValueDates_, 
-                                 averagingMethod_));
+                                 averagingMethod_, lookbackDays_,
+                                 lockoutDays_, applyObservationShift_));
 
         if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
@@ -331,4 +332,18 @@ namespace QuantLib {
         return *this;
     }
 
+    MakeOIS& MakeOIS::withLookbackDays(Natural lookbackDays) {
+        lookbackDays_ = lookbackDays;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withLockoutDays(Natural lockoutDays) {
+        lockoutDays_ = lockoutDays;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withApplyObservationShift(bool applyObservationShift) {
+        applyObservationShift_ = applyObservationShift;
+        return *this;
+    }
 }

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -342,8 +342,9 @@ namespace QuantLib {
         return *this;
     }
 
-    MakeOIS& MakeOIS::withApplyObservationShift(bool applyObservationShift) {
+    MakeOIS& MakeOIS::withObservationShift(bool applyObservationShift) {
         applyObservationShift_ = applyObservationShift;
         return *this;
     }
+
 }

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -88,6 +88,10 @@ namespace QuantLib {
 
         MakeOIS& withAveragingMethod(RateAveraging::Type averagingMethod);
 
+        MakeOIS& withLookbackDays(Natural lookbackDays);
+        MakeOIS& withLockoutDays(Natural lockoutDays);
+        MakeOIS& withApplyObservationShift(bool applyObservationShift);
+
         MakeOIS& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
       private:
@@ -124,6 +128,9 @@ namespace QuantLib {
 
         bool telescopicValueDates_ = false;
         RateAveraging::Type averagingMethod_ = RateAveraging::Compound;
+        Natural lookbackDays_ = Null<Natural>();
+        Natural lockoutDays_ = 0;
+        bool applyObservationShift_ = false;
     };
 
 }

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -90,7 +90,7 @@ namespace QuantLib {
 
         MakeOIS& withLookbackDays(Natural lookbackDays);
         MakeOIS& withLockoutDays(Natural lockoutDays);
-        MakeOIS& withApplyObservationShift(bool applyObservationShift);
+        MakeOIS& withObservationShift(bool applyObservationShift = true);
 
         MakeOIS& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -38,7 +38,10 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
-                                               RateAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod,
+                                               Natural lookbackDays,
+                                               Natural lockoutDays,
+                                               bool applyObservationShift)
     : OvernightIndexedSwap(type,
                            std::vector<Real>(1, nominal),
                            std::move(schedule),
@@ -50,7 +53,10 @@ namespace QuantLib {
                            paymentAdjustment,
                            paymentCalendar,
                            telescopicValueDates,
-                           averagingMethod) {}
+                           averagingMethod,
+                           lookbackDays,
+                           lockoutDays,
+                           applyObservationShift) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                const std::vector<Real>& nominals,
@@ -63,7 +69,10 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
-                                               RateAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod,
+                                               Natural lookbackDays,
+                                               Natural lockoutDays,
+                                               bool applyObservationShift)
     : OvernightIndexedSwap(type,
                            nominals,
                            schedule,
@@ -77,7 +86,10 @@ namespace QuantLib {
                            paymentAdjustment,
                            paymentCalendar,
                            telescopicValueDates,
-                           averagingMethod) {}
+                           averagingMethod, 
+                           lookbackDays, 
+                           lockoutDays, 
+                           applyObservationShift) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                Real nominal,
@@ -91,7 +103,10 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
-                                               RateAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod,
+                                               Natural lookbackDays,
+                                               Natural lockoutDays,
+                                               bool applyObservationShift)
     : OvernightIndexedSwap(type,
                            std::vector<Real>(1, nominal),
                            std::move(fixedSchedule),
@@ -105,7 +120,10 @@ namespace QuantLib {
                            paymentAdjustment,
                            paymentCalendar,
                            telescopicValueDates,
-                           averagingMethod) {}
+                           averagingMethod,
+                           lookbackDays,
+                           lockoutDays,
+                           applyObservationShift) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                std::vector<Real> fixedNominals,
@@ -120,11 +138,16 @@ namespace QuantLib {
                                                BusinessDayConvention paymentAdjustment,
                                                const Calendar& paymentCalendar,
                                                bool telescopicValueDates,
-                                               RateAveraging::Type averagingMethod)
+                                               RateAveraging::Type averagingMethod,
+                                               Natural lookbackDays,
+                                               Natural lockoutDays,
+                                               bool applyObservationShift)
     : FixedVsFloatingSwap(type, std::move(fixedNominals), std::move(fixedSchedule), fixedRate, std::move(fixedDC),
                           overnightNominals, std::move(overnightSchedule), overnightIndex,
                           spread, DayCounter(), ext::nullopt, paymentLag, paymentCalendar),
-                          overnightIndex_(overnightIndex), averagingMethod_(averagingMethod) {
+                          overnightIndex_(overnightIndex), averagingMethod_(averagingMethod),
+                          lookbackDays_(lookbackDays), lockoutDays_(lockoutDays),
+                          applyObservationShift_(applyObservationShift) {
         legs_[1] =
             OvernightLeg(floatingSchedule(), overnightIndex_)
                 .withNotionals(overnightNominals)
@@ -135,7 +158,10 @@ namespace QuantLib {
                 .withPaymentCalendar(paymentCalendar.empty() ?
                                      floatingSchedule().calendar() :
                                      paymentCalendar)
-                .withAveragingMethod(averagingMethod_);
+                .withAveragingMethod(averagingMethod_)
+                .withLookbackDays(lookbackDays_)
+                .withLockoutDays(lockoutDays_)
+                .withApplyObservationShift(applyObservationShift_);
         for (const auto& c : legs_[1])
             registerWith(c);
     }

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -161,7 +161,7 @@ namespace QuantLib {
                 .withAveragingMethod(averagingMethod_)
                 .withLookbackDays(lookbackDays_)
                 .withLockoutDays(lockoutDays_)
-                .withApplyObservationShift(applyObservationShift_);
+                .withObservationShift(applyObservationShift_);
         for (const auto& c : legs_[1])
             registerWith(c);
     }

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -52,7 +52,10 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                             Natural lookbackDays = Null<Natural>(),
+                             Natural lockoutDays = 0,
+                             bool applyObservationShift = false);
 
         OvernightIndexedSwap(Type type,
                              const std::vector<Real>& nominals,
@@ -65,7 +68,10 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                             Natural lookbackDays = Null<Natural>(),
+                             Natural lockoutDays = 0,
+                             bool applyObservationShift = false);
 
         OvernightIndexedSwap(Type type,
                              Real nominal,
@@ -79,7 +85,10 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                             Natural lookbackDays = Null<Natural>(),
+                             Natural lockoutDays = 0,
+                             bool applyObservationShift = false);
 
         OvernightIndexedSwap(Type type,
                              std::vector<Real> fixedNominals,
@@ -94,7 +103,10 @@ namespace QuantLib {
                              BusinessDayConvention paymentAdjustment = Following,
                              const Calendar& paymentCalendar = Calendar(),
                              bool telescopicValueDates = false,
-                             RateAveraging::Type averagingMethod = RateAveraging::Compound);
+                             RateAveraging::Type averagingMethod = RateAveraging::Compound,
+                             Natural lookbackDays = Null<Natural>(),
+                             Natural lockoutDays = 0,
+                             bool applyObservationShift = false);
 
         //! \name Inspectors
         //@{
@@ -109,6 +121,9 @@ namespace QuantLib {
         const Leg& overnightLeg() const { return floatingLeg(); }
 
         RateAveraging::Type averagingMethod() const { return averagingMethod_; }
+        Natural lookbackDays() const { return lookbackDays_; }
+        Natural lockoutDays() const { return lockoutDays_; }
+        bool applyObservationShift() const { return applyObservationShift_; }
         //@}
 
         //! \name Results
@@ -121,6 +136,9 @@ namespace QuantLib {
 
         ext::shared_ptr<OvernightIndex> overnightIndex_;
         RateAveraging::Type averagingMethod_;
+        Natural lookbackDays_;
+        Natural lockoutDays_;
+        bool applyObservationShift_;
     };
 
 }

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -314,6 +314,13 @@ BOOST_AUTO_TEST_CASE(testPastCouponRateWithLookbackAndObservationShift) {
     CHECK_OIS_COUPON_RESULT("coupon rate", pastCoupon->rate(), expectedRate, 1e-12);
 }
 
+#define CHECK_OIS_COUPON_DATES(what, actual, expected)   \
+    if (actual != expected) {                            \
+        BOOST_ERROR("Failed to reproduce " what ":"      \
+                    << "\n    expected:   " << expected  \
+                    << "\n    actual: " << actual);      \
+    }
+
 BOOST_AUTO_TEST_CASE(testPastCouponRateWithLockout) {
     BOOST_TEST_MESSAGE("Testing rate for past overnight-indexed coupon with lockout...");
 
@@ -325,10 +332,28 @@ BOOST_AUTO_TEST_CASE(testPastCouponRateWithLockout) {
     const Size n = fixingDates.size();
 
     Date expectedLockoutDate = Date(25, July, 2019);
-    CHECK_OIS_COUPON_RESULT("lockout date", fixingDates[n - 4], expectedLockoutDate, 1e-12);
-    CHECK_OIS_COUPON_RESULT("day T - 2 fixing", fixingDates[n - 3], expectedLockoutDate, 1e-12);
-    CHECK_OIS_COUPON_RESULT("day T - 1 fixing", fixingDates[n - 2], expectedLockoutDate, 1e-12);
-    CHECK_OIS_COUPON_RESULT("day T fixing", fixingDates[n - 1], expectedLockoutDate, 1e-12);
+    CHECK_OIS_COUPON_DATES("lockout date", fixingDates[n - 4], expectedLockoutDate);
+    CHECK_OIS_COUPON_DATES("day T - 2 fixing", fixingDates[n - 3], expectedLockoutDate);
+    CHECK_OIS_COUPON_DATES("day T - 1 fixing", fixingDates[n - 2], expectedLockoutDate);
+    CHECK_OIS_COUPON_DATES("day T fixing", fixingDates[n - 1], expectedLockoutDate);
+}
+
+BOOST_AUTO_TEST_CASE(testPastCouponRateWithLookbackObservationShiftAndLockout) {
+    BOOST_TEST_MESSAGE("Testing rate for past overnight-indexed coupon with lookback period, "
+                       "observation shift and lockout...");
+
+    CommonVars vars;
+
+    // coupon entirely in the past with lookback period with observation shift
+    // and lockout this unit test replicates an example available on NY FED website:
+    // https://www.newyorkfed.org/medialibrary/Microsites/arrc/files/2020/ARRC-BWLG-Examples-Other-Lookback-Options.xlsx
+
+    auto pastCoupon = vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), 5, 3, true);
+
+    // expected values here and below come from manual calculations based on past dates and rates
+    Rate expectedRate = 0.024693783702;
+
+    CHECK_OIS_COUPON_RESULT("coupon rate", pastCoupon->rate(), expectedRate, 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(testIncorrectNumberOfLockoutDays) {

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -476,9 +476,18 @@ BOOST_AUTO_TEST_CASE(testTelescopicFormulaWhenLookbackWithObservationShiftAndNoI
 
     Rate actualRate = coupon15July->rate();
 
+    auto coupon15JulyWithTelescopicDates =
+        vars.makeCoupon(Date(1, July, 2019), Date(15, July, 2019), 3, 0, true, true);
+
+    CHECK_OIS_COUPON_RESULT("telescopic value dates coupon rate", actualRate,
+                            coupon15JulyWithTelescopicDates->rate(), 1e-12);
+
     Rate expectedRateTelescopicSeries =
         (vars.forecastCurve->discount(Date(26, June, 2019)) /
              vars.forecastCurve->discount(Date(10, July, 2019)) - 1.0) * 360.0 / 14;
+
+    CHECK_OIS_COUPON_RESULT("coupon rate using telescopic formula", actualRate,
+                            expectedRateTelescopicSeries, 1e-12);
 
     auto& fixingDates = coupon15July->fixingDates();
     auto& dts = coupon15July->dt();
@@ -491,9 +500,6 @@ BOOST_AUTO_TEST_CASE(testTelescopicFormulaWhenLookbackWithObservationShiftAndNoI
 	}
     expectedRateIterativeFormula -= 1.0;
     expectedRateIterativeFormula /= coupon15July->accrualPeriod();
-
-    CHECK_OIS_COUPON_RESULT("coupon rate using telescopic formula", actualRate,
-                            expectedRateTelescopicSeries, 1e-12);
 
     CHECK_OIS_COUPON_RESULT("coupon rate using iterative formula", actualRate,
                             expectedRateIterativeFormula, 1e-12);

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -370,8 +370,7 @@ BOOST_AUTO_TEST_CASE(testIncorrectNumberOfLockoutDays) {
                       Error);
 
     // Negative number of lockout days
-    BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), Null<Natural>(),
-                                      numberOfFixings),
+    BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), Null<Natural>(), -1),
                       Error);
 }
 

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -43,11 +43,11 @@ struct CommonVars {
                                                        Natural fixingDays = Null<Natural>(),
                                                        Natural lockoutDays = 0,
                                                        bool applyObservationShift = false,
-                                                       bool telescopicValueDates = false) {
+                                                       bool telescopicValueDates = false,
+                                                       RateAveraging::Type averaging = RateAveraging::Compound) {
         return ext::make_shared<OvernightIndexedCoupon>(
             endDate, notional, startDate, endDate, sofr, 1.0, 0.0, Date(), Date(), DayCounter(),
-            telescopicValueDates, RateAveraging::Compound, fixingDays, lockoutDays,
-            applyObservationShift);
+            telescopicValueDates, averaging, fixingDays, lockoutDays, applyObservationShift);
     }
 
     CommonVars(const Date& evaluationDate) {
@@ -469,6 +469,24 @@ BOOST_AUTO_TEST_CASE(testErrorWhenTelescopicSeriesEnforcedWithLookback) {
     CommonVars vars;
 
     BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), 2, 0, false, true),
+                      Error);
+}
+
+BOOST_AUTO_TEST_CASE(testErrorWhenLookbackOrLockoutAppliedForSimpleAveraging) {
+    BOOST_TEST_MESSAGE("Testing error when lookback or lockout applied for simple averaging...");
+
+    CommonVars vars;
+
+    BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), 2, 0, false, false,
+                                      RateAveraging::Simple),
+                      Error);
+
+    BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), Null<Natural>(), 2,
+                                      false, false, RateAveraging::Simple),
+                      Error);
+
+    BOOST_CHECK_THROW(vars.makeCoupon(Date(1, July, 2019), Date(31, July, 2019), Null<Natural>(), 0,
+                                      true, false, RateAveraging::Simple),
                       Error);
 }
 

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -507,8 +507,8 @@ BOOST_AUTO_TEST_CASE(testTelescopicFormulaWhenLookbackWithObservationShiftAndNoI
 
 }
 
-BOOST_AUTO_TEST_CASE(testErrorWhenTelescopicSeriesEnforcedWithLookback) {
-    BOOST_TEST_MESSAGE("Testing error when telescopic series enforced with lookback...");
+BOOST_AUTO_TEST_CASE(testErrorWhenTelescopicValueDatesEnforcedWithLookback) {
+    BOOST_TEST_MESSAGE("Testing error when telescopic value dates enforced with lookback...");
 
     CommonVars vars;
 


### PR DESCRIPTION
In this PR I would like to add new functionality allowing to handle lookbacks, with and without observation shifts, and lockouts in the overnight indexed coupon.

The methodology for lookbacks and lockouts is outlined in a document by [NY FED](https://www.newyorkfed.org/medialibrary/Microsites/arrc/files/2021/users-guide-to-sofr2021-update.pdf) (pages 16-22).
Excel examples, based on which the unit tests were created, can also be found on the NY FED [website](https://www.newyorkfed.org/medialibrary/Microsites/arrc/files/2020/ARRC-BWLG-Examples-Other-Lookback-Options.xlsx).

Lookback days do not need to define a separate member in the `OvernightIndexedCoupon` class, instead utilize the `fixingDays_` member, because it already serves that purpose. It should be noted however that applying a lookback (with or without observation shift) might make it not possible to apply the telescopic formula and each fixing within the compounded coupon will have to be projected separately. This has to do with the fact that the value dates (and their accrual) over which the fixing is projected will no longer cancel out with the accrual of the interest period for that fixing.

To further elaborate on this, we can define a single SOFR rate projection $F(T_{i}^{V}, T_{i+1}^{V})$ as:

$$ F(T_{i}^{V}, T_{i+1}^{V}) = \left [ \frac{P(t,T_{i}^{V})}{P(t,T_{i+1}^{V})} - 1 \right ]\frac{1}{\alpha (T_{i}^{V}T_{i+1}^{V})}, $$

where $P(t,T)$ is a discount factor at time $T$, and $\alpha (T_{i}^{V},T_{i+1}^{V})$ is a time fraction between value dates $T_{i}^{V}$ and $T_{i+1}^{V}$.

Now, if we consider the formula for the compounded rate $FC(T_{J},T_{K})$ over the coupon period $T_{J},T_{K}$:

$$ FC(T_{J},T_{K}) = \left [ \prod_{k=J}^{K-1} \left ( 1+\alpha(T_{k}^{I},T_{k+1}^{I})F(T_{k}^{V},T_{k+1}^{V}) \right ) - 1 \right ] \frac{1}{\alpha (T_{J},T_{K})},$$

we can see that each fixing in the compounded rate is accrued at $\alpha(T_{i}^{I},T_{i+1}^{I})$. In case where there's lookback the interest $T_{i}^{I},T_{i+1}^{I}$ and value date periods $T_{i}^{V},T_{i+1}^{V}$ will not be the same and the telescopic formula will not be applicable. Also in case of an observation shift these periods might not be the same. This has to do with the fact that value dates are defined relative to the fixing date based on the fixing delay of an interest rate index. When the lookback period in the coupon is different than the fixing delay in the index, even the observation shift will not align value dates with interest dates.

It can be shown that the same applies to lockout periods. Value dates (at which the projection is calculated) correspond to the locked-out fixing, while the interest dates (at which the interest over that fixing is accrued) are not fixed at lockout, hence they do not cancel out.

Where possible, I tried to enrich the comments in the code addressing those issues.

The changes to the coupon pricer are quite significant, so I would appreciate any feedback - also given the complexity of the calculations, especially for coupon projections. I implemented unit tests that should address the corner cases, but I might have omitted/overlooked something.

This PR addresses https://github.com/lballabio/QuantLib/issues/1422.