### PR TITLE
Deprecate passing interpolation flag to YoY indexes

### DIFF
--- a/ql/experimental/inflation/genericindexes.hpp
+++ b/ql/experimental/inflation/genericindexes.hpp
@@ -58,6 +58,25 @@ namespace QuantLib {
       public:
         YYGenericCPI(Frequency frequency,
                      bool revised,
+                     const Period &lag,
+                     const Currency &ccy,
+                     const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_CPI",
+                            GenericRegion(),
+                            revised,
+                            frequency,
+                            lag,
+                            ccy,
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
+        YYGenericCPI(Frequency frequency,
+                     bool revised,
                      bool interpolated,
                      const Period &lag,
                      const Currency &ccy,
@@ -70,6 +89,8 @@ namespace QuantLib {
                             lag,
                             ccy,
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
+++ b/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
@@ -184,7 +184,7 @@ namespace QuantLib {
         RelinkableHandle<YoYInflationTermStructure> hYoY(
                                        YoYCapFloorTermPriceSurface_->YoYTS());
         ext::shared_ptr<YoYInflationIndex> anIndex(
-                                           new YYGenericCPI(frequency_, false,
+                                           new YYGenericCPI(frequency_,
                                                             false, lag_,
                                                             Currency(), hYoY));
 

--- a/ql/indexes/inflation/aucpi.hpp
+++ b/ql/indexes/inflation/aucpi.hpp
@@ -46,6 +46,23 @@ namespace QuantLib {
       public:
         YYAUCPI(Frequency frequency,
                 bool revised,
+                const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_CPI",
+                            AustraliaRegion(),
+                            revised,
+                            frequency,
+                            Period(2, Months),
+                            AUDCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
+        YYAUCPI(Frequency frequency,
+                bool revised,
                 bool interpolated,
                 const Handle<YoYInflationTermStructure>& ts = {})
         : YoYInflationIndex("YY_CPI",
@@ -56,6 +73,8 @@ namespace QuantLib {
                             Period(2, Months),
                             AUDCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflation/euhicp.hpp
+++ b/ql/indexes/inflation/euhicp.hpp
@@ -61,6 +61,21 @@ namespace QuantLib {
     //! Quoted year-on-year EU HICP (i.e. not a ratio of EU HICP)
     class YYEUHICP : public YoYInflationIndex {
       public:
+        explicit YYEUHICP(const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_HICP",
+                            EURegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            EURCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
         explicit YYEUHICP(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
@@ -72,11 +87,28 @@ namespace QuantLib {
                             Period(1, Months),
                             EURCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
     //! Quoted year-on-year EU HICPXT
     class YYEUHICPXT : public YoYInflationIndex {
       public:
+        explicit YYEUHICPXT(const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_HICPXT",
+                            EURegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            EURCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
         explicit YYEUHICPXT(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
@@ -88,6 +120,8 @@ namespace QuantLib {
                             Period(1, Months),
                             EURCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflation/frhicp.hpp
+++ b/ql/indexes/inflation/frhicp.hpp
@@ -42,6 +42,21 @@ namespace QuantLib {
     //! Quoted year-on-year FR HICP (i.e. not a ratio)
     class YYFRHICP : public YoYInflationIndex {
       public:
+        explicit YYFRHICP(const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_HICP",
+                            FranceRegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            EURCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
         explicit YYFRHICP(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
@@ -53,6 +68,8 @@ namespace QuantLib {
                             Period(1, Months),
                             EURCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflation/ukrpi.hpp
+++ b/ql/indexes/inflation/ukrpi.hpp
@@ -42,6 +42,21 @@ namespace QuantLib {
     //! Quoted year-on-year UK RPI (i.e. not a ratio of UK RPI)
     class YYUKRPI : public YoYInflationIndex {
       public:
+        explicit YYUKRPI(const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_RPI",
+                            UKRegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            GBPCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
         explicit YYUKRPI(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
@@ -53,6 +68,8 @@ namespace QuantLib {
                             Period(1, Months),
                             GBPCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflation/uscpi.hpp
+++ b/ql/indexes/inflation/uscpi.hpp
@@ -47,6 +47,21 @@ namespace QuantLib {
     //! Quoted year-on-year US CPI (i.e. not a ratio of US CPI)
     class YYUSCPI : public YoYInflationIndex {
       public:
+        explicit YYUSCPI(const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_CPI",
+                            USRegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            USDCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
         explicit YYUSCPI(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
@@ -58,6 +73,8 @@ namespace QuantLib {
                             Period(1, Months),
                             USDCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflation/zacpi.hpp
+++ b/ql/indexes/inflation/zacpi.hpp
@@ -43,6 +43,22 @@ namespace QuantLib {
     class YYZACPI : public YoYInflationIndex {
       public:
         explicit YYZACPI(
+            const Handle<YoYInflationTermStructure>& ts = {})
+        : YoYInflationIndex("YY_CPI",
+                            ZARegion(),
+                            false,
+                            Monthly,
+                            Period(1, Months),
+                            ZARCurrency(),
+                            ts) {}
+
+        QL_DEPRECATED_DISABLE_WARNING
+
+        /*! \deprecated Use the overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the overload without the interpolated parameter")]]
+        explicit YYZACPI(
             bool interpolated,
             const Handle<YoYInflationTermStructure>& ts = {})
         : YoYInflationIndex("YY_CPI",
@@ -53,6 +69,8 @@ namespace QuantLib {
                             Period(1, Months),
                             ZARCurrency(),
                             ts) {}
+
+        QL_DEPRECATED_ENABLE_WARNING
     };
 
 }

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -241,14 +241,32 @@ namespace QuantLib {
 
 
     YoYInflationIndex::YoYInflationIndex(const ext::shared_ptr<ZeroInflationIndex>& underlyingIndex,
-                                         bool interpolated,
                                          Handle<YoYInflationTermStructure> yoyInflation)
     : InflationIndex("YYR_" + underlyingIndex->familyName(), underlyingIndex->region(),
                      underlyingIndex->revised(), underlyingIndex->frequency(),
                      underlyingIndex->availabilityLag(), underlyingIndex->currency()),
-      interpolated_(interpolated), ratio_(true), underlyingIndex_(underlyingIndex),
+      interpolated_(false), ratio_(true), underlyingIndex_(underlyingIndex),
       yoyInflation_(std::move(yoyInflation)) {
         registerWith(underlyingIndex_);
+        registerWith(yoyInflation_);
+    }
+
+    YoYInflationIndex::YoYInflationIndex(const ext::shared_ptr<ZeroInflationIndex>& underlyingIndex,
+                                         bool interpolated,
+                                         Handle<YoYInflationTermStructure> yoyInflation)
+    : YoYInflationIndex(underlyingIndex, yoyInflation) {
+        interpolated_ = interpolated;
+    }
+
+    YoYInflationIndex::YoYInflationIndex(const std::string& familyName,
+                                         const Region& region,
+                                         bool revised,
+                                         Frequency frequency,
+                                         const Period& availabilityLag,
+                                         const Currency& currency,
+                                         Handle<YoYInflationTermStructure> yoyInflation)
+    : InflationIndex(familyName, region, revised, frequency, availabilityLag, currency),
+      interpolated_(false), ratio_(false), yoyInflation_(std::move(yoyInflation)) {
         registerWith(yoyInflation_);
     }
 
@@ -260,9 +278,8 @@ namespace QuantLib {
                                          const Period& availabilityLag,
                                          const Currency& currency,
                                          Handle<YoYInflationTermStructure> yoyInflation)
-    : InflationIndex(familyName, region, revised, frequency, availabilityLag, currency),
-      interpolated_(interpolated), ratio_(false), yoyInflation_(std::move(yoyInflation)) {
-        registerWith(yoyInflation_);
+    : YoYInflationIndex(familyName, region, revised, frequency, availabilityLag, currency, yoyInflation) {
+        interpolated_ = interpolated;
     }
 
 
@@ -369,13 +386,17 @@ namespace QuantLib {
 
     ext::shared_ptr<YoYInflationIndex> YoYInflationIndex::clone(
                            const Handle<YoYInflationTermStructure>& h) const {
+        QL_DEPRECATED_DISABLE_WARNING
         if (ratio_) {
-            return ext::make_shared<YoYInflationIndex>(underlyingIndex_, interpolated_, h);
+            return ext::shared_ptr<YoYInflationIndex>(
+                new YoYInflationIndex(underlyingIndex_, interpolated_, h));
         } else {
-            return ext::make_shared<YoYInflationIndex>(familyName_, region_, revised_,
-                                                       interpolated_, frequency_,
-                                                       availabilityLag_, currency_, h);
+            return ext::shared_ptr<YoYInflationIndex>(
+                new YoYInflationIndex(familyName_, region_, revised_,
+                                      interpolated_, frequency_,
+                                      availabilityLag_, currency_, h));
         }
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
 

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -197,6 +197,14 @@ namespace QuantLib {
         */
         YoYInflationIndex(
             const ext::shared_ptr<ZeroInflationIndex>& underlyingIndex,
+            Handle<YoYInflationTermStructure> ts = {});
+
+        /*! \deprecated Use the similar overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the similar overload without the interpolated parameter")]]
+        YoYInflationIndex(
+            const ext::shared_ptr<ZeroInflationIndex>& underlyingIndex,
             bool interpolated,
             Handle<YoYInflationTermStructure> ts = {});
 
@@ -209,12 +217,24 @@ namespace QuantLib {
             const std::string& familyName,
             const Region& region,
             bool revised,
-            bool interpolated,
             Frequency frequency,
             const Period& availabilityLag,
             const Currency& currency,
             Handle<YoYInflationTermStructure> ts = {});
 
+        /*! \deprecated Use the similar overload without the interpolated parameter.
+                        Deprecated in version 1.38.
+        */
+        [[deprecated("Use the similar overload without the interpolated parameter")]]
+        YoYInflationIndex(
+            const std::string& familyName,
+            const Region& region,
+            bool revised,
+            bool interpolated,
+            Frequency frequency,
+            const Period& availabilityLag,
+            const Currency& currency,
+            Handle<YoYInflationTermStructure> ts = {});
         //@}
 
         //! \name Index interface

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -1616,8 +1616,10 @@ BOOST_AUTO_TEST_CASE(testCpiYoYQuotedLinearInterpolation) {
 
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
-    auto testIndex1 = ext::make_shared<YYUKRPI>(false);
-    auto testIndex2 = ext::make_shared<YYUKRPI>(true);
+    auto testIndex1 = ext::make_shared<YYUKRPI>();
+    QL_DEPRECATED_DISABLE_WARNING
+    auto testIndex2 = ext::shared_ptr<YYUKRPI>(new YYUKRPI(true));
+    QL_DEPRECATED_ENABLE_WARNING
 
     testIndex1->addFixing(Date(1, November, 2020), 0.02935);
     testIndex1->addFixing(Date(1, December, 2020), 0.02954);
@@ -1671,8 +1673,11 @@ BOOST_AUTO_TEST_CASE(testCpiYoYRatioFlatInterpolation) {
 
     auto underlying = ext::make_shared<UKRPI>();
 
-    auto testIndex1 = ext::make_shared<YoYInflationIndex>(underlying, false);
-    auto testIndex2 = ext::make_shared<YoYInflationIndex>(underlying, true);
+    auto testIndex1 = ext::make_shared<YoYInflationIndex>(underlying);
+    QL_DEPRECATED_DISABLE_WARNING
+    auto testIndex2 = ext::shared_ptr<YoYInflationIndex>(
+                                     new YoYInflationIndex(underlying, true));
+    QL_DEPRECATED_ENABLE_WARNING
 
     underlying->addFixing(Date(1, November, 2019), 291.0);
     underlying->addFixing(Date(1, December, 2019), 291.9);
@@ -1713,8 +1718,11 @@ BOOST_AUTO_TEST_CASE(testCpiYoYRatioLinearInterpolation) {
 
     auto underlying = ext::make_shared<UKRPI>();
 
-    auto testIndex1 = ext::make_shared<YoYInflationIndex>(underlying, false);
-    auto testIndex2 = ext::make_shared<YoYInflationIndex>(underlying, true);
+    auto testIndex1 = ext::make_shared<YoYInflationIndex>(underlying);
+    QL_DEPRECATED_DISABLE_WARNING
+    auto testIndex2 = ext::shared_ptr<YoYInflationIndex>(
+                                     new YoYInflationIndex(underlying, true));
+    QL_DEPRECATED_ENABLE_WARNING
 
     underlying->addFixing(Date(1, November, 2019), 291.0);
     underlying->addFixing(Date(1, December, 2019), 291.9);

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -819,6 +819,8 @@ BOOST_AUTO_TEST_CASE(testInterpolatedZeroTermStructure) {
 BOOST_AUTO_TEST_CASE(testQuotedYYIndex) {
     BOOST_TEST_MESSAGE("Testing quoted year-on-year inflation indices...");
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     YYEUHICP yyeuhicp(true);
     if (yyeuhicp.name() != "EU YY_HICP"
         || yyeuhicp.frequency() != Monthly
@@ -835,7 +837,9 @@ BOOST_AUTO_TEST_CASE(testQuotedYYIndex) {
                     << yyeuhicp.availabilityLag() << ")");
     }
 
-    YYUKRPI yyukrpi(false);
+    QL_DEPRECATED_ENABLE_WARNING
+
+    YYUKRPI yyukrpi;
     if (yyukrpi.name() != "UK YY_RPI"
         || yyukrpi.frequency() != Monthly
         || yyukrpi.revised()
@@ -857,8 +861,11 @@ BOOST_AUTO_TEST_CASE(testQuotedYYIndexFutureFixing) {
 
     // we create indexes without a term structure, so
     // they won't be able to forecast fixings
-    YYEUHICP quoted_flat(false);
+    YYEUHICP quoted_flat;
+
+    QL_DEPRECATED_DISABLE_WARNING
     YYEUHICP quoted_linear(true);
+    QL_DEPRECATED_ENABLE_WARNING
 
     // let's say we're at some point in April 2024...
     Settings::instance().evaluationDate() = {10, April, 2024};
@@ -907,7 +914,9 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndex) {
     auto euhicp = ext::make_shared<EUHICP>();
     auto ukrpi = ext::make_shared<UKRPI>();
 
+    QL_DEPRECATED_DISABLE_WARNING
     YoYInflationIndex yyeuhicpr(euhicp, true);
+    QL_DEPRECATED_ENABLE_WARNING
     if (yyeuhicpr.name() != "EU YYR_HICP"
         || yyeuhicpr.frequency() != Monthly
         || yyeuhicpr.revised()
@@ -923,7 +932,7 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndex) {
                     << yyeuhicpr.availabilityLag() << ")");
     }
 
-    YoYInflationIndex yyukrpir(ukrpi, false);
+    YoYInflationIndex yyukrpir(ukrpi);
     if (yyukrpir.name() != "UK YYR_RPI"
         || yyukrpir.frequency() != Monthly
         || yyukrpir.revised()
@@ -966,8 +975,11 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndex) {
         ukrpi->addFixing(rpiSchedule[i], fixData[i]);
     }
 
-    auto iir = ext::make_shared<YoYInflationIndex>(ukrpi, false);
-    auto iirYES = ext::make_shared<YoYInflationIndex>(ukrpi, true);
+    auto iir = ext::make_shared<YoYInflationIndex>(ukrpi);
+    QL_DEPRECATED_DISABLE_WARNING
+    auto iirYES = ext::shared_ptr<YoYInflationIndex>(
+                                          new YoYInflationIndex(ukrpi, true));
+    QL_DEPRECATED_ENABLE_WARNING
 
     Date todayMinusLag = evaluationDate - iir->availabilityLag();
     std::pair<Date,Date> lim = inflationPeriod(todayMinusLag, iir->frequency());
@@ -1025,8 +1037,10 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndexFutureFixing) {
     // we create indexes without a term structure, so
     // they won't be able to forecast fixings
     auto euhicp = ext::make_shared<EUHICP>();
-    YoYInflationIndex ratio_flat(euhicp, false);
+    YoYInflationIndex ratio_flat(euhicp);
+    QL_DEPRECATED_DISABLE_WARNING
     YoYInflationIndex ratio_linear(euhicp, true);
+    QL_DEPRECATED_ENABLE_WARNING
 
     // let's say we're at some point in April 2024...
     Settings::instance().evaluationDate() = {10, April, 2024};
@@ -1101,9 +1115,8 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
     };
 
     RelinkableHandle<YoYInflationTermStructure> hy;
-    bool interp = false;
     auto rpi = ext::make_shared<UKRPI>();
-    auto iir = ext::make_shared<YoYInflationIndex>(rpi, interp, hy);
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
     for (Size i=0; i<std::size(fixData); i++) {
         rpi->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -1257,9 +1270,8 @@ BOOST_AUTO_TEST_CASE(testYYTermStructureWithLag) {
         207.3 };
 
     RelinkableHandle<YoYInflationTermStructure> hy;
-    bool interp = false;
     auto rpi = ext::make_shared<UKRPI>();
-    auto iir = ext::make_shared<YoYInflationIndex>(rpi, interp, hy);
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
     for (Size i=0; i<std::size(fixData); i++) {
         rpi->addFixing(rpiSchedule[i], fixData[i]);
     }
@@ -1568,8 +1580,10 @@ BOOST_AUTO_TEST_CASE(testCpiYoYQuotedFlatInterpolation) {
 
     Settings::instance().evaluationDate() = Date(10, February, 2022);
 
-    auto testIndex1 = ext::make_shared<YYUKRPI>(false);
-    auto testIndex2 = ext::make_shared<YYUKRPI>(true);
+    auto testIndex1 = ext::make_shared<YYUKRPI>();
+    QL_DEPRECATED_DISABLE_WARNING
+    auto testIndex2 = ext::shared_ptr<YYUKRPI>(new YYUKRPI(true));
+    QL_DEPRECATED_ENABLE_WARNING
 
     testIndex1->addFixing(Date(1, November, 2020), 0.02935);
     testIndex1->addFixing(Date(1, December, 2020), 0.02954);

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -140,8 +140,7 @@ struct CommonVars {
             rpi->addFixing(rpiSchedule[i], fixData[i]);
         }
         // link from yoy index to yoy TS
-        bool interp = false;
-        iir = ext::make_shared<YoYInflationIndex>(rpi, interp, hy);
+        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
         ext::shared_ptr<YieldTermStructure> nominalFF(
                 new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -148,8 +148,7 @@ struct CommonVars {
             rpi->addFixing(rpiSchedule[i], fixData[i]);
         }
         // link from yoy index to yoy TS
-        bool interp = false;
-        iir = ext::make_shared<YoYInflationIndex>(rpi, interp, hy);
+        iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
         ext::shared_ptr<YieldTermStructure> nominalFF(
                         new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -94,8 +94,12 @@ void setup() {
     Date eval = Date(Day(23), Month(11), Year(2007));
     Settings::instance().evaluationDate() = eval;
 
-    yoyIndexUK = ext::make_shared<YoYInflationIndex>(ext::make_shared<UKRPI>(), true, yoyUK);
-    yoyIndexEU = ext::make_shared<YoYInflationIndex>(ext::make_shared<EUHICP>(), true, yoyEU);
+    QL_DEPRECATED_DISABLE_WARNING
+    yoyIndexUK = ext::shared_ptr<YoYInflationIndex>(
+        new YoYInflationIndex(ext::make_shared<UKRPI>(), true, yoyUK));
+    yoyIndexEU = ext::shared_ptr<YoYInflationIndex>(
+        new YoYInflationIndex(ext::make_shared<EUHICP>(), true, yoyEU));
+    QL_DEPRECATED_ENABLE_WARNING
 
     // nominal yield curve (interpolated; times assume year parts have 365 days)
     Real timesEUR[] = {0.0109589, 0.0684932, 0.263014, 0.317808, 0.567123, 0.816438,

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -94,12 +94,8 @@ void setup() {
     Date eval = Date(Day(23), Month(11), Year(2007));
     Settings::instance().evaluationDate() = eval;
 
-    QL_DEPRECATED_DISABLE_WARNING
-    yoyIndexUK = ext::shared_ptr<YoYInflationIndex>(
-        new YoYInflationIndex(ext::make_shared<UKRPI>(), true, yoyUK));
-    yoyIndexEU = ext::shared_ptr<YoYInflationIndex>(
-        new YoYInflationIndex(ext::make_shared<EUHICP>(), true, yoyEU));
-    QL_DEPRECATED_ENABLE_WARNING
+    yoyIndexUK = ext::make_shared<YoYInflationIndex>(ext::make_shared<UKRPI>(), yoyUK);
+    yoyIndexEU = ext::make_shared<YoYInflationIndex>(ext::make_shared<EUHICP>(), yoyEU);
 
     // nominal yield curve (interpolated; times assume year parts have 365 days)
     Real timesEUR[] = {0.0109589, 0.0684932, 0.263014, 0.317808, 0.567123, 0.816438,
@@ -322,14 +318,14 @@ BOOST_AUTO_TEST_CASE(testYoYPriceSurfaceToVol) {
 
     // now use it for something ... like stating what the T=const lines look like
     const Real volATyear1[] = {
-          0.0128, 0.0093, 0.0083, 0.0073, 0.0064,
+          0.0129, 0.0094, 0.0083, 0.0073, 0.0064,
           0.0058, 0.0042, 0.0046, 0.0053, 0.0064,
           0.0098
     };
     const Real volATyear3[] = {
-          0.0079, 0.0058, 0.0051, 0.0045, 0.0039,
-          0.0035, 0.0026, 0.0028, 0.0033, 0.0039,
-          0.0060
+          0.0080, 0.0058, 0.0051, 0.0045, 0.0040,
+          0.0035, 0.0026, 0.0028, 0.0033, 0.0040,
+          0.0061
     };
 
     Date d = yoySurf->baseDate() + Period(1,Years);


### PR DESCRIPTION
Continuation of https://github.com/lballabio/QuantLib/pull/2099.  Another step in moving interpolation out of the indexes and into the coupons.