### PR TITLE
Fix lower/upper bounds for global bootstrap

### DIFF
--- a/ql/termstructures/yield/bootstraptraits.hpp
+++ b/ql/termstructures/yield/bootstraptraits.hpp
@@ -38,6 +38,7 @@ namespace QuantLib {
     namespace detail {
         const Real avgRate = 0.05;
         const Real maxRate = 1.0;
+        const Real maxDF = 10.0;
     }
 
     //! Discount-curve traits
@@ -99,6 +100,18 @@ namespace QuantLib {
         {
             Time dt = c->times()[i] - c->times()[i-1];
             return c->data()[i-1] * std::exp(detail::maxRate * dt);
+        }
+
+        // possible constraints for global optimization
+        template <class C>
+        static Real minValueGlobal(Size i, const C* c, bool validData)
+        {
+            return 0;
+        }
+        template <class C>
+        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        {
+            return detail::maxDF;
         }
 
         // root-finding update
@@ -177,6 +190,18 @@ namespace QuantLib {
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
+            return detail::maxRate;
+        }
+
+        // possible constraints for global optimization
+        template <class C>
+        static Real minValueGlobal(Size i, const C* c, bool validData)
+        {
+            return -detail::maxRate;
+        }
+        template <class C>
+        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        {
             return detail::maxRate;
         }
 
@@ -261,6 +286,18 @@ namespace QuantLib {
             return detail::maxRate;
         }
 
+        // possible constraints for global optimization
+        template <class C>
+        static Real minValueGlobal(Size i, const C* c, bool validData)
+        {
+            return -detail::maxRate;
+        }
+        template <class C>
+        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        {
+            return detail::maxRate;
+        }
+
         // root-finding update
         static void updateGuess(std::vector<Real>& data,
                                 Real forward,
@@ -327,8 +364,7 @@ namespace QuantLib {
                 // We choose as min a value very unlikely to be exceeded.
                 result = -detail::maxRate;
             }
-            Real t = c->timeFromReference(c->dates()[i]);
-            return std::max(result, -1.0 / t + 1E-8);
+            return std::max(result, -1.0 / c->times()[i] + 1E-8);
         }
         template <class C>
         static Real maxValueAfter(Size,
@@ -342,6 +378,18 @@ namespace QuantLib {
             }
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
+            return detail::maxRate;
+        }
+
+        // possible constraints for global optimization
+        template <class C>
+        static Real minValueGlobal(Size i, const C* c, bool validData)
+        {
+            return std::max(-detail::maxRate, -1.0 / c->times()[i] + 1E-8);
+        }
+        template <class C>
+        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        {
             return detail::maxRate;
         }
 


### PR DESCRIPTION
Currently global bootstrap uses minValueAfter/maxValueAfter methods from Traits to come up with lower/upper bounds. This is problematic. These methods depend on the previous point in the curve. In the iterative bootstrap these methods are called after the previous point is already known exactly. However, in the global bootstrap all points are still filled with Traits::initialValue. This makes the bounds too tight and leads to bad results for curves with higher interest rates.

Instead add separate minValueGlobal/maxValueGlobal methods that do not rely on previous data.