### PR TITLE
Add DepositRateHelper and FraRateHelper constructors with fixed dates

### DIFF
--- a/ql/termstructures/bootstraphelper.hpp
+++ b/ql/termstructures/bootstraphelper.hpp
@@ -144,7 +144,6 @@ namespace QuantLib {
       protected:
         virtual void initializeDates() = 0;
         Date evaluationDate_;
-      private:
         bool updateDates_;
     };
 

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -129,6 +129,9 @@ namespace QuantLib {
                           const ext::shared_ptr<IborIndex>& iborIndex);
         DepositRateHelper(Rate rate,
                           const ext::shared_ptr<IborIndex>& iborIndex);
+        DepositRateHelper(const Handle<Quote>& rate,
+                          Date fixingDate,
+                          const ext::shared_ptr<IborIndex>& iborIndex);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -227,6 +230,13 @@ namespace QuantLib {
         FraRateHelper(Rate rate,
                       Natural immOffsetStart,
                       Natural immOffsetEnd,
+                      const ext::shared_ptr<IborIndex>& iborIndex,
+                      Pillar::Choice pillar = Pillar::LastRelevantDate,
+                      Date customPillarDate = Date(),
+                      bool useIndexedCoupon = true);
+        FraRateHelper(const Handle<Quote>& rate,
+                      Date startDate,
+                      Date endDate,
                       const ext::shared_ptr<IborIndex>& iborIndex,
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(),


### PR DESCRIPTION
This is useful for non-standard conventions and to avoid dependency on evaluation date.