### PR TITLE
Added Warsaw Stock Exchange Calendar (Poland)

### DIFF
--- a/ql/indexes/ibor/wibor.hpp
+++ b/ql/indexes/ibor/wibor.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
 		Wibor(const Period& tenor,
               const Handle<YieldTermStructure>& h = {})
 			: IborIndex("WIBOR", tenor, (tenor == 1 * Days ? 0 : 2), PLNCurrency(),
-				Poland(), ModifiedFollowing, false,
+				Poland(Poland::Settlement), ModifiedFollowing, false,
 				Actual365Fixed(), h) {}
 	};
 

--- a/ql/time/calendars/poland.cpp
+++ b/ql/time/calendars/poland.cpp
@@ -24,7 +24,6 @@ namespace QuantLib {
 
     Poland::Poland(Poland::Market market) {
         // all calendar instances share the same implementation instance
-        // static ext::shared_ptr<Calendar::Impl> impl(new Poland::Impl);
         static auto settlementImpl = ext::make_shared<Poland::SettlementImpl>();
         static auto wseImpl = ext::make_shared<Poland::WseImpl>();
         switch (market) {

--- a/ql/time/calendars/poland.cpp
+++ b/ql/time/calendars/poland.cpp
@@ -18,16 +18,28 @@
 */
 
 #include <ql/time/calendars/poland.hpp>
+#include <ql/errors.hpp>
 
 namespace QuantLib {
 
-    Poland::Poland() {
+    Poland::Poland(Poland::Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Poland::Impl);
-        impl_ = impl;
+        // static ext::shared_ptr<Calendar::Impl> impl(new Poland::Impl);
+        static auto settlementImpl = ext::make_shared<Poland::SettlementImpl>();
+        static auto wseImpl = ext::make_shared<Poland::WseImpl>();
+        switch (market) {
+          case Settlement:
+            impl_ = settlementImpl;
+            break;
+          case WSE:
+            impl_ = wseImpl;
+            break;
+          default:
+            QL_FAIL("unknown market");
+        }
     }
 
-    bool Poland::Impl::isBusinessDay(const Date& date) const {
+    bool Poland::SettlementImpl::isBusinessDay(const Date& date) const {
         Weekday w = date.weekday();
         Day d = date.dayOfMonth(), dd = date.dayOfYear();
         Month m = date.month();
@@ -58,6 +70,21 @@ namespace QuantLib {
             || (d == 26 && m == December))
             return false; // NOLINT(readability-simplify-boolean-expr)
         return true;
+    }
+
+    
+    bool Poland::WseImpl::isBusinessDay(const Date& date) const {
+        // Additional holidays for Warsaw Stock Exchange
+        // see https://www.gpw.pl/session-details
+        Day d = date.dayOfMonth();
+        Month m = date.month();
+
+        if (
+            (d == 24  && m == December)
+            || (d == 31  && m == December)
+            ) return false; // NOLINT(readability-simplify-boolean-expr)
+
+        return SettlementImpl::isBusinessDay(date);
     }
 
 }

--- a/ql/time/calendars/poland.hpp
+++ b/ql/time/calendars/poland.hpp
@@ -50,13 +50,23 @@ namespace QuantLib {
     */
     class Poland : public Calendar {
       private:
-        class Impl final : public Calendar::WesternImpl {
+        class SettlementImpl : public Calendar::WesternImpl {
           public:
-            std::string name() const override { return "Poland"; }
+            std::string name() const override { return "Poland Settlement"; }
+            bool isBusinessDay(const Date&) const override;
+        };
+        class WseImpl final : public SettlementImpl {
+          public:
+            std::string name() const override { return "Warsaw stock exchange"; }
             bool isBusinessDay(const Date&) const override;
         };
       public:
-        Poland();
+        //! PL calendars
+        enum Market { Settlement,  //!< Settlement calendar
+                      WSE,         //!< Warsaw stock exchange calendar
+        };
+
+        explicit Poland(Market market = Settlement);
     };
 
 }


### PR DESCRIPTION
Hi Luigi, hi all,

I'm here since v1.23 and up until now I have been building my own version of library which has additional polish calendar which is in line with Warsaw Stock Exchange calendar (https://www.gpw.pl/session-details -> click tab Exchange holidays) which consists two more holidays than standard polish calendar that is: 24 December and 31 December. These are days without market session in Poland. It is not a big deal, but I thought that why not make PR in upstream repo.
I believe adding to library such WSE calendar would be small attraction for users calculating dates according to stock exchange calendar in Poland. 

Instead one Poland calendar I offered two: _Poland Settlement_ and _Warsaw stock exchange_. _Poland Settlement_ would be default one to keep backward compatibility, and if one would need WSE calendar, he need to explicitly chose it.

Credits also to @adamgrad5 for coworking on this PR.

I hope you find this PR useful. If so, I'll create relevant PR to SWIG repo as well.