### PR TITLE
Fix Chile holidays

### DIFF
--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -197,7 +197,7 @@ namespace QuantLib {
     }
 
     Day Calendar::WesternImpl::easterMonday(Year y) {
-        static const Day EasterMonday[] = {
+        static const unsigned char EasterMonday[] = {
                   98,  90, 103,  95, 114, 106,  91, 111, 102,   // 1901-1909
              87, 107,  99,  83, 103,  95, 115,  99,  91, 111,   // 1910-1919
              96,  87, 107,  92, 112, 103,  95, 108, 100,  91,   // 1920-1929
@@ -239,7 +239,7 @@ namespace QuantLib {
     }
 
     Day Calendar::OrthodoxImpl::easterMonday(Year y) {
-        static const Day EasterMonday[] = {
+        static const unsigned char EasterMonday[] = {
                  105, 118, 110, 102, 121, 106, 126, 118, 102,   // 1901-1909
             122, 114,  99, 118, 110,  95, 115, 106, 126, 111,   // 1910-1919
             103, 122, 107,  99, 119, 110, 123, 115, 107, 126,   // 1920-1929

--- a/ql/time/calendars/chile.cpp
+++ b/ql/time/calendars/chile.cpp
@@ -21,6 +21,35 @@
 
 namespace QuantLib {
 
+    namespace {
+
+        // Celebrated on the Winter Solstice day, except in 2021, when it was the day after.
+        inline bool isAboriginalPeopleDay(Day d, Month m, Year y) {
+            static const unsigned char aboriginalPeopleDay[] = {
+                    21, 21, 21, 20, 20, 21, 21, 20, 20,   // 2021-2029
+                21, 21, 20, 20, 21, 21, 20, 20, 21, 21,   // 2030-2039
+                20, 20, 21, 21, 20, 20, 21, 21, 20, 20,   // 2040-2049
+                20, 21, 20, 20, 20, 21, 20, 20, 20, 21,   // 2050-2059
+                20, 20, 20, 21, 20, 20, 20, 21, 20, 20,   // 2060-2069
+                20, 21, 20, 20, 20, 21, 20, 20, 20, 20,   // 2070-2079
+                20, 20, 20, 20, 20, 20, 20, 20, 20, 20,   // 2080-2089
+                20, 20, 20, 20, 20, 20, 20, 20, 20, 20,   // 2090-2099
+                21, 21, 21, 21, 21, 21, 21, 21, 20, 21,   // 2100-2109
+                21, 21, 20, 21, 21, 21, 20, 21, 21, 21,   // 2110-2119
+                20, 21, 21, 21, 20, 21, 21, 21, 20, 21,   // 2120-2129
+                21, 21, 20, 21, 21, 21, 20, 20, 21, 21,   // 2130-2139
+                20, 20, 21, 21, 20, 20, 21, 21, 20, 20,   // 2140-2149
+                21, 21, 20, 20, 21, 21, 20, 20, 21, 21,   // 2150-2159
+                20, 20, 21, 21, 20, 20, 21, 21, 20, 20,   // 2160-2169
+                20, 21, 20, 20, 20, 21, 20, 20, 20, 21,   // 2170-2179
+                20, 20, 20, 21, 20, 20, 20, 21, 20, 20,   // 2180-2189
+                20, 21, 20, 20, 20, 21, 20, 20, 20, 20    // 2190-2199
+            };
+            return m == June && y >= 2021 && d == aboriginalPeopleDay[y-2021];
+        }
+
+    }
+
     Chile::Chile(Market) {
         // all calendar instances share the same implementation instance
         static ext::shared_ptr<Calendar::Impl> impl(new Chile::SseImpl);
@@ -39,16 +68,20 @@ namespace QuantLib {
             // New Year's Day
             || (d == 1 && m == January)
             || (d == 2 && m == January && w == Monday && y > 2016)
+            // Papal visit in 2018
+            || (d == 16 && m == January && y == 2018)
             // Good Friday
             || (dd == em-3)
             // Easter Saturday
             || (dd == em-2)
+            // Census Day in 2017
+            || (d == 19 && m == April && y == 2017)
             // Labour Day
             || (d == 1 && m == May)
             // Navy Day
             || (d == 21 && m == May)
             // Day of Aboriginal People
-            || (d == 21 && m == June && y >= 2021)
+            || isAboriginalPeopleDay(d, m, y)
             // St. Peter and St. Paul
             || (d >= 26 && d <= 29 && m == June && w == Monday)
             || (d == 2 && m == July && w == Monday)
@@ -57,6 +90,7 @@ namespace QuantLib {
             // Assumption Day
             || (d == 15 && m == August)
             // Independence Day
+            || (d == 16 && m == September && y == 2022)
             || (d == 17 && m == September && ((w == Monday && y >= 2007) || (w == Friday && y > 2016)))
             || (d == 18 && m == September)
             // Army Day

--- a/ql/time/calendars/chile.hpp
+++ b/ql/time/calendars/chile.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         <li>Easter Saturday</li>
         <li>Labour Day, May 1st</li>
         <li>Navy Day, May 21st</li>
-        <li>Day of Aboriginal People, June 21st (since 2021)</li>
+        <li>Day of Aboriginal People, around June 21st (observed on each Winter Solstice) (since 2021)</li>
         <li>Saint Peter and Saint Paul, June 29th (moved to the nearest Monday if it falls on a weekday)</li>
         <li>Our Lady of Mount Carmel, July 16th</li>
         <li>Assumption Day, August 15th</li>


### PR DESCRIPTION
* Day of Aboriginal People is on the day of the Winter Solstice, which is not always June 21th. (Except for 2021, when it was on June 21th even though the solstice was on the 20th.)

* Add 2022-09-16, which was a day in lieu of Independence Day.

* Add 2018-01-16, which was a regional holiday for the Papal visit.

* Add 2017-04-19, which was a Census Day.