### PR TITLE
Speed up adding fixings

### DIFF
--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -101,7 +101,7 @@ namespace QuantLib {
                         bool forceOverwrite = false) {
             checkNativeFixingsAllowed();
             std::string tag = name();
-            TimeSeries<Real> h = IndexManager::instance().getHistory(tag);
+            TimeSeries<Real>& h = IndexManager::instance().getHistoryRef(tag);
             bool noInvalidFixing = true, noDuplicatedFixing = true;
             Date invalidDate, duplicatedDate;
             Real nullValue = Null<Real>();
@@ -128,7 +128,6 @@ namespace QuantLib {
                     invalidValue = *(vBegin++);
                 }
             }
-            IndexManager::instance().setHistory(tag, h);
             QL_REQUIRE(noInvalidFixing, "At least one invalid fixing provided: "
                                             << invalidDate.weekday() << " " << invalidDate << ", "
                                             << invalidValue);

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -29,6 +29,10 @@ namespace QuantLib {
         return data_[name].value();
     }
 
+    TimeSeries<Real>& IndexManager::getHistoryRef(const std::string& name) {
+        return data_[name].ref();
+    }
+
     void IndexManager::setHistory(const std::string& name, TimeSeries<Real> history) {
         data_[name] = std::move(history);
     }

--- a/ql/indexes/indexmanager.hpp
+++ b/ql/indexes/indexmanager.hpp
@@ -45,6 +45,8 @@ namespace QuantLib {
         bool hasHistory(const std::string& name) const;
         //! returns the (possibly empty) history of the index fixings
         const TimeSeries<Real>& getHistory(const std::string& name) const;
+        //! returns a ref to the (possibly empty) history of the index fixings
+         TimeSeries<Real>& getHistoryRef(const std::string& name);
         //! stores the historical fixings of the index
         void setHistory(const std::string& name, TimeSeries<Real> history);
         //! observer notifying of changes in the index fixings

--- a/ql/utilities/observablevalue.hpp
+++ b/ql/utilities/observablevalue.hpp
@@ -57,6 +57,8 @@ namespace QuantLib {
         operator ext::shared_ptr<Observable>() const;
         //! explicit inspector
         const T& value() const;
+        //! explicit reference
+        T& ref();
       private:
         T value_;
         ext::shared_ptr<Observable> observable_;
@@ -118,6 +120,10 @@ namespace QuantLib {
         return value_;
     }
 
+    template <class T>
+    T& ObservableValue<T>::ref() {
+        return value_;
+    }
 }
 
 #endif


### PR DESCRIPTION
We rely on `Index::addFixing()` to add historical fixings. When we add a large number of fixings (e.g. 10k - 100k) we see that this takes quite long, in the order of seconds, maybe 10s.

There is `Index::addFixings()` which is called from `Index::addFIxing()` and allows to add multiple fixings at once, but it can not be used generically since inflation indices overrides `Index::addFixing()` with their own logic. We have some custom index implementations which overwrite this method too. 

In the end, they all call into `Index::addFixings()` though, so it seems this is the right place for a performance optimization. This is what I am trying to do here. I observe a speed up of >100x when many fixings are set, this is achieved by avoiding the copy of the time series storing the historical fixings on each call of `Index::addFixings()`.


