### PR TITLE
Extend `Index` interface

### DIFF
--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                  possible inconsistencies due to "seeing in the
                  future"
     */
-    class Index : public Observable {
+    class Index : public Observable, public Observer {
       public:
         ~Index() override = default;
         //! Returns the name of the index.
@@ -80,6 +80,10 @@ namespace QuantLib {
         /*! the date passed as arguments must be the actual calendar
             date of the fixing; no settlement days must be used.
         */
+        //! \name Observer interface
+        //@{
+        void update() override;
+        //@}
         virtual void addFixing(const Date& fixingDate, Real fixing, bool forceOverwrite = false);
         //! stores historical fixings from a TimeSeries
         /*! the dates in the TimeSeries must be the actual calendar
@@ -150,6 +154,9 @@ namespace QuantLib {
         return timeSeries()[fixingDate];
     }
 
+    inline void Index::update() {
+        notifyObservers();
+    }
 
 }
 

--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -29,6 +29,7 @@
 
 #include <ql/indexes/indexmanager.hpp>
 #include <ql/math/comparison.hpp>
+#include <ql/patterns/observable.hpp>
 #include <ql/time/calendar.hpp>
 
 namespace QuantLib {
@@ -61,6 +62,11 @@ namespace QuantLib {
             date of the fixing; no settlement days must be used.
         */
         virtual Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const = 0;
+        //! returns a past fixing at the given date
+        /*! the date passed as arguments must be the actual calendar
+            date of the fixing; no settlement days must be used.
+        */
+        virtual Real pastFixing(const Date& fixingDate) const;
         //! returns the fixing TimeSeries
         const TimeSeries<Real>& timeSeries() const {
             return IndexManager::instance().getHistory(name());
@@ -138,6 +144,12 @@ namespace QuantLib {
     inline bool Index::hasHistoricalFixing(const Date& fixingDate) const {
         return IndexManager::instance().hasHistoricalFixing(name(), fixingDate);
     }
+
+    inline Real Index::pastFixing(const Date& fixingDate) const {
+        QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
+        return timeSeries()[fixingDate];
+    }
+
 
 }
 

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -69,11 +69,6 @@ namespace QuantLib {
         QL_FAIL("Missing " << name() << " fixing for " << fixingDate);
     }
 
-    Real EquityIndex::pastFixing(const Date& fixingDate) const {
-        QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
-        return timeSeries()[fixingDate];
-    }
-
     Real EquityIndex::forecastFixing(const Date& fixingDate) const {
         QL_REQUIRE(!interest_.empty(),
                    "null interest rate term structure set to this instance of " << name());

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -92,7 +92,6 @@ namespace QuantLib {
         //@{
         //! It can be overridden to implement particular conventions
         virtual Real forecastFixing(const Date& fixingDate) const;
-        virtual Real pastFixing(const Date& fixingDate) const;
         // @}
         //! \name Other methods
         //@{

--- a/ql/indexes/equityindex.hpp
+++ b/ql/indexes/equityindex.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         handle to the current index spot. If spot handle is empty,
         today's fixing will be used, instead.
     */
-    class EquityIndex : public Index, public Observer {
+    class EquityIndex : public Index {
       public:
         EquityIndex(std::string name,
                     Calendar fixingCalendar,
@@ -74,10 +74,6 @@ namespace QuantLib {
         Calendar fixingCalendar() const override { return fixingCalendar_; }
         bool isValidFixingDate(const Date& fixingDate) const override;
         Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
         //! \name Inspectors
         //@{
@@ -112,8 +108,6 @@ namespace QuantLib {
     inline bool EquityIndex::isValidFixingDate(const Date& d) const {
         return fixingCalendar().isBusinessDay(d);
     }
-
-    inline void EquityIndex::update() { notifyObservers(); }
 }
 
 #endif

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -62,7 +62,7 @@ namespace QuantLib {
 
 
     //! Base class for inflation-rate indexes,
-    class InflationIndex : public Index, public Observer {
+    class InflationIndex : public Index {
       public:
         InflationIndex(std::string familyName,
                        Region region,
@@ -101,11 +101,6 @@ namespace QuantLib {
             the same value in every calendar day in the month.
         */
         void addFixing(const Date& fixingDate, Rate fixing, bool forceOverwrite = false) override;
-        //@}
-
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
 
         //! \name Inspectors
@@ -285,10 +280,6 @@ namespace QuantLib {
 
     inline std::string InflationIndex::name() const {
         return name_;
-    }
-
-    inline void InflationIndex::update() {
-        notifyObservers();
     }
 
     inline std::string InflationIndex::familyName() const {

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -96,6 +96,9 @@ namespace QuantLib {
         */
         Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override = 0;
 
+        //! returns a past fixing at the given date
+        Real pastFixing(const Date& fixingDate) const override = 0;
+
         /*! this method creates all the "fixings" for the relevant
             period of the index.  E.g. for monthly indices it will put
             the same value in every calendar day in the month.
@@ -159,6 +162,8 @@ namespace QuantLib {
                      the Index interface) is currently ignored.
         */
         Real fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
+        //! returns a past fixing at the given date
+        Real pastFixing(const Date& fixingDate) const override;
         //@}
         //! \name Other methods
         //@{
@@ -237,6 +242,12 @@ namespace QuantLib {
         */
         Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
 
+        /*! returns a past fixing at the given date
+         *  \warning This is only supported for flat YOY indices providing their own timeseries
+         *           via the `addFixing` or `addFixings` method,
+         *           aka where ratio() == interpolated() == false.
+         */
+        Real pastFixing(const Date& fixingDate) const override;
         //@}
         //! \name Other methods
         //@{

--- a/ql/indexes/interestrateindex.hpp
+++ b/ql/indexes/interestrateindex.hpp
@@ -36,8 +36,7 @@ namespace QuantLib {
 
     //! base class for interest rate indexes
     /*! \todo add methods returning InterestRate */
-    class InterestRateIndex : public Index,
-                              public Observer {
+    class InterestRateIndex : public Index {
       public:
         InterestRateIndex(std::string familyName,
                           const Period& tenor,
@@ -51,10 +50,6 @@ namespace QuantLib {
         Calendar fixingCalendar() const override;
         bool isValidFixingDate(const Date& fixingDate) const override;
         Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
         //! \name Inspectors
         //@{
@@ -104,10 +99,6 @@ namespace QuantLib {
 
     inline bool InterestRateIndex::isValidFixingDate(const Date& d) const {
         return fixingCalendar().isBusinessDay(d);
-    }
-
-    inline void InterestRateIndex::update() {
-        notifyObservers();
     }
 
     inline Date InterestRateIndex::fixingDate(const Date& valueDate) const {

--- a/ql/indexes/interestrateindex.hpp
+++ b/ql/indexes/interestrateindex.hpp
@@ -79,7 +79,6 @@ namespace QuantLib {
         //@{
         //! It can be overridden to implement particular conventions
         virtual Rate forecastFixing(const Date& fixingDate) const = 0;
-        virtual Rate pastFixing(const Date& fixingDate) const;
         // @}
       protected:
         std::string familyName_;
@@ -122,13 +121,6 @@ namespace QuantLib {
                    fixingDate << " is not a valid fixing date");
         return fixingCalendar().advance(fixingDate, fixingDays_, Days);
     }
-
-    inline Rate InterestRateIndex::pastFixing(const Date& fixingDate) const {
-        QL_REQUIRE(isValidFixingDate(fixingDate),
-                   fixingDate << " is not a valid fixing date");
-        return timeSeries()[fixingDate];
-    }
-
 }
 
 #endif


### PR DESCRIPTION
As most of the derived indices already 

- derive from `public Observer` and
- implement their own `Real pastFixing(const Date& fixingDate) const`

I have added them to the `Index` interface as they seems to be a natural and useful extension of the interface.

The basic implementation
```c++
inline Real Index::pastFixing(const Date& fixingDate) const {
    QL_REQUIRE(isValidFixingDate(fixingDate), fixingDate << " is not a valid fixing date");
    return timeSeries()[fixingDate];
}
```
is overwritten for the inflation indices as their fixing is a bit more elaborated.