### PR TITLE
added a recent temporary holiday

### DIFF
--- a/ql/time/calendars/southkorea.cpp
+++ b/ql/time/calendars/southkorea.cpp
@@ -206,6 +206,7 @@ namespace QuantLib {
             // Special temporary holiday
             || (d == 17 && m == August && y == 2020)
             || (d == 2 && m == October && y == 2023)
+            || (d == 1 && m == October && y == 2024)
 
             // Harvest Moon Day
             || ((d == 27 || d == 28 || d == 29) && m == September && y == 2004)

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -1770,6 +1770,7 @@ BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
     expectedHol.emplace_back(16, September, 2024);
     expectedHol.emplace_back(17, September, 2024);
     expectedHol.emplace_back(18, September, 2024);
+    expectedHol.emplace_back(1, October, 2024);
     expectedHol.emplace_back(3, October, 2024);
     expectedHol.emplace_back(9, October, 2024);
     expectedHol.emplace_back(25, December, 2024);
@@ -2518,6 +2519,7 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(16, September, 2024);
     expectedHol.emplace_back(17, September, 2024);
     expectedHol.emplace_back(18, September, 2024);
+    expectedHol.emplace_back(1, October, 2024);
     expectedHol.emplace_back(3, October, 2024);
     expectedHol.emplace_back(9, October, 2024);
     expectedHol.emplace_back(25, December, 2024);


### PR DESCRIPTION
I have added a recent temporary holiday for the calendar SouthKorea.

Please refer to https://www.koreatimes.co.kr/www/biz/2024/10/602_382094.html (Though I couldn't find official information written in English, however it seems enough).