### PR TITLE
Ensure that inflation curves are bootstrapped before access

### DIFF
--- a/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
@@ -147,6 +147,7 @@ namespace QuantLib {
       private:
         // methods
         void performCalculations() const override;
+        Rate yoyRateImpl(Time t) const override;
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;
         Real accuracy_;
@@ -200,6 +201,12 @@ namespace QuantLib {
     template <class I, template <class> class B, class T>
     void PiecewiseYoYInflationCurve<I,B,T>::performCalculations() const {
         bootstrap_.calculate();
+    }
+
+    template <class I, template <class> class B, class T>
+    Rate PiecewiseYoYInflationCurve<I,B,T>::yoyRateImpl(Time t) const {
+        calculate();
+        return base_curve::yoyRateImpl(t);
     }
 
     template <class I, template <class> class B, class T>

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -119,6 +119,7 @@ namespace QuantLib {
       private:
         // methods
         void performCalculations() const override;
+        Rate zeroRateImpl(Time t) const override;
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;
         Real accuracy_;
@@ -172,6 +173,12 @@ namespace QuantLib {
     template <class I, template <class> class B, class T>
     void PiecewiseZeroInflationCurve<I,B,T>::performCalculations() const {
         bootstrap_.calculate();
+    }
+
+    template <class I, template <class> class B, class T>
+    Rate PiecewiseZeroInflationCurve<I,B,T>::zeroRateImpl(Time t) const {
+        calculate();
+        return base_curve::zeroRateImpl(t);
     }
 
     template <class I, template<class> class B, class T>


### PR DESCRIPTION
So far the inflation bootstrap was done as a side effect of calling `checkRange`, but that would be skipped if extrapolation was enabled and the base date was fixed.