### PR TITLE
Enable C4127 at W3 warning level

### DIFF
--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -29,12 +29,11 @@ if (MSVC)
     # /wd26812
     # Suppress warnings: "Prefer enum class over enum" (Enum.3)
 
-    add_compile_options(/wd4267 /wd4819 /wd26812)
+    # /w34127
+    # Enable warning under W3: conditional expression is constant
 
-    # prevent warnings when using /std:c++17 and above
-    if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
-        # E.g. caused by #include <boost/numeric/ublas/matrix.hpp>
-        # In c++17 std::iterator is deprecated. As of boost 1.81 boost::ublas has not provided a fix for this.
-        add_compile_definitions(_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
-    endif()
+    add_compile_options(/wd4267 /wd4819 /wd26812 /w34127)
+
+    # Silence all C++17 deprecation warnings, same as in the vcxproj files
+    add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
 endif()

--- a/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
@@ -58,9 +58,9 @@ namespace QuantLib {
                                                          requiredSamples_,
                                                          maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/ql/experimental/exoticoptions/mceverestengine.hpp
+++ b/ql/experimental/exoticoptions/mceverestengine.hpp
@@ -59,7 +59,7 @@ namespace QuantLib {
                                                         maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
 
-            if (RNG::allowsErrorEstimate) {
+            if constexpr (RNG::allowsErrorEstimate) {
                 results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
             }

--- a/ql/experimental/exoticoptions/mchimalayaengine.hpp
+++ b/ql/experimental/exoticoptions/mchimalayaengine.hpp
@@ -57,9 +57,9 @@ namespace QuantLib {
                                                         maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
 
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       private:

--- a/ql/experimental/exoticoptions/mcpagodaengine.hpp
+++ b/ql/experimental/exoticoptions/mcpagodaengine.hpp
@@ -57,7 +57,7 @@ namespace QuantLib {
                                                         requiredSamples_,
                                                         maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
+            if constexpr (RNG::allowsErrorEstimate)
                 results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
         }

--- a/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
+++ b/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
         void calculate() const;
 
       protected:
-        virtual ext::shared_ptr<LongstaffSchwartzMultiPathPricer> 
+        virtual ext::shared_ptr<LongstaffSchwartzMultiPathPricer>
                                                     lsmPathPricer() const = 0;
 
         TimeGrid timeGrid() const;
@@ -112,7 +112,7 @@ namespace QuantLib {
                    "timeSteps must be positive, " << timeSteps <<
                    " not allowed");
         QL_REQUIRE(timeStepsPerYear != 0,
-                   "timeStepsPerYear must be positive, " 
+                   "timeStepsPerYear must be positive, "
                     << timeStepsPerYear << " not allowed");
         this->registerWith(process_);
     }
@@ -122,7 +122,7 @@ namespace QuantLib {
     inline
     ext::shared_ptr<typename
         MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::path_pricer_type>
-        MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::pathPricer() 
+        MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::pathPricer()
         const {
 
         QL_REQUIRE(pathPricer_, "path pricer unknown");
@@ -132,7 +132,7 @@ namespace QuantLib {
     template <class GenericEngine, template <class> class MC,
               class RNG, class S>
     inline
-    void MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::calculate() 
+    void MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::calculate()
     const {
         pathPricer_ = this->lsmPathPricer();
         this->mcModel_ = ext::shared_ptr<MonteCarloModel<MC,RNG,S> >(
@@ -147,7 +147,7 @@ namespace QuantLib {
                                           requiredSamples_,
                                           maxSamples_);
         this->results_.value = this->mcModel_->sampleAccumulator().mean();
-        if (RNG::allowsErrorEstimate) {
+        if constexpr (RNG::allowsErrorEstimate) {
             this->results_.errorEstimate =
                 this->mcModel_->sampleAccumulator().errorEstimate();
         }
@@ -177,7 +177,7 @@ namespace QuantLib {
     inline
     ext::shared_ptr<typename
     MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::path_generator_type>
-    MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::pathGenerator() 
+    MCLongstaffSchwartzPathEngine<GenericEngine,MC,RNG,S>::pathGenerator()
     const {
 
         Size dimensions = process_->factors();

--- a/ql/experimental/mcbasket/mcpathbasketengine.hpp
+++ b/ql/experimental/mcbasket/mcpathbasketengine.hpp
@@ -64,7 +64,7 @@ namespace QuantLib {
                                                         requiredSamples_,
                                                         maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
+            if constexpr (RNG::allowsErrorEstimate)
                 results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
         }

--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -88,14 +88,14 @@ namespace QuantLib {
             }
 
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            
+
             if (this->controlVariate_) {
                 // control variate might lead to small negative
                 // option values for deep OTM options
                 this->results_.value = std::max(0.0, this->results_.value);
             }
-                
-            if (RNG::allowsErrorEstimate)
+
+            if constexpr (RNG::allowsErrorEstimate)
                 results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
 

--- a/ql/pricingengines/barrier/mcbarrierengine.hpp
+++ b/ql/pricingengines/barrier/mcbarrierengine.hpp
@@ -83,9 +83,9 @@ namespace QuantLib {
                                                          requiredSamples_,
                                                          maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/ql/pricingengines/basket/mceuropeanbasketengine.hpp
+++ b/ql/pricingengines/basket/mceuropeanbasketengine.hpp
@@ -65,9 +65,9 @@ namespace QuantLib {
                                                         requiredSamples_,
                                                         maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/ql/pricingengines/capfloor/mchullwhiteengine.hpp
+++ b/ql/pricingengines/capfloor/mchullwhiteengine.hpp
@@ -89,7 +89,7 @@ namespace QuantLib {
                                   requiredSamples_,
                                   maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
+            if constexpr (RNG::allowsErrorEstimate)
                 results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
         }
@@ -248,4 +248,3 @@ namespace QuantLib {
 
 
 #endif
-

--- a/ql/pricingengines/cliquet/mcperformanceengine.hpp
+++ b/ql/pricingengines/cliquet/mcperformanceengine.hpp
@@ -53,9 +53,9 @@ namespace QuantLib {
                                                          requiredSamples_,
                                                          maxSamples_);
             results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -59,9 +59,9 @@ namespace QuantLib {
                                               requiredSamples_,
                                               maxSamples_);
             this->results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            this->results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                this->results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/ql/pricingengines/forward/mcvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/mcvarianceswapengine.hpp
@@ -92,7 +92,7 @@ namespace QuantLib {
             results_.value =
                 multiplier * (results_.variance - arguments_.strike);
 
-            if (RNG::allowsErrorEstimate) {
+            if constexpr (RNG::allowsErrorEstimate) {
                 Real varianceError =
                     this->mcModel_->sampleAccumulator().errorEstimate();
                 results_.errorEstimate = multiplier * varianceError;

--- a/ql/pricingengines/lookback/mclookbackengine.hpp
+++ b/ql/pricingengines/lookback/mclookbackengine.hpp
@@ -58,7 +58,7 @@ namespace QuantLib {
                                                          requiredSamples_,
                                                          maxSamples_);
             this->results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
+            if constexpr (RNG::allowsErrorEstimate)
                 this->results_.errorEstimate =
                     this->mcModel_->sampleAccumulator().errorEstimate();
         }

--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -203,7 +203,7 @@ namespace QuantLib {
         this->results_.value = this->mcModel_->sampleAccumulator().mean();
         this->results_.additionalResults["exerciseProbability"] =
             this->pathPricer_->exerciseProbability();
-        if (RNG::allowsErrorEstimate) {
+        if constexpr (RNG::allowsErrorEstimate) {
             this->results_.errorEstimate =
                 this->mcModel_->sampleAccumulator().errorEstimate();
         }

--- a/ql/pricingengines/vanilla/mcvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/mcvanillaengine.hpp
@@ -42,9 +42,9 @@ namespace QuantLib {
                                               requiredSamples_,
                                               maxSamples_);
             this->results_.value = this->mcModel_->sampleAccumulator().mean();
-            if (RNG::allowsErrorEstimate)
-            this->results_.errorEstimate =
-                this->mcModel_->sampleAccumulator().errorEstimate();
+            if constexpr (RNG::allowsErrorEstimate)
+                this->results_.errorEstimate =
+                    this->mcModel_->sampleAccumulator().errorEstimate();
         }
 
       protected:

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -116,7 +116,7 @@ CalibrationData AndreasenHugeExampleData() {
     const Size nStrikes = LENGTH(raw);
     const Size nMaturities = LENGTH(maturityTimes);
 
-    QL_REQUIRE(nMaturities == LENGTH(raw[1])-1, "check raw data");
+    static_assert(nMaturities == LENGTH(raw[1])-1, "check raw data");
 
     AndreasenHugeVolatilityInterpl::CalibrationSet calibrationSet;
 

--- a/test-suite/nthtodefault.cpp
+++ b/test-suite/nthtodefault.cpp
@@ -152,14 +152,14 @@ BOOST_AUTO_TEST_CASE(testGauss, *precondition(if_speed(Slow))) {
     ext::shared_ptr<SimpleQuote> simpleQuote (new SimpleQuote(0.0));
     Handle<Quote> correlationHandle (simpleQuote);
 
-    ext::shared_ptr<DefaultLossModel> copula( new 
-        ConstantLossModel<GaussianCopulaPolicy>( correlationHandle, 
-        std::vector<Real>(names, recovery), 
-        LatentModelIntegrationType::GaussianQuadrature, names, 
+    ext::shared_ptr<DefaultLossModel> copula( new
+        ConstantLossModel<GaussianCopulaPolicy>( correlationHandle,
+        std::vector<Real>(names, recovery),
+        LatentModelIntegrationType::GaussianQuadrature, names,
         GaussianCopulaPolicy::initTraits()));
 
     /* If you like the action you can price with the simulation engine below
-    instead below. But you need at least 1e6 simulations to pass the pricing 
+    instead below. But you need at least 1e6 simulations to pass the pricing
     error tests
     */
     //ext::shared_ptr<GaussianDefProbLM> gLM(
@@ -170,9 +170,9 @@ BOOST_AUTO_TEST_CASE(testGauss, *precondition(if_speed(Slow))) {
     //Size numSimulations = 1000000;
     //// Size numCoresUsed = 4; use your are in the multithread branch
     //// Sobol, many cores
-    //ext::shared_ptr<RandomDefaultLM<GaussianCopulaPolicy> > copula( 
-    //    new RandomDefaultLM<GaussianCopulaPolicy>(gLM, 
-    //        std::vector<Real>(names, recovery), numSimulations, 1.e-6, 
+    //ext::shared_ptr<RandomDefaultLM<GaussianCopulaPolicy> > copula(
+    //    new RandomDefaultLM<GaussianCopulaPolicy>(gLM,
+    //        std::vector<Real>(names, recovery), numSimulations, 1.e-6,
     //        2863311530));
 
     // Set up pool and basket
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(testGauss, *precondition(if_speed(Slow))) {
 
     std::vector<Issuer> issuers;
     for(Size i=0; i<names; i++) {
-        std::vector<QuantLib::Issuer::key_curve_pair> curves(1, 
+        std::vector<QuantLib::Issuer::key_curve_pair> curves(1,
             std::make_pair(NorthAmericaCorpDefaultKey(
                 EURCurrency(), QuantLib::SeniorSec,
                 Period(), 1. // amount threshold
@@ -195,10 +195,10 @@ BOOST_AUTO_TEST_CASE(testGauss, *precondition(if_speed(Slow))) {
         thePool->add(namesIds[i], issuers[i], NorthAmericaCorpDefaultKey(
                 EURCurrency(), QuantLib::SeniorSec, Period(), 1.));
 
-    std::vector<DefaultProbKey> defaultKeys(probabilities.size(), 
+    std::vector<DefaultProbKey> defaultKeys(probabilities.size(),
         NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
 
-    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds, 
+    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds,
         std::vector<Real>(names, namesNotional/names), thePool, 0., 1.));
 
     ext::shared_ptr<PricingEngine> engine(
@@ -211,18 +211,18 @@ BOOST_AUTO_TEST_CASE(testGauss, *precondition(if_speed(Slow))) {
         ntd.back().setPricingEngine(engine);
     }
 
-    QL_REQUIRE (LENGTH(hwCorrelation) == 3,
+    static_assert(LENGTH(hwCorrelation) == 3,
                 "correlation length does not match");
 
     Real diff, maxDiff = 0;
 
     basket->setLossModel(copula);
-    
+
     for (Size j = 0; j < LENGTH(hwCorrelation); j++) {
         simpleQuote->setValue (hwCorrelation[j]);
         for (Size i = 0; i < ntd.size(); i++) {
             QL_REQUIRE (ntd[i].rank() == hwData[i].rank, "rank does not match");
-            QL_REQUIRE (LENGTH(hwCorrelation) == LENGTH(hwData[i].spread),
+            static_assert(LENGTH(hwCorrelation) == LENGTH(hwData[i].spread),
                         "vector length does not match");
             diff = 1e4 * ntd[i].fairPremium() - hwData[i].spread[j];
             maxDiff = std::max(maxDiff, fabs (diff));
@@ -293,9 +293,9 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
 
     TCopulaPolicy::initTraits iniT;
     iniT.tOrders = std::vector<QuantLib::Integer>(2,5);
-    ext::shared_ptr<DefaultLossModel> copula( new 
-        ConstantLossModel<TCopulaPolicy>( correlationHandle, 
-        std::vector<Real>(names, recovery), 
+    ext::shared_ptr<DefaultLossModel> copula( new
+        ConstantLossModel<TCopulaPolicy>( correlationHandle,
+        std::vector<Real>(names, recovery),
         LatentModelIntegrationType::GaussianQuadrature, names, iniT));
 
     // Set up pool and basket
@@ -305,7 +305,7 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
 
     std::vector<Issuer> issuers;
     for(Size i=0; i<names; i++) {
-        std::vector<QuantLib::Issuer::key_curve_pair> curves(1, 
+        std::vector<QuantLib::Issuer::key_curve_pair> curves(1,
             std::make_pair(NorthAmericaCorpDefaultKey(
                 EURCurrency(), QuantLib::SeniorSec,
                 Period(), 1. // amount threshold
@@ -318,10 +318,10 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
         thePool->add(namesIds[i], issuers[i], NorthAmericaCorpDefaultKey(
                 EURCurrency(), QuantLib::SeniorSec, Period(), 1.));
 
-    std::vector<DefaultProbKey> defaultKeys(probabilities.size(), 
+    std::vector<DefaultProbKey> defaultKeys(probabilities.size(),
         NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
 
-    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds, 
+    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds,
         std::vector<Real>(names, namesNotional/names), thePool, 0., 1.));
 
     ext::shared_ptr<PricingEngine> engine(
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
         ntd.back().setPricingEngine(engine);
     }
 
-    QL_REQUIRE (LENGTH(hwCorrelation) == 3,
+    static_assert(LENGTH(hwCorrelation) == 3,
                 "correlation length does not match");
 
     Real maxDiff = 0;
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
     //     simpleQuote->setValue (hwCorrelation[j]);
     //     for (Size i = 0; i < ntd.size(); i++) {
     //         QL_REQUIRE (ntd[i].rank() == hwData[i].rank, "rank does not match");
-    //         QL_REQUIRE (LENGTH(hwCorrelation) == LENGTH(hwData[i].spread),
+    //         static_assert(LENGTH(hwCorrelation) == LENGTH(hwData[i].spread),
     //                     "vector length does not match");
     //         diff = 1e4 * ntd[i].fairPremium() - hwData[i].spread[j];
     //         maxDiff = std::max(maxDiff, fabs (diff));
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(testStudent, *precondition(if_speed(Slow))) {
 
     //instead of this BEGIN
     simpleQuote->setValue (0.3);
-    
+
     for (Size i = 0; i < ntd.size(); i++) {
         QL_REQUIRE (ntd[i].rank() == hwDataDist[i].rank, "rank does not match");
 


### PR DESCRIPTION
Making this warning part of W3 means that all compile-time conditionals are enforced as such in the CI, which is a good thing for runtime performance. 