### PR TITLE
Add the KOFR index

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -848,6 +848,7 @@
     <ClInclude Include="ql\indexes\ibor\gbplibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\jibar.hpp" />
     <ClInclude Include="ql\indexes\ibor\jpylibor.hpp" />
+    <ClInclude Include="ql\indexes\ibor\kofr.hpp" />
     <ClInclude Include="ql\indexes\ibor\libor.hpp" />
     <ClInclude Include="ql\indexes\ibor\mosprime.hpp" />
     <ClInclude Include="ql\indexes\ibor\nzdlibor.hpp" />
@@ -2137,6 +2138,7 @@
     <ClCompile Include="ql\indexes\ibor\euribor.cpp" />
     <ClCompile Include="ql\indexes\ibor\eurlibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\fedfunds.cpp" />
+    <ClCompile Include="ql\indexes\ibor\kofr.cpp" />
     <ClCompile Include="ql\indexes\ibor\libor.cpp" />
     <ClCompile Include="ql\indexes\ibor\shibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\sofr.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -669,6 +669,9 @@
     <ClInclude Include="ql\indexes\ibor\jpylibor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\ibor\kofr.hpp">
+      <Filter>indexes\ibor</Filter>
+    </ClInclude>
     <ClInclude Include="ql\indexes\ibor\libor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
@@ -4611,6 +4614,9 @@
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\fedfunds.cpp">
+      <Filter>indexes\ibor</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\ibor\kofr.cpp">
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\libor.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -235,6 +235,7 @@ set(QL_SOURCES
     indexes/ibor/euribor.cpp
     indexes/ibor/eurlibor.cpp
     indexes/ibor/fedfunds.cpp
+    indexes/ibor/kofr.cpp
     indexes/ibor/libor.cpp
     indexes/ibor/shibor.cpp
     indexes/ibor/sofr.cpp
@@ -1261,6 +1262,7 @@ set(QL_HEADERS
     indexes/ibor/gbplibor.hpp
     indexes/ibor/jibar.hpp
     indexes/ibor/jpylibor.hpp
+    indexes/ibor/kofr.hpp
     indexes/ibor/libor.hpp
     indexes/ibor/mosprime.hpp
     indexes/ibor/nzdlibor.hpp

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -23,6 +23,7 @@ this_include_HEADERS = \
     gbplibor.hpp \
     jibar.hpp \
     jpylibor.hpp \
+    kofr.hpp \
     libor.hpp \
     mosprime.hpp \
     nzdlibor.hpp \
@@ -50,6 +51,7 @@ cpp_files = \
     euribor.cpp \
     eurlibor.cpp \
     fedfunds.cpp \
+    kofr.cpp \
     libor.cpp \
     shibor.cpp \
     sofr.cpp \

--- a/ql/indexes/ibor/all.hpp
+++ b/ql/indexes/ibor/all.hpp
@@ -20,6 +20,7 @@
 #include <ql/indexes/ibor/gbplibor.hpp>
 #include <ql/indexes/ibor/jibar.hpp>
 #include <ql/indexes/ibor/jpylibor.hpp>
+#include <ql/indexes/ibor/kofr.hpp>
 #include <ql/indexes/ibor/libor.hpp>
 #include <ql/indexes/ibor/mosprime.hpp>
 #include <ql/indexes/ibor/nzdlibor.hpp>

--- a/ql/indexes/ibor/kofr.cpp
+++ b/ql/indexes/ibor/kofr.cpp
@@ -1,0 +1,31 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Jongbong An
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/currencies/asia.hpp>
+#include <ql/indexes/ibor/kofr.hpp>
+#include <ql/indexes/iborindex.hpp>
+#include <ql/time/calendars/southkorea.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+
+namespace QuantLib {
+    Kofr::Kofr(const Handle<YieldTermStructure>& h)
+    : OvernightIndex(
+          "KOFR", 0, KRWCurrency(), SouthKorea(SouthKorea::Settlement), Actual365Fixed(), h) {}
+
+}

--- a/ql/indexes/ibor/kofr.hpp
+++ b/ql/indexes/ibor/kofr.hpp
@@ -1,0 +1,44 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2024 Jongbong An
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file kofr.hpp
+    \brief %KOFR index
+*/
+
+#ifndef quantlib_kofr_hpp
+#define quantlib_kofr_hpp
+
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    //! %KOFR index.
+    /*! Korea Overnight Financing Repo Rate (KOFR) published by Korea Securities Depository (KSD)
+    Please refer to
+    (1) https://www.bok.or.kr/eng/main/contents.do?menuNo=400399 (Overview)
+    (2) https://www.kofr.kr/main.jsp (Detailed information)
+    */
+   class Kofr : public OvernightIndex {
+      public:
+        explicit Kofr(const Handle<YieldTermStructure>& h = {});
+    };
+    
+}
+
+#endif


### PR DESCRIPTION
Korea Overnight Financing Repo Rate (KOFR) published by Korea Securities Depository (KSD)
    
Please refer to
(1) https://www.bok.or.kr/eng/main/contents.do?menuNo=400399 (Overview)
(2) https://www.kofr.kr/main.jsp (Detailed information)