### PR TITLE
Deprecate `indexIsInterpolated` parameter in YoY inflation curves

### DIFF
--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -606,8 +606,6 @@ namespace QuantLib {
         }
 
         Date baseDate =
-            yoyIndex()->interpolated() ?
-            nominalTS_->referenceDate() - observationLag() :
             inflationPeriod(nominalTS_->referenceDate() - observationLag(),
                             yoyIndex()->frequency()).first;
         // usually this base rate is known
@@ -619,8 +617,7 @@ namespace QuantLib {
         auto pYITS =
             ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
                       nominalTS_->referenceDate(), baseDate, baseYoYRate,
-                      yoyIndex()->frequency(), yoyIndex()->interpolated(),
-                      dayCounter(), YYhelpers);
+                      yoyIndex()->frequency(), dayCounter(), YYhelpers);
         pYITS->recalculate();
         yoy_ = pYITS;   // store
 

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -117,6 +117,7 @@ namespace QuantLib {
 
         // start of curve data
         static Date initialDate(const YoYInflationTermStructure* t) {
+            QL_DEPRECATED_DISABLE_WARNING
             if (t->hasExplicitBaseDate()) {
                 return t->baseDate();
             } else if (t->indexIsInterpolated()) {
@@ -125,6 +126,7 @@ namespace QuantLib {
                 return inflationPeriod(t->referenceDate() - t->observationLag(),
                                        t->frequency()).first;
             }
+            QL_DEPRECATED_ENABLE_WARNING
         }
 
         // value at reference date

--- a/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
@@ -48,16 +48,28 @@ namespace QuantLib {
                                       std::vector<Date> dates,
                                       const std::vector<Rate>& rates,
                                       Frequency frequency,
+                                      const DayCounter& dayCounter,
+                                      const ext::shared_ptr<Seasonality>& seasonality = {},
+                                      const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the overload without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use the overload without indexIsInterpolated")]]
+        InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                      std::vector<Date> dates,
+                                      const std::vector<Rate>& rates,
+                                      Frequency frequency,
                                       bool indexIsInterpolated,
                                       const DayCounter& dayCounter,
                                       const ext::shared_ptr<Seasonality>& seasonality = {},
                                       const Interpolator& interpolator = Interpolator());
 
-        /*! \deprecated Use the other overload and pass the base date directly
-                        as the first date in the vector instead of using a lag.
+        /*! \deprecated Use the overload without lag and indexIsInterpolated and
+                        pass the base date as the first date in the vector.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use the overload without lag and indexIsInterpolated and pass the base date as the first date in the vector")]]
         InterpolatedYoYInflationCurve(const Date& referenceDate,
                                       const Calendar& calendar,
                                       const DayCounter& dayCounter,
@@ -98,16 +110,28 @@ namespace QuantLib {
                                       Date baseDate,
                                       Rate baseYoYRate,
                                       Frequency frequency,
+                                      const DayCounter& dayCounter,
+                                      const ext::shared_ptr<Seasonality>& seasonality = {},
+                                      const Interpolator& interpolator = Interpolator());
+
+        /*! \deprecated Use the overload without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use the overload without indexIsInterpolated")]]
+        InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                      Date baseDate,
+                                      Rate baseYoYRate,
+                                      Frequency frequency,
                                       bool indexIsInterpolated,
                                       const DayCounter& dayCounter,
                                       const ext::shared_ptr<Seasonality>& seasonality = {},
                                       const Interpolator& interpolator = Interpolator());
 
-        /*! \deprecated Use the other overload and pass the base date directly
-                        instead of using a lag.
+        /*! \deprecated Use the overload without lag and indexIsInterpolated and
+                        pass the base date as the first date in the vector.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use the overload without lag and indexIsInterpolated and pass the base date as the first date in the vector")]]
         InterpolatedYoYInflationCurve(const Date& referenceDate,
                                       const Calendar& calendar,
                                       const DayCounter& dayCounter,
@@ -130,12 +154,11 @@ namespace QuantLib {
         std::vector<Date> dates,
         const std::vector<Rate>& rates,
         Frequency frequency,
-        bool indexIsInterpolated,
         const DayCounter& dayCounter,
         const ext::shared_ptr<Seasonality>& seasonality,
         const Interpolator& interpolator)
-    : YoYInflationTermStructure(referenceDate, dates.at(0), rates[0], frequency,
-                                indexIsInterpolated, dayCounter, seasonality),
+    : YoYInflationTermStructure(referenceDate, dates.at(0), rates[0],
+                                frequency, dayCounter, seasonality),
       InterpolatedCurve<Interpolator>(std::vector<Time>(), rates, interpolator),
       dates_(std::move(dates)) {
 
@@ -158,6 +181,36 @@ namespace QuantLib {
     }
 
     template <class Interpolator>
+    InterpolatedYoYInflationCurve<Interpolator>::InterpolatedYoYInflationCurve(
+        const Date& referenceDate,
+        std::vector<Date> dates,
+        const std::vector<Rate>& rates,
+        Frequency frequency,
+        bool indexIsInterpolated,
+        const DayCounter& dayCounter,
+        const ext::shared_ptr<Seasonality>& seasonality,
+        const Interpolator& interpolator)
+    : InterpolatedYoYInflationCurve(referenceDate, dates, rates, frequency,
+                                    dayCounter, seasonality, interpolator) {
+        QL_DEPRECATED_DISABLE_WARNING
+        indexIsInterpolated_ = indexIsInterpolated;
+        QL_DEPRECATED_ENABLE_WARNING
+    }
+
+    template <class Interpolator>
+    InterpolatedYoYInflationCurve<Interpolator>::
+    InterpolatedYoYInflationCurve(const Date& referenceDate,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality,
+                                  const Interpolator& interpolator)
+    : YoYInflationTermStructure(referenceDate, baseDate, baseYoYRate,
+                                frequency, dayCounter, seasonality),
+      InterpolatedCurve<Interpolator>(interpolator) {}
+
+    template <class Interpolator>
     InterpolatedYoYInflationCurve<Interpolator>::
     InterpolatedYoYInflationCurve(const Date& referenceDate,
                                   Date baseDate,
@@ -167,9 +220,12 @@ namespace QuantLib {
                                   const DayCounter& dayCounter,
                                   const ext::shared_ptr<Seasonality>& seasonality,
                                   const Interpolator& interpolator)
-    : YoYInflationTermStructure(referenceDate, baseDate, baseYoYRate, frequency,
-                                indexIsInterpolated, dayCounter, seasonality),
-      InterpolatedCurve<Interpolator>(interpolator) {}
+    : InterpolatedYoYInflationCurve(referenceDate, baseDate, baseYoYRate, frequency,
+                                    dayCounter, seasonality, interpolator) {
+        QL_DEPRECATED_DISABLE_WARNING
+        indexIsInterpolated_ = indexIsInterpolated;
+        QL_DEPRECATED_ENABLE_WARNING
+    }
 
 
     QL_DEPRECATED_DISABLE_WARNING

--- a/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
@@ -47,8 +47,35 @@ namespace QuantLib {
       public:
         typedef Traits traits_type;
         typedef Interpolator interpolator_type;
+
         //! \name Constructors
         //@{
+
+        PiecewiseYoYInflationCurve(
+            const Date& referenceDate,
+            Date baseDate,
+            Rate baseYoYRate,
+            Frequency frequency,
+            const DayCounter& dayCounter,
+            std::vector<ext::shared_ptr<typename Traits::helper> > instruments,
+            const ext::shared_ptr<Seasonality>& seasonality = {},
+            Real accuracy = 1.0e-12,
+            const Interpolator& i = Interpolator())
+        : base_curve(referenceDate,
+                     baseDate,
+                     baseYoYRate,
+                     frequency,
+                     dayCounter,
+                     seasonality,
+                     i),
+          instruments_(std::move(instruments)), accuracy_(accuracy) {
+            bootstrap_.setup(this);
+        }
+
+        /*! \deprecated Use the overload without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use the overload without indexIsInterpolated")]]
         PiecewiseYoYInflationCurve(
             const Date& referenceDate,
             Date baseDate,
@@ -60,26 +87,21 @@ namespace QuantLib {
             const ext::shared_ptr<Seasonality>& seasonality = {},
             Real accuracy = 1.0e-12,
             const Interpolator& i = Interpolator())
-        : base_curve(referenceDate,
-                     baseDate,
-                     baseYoYRate,
-                     frequency,
-                     indexIsInterpolated,
-                     dayCounter,
-                     seasonality,
-                     i),
-          instruments_(std::move(instruments)), accuracy_(accuracy) {
-            bootstrap_.setup(this);
+        : PiecewiseYoYInflationCurve(referenceDate, baseDate, baseYoYRate, frequency,
+                                     dayCounter, instruments, seasonality, accuracy, i) {
+            QL_DEPRECATED_DISABLE_WARNING
+            this->indexIsInterpolated_ = indexIsInterpolated;
+            QL_DEPRECATED_ENABLE_WARNING
         }
 
 
         QL_DEPRECATED_DISABLE_WARNING
 
-        /*! \deprecated Use the other overload and pass the base date directly
-                        instead of using a lag.
+        /*! \deprecated Use the overload without lag and indexIsInterpolated and
+                        pass the base date as the first date in the vector.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use the overload without lag and indexIsInterpolated and pass the base date as the first date in the vector")]]
         PiecewiseYoYInflationCurve(
             const Date& referenceDate,
             const Calendar& calendar,

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -263,6 +263,35 @@ namespace QuantLib {
     }
 
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality, baseYoYRate) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    const Date& referenceDate,
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(referenceDate, baseDate, frequency, dayCounter, seasonality, baseYoYRate) {}
+
+    YoYInflationTermStructure::YoYInflationTermStructure(
+                                    Natural settlementDays,
+                                    const Calendar& calendar,
+                                    Date baseDate,
+                                    Rate baseYoYRate,
+                                    Frequency frequency,
+                                    const DayCounter& dayCounter,
+                                    const ext::shared_ptr<Seasonality> &seasonality)
+    : InflationTermStructure(settlementDays, calendar, baseDate, frequency, dayCounter, seasonality, baseYoYRate) {}
+
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     Date baseDate,
                                     Rate baseYoYRate,
@@ -270,8 +299,9 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const DayCounter& dayCounter,
                                     const ext::shared_ptr<Seasonality> &seasonality)
-    : InflationTermStructure(baseDate, frequency, dayCounter, seasonality, baseYoYRate),
-      indexIsInterpolated_(indexIsInterpolated) {}
+    : YoYInflationTermStructure(baseDate, baseYoYRate, frequency, dayCounter, seasonality) {
+        indexIsInterpolated_ = indexIsInterpolated;
+    }
 
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     const Date& referenceDate,
@@ -281,9 +311,10 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const DayCounter& dayCounter,
                                     const ext::shared_ptr<Seasonality> &seasonality)
-    : InflationTermStructure(referenceDate, baseDate, frequency,
-                             dayCounter, seasonality, baseYoYRate),
-      indexIsInterpolated_(indexIsInterpolated) {}
+    : YoYInflationTermStructure(referenceDate, baseDate, baseYoYRate,
+                                frequency, dayCounter, seasonality) {
+        indexIsInterpolated_ = indexIsInterpolated;
+    }
 
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     Natural settlementDays,
@@ -294,11 +325,10 @@ namespace QuantLib {
                                     bool indexIsInterpolated,
                                     const DayCounter& dayCounter,
                                     const ext::shared_ptr<Seasonality> &seasonality)
-    : InflationTermStructure(settlementDays, calendar, baseDate, frequency,
-                             dayCounter, seasonality, baseYoYRate),
-      indexIsInterpolated_(indexIsInterpolated) {}
-
-    QL_DEPRECATED_DISABLE_WARNING
+    : YoYInflationTermStructure(settlementDays, calendar, baseDate, baseYoYRate,
+                                frequency, dayCounter, seasonality) {
+        indexIsInterpolated_ = indexIsInterpolated;
+    }
 
     YoYInflationTermStructure::YoYInflationTermStructure(
                                     const DayCounter& dayCounter,
@@ -339,10 +369,9 @@ namespace QuantLib {
 
     QL_DEPRECATED_ENABLE_WARNING
 
-
     Rate YoYInflationTermStructure::yoyRate(const Date &d, const Period& instObsLag,
-                                              bool forceLinearInterpolation,
-                                              bool extrapolate) const {
+                                            bool forceLinearInterpolation,
+                                            bool extrapolate) const {
 
         Period useLag = instObsLag;
         if (instObsLag == Period(-1,Days)) {
@@ -364,6 +393,7 @@ namespace QuantLib {
             Rate y2 = yoyRateImpl(t2);
             yoyRate = y1 + (y2-y1) * (dt/dp);
         } else {
+            QL_DEPRECATED_DISABLE_WARNING
             if (indexIsInterpolated()) {
                 InflationTermStructure::checkRange(d-useLag, extrapolate);
                 Time t = timeFromReference(d-useLag);
@@ -374,6 +404,7 @@ namespace QuantLib {
                 Time t = timeFromReference(dd.first);
                 yoyRate = yoyRateImpl(t);
             }
+            QL_DEPRECATED_ENABLE_WARNING
         }
 
         if (hasSeasonality()) {

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -254,10 +254,39 @@ namespace QuantLib {
         YoYInflationTermStructure(Date baseDate,
                                   Rate baseYoYRate,
                                   Frequency frequency,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        YoYInflationTermStructure(const Date& referenceDate,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        YoYInflationTermStructure(Natural settlementDays,
+                                  const Calendar& calendar,
+                                  Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
+                                  const DayCounter& dayCounter,
+                                  const ext::shared_ptr<Seasonality>& seasonality = {});
+
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
+        YoYInflationTermStructure(Date baseDate,
+                                  Rate baseYoYRate,
+                                  Frequency frequency,
                                   bool indexIsInterpolated,
                                   const DayCounter& dayCounter,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
         YoYInflationTermStructure(const Date& referenceDate,
                                   Date baseDate,
                                   Rate baseYoYRate,
@@ -266,6 +295,10 @@ namespace QuantLib {
                                   const DayCounter& dayCounter,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
         YoYInflationTermStructure(Natural settlementDays,
                                   const Calendar& calendar,
                                   Date baseDate,
@@ -275,11 +308,10 @@ namespace QuantLib {
                                   const DayCounter& dayCounter,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
-        /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
         YoYInflationTermStructure(const DayCounter& dayCounter,
                                   Rate baseYoYRate,
                                   const Period& lag,
@@ -287,11 +319,10 @@ namespace QuantLib {
                                   bool indexIsInterpolated,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
-        /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
         YoYInflationTermStructure(const Date& referenceDate,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,
@@ -301,11 +332,10 @@ namespace QuantLib {
                                   bool indexIsInterpolated,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
 
-        /*! \deprecated Use another overload and pass the base date directly
-                        instead of using a lag.
+        /*! \deprecated Use an overload with an explicit base date and without indexIsInterpolated.
                         Deprecated in version 1.34.
         */
-        QL_DEPRECATED
+        [[deprecated("Use an overload with an explicit base date and without indexIsInterpolated")]]
         YoYInflationTermStructure(Natural settlementDays,
                                   const Calendar& calendar,
                                   const DayCounter& dayCounter,
@@ -315,6 +345,10 @@ namespace QuantLib {
                                   bool indexIsInterpolated,
                                   const ext::shared_ptr<Seasonality>& seasonality = {});
         //@}
+
+        QL_DEPRECATED_DISABLE_WARNING
+        ~YoYInflationTermStructure() override = default;
+        QL_DEPRECATED_ENABLE_WARNING
 
         //! \name Inspectors
         //@{
@@ -338,12 +372,20 @@ namespace QuantLib {
                      bool extrapolate = false) const;
         //@}
 
+        /*! \deprecated This method will disappear. When it does, the curve will behave as if it returned false.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("This method will disappear. When it does, the curve will behave as if it returned false")]]
         virtual bool indexIsInterpolated() const;
       protected:
         //! to be defined in derived classes
         virtual Rate yoyRateImpl(Time time) const = 0;
-      private:
-        bool indexIsInterpolated_;
+
+        /*! \deprecated This data member will disappear. When it does, the curve will behave as if it was false.
+                        Deprecated in version 1.37.
+        */
+        [[deprecated("This data member will disappear. When it does, the curve will behave as if it was false")]]
+        bool indexIsInterpolated_ = false;
     };
 
 
@@ -383,7 +425,9 @@ namespace QuantLib {
     }
 
     inline bool YoYInflationTermStructure::indexIsInterpolated() const {
+        QL_DEPRECATED_DISABLE_WARNING
         return indexIsInterpolated_;
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 }

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -1145,8 +1145,7 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
     auto pYYTS =
         ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
                 evaluationDate, baseDate, baseYYRate,
-                iir->frequency(),iir->interpolated(), dc,
-                helpers);
+                iir->frequency(), dc, helpers);
 
     // validation
     // yoy swaps should reprice to zero

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -180,8 +180,7 @@ struct CommonVars {
         Rate baseYYRate = yyData[0].rate/100.0;
         auto pYYTS =
             ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
-                        evaluationDate, baseDate, baseYYRate, iir->frequency(),
-                        iir->interpolated(), dc, helpers);
+                evaluationDate, baseDate, baseYYRate, iir->frequency(), dc, helpers);
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
 
         // make sure that the index has the latest yoy term structure

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -188,8 +188,7 @@ struct CommonVars {
         Rate baseYYRate = yyData[0].rate/100.0;
         auto pYYTS =
             ext::make_shared<PiecewiseYoYInflationCurve<Linear>>(
-                        evaluationDate, baseDate, baseYYRate, iir->frequency(),
-                        iir->interpolated(), dc, helpers);
+                evaluationDate, baseDate, baseYYRate, iir->frequency(), dc, helpers);
         yoyTS = ext::dynamic_pointer_cast<YoYInflationTermStructure>(pYYTS);
 
         // make sure that the index has the latest yoy term structure

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -171,19 +171,22 @@ void setup() {
 
     d.clear();
     r.clear();
-    Date baseDate = TARGET().advance(eval, -2, Months, ModifiedFollowing);
-    for (Size i = 0; i < std::size(yoyEUrates); i++) {
-        Date dd = TARGET().advance(baseDate, i, Years, ModifiedFollowing);
+    // the base date is based on the last published index fixing
+    Date baseDate = inflationPeriod(eval - 1*Months, yoyIndexEU->frequency()).first;
+    d.push_back(baseDate);
+    r.push_back(yoyEUrates[0]);
+
+    // cap maturities are based on the observation lag
+    Date capStartDate = TARGET().advance(eval, -2, Months, ModifiedFollowing);
+    for (Size i = 1; i < std::size(yoyEUrates); i++) {
+        Date dd = TARGET().advance(capStartDate, i, Years, ModifiedFollowing);
         d.push_back(dd);
         r.push_back(yoyEUrates[i]);
     }
 
-    bool indexIsInterpolated = true;    // actually false for UKRPI but smooth surfaces are
-                                        // better for finding intersections etc
-
     auto pYTSEU =
         ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
-                    eval, d, r, Monthly, indexIsInterpolated, Actual365Fixed());
+                    eval, d, r, Monthly, Actual365Fixed());
     yoyEU.linkTo(pYTSEU);
 
     // price data
@@ -364,7 +367,7 @@ BOOST_AUTO_TEST_CASE(testYoYPriceSurfaceToATM) {
                           0.0258498, 0.0262883, 0.0267915};
     const Real swaps[] = {0.024586, 0.0247575, 0.0249396, 0.0252596,
                           0.0258498, 0.0262883, 0.0267915};
-    const Real ayoy[] = {0.0247659, 0.0251437, 0.0255945, 0.0265234,
+    const Real ayoy[] = {0.0247659, 0.0251437, 0.0255945, 0.0265015,
                            0.0280457, 0.0285534, 0.0295884};
     Real eps = 2e-5;
     for(Size i = 0; i < yyATMt.first.size(); i++) {


### PR DESCRIPTION
Follows the changes in #1896 and #2073.  After those PRs the base date is passed explicitly, and the YoY indexes should now be asked for fixings only at the start of the month.  This makes `indexIsInterpolated` obsolete.  The old code still using it was deprecated in those two PRs and will be removed before `indexIsInterpolated` is.