### PR TITLE
Allow optimizing additional variables during global bootstrap

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1687,6 +1687,7 @@
     <ClInclude Include="ql\termstructures\credit\survivalprobabilitystructure.hpp" />
     <ClInclude Include="ql\termstructures\defaulttermstructure.hpp" />
     <ClInclude Include="ql\termstructures\globalbootstrap.hpp" />
+    <ClInclude Include="ql\termstructures\globalbootstrapvars.hpp" />
     <ClInclude Include="ql\termstructures\inflation\all.hpp" />
     <ClInclude Include="ql\termstructures\inflation\inflationhelpers.hpp" />
     <ClInclude Include="ql\termstructures\inflation\inflationtraits.hpp" />
@@ -2712,6 +2713,7 @@
     <ClCompile Include="ql\termstructures\credit\hazardratestructure.cpp" />
     <ClCompile Include="ql\termstructures\credit\survivalprobabilitystructure.cpp" />
     <ClCompile Include="ql\termstructures\defaulttermstructure.cpp" />
+    <ClCompile Include="ql\termstructures\globalbootstrapvars.cpp" />
     <ClCompile Include="ql\termstructures\inflation\inflationhelpers.cpp" />
     <ClCompile Include="ql\termstructures\inflation\seasonality.cpp" />
     <ClCompile Include="ql\termstructures\inflationtermstructure.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -1944,6 +1944,9 @@
     <ClInclude Include="ql\termstructures\globalbootstrap.hpp">
       <Filter>termstructures</Filter>
     </ClInclude>
+    <ClInclude Include="ql\termstructures\globalbootstrapvars.hpp">
+      <Filter>termstructures</Filter>
+    </ClInclude>
     <ClInclude Include="ql\termstructures\inflationtermstructure.hpp">
       <Filter>termstructures</Filter>
     </ClInclude>
@@ -5472,6 +5475,9 @@
       <Filter>models\equity</Filter>
     </ClCompile>
     <ClCompile Include="ql\termstructures\defaulttermstructure.cpp">
+      <Filter>termstructures</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\termstructures\globalbootstrapvars.cpp">
       <Filter>termstructures</Filter>
     </ClCompile>
     <ClCompile Include="ql\termstructures\inflationtermstructure.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -809,6 +809,7 @@ set(QL_SOURCES
     termstructures/credit/hazardratestructure.cpp
     termstructures/credit/survivalprobabilitystructure.cpp
     termstructures/defaulttermstructure.cpp
+    termstructures/globalbootstrapvars.cpp
     termstructures/inflation/inflationhelpers.cpp
     termstructures/inflation/seasonality.cpp
     termstructures/inflationtermstructure.cpp
@@ -2058,6 +2059,7 @@ set(QL_HEADERS
     termstructures/credit/survivalprobabilitystructure.hpp
     termstructures/defaulttermstructure.hpp
     termstructures/globalbootstrap.hpp
+    termstructures/globalbootstrapvars.hpp
     termstructures/inflation/inflationhelpers.hpp
     termstructures/inflation/inflationtraits.hpp
     termstructures/inflation/interpolatedyoyinflationcurve.hpp

--- a/ql/termstructures/Makefile.am
+++ b/ql/termstructures/Makefile.am
@@ -10,6 +10,7 @@ this_include_HEADERS = \
 	bootstraphelper.hpp \
 	defaulttermstructure.hpp \
 	globalbootstrap.hpp \
+	globalbootstrapvars.hpp \
 	inflationtermstructure.hpp \
 	interpolatedcurve.hpp \
 	iterativebootstrap.hpp \
@@ -19,6 +20,7 @@ this_include_HEADERS = \
 
 cpp_files = \
 	defaulttermstructure.cpp \
+	globalbootstrapvars.cpp \
 	inflationtermstructure.cpp \
 	voltermstructure.cpp \
 	yieldtermstructure.cpp

--- a/ql/termstructures/all.hpp
+++ b/ql/termstructures/all.hpp
@@ -5,6 +5,7 @@
 #include <ql/termstructures/bootstraphelper.hpp>
 #include <ql/termstructures/defaulttermstructure.hpp>
 #include <ql/termstructures/globalbootstrap.hpp>
+#include <ql/termstructures/globalbootstrapvars.hpp>
 #include <ql/termstructures/inflationtermstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/termstructures/iterativebootstrap.hpp>

--- a/ql/termstructures/globalbootstrapvars.cpp
+++ b/ql/termstructures/globalbootstrapvars.cpp
@@ -1,0 +1,49 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <ql/termstructures/globalbootstrapvars.hpp>
+#include <ql/utilities/null.hpp>
+#include <ql/utilities/vectors.hpp>
+#include <utility>
+
+namespace QuantLib {
+
+    SimpleQuoteVariables::SimpleQuoteVariables(std::vector<ext::shared_ptr<SimpleQuote>> quotes,
+                                               std::vector<Real> initialGuesses,
+                                               std::vector<Real> lowerBounds)
+    : quotes_(std::move(quotes)), initialGuesses_(std::move(initialGuesses)),
+      lowerBounds_(std::move(lowerBounds)) {
+        QL_REQUIRE(initialGuesses_.size() <= quotes_.size(), "too many initialGuesses");
+        QL_REQUIRE(lowerBounds_.size() <= quotes_.size(), "too many lowerBounds");
+    }
+
+    Array SimpleQuoteVariables::initialize(bool validData) {
+        Array guesses(quotes_.size());
+        for (Size i = 0, size = guesses.size(); i < size; ++i) {
+            Real guess;
+            if (validData) {
+                guess = quotes_[i]->value();
+            } else {
+                guess = detail::get(initialGuesses_, i, 0.0);
+                quotes_[i]->setValue(guess);
+            }
+            guesses[i] = transformInverse(guess, i);
+        }
+        return guesses;
+    }
+
+    void SimpleQuoteVariables::update(const Array& x) {
+        for (Size i = 0, size = x.size(); i < size; ++i) {
+            quotes_[i]->setValue(transformDirect(x[i], i));
+        }
+    }
+
+    Real SimpleQuoteVariables::transformDirect(Real x, Size i) const {
+        const Real lb = detail::get(lowerBounds_, i, Null<Real>());
+        return lb == Null<Real>() ? x : std::exp(x) + lb;
+    }
+
+    Real SimpleQuoteVariables::transformInverse(Real x, Size i) const {
+        const Real lb = detail::get(lowerBounds_, i, Null<Real>());
+        return lb == Null<Real>() ? x : std::log(x - lb);
+    }
+}

--- a/ql/termstructures/globalbootstrapvars.hpp
+++ b/ql/termstructures/globalbootstrapvars.hpp
@@ -1,0 +1,32 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef quantlib_global_bootstrap_vars_hpp
+#define quantlib_global_bootstrap_vars_hpp
+
+#include <ql/quotes/simplequote.hpp>
+#include <ql/shared_ptr.hpp>
+#include <ql/termstructures/globalbootstrap.hpp>
+
+namespace QuantLib {
+
+class SimpleQuoteVariables : public AdditionalBootstrapVariables {
+  public:
+    explicit SimpleQuoteVariables(
+        std::vector<ext::shared_ptr<SimpleQuote>> quotes,
+        std::vector<Real> initialGuesses = {},
+        std::vector<Real> lowerBounds = {});
+
+    Array initialize(bool validData) override;
+    void update(const Array& x) override;
+
+  private:
+    Real transformDirect(Real x, Size i) const;
+    Real transformInverse(Real x, Size i) const;
+
+    std::vector<ext::shared_ptr<SimpleQuote>> quotes_;
+    std::vector<Real> initialGuesses_, lowerBounds_;
+};
+
+} // namespace QuantLib
+
+#endif


### PR DESCRIPTION
This is useful to find model parameters used by rate helpers, for example, convexity adjustments for futures.

This change adds a generic interface (AdditionalBootstrapVariables) and a specific implementation for variables implemented as SimpleQuotes (SimpleQuoteVariables).