### PR TITLE
Explicit type conversion in `additionalResults`

### DIFF
--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -323,7 +323,7 @@ namespace QuantLib {
             w, strike, atmForward, stdDev, annuity, displacement);
         results_.additionalResults["timeToExpiry"] = exerciseTime;
         results_.additionalResults["impliedVolatility"] = Real(stdDev / std::sqrt(exerciseTime));
-        results_.additionalResults["forwardPrice"] = results_.value / discountCurve_->discount(exerciseDate);
+        results_.additionalResults["forwardPrice"] = Real(results_.value / discountCurve_->discount(exerciseDate));
     }
 
     }  // namespace detail


### PR DESCRIPTION
This fixes an error occurring when expression templates are used for the `Real` datatype operations. Since `additionalResults` is using `boost::any` as storage type, expressions get stored directly and not their evaluated version. The causes runtime failures like the one seen in [this build](https://github.com/auto-differentiation/QuantLib-Risks-Cpp/actions/runs/9985832697).

This PR adds an explicit conversion which avoids this error, as proven in [this pipline](https://github.com/auto-differentiation/QuantLib-Risks-Cpp/actions/runs/9987486375).