### PR TITLE
Optionally allow using forward price for swaption implied-volatility calculation

### DIFF
--- a/ql/instruments/swaption.cpp
+++ b/ql/instruments/swaption.cpp
@@ -188,8 +188,9 @@ namespace QuantLib {
                                            Volatility maxVol,
                                            VolatilityType type,
                                            Real displacement) const {
-        //calculate();
+
         QL_REQUIRE(!isExpired(), "instrument expired");
+        QL_REQUIRE(exercise_->type() == Exercise::European, "not a European option");
 
         ImpliedSwaptionVolHelper f(*this, d, targetValue, displacement, type);
         //Brent solver;

--- a/ql/instruments/swaption.hpp
+++ b/ql/instruments/swaption.hpp
@@ -87,6 +87,7 @@ namespace QuantLib {
     */
     class Swaption : public Option {
       public:
+        enum PriceType { Spot, Forward };
         class arguments;
         class engine;
         Swaption(ext::shared_ptr<FixedVsFloatingSwap> swap,
@@ -131,7 +132,8 @@ namespace QuantLib {
                               Volatility minVol = 1.0e-7,
                               Volatility maxVol = 4.0,
                               VolatilityType type = ShiftedLognormal,
-                              Real displacement = 0.0) const;
+                              Real displacement = 0.0,
+                              PriceType priceType = Spot) const;
       private:
         // arguments
         ext::shared_ptr<FixedVsFloatingSwap> swap_;

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -320,6 +320,7 @@ namespace QuantLib {
             w, strike, atmForward, stdDev, annuity, displacement);
         results_.additionalResults["timeToExpiry"] = exerciseTime;
         results_.additionalResults["impliedVolatility"] = Real(stdDev / std::sqrt(exerciseTime));
+        results_.additionalResults["forwardPrice"] = results_.value / discountCurve_->discount(exerciseDate);
     }
 
     }  // namespace detail

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -79,7 +79,7 @@ namespace QuantLib {
 
     // shifted lognormal type engine
     struct Black76Spec {
-        static const VolatilityType type = ShiftedLognormal;
+        static constexpr VolatilityType type = ShiftedLognormal;
         Real value(const Option::Type type, const Real strike,
                    const Real atmForward, const Real stdDev, const Real annuity,
                    const Real displacement) {
@@ -103,7 +103,7 @@ namespace QuantLib {
 
     // normal type engine
     struct BachelierSpec {
-        static const VolatilityType type = Normal;
+        static constexpr VolatilityType type = Normal;
         Real value(const Option::Type type, const Real strike,
                    const Real atmForward, const Real stdDev, const Real annuity,
                    const Real) {
@@ -220,6 +220,9 @@ namespace QuantLib {
     template<class Spec>
     void BlackStyleSwaptionEngine<Spec>::calculate() const {
         static const Spread basisPoint = 1.0e-4;
+
+        QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
+                   "not a European option");
 
         Date exerciseDate = arguments_.exercise->date(0);
 


### PR DESCRIPTION
For European swaption, sometimes the price is quoted as a forward price to be paid at exercise time.

This PR allows to use such a quoted price for implied-volatility calculation.  The forward price is also returned by the Black and Bachelier swaption engines as an additional result.