### PR TITLE
Use std headers in examples and tests

### DIFF
--- a/Examples/GlobalOptimizer/GlobalOptimizer.cpp
+++ b/Examples/GlobalOptimizer/GlobalOptimizer.cpp
@@ -24,10 +24,9 @@
 #include <ql/experimental/math/fireflyalgorithm.hpp>
 #include <ql/experimental/math/hybridsimulatedannealing.hpp>
 #include <ql/experimental/math/particleswarmoptimization.hpp>
-#include <ql/functional.hpp>
 #include <ql/math/optimization/differentialevolution.hpp>
 #include <ql/math/optimization/simulatedannealing.hpp>
-#include <ql/tuple.hpp>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <utility>

--- a/Examples/MultidimIntegral/MultidimIntegral.cpp
+++ b/Examples/MultidimIntegral/MultidimIntegral.cpp
@@ -25,9 +25,7 @@ FOR A PARTICULAR PURPOSE.  See the license for more details.
 #include <ql/experimental/math/multidimquadrature.hpp>
 #include <ql/math/integrals/trapezoidintegral.hpp>
 #include <ql/patterns/singleton.hpp>
-#include <ql/functional.hpp>
-
-
+#include <functional>
 #include <iostream>
 #include <iomanip>
 

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -41,7 +41,7 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
-#include <ql/tuple.hpp>
+#include <tuple>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -907,19 +907,18 @@ BOOST_AUTO_TEST_CASE(testSpuriousOscillations) {
     option.setupArguments(hestonEngine->getArguments());
 
     const std::tuple<FdmSchemeDesc, std::string, bool> descs[] = {
-        std::make_tuple(FdmSchemeDesc::CraigSneyd(), "Craig-Sneyd", true),
-        std::make_tuple(FdmSchemeDesc::Hundsdorfer(), "Hundsdorfer", true),
-        std::make_tuple(
-           FdmSchemeDesc::ModifiedHundsdorfer(), "Mod. Hundsdorfer", true),
-        std::make_tuple(FdmSchemeDesc::Douglas(), "Douglas", true),
-        std::make_tuple(FdmSchemeDesc::CrankNicolson(), "Crank-Nicolson", true),
-        std::make_tuple(FdmSchemeDesc::ImplicitEuler(), "Implicit", false),
-        std::make_tuple(FdmSchemeDesc::TrBDF2(), "TR-BDF2", false)
+        {FdmSchemeDesc::CraigSneyd(), "Craig-Sneyd", true},
+        {FdmSchemeDesc::Hundsdorfer(), "Hundsdorfer", true},
+        {FdmSchemeDesc::ModifiedHundsdorfer(), "Mod. Hundsdorfer", true},
+        {FdmSchemeDesc::Douglas(), "Douglas", true},
+        {FdmSchemeDesc::CrankNicolson(), "Crank-Nicolson", true},
+        {FdmSchemeDesc::ImplicitEuler(), "Implicit", false},
+        {FdmSchemeDesc::TrBDF2(), "TR-BDF2", false}
     };
 
-    for (const auto& desc : descs) {
+    for (const auto & [desc, name, spurious] : descs) {
         const ext::shared_ptr<FdmHestonSolver> solver = ext::make_shared<FdmHestonSolver>(
-            Handle<HestonProcess>(process), hestonEngine->getSolverDesc(1.0), std::get<0>(desc));
+            Handle<HestonProcess>(process), hestonEngine->getSolverDesc(1.0), desc);
 
         std::vector<Real> gammas;
         for (Real x=99; x < 101.001; x+=0.1) {
@@ -936,11 +935,11 @@ BOOST_AUTO_TEST_CASE(testSpuriousOscillations) {
         const Real tol = 0.01;
         const bool hasSpuriousOscillations = maximum > tol;
 
-        if (hasSpuriousOscillations != std::get<2>(desc)) {
+        if (hasSpuriousOscillations != spurious) {
             BOOST_ERROR("unable to reproduce spurious oscillation behaviour "
-                        << "\n   scheme name          : " << std::get<1>(desc)
+                        << "\n   scheme name          : " << name
                         << "\n   oscillations observed: " << hasSpuriousOscillations
-                        << "\n   oscillations expected: " << std::get<2>(desc));
+                        << "\n   oscillations expected: " << spurious);
         }
     }
 }

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -22,7 +22,6 @@
 #include "preconditions.hpp"
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
-#include <ql/functional.hpp>
 #include <ql/math/integrals/discreteintegrals.hpp>
 #include <ql/math/interpolations/bicubicsplineinterpolation.hpp>
 #include <ql/math/interpolations/bilinearinterpolation.hpp>
@@ -73,6 +72,7 @@
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <boost/numeric/ublas/operation.hpp>
 #include <boost/numeric/ublas/vector.hpp>
+#include <functional>
 #include <numeric>
 #include <utility>
 

--- a/test-suite/fdsabr.cpp
+++ b/test-suite/fdsabr.cpp
@@ -20,7 +20,6 @@
 #include "preconditions.hpp"
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
-#include <ql/functional.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/math/comparison.hpp>
 #include <ql/math/randomnumbers/rngtraits.hpp>
@@ -34,6 +33,7 @@
 #include <ql/quotes/simplequote.hpp>
 #include <ql/shared_ptr.hpp>
 #include <ql/termstructures/volatility/sabr.hpp>
+#include <functional>
 #include <utility>
 
 using namespace QuantLib;

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -45,11 +45,11 @@
 #include <ql/math/optimization/levenbergmarquardt.hpp>
 #include <ql/math/randomnumbers/sobolrsg.hpp>
 #include <ql/math/richardsonextrapolation.hpp>
-#include <ql/tuple.hpp>
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/utilities/null.hpp>
 #include <cmath>
 #include <utility>
+#include <tuple>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -2313,23 +2313,20 @@ BOOST_AUTO_TEST_CASE(testBSplines) {
     const BSpline bspline(p, knots.size()-p-2, knots);
 
     std::vector<std::tuple<Natural, Real, Real>> referenceValues = {
-        std::make_tuple(0, -0.95, 9.5238095238e-04),
-        std::make_tuple(0, -0.01, 0.37337142857),
-        std::make_tuple(0, 0.49, 0.84575238095),
-        std::make_tuple(0, 1.21, 0.0),
-        std::make_tuple(1, 1.49, 0.562987654321),
-        std::make_tuple(1, 1.59, 0.490888888889),
-        std::make_tuple(2, 1.99, 0.62429409171),
-        std::make_tuple(3, 1.19, 0.0),
-        std::make_tuple(3, 1.99, 0.12382936508),
-        std::make_tuple(3, 3.59, 0.765914285714)
+        {0, -0.95, 9.5238095238e-04},
+        {0, -0.01, 0.37337142857},
+        {0, 0.49, 0.84575238095},
+        {0, 1.21, 0.0},
+        {1, 1.49, 0.562987654321},
+        {1, 1.59, 0.490888888889},
+        {2, 1.99, 0.62429409171},
+        {3, 1.19, 0.0},
+        {3, 1.99, 0.12382936508},
+        {3, 3.59, 0.765914285714}
     };
 
     const Real tol = 1e-10;
-    for (auto& referenceValue : referenceValues) {
-        const Natural idx = std::get<0>(referenceValue);
-        const Real x = std::get<1>(referenceValue);
-        const Real expected = std::get<2>(referenceValue);
+    for (const auto& [idx, x, expected] : referenceValues) {
 
         const Real calculated = bspline(idx, x);
 
@@ -2758,7 +2755,7 @@ BOOST_AUTO_TEST_CASE(testLaplaceInterpolation) {
 
     // no point
 
-    LaplaceInterpolation l0([](const std::vector<Size>& x) { return Null<Real>(); }, {});
+    LaplaceInterpolation l0([](const std::vector<Size>&) { return Null<Real>(); }, {});
     BOOST_CHECK_CLOSE(l0({}), 0.0, tol);
 
     // single test cases from actual issues observed in the field

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -22,8 +22,8 @@
 #include "utilities.hpp"
 #include <ql/math/randomnumbers/rngtraits.hpp>
 #include <ql/math/linearleastsquaresregression.hpp>
-#include <ql/functional.hpp>
 #include <boost/circular_buffer.hpp>
+#include <functional>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;

--- a/test-suite/normalclvmodel.cpp
+++ b/test-suite/normalclvmodel.cpp
@@ -23,7 +23,6 @@
 #include <ql/experimental/finitedifferences/fdornsteinuhlenbeckvanillaengine.hpp>
 #include <ql/experimental/models/normalclvmodel.hpp>
 #include <ql/experimental/volatility/sabrvoltermstructure.hpp>
-#include <ql/functional.hpp>
 #include <ql/instruments/doublebarrieroption.hpp>
 #include <ql/instruments/forwardvanillaoption.hpp>
 #include <ql/instruments/impliedvolatility.hpp>
@@ -46,6 +45,7 @@
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
+#include <functional>
 #include <utility>
 
 using namespace QuantLib;

--- a/test-suite/utilities.hpp
+++ b/test-suite/utilities.hpp
@@ -28,7 +28,6 @@
 #include <ql/quote.hpp>
 #include <ql/patterns/observable.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
-#include <ql/functional.hpp>
 #include <boost/test/unit_test.hpp>
 #if BOOST_VERSION < 105900
 #include <boost/test/floating_point_comparison.hpp>
@@ -36,6 +35,7 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 #include <cmath>
+#include <functional>
 #include <iomanip>
 #include <numeric>
 #include <string>


### PR DESCRIPTION
That is, `<tuple>` and `<functional>` instead of `<ql/tuple.hpp>` and `<ql/functional.hpp>`.  The latter are obsolete, so we avoid them in examples and tests, which are the source files people would use as models for their own coding.