### PR TITLE
if using MSVC, then add /MP flag to speed up builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ if (QL_USE_STD_CLASSES)
     set(QL_USE_STD_SHARED_PTR ON)
 endif()
 
+if (MSVC)
+    # take advantage of parallel compilation - https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170
+    add_compile_options(-MP)
+endif()
+
 # Set the default warning level we use to pass the GitHub workflows
 if (QL_ENABLE_DEFAULT_WARNING_LEVEL)
     if (MSVC)


### PR DESCRIPTION
From a basic test using GitHub actions, I compared the **Windows build with all configurations** workflows.

From here I can see an average of around 2h15m - https://github.com/lballabio/QuantLib/actions/workflows/msvc-all-configs.yml

And in my test it was just over 1h.