### PR TITLE
Deprecate most of the `IndexManager` public interface.

### DIFF
--- a/ql/cashflows/digitalcoupon.cpp
+++ b/ql/cashflows/digitalcoupon.cpp
@@ -238,9 +238,7 @@ namespace QuantLib {
             rate_ = underlyingRate + callCsi_ * callPayoff() + putCsi_  * putPayoff();
         } else if (fixingDate == today) {
             // might have been fixed
-            Rate pastFixing =
-                IndexManager::instance().getHistory((underlying_->index())->name())[fixingDate];
-            if (pastFixing != Null<Real>()) {
+            if (underlying_->index()->hasHistoricalFixing(fixingDate)) {
                 rate_ = underlyingRate + callCsi_ * callPayoff() + putCsi_  * putPayoff();
             } else {
                 rate_ = underlyingRate + callCsi_ * callOptionRate() + putCsi_ * putOptionRate();

--- a/ql/cashflows/overnightindexedcouponpricer.cpp
+++ b/ql/cashflows/overnightindexedcouponpricer.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
 
         const ext::shared_ptr<OvernightIndex> index =
             ext::dynamic_pointer_cast<OvernightIndex>(coupon_->index());
-        const auto& pastFixings = IndexManager::instance().getHistory(index->name());
+        const auto& pastFixings = index->timeSeries();
 
         const auto& fixingDates = coupon_->fixingDates();
         const auto& valueDates = coupon_->valueDates();
@@ -194,11 +194,13 @@ namespace QuantLib {
 
         Real accumulatedRate = 0.0;
 
+        const auto& pastFixings = index->timeSeries();
+
         // already fixed part
         Date today = Settings::instance().evaluationDate();
         while (i < n && fixingDates[i] < today) {
             // rate must have been fixed
-            Rate pastFixing = IndexManager::instance().getHistory(index->name())[fixingDates[i]];
+            Rate pastFixing = pastFixings[fixingDates[i]];
             QL_REQUIRE(pastFixing != Null<Real>(),
                        "Missing " << index->name() << " fixing for " << fixingDates[i]);
             accumulatedRate += pastFixing * dt[i];
@@ -209,8 +211,7 @@ namespace QuantLib {
         if (i < n && fixingDates[i] == today) {
             // might have been fixed
             try {
-                Rate pastFixing =
-                    IndexManager::instance().getHistory(index->name())[fixingDates[i]];
+                Rate pastFixing = pastFixings[fixingDates[i]];
                 if (pastFixing != Null<Real>()) {
                     accumulatedRate += pastFixing * dt[i];
                     ++i;

--- a/ql/experimental/commodities/commodityindex.cpp
+++ b/ql/experimental/commodities/commodityindex.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
       forwardCurve_(std::move(forwardCurve)), exchangeContracts_(std::move(exchangeContracts)),
       nearbyOffset_(nearbyOffset) {
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(name()));
+        registerWith(notifier());
 
         if (forwardCurve_ != nullptr)
             // registerWith(forwardCurve_);

--- a/ql/index.cpp
+++ b/ql/index.cpp
@@ -42,7 +42,9 @@ namespace QuantLib {
 
     void Index::clearFixings() {
         checkNativeFixingsAllowed();
+        QL_DEPRECATED_DISABLE_WARNING
         IndexManager::instance().clearHistory(name());
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     void Index::checkNativeFixingsAllowed() {

--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -69,7 +69,9 @@ namespace QuantLib {
         virtual Real pastFixing(const Date& fixingDate) const;
         //! returns the fixing TimeSeries
         const TimeSeries<Real>& timeSeries() const {
+            QL_DEPRECATED_DISABLE_WARNING
             return IndexManager::instance().getHistory(name());
+            QL_DEPRECATED_ENABLE_WARNING
         }
         //! check if index allows for native fixings.
         /*! If this returns false, calls to addFixing and similar
@@ -107,13 +109,23 @@ namespace QuantLib {
         //! clears all stored historical fixings
         void clearFixings();
 
+      protected:
+        ext::shared_ptr<Observable> notifier() const {
+            QL_DEPRECATED_DISABLE_WARNING
+            return IndexManager::instance().notifier(name());
+            QL_DEPRECATED_ENABLE_WARNING
+        }
+
       private:
         //! check if index allows for native fixings
         void checkNativeFixingsAllowed();
+
     };
 
     inline bool Index::hasHistoricalFixing(const Date& fixingDate) const {
+        QL_DEPRECATED_DISABLE_WARNING
         return IndexManager::instance().hasHistoricalFixing(name(), fixingDate);
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     inline Real Index::pastFixing(const Date& fixingDate) const {

--- a/ql/indexes/equityindex.cpp
+++ b/ql/indexes/equityindex.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         registerWith(dividend_);
         registerWith(spot_);
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(EquityIndex::name()));
+        registerWith(notifier());
     }
 
     Real EquityIndex::fixing(const Date& fixingDate, bool forecastTodaysFixing) const {

--- a/ql/indexes/indexmanager.cpp
+++ b/ql/indexes/indexmanager.cpp
@@ -30,7 +30,9 @@ namespace QuantLib {
     }
 
     void IndexManager::setHistory(const std::string& name, TimeSeries<Real> history) {
+        QL_DEPRECATED_DISABLE_WARNING
         notifier(name)->notifyObservers();
+        QL_DEPRECATED_ENABLE_WARNING
         data_[name] = std::move(history);
     }
 
@@ -59,13 +61,17 @@ namespace QuantLib {
     }
 
     void IndexManager::clearHistory(const std::string& name) {
+        QL_DEPRECATED_DISABLE_WARNING
         notifier(name)->notifyObservers();
+        QL_DEPRECATED_ENABLE_WARNING
         data_.erase(name);
     }
 
     void IndexManager::clearHistories() {
+        QL_DEPRECATED_DISABLE_WARNING
         for (auto const& d : data_)
             notifier(d.first)->notifyObservers();
+        QL_DEPRECATED_ENABLE_WARNING
         data_.clear();
     }
 

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -126,7 +126,7 @@ namespace QuantLib {
       frequency_(frequency), availabilityLag_(availabilityLag), currency_(std::move(currency)) {
         name_ = region_.name() + " " + familyName_;
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(InflationIndex::name()));
+        registerWith(notifier());
     }
 
     Calendar InflationIndex::fixingCalendar() const {

--- a/ql/indexes/interestrateindex.cpp
+++ b/ql/indexes/interestrateindex.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
         name_ = out.str();
 
         registerWith(Settings::instance().evaluationDate());
-        registerWith(IndexManager::instance().notifier(InterestRateIndex::name()));
+        registerWith(notifier());
     }
 
     Rate InterestRateIndex::fixing(const Date& fixingDate,

--- a/ql/instruments/overnightindexfuture.cpp
+++ b/ql/instruments/overnightindexfuture.cpp
@@ -46,8 +46,7 @@ namespace QuantLib {
         Date d1 = valueDate_;
         // d1 could be a holiday
         Date fixingDate = calendar.adjust(d1, Preceding);
-        const TimeSeries<Real>& history = IndexManager::instance()
-            .getHistory(overnightIndex_->name());
+        const auto& history = overnightIndex_->timeSeries();
         Real fwd;
         while (d1 < maturityDate_) {
             Date d2 = calendar.advance(d1, 1, Days);
@@ -86,8 +85,7 @@ namespace QuantLib {
             forwardDiscountStart = today;
             // for valuations inside the reference period, index quotes
             // must have been populated in the history
-            const TimeSeries<Real>& history = IndexManager::instance()
-                .getHistory(overnightIndex_->name());
+            const auto& history = overnightIndex_->timeSeries();
             Date d1 = valueDate_;
             // d1 could be a holiday
             Date fixingDate = calendar.adjust(d1, Preceding);

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -96,39 +96,19 @@ BOOST_AUTO_TEST_CASE(testFixingHasHistoricalFixing) {
 
     name = euribor3M->name();
     testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_upper_copy(euribor3M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_lower_copy(euribor3M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     name = euribor6M->name();
     testCase(name, fixingFound, euribor6M->hasHistoricalFixing(today));
     testCase(name, fixingFound, euribor6M_a->hasHistoricalFixing(today));
-    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_upper_copy(euribor6M->name());
-    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_lower_copy(euribor6M->name());
-    testCase(name, fixingFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     IndexManager::instance().clearHistories();
 
     name = euribor3M->name();
     testCase(name, fixingNotFound, euribor3M->hasHistoricalFixing(today));
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_upper_copy(euribor3M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_lower_copy(euribor3M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 
     name = euribor6M->name();
     testCase(name, fixingNotFound, euribor6M->hasHistoricalFixing(today));
     testCase(name, fixingNotFound, euribor6M_a->hasHistoricalFixing(today));
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_upper_copy(euribor6M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
-    name = boost::to_lower_copy(euribor6M->name());
-    testCase(name, fixingNotFound, IndexManager::instance().hasHistoricalFixing(name, today));
 }
 
 BOOST_AUTO_TEST_CASE(testTenorNormalization) {

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -342,10 +342,7 @@ BOOST_AUTO_TEST_CASE(testSwaps) {
         Date startDate = calendar.advance(settlement,start[i],Months);
         if (startDate < today) {
             Date fixingDate = calendar.advance(startDate,-2,Days);
-            TimeSeries<Real> pastFixings;
-            pastFixings[fixingDate] = 0.03;
-            IndexManager::instance().setHistory(euribor->name(),
-                                                pastFixings);
+            euribor->addFixing(fixingDate, 0.03);
         }
 
         for (Size j=0; j<std::size(length); j++) {


### PR DESCRIPTION
It will not be removed, but moved to the private section for use by `Index`.  Client code will go through indexes.