### PR TITLE
Added missing assignment in MXVCurrency constructor

### DIFF
--- a/ql/currencies/america.cpp
+++ b/ql/currencies/america.cpp
@@ -140,6 +140,7 @@ namespace QuantLib {
     // Mexican Unidad de Inversion
     MXVCurrency::MXVCurrency() {
         static auto mxvData = ext::make_shared<Data>("Mexican Unidad de Inversion", "MXV", 979, "MXV", "", 1, Rounding());
+        data_ = mxvData;
     }
 
     // Unidad de Valor Real


### PR DESCRIPTION
Fixed #2209 issue: assigns the `mxvData` shared pointer to the `data_` member variable in the `MXVCurrency` constructor.