### PR TITLE
Pass extrapolate to constructor

### DIFF
--- a/ql/math/interpolation.hpp
+++ b/ql/math/interpolation.hpp
@@ -115,6 +115,9 @@ namespace QuantLib {
             I2 yBegin_;
         };
 
+        explicit Interpolation(bool extrapolate)
+            : Extrapolator(extrapolate) {}
+
         Interpolation() = default;
         ~Interpolation() override = default;
         bool empty() const { return !impl_; }

--- a/ql/math/interpolations/bilinearinterpolation.hpp
+++ b/ql/math/interpolations/bilinearinterpolation.hpp
@@ -75,7 +75,8 @@ namespace QuantLib {
         template <class I1, class I2, class M>
         BilinearInterpolation(const I1& xBegin, const I1& xEnd,
                               const I2& yBegin, const I2& yEnd,
-                              const M& zData) {
+                              const M& zData, bool extrapolate = false)
+        : Interpolation2D(extrapolate) {
             impl_ = ext::shared_ptr<Interpolation2D::Impl>(
                   new detail::BilinearInterpolationImpl<I1,I2,M>(xBegin, xEnd,
                                                                  yBegin, yEnd,
@@ -89,8 +90,8 @@ namespace QuantLib {
         template <class I1, class I2, class M>
         Interpolation2D interpolate(const I1& xBegin, const I1& xEnd,
                                     const I2& yBegin, const I2& yEnd,
-                                    const M& z) const {
-            return BilinearInterpolation(xBegin,xEnd,yBegin,yEnd,z);
+                                    const M& z, bool extrapolate = false) const {
+            return BilinearInterpolation(xBegin,xEnd,yBegin,yEnd,z,extrapolate);
         }
     };
 

--- a/ql/math/interpolations/cubicinterpolation.hpp
+++ b/ql/math/interpolations/cubicinterpolation.hpp
@@ -130,7 +130,7 @@ namespace QuantLib {
             Akima,
 
             //! Kruger approximation (local, monotonic, non-linear)
-            Kruger, 
+            Kruger,
 
             //! Weighted harmonic mean approximation (local, monotonic, non-linear)
             Harmonic,
@@ -163,7 +163,9 @@ namespace QuantLib {
                            CubicInterpolation::BoundaryCondition leftCond,
                            Real leftConditionValue,
                            CubicInterpolation::BoundaryCondition rightCond,
-                           Real rightConditionValue) {
+                           Real rightConditionValue,
+                           bool extrapolate = false)
+        : Interpolation(extrapolate) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::CubicInterpolationImpl<I1,I2>(xBegin, xEnd, yBegin,
                                                       da,
@@ -198,11 +200,13 @@ namespace QuantLib {
         template <class I1, class I2>
         CubicNaturalSpline(const I1& xBegin,
                            const I1& xEnd,
-                           const I2& yBegin)
+                           const I2& yBegin,
+                           bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Spline, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class MonotonicCubicNaturalSpline : public CubicInterpolation {
@@ -211,11 +215,13 @@ namespace QuantLib {
         template <class I1, class I2>
         MonotonicCubicNaturalSpline(const I1& xBegin,
                                     const I1& xEnd,
-                                    const I2& yBegin)
+                                    const I2& yBegin,
+                                    bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Spline, true,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class CubicSplineOvershootingMinimization1 : public CubicInterpolation {
@@ -224,11 +230,13 @@ namespace QuantLib {
         template <class I1, class I2>
         CubicSplineOvershootingMinimization1 (const I1& xBegin,
                                            const I1& xEnd,
-                                           const I2& yBegin)
+                                           const I2& yBegin,
+                                           bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              SplineOM1, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class CubicSplineOvershootingMinimization2 : public CubicInterpolation {
@@ -237,11 +245,13 @@ namespace QuantLib {
         template <class I1, class I2>
         CubicSplineOvershootingMinimization2 (const I1& xBegin,
                                            const I1& xEnd,
-                                           const I2& yBegin)
+                                           const I2& yBegin,
+                                           bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              SplineOM2, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class AkimaCubicInterpolation : public CubicInterpolation {
@@ -250,11 +260,13 @@ namespace QuantLib {
         template <class I1, class I2>
         AkimaCubicInterpolation(const I1& xBegin,
                                 const I1& xEnd,
-                                const I2& yBegin)
+                                const I2& yBegin,
+                                bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Akima, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class KrugerCubic : public CubicInterpolation {
@@ -263,11 +275,13 @@ namespace QuantLib {
         template <class I1, class I2>
         KrugerCubic(const I1& xBegin,
                     const I1& xEnd,
-                    const I2& yBegin)
+                    const I2& yBegin,
+                    bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Kruger, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class HarmonicCubic : public CubicInterpolation {
@@ -276,11 +290,13 @@ namespace QuantLib {
         template <class I1, class I2>
         HarmonicCubic(const I1& xBegin,
                       const I1& xEnd,
-                      const I2& yBegin)
+                      const I2& yBegin,
+                      bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Harmonic, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class FritschButlandCubic : public CubicInterpolation {
@@ -289,11 +305,13 @@ namespace QuantLib {
         template <class I1, class I2>
         FritschButlandCubic(const I1& xBegin,
                             const I1& xEnd,
-                            const I2& yBegin)
+                            const I2& yBegin,
+                            bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              FritschButland, true,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class Parabolic : public CubicInterpolation {
@@ -302,11 +320,13 @@ namespace QuantLib {
         template <class I1, class I2>
         Parabolic(const I1& xBegin,
                   const I1& xEnd,
-                  const I2& yBegin)
+                  const I2& yBegin,
+                  bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              CubicInterpolation::Parabolic, false,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     class MonotonicParabolic : public CubicInterpolation {
@@ -315,11 +335,13 @@ namespace QuantLib {
         template <class I1, class I2>
         MonotonicParabolic(const I1& xBegin,
                            const I1& xEnd,
-                           const I2& yBegin)
+                           const I2& yBegin,
+                           bool extrapolate = false)
         : CubicInterpolation(xBegin, xEnd, yBegin,
                              Parabolic, true,
                              SecondDerivative, 0.0,
-                             SecondDerivative, 0.0) {}
+                             SecondDerivative, 0.0,
+                             extrapolate) {}
     };
 
     //! %Cubic interpolation factory and traits
@@ -334,10 +356,12 @@ namespace QuantLib {
               Real leftConditionValue = 0.0,
               CubicInterpolation::BoundaryCondition rightCondition
                   = CubicInterpolation::SecondDerivative,
-              Real rightConditionValue = 0.0)
+              Real rightConditionValue = 0.0,
+              bool extrapolate = false)
         : da_(da), monotonic_(monotonic),
           leftType_(leftCondition), rightType_(rightCondition),
-          leftValue_(leftConditionValue), rightValue_(rightConditionValue) {}
+          leftValue_(leftConditionValue), rightValue_(rightConditionValue),
+          extrapolate_(extrapolate) {}
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin,
                                   const I1& xEnd,
@@ -345,7 +369,8 @@ namespace QuantLib {
             return CubicInterpolation(xBegin, xEnd, yBegin,
                                       da_, monotonic_,
                                       leftType_, leftValue_,
-                                      rightType_, rightValue_);
+                                      rightType_, rightValue_,
+                                      extrapolate_);
         }
         static const bool global = true;
         static const Size requiredPoints = 2;
@@ -354,6 +379,7 @@ namespace QuantLib {
         bool monotonic_;
         CubicInterpolation::BoundaryCondition leftType_, rightType_;
         Real leftValue_, rightValue_;
+        bool extrapolate_;
     };
 
 
@@ -385,7 +411,7 @@ namespace QuantLib {
                     || rightType_ == CubicInterpolation::Lagrange) {
                     QL_REQUIRE((xEnd-xBegin) >= 4,
                                "Lagrange boundary condition requires at least "
-                               "4 points (" << (xEnd-xBegin) << " are given)"); 
+                               "4 points (" << (xEnd-xBegin) << " are given)");
                 }
             }
 

--- a/ql/math/interpolations/extrapolation.hpp
+++ b/ql/math/interpolations/extrapolation.hpp
@@ -31,6 +31,8 @@ namespace QuantLib {
     //! base class for classes possibly allowing extrapolation
     class Extrapolator {
       public:
+        explicit Extrapolator(bool extrapolate)
+          : extrapolate_(extrapolate) {}
         Extrapolator() = default;
         virtual ~Extrapolator() = default;
         //! \name modifiers

--- a/ql/math/interpolations/interpolation2d.hpp
+++ b/ql/math/interpolations/interpolation2d.hpp
@@ -138,6 +138,10 @@ namespace QuantLib {
         };
 
         Interpolation2D() = default;
+
+        explicit Interpolation2D(bool extrapolate)
+            : Extrapolator(extrapolate) {}
+
         Real operator()(Real x, Real y,
                         bool allowExtrapolation = false) const {
             checkRange(x,y,allowExtrapolation);

--- a/ql/math/interpolations/linearinterpolation.hpp
+++ b/ql/math/interpolations/linearinterpolation.hpp
@@ -44,7 +44,8 @@ namespace QuantLib {
         /*! \pre the \f$ x \f$ values must be sorted. */
         template <class I1, class I2>
         LinearInterpolation(const I1& xBegin, const I1& xEnd,
-                            const I2& yBegin) {
+                            const I2& yBegin, bool extrapolate = false)
+        : Interpolation(extrapolate) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::LinearInterpolationImpl<I1,I2>(xBegin, xEnd,
                                                        yBegin));

--- a/ql/termstructure.cpp
+++ b/ql/termstructure.cpp
@@ -23,15 +23,15 @@
 
 namespace QuantLib {
 
-    TermStructure::TermStructure(DayCounter dc)
-    : settlementDays_(Null<Natural>()), dayCounter_(std::move(dc)) {}
+    TermStructure::TermStructure(DayCounter dc, bool extrapolate)
+    : Extrapolator(extrapolate), settlementDays_(Null<Natural>()), dayCounter_(std::move(dc)) {}
 
-    TermStructure::TermStructure(const Date& referenceDate, Calendar cal, DayCounter dc)
-    : calendar_(std::move(cal)), referenceDate_(referenceDate), settlementDays_(Null<Natural>()),
+    TermStructure::TermStructure(const Date& referenceDate, Calendar cal, DayCounter dc, bool extrapolate)
+    : Extrapolator(extrapolate), calendar_(std::move(cal)), referenceDate_(referenceDate), settlementDays_(Null<Natural>()),
       dayCounter_(std::move(dc)) {}
 
-    TermStructure::TermStructure(Natural settlementDays, Calendar cal, DayCounter dc)
-    : moving_(true), updated_(false), calendar_(std::move(cal)), settlementDays_(settlementDays),
+    TermStructure::TermStructure(Natural settlementDays, Calendar cal, DayCounter dc, bool extrapolate)
+    : Extrapolator(extrapolate), moving_(true), updated_(false), calendar_(std::move(cal)), settlementDays_(settlementDays),
       dayCounter_(std::move(dc)) {
         registerWith(Settings::instance().evaluationDate());
     }

--- a/ql/termstructure.hpp
+++ b/ql/termstructure.hpp
@@ -64,13 +64,18 @@ namespace QuantLib {
                      constructor must manage their own reference date
                      by overriding the referenceDate() method.
         */
-        explicit TermStructure(DayCounter dc = DayCounter());
+        explicit TermStructure(DayCounter dc = DayCounter(),
+                               bool extrapolate = false);
         //! initialize with a fixed reference date
         explicit TermStructure(const Date& referenceDate,
                                Calendar calendar = Calendar(),
-                               DayCounter dc = DayCounter());
+                               DayCounter dc = DayCounter(),
+                               bool extrapolate = false);
         //! calculate the reference date based on the global evaluation date
-        TermStructure(Natural settlementDays, Calendar, DayCounter dc = DayCounter());
+        TermStructure(Natural settlementDays,
+                      Calendar calendar,
+                      DayCounter dc = DayCounter(),
+                      bool extrapolate = false);
         //@}
         ~TermStructure() override = default;
         //! \name Dates and Time

--- a/ql/termstructures/defaulttermstructure.cpp
+++ b/ql/termstructures/defaulttermstructure.cpp
@@ -27,8 +27,8 @@
 namespace QuantLib {
 
     DefaultProbabilityTermStructure::DefaultProbabilityTermStructure(
-        const DayCounter& dc, std::vector<Handle<Quote> > jumps, const std::vector<Date>& jumpDates)
-    : TermStructure(dc), jumps_(std::move(jumps)), jumpDates_(jumpDates),
+        const DayCounter& dc, std::vector<Handle<Quote> > jumps, const std::vector<Date>& jumpDates, bool extrapolate)
+    : TermStructure(dc, extrapolate), jumps_(std::move(jumps)), jumpDates_(jumpDates),
       jumpTimes_(jumpDates.size()), nJumps_(jumps_.size()) {
         setJumps();
         for (Size i=0; i<nJumps_; ++i)
@@ -40,8 +40,9 @@ namespace QuantLib {
         const Calendar& cal,
         const DayCounter& dc,
         std::vector<Handle<Quote> > jumps,
-        const std::vector<Date>& jumpDates)
-    : TermStructure(referenceDate, cal, dc), jumps_(std::move(jumps)), jumpDates_(jumpDates),
+        const std::vector<Date>& jumpDates,
+        bool extrapolate)
+    : TermStructure(referenceDate, cal, dc, extrapolate), jumps_(std::move(jumps)), jumpDates_(jumpDates),
       jumpTimes_(jumpDates.size()), nJumps_(jumps_.size()) {
         setJumps();
         for (Size i=0; i<nJumps_; ++i)
@@ -53,8 +54,9 @@ namespace QuantLib {
         const Calendar& cal,
         const DayCounter& dc,
         std::vector<Handle<Quote> > jumps,
-        const std::vector<Date>& jumpDates)
-    : TermStructure(settlementDays, cal, dc), jumps_(std::move(jumps)), jumpDates_(jumpDates),
+        const std::vector<Date>& jumpDates,
+        bool extrapolate)
+    : TermStructure(settlementDays, cal, dc, extrapolate), jumps_(std::move(jumps)), jumpDates_(jumpDates),
       jumpTimes_(jumpDates.size()), nJumps_(jumps_.size()) {
         setJumps();
         for (Size i=0; i<nJumps_; ++i)

--- a/ql/termstructures/defaulttermstructure.hpp
+++ b/ql/termstructures/defaulttermstructure.hpp
@@ -48,19 +48,22 @@ namespace QuantLib {
         DefaultProbabilityTermStructure(
             const DayCounter& dc = DayCounter(),
             std::vector<Handle<Quote> > jumps = {},
-            const std::vector<Date>& jumpDates = {});
+            const std::vector<Date>& jumpDates = {},
+            bool extrapolate = false);
         DefaultProbabilityTermStructure(
             const Date& referenceDate,
             const Calendar& cal = Calendar(),
             const DayCounter& dc = DayCounter(),
             std::vector<Handle<Quote> > jumps = {},
-            const std::vector<Date>& jumpDates = {});
+            const std::vector<Date>& jumpDates = {},
+            bool extrapolate = false);
         DefaultProbabilityTermStructure(
             Natural settlementDays,
             const Calendar& cal,
             const DayCounter& dc = DayCounter(),
             std::vector<Handle<Quote> > jumps = {},
-            const std::vector<Date>& jumpDates = {});
+            const std::vector<Date>& jumpDates = {},
+            bool extrapolate = false);
         //@}
 
         /*! \name Survival probabilities
@@ -121,7 +124,7 @@ namespace QuantLib {
             These methods returns the hazard rate at a given date or time.
             In the latter case, the time is calculated as a fraction of year
             from the reference date.
-            
+
             Hazard rates are defined with annual frequency and continuous
             compounding.
         */

--- a/ql/termstructures/volatility/equityfx/localvolsurface.hpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.hpp
@@ -47,11 +47,13 @@ namespace QuantLib {
         LocalVolSurface(const Handle<BlackVolTermStructure>& blackTS,
                         Handle<YieldTermStructure> riskFreeTS,
                         Handle<YieldTermStructure> dividendTS,
-                        Handle<Quote> underlying);
+                        Handle<Quote> underlying,
+                        bool extrapolate = false);
         LocalVolSurface(const Handle<BlackVolTermStructure>& blackTS,
                         Handle<YieldTermStructure> riskFreeTS,
                         Handle<YieldTermStructure> dividendTS,
-                        Real underlying);
+                        Real underlying,
+                        bool extrapolate = false);
         //! \name TermStructure interface
         //@{
         const Date& referenceDate() const override;

--- a/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
+++ b/ql/termstructures/volatility/equityfx/localvoltermstructure.cpp
@@ -22,20 +22,23 @@
 namespace QuantLib {
 
     LocalVolTermStructure::LocalVolTermStructure(BusinessDayConvention bdc,
-                                                 const DayCounter& dc)
-    : VolatilityTermStructure(bdc, dc) {}
+                                                 const DayCounter& dc,
+                                                 bool extrapolate)
+    : VolatilityTermStructure(bdc, dc, extrapolate) {}
 
     LocalVolTermStructure::LocalVolTermStructure(const Date& referenceDate,
                                                  const Calendar& cal,
                                                  BusinessDayConvention bdc,
-                                                 const DayCounter& dc)
-    : VolatilityTermStructure(referenceDate, cal, bdc, dc) {}
+                                                 const DayCounter& dc,
+                                                 bool extrapolate)
+    : VolatilityTermStructure(referenceDate, cal, bdc, dc, extrapolate) {}
 
     LocalVolTermStructure::LocalVolTermStructure(Natural settlementDays,
                                                  const Calendar& cal,
                                                  BusinessDayConvention bdc,
-                                                 const DayCounter& dc)
-    : VolatilityTermStructure(settlementDays, cal, bdc, dc) {}
+                                                 const DayCounter& dc,
+                                                 bool extrapolate)
+    : VolatilityTermStructure(settlementDays, cal, bdc, dc, extrapolate) {}
 
     Volatility LocalVolTermStructure::localVol(const Date& d,
                                                Real underlyingLevel,

--- a/ql/termstructures/volatility/equityfx/localvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/localvoltermstructure.hpp
@@ -48,17 +48,20 @@ namespace QuantLib {
                      by overriding the referenceDate() method.
         */
         LocalVolTermStructure(BusinessDayConvention bdc = Following,
-                              const DayCounter& dc = DayCounter());
+                              const DayCounter& dc = DayCounter(),
+                              bool extrapolate = false);
         //! initialize with a fixed reference date
         LocalVolTermStructure(const Date& referenceDate,
                               const Calendar& cal = Calendar(),
                               BusinessDayConvention bdc = Following,
-                              const DayCounter& dc = DayCounter());
+                              const DayCounter& dc = DayCounter(),
+                              bool extrapolate = false);
         //! calculate the reference date based on the global evaluation date
         LocalVolTermStructure(Natural settlementDays,
                               const Calendar&,
                               BusinessDayConvention bdc = Following,
-                              const DayCounter& dc = DayCounter());
+                              const DayCounter& dc = DayCounter(),
+                              bool extrapolate = false);
         //@}
         ~LocalVolTermStructure() override = default;
         //! \name Local Volatility

--- a/ql/termstructures/volatility/equityfx/noexceptlocalvolsurface.hpp
+++ b/ql/termstructures/volatility/equityfx/noexceptlocalvolsurface.hpp
@@ -35,16 +35,18 @@ namespace QuantLib {
                                 const Handle<YieldTermStructure>& riskFreeTS,
                                 const Handle<YieldTermStructure>& dividendTS,
                                 const Handle<Quote>& underlying,
-                                Real illegalLocalVolOverwrite)
-        : LocalVolSurface(blackTS, riskFreeTS, dividendTS, underlying),
+                                Real illegalLocalVolOverwrite,
+                                bool extrapolate = false)
+        : LocalVolSurface(blackTS, riskFreeTS, dividendTS, underlying, extrapolate),
           illegalLocalVolOverwrite_(illegalLocalVolOverwrite) { }
 
         NoExceptLocalVolSurface(const Handle<BlackVolTermStructure>& blackTS,
                                 const Handle<YieldTermStructure>& riskFreeTS,
                                 const Handle<YieldTermStructure>& dividendTS,
                                 Real underlying,
-                                Real illegalLocalVolOverwrite)
-        : LocalVolSurface(blackTS, riskFreeTS, dividendTS, underlying),
+                                Real illegalLocalVolOverwrite,
+                                bool extrapolate = false)
+        : LocalVolSurface(blackTS, riskFreeTS, dividendTS, underlying, extrapolate),
           illegalLocalVolOverwrite_(illegalLocalVolOverwrite) { }
 
       protected:

--- a/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
+++ b/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
@@ -48,7 +48,7 @@
     #define SWAPTIONVOLCUBE_TOL 100.0e-4
 #endif
 
-namespace QuantLib {    
+namespace QuantLib {
 
     class Interpolation2D;
     class EndCriteria;
@@ -56,7 +56,7 @@ namespace QuantLib {
 
     //! XABR Swaption Volatility Cube
     /*! This class implements the XABR Swaption Volatility Cube
-        which is a generic for different SABR, ZABR and 
+        which is a generic for different SABR, ZABR and
         different smile models that can be used to instantiate concrete cubes.
     */
     template<class Model>
@@ -929,10 +929,9 @@ namespace QuantLib {
                     ext::make_shared<BilinearInterpolation>(
                         optionTimes_.begin(), optionTimes_.end(),
                         swapLengths_.begin(), swapLengths_.end(),
-                        transposedPoints_[k]);
+                        transposedPoints_[k], true);
             interpolators_.push_back(ext::shared_ptr<Interpolation2D>(
                 new FlatExtrapolator2D(interpolation)));
-            interpolators_[k]->enableExtrapolation();
         }
         setPoints(points);
      }
@@ -1161,7 +1160,7 @@ namespace QuantLib {
     //                      SabrSwaptionVolatilityCube                      //
     //======================================================================//
 
-    //! Swaption Volatility Cube SABR 
+    //! Swaption Volatility Cube SABR
     /*! This struct defines the types used by SABR Volatility cubes
         for interpolation (SABRInterpolation) and for modeling the
         smile (SabrSmileSection).

--- a/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvoldiscrete.cpp
@@ -51,9 +51,9 @@ namespace QuantLib {
 
         optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
                                                  optionInterpolatorTimes_.end(),
-                                                 optionInterpolatorDatesAsReal_.begin());
+                                                 optionInterpolatorDatesAsReal_.begin(),
+                                                 true);
         optionInterpolator_.update();
-        optionInterpolator_.enableExtrapolation();
         cachedReferenceDate_ = referenceDate();
     }
 
@@ -84,9 +84,9 @@ namespace QuantLib {
 
         optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
                                                  optionInterpolatorTimes_.end(),
-                                                 optionInterpolatorDatesAsReal_.begin());
+                                                 optionInterpolatorDatesAsReal_.begin(),
+                                                 true);
         optionInterpolator_.update();
-        optionInterpolator_.enableExtrapolation();
     }
 
     SwaptionVolatilityDiscrete::SwaptionVolatilityDiscrete(
@@ -116,9 +116,9 @@ namespace QuantLib {
 
         optionInterpolator_= LinearInterpolation(optionInterpolatorTimes_.begin(),
                                                  optionInterpolatorTimes_.end(),
-                                                 optionInterpolatorDatesAsReal_.begin());
+                                                 optionInterpolatorDatesAsReal_.begin(),
+                                                 true);
         optionInterpolator_.update();
-        optionInterpolator_.enableExtrapolation();
     }
 
     void SwaptionVolatilityDiscrete::checkOptionDates(const Date& reference) const {
@@ -173,7 +173,7 @@ namespace QuantLib {
     }
 
     void SwaptionVolatilityDiscrete::initializeSwapLengths() const {
-        for (Size i=0; i<nSwapTenors_; ++i) 
+        for (Size i=0; i<nSwapTenors_; ++i)
             swapLengths_[i] = swapLength(swapTenors_[i]);
     }
 

--- a/ql/termstructures/volatility/swaption/swaptionvolstructure.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolstructure.cpp
@@ -26,22 +26,25 @@ namespace QuantLib {
 
     SwaptionVolatilityStructure::SwaptionVolatilityStructure(
                                                     BusinessDayConvention bdc,
-                                                    const DayCounter& dc)
-    : VolatilityTermStructure(bdc, dc) {}
+                                                    const DayCounter& dc,
+                                                    bool extrapolate)
+    : VolatilityTermStructure(bdc, dc, extrapolate) {}
 
     SwaptionVolatilityStructure::SwaptionVolatilityStructure(
                                                 const Date& referenceDate,
                                                 const Calendar& calendar,
                                                 BusinessDayConvention bdc,
-                                                const DayCounter& dc)
-    : VolatilityTermStructure(referenceDate, calendar, bdc, dc) {}
+                                                const DayCounter& dc,
+                                                bool extrapolate)
+    : VolatilityTermStructure(referenceDate, calendar, bdc, dc, extrapolate) {}
 
     SwaptionVolatilityStructure::SwaptionVolatilityStructure(
                                                 Natural settlementDays,
                                                 const Calendar& calendar,
                                                 BusinessDayConvention bdc,
-                                                const DayCounter& dc)
-    : VolatilityTermStructure(settlementDays, calendar, bdc, dc) {}
+                                                const DayCounter& dc,
+                                                bool extrapolate)
+    : VolatilityTermStructure(settlementDays, calendar, bdc, dc, extrapolate) {}
 
 
     Time SwaptionVolatilityStructure::swapLength(const Period& p) const {

--- a/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolstructure.hpp
@@ -50,17 +50,20 @@ namespace QuantLib {
                      by overriding the referenceDate() method.
         */
         SwaptionVolatilityStructure(BusinessDayConvention bdc,
-                                    const DayCounter& dc = DayCounter());
+                                    const DayCounter& dc = DayCounter(),
+                                    bool extrapolate = false);
         //! initialize with a fixed reference date
         SwaptionVolatilityStructure(const Date& referenceDate,
                                     const Calendar& calendar,
                                     BusinessDayConvention bdc,
-                                    const DayCounter& dc = DayCounter());
+                                    const DayCounter& dc = DayCounter(),
+                                    bool extrapolate = false);
         //! calculate the reference date based on the global evaluation date
         SwaptionVolatilityStructure(Natural settlementDays,
                                     const Calendar&,
                                     BusinessDayConvention bdc,
-                                    const DayCounter& dc = DayCounter());
+                                    const DayCounter& dc = DayCounter(),
+                                    bool extrapolate = false);
         //@}
         ~SwaptionVolatilityStructure() override = default;
         //! \name Volatility, variance and smile

--- a/ql/termstructures/voltermstructure.cpp
+++ b/ql/termstructures/voltermstructure.cpp
@@ -22,20 +22,23 @@
 namespace QuantLib {
 
     VolatilityTermStructure::VolatilityTermStructure(BusinessDayConvention bdc,
-                                                     const DayCounter& dc)
-    : TermStructure(dc), bdc_(bdc) {}
+                                                     const DayCounter& dc,
+                                                     bool extrapolate)
+    : TermStructure(dc, extrapolate), bdc_(bdc) {}
 
     VolatilityTermStructure::VolatilityTermStructure(const Date& referenceDate,
                                                      const Calendar& cal,
                                                      BusinessDayConvention bdc,
-                                                     const DayCounter& dc)
-    : TermStructure(referenceDate, cal, dc), bdc_(bdc) {}
+                                                     const DayCounter& dc,
+                                                     bool extrapolate)
+    : TermStructure(referenceDate, cal, dc, extrapolate), bdc_(bdc) {}
 
     VolatilityTermStructure::VolatilityTermStructure(Natural settlementDays,
                                                      const Calendar& cal,
                                                      BusinessDayConvention bdc,
-                                                     const DayCounter& dc)
-    : TermStructure(settlementDays, cal, dc), bdc_(bdc) {}
+                                                     const DayCounter& dc,
+                                                     bool extrapolate)
+    : TermStructure(settlementDays, cal, dc, extrapolate), bdc_(bdc) {}
 
     void VolatilityTermStructure::checkStrike(Rate k,
                                               bool extrapolate) const {

--- a/ql/termstructures/voltermstructure.hpp
+++ b/ql/termstructures/voltermstructure.hpp
@@ -45,17 +45,20 @@ namespace QuantLib {
                      by overriding the referenceDate() method.
         */
         VolatilityTermStructure(BusinessDayConvention bdc,
-                                const DayCounter& dc = DayCounter());
+                                const DayCounter& dc = DayCounter(),
+                                bool extrapolate = false);
         //! initialize with a fixed reference date
         VolatilityTermStructure(const Date& referenceDate,
                                 const Calendar& cal,
                                 BusinessDayConvention bdc,
-                                const DayCounter& dc = DayCounter());
+                                const DayCounter& dc = DayCounter(),
+                                bool extrapolate = false);
         //! calculate the reference date based on the global evaluation date
         VolatilityTermStructure(Natural settlementDays,
                                 const Calendar& cal,
                                 BusinessDayConvention bdc,
-                                const DayCounter& dc = DayCounter());
+                                const DayCounter& dc = DayCounter(),
+                                bool extrapolate = false);
         //@}
         //! the business day convention used in tenor to date conversion
         virtual BusinessDayConvention businessDayConvention() const;

--- a/ql/termstructures/yield/zerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/zerospreadedtermstructure.hpp
@@ -50,7 +50,8 @@ namespace QuantLib {
                                   Handle<Quote> spread,
                                   Compounding comp = Continuous,
                                   Frequency freq = NoFrequency,
-                                  DayCounter dc = DayCounter());
+                                  DayCounter dc = DayCounter(),
+                                  bool extrapolate = false);
         //! \name YieldTermStructure interface
         //@{
         DayCounter dayCounter() const override;
@@ -82,7 +83,8 @@ namespace QuantLib {
                                                                 Handle<Quote> spread,
                                                                 Compounding comp,
                                                                 Frequency freq,
-                                                                DayCounter dc)
+                                                                DayCounter dc,
+                                                                bool extrapolate)
     : originalCurve_(std::move(h)), spread_(std::move(spread)), comp_(comp), freq_(freq),
       dc_(std::move(dc)) {
         if (!originalCurve_.empty())

--- a/ql/termstructures/yield/zeroyieldstructure.cpp
+++ b/ql/termstructures/yield/zeroyieldstructure.cpp
@@ -23,23 +23,26 @@
 
 namespace QuantLib {
 
-    ZeroYieldStructure::ZeroYieldStructure(const DayCounter& dc)
-    : YieldTermStructure(dc) {}
+    ZeroYieldStructure::ZeroYieldStructure(const DayCounter& dc,
+                                           bool extrapolate)
+    : YieldTermStructure(dc, extrapolate) {}
 
     ZeroYieldStructure::ZeroYieldStructure(
                                     const Date& refDate,
                                     const Calendar& cal,
                                     const DayCounter& dc,
                                     const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates)
-    : YieldTermStructure(refDate, cal, dc, jumps, jumpDates) {}
+                                    const std::vector<Date>& jumpDates,
+                                    bool extrapolate)
+    : YieldTermStructure(refDate, cal, dc, jumps, jumpDates, extrapolate) {}
 
     ZeroYieldStructure::ZeroYieldStructure(
                                     Natural settlementDays,
                                     const Calendar& cal,
                                     const DayCounter& dc,
                                     const std::vector<Handle<Quote> >& jumps,
-                                    const std::vector<Date>& jumpDates)
-    : YieldTermStructure(settlementDays, cal, dc, jumps, jumpDates) {}
+                                    const std::vector<Date>& jumpDates,
+                                    bool extrapolate)
+    : YieldTermStructure(settlementDays, cal, dc, jumps, jumpDates, extrapolate) {}
 
 }

--- a/ql/termstructures/yield/zeroyieldstructure.hpp
+++ b/ql/termstructures/yield/zeroyieldstructure.hpp
@@ -49,19 +49,22 @@ namespace QuantLib {
         */
         //@{
         explicit ZeroYieldStructure(
-            const DayCounter& dc = DayCounter());
+            const DayCounter& dc = DayCounter(),
+            bool extrapolate = false);
         explicit ZeroYieldStructure(
             const Date& referenceDate,
             const Calendar& calendar = Calendar(),
             const DayCounter& dc = DayCounter(),
             const std::vector<Handle<Quote> >& jumps = {},
-            const std::vector<Date>& jumpDates = {});
+            const std::vector<Date>& jumpDates = {},
+            bool extrapolate = false);
         ZeroYieldStructure(
             Natural settlementDays,
             const Calendar& calendar,
             const DayCounter& dc = DayCounter(),
             const std::vector<Handle<Quote> >& jumps = {},
-            const std::vector<Date>& jumpDates = {});
+            const std::vector<Date>& jumpDates = {},
+            bool extrapolate = false);
         //@}
       protected:
         /*! \name Calculations

--- a/ql/termstructures/yieldtermstructure.cpp
+++ b/ql/termstructures/yieldtermstructure.cpp
@@ -30,14 +30,17 @@ namespace QuantLib {
         const Time dt = 0.0001;
     }
 
-    YieldTermStructure::YieldTermStructure(const DayCounter& dc) : TermStructure(dc) {}
+    YieldTermStructure::YieldTermStructure(const DayCounter& dc,
+                                           bool extrapolate)
+    : TermStructure(dc, extrapolate) {}
 
     YieldTermStructure::YieldTermStructure(const Date& referenceDate,
                                            const Calendar& cal,
                                            const DayCounter& dc,
                                            std::vector<Handle<Quote> > jumps,
-                                           const std::vector<Date>& jumpDates)
-    : TermStructure(referenceDate, cal, dc), jumps_(std::move(jumps)), jumpDates_(jumpDates),
+                                           const std::vector<Date>& jumpDates,
+                                           bool extrapolate)
+    : TermStructure(referenceDate, cal, dc, extrapolate), jumps_(std::move(jumps)), jumpDates_(jumpDates),
       jumpTimes_(jumpDates.size()), nJumps_(jumps_.size()) {
         setJumps(YieldTermStructure::referenceDate());
         for (Size i=0; i<nJumps_; ++i)
@@ -48,8 +51,9 @@ namespace QuantLib {
                                            const Calendar& cal,
                                            const DayCounter& dc,
                                            std::vector<Handle<Quote> > jumps,
-                                           const std::vector<Date>& jumpDates)
-    : TermStructure(settlementDays, cal, dc), jumps_(std::move(jumps)), jumpDates_(jumpDates),
+                                           const std::vector<Date>& jumpDates,
+                                           bool extrapolate)
+    : TermStructure(settlementDays, cal, dc, extrapolate), jumps_(std::move(jumps)), jumpDates_(jumpDates),
       jumpTimes_(jumpDates.size()), nJumps_(jumps_.size()) {
         setJumps(YieldTermStructure::referenceDate());
         for (Size i=0; i<nJumps_; ++i)

--- a/ql/termstructures/yieldtermstructure.hpp
+++ b/ql/termstructures/yieldtermstructure.hpp
@@ -48,17 +48,20 @@ namespace QuantLib {
             constructors.
         */
         //@{
-        explicit YieldTermStructure(const DayCounter& dc = DayCounter());
+        explicit YieldTermStructure(const DayCounter& dc = DayCounter(),
+                                    bool extrapolate = false);
         YieldTermStructure(const Date& referenceDate,
                            const Calendar& cal = Calendar(),
                            const DayCounter& dc = DayCounter(),
                            std::vector<Handle<Quote> > jumps = {},
-                           const std::vector<Date>& jumpDates = {});
+                           const std::vector<Date>& jumpDates = {},
+                           bool extrapolate = false);
         YieldTermStructure(Natural settlementDays,
                            const Calendar& cal,
                            const DayCounter& dc = DayCounter(),
                            std::vector<Handle<Quote> > jumps = {},
-                           const std::vector<Date>& jumpDates = {});
+                           const std::vector<Date>& jumpDates = {},
+                           bool extrapolate = false);
         //@}
 
         /*! \name Discount factors

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -149,8 +149,7 @@ Real fokkerPlanckPrice1D(const ext::shared_ptr<FdmMesher>& mesher,
         payoffTimesDensity[i] = (*payoff)(std::exp(x[i]))*p[i];
     }
 
-    CubicNaturalSpline f(x.begin(), x.end(), payoffTimesDensity.begin());
-    f.enableExtrapolation();
+    CubicNaturalSpline f(x.begin(), x.end(), payoffTimesDensity.begin(), true);
     return GaussLobattoIntegral(1000, 1e-6)(f, x.front(), x.back());
 }
 
@@ -1576,8 +1575,7 @@ BOOST_AUTO_TEST_CASE(testLocalVolsvSLVPropDensity) {
         ext::make_shared<HestonModel>(hestonProcess));
 
     const Handle<LocalVolTermStructure> localVol(
-        ext::make_shared<NoExceptLocalVolSurface>(vTS, rTS, qTS, spot, 0.3));
-    localVol->enableExtrapolation(true);
+        ext::make_shared<NoExceptLocalVolSurface>(vTS, rTS, qTS, spot, 0.3, true));
 
     const Size vGrid = 151;
     const Size xGrid = 51;


### PR DESCRIPTION
Currently extrapolation can only be enabled using the `Extrapolator::enableExtrapolation` method, but it's useful to be able to enable it when constructing the extrapolator for the following reasons:

1. It allows the extrapolator to be const once constructed.
2. It works with prvalues, not just with lvalues.

In order to keep this PR relatively small, there are some other subclasses of `Extrapolator` that I haven't yet changed, but I may create another PR to change those later.

By the way, I notice that `extrapolate` is passed as a function argument to some functions like `checkRange` and `checkStrike`, but as far as I can tell there is nothing that enforces the value to be the same as `Extrapolator::extrapolate_`. Is there a situation in which they can legitimately be different? If not, then how about we deprecate the `extrapolate` function argument and use the value of the member variable directly?