### PR TITLE
Array Construction Edge-Case Fix

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -66,6 +66,8 @@ namespace QuantLib {
         Array(const Array&);
         Array(Array&&) noexcept;
         Array(std::initializer_list<Real>);
+        template <typename T, typename = std::enable_if_t<std::is_convertible_v<T, Real>>>
+        Array(std::initializer_list<T> init);
         //! creates the array from an iterable sequence
         template <class ForwardIterator>
         Array(ForwardIterator begin, ForwardIterator end);
@@ -335,6 +337,11 @@ namespace QuantLib {
         // We have to detect integral types and dispatch.
         detail::_fill_array_(*this, data_, n_, begin, end,
                              std::is_integral<ForwardIterator>());
+    }
+
+    template <typename T, typename>
+    Array::Array(std::initializer_list<T> init) {
+        detail::_fill_array_(*this, data_, n_, init.begin(), init.end(), std::false_type());
     }
 
     inline Array& Array::operator=(const Array& from) {

--- a/test-suite/array.cpp
+++ b/test-suite/array.cpp
@@ -115,6 +115,20 @@ BOOST_AUTO_TEST_CASE(testConstruction) {
                         << calculated);
         }
     }
+
+    // recast initializer list to Real
+    Array a11({1, 2, 3, 4, 5});
+    if (a2.size() != size)
+        BOOST_ERROR("Array not of the required size"
+                    << "\n    required:  " << size
+                    << "\n    resulting: " << a2.size());
+    for (i=0; i<size; ++i) {
+        if (a11[i] != Real(i+1))
+            BOOST_ERROR(io::ordinal(i+1) << " element not with required value"
+                        << "\n    required:  " << Real(i+1)
+                        << "\n    resulting: " << a11[i]);
+    }
+
 }
 
 BOOST_AUTO_TEST_CASE(testArrayFunctions) {

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -2488,7 +2488,7 @@ BOOST_AUTO_TEST_CASE(testAccurateAmericanBasketOptions) {
     );
 
     BasketOption basketOption(
-        ext::make_shared<AverageBasketPayoff>(payoff, Array({1})),
+        ext::make_shared<AverageBasketPayoff>(payoff, Array({Real(1.)})),
         exercise
     );
     basketOption.setPricingEngine(


### PR DESCRIPTION
## Motive

Building QuantLib on MacOS, note the warning:

```bash
QuantLib/test-suite/basketoption.cpp:2491:61: warning: braces around scalar initializer [-Wbraced-scalar-init]
        ext::make_shared<AverageBasketPayoff>(payoff, Array({1})),
                                                            ^~~
1 warning generated.
```

## Breakdown

This warning is caused by the `Array` constructors:

```c++
class Array {
    ...
    explicit Array(Size size);
    ...
    Array(std::initializer_list<Real>);
    ...
}
```

The compiler gets confused and thinks we're calling the first constructor, but with `{}`.

## Fix

The obvious fix is to change `Array({1})` to `Array({Real(1.)})`. This change was made in this PR for good practice but it is only kicking the can down the road.

A more robust fix I suggest (view the `array.hpp` diff) is to add a constructor that catches a construction with a non-`Real` initialiser list. `Array` is clearly meant to be a mathematical vector rather than a container and so I don't see a scenario where an `Array` should be strictly `int` as that'd be restrictive for linear algebra.

I added to the tests as to validate the behaviour. Feel free to suggest which fix you prefer, the extra constructor or the edit in `basketoption.cpp`.