### PR TITLE
Set C++ standard also for client code using CMake

### DIFF
--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2365,8 +2365,9 @@ target_compile_definitions(ql_library PRIVATE
 target_compile_options(ql_library PRIVATE
     ${OpenMP_CXX_FLAGS})
 
+# CMAKE_CXX_STANDARD is always set in top-level CMakeLists
 target_compile_features(ql_library PUBLIC
-    cxx_std_${CMAKE_CXX_STANDARD})
+    cxx_std_${CMAKE_CXX_STANDARD})  
 
 if(MSVC AND CMAKE_UNITY_BUILD)
     # for Unity builds, we need to add /bigobj

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2365,6 +2365,9 @@ target_compile_definitions(ql_library PRIVATE
 target_compile_options(ql_library PRIVATE
     ${OpenMP_CXX_FLAGS})
 
+target_compile_features(ql_library PUBLIC
+    cxx_std_${CMAKE_CXX_STANDARD})
+
 if(MSVC AND CMAKE_UNITY_BUILD)
     # for Unity builds, we need to add /bigobj
     target_compile_options(ql_library PRIVATE "/bigobj")


### PR DESCRIPTION
This makes the `cxx_std_17` a compile feature of the library, meaning that it will be propagated to client code with CMake, that uses `find_package(QuantLib)`. Any code linking to `QuantLib` after that will get the C++ standard flags (can be overridden).

This avoids that client code needs to be modified when QuantLib changes its default C++ standard.