### PR TITLE
Correct holidays of 2024 for Indian NSE calendar

### DIFF
--- a/ql/time/calendars/india.cpp
+++ b/ql/time/calendars/india.cpp
@@ -442,15 +442,19 @@ namespace QuantLib {
                 || (d == 9 && m == April)
                 // Id-Ul-Fitr (Ramadan Eid)
                 || (d == 11 && m == April)
-                // Ram Navamiz
+                // Ram Navami
                 || (d == 17 && m == April)
                 // Mahavir Jayanti
                 || (d == 21 && m == April)
+                // General Parliamentary Elections
+                || (d == 20 && m == May)
                 // Buddha Pournima
                 || (d == 23 && m == May)
-                // Bakri Id (estimated Sunday 16th or Monday 17th)
+                // Bakri Eid
                 || (d == 17 && m == June)
-                // Id-E-Milad (estimated Sunday 15th or Monday 16th)
+                // Moharram
+                || (d == 17 && m == July)
+                // Eid-E-Milad (estimated Sunday 15th or Monday 16th)
                 || (d == 16 && m == September)
                 // Diwali-Laxmi Pujan
                 || (d == 1 && m == November)

--- a/ql/time/calendars/india.hpp
+++ b/ql/time/calendars/india.hpp
@@ -30,7 +30,7 @@
 namespace QuantLib {
 
     //! Indian calendars
-    /*! Holidays for the National Stock Exchange
+    /*! Clearing holidays for the National Stock Exchange
         (data from <http://www.nse-india.com/>):
         <ul>
         <li>Saturdays</li>
@@ -64,7 +64,7 @@ namespace QuantLib {
         <li>Guru Nanak Jayanti</li>
         </ul>
 
-        Note: The holidays Ramzan Id, Bakri Id and Id-E-Milad rely on estimates for 2023-2025.
+        Note: The holidays Ramzan Id, Bakri Id and Id-E-Milad rely on estimates for 2024-2025.
         \ingroup calendars
     */
     class India : public Calendar {


### PR DESCRIPTION
Hi,
Long overdue but here are at least the slimmed down corrections as suggested in #1929. 

I didn't add a separate implementation for RBI, but perhaps we can do so in the future if they appear to diverge.