### PR TITLE
Improve global bootstrap optimizer configuration

### DIFF
--- a/ql/math/optimization/endcriteria.cpp
+++ b/ql/math/optimization/endcriteria.cpp
@@ -158,23 +158,31 @@ namespace QuantLib {
         return gradientNormEpsilon_;
     }
 
+    bool EndCriteria::succeeded(EndCriteria::Type ecType) {
+        return ecType == StationaryPoint ||
+               ecType == StationaryFunctionValue ||
+               ecType == StationaryFunctionAccuracy;
+    }
+
     std::ostream& operator<<(std::ostream& out, EndCriteria::Type ec) {
         switch (ec) {
-        case QuantLib::EndCriteria::None:
+          case EndCriteria::None:
             return out << "None";
-        case QuantLib::EndCriteria::MaxIterations:
+          case EndCriteria::MaxIterations:
             return out << "MaxIterations";
-        case QuantLib::EndCriteria::StationaryPoint:
+          case EndCriteria::StationaryPoint:
             return out << "StationaryPoint";
-        case QuantLib::EndCriteria::StationaryFunctionValue:
+          case EndCriteria::StationaryFunctionValue:
             return out << "StationaryFunctionValue";
-        case QuantLib::EndCriteria::StationaryFunctionAccuracy:
+          case EndCriteria::StationaryFunctionAccuracy:
             return out << "StationaryFunctionAccuracy";
-        case QuantLib::EndCriteria::ZeroGradientNorm:
+          case EndCriteria::ZeroGradientNorm:
             return out << "ZeroGradientNorm";
-        case QuantLib::EndCriteria::Unknown:
+          case EndCriteria::FunctionEpsilonTooSmall:
+            return out << "FunctionEpsilonTooSmall";
+          case EndCriteria::Unknown:
             return out << "Unknown";
-        default:
+          default:
             QL_FAIL("unknown EndCriteria::Type (" << Integer(ec) << ")");
         }
     }

--- a/ql/math/optimization/endcriteria.hpp
+++ b/ql/math/optimization/endcriteria.hpp
@@ -45,6 +45,7 @@ namespace QuantLib {
                    StationaryFunctionValue,
                    StationaryFunctionAccuracy,
                    ZeroGradientNorm,
+                   FunctionEpsilonTooSmall,
                    Unknown};
 
         //! Initialization constructor
@@ -95,6 +96,7 @@ namespace QuantLib {
         /*! Test if the gradient norm value is below gradientNormEpsilon */
         bool checkZeroGradientNorm(Real gNorm, EndCriteria::Type& ecType) const;
 
+        static bool succeeded(EndCriteria::Type ecType);
       protected:
         //! Maximum number of iterations
         Size maxIterations_;

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -101,6 +101,8 @@ namespace QuantLib {
                        wa1.get(), wa2.get(), wa3.get(), wa4.get(),
                        lmdifCostFunction,
                        lmdifJacFunction);
+        // for the time being
+        info_ = info;
         // check requirements & endCriteria evaluation
         QL_REQUIRE(info != 0, "MINPACK: improper input parameters");
         QL_REQUIRE(info != 7, "MINPACK: xtol is too small. no further "

--- a/ql/math/optimization/levenbergmarquardt.hpp
+++ b/ql/math/optimization/levenbergmarquardt.hpp
@@ -40,7 +40,7 @@ namespace QuantLib {
         of the problem is used instead. Note that
         the default implementation of the jacobian
         in CostFunction uses a central difference
-        (oder 2, but requiring more function
+        (order 2, but requiring more function
         evaluations) compared to the forward
         difference implemented here (order 1).
 
@@ -53,10 +53,7 @@ namespace QuantLib {
                            Real gtol = 1.0e-8,
                            bool useCostFunctionsJacobian = false);
         EndCriteria::Type minimize(Problem& P,
-                                   const EndCriteria& endCriteria //= EndCriteria()
-                                   ) override;
-        //      = EndCriteria(400, 1.0e-8, 1.0e-8)
-        virtual Integer getInfo() const;
+                                   const EndCriteria& endCriteria) override;
         void fcn(int m,
                  int n,
                  Real* x,
@@ -72,9 +69,8 @@ namespace QuantLib {
         Problem* currentProblem_;
         Array initCostValues_;
         Matrix initJacobian_;
-        mutable Integer info_ = 0;
         const Real epsfcn_, xtol_, gtol_;
-        bool useCostFunctionsJacobian_;
+        const bool useCostFunctionsJacobian_;
     };
 
 }

--- a/ql/math/optimization/levenbergmarquardt.hpp
+++ b/ql/math/optimization/levenbergmarquardt.hpp
@@ -54,6 +54,7 @@ namespace QuantLib {
                            bool useCostFunctionsJacobian = false);
         EndCriteria::Type minimize(Problem& P,
                                    const EndCriteria& endCriteria) override;
+
         void fcn(int m,
                  int n,
                  Real* x,
@@ -65,10 +66,16 @@ namespace QuantLib {
                  Real* fjac,
                  int* iflag);
 
+        /*! \deprecated Don't use this method; inspect the result of minimize instead.
+                        Deprecated in version 1.36.
+        */
+        [[deprecated("Don't use this method; inspect the result of minimize instead")]]
+        virtual Integer getInfo() const { return info_; }
       private:
         Problem* currentProblem_;
         Array initCostValues_;
         Matrix initJacobian_;
+        mutable Integer info_ = 0; // remove together with getInfo
         const Real epsfcn_, xtol_, gtol_;
         const bool useCostFunctionsJacobian_;
     };

--- a/ql/termstructures/localbootstrap.hpp
+++ b/ql/termstructures/localbootstrap.hpp
@@ -240,9 +240,8 @@ namespace QuantLib {
             EndCriteria::Type endType = solver.minimize(toSolve, endCriteria);
 
             // check the end criteria
-            QL_REQUIRE(endType == EndCriteria::StationaryFunctionAccuracy ||
-                       endType == EndCriteria::StationaryFunctionValue,
-                       "Unable to strip yieldcurve to required accuracy " );
+            QL_REQUIRE(EndCriteria::succeeded(endType),
+                       "Unable to strip yieldcurve to required accuracy: " << endType);
             ++iInst;
         } while ( iInst < nInsts );
         validCurve_ = true;


### PR DESCRIPTION
Currently global bootstrap uses "accuracy" in several different ways:
* For all parameters passed to LevenbergMarquardt.
* For all epsilon parameters passed to EndCriteria.
* As the upper bound on the final value of the cost function.

This overloading makes it quite inflexible. Instead:
* Allow passing optimizer and EndCriteria to the constructor, which allows full control over all parameters.
* Instead of checking the final value of the cost function, check the result type from the optimizer.

Also, cleanup LevenbergMarquardt optimizer: remove commented out code, fix parameters passed to MINPACK.