### PR TITLE
Add RelinkableHandle::reset()

### DIFF
--- a/ql/handle.hpp
+++ b/ql/handle.hpp
@@ -135,6 +135,7 @@ namespace QuantLib {
                     bool registerAsObserver = true);
         void linkTo(ext::shared_ptr<T>&& h,
                     bool registerAsObserver = true);
+        void reset();
     };
 
 
@@ -219,6 +220,11 @@ namespace QuantLib {
     inline void RelinkableHandle<T>::linkTo(ext::shared_ptr<T>&& h,
                                             bool registerAsObserver) {
         this->link_->linkTo(std::move(h), registerAsObserver);
+    }
+
+    template <class T>
+    inline void RelinkableHandle<T>::reset() {
+        this->link_->linkTo(nullptr);
     }
 
 }


### PR DESCRIPTION
So it does not have to be added in SWIG[1].

[1] https://github.com/lballabio/QuantLib-SWIG/blob/7d8d4c6c3bc71c195719a4df81b0650e60578da1/SWIG/common.i#L128