### PR TITLE
Modernising Tag-Dispatch template with C++17 constexpr if for LinearRegression

### DIFF
--- a/ql/math/linearleastsquaresregression.hpp
+++ b/ql/math/linearleastsquaresregression.hpp
@@ -48,44 +48,29 @@ namespace QuantLib {
             const Size i_;
        };
 
-        // 1d implementation (arithmetic types)
-        template <class xContainer, bool>
+        template <class xContainer>
         class LinearFcts {
           public:
             typedef typename xContainer::value_type ArgumentType;
-            LinearFcts (const xContainer &x, Real intercept) {
+            LinearFcts(const xContainer &x, Real intercept) {
                 if (intercept != 0.0)
-                    v.push_back([=](ArgumentType x){ return intercept; });
-                v.push_back([](ArgumentType x){ return x; });
+                    v.push_back([=](ArgumentType){ return intercept; });
+                if constexpr (std::is_arithmetic_v<ArgumentType>) {
+                    v.push_back([](ArgumentType x){ return x; });
+                } else {
+                    Size m = x.begin()->size();
+                    for (Size i = 0; i < m; ++i)
+                        v.push_back(LinearFct<ArgumentType>(i));
+                }
             }
 
             const std::vector< std::function<Real(ArgumentType)> > & fcts() {
                 return v;
             }
-
           private:
             std::vector< std::function<Real(ArgumentType)> > v;
         };
 
-        // multi-dimensional implementation (container types)
-        template <class xContainer>
-        class LinearFcts<xContainer, false>  {
-          public:
-            typedef typename xContainer::value_type ArgumentType;
-            LinearFcts (const xContainer &x, Real intercept) {
-                if (intercept != 0.0)
-                    v.push_back([=](ArgumentType x){ return intercept; });
-                Size m = x.begin()->size();
-                for (Size i = 0; i < m; ++i)
-                    v.push_back(LinearFct<ArgumentType>(i));
-            }
-
-            const std::vector< std::function<Real(ArgumentType)> > & fcts() {
-               return v;
-            }
-          private:
-            std::vector< std::function<Real(ArgumentType)> > v;
-        };
     }
 
     class LinearRegression : public GeneralLinearLeastSquares {
@@ -105,9 +90,7 @@ namespace QuantLib {
         LinearRegression::LinearRegression(const xContainer& x, 
                                            const yContainer& y, Real intercept) 
     : GeneralLinearLeastSquares(x, y,
-          details::LinearFcts<xContainer, 
-              std::is_arithmetic_v<typename xContainer::value_type>>
-                                                        (x, intercept).fcts()) {
+          details::LinearFcts<xContainer>(x, intercept).fcts()) {
     }
 
     template <class xContainer, class yContainer, class vContainer> inline

--- a/ql/math/linearleastsquaresregression.hpp
+++ b/ql/math/linearleastsquaresregression.hpp
@@ -106,7 +106,7 @@ namespace QuantLib {
                                            const yContainer& y, Real intercept) 
     : GeneralLinearLeastSquares(x, y,
           details::LinearFcts<xContainer, 
-              std::is_arithmetic<typename xContainer::value_type>::value>
+              std::is_arithmetic_v<typename xContainer::value_type>>
                                                         (x, intercept).fcts()) {
     }
 

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test1dLinearRegression) {
     }    
 
     // an alternative container type 
-    boost::circular_buffer<Real> cx(x.begin(), x.end()), cy(y.begin(), y.end());
+    std::vector<Real> cx(x.begin(), x.end()), cy(y.begin(), y.end());
     LinearRegression m1(cx, cy);
 
     for (Size i=0; i < 2; ++i) {

--- a/test-suite/linearleastsquaresregression.cpp
+++ b/test-suite/linearleastsquaresregression.cpp
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(test1dLinearRegression) {
     }    
 
     // an alternative container type 
-    std::vector<Real> cx(x.begin(), x.end()), cy(y.begin(), y.end());
+    boost::circular_buffer<Real> cx(x.begin(), x.end()), cy(y.begin(), y.end());
     LinearRegression m1(cx, cy);
 
     for (Size i=0; i < 2; ++i) {


### PR DESCRIPTION
## Overview

View `test-suite/linearleastsquaresregression.cpp::226`:

```c++
boost::circular_buffer<Real> cx(x.begin(), x.end()), cy(y.begin(), y.end());
LinearRegression m1(cx, cy); // here

for (Size i=0; i < 2; ++i) {
// ...
```

Which calls this constructor:

```c++
template <class xContainer, class yContainer> inline
    LinearRegression::LinearRegression(const xContainer& x, 
                                       const yContainer& y, Real intercept) 
: GeneralLinearLeastSquares(x, y,
      details::LinearFcts<xContainer, 
          std::is_arithmetic<typename xContainer::value_type>::value>
                                                    (x, intercept).fcts()) {
}
```

The unary type trait resolves which constructor be used for `LinearFcts`, 1d or multi-dimensional.

## Change

The idea is to modernise the logic by applying some C++17 best practices. We join the constructors into one, and differentiate 1d and multi-dim with:

```c++
if constexpr (std::is_arithmetic_v<ArgumentType>)
```

This is now evaluated at compile time and we use `std::is_arithmetic_v` as per the C++17 best practice.