### PR TITLE
Simplify `Null<T>` implementation

### DIFF
--- a/ql/cashflows/cpicoupon.cpp
+++ b/ql/cashflows/cpicoupon.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                          const Date& refPeriodStart,
                          const Date& refPeriodEnd,
                          const Date& exCouponDate)
-    : CPICoupon(baseCPI, Null<Date>(), paymentDate, nominal, startDate, endDate,
+    : CPICoupon(baseCPI, Date(), paymentDate, nominal, startDate, endDate,
                 index, observationLag, observationInterpolation, dayCounter,
                 fixedRate, refPeriodStart, refPeriodEnd, exCouponDate) {}
 
@@ -84,7 +84,7 @@ namespace QuantLib {
       observationInterpolation_(observationInterpolation), baseDate_(baseDate) {
 
         QL_REQUIRE(index_, "no index provided");
-        QL_REQUIRE(baseCPI_ != Null<Rate>() || baseDate != Null<Date>(),
+        QL_REQUIRE(baseCPI_ != Null<Rate>() || baseDate != Date(),
                    "baseCPI and baseDate can not be both null, provide a valid baseCPI or baseDate");
         QL_REQUIRE(baseCPI_ == Null<Rate>() || std::fabs(baseCPI_) > 1e-16,
                    "|baseCPI_| < 1e-16, future divide-by-zero problem");
@@ -150,7 +150,7 @@ namespace QuantLib {
       interpolation_(interpolation), frequency_(index ? index->frequency() : NoFrequency) {
         QL_REQUIRE(index, "no index provided");
         QL_REQUIRE(
-            baseFixing_ != Null<Rate>() || baseDate != Null<Date>(),
+            baseFixing_ != Null<Rate>() || baseDate != Date(),
             "baseCPI and baseDate can not be both null, provide a valid baseCPI or baseDate");
         QL_REQUIRE(baseFixing_ == Null<Rate>() || std::fabs(baseFixing_) > 1e-16,
                    "|baseCPI_| < 1e-16, future divide-by-zero problem");
@@ -182,7 +182,7 @@ namespace QuantLib {
                    const Period& observationLag)
     : schedule_(std::move(schedule)), index_(std::move(index)), baseCPI_(baseCPI),
       observationLag_(observationLag), paymentDayCounter_(Thirty360(Thirty360::BondBasis)),
-      paymentCalendar_(schedule_.calendar()), baseDate_(Null<Date>()) {}
+      paymentCalendar_(schedule_.calendar()) {}
 
 
     CPILeg& CPILeg::withObservationInterpolation(CPI::InterpolationType interp) {
@@ -283,7 +283,7 @@ namespace QuantLib {
         if (n>0) {
             QL_REQUIRE(!fixedRates_.empty(), "no fixedRates given");
 
-            if (baseDate_ == Null<Date>() && baseCPI_ == Null<Real>()) {
+            if (baseDate_ == Date() && baseCPI_ == Null<Real>()) {
                 baseDate = schedule_.date(0) - observationLag_;
             }
 

--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -250,7 +250,7 @@ namespace QuantLib {
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_ = Following;
         bool exCouponEndOfMonth_ = false;
-        Date baseDate_ = Null<Date>();
+        Date baseDate_ = Date();
     };
 
 

--- a/ql/cashflows/timebasket.cpp
+++ b/ql/cashflows/timebasket.cpp
@@ -47,7 +47,7 @@ namespace QuantLib {
         for (auto j : *this) {
             Date date = j.first;
             Real value = j.second;
-            Date pDate = Null<Date>(), nDate = Null<Date>();
+            Date pDate = Date(), nDate = Date();
 
             auto bi =
                 std::lower_bound(sbuckets.begin(), sbuckets.end(), date);
@@ -60,7 +60,7 @@ namespace QuantLib {
             if (bi != sbuckets.begin() && bi != sbuckets.end())
                 nDate = *(bi-1);
 
-            if (pDate == date || nDate == Null<Date>()) {
+            if (pDate == date || nDate == Date()) {
                 result[pDate] += value;
             } else {
                 Real pDays = Real(pDate-date);

--- a/ql/experimental/credit/defaultevent.cpp
+++ b/ql/experimental/credit/defaultevent.cpp
@@ -97,7 +97,7 @@ namespace QuantLib {
     : bondsCurrency_(std::move(curr)), defaultDate_(creditEventDate), eventType_(atomicEvType),
       bondsSeniority_(bondsSen),
       defSettlement_(settleDate, recoveryRates.empty() ? makeIsdaConvMap() : recoveryRates) {
-        if(settleDate != Null<Date>()) {// has settled
+        if (settleDate != Date()) {// has settled
             QL_REQUIRE(settleDate >= creditEventDate,
               "Settlement date should be after default date.");
             QL_REQUIRE(recoveryRates.find(bondsSen) != recoveryRates.end(),
@@ -114,7 +114,7 @@ namespace QuantLib {
                                Real recoveryRate)
     : bondsCurrency_(std::move(curr)), defaultDate_(creditEventDate), eventType_(atomicEvType),
       bondsSeniority_(bondsSen), defSettlement_(settleDate, bondsSen, recoveryRate) {
-        if(settleDate != Null<Date>()) {
+        if (settleDate != Date()) {
             QL_REQUIRE(settleDate >= creditEventDate,
             "Settlement date should be after default date.");
         }

--- a/ql/experimental/credit/defaultevent.hpp
+++ b/ql/experimental/credit/defaultevent.hpp
@@ -96,7 +96,7 @@ namespace QuantLib {
                      Currency curr,
                      Seniority bondsSen,
                      // Settlement information:
-                     const Date& settleDate = Null<Date>(),
+                     const Date& settleDate = Date(),
                      const std::map<Seniority, Real>& recoveryRates = rate_map());
         /*! Use NoSeniority to settle to all seniorities with that
             recovery. In that case the event is assumed to have
@@ -114,7 +114,7 @@ namespace QuantLib {
         bool isRestructuring() const { return eventType_.isRestructuring(); }
         bool isDefault() const { return !isRestructuring();}
         bool hasSettled() const {
-            return defSettlement_.date() != Null<Date>();
+            return defSettlement_.date() != Date();
         }
         const DefaultSettlement& settlement() const {
             return defSettlement_;

--- a/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
+++ b/ql/experimental/exoticoptions/partialtimebarrieroption.cpp
@@ -51,8 +51,7 @@ namespace QuantLib {
     PartialTimeBarrierOption::arguments::arguments()
     : barrierType(PartialBarrier::Type(-1)),
       barrierRange(PartialBarrier::Range(-1)),
-      barrier(Null<Real>()), rebate(Null<Real>()),
-      coverEventDate(Null<Date>()) {}
+      barrier(Null<Real>()), rebate(Null<Real>()) {}
 
     void PartialTimeBarrierOption::arguments::validate() const {
         OneAssetOption::arguments::validate();
@@ -78,7 +77,7 @@ namespace QuantLib {
 
         QL_REQUIRE(barrier != Null<Real>(), "no barrier given");
         QL_REQUIRE(rebate != Null<Real>(), "no rebate given");
-        QL_REQUIRE(coverEventDate != Null<Date>(), "no cover event date given");
+        QL_REQUIRE(coverEventDate != Date(), "no cover event date given");
         QL_REQUIRE(coverEventDate < exercise->lastDate(),
                    "cover event date equal or later than exercise date");
     }

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -149,7 +149,7 @@ namespace QuantLib {
     }
 
     Date Bond::maturityDate() const {
-        if (maturityDate_!=Null<Date>())
+        if (maturityDate_ != Date())
             return maturityDate_;
         else
             return BondFunctions::maturityDate(*this);

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
     : side_(side), notional_(notional), upfront_(ext::nullopt), runningSpread_(spread),
       settlesAccrual_(settlesAccrual), paysAtDefaultTime_(paysAtDefaultTime),
       claim_(std::move(claim)),
-      protectionStart_(protectionStart == Null<Date>() ? schedule[0] : protectionStart),
+      protectionStart_(protectionStart == Date() ? schedule[0] : protectionStart),
       tradeDate_(tradeDate), cashSettlementDays_(cashSettlementDays) {
 
         init(schedule, convention, dayCounter, lastPeriodDayCounter, rebatesAccrual);
@@ -78,7 +78,7 @@ namespace QuantLib {
     : side_(side), notional_(notional), upfront_(upfront), runningSpread_(runningSpread),
       settlesAccrual_(settlesAccrual), paysAtDefaultTime_(paysAtDefaultTime),
       claim_(std::move(claim)),
-      protectionStart_(protectionStart == Null<Date>() ? schedule[0] : protectionStart),
+      protectionStart_(protectionStart == Date() ? schedule[0] : protectionStart),
       tradeDate_(tradeDate), cashSettlementDays_(cashSettlementDays) {
 
         init(schedule, convention, dayCounter, lastPeriodDayCounter, rebatesAccrual, upfrontDate);
@@ -460,10 +460,8 @@ namespace QuantLib {
         QL_REQUIRE(!leg.empty(), "coupons not set");
         QL_REQUIRE(upfrontPayment, "upfront payment not set");
         QL_REQUIRE(claim, "claim not set");
-        QL_REQUIRE(protectionStart != Null<Date>(),
-                   "protection start date not set");
-        QL_REQUIRE(maturity != Null<Date>(),
-                   "maturity date not set");
+        QL_REQUIRE(protectionStart != Date(), "protection start date not set");
+        QL_REQUIRE(maturity != Date(), "maturity date not set");
     }
 
     void CreditDefaultSwap::results::reset() {
@@ -494,7 +492,7 @@ namespace QuantLib {
         if (rule == DateGeneration::CDS2015 && (anchorDate == Date(20, Dec, anchorDate.year()) ||
             anchorDate == Date(20, Jun, anchorDate.year()))) {
             if (tenor.length() == 0) {
-                return Null<Date>();
+                return Date();
             } else {
                 anchorDate -= 3 * Months;
             }

--- a/ql/instruments/creditdefaultswap.hpp
+++ b/ql/instruments/creditdefaultswap.hpp
@@ -347,7 +347,7 @@ namespace QuantLib {
 
     /*! Return the CDS maturity date given the CDS trade date, \p tradeDate, the CDS \p tenor and a CDS \p rule.
 
-        A \c Null<Date>() is returned when a \p rule of \c CDS2015 and a \p tenor length of zero fail to yield a valid
+        A null date is returned when a \p rule of \c CDS2015 and a \p tenor length of zero fail to yield a valid
         CDS maturity date.
 
         \warning An exception will be thrown if the \p rule is not \c CDS2015, \c CDS or \c OldCDS.

--- a/ql/instruments/forwardvanillaoption.hpp
+++ b/ql/instruments/forwardvanillaoption.hpp
@@ -36,8 +36,7 @@ namespace QuantLib {
     template <class ArgumentsType>
     class ForwardOptionArguments : public ArgumentsType {
       public:
-        ForwardOptionArguments() : moneyness(Null<Real>()),
-                                   resetDate(Null<Date>()) {}
+        ForwardOptionArguments() : moneyness(Null<Real>()) {}
         void validate() const override;
         Real moneyness;
         Date resetDate;
@@ -72,7 +71,7 @@ namespace QuantLib {
         QL_REQUIRE(moneyness != Null<Real>(), "null moneyness given");
         QL_REQUIRE(moneyness > 0.0, "negative or zero moneyness given");
 
-        QL_REQUIRE(resetDate != Null<Date>(), "null reset date given");
+        QL_REQUIRE(resetDate != Date(), "null reset date given");
         QL_REQUIRE(resetDate >= Settings::instance().evaluationDate(),
                    "reset date in the past");
         QL_REQUIRE(this->exercise->lastDate() > resetDate,

--- a/ql/instruments/makecds.cpp
+++ b/ql/instruments/makecds.cpp
@@ -46,7 +46,7 @@ namespace QuantLib {
 
     MakeCreditDefaultSwap::operator ext::shared_ptr<CreditDefaultSwap>() const {
 
-        Date tradeDate = (tradeDate_ != Null<Date>()) ? tradeDate_ : Settings::instance().evaluationDate();
+        Date tradeDate = (tradeDate_ != Date()) ? tradeDate_ : Settings::instance().evaluationDate();
         Date upfrontDate = WeekendsOnly().advance(tradeDate, cashSettlementDays_, Days);
 
         Date protectionStart;

--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                                Rate strike)
     : swapIndex_(std::move(swapIndex)), delivery_(Settlement::Physical),
       settlementMethod_(Settlement::PhysicalOTC), optionTenor_(optionTenor),
-      optionConvention_(ModifiedFollowing), fixingDate_(Null<Date>()), strike_(strike),
+      optionConvention_(ModifiedFollowing), strike_(strike),
       underlyingType_(Swap::Payer), nominal_(1.0) {}
 
     MakeSwaption::MakeSwaption(ext::shared_ptr<SwapIndex> swapIndex,
@@ -58,10 +58,10 @@ namespace QuantLib {
         // if the evaluation date is not a business day
         // then move to the next business day
         refDate = fixingCalendar.adjust(refDate);
-        if (fixingDate_ == Null<Date>())
+        if (fixingDate_ == Date())
             fixingDate_ = fixingCalendar.advance(refDate, optionTenor_,
                                                  optionConvention_);
-        if (exerciseDate_ == Null<Date>()) {
+        if (exerciseDate_ == Date()) {
             exercise_ = ext::shared_ptr<Exercise>(new
                 EuropeanExercise(fixingDate_));
         } else {

--- a/ql/instruments/simplechooseroption.hpp
+++ b/ql/instruments/simplechooseroption.hpp
@@ -50,7 +50,7 @@ namespace QuantLib {
     //! Extra %arguments for single chooser option
     class SimpleChooserOption::arguments : public OneAssetOption::arguments {
       public:
-        arguments() : choosingDate(Null<Date>()) {}
+        arguments() = default;
         void validate() const override;
         Date choosingDate;
     };

--- a/ql/legacy/libormarketmodels/lfmcovarparam.hpp
+++ b/ql/legacy/libormarketmodels/lfmcovarparam.hpp
@@ -45,9 +45,9 @@ namespace QuantLib {
         Size size() const { return size_; }
         Size factors() const { return factors_; }
 
-        virtual Matrix diffusion(Time t, const Array& x = Null<Array>()) const = 0;
-        virtual Matrix covariance(Time t, const Array& x = Null<Array>()) const;
-        virtual Matrix integratedCovariance(Time t, const Array& x = Null<Array>()) const;
+        virtual Matrix diffusion(Time t, const Array& x = {}) const = 0;
+        virtual Matrix covariance(Time t, const Array& x = {}) const;
+        virtual Matrix integratedCovariance(Time t, const Array& x = {}) const;
 
       protected:
         const Size size_;

--- a/ql/legacy/libormarketmodels/lfmcovarproxy.hpp
+++ b/ql/legacy/libormarketmodels/lfmcovarproxy.hpp
@@ -40,12 +40,11 @@ namespace QuantLib {
         ext::shared_ptr<LmVolatilityModel>  volatilityModel() const;
         ext::shared_ptr<LmCorrelationModel> correlationModel() const;
 
-        Matrix diffusion(Time t, const Array& x = Null<Array>()) const override;
-        Matrix covariance(Time t, const Array& x = Null<Array>()) const override;
+        Matrix diffusion(Time t, const Array& x = {}) const override;
+        Matrix covariance(Time t, const Array& x = {}) const override;
 
         using LfmCovarianceParameterization::integratedCovariance;
-        virtual Real integratedCovariance(
-            Size i, Size j, Time t, const Array& x = Null<Array>()) const;
+        virtual Real integratedCovariance(Size i, Size j, Time t, const Array& x = {}) const;
 
       protected:
         const ext::shared_ptr<LmVolatilityModel>  volaModel_;

--- a/ql/legacy/libormarketmodels/lfmhullwhiteparam.hpp
+++ b/ql/legacy/libormarketmodels/lfmhullwhiteparam.hpp
@@ -45,9 +45,9 @@ namespace QuantLib {
             const ext::shared_ptr<OptionletVolatilityStructure> & capletVol,
             const Matrix& correlation = Matrix(), Size factors = 1);
 
-        Matrix diffusion(Time t, const Array& x = Null<Array>()) const override;
-        Matrix covariance(Time t, const Array& x = Null<Array>()) const override;
-        Matrix integratedCovariance(Time t, const Array& x = Null<Array>()) const override;
+        Matrix diffusion(Time t, const Array& x = {}) const override;
+        Matrix covariance(Time t, const Array& x = {}) const override;
+        Matrix integratedCovariance(Time t, const Array& x = {}) const override;
 
       protected:
         Size nextIndexReset(Time t) const;

--- a/ql/legacy/libormarketmodels/lmconstwrappercorrmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmconstwrappercorrmodel.hpp
@@ -38,13 +38,13 @@ namespace QuantLib {
 
         Size factors() const override { return corrModel_->factors(); }
 
-        Matrix correlation(Time t, const Array& x = Null<Array>()) const override {
+        Matrix correlation(Time t, const Array& x = {}) const override {
             return corrModel_->correlation(t, x);
         }
-        Matrix pseudoSqrt(Time t, const Array& x = Null<Array>()) const override {
+        Matrix pseudoSqrt(Time t, const Array& x = {}) const override {
             return corrModel_->pseudoSqrt(t, x);
         }
-        Real correlation(Size i, Size j, Time t, const Array& x = Null<Array>()) const override {
+        Real correlation(Size i, Size j, Time t, const Array& x = {}) const override {
             return corrModel_->correlation(i, j, t, x);
         }
         bool isTimeIndependent() const override { return corrModel_->isTimeIndependent(); }

--- a/ql/legacy/libormarketmodels/lmconstwrappervolmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmconstwrappervolmodel.hpp
@@ -37,15 +37,14 @@ namespace QuantLib {
           volaModel_(volaModel) {
         }
 
-        Array volatility(Time t, const Array& x = Null<Array>()) const override {
+        Array volatility(Time t, const Array& x = {}) const override {
             return volaModel_->volatility(t, x);
         }
         Volatility volatility(
-            Size i, Time t, const Array& x = Null<Array>()) {
+            Size i, Time t, const Array& x = {}) {
             return volaModel_->volatility(i, t, x);
         }
-        Real
-        integratedVariance(Size i, Size j, Time u, const Array& x = Null<Array>()) const override {
+        Real integratedVariance(Size i, Size j, Time u, const Array& x = {}) const override {
             return volaModel_->integratedVariance(i, j, u, x);
         }
 

--- a/ql/legacy/libormarketmodels/lmcorrmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmcorrmodel.hpp
@@ -43,9 +43,9 @@ namespace QuantLib {
         std::vector<Parameter>& params();
         void setParams(const std::vector<Parameter> & arguments);
 
-        virtual Matrix correlation(Time t, const Array& x = Null<Array>()) const = 0;
-        virtual Matrix pseudoSqrt(Time t, const Array& x = Null<Array>()) const;
-        virtual Real correlation(Size i, Size j, Time t, const Array& x = Null<Array>()) const;
+        virtual Matrix correlation(Time t, const Array& x = {}) const = 0;
+        virtual Matrix pseudoSqrt(Time t, const Array& x = {}) const;
+        virtual Real correlation(Size i, Size j, Time t, const Array& x = {}) const;
         virtual bool isTimeIndependent() const;
 
     protected:

--- a/ql/legacy/libormarketmodels/lmexpcorrmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmexpcorrmodel.hpp
@@ -46,8 +46,8 @@ namespace QuantLib {
       public:
         LmExponentialCorrelationModel(Size size, Real rho);
 
-        Matrix correlation(Time t, const Array& x = Null<Array>()) const override;
-        Matrix pseudoSqrt(Time t, const Array& x = Null<Array>()) const override;
+        Matrix correlation(Time t, const Array& x = {}) const override;
+        Matrix pseudoSqrt(Time t, const Array& x = {}) const override;
         Real correlation(Size i, Size j, Time t, const Array& x) const override;
         bool isTimeIndependent() const override;
 

--- a/ql/legacy/libormarketmodels/lmextlinexpvolmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmextlinexpvolmodel.hpp
@@ -49,11 +49,10 @@ namespace QuantLib {
         LmExtLinearExponentialVolModel(const std::vector<Time>& fixingTimes,
                                        Real a, Real b, Real c, Real d);
 
-        Array volatility(Time t, const Array& x = Null<Array>()) const override;
-        Volatility volatility(Size i, Time t, const Array& x = Null<Array>()) const override;
+        Array volatility(Time t, const Array& x = {}) const override;
+        Volatility volatility(Size i, Time t, const Array& x = {}) const override;
 
-        Real
-        integratedVariance(Size i, Size j, Time u, const Array& x = Null<Array>()) const override;
+        Real integratedVariance(Size i, Size j, Time u, const Array& x = {}) const override;
     };
 
 }

--- a/ql/legacy/libormarketmodels/lmfixedvolmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmfixedvolmodel.hpp
@@ -32,7 +32,7 @@ namespace QuantLib {
       public:
         LmFixedVolatilityModel(Array volatilities, const std::vector<Time>& startTimes);
 
-        Array volatility(Time t, const Array& x = Null<Array>()) const override;
+        Array volatility(Time t, const Array& x = {}) const override;
         Volatility volatility(Size i, Time t, const Array& x) const override;
 
       private:

--- a/ql/legacy/libormarketmodels/lmlinexpcorrmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmlinexpcorrmodel.hpp
@@ -47,8 +47,8 @@ namespace QuantLib {
         LmLinearExponentialCorrelationModel(Size size, Real rho, Real beta,
                                             Size factors = Null<Size>());
 
-        Matrix correlation(Time t, const Array& x = Null<Array>()) const override;
-        Matrix pseudoSqrt(Time t, const Array& x = Null<Array>()) const override;
+        Matrix correlation(Time t, const Array& x = {}) const override;
+        Matrix pseudoSqrt(Time t, const Array& x = {}) const override;
         Real correlation(Size i, Size j, Time t, const Array& x) const override;
 
         Size factors() const override;

--- a/ql/legacy/libormarketmodels/lmlinexpvolmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmlinexpvolmodel.hpp
@@ -45,15 +45,13 @@ namespace QuantLib {
 
     class LmLinearExponentialVolatilityModel : public LmVolatilityModel {
       public:
-        LmLinearExponentialVolatilityModel(
-                                         const std::vector<Time>& fixingTimes,
-                                         Real a, Real b, Real c, Real d);
+        LmLinearExponentialVolatilityModel(const std::vector<Time>& fixingTimes,
+                                           Real a, Real b, Real c, Real d);
 
-        Array volatility(Time t, const Array& x = Null<Array>()) const override;
-        Volatility volatility(Size i, Time t, const Array& x = Null<Array>()) const override;
+        Array volatility(Time t, const Array& x = {}) const override;
+        Volatility volatility(Size i, Time t, const Array& x = {}) const override;
 
-        Real
-        integratedVariance(Size i, Size j, Time u, const Array& x = Null<Array>()) const override;
+        Real integratedVariance(Size i, Size j, Time u, const Array& x = {}) const override;
 
       private:
         void generateArguments() override;

--- a/ql/legacy/libormarketmodels/lmvolmodel.hpp
+++ b/ql/legacy/libormarketmodels/lmvolmodel.hpp
@@ -40,10 +40,9 @@ namespace QuantLib {
         std::vector<Parameter> & params();
         void setParams(const std::vector<Parameter> & arguments);
 
-        virtual Array volatility(Time t, const Array& x = Null<Array>()) const = 0;
-        virtual Volatility volatility(Size i, Time t, const Array& x = Null<Array>()) const;
-        virtual Real integratedVariance(Size i, Size j, Time u,
-                                        const Array& x = Null<Array>()) const;
+        virtual Array volatility(Time t, const Array& x = {}) const = 0;
+        virtual Volatility volatility(Size i, Time t, const Array& x = {}) const;
+        virtual Real integratedVariance(Size i, Size j, Time u, const Array& x = {}) const;
 
       protected:
         const Size size_;

--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -146,25 +146,6 @@ namespace QuantLib {
         Size n_;
     };
 
-    #ifdef QL_NULL_AS_FUNCTIONS
-
-    //! specialization of null template for this class
-    template <>
-    inline Array Null<Array>() {
-        return {};
-    }
-
-    #else
-
-    //! specialization of null template for this class
-    template <>
-    class Null<Array> {
-      public:
-        Null() = default;
-        operator Array() const { return Array(); }
-    };
-
-    #endif
 
     /*! \relates Array */
     Real DotProduct(const Array&, const Array&);

--- a/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
@@ -47,8 +47,8 @@ namespace QuantLib {
                                    const Real shift,
                                    Natural settlementDays,
                                    RateAveraging::Type averagingMethod)
-    : BlackCalibrationHelper(volatility, errorType, type, shift), exerciseDate_(Null<Date>()),
-      endDate_(Null<Date>()), maturity_(maturity), length_(length), fixedLegTenor_(fixedLegTenor),
+    : BlackCalibrationHelper(volatility, errorType, type, shift),
+      maturity_(maturity), length_(length), fixedLegTenor_(fixedLegTenor),
       index_(std::move(index)), termStructure_(std::move(termStructure)),
       fixedLegDayCounter_(std::move(fixedLegDayCounter)),
       floatingLegDayCounter_(std::move(floatingLegDayCounter)), strike_(strike), nominal_(nominal),
@@ -73,7 +73,7 @@ namespace QuantLib {
                                    Natural settlementDays,
                                    RateAveraging::Type averagingMethod)
     : BlackCalibrationHelper(volatility, errorType, type, shift), exerciseDate_(exerciseDate),
-      endDate_(Null<Date>()), maturity_(0 * Days), length_(length), fixedLegTenor_(fixedLegTenor),
+      maturity_(0 * Days), length_(length), fixedLegTenor_(fixedLegTenor),
       index_(std::move(index)), termStructure_(std::move(termStructure)),
       fixedLegDayCounter_(std::move(fixedLegDayCounter)),
       floatingLegDayCounter_(std::move(floatingLegDayCounter)), strike_(strike), nominal_(nominal),
@@ -153,7 +153,7 @@ namespace QuantLib {
 
         Calendar calendar = index_->fixingCalendar();
         Date exerciseDate = exerciseDate_;
-        if (exerciseDate == Null<Date>())
+        if (exerciseDate == Date())
             exerciseDate = calendar.advance(termStructure_->referenceDate(),
                                             maturity_,
                                             index_->businessDayConvention());
@@ -167,7 +167,7 @@ namespace QuantLib {
         }
 
         Date endDate = endDate_;
-        if (endDate == Null<Date>())
+        if (endDate == Date())
             endDate = calendar.advance(startDate, length_,
                                        index_->businessDayConvention());
         Schedule fixedSchedule(startDate, endDate, fixedLegTenor_, calendar,

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.cpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.cpp
@@ -151,7 +151,7 @@ Real Gaussian1dModel::zerobondOption(
 
     Time fixingTime = termStructure()->timeFromReference(expiry);
     Time referenceTime =
-        referenceDate == Null<Date>()
+        referenceDate == Date()
             ? 0.0
             : termStructure()->timeFromReference(referenceDate);
 

--- a/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
+++ b/ql/models/shortrate/onefactormodels/gaussian1dmodel.hpp
@@ -87,7 +87,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
                    const Handle<YieldTermStructure>& yts = Handle<YieldTermStructure>()) const;
 
     Real zerobond(const Date& maturity,
-                  const Date& referenceDate = Null<Date>(),
+                  const Date& referenceDate = Date(),
                   Real y = 0.0,
                   const Handle<YieldTermStructure>& yts = Handle<YieldTermStructure>()) const;
 
@@ -96,7 +96,7 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
                         const Date& valueDate,
                         const Date& maturity,
                         Rate strike,
-                        const Date& referenceDate = Null<Date>(),
+                        const Date& referenceDate = Date(),
                         Real y = 0.0,
                         const Handle<YieldTermStructure>& yts = Handle<YieldTermStructure>(),
                         Real yStdDevs = 7.0,
@@ -106,20 +106,20 @@ class Gaussian1dModel : public TermStructureConsistentModel, public LazyObject {
 
     Real
     forwardRate(const Date& fixing,
-                const Date& referenceDate = Null<Date>(),
+                const Date& referenceDate = Date(),
                 Real y = 0.0,
                 const ext::shared_ptr<IborIndex>& iborIdx = ext::shared_ptr<IborIndex>()) const;
 
     Real swapRate(const Date& fixing,
                   const Period& tenor,
-                  const Date& referenceDate = Null<Date>(),
+                  const Date& referenceDate = Date(),
                   Real y = 0.0,
                   const ext::shared_ptr<SwapIndex>& swapIdx = ext::shared_ptr<SwapIndex>()) const;
 
     Real
     swapAnnuity(const Date& fixing,
                 const Period& tenor,
-                const Date& referenceDate = Null<Date>(),
+                const Date& referenceDate = Date(),
                 Real y = 0.0,
                 const ext::shared_ptr<SwapIndex>& swapIdx = ext::shared_ptr<SwapIndex>()) const;
 
@@ -252,7 +252,7 @@ Gaussian1dModel::zerobond(const Date &maturity, const Date &referenceDate,
                           const Real y, const Handle<YieldTermStructure> &yts) const {
 
     return zerobond(termStructure()->timeFromReference(maturity),
-                    referenceDate != Null<Date>()
+                    referenceDate != Date()
                         ? termStructure()->timeFromReference(referenceDate)
                         : 0.0,
                     y, yts);

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -670,17 +670,17 @@ namespace QuantLib {
                     modelCall.push_back(
                         calibrationPoint.second.isCaplet_ ?
                             capletPriceInternal(Option::Call, calibrationPoint.first, strikes[j],
-                                                Null<Date>(), 0.0, true) :
+                                                Date(), 0.0, true) :
                             swaptionPriceInternal(Option::Call, calibrationPoint.first,
                                                   calibrationPoint.second.tenor_, strikes[j],
-                                                  Null<Date>(), 0.0, true));
+                                                  Date(), 0.0, true));
                     modelPut.push_back(
                         calibrationPoint.second.isCaplet_ ?
                             capletPriceInternal(Option::Put, calibrationPoint.first, strikes[j],
-                                                Null<Date>(), 0.0, true) :
+                                                Date(), 0.0, true) :
                             swaptionPriceInternal(Option::Put, calibrationPoint.first,
                                                   calibrationPoint.second.tenor_, strikes[j],
-                                                  Null<Date>(), 0.0, true));
+                                                  Date(), 0.0, true));
                     marketVega.push_back(sec->vega(strikes[j], calibrationPoint.second.annuity_));
                 }
                 modelOutputs_.smileStrikes_.push_back(strikes);
@@ -1029,7 +1029,7 @@ namespace QuantLib {
 
         Time fixingTime = termStructure()->timeFromReference(expiry);
         Time referenceTime =
-            referenceDate == Null<Date>()
+            referenceDate == Date()
                 ? 0.0
                 : termStructure()->timeFromReference(referenceDate);
 
@@ -1099,7 +1099,7 @@ namespace QuantLib {
 
         Time fixingTime = termStructure()->timeFromReference(expiry);
         Time referenceTime =
-            referenceDate == Null<Date>()
+            referenceDate == Date()
                 ? 0.0
                 : termStructure()->timeFromReference(referenceDate);
 

--- a/ql/models/shortrate/onefactormodels/markovfunctional.hpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.hpp
@@ -437,7 +437,7 @@ namespace QuantLib {
 
         Real forwardRateInternal(
             const Date& fixing,
-            const Date& referenceDate = Null<Date>(),
+            const Date& referenceDate = Date(),
             Real y = 0.0,
             bool zeroFixingDays = false,
             ext::shared_ptr<IborIndex> iborIdx = ext::shared_ptr<IborIndex>()) const;
@@ -445,7 +445,7 @@ namespace QuantLib {
         Real
         swapRateInternal(const Date& fixing,
                          const Period& tenor,
-                         const Date& referenceDate = Null<Date>(),
+                         const Date& referenceDate = Date(),
                          Real y = 0.0,
                          bool zeroFixingDays = false,
                          ext::shared_ptr<SwapIndex> swapIdx = ext::shared_ptr<SwapIndex>()) const;
@@ -453,7 +453,7 @@ namespace QuantLib {
         Real swapAnnuityInternal(
             const Date& fixing,
             const Period& tenor,
-            const Date& referenceDate = Null<Date>(),
+            const Date& referenceDate = Date(),
             Real y = 0.0,
             bool zeroFixingDays = false,
             ext::shared_ptr<SwapIndex> swapIdx = ext::shared_ptr<SwapIndex>()) const;
@@ -462,7 +462,7 @@ namespace QuantLib {
             const Option::Type& type,
             const Date& expiry,
             Rate strike,
-            const Date& referenceDate = Null<Date>(),
+            const Date& referenceDate = Date(),
             Real y = 0.0,
             bool zeroFixingDays = false,
             ext::shared_ptr<IborIndex> iborIdx = ext::shared_ptr<IborIndex>()) const;
@@ -472,7 +472,7 @@ namespace QuantLib {
             const Date& expiry,
             const Period& tenor,
             Rate strike,
-            const Date& referenceDate = Null<Date>(),
+            const Date& referenceDate = Date(),
             Real y = 0.0,
             bool zeroFixingDays = false,
             const ext::shared_ptr<SwapIndex>& swapIdx = ext::shared_ptr<SwapIndex>()) const;

--- a/ql/prices.hpp
+++ b/ql/prices.hpp
@@ -104,25 +104,6 @@ namespace QuantLib {
         Real open_, close_, high_, low_;
     };
 
-    #ifdef QL_NULL_AS_FUNCTIONS
-
-    template <>
-    inline IntervalPrice Null<IntervalPrice>() {
-        return {};
-    };
-
-    #else
-
-    template <>
-    class Null<IntervalPrice>
-    {
-      public:
-        Null() = default;
-        operator IntervalPrice() const { return {}; }
-    };
-
-    #endif
-
 }
 
 #endif

--- a/ql/pricingengines/credit/isdacdsengine.cpp
+++ b/ql/pricingengines/credit/isdacdsengine.cpp
@@ -194,7 +194,7 @@ namespace QuantLib {
             Q0 = Q1;
         }
         protectionNpv *= arguments_.claim->amount(
-            Null<Date>(), arguments_.notional, recoveryRate_);
+            Date(), arguments_.notional, recoveryRate_);
 
         results_.defaultLegNPV = protectionNpv;
 

--- a/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dfloatfloatswaptionengine.cpp
@@ -166,7 +166,7 @@ namespace QuantLib {
         }
         // end probability computation
 
-        Date event1 = Null<Date>(), event0;
+        Date event1 = Date(), event0;
         Time event1Time = Null<Real>(), event0Time;
 
         ext::shared_ptr<IborIndex> ibor1 =

--- a/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dnonstandardswaptionengine.cpp
@@ -174,9 +174,9 @@ namespace QuantLib {
                 npvp1.push_back(npvTmp1);
             }
         }
-        // end probabkility computation
+        // end probability computation
 
-        Date expiry1 = Null<Date>(), expiry0;
+        Date expiry1 = Date(), expiry0;
         Time expiry1Time = Null<Real>(), expiry0Time;
 
         do {

--- a/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
+++ b/ql/pricingengines/swaption/gaussian1dswaptionengine.cpp
@@ -68,9 +68,9 @@ namespace QuantLib {
                 npvp1.push_back(npvTmp1);
             }
         }
-        // end probabkility computation
+        // end probability computation
 
-        Date expiry1 = Null<Date>(), expiry0;
+        Date expiry1 = Date(), expiry0;
         Time expiry1Time = Null<Real>(), expiry0Time;
 
         do {

--- a/ql/processes/gsrprocess.cpp
+++ b/ql/processes/gsrprocess.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
 
     Real GsrProcess::time(const Date &d) const {
         QL_REQUIRE(
-            referenceDate_ != Null<Date>() && dc_ != DayCounter(),
+            referenceDate_ != Date() && dc_ != DayCounter(),
             "time can not be computed without reference date and day counter");
         return dc_.yearFraction(referenceDate_, d);
     }

--- a/ql/processes/gsrprocess.hpp
+++ b/ql/processes/gsrprocess.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
                    const Array& vols,
                    const Array& reversions,
                    Real T = 60.0,
-                   const Date& referenceDate = Null<Date>(),
+                   const Date& referenceDate = Date(),
                    DayCounter dc = DayCounter());
         //! \name StochasticProcess1D interface
         //@{

--- a/ql/termstructures/volatility/gaussian1dsmilesection.cpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.cpp
@@ -37,9 +37,9 @@ namespace QuantLib {
       fixingDate_(fixingDate), swapIndex_(std::move(swapIndex)), model_(model),
       engine_(swaptionEngine) {
 
-        atm_ = model_->swapRate(fixingDate_, swapIndex_->tenor(), Null<Date>(), 0.0, swapIndex_);
+        atm_ = model_->swapRate(fixingDate_, swapIndex_->tenor(), Date(), 0.0, swapIndex_);
         annuity_ =
-            model_->swapAnnuity(fixingDate_, swapIndex_->tenor(), Null<Date>(), 0.0, swapIndex_);
+            model_->swapAnnuity(fixingDate_, swapIndex_->tenor(), Date(), 0.0, swapIndex_);
 
         if (engine_ == nullptr) {
             engine_ = ext::make_shared<Gaussian1dSwaptionEngine>(
@@ -56,7 +56,7 @@ namespace QuantLib {
     : SmileSection(fixingDate, dc, model->termStructure()->referenceDate()),
       fixingDate_(fixingDate), iborIndex_(std::move(iborIndex)), model_(model), engine_(capEngine) {
 
-        atm_ = model_->forwardRate(fixingDate_, Null<Date>(), 0.0, iborIndex_);
+        atm_ = model_->forwardRate(fixingDate_, Date(), 0.0, iborIndex_);
         CapFloor c =
             MakeCapFloor(CapFloor::Cap, iborIndex_->tenor(), iborIndex_, Null<Real>(), 0 * Days)
                 .withEffectiveDate(fixingDate_, false);

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -374,24 +374,6 @@ namespace QuantLib {
 
     }
 
-    #ifdef QL_NULL_AS_FUNCTIONS
-
-    //! specialization of Null template for the Date class
-    template <>
-    inline Date Null<Date>() {
-        return {};
-    }
-
-    #else
-
-    template <>
-    class Null<Date> {
-      public:
-        Null() = default;
-        operator Date() const { return {}; }
-    };
-
-    #endif
 
     // inline definitions
 

--- a/ql/utilities/null.hpp
+++ b/ql/utilities/null.hpp
@@ -32,37 +32,20 @@
 
 namespace QuantLib {
 
-    namespace detail {
-
-        template <bool>
-        struct FloatingPointNull;
-
-        // null value for floating-point types
-        template <>
-        struct FloatingPointNull<true> {
-            constexpr static float nullValue() {
-                // a specific values that should fit into any Real
-                return (std::numeric_limits<float>::max)();
-            }
-        };
-
-        // null value for integer types
-        template <>
-        struct FloatingPointNull<false> {
-            constexpr static int nullValue() {
-                // a specific values that should fit into any Integer
-                return (std::numeric_limits<int>::max)();
-            }
-        };
-
-    }
-
     #ifdef QL_NULL_AS_FUNCTIONS
 
     //! template function providing a null value for a given type.
     template <typename T>
     T Null() {
-        return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
+        if constexpr (std::is_floating_point_v<T>) {
+            // a specific, unlikely value that should fit into any Real
+            return (std::numeric_limits<float>::max)();
+        } else if constexpr (std::is_integral_v<T>) {
+            // this should fit into any Integer
+            return (std::numeric_limits<int>::max)();
+        } else {
+            return T();
+        }
     }
 
     #else
@@ -77,7 +60,15 @@ namespace QuantLib {
       public:
         Null() = default;
         operator T() const {
-            return T(detail::FloatingPointNull<std::is_floating_point<T>::value>::nullValue());
+            if constexpr (std::is_floating_point_v<T>) {
+                // a specific, unlikely value that should fit into any Real
+                return (std::numeric_limits<float>::max)();
+            } else if constexpr (std::is_integral_v<T>) {
+                // this should fit into any Integer
+                return (std::numeric_limits<int>::max)();
+            } else {
+                return T();
+            }
         }
     };
 

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(testLambdaBootstrapping) {
 
     ext::shared_ptr<LiborForwardModelProcess> process = makeProcess();
 
-    Matrix covar = process->covariance(0.0, Null<Array>(), 1.0);
+    Matrix covar = process->covariance(0.0, {}, 1.0);
 
     for (Size i=0; i<9; ++i) {
         const Real calculated = std::sqrt(covar[i+1][i+1]);

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -139,11 +139,11 @@ struct CommonVars {
              Rate fixedRate,
              Spread spread,
              bool telescopicValueDates,
-             Date effectiveDate = Null<Date>(),
+             Date effectiveDate = Date(),
              Integer paymentLag = 0,
              RateAveraging::Type averagingMethod = RateAveraging::Compound) {
         return MakeOIS(length, estrIndex, fixedRate, 0 * Days)
-            .withEffectiveDate(effectiveDate == Null<Date>() ? settlement : effectiveDate)
+            .withEffectiveDate(effectiveDate == Date() ? settlement : effectiveDate)
             .withOvernightLegSpread(spread)
             .withNominal(nominal)
             .withPaymentLag(paymentLag)
@@ -252,7 +252,7 @@ void testBootstrap(bool telescopicValueDates,
         Period term = i.n * i.unit;
         // test telescopic value dates (in bootstrap) against non telescopic value dates (swap here)
         ext::shared_ptr<OvernightIndexedSwap> swap =
-            vars.makeSwap(term, 0.0, 0.0, false, Null<Date>(), paymentLag, averagingMethod);
+            vars.makeSwap(term, 0.0, 0.0, false, Date(), paymentLag, averagingMethod);
         Rate calculated = swap->fairRate();
         Rate error = std::fabs(expected-calculated);
 
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapWithCustomPricer) {
         Period term = i.n * i.unit;
 
         ext::shared_ptr<OvernightIndexedSwap> swap =
-            vars.makeSwap(term, 0.0, 0.0, false, Null<Date>(), paymentLag, averagingMethod);
+            vars.makeSwap(term, 0.0, 0.0, false, Date(), paymentLag, averagingMethod);
         setCouponPricer(swap->overnightLeg(), pricer);
 
         Rate calculated = swap->fairRate();

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -865,7 +865,7 @@ BOOST_AUTO_TEST_CASE(testCDS2015ZeroMonthsMatured) {
     };
 
     for (const Date& input: inputs) {
-        BOOST_CHECK_EQUAL(cdsMaturity(input, tenor, rule), Null<Date>());
+        BOOST_CHECK_EQUAL(cdsMaturity(input, tenor, rule), Date());
     }
 }
 


### PR DESCRIPTION
- reimplemented `Null<T>` (both function and class) with `constexpr if`, which is simpler to read and also more flexible since we can now define a reasonable default for non-numeric types and thus remove the specializations we used to need;
- `Array x = Null<Array>()` is probably more readable as `Array x = {}`;
- null dates were sometimes written as `Null<Date>()` and sometimes as `Date()`, I settled on the latter throughout.