### PR TITLE
Change the order of `QL_DEPRECATED_...` macro definition

### DIFF
--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -196,13 +196,6 @@
         __pragma(warning(disable : 4996))
 #    define QL_DEPRECATED_ENABLE_WARNING \
         __pragma(warning(pop))
-#elif defined(__GNUC__)
-#    define QL_DEPRECATED __attribute__((deprecated))
-#    define QL_DEPRECATED_DISABLE_WARNING                               \
-        _Pragma("GCC diagnostic push")                                  \
-        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#    define QL_DEPRECATED_ENABLE_WARNING \
-        _Pragma("GCC diagnostic pop")
 #elif defined(__clang__)
 #    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                                 \
@@ -210,6 +203,13 @@
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #    define QL_DEPRECATED_ENABLE_WARNING \
         _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#    define QL_DEPRECATED __attribute__((deprecated))
+#    define QL_DEPRECATED_DISABLE_WARNING                               \
+        _Pragma("GCC diagnostic push")                                  \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#    define QL_DEPRECATED_ENABLE_WARNING \
+        _Pragma("GCC diagnostic pop")
 #else
 // we don't know how to enable it, just define the macros away
 #    define QL_DEPRECATED

--- a/ql/qldefines.hpp.cfg
+++ b/ql/qldefines.hpp.cfg
@@ -197,13 +197,6 @@
         __pragma(warning(disable : 4996))
 #    define QL_DEPRECATED_ENABLE_WARNING \
         __pragma(warning(pop))
-#elif defined(__GNUC__)
-#    define QL_DEPRECATED __attribute__((deprecated))
-#    define QL_DEPRECATED_DISABLE_WARNING                               \
-        _Pragma("GCC diagnostic push")                                  \
-        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#    define QL_DEPRECATED_ENABLE_WARNING \
-        _Pragma("GCC diagnostic pop")
 #elif defined(__clang__)
 #    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                                 \
@@ -211,6 +204,13 @@
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #    define QL_DEPRECATED_ENABLE_WARNING \
         _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+#    define QL_DEPRECATED __attribute__((deprecated))
+#    define QL_DEPRECATED_DISABLE_WARNING                               \
+        _Pragma("GCC diagnostic push")                                  \
+        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#    define QL_DEPRECATED_ENABLE_WARNING \
+        _Pragma("GCC diagnostic pop")
 #else
 // we don't know how to enable it, just define the macros away
 #    define QL_DEPRECATED


### PR DESCRIPTION
The definition should be turned around as `clang` defines `__GNUC__` itself (in my case for `clang++18` to `__GNUC__ == 4`, probably to be underneath a valid `gcc` version).

More an esthetic PR as `clang` is able to handle the `_Pragma("GCC ...")` too.