### PR TITLE
Add date generation rule to OISRateHelper constructor

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -49,7 +49,8 @@ namespace QuantLib {
                                  Natural lookbackDays,
                                  Natural lockoutDays,
                                  bool applyObservationShift,
-                                 ext::shared_ptr<FloatingRateCouponPricer> pricer)
+                                 ext::shared_ptr<FloatingRateCouponPricer> pricer,
+                                 DateGeneration::Rule rule)
     : RelativeDateRateHelper(fixedRate), settlementDays_(settlementDays), tenor_(tenor),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
       paymentLag_(paymentLag), paymentConvention_(paymentConvention),
@@ -58,7 +59,7 @@ namespace QuantLib {
       averagingMethod_(averagingMethod), endOfMonth_(endOfMonth),
       fixedPaymentFrequency_(fixedPaymentFrequency), fixedCalendar_(std::move(fixedCalendar)),
       lookbackDays_(lookbackDays), lockoutDays_(lockoutDays), applyObservationShift_(applyObservationShift),
-      pricer_(std::move(pricer)) {
+      pricer_(std::move(pricer)), rule_(rule) {
         initialize(overnightIndex, customPillarDate);
     }
 
@@ -82,7 +83,8 @@ namespace QuantLib {
                                  Natural lookbackDays,
                                  Natural lockoutDays,
                                  bool applyObservationShift,
-                                 ext::shared_ptr<FloatingRateCouponPricer> pricer)
+                                 ext::shared_ptr<FloatingRateCouponPricer> pricer,
+                                 DateGeneration::Rule rule)
     : RelativeDateRateHelper(fixedRate, false), startDate_(startDate), endDate_(endDate),
       discountHandle_(std::move(discount)), telescopicValueDates_(telescopicValueDates),
       paymentLag_(paymentLag), paymentConvention_(paymentConvention),
@@ -91,7 +93,7 @@ namespace QuantLib {
       averagingMethod_(averagingMethod), endOfMonth_(endOfMonth),
       fixedPaymentFrequency_(fixedPaymentFrequency), fixedCalendar_(std::move(fixedCalendar)),
       lookbackDays_(lookbackDays), lockoutDays_(lockoutDays), applyObservationShift_(applyObservationShift),
-      pricer_(std::move(pricer)) {
+      pricer_(std::move(pricer)), rule_(rule) {
         initialize(overnightIndex, customPillarDate);
     }
 
@@ -128,6 +130,7 @@ namespace QuantLib {
             .withAveragingMethod(averagingMethod_)
             .withLookbackDays(lookbackDays_)
             .withLockoutDays(lockoutDays_)
+            .withRule(rule_)
             .withObservationShift(applyObservationShift_);
         if (endOfMonth_) {
             tmp.withEndOfMonth(*endOfMonth_);

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -58,7 +58,8 @@ namespace QuantLib {
                       Natural lookbackDays = Null<Natural>(),
                       Natural lockoutDays = 0,
                       bool applyObservationShift = false,
-                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {});
+                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
+                      DateGeneration::Rule rule = DateGeneration::Backward);
         OISRateHelper(const Date& startDate,
                       const Date& endDate,
                       const Handle<Quote>& fixedRate,
@@ -80,7 +81,8 @@ namespace QuantLib {
                       Natural lookbackDays = Null<Natural>(),
                       Natural lockoutDays = 0,
                       bool applyObservationShift = false,
-                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {});
+                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
+                      DateGeneration::Rule rule = DateGeneration::Backward));
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -127,6 +129,8 @@ namespace QuantLib {
         Natural lockoutDays_;
         bool applyObservationShift_;
         ext::shared_ptr<FloatingRateCouponPricer> pricer_;
+        DateGeneration::Rule rule_ = DateGeneration::Backward;
+
     };
 
     /*! \deprecated Use OISRateHelper instead.

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -82,7 +82,7 @@ namespace QuantLib {
                       Natural lockoutDays = 0,
                       bool applyObservationShift = false,
                       ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
-                      DateGeneration::Rule rule = DateGeneration::Backward));
+                      DateGeneration::Rule rule = DateGeneration::Backward);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;


### PR DESCRIPTION
At the moment OISRateHelpers at construction call MakeOIS using a hardcoded Backward date generating rule.
The purpose of this pull request is to allow bootstrapping a curve such that the ois instruments are flexible to use either Forward or Backward DateGeneration rule, so that one can reprice consistently the OIS swaps that were used in building the curve (and with the correct dates such as SOFR swaps for example).  Defaults to Backward (i.e as it currently is)