### PR TITLE
Added `Handle<Quote>` for spread in `OISRateHelper`

### DIFF
--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -248,7 +248,7 @@ namespace QuantLib {
                                            BusinessDayConvention paymentConvention,
                                            Frequency paymentFrequency,
                                            const Calendar& paymentCalendar,
-                                           Handle<Quote> overnightSpread,
+                                           Spread overnightSpread,
                                            ext::optional<bool> endOfMonth,
                                            ext::optional<Frequency> fixedPaymentFrequency,
                                            const Calendar& fixedCalendar,
@@ -258,7 +258,7 @@ namespace QuantLib {
                                            const ext::shared_ptr<FloatingRateCouponPricer>& pricer)
     : OISRateHelper(startDate, endDate, fixedRate, overnightIndex, std::move(discount), telescopicValueDates,
                     paymentLag, paymentConvention, paymentFrequency, paymentCalendar, 
-                    std::variant<Spread, Handle<Quote>>(std::move(overnightSpread)),
+                    std::variant<Spread, Handle<Quote>>(overnightSpread),
                     Pillar::LastRelevantDate, Date(), averagingMethod, endOfMonth, fixedPaymentFrequency,
                     fixedCalendar, lookbackDays, lockoutDays, applyObservationShift, pricer) {}
 
@@ -274,7 +274,7 @@ namespace QuantLib {
                                            Frequency paymentFrequency,
                                            const Calendar& paymentCalendar,
                                            const Period&,
-                                           Handle<Quote> overnightSpread,
+                                           Spread overnightSpread,
                                            ext::optional<bool> endOfMonth,
                                            ext::optional<Frequency> fixedPaymentFrequency,
                                            const Calendar& fixedCalendar)

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -257,7 +257,8 @@ namespace QuantLib {
                                            bool applyObservationShift,
                                            const ext::shared_ptr<FloatingRateCouponPricer>& pricer)
     : OISRateHelper(startDate, endDate, fixedRate, overnightIndex, std::move(discount), telescopicValueDates,
-                    paymentLag, paymentConvention, paymentFrequency, paymentCalendar, std::move(overnightSpread),
+                    paymentLag, paymentConvention, paymentFrequency, paymentCalendar, 
+                    std::variant<Spread, Handle<Quote>>(std::move(overnightSpread)),
                     Pillar::LastRelevantDate, Date(), averagingMethod, endOfMonth, fixedPaymentFrequency,
                     fixedCalendar, lookbackDays, lockoutDays, applyObservationShift, pricer) {}
 

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -153,7 +153,7 @@ namespace QuantLib {
                            BusinessDayConvention paymentConvention = Following,
                            Frequency paymentFrequency = Annual,
                            const Calendar& paymentCalendar = Calendar(),
-                           Handle<Quote> overnightSpread = {},
+                           Spread overnightSpread = {},
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
                            const Calendar& fixedCalendar = Calendar(),
@@ -179,7 +179,7 @@ namespace QuantLib {
                            Frequency paymentFrequency,
                            const Calendar& paymentCalendar,
                            const Period& forwardStart,
-                           Handle<Quote> overnightSpread = {},
+                           Spread overnightSpread = {},
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
                            const Calendar& fixedCalendar = Calendar());

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -28,6 +28,7 @@
 #include <ql/termstructures/yield/ratehelpers.hpp>
 #include <ql/instruments/overnightindexedswap.hpp>
 #include <ql/optional.hpp>
+#include <variant>
 
 namespace QuantLib {
 
@@ -37,52 +38,54 @@ namespace QuantLib {
     class OISRateHelper : public RelativeDateRateHelper {
       public:
         OISRateHelper(Natural settlementDays,
-                      const Period& tenor, // swap maturity
-                      const Handle<Quote>& fixedRate,
-                      const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                      // exogenous discounting curve
-                      Handle<YieldTermStructure> discountingCurve = {},
-                      bool telescopicValueDates = false,
-                      Integer paymentLag = 0,
-                      BusinessDayConvention paymentConvention = Following,
-                      Frequency paymentFrequency = Annual,
-                      Calendar paymentCalendar = Calendar(),
-                      const Period& forwardStart = 0 * Days,
-                      Handle<Quote> overnightSpread = {},
-                      Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date(),
-                      RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                      ext::optional<bool> endOfMonth = ext::nullopt,
-                      ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
-                      Calendar fixedCalendar = Calendar(),
-                      Natural lookbackDays = Null<Natural>(),
-                      Natural lockoutDays = 0,
-                      bool applyObservationShift = false,
-                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
-                      DateGeneration::Rule rule = DateGeneration::Backward);
+          const Period& tenor, // swap maturity
+          const Handle<Quote>& fixedRate,
+          const ext::shared_ptr<OvernightIndex>& overnightIndex,
+          // exogenous discounting curve
+          Handle<YieldTermStructure> discountingCurve = {},
+          bool telescopicValueDates = false,
+          Integer paymentLag = 0,
+          BusinessDayConvention paymentConvention = Following,
+          Frequency paymentFrequency = Annual,
+          Calendar paymentCalendar = Calendar(),
+          const Period& forwardStart = 0 * Days,
+          std::variant<Spread, Handle<Quote>> overnightSpread = Spread(0.0),
+          Pillar::Choice pillar = Pillar::LastRelevantDate,
+          Date customPillarDate = Date(),
+          RateAveraging::Type averagingMethod = RateAveraging::Compound,
+          ext::optional<bool> endOfMonth = ext::nullopt,
+          ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+          Calendar fixedCalendar = Calendar(),
+          Natural lookbackDays = Null<Natural>(),
+          Natural lockoutDays = 0,
+          bool applyObservationShift = false,
+          ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
+          DateGeneration::Rule rule = DateGeneration::Backward);
+
         OISRateHelper(const Date& startDate,
-                      const Date& endDate,
-                      const Handle<Quote>& fixedRate,
-                      const ext::shared_ptr<OvernightIndex>& overnightIndex,
-                      // exogenous discounting curve
-                      Handle<YieldTermStructure> discountingCurve = {},
-                      bool telescopicValueDates = false,
-                      Integer paymentLag = 0,
-                      BusinessDayConvention paymentConvention = Following,
-                      Frequency paymentFrequency = Annual,
-                      Calendar paymentCalendar = Calendar(),
-                      Handle<Quote> overnightSpread = {},
-                      Pillar::Choice pillar = Pillar::LastRelevantDate,
-                      Date customPillarDate = Date(),
-                      RateAveraging::Type averagingMethod = RateAveraging::Compound,
-                      ext::optional<bool> endOfMonth = ext::nullopt,
-                      ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
-                      Calendar fixedCalendar = Calendar(),
-                      Natural lookbackDays = Null<Natural>(),
-                      Natural lockoutDays = 0,
-                      bool applyObservationShift = false,
-                      ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
-                      DateGeneration::Rule rule = DateGeneration::Backward);
+          const Date& endDate,
+          const Handle<Quote>& fixedRate,
+          const ext::shared_ptr<OvernightIndex>& overnightIndex,
+          // exogenous discounting curve
+          Handle<YieldTermStructure> discountingCurve = {},
+          bool telescopicValueDates = false,
+          Integer paymentLag = 0,
+          BusinessDayConvention paymentConvention = Following,
+          Frequency paymentFrequency = Annual,
+          Calendar paymentCalendar = Calendar(),
+          std::variant<Spread, Handle<Quote>> overnightSpread = Spread(0.0),
+          Pillar::Choice pillar = Pillar::LastRelevantDate,
+          Date customPillarDate = Date(),
+          RateAveraging::Type averagingMethod = RateAveraging::Compound,
+          ext::optional<bool> endOfMonth = ext::nullopt,
+          ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
+          Calendar fixedCalendar = Calendar(),
+          Natural lookbackDays = Null<Natural>(),
+          Natural lockoutDays = 0,
+          bool applyObservationShift = false,
+          ext::shared_ptr<FloatingRateCouponPricer> pricer = {},
+          DateGeneration::Rule rule = DateGeneration::Backward);
+
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/termstructures/yield/oisratehelper.hpp
+++ b/ql/termstructures/yield/oisratehelper.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
                       Frequency paymentFrequency = Annual,
                       Calendar paymentCalendar = Calendar(),
                       const Period& forwardStart = 0 * Days,
-                      Spread overnightSpread = 0.0,
+                      Handle<Quote> overnightSpread = {},
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(),
                       RateAveraging::Type averagingMethod = RateAveraging::Compound,
@@ -71,7 +71,7 @@ namespace QuantLib {
                       BusinessDayConvention paymentConvention = Following,
                       Frequency paymentFrequency = Annual,
                       Calendar paymentCalendar = Calendar(),
-                      Spread overnightSpread = 0.0,
+                      Handle<Quote> overnightSpread = {},
                       Pillar::Choice pillar = Pillar::LastRelevantDate,
                       Date customPillarDate = Date(),
                       RateAveraging::Type averagingMethod = RateAveraging::Compound,
@@ -119,7 +119,7 @@ namespace QuantLib {
         Frequency paymentFrequency_;
         Calendar paymentCalendar_;
         Period forwardStart_;
-        Spread overnightSpread_;
+        Handle<Quote> overnightSpread_;
         Pillar::Choice pillarChoice_;
         RateAveraging::Type averagingMethod_;
         ext::optional<bool> endOfMonth_;
@@ -150,7 +150,7 @@ namespace QuantLib {
                            BusinessDayConvention paymentConvention = Following,
                            Frequency paymentFrequency = Annual,
                            const Calendar& paymentCalendar = Calendar(),
-                           Spread overnightSpread = 0.0,
+                           Handle<Quote> overnightSpread = {},
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
                            const Calendar& fixedCalendar = Calendar(),
@@ -176,7 +176,7 @@ namespace QuantLib {
                            Frequency paymentFrequency,
                            const Calendar& paymentCalendar,
                            const Period& forwardStart,
-                           Spread overnightSpread = 0.0,
+                           Handle<Quote> overnightSpread = {},
                            ext::optional<bool> endOfMonth = ext::nullopt,
                            ext::optional<Frequency> fixedPaymentFrequency = ext::nullopt,
                            const Calendar& fixedCalendar = Calendar());

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -202,7 +202,7 @@ void testBootstrap(bool telescopicValueDates,
     Natural paymentLag = 2;
 
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
+    auto spread = makeQuoteHandle(0.0);
 
     auto euribor3m = ext::make_shared<Euribor3M>();
     auto estr = ext::make_shared<Estr>();
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapWithCustomPricer) {
         ext::make_shared<ArithmeticAveragedOvernightIndexedCouponPricer>(0.02, 0.15, true);
 
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
+    auto spread = makeQuoteHandle(0.0);
 
     auto euribor3m = ext::make_shared<Euribor3M>();
     auto estr = ext::make_shared<Estr>();
@@ -492,7 +492,7 @@ void testBootstrapWithLookback(Natural lookbackDays,
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
 
     auto estr = ext::make_shared<Estr>();
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
+    auto spread = makeQuoteHandle(0.0);
 
 
     for (auto& i : estrSwapData) {
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapRegression) {
 
     std::vector<ext::shared_ptr<RateHelper> > helpers;
     auto index = ext::make_shared<FedFunds>();
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
+    auto spread = makeQuoteHandle(0.0);
 
     helpers.push_back(
         ext::make_shared<DepositRateHelper>(data[0].rate,

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapRegression) {
 
     std::vector<ext::shared_ptr<RateHelper> > helpers;
     auto index = ext::make_shared<FedFunds>();
-    auto spread = makeQuoteHandle(0.0);
+    Spread spread = 0.0;
 
     helpers.push_back(
         ext::make_shared<DepositRateHelper>(data[0].rate,

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -202,6 +202,7 @@ void testBootstrap(bool telescopicValueDates,
     Natural paymentLag = 2;
 
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
+    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
 
     auto euribor3m = ext::make_shared<Euribor3M>();
     auto estr = ext::make_shared<Estr>();
@@ -235,7 +236,7 @@ void testBootstrap(bool telescopicValueDates,
                                                       Annual,
                                                       Calendar(),
                                                       0 * Days,
-                                                      0.0,
+                                                      spread,
                                                       Pillar::LastRelevantDate,
                                                       Date(),
                                                       averagingMethod);
@@ -417,6 +418,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapWithCustomPricer) {
         ext::make_shared<ArithmeticAveragedOvernightIndexedCouponPricer>(0.02, 0.15, true);
 
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
+    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
 
     auto euribor3m = ext::make_shared<Euribor3M>();
     auto estr = ext::make_shared<Estr>();
@@ -437,7 +439,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapWithCustomPricer) {
                                                       Annual,
                                                       Calendar(),
                                                       0 * Days,
-                                                      0.0,
+                                                      spread,
                                                       Pillar::LastRelevantDate,
                                                       Date(),
                                                       averagingMethod,
@@ -490,6 +492,8 @@ void testBootstrapWithLookback(Natural lookbackDays,
     std::vector<ext::shared_ptr<RateHelper> > estrHelpers;
 
     auto estr = ext::make_shared<Estr>();
+    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
+
 
     for (auto& i : estrSwapData) {
         Real rate = 0.01 * i.rate;
@@ -506,7 +510,7 @@ void testBootstrapWithLookback(Natural lookbackDays,
                                                       Annual,
                                                       Calendar(),
                                                       0 * Days,
-                                                      0.0,
+                                                      spread,
                                                       Pillar::LastRelevantDate,
                                                       Date(),
                                                       RateAveraging::Compound,
@@ -670,6 +674,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapRegression) {
 
     std::vector<ext::shared_ptr<RateHelper> > helpers;
     auto index = ext::make_shared<FedFunds>();
+    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.00)));
 
     helpers.push_back(
         ext::make_shared<DepositRateHelper>(data[0].rate,
@@ -689,7 +694,7 @@ BOOST_AUTO_TEST_CASE(testBootstrapRegression) {
                                   index,
                                   Handle<YieldTermStructure>(),
                                   false, 2,
-                                  Following, Annual, Calendar(), 0*Days, 0.0,
+                                  Following, Annual, Calendar(), 0*Days, spread,
                                   // this bootstrap fails with the default LastRelevantDate choice
                                   Pillar::MaturityDate));
     }


### PR DESCRIPTION
Replaced the `Spread` type with `Handle<Quote>` for the `overnightSpread` parameter as requested in https://github.com/lballabio/QuantLib/issues/1681.

What did you mean in this line? What can be improved? Because I've taken inspiration from this code to write `impliedQuote` in `OISRateHelper`
https://github.com/lballabio/QuantLib/blob/4655f19ca2816c3c5f7b43fca4daf947719baf56/ql/termstructures/yield/ratehelpers.cpp#L745