### PR TITLE
Small fixes for AAD

### DIFF
--- a/ql/experimental/credit/spotlosslatentmodel.hpp
+++ b/ql/experimental/credit/spotlosslatentmodel.hpp
@@ -185,7 +185,7 @@ namespace QuantLib {
     {
         Real sumMs = 
             std::inner_product(this->factorWeights_[iName].begin(), 
-                               this->factorWeights_[iName].end(), m.begin(), 0.);
+                               this->factorWeights_[iName].end(), m.begin(), Real(0.));
         Real res = this->cumulativeZ((invCumYProb - sumMs) / 
                 this->idiosyncFctrs_[iName] );
         #if defined(QL_EXTRA_SAFETY_CHECKS)
@@ -236,12 +236,12 @@ namespace QuantLib {
         //Size iRR = iName + basket_->size();// should be live pool
         const Real sumMs =
           std::inner_product(fctrs_[iName].begin(), fctrs_[iName].end(), 
-              mktFactors.begin(), 0.);
+              mktFactors.begin(), Real(0.));
         const Real sumBetaLoss = 
           std::inner_product(fctrs_[iName + numNames_].begin(),
               fctrs_[iName + numNames_].end(),
               fctrs_[iName + numNames_].begin(), 
-              0.);
+              Real(0.));
         return this->cumulativeZ((sumMs + std::sqrt(1.-crossIdiosyncFctrs_[iName])
                  * std::sqrt(1.+modelA_*modelA_) * 
                    invUncondRR
@@ -264,7 +264,7 @@ namespace QuantLib {
                 basket_->defaultKeys()[iName]);
         const Probability pdef = dfts->defaultProbability(d, true);
         // before asking for -\infty
-        if (pdef < 1.e-10) return 0.;
+        if (pdef < 1.e-10) return Real(0.);
 
         Size iRecovery = iName + numNames_;// should be live pool
         return cumulativeY(
@@ -361,7 +361,7 @@ namespace QuantLib {
                 \sum_k a^2_{i,k} a^2_{N+i,k}
             */
         {
-            Real cumul = 0.;
+            Real cumul = Real(0.);
             for(Size iB=0; iB<factorWeights[iName].size(); iB++)
                 // actually this size is unique
                 cumul += factorWeights[iName][iB] * 

--- a/ql/pricingengines/blackformula.cpp
+++ b/ql/pricingengines/blackformula.cpp
@@ -836,7 +836,7 @@ namespace QuantLib {
 
     namespace {
 
-        boost::math::normal_distribution<double> normal_dist;
+        boost::math::normal_distribution<Real> normal_dist;
 
         Real phi(const Real x) {
             return boost::math::pdf(normal_dist, x);


### PR DESCRIPTION
This PR fixes instances where `Real` is instantiated as `double`. These issues were discovered in [QuantLib-Risks-Cpp](https://github.com/auto-differentiation/QuantLib-Risks-Cpp/). The changes are:

- boost::math::normal_distribution<~double~ -> Real> in [blackformula.cpp](https://github.com/lballabio/QuantLib/blob/master/ql/pricingengines/blackformula.cpp)
- All meaningful instantiations of `Real` as `0.` (or variations) changed to `Real(0.)` for consistency in [spotlosslatentmodel.hpp](https://github.com/lballabio/QuantLib/blob/master/ql/experimental/credit/spotlosslatentmodel.hpp)