### PR TITLE
Fix Brazilian holidays (São Paulo city holidays)

### DIFF
--- a/ql/time/calendars/brazil.cpp
+++ b/ql/time/calendars/brazil.cpp
@@ -98,7 +98,7 @@ namespace QuantLib {
             // Labor Day
             || (d == 1 && m == May)
             // Revolution Day
-            || (d == 9 && m == July)
+            || (d == 9 && m == July && y < 2022)
             // Independence Day
             || (d == 7 && m == September)
             // Nossa Sra. Aparecida Day
@@ -108,7 +108,7 @@ namespace QuantLib {
             // Republic Day
             || (d == 15 && m == November)
             // Black Consciousness Day
-            || (d == 20 && m == November && y >= 2007)
+            || (d == 20 && m == November && y >= 2007 && y != 2022 && y != 2023)
             // Christmas Eve
             || (d == 24 && m == December)
             // Christmas

--- a/ql/time/calendars/brazil.hpp
+++ b/ql/time/calendars/brazil.hpp
@@ -56,12 +56,12 @@ namespace QuantLib {
         <li>Sao Paulo City Day, January 25th (up to 2021 included)</li>
         <li>Tiradentes's Day, April 21th</li>
         <li>Labour Day, May 1st</li>
-        <li>Revolution Day, July 9th</li>
+        <li>Revolution Day, July 9th (up to 2021 included)</li>
         <li>Independence Day, September 7th</li>
         <li>Nossa Sra. Aparecida Day, October 12th</li>
         <li>All Souls Day, November 2nd</li>
         <li>Republic Day, November 15th</li>
-        <li>Black Consciousness Day, November 20th (since 2007)</li>
+        <li>Black Consciousness Day, November 20th (since 2007, except 2022 and 2023)</li>
         <li>Christmas Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Passion of Christ</li>


### PR DESCRIPTION
Hi all,

São Paulo city holidays became trading days in Brazil since 2022. 

There are 3 city holidays: January 25th, July 9th, and November 20th. However, only one of them (January 25th) was correctly handled in the code. I noticed this issue yesterday, on July 9th.

November 20th was considered a trading day in 2022-23, but in 2024, it became a national holiday.


[News (Portuguese)](https://www.cnnbrasil.com.br/economia/financas/b3-tera-pregao-em-feriados-municipais-de-sp-a-partir-de-2022/)


[B3 trading calendar](https://www.b3.com.br/en_us/solutions/platforms/puma-trading-system/for-members-and-traders/trading-calendar/holidays/)

First PR, please advise if further testing is needed. Best,