### PR TITLE
Start of month functions

### DIFF
--- a/ql/time/calendar.hpp
+++ b/ql/time/calendar.hpp
@@ -109,6 +109,12 @@ namespace QuantLib {
         */
         bool isWeekend(Weekday w) const;
         /*! Returns <tt>true</tt> iff in the given market, the date is on
+            or before the first business day for that month.
+        */
+        bool isStartOfMonth(const Date& d) const;
+        //! first business day of the month to which the given date belongs
+        Date startOfMonth(const Date& d) const;
+        /*! Returns <tt>true</tt> iff in the given market, the date is on
             or after the last business day for that month.
         */
         bool isEndOfMonth(const Date& d) const;
@@ -238,6 +244,14 @@ namespace QuantLib {
             return true;
 
         return impl_->isBusinessDay(_d);
+    }
+
+    inline bool Calendar::isStartOfMonth(const Date& d) const {
+        return (d.month() != adjust(d-1, Preceding).month());
+    }
+
+    inline Date Calendar::startOfMonth(const Date& d) const {
+        return adjust(Date::startOfMonth(d), Following);
     }
 
     inline bool Calendar::isEndOfMonth(const Date& d) const {

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -207,6 +207,10 @@ namespace QuantLib {
         static Date maxDate();
         //! whether the given year is a leap one
         static bool isLeap(Year y);
+        //! first day of the month to which the given date belongs
+        static Date startOfMonth(const Date& d);
+        //! whether a date is the first day of its month
+        static bool isStartOfMonth(const Date& d);
         //! last day of the month to which the given date belongs
         static Date endOfMonth(const Date& d);
         //! whether a date is the last day of its month
@@ -423,6 +427,16 @@ namespace QuantLib {
 
     inline Date Date::operator-(const Period& p) const {
         return advance(*this,-p.length(),p.units());
+    }
+
+    inline Date Date::startOfMonth(const Date& d) {
+        Month m = d.month();
+        Year y = d.year();
+        return Date(1, m, y);
+    }
+
+    inline bool Date::isStartOfMonth(const Date& d) {
+       return (d.dayOfMonth() == 1);
     }
 
     inline Date Date::endOfMonth(const Date& d) {

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3369,6 +3369,26 @@ BOOST_AUTO_TEST_CASE(testMexicoInaugurationDay) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testStartOfMonth) {
+    BOOST_TEST_MESSAGE("Testing start-of-month calculation...");
+
+    Calendar c = TARGET(); // any calendar would be OK
+
+    Date som, counter = Date::minDate() + 2 * Months;
+    Date last = Date::maxDate();
+
+    while (counter < last) {
+        som = c.startOfMonth(counter);
+        // check that som is som
+        if (!c.isStartOfMonth(som))
+            BOOST_FAIL("\n  " << som.weekday() << " " << som << " is not the first business day in "
+                              << som.month() << " " << som.year() << " according to " << c.name());
+        // check that som is in the same month as counter
+        if (som.month() != counter.month())
+            BOOST_FAIL("\n  " << som << " is not in the same month as " << counter);
+        counter = counter + 1;
+    }
+}
 
 BOOST_AUTO_TEST_CASE(testEndOfMonth) {
     BOOST_TEST_MESSAGE("Testing end-of-month calculation...");

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3386,6 +3386,11 @@ BOOST_AUTO_TEST_CASE(testStartOfMonth) {
         // check that som is in the same month as counter
         if (som.month() != counter.month())
             BOOST_FAIL("\n  " << som << " is not in the same month as " << counter);
+        // Check that previous business day is in a different month
+        if (c.advance(som, -1, Days, Unadjusted).month() == som.month())
+            BOOST_FAIL("\n  " << c.advance(som, -1, Days, Unadjusted)
+                              << " is in the same month as "
+                              << som);
         counter = counter + 1;
     }
 }
@@ -3407,6 +3412,11 @@ BOOST_AUTO_TEST_CASE(testEndOfMonth) {
         // check that eom is in the same month as counter
         if (eom.month() != counter.month())
             BOOST_FAIL("\n  " << eom << " is not in the same month as " << counter);
+        // Check that next business day is in a different month
+        if (c.advance(eom, 1, Days, Unadjusted).month() == eom.month())
+            BOOST_FAIL("\n  " << c.advance(eom, 1, Days, Unadjusted) 
+                              << " is in the same month as "
+                              << eom);
         counter = counter + 1;
     }
 }


### PR DESCRIPTION
I noticed your comment in [Luigi's blog](https://www.implementingquantlib.com/2024/07/holidays-in-quantlib.html) about the lack of start-of-month functions. So here they are.