### PR TITLE
Move transformation used in GlobalBootstrap into Traits

### DIFF
--- a/ql/termstructures/yield/bootstraptraits.hpp
+++ b/ql/termstructures/yield/bootstraptraits.hpp
@@ -38,7 +38,6 @@ namespace QuantLib {
     namespace detail {
         const Real avgRate = 0.05;
         const Real maxRate = 1.0;
-        const Real maxDF = 10.0;
     }
 
     //! Discount-curve traits
@@ -102,16 +101,16 @@ namespace QuantLib {
             return c->data()[i-1] * std::exp(detail::maxRate * dt);
         }
 
-        // possible constraints for global optimization
+        // transformation to add constraints to an unconstrained optimization
         template <class C>
-        static Real minValueGlobal(Size i, const C* c, bool validData)
+        static Real transformDirect(Real x, Size i, const C* c)
         {
-            return 0;
+            return std::exp(x);
         }
         template <class C>
-        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        static Real transformInverse(Real x, Size i, const C* c)
         {
-            return detail::maxDF;
+            return std::log(x);
         }
 
         // root-finding update
@@ -193,16 +192,16 @@ namespace QuantLib {
             return detail::maxRate;
         }
 
-        // possible constraints for global optimization
+        // transformation to add constraints to an unconstrained optimization
         template <class C>
-        static Real minValueGlobal(Size i, const C* c, bool validData)
+        static Real transformDirect(Real x, Size i, const C* c)
         {
-            return -detail::maxRate;
+            return x;
         }
         template <class C>
-        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        static Real transformInverse(Real x, Size i, const C* c)
         {
-            return detail::maxRate;
+            return x;
         }
 
         // root-finding update
@@ -286,16 +285,16 @@ namespace QuantLib {
             return detail::maxRate;
         }
 
-        // possible constraints for global optimization
+        // transformation to add constraints to an unconstrained optimization
         template <class C>
-        static Real minValueGlobal(Size i, const C* c, bool validData)
+        static Real transformDirect(Real x, Size i, const C* c)
         {
-            return -detail::maxRate;
+            return x;
         }
         template <class C>
-        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        static Real transformInverse(Real x, Size i, const C* c)
         {
-            return detail::maxRate;
+            return x;
         }
 
         // root-finding update
@@ -381,16 +380,16 @@ namespace QuantLib {
             return detail::maxRate;
         }
 
-        // possible constraints for global optimization
+        // transformation to add constraints to an unconstrained optimization
         template <class C>
-        static Real minValueGlobal(Size i, const C* c, bool validData)
+        static Real transformDirect(Real x, Size i, const C* c)
         {
-            return std::max(-detail::maxRate, -1.0 / c->times()[i] + 1E-8);
+            return std::exp(x) + (-1.0 / c->times()[i] + 1E-8);
         }
         template <class C>
-        static Real maxValueGlobal(Size i, const C* c, bool validData)
+        static Real transformInverse(Real x, Size i, const C* c)
         {
-            return detail::maxRate;
+            return std::log(x - (-1.0 / c->times()[i] + 1E-8));
         }
 
         // root-finding update


### PR DESCRIPTION
Also, use exp instead of atan transformation for discount factors. This is an improvement on #2120 based on these observations:

* Rates-based traits don't need any constraints in the optimization, so we don't need any transformation with them. This removes unnecessary computations.

* Discount factors are only bounded on one side (have to be positive), so instead of estimating a max value to use atan, we can simply use exp. This is faster and uses fewer magic numbers.

  Another issue with atan is that it changes the gradients too much when the value is far from the middle of the range. This pushes optimization away from the correct solution when rates are low. This makes it hard to find value of maxDF that works for both very low and very high rates.