### PR TITLE
Add the SARON index

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -171,6 +171,8 @@ QuantLib is
     Copyright (C) 2024 Jacques du Toit
     Copyright (C) 2024 Jongbong An
 
+    Copyright (C) 2025 Paolo D'Elia
+
 QuantLib includes code taken from Peter Jäckel's book "Monte Carlo
 Methods in Finance".
 

--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -846,6 +846,7 @@
     <ClInclude Include="ql\indexes\ibor\nzocr.hpp" />
     <ClInclude Include="ql\indexes\ibor\pribor.hpp" />
     <ClInclude Include="ql\indexes\ibor\robor.hpp" />
+    <ClInclude Include="ql\indexes\ibor\saron.hpp" />
     <ClInclude Include="ql\indexes\ibor\seklibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\shibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\sofr.hpp" />
@@ -2139,6 +2140,7 @@
     <ClCompile Include="ql\indexes\ibor\fedfunds.cpp" />
     <ClCompile Include="ql\indexes\ibor\kofr.cpp" />
     <ClCompile Include="ql\indexes\ibor\libor.cpp" />
+    <ClCompile Include="ql\indexes\ibor\saron.cpp" />
     <ClCompile Include="ql\indexes\ibor\shibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\sofr.cpp" />
     <ClCompile Include="ql\indexes\ibor\sonia.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -687,6 +687,9 @@
     <ClInclude Include="ql\indexes\ibor\robor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\ibor\saron.hpp">
+      <Filter>indexes\ibor</Filter>
+    </ClInclude>
     <ClInclude Include="ql\indexes\ibor\seklibor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
@@ -4653,6 +4656,9 @@
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\libor.cpp">
+      <Filter>indexes\ibor</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\ibor\saron.cpp">
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\shibor.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -225,6 +225,7 @@ set(QL_SOURCES
     indexes/ibor/fedfunds.cpp
     indexes/ibor/kofr.cpp
     indexes/ibor/libor.cpp
+    indexes/ibor/saron.cpp
     indexes/ibor/shibor.cpp
     indexes/ibor/sofr.cpp
     indexes/ibor/sonia.cpp
@@ -1270,6 +1271,7 @@ set(QL_HEADERS
     indexes/ibor/nzocr.hpp
     indexes/ibor/pribor.hpp
     indexes/ibor/robor.hpp
+    indexes/ibor/saron.hpp
     indexes/ibor/seklibor.hpp
     indexes/ibor/shibor.hpp
     indexes/ibor/sofr.hpp

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -30,6 +30,7 @@ this_include_HEADERS = \
     nzocr.hpp \
     pribor.hpp \
     robor.hpp \
+    saron.hpp \
     seklibor.hpp \
     shibor.hpp \
     sofr.hpp \
@@ -53,6 +54,7 @@ cpp_files = \
     fedfunds.cpp \
     kofr.cpp \
     libor.cpp \
+    saron.cpp \
     shibor.cpp \
     sofr.cpp \
     sonia.cpp

--- a/ql/indexes/ibor/all.hpp
+++ b/ql/indexes/ibor/all.hpp
@@ -27,6 +27,7 @@
 #include <ql/indexes/ibor/nzocr.hpp>
 #include <ql/indexes/ibor/pribor.hpp>
 #include <ql/indexes/ibor/robor.hpp>
+#include <ql/indexes/ibor/saron.hpp>
 #include <ql/indexes/ibor/seklibor.hpp>
 #include <ql/indexes/ibor/shibor.hpp>
 #include <ql/indexes/ibor/sofr.hpp>

--- a/ql/indexes/ibor/saron.cpp
+++ b/ql/indexes/ibor/saron.cpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2025 Paolo D'Elia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/indexes/ibor/saron.hpp>
+#include <ql/time/calendars/switzerland.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/currencies/europe.hpp>
+
+namespace QuantLib {
+
+    Saron::Saron(const Handle<YieldTermStructure>& h)
+    : OvernightIndex("SARON", 0, CHFCurrency(), Switzerland(), Actual360(), h) {}
+
+}

--- a/ql/indexes/ibor/saron.hpp
+++ b/ql/indexes/ibor/saron.hpp
@@ -1,0 +1,39 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2025 Paolo D'Elia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file saron.hpp
+    \brief %SARON index
+*/
+
+#ifndef quantlib_saron_hpp
+#define quantlib_saron_hpp
+
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    //! %SARON (Swiss Average Rate Overnight) index.
+    class Saron : public OvernightIndex {
+      public:
+        explicit Saron(const Handle<YieldTermStructure>& h = {});
+    };
+
+}
+
+#endif


### PR DESCRIPTION
Added the `SARON` ([Swiss Average Rate Overnight](https://www.snb.ch/en/the-snb/mandates-goals/statistics/statistics-pub/current_interest_exchange_rates#t00)) index to the QuantLib library.