### PR TITLE
XCcy Helpers

### DIFF
--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -20,6 +20,7 @@
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/simplecashflow.hpp>
+#include <ql/cashflows/overnightindexedcoupon.hpp>
 #include <ql/experimental/termstructures/crosscurrencyratehelpers.hpp>
 #include <ql/utilities/null_deleter.hpp>
 #include <utility>
@@ -63,21 +64,28 @@ namespace QuantLib {
             auto freqPeriod = paymentFrequency == NoFrequency ? idx->tenor() : Period(paymentFrequency);
             Schedule sch = legSchedule(evaluationDate, tenor, freqPeriod, fixingDays, calendar,
                                        convention, endOfMonth);
+            auto overnightIndex = ext::dynamic_pointer_cast<OvernightIndex>(idx);
+            if (overnightIndex != nullptr) {
+                return OvernightLeg(sch, overnightIndex)
+                    .withNotionals(1.0)
+                    .withPaymentLag(paymentLag);
+            }
             return IborLeg(sch, idx).withNotionals(1.0).withPaymentLag(paymentLag);
         }
 
-        std::pair<Real, Real> npvbpsConstNotionalLeg(const Leg& iborLeg,
-                                                     const Handle<YieldTermStructure>& discountCurveHandle) {
+        std::pair<Real, Real>
+        npvbpsConstNotionalLeg(const Leg& iborLeg,
+                               const Date& initialNotionalExchangeDate,
+                               const Date& finalNotionalExchangeDate,
+                               const Handle<YieldTermStructure>& discountCurveHandle) {
             const Spread basisPoint = 1.0e-4;
             Date refDt = discountCurveHandle->referenceDate();
             const YieldTermStructure& discountRef = **discountCurveHandle;
             bool includeSettleDtFlows = true;
             auto [npv, bps] = CashFlows::npvbps(iborLeg, discountRef, includeSettleDtFlows, refDt, refDt);
             // Include NPV of the notional exchange at start and maturity.
-            // on the settlement date
-            npv += (-1.0) * discountRef.discount(CashFlows::startDate(iborLeg));
-            // on maturity date  
-            npv += discountRef.discount(CashFlows::maturityDate(iborLeg));
+            npv += (-1.0) * discountRef.discount(initialNotionalExchangeDate);
+            npv += discountRef.discount(finalNotionalExchangeDate);
             bps /= basisPoint;
             return { npv, bps };
         }
@@ -102,15 +110,31 @@ namespace QuantLib {
         class ResettingLegCalculator : public AcyclicVisitor, public Visitor<Coupon> {
           public:
             explicit ResettingLegCalculator(const YieldTermStructure& discountCurve,
-                                            const YieldTermStructure& foreignCurve)
-            : helper_(discountCurve, foreignCurve) {}
+                                            const YieldTermStructure& foreignCurve,
+                                            Integer paymentLag,
+                                            Calendar paymentCalendar,
+                                            BusinessDayConvention convention)
+            : helper_(discountCurve, foreignCurve), paymentLag_(paymentLag),
+              paymentCalendar_(std::move(paymentCalendar)), convention_(convention) {}
+
             void visit(Coupon& c) override {
                 Date start = c.accrualStartDate();
                 Date end = c.accrualEndDate();
                 Time accrual = c.accrualPeriod();
                 Real adjustedNotional = c.nominal() * helper_.notionalAdjustment(start);
-                DiscountFactor discountStart = helper_.discount(start);
-                DiscountFactor discountEnd = helper_.discount(end);
+
+                DiscountFactor discountStart, discountEnd;
+
+                if (paymentLag_ == 0) {
+                    discountStart = helper_.discount(start);
+                    discountEnd = helper_.discount(end);
+                } else {
+                    Date paymentStart =
+                        paymentCalendar_.advance(start, paymentLag_, Days, convention_);
+                    Date paymentEnd = paymentCalendar_.advance(end, paymentLag_, Days, convention_);
+                    discountStart = helper_.discount(paymentStart);
+                    discountEnd = helper_.discount(paymentEnd);
+                }
 
                 // NPV of a resetting coupon consists of a redemption of borrowed amount occurring
                 // at the end of the accrual period plus the accrued interest, minus the borrowed
@@ -121,7 +145,7 @@ namespace QuantLib {
                     adjustedNotional * discountEnd * (1.0 + c.rate() * accrual);
                 Real npvBorrowedAmount = -adjustedNotional * discountStart;
 
-                npv_ += npvRedeemedAmount + npvBorrowedAmount;
+                npv_ += (npvRedeemedAmount + npvBorrowedAmount);
                 bps_ += adjustedNotional * discountEnd * accrual;
             }
             Real NPV() const { return npv_; }
@@ -131,15 +155,22 @@ namespace QuantLib {
             ResettingLegHelper helper_;
             Real npv_ = 0.0;
             Real bps_ = 0.0;
+            Integer paymentLag_;
+            Calendar paymentCalendar_;
+            BusinessDayConvention convention_;
         };
 
         std::pair<Real, Real> npvbpsResettingLeg(const Leg& iborLeg,
+                                                 Integer paymentLag,
+                                                 const Calendar& paymentCalendar,
+                                                 BusinessDayConvention convention,
                                                  const Handle<YieldTermStructure>& discountCurveHandle,
                                                  const Handle<YieldTermStructure>& foreignCurveHandle) {
             const YieldTermStructure& discountCurveRef = **discountCurveHandle;
             const YieldTermStructure& foreignCurveRef = **foreignCurveHandle;
 
-            ResettingLegCalculator calc(discountCurveRef, foreignCurveRef);
+            ResettingLegCalculator calc(discountCurveRef, foreignCurveRef, paymentLag,
+                                        paymentCalendar, convention);
             for (const auto& i : iborLeg) {
                 CashFlow& cf = *i;
                 cf.accept(calc);
@@ -168,7 +199,8 @@ namespace QuantLib {
       collateralHandle_(std::move(collateralCurve)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
-      paymentFrequency_(paymentFrequency), paymentLag_(paymentLag) {
+      paymentFrequency_(paymentFrequency), paymentLag_(paymentLag),
+      initialNotionalExchangeDate_(Date()), finalNotionalExchangeDate_(Date()) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
         registerWith(collateralHandle_);
@@ -180,10 +212,17 @@ namespace QuantLib {
                                        endOfMonth_, baseCcyIdx_, paymentFrequency_, paymentLag_);
         quoteCcyIborLeg_ = buildIborLeg(evaluationDate_, tenor_, fixingDays_, calendar_,
                                         convention_, endOfMonth_, quoteCcyIdx_, paymentFrequency_, paymentLag_);
-        earliestDate_ =
-            std::min(CashFlows::startDate(baseCcyIborLeg_), CashFlows::startDate(quoteCcyIborLeg_));
+        earliestDate_ = std::min(CashFlows::startDate(baseCcyIborLeg_), 
+                                CashFlows::startDate(quoteCcyIborLeg_));
         maturityDate_ = std::max(CashFlows::maturityDate(baseCcyIborLeg_),
                                  CashFlows::maturityDate(quoteCcyIborLeg_));
+        if (paymentLag_ == 0) {
+            initialNotionalExchangeDate_ = earliestDate_;
+            finalNotionalExchangeDate_ = maturityDate_;
+        } else {
+            initialNotionalExchangeDate_ = calendar_.advance(earliestDate_, paymentLag_, Days, convention_);
+            finalNotionalExchangeDate_ = calendar_.advance(maturityDate_, paymentLag_, Days, convention_);
+        }
         Date lastPaymentDate = std::max(baseCcyIborLeg_.back()->date(), quoteCcyIborLeg_.back()->date());
         latestRelevantDate_ = latestDate_ = std::max(maturityDate_, lastPaymentDate);
     }
@@ -242,8 +281,8 @@ namespace QuantLib {
                                            paymentLag) {}
 
     Real ConstNotionalCrossCurrencyBasisSwapRateHelper::impliedQuote() const {
-        auto [npvBaseCcy, bpsBaseCcy] = npvbpsConstNotionalLeg(baseCcyIborLeg_, baseCcyLegDiscountHandle());
-        auto [npvQuoteCcy, bpsQuoteCcy] = npvbpsConstNotionalLeg(quoteCcyIborLeg_, quoteCcyLegDiscountHandle());
+        auto [npvBaseCcy, bpsBaseCcy] = npvbpsConstNotionalLeg(baseCcyIborLeg_, initialNotionalExchangeDate_, finalNotionalExchangeDate_, baseCcyLegDiscountHandle());
+        auto [npvQuoteCcy, bpsQuoteCcy] = npvbpsConstNotionalLeg(quoteCcyIborLeg_, initialNotionalExchangeDate_, finalNotionalExchangeDate_, quoteCcyLegDiscountHandle());
         Real bps = isBasisOnFxBaseCurrencyLeg_ ? -bpsBaseCcy : bpsQuoteCcy;
         return -(npvQuoteCcy - npvBaseCcy) / bps;
     }
@@ -291,16 +330,18 @@ namespace QuantLib {
         Real npvQuoteCcy = 0.0, bpsQuoteCcy = 0.0;
         if (isFxBaseCurrencyLegResettable_) {
             std::tie(npvBaseCcy, bpsBaseCcy) =
-                npvbpsResettingLeg(baseCcyIborLeg_, baseCcyLegDiscountHandle(),
-                                   quoteCcyLegDiscountHandle());
+                npvbpsResettingLeg(baseCcyIborLeg_, paymentLag_, calendar_, convention_,
+                                   baseCcyLegDiscountHandle(), quoteCcyLegDiscountHandle());
             std::tie(npvQuoteCcy, bpsQuoteCcy) =
-                npvbpsConstNotionalLeg(quoteCcyIborLeg_, quoteCcyLegDiscountHandle());
+                npvbpsConstNotionalLeg(quoteCcyIborLeg_, initialNotionalExchangeDate_,
+                                       finalNotionalExchangeDate_, quoteCcyLegDiscountHandle());
         } else {
             std::tie(npvBaseCcy, bpsBaseCcy) =
-                npvbpsConstNotionalLeg(baseCcyIborLeg_, baseCcyLegDiscountHandle());
-            std::tie(npvQuoteCcy, bpsQuoteCcy) =
-                npvbpsResettingLeg(quoteCcyIborLeg_, quoteCcyLegDiscountHandle(),
-                                   baseCcyLegDiscountHandle());
+                npvbpsConstNotionalLeg(baseCcyIborLeg_, initialNotionalExchangeDate_,
+                                       finalNotionalExchangeDate_, baseCcyLegDiscountHandle());
+            std::tie(npvQuoteCcy, bpsQuoteCcy) = npvbpsResettingLeg(
+                                       quoteCcyIborLeg_, paymentLag_, calendar_, convention_,
+                                       quoteCcyLegDiscountHandle(), baseCcyLegDiscountHandle());
         }
 
         Real bps = isBasisOnFxBaseCurrencyLeg_ ? -bpsBaseCcy : bpsQuoteCcy;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -20,7 +20,6 @@
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/simplecashflow.hpp>
-#include <ql/cashflows/overnightindexedcoupon.hpp>
 #include <ql/experimental/termstructures/crosscurrencyratehelpers.hpp>
 #include <ql/utilities/null_deleter.hpp>
 #include <utility>
@@ -64,12 +63,6 @@ namespace QuantLib {
             auto freqPeriod = paymentFrequency == NoFrequency ? idx->tenor() : Period(paymentFrequency);
             Schedule sch = legSchedule(evaluationDate, tenor, freqPeriod, fixingDays, calendar,
                                        convention, endOfMonth);
-            auto overnightIndex = ext::dynamic_pointer_cast<OvernightIndex>(idx);
-            if (overnightIndex != nullptr) {
-                return OvernightLeg(sch, overnightIndex)
-                    .withNotionals(1.0)
-                    .withPaymentLag(paymentLag);
-            }
             return IborLeg(sch, idx).withNotionals(1.0).withPaymentLag(paymentLag);
         }
 

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -46,7 +46,9 @@ namespace QuantLib {
                                              ext::shared_ptr<IborIndex> quoteCurrencyIndex,
                                              Handle<YieldTermStructure> collateralCurve,
                                              bool isFxBaseCurrencyCollateralCurrency,
-                                             bool isBasisOnFxBaseCurrencyLeg);
+                                             bool isBasisOnFxBaseCurrencyLeg,
+                                             Frequency paymentFrequency,
+                                             Integer paymentLag);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -62,6 +64,8 @@ namespace QuantLib {
         Handle<YieldTermStructure> collateralHandle_;
         bool isFxBaseCurrencyCollateralCurrency_;
         bool isBasisOnFxBaseCurrencyLeg_;
+        Frequency paymentFrequency_;
+        Integer paymentLag_;
 
         Leg baseCcyIborLeg_;
         Leg quoteCcyIborLeg_;
@@ -105,7 +109,9 @@ namespace QuantLib {
             const ext::shared_ptr<IborIndex>& quoteCurrencyIndex,
             const Handle<YieldTermStructure>& collateralCurve,
             bool isFxBaseCurrencyCollateralCurrency,
-            bool isBasisOnFxBaseCurrencyLeg);
+            bool isBasisOnFxBaseCurrencyLeg,
+            Frequency paymentFrequency = NoFrequency,
+            Integer paymentLag = 0);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -142,7 +148,9 @@ namespace QuantLib {
                                             const Handle<YieldTermStructure>& collateralCurve,
                                             bool isFxBaseCurrencyCollateralCurrency,
                                             bool isBasisOnFxBaseCurrencyLeg,
-                                            bool isFxBaseCurrencyLegResettable);
+                                            bool isFxBaseCurrencyLegResettable,
+                                            Frequency paymentFrequency = NoFrequency,
+                                            Integer paymentLag = 0);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -70,6 +70,9 @@ namespace QuantLib {
         Leg baseCcyIborLeg_;
         Leg quoteCcyIborLeg_;
 
+        Date initialNotionalExchangeDate_;
+        Date finalNotionalExchangeDate_;
+
         RelinkableHandle<YieldTermStructure> termStructureHandle_;
     };
 

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -18,6 +18,9 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include "ql/indexes/ibor/eonia.hpp"
+#include "ql/indexes/ibor/sofr.hpp"
+#include "ql/pricingengines/vanilla/all.hpp"
 #include <ql/experimental/termstructures/crosscurrencyratehelpers.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/indexes/ibor/usdlibor.hpp>
@@ -60,6 +63,8 @@ struct CommonVars {
 
     ext::shared_ptr<IborIndex> baseCcyIdx;
     ext::shared_ptr<IborIndex> quoteCcyIdx;
+    ext::shared_ptr<IborIndex> quoteOvernightIndex;
+    ext::shared_ptr<IborIndex> baseOvernightIndex;
 
     RelinkableHandle<YieldTermStructure> baseCcyIdxHandle;
     RelinkableHandle<YieldTermStructure> quoteCcyIdxHandle;
@@ -77,7 +82,7 @@ struct CommonVars {
         Period tenor(q.n, q.units);
         return ext::shared_ptr<RateHelper>(new ConstNotionalCrossCurrencyBasisSwapRateHelper(
                 quoteHandle, tenor, instrumentSettlementDays, calendar, businessConvention, endOfMonth,
-                baseCcyIdx, quoteCcyIdx, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+            baseCcyIdx, quoteCcyIdx, collateralHandle, isFxBaseCurrencyCollateralCurrency,
                 isBasisOnFxBaseCurrencyLeg));
     }
 
@@ -102,13 +107,25 @@ struct CommonVars {
                             const Handle<YieldTermStructure>& collateralHandle,
                             bool isFxBaseCurrencyCollateralCurrency,
                             bool isBasisOnFxBaseCurrencyLeg,
-                            bool isFxBaseCurrencyLegResettable) const {
+                            bool isFxBaseCurrencyLegResettable,
+                            Frequency paymentFrequency = NoFrequency,
+                            Integer paymentLag = 0,
+                            bool useOvernightIndex = false) const {
         Handle<Quote> quoteHandle(ext::make_shared<SimpleQuote>(q.basis * basisPoint));
         Period tenor(q.n, q.units);
+        ext::shared_ptr<IborIndex> baseIndex, quoteIndex;
+        if (useOvernightIndex) {
+            baseIndex = baseOvernightIndex;
+            quoteIndex = quoteOvernightIndex;
+        } else {
+            baseIndex = baseCcyIdx;
+            quoteIndex = quoteCcyIdx;
+        }
+
         return ext::shared_ptr<RateHelper>(new MtMCrossCurrencyBasisSwapRateHelper(
                 quoteHandle, tenor, instrumentSettlementDays, calendar, businessConvention, endOfMonth,
-                baseCcyIdx, quoteCcyIdx, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable));
+            baseIndex, quoteIndex, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag));
     }
 
     std::vector<ext::shared_ptr<RateHelper> >
@@ -116,13 +133,17 @@ struct CommonVars {
                                   const Handle<YieldTermStructure>& collateralHandle,
                                   bool isFxBaseCurrencyCollateralCurrency,
                                   bool isBasisOnFxBaseCurrencyLeg,
-                                  bool isFxBaseCurrencyLegResettable) const {
+                                  bool isFxBaseCurrencyLegResettable,
+                                  Frequency paymentFrequency = NoFrequency,
+                                  Integer paymentLag = 0,
+                                  bool useOvernightQuoteIndex = false) const {
         std::vector<ext::shared_ptr<RateHelper> > instruments;
         instruments.reserve(xccyData.size());
         for (const auto& i : xccyData) {
             instruments.push_back(resettingXccyRateHelper(
                     i, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-                    isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable));
+                    isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable,
+                    paymentFrequency, paymentLag, useOvernightQuoteIndex));
         }
 
         return instruments;
@@ -194,6 +215,8 @@ struct CommonVars {
 
         baseCcyIdx = ext::shared_ptr<IborIndex>(new Euribor3M(baseCcyIdxHandle));
         quoteCcyIdx = ext::shared_ptr<IborIndex>(new USDLibor(3 * Months, quoteCcyIdxHandle));
+        baseOvernightIndex = ext::shared_ptr<IborIndex>(new Eonia(baseCcyIdxHandle));
+        quoteOvernightIndex = ext::shared_ptr<IborIndex>(new Sofr(quoteCcyIdxHandle));
 
         /* Data source:
            N. Moreni, A. Pallavicini (2015)
@@ -281,7 +304,10 @@ void testConstantNotionalCrossCurrencySwapsNPV(bool isFxBaseCurrencyCollateralCu
 
 void testResettingCrossCurrencySwaps(bool isFxBaseCurrencyCollateralCurrency,
                                      bool isBasisOnFxBaseCurrencyLeg,
-                                     bool isFxBaseCurrencyLegResettable) {
+                                     bool isFxBaseCurrencyLegResettable,
+                                     Frequency paymentFrequency = NoFrequency,
+                                     Integer paymentLag = 0,
+                                     bool useOvernightIndex = false) {
 
     CommonVars vars;
 
@@ -291,7 +317,8 @@ void testResettingCrossCurrencySwaps(bool isFxBaseCurrencyCollateralCurrency,
     std::vector<ext::shared_ptr<RateHelper> > resettingInstruments =
         vars.buildResettingXccyRateHelpers(
             vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable);
+            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag,
+            useOvernightIndex);
 
     std::vector<ext::shared_ptr<RateHelper> > constNotionalInstruments =
         vars.buildConstantNotionalXccyRateHelpers(vars.basisData, collateralHandle,
@@ -417,6 +444,43 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithCollateralAndBasisInQuoteCcy) {
 
     testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
                                      isFxBaseCurrencyLegResettable);
+}
+
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithArbitraryFreq) {
+    BOOST_TEST_MESSAGE(
+        "Testing resetting basis swaps with collateral in quote ccy and basis in base ccy...");
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isFxBaseCurrencyLegResettable = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+
+    testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
+                                    isFxBaseCurrencyLegResettable,
+                                    Weekly);
+}
+
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithPaymentLag) {
+    BOOST_TEST_MESSAGE(
+        "Testing resetting basis swaps with collateral in quote ccy and basis in base ccy...");
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isFxBaseCurrencyLegResettable = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+
+    testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
+                                    isFxBaseCurrencyLegResettable, NoFrequency, 2);
+}
+
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithOvernightIndex) {
+    BOOST_TEST_MESSAGE(
+        "Testing resetting basis swaps with collateral in quote ccy and basis in base ccy...");
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isFxBaseCurrencyLegResettable = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+
+    testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
+                                    isFxBaseCurrencyLegResettable, NoFrequency, 0, true);
 }
 
 BOOST_AUTO_TEST_CASE(testExceptionWhenInstrumentTenorShorterThanIndexFrequency) {


### PR DESCRIPTION
I've added a number of parameters to align xccy helpers with market conventions: ability to pass an overnight index, custom payment frequency (previously inherited from the ibor index but does not make sense for overnight indices) and finally a payment lag. Most of the time but not always the payment frequency is 3 months and payment lag 2 days. In some cases at the short end of the curve the payment lag is 0 and the payment frequency can be 1 month or 3 months. However in the interest of avoiding breaking changes, the default payment frequency is set to NoFrequency (which reverts to the old behaviour of deriving it from the ibor index) and the default payment lag is 0.
Note that the SWIG project also needs to change to pass these parameters from the Python (or other) languages.