### PR TITLE
`analyticpartialtimebarrieroptionengine.cpp(108) : warning C4702: unreachable code`

### DIFF
--- a/ql/pricingengines/barrier/analyticpartialtimebarrieroptionengine.cpp
+++ b/ql/pricingengines/barrier/analyticpartialtimebarrieroptionengine.cpp
@@ -104,8 +104,6 @@ namespace QuantLib {
             default:
               QL_FAIL("unknown barrier type");
           }
-
-        return 0.0;
     }
 
     void AnalyticPartialTimeBarrierOptionEngine::calculate() const {


### PR DESCRIPTION
I don't know why, but **only** the debug build on Windows complains about:

```
[2/25] Building CXX object ql\CMakeFiles\ql_library.dir\pricingengines\barrier\analyticpartialtimebarrieroptionengine.cpp.obj
FAILED: ql/CMakeFiles/ql_library.dir/pricingengines/barrier/analyticpartialtimebarrieroptionengine.cpp.obj
ccache.exe C:\PROGRA~1\MICROS~2\2022\PROFES~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe  /nologo /TP -DBOOST_ALL_NO_LIB -DNOMINMAX -DQL_COMPILATION -D_CRT_SECURE_NO_WARNINGS -D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS -IE:\Users\rke\cpp\QuantLib.rke.master\build\debug -IE:\Users\rke\cpp\QuantLib.rke.master -external:IE:\Tools\boost_1_88_0 -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++17 -MTd -W3 /wd4267 /wd4819 /wd26812 /w34127 /w34702 /w35262 -WX /showIncludes /Foql\CMakeFiles\ql_library.dir\pricingengines\barrier\analyticpartialtimebarrieroptionengine.cpp.obj /Fdql\CMakeFiles\ql_library.dir\ql_library.pdb /FS -c E:\Users\rke\cpp\QuantLib.rke.master\ql\pricingengines\barrier\analyticpartialtimebarrieroptionengine.cpp
Warning: using boost::any is deprecated.  Enable std::any instead.
E:\Users\rke\cpp\QuantLib.rke.master\ql\pricingengines\barrier\analyticpartialtimebarrieroptionengine.cpp(108) : error C2220: the following warning is treated as an error
E:\Users\rke\cpp\QuantLib.rke.master\ql\pricingengines\barrier\analyticpartialtimebarrieroptionengine.cpp(108) : warning C4702: unreachable code
```