### PR TITLE
Feature: Fast Valuation of Seasoned OIS Swaps

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -171,6 +171,8 @@ QuantLib is
     Copyright (C) 2024 Jacques du Toit
     Copyright (C) 2024 Jongbong An
 
+    Copyright (C) 2025 Paolo D'Elia
+
 QuantLib includes code taken from Peter Jäckel's book "Monte Carlo
 Methods in Finance".
 

--- a/ql/cashflows/overnightindexedcouponpricer.cpp
+++ b/ql/cashflows/overnightindexedcouponpricer.cpp
@@ -195,7 +195,6 @@ namespace QuantLib {
 
         const ext::shared_ptr<OvernightIndex> index =
             ext::dynamic_pointer_cast<OvernightIndex>(coupon_->index());
-        const auto& fixingCalendar = index->fixingCalendar();
 
         const auto& fixingDates = coupon_->fixingDates();
         const auto& valueDates = coupon_->valueDates();

--- a/ql/cashflows/overnightindexedcouponpricer.cpp
+++ b/ql/cashflows/overnightindexedcouponpricer.cpp
@@ -76,7 +76,7 @@ namespace QuantLib {
                 // rate must have been fixed
                 updateCompoundFactor(compoundFactor, index, i, fixingDates, interestDates, dt, date);
                 ++i;
-            }    
+            }
         };
 
         if (indexCompoundedFactor == Null<Real>() 

--- a/ql/cashflows/overnightindexedcouponpricer.hpp
+++ b/ql/cashflows/overnightindexedcouponpricer.hpp
@@ -63,7 +63,10 @@ namespace QuantLib {
           const ext::shared_ptr<OvernightIndex> index, const Dates& fixingDates,
           const Dates& interestDates, const Times& dt, const Date& today, 
           const Date& date) const;
-        void handleFutureFixings();
+        void handleFutureFixings(Size& i, Size n, Real& compoundFactor,
+          const ext::shared_ptr<OvernightIndex> index, const Dates& fixingDates,
+          const Dates& valueDates, const Dates& interestDates, const Times& dt, 
+          const Date& today, const Date& date) const;
     };
 
     /*! pricer for arithmetically averaged overnight indexed coupons

--- a/ql/cashflows/overnightindexedcouponpricer.hpp
+++ b/ql/cashflows/overnightindexedcouponpricer.hpp
@@ -37,6 +37,8 @@ namespace QuantLib {
 
     //! CompoudAveragedOvernightIndexedCouponPricer pricer
     class CompoundingOvernightIndexedCouponPricer : public FloatingRateCouponPricer {
+      using Dates = std::vector<Date>;
+      using Times = std::vector<Time>;
       public:
         //! \name FloatingRateCoupon interface
         //@{
@@ -52,6 +54,16 @@ namespace QuantLib {
 
       protected:
         const OvernightIndexedCoupon* coupon_ = nullptr;
+
+      private:
+        void handlePastFixings(Size& i, const Size n, Real& compoundFactor, const ext::shared_ptr<OvernightIndex> index, 
+                               const Dates& fixingDates, const Dates& valueDates, const Dates& interestDates,
+                               const Times& dt, const Date& today, const Date& date, const bool applyObservationShift) const;
+        void handleTodayFixing(Size& i, Size n, Real& compoundFactor, 
+          const ext::shared_ptr<OvernightIndex> index, const Dates& fixingDates,
+          const Dates& interestDates, const Times& dt, const Date& today, 
+          const Date& date) const;
+        void handleFutureFixings();
     };
 
     /*! pricer for arithmetically averaged overnight indexed coupons

--- a/ql/index.hpp
+++ b/ql/index.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
                  possible inconsistencies due to "seeing in the
                  future"
     */
-    class Index : public Observable, public Observer {
+    class Index : virtual public Observable, virtual public Observer {
       public:
         ~Index() override = default;
         //! Returns the name of the index.
@@ -91,7 +91,7 @@ namespace QuantLib {
         /*! the dates in the TimeSeries must be the actual calendar
             dates of the fixings; no settlement days must be used.
         */
-        void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false);
+        virtual void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false);
         //! stores historical fixings at the given dates
         /*! the dates passed as arguments must be the actual calendar
             dates of the fixings; no settlement days must be used.

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -95,6 +95,12 @@ namespace QuantLib {
     Rate OvernightIndex::compoundedFixings(const Date& fromFixingDate, const Date& toFixingDate) {
         calculate();
         auto yearFraction = dayCounter_.yearFraction(fromFixingDate, toFixingDate);
+        auto compIndexEnd = compoundIndex_[toFixingDate];
+        auto compIndexStart = compoundIndex_[fromFixingDate];
+
+        if (compIndexStart == Null<Rate>() || compIndexEnd == Null<Rate>())
+            return Null<Rate>();
+
         return (compoundIndex_[toFixingDate] / compoundIndex_[fromFixingDate] - 1) / yearFraction;  
     }
  

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -127,6 +127,10 @@ namespace QuantLib {
 
         const auto& ts = Index::timeSeries();
         auto fixingDates = ts.dates();
+        if (fixingDates.empty()) {
+            compoundIndex_ = TimeSeries<Real>();
+            return;
+        }
         auto fixingCalendar = InterestRateIndex::fixingCalendar();
         auto lastFixingDate = getLastFixingDate(fixingCalendar, fixingDates);
 

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -98,10 +98,21 @@ namespace QuantLib {
         auto compIndexEnd = compoundIndex_[toFixingDate];
         auto compIndexStart = compoundIndex_[fromFixingDate];
 
-        if (compIndexStart == Null<Rate>() || compIndexEnd == Null<Rate>())
-            return Null<Rate>();
+        if (compIndexStart == Null<Real>() || compIndexEnd == Null<Real>())
+            return Null<Real>();
 
         return (compoundIndex_[toFixingDate] / compoundIndex_[fromFixingDate] - 1) / yearFraction;  
+    }
+
+    Real OvernightIndex::compoundedFactor(const Date& fromFixingDate, const Date& toFixingDate) {
+        calculate();
+        auto compIndexEnd = compoundIndex_[toFixingDate];
+        auto compIndexStart = compoundIndex_[fromFixingDate];
+
+        if (compIndexStart == Null<Real>() || compIndexEnd == Null<Real>())
+            return Null<Real>();
+
+        return compIndexEnd / compIndexStart;
     }
  
     void OvernightIndex::performCalculations() const {

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -117,14 +117,16 @@ namespace QuantLib {
         std::vector<Real> compIndexValues;
         std::vector<Date> compIndexDates;
         compIndexValues.push_back(Real(1.000));
+        compIndexDates.push_back(currentFixingDay);
 
         while(currentFixingDay <= lastFixingDate) {
-            compIndexDates.push_back(currentFixingDay);
             auto nextFixingDay = fixingCalendar.advance(currentFixingDay, Period(1, Days));
             compIndexValues.push_back(
-                compIndexValues.back() +
+                compIndexValues.back() *
                 (1 + ts[currentFixingDay] 
                     * dayCounter_.yearFraction(currentFixingDay, nextFixingDay)));
+            compIndexDates.push_back(nextFixingDay);
+            currentFixingDay = nextFixingDay;
         }
 
         compoundIndex_ = TimeSeries<Real>(compIndexDates.begin(), 

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -62,16 +62,15 @@ namespace QuantLib {
 
     ext::shared_ptr<IborIndex> IborIndex::clone(
                                const Handle<YieldTermStructure>& h) const {
-        return ext::make_shared<IborIndex>(
-                                        familyName(),
-                                                      tenor(),
-                                                      fixingDays(),
-                                                      currency(),
-                                                      fixingCalendar(),
-                                                      businessDayConvention(),
-                                                      endOfMonth(),
-                                                      dayCounter(),
-                                                      h);
+        return ext::make_shared<IborIndex>(familyName(),
+                                           tenor(),
+                                           fixingDays(),
+                                           currency(),
+                                           fixingCalendar(),
+                                           businessDayConvention(),
+                                           endOfMonth(),
+                                           dayCounter(),
+                                           h);
     }
 
 

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -23,7 +23,6 @@
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/time/schedule.hpp>
 #include <utility>
-#include <numeric>
 
 namespace QuantLib {
 

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -95,6 +95,8 @@ namespace QuantLib {
                        const Handle<YieldTermStructure>& h = {});
         //! returns a copy of itself linked to a different forwarding curve
         ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+      private:
+        TimeSeries<Real> compoundIndex_;
     };
 
 

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/indexes/interestrateindex.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/patterns/lazyobject.hpp>
 
 namespace QuantLib {
 
@@ -85,7 +86,8 @@ namespace QuantLib {
     };
 
 
-    class OvernightIndex : public IborIndex {
+    class OvernightIndex : public IborIndex,
+                           virtual public LazyObject {
       public:
         OvernightIndex(const std::string& familyName,
                        Natural settlementDays,
@@ -95,8 +97,14 @@ namespace QuantLib {
                        const Handle<YieldTermStructure>& h = {});
         //! returns a copy of itself linked to a different forwarding curve
         ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        void update() override;
+        void addFixing(const Date& fixingDate, Real fixing, bool forceOverwrite = false) override;
+        void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false) override;
+        Rate compoundedFixings(const Date& fromFixingDate, const Date& toFixingDate);
+      protected:
+          void performCalculations() const override;
       private:
-        TimeSeries<Real> compoundIndex_;
+        mutable TimeSeries<Real> compoundIndex_;
     };
 
 

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -97,10 +97,31 @@ namespace QuantLib {
                        const Handle<YieldTermStructure>& h = {});
         //! returns a copy of itself linked to a different forwarding curve
         ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        //! \name Observer interface
+        //@{
         void update() override;
+        //@}
+        //! stores the historical fixing at the given date
+        /*! the date passed as arguments must be the actual calendar
+            date of the fixing; no settlement days must be used.
+        */
         void addFixing(const Date& fixingDate, Real fixing, bool forceOverwrite = false) override;
+        //! stores historical fixings from a TimeSeries
+        /*! the dates in the TimeSeries must be the actual calendar
+            dates of the fixings; no settlement days must be used.
+        */
         void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false) override;
+        //! Computes the compounded fixings over a given date range
+        /*!
+            This method calculates the compounded rate for the index over the specified
+            date range, using historical fixings stored in the index's time series.
+        */
         Rate compoundedFixings(const Date& fromFixingDate, const Date& toFixingDate);
+        //! Computes the compounded factor over a given date range
+        /*!
+            This method calculates the compounded factor for the index over the specified
+            date range, using historical fixings stored in the index's time series.
+        */
         Real compoundedFactor(const Date& fromFixingDate, const Date& toFixingDate);
       protected:
           void performCalculations() const override;

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -101,6 +101,7 @@ namespace QuantLib {
         void addFixing(const Date& fixingDate, Real fixing, bool forceOverwrite = false) override;
         void addFixings(const TimeSeries<Real>& t, bool forceOverwrite = false) override;
         Rate compoundedFixings(const Date& fromFixingDate, const Date& toFixingDate);
+        Real compoundedFactor(const Date& fromFixingDate, const Date& toFixingDate);
       protected:
           void performCalculations() const override;
       private:

--- a/ql/indexes/iborindex.hpp
+++ b/ql/indexes/iborindex.hpp
@@ -86,9 +86,20 @@ namespace QuantLib {
     };
 
 
+    /*! Base class for overnight indexes, (e.g. %SOFR, %ESTR, etc.)
+    */
     class OvernightIndex : public IborIndex,
                            virtual public LazyObject {
       public:
+        //! Constructor for the OvernightIndex
+        /*!
+            \param familyName The name of the index family (e.g., "ESTR").
+            \param settlementDays The number of settlement days for the index.
+            \param currency The currency of the index.
+            \param fixingCalendar The calendar used for fixing dates.
+            \param dayCounter The day count convention for the index.
+            \param h The yield term structure used for forecasting fixings (optional).
+        */
         OvernightIndex(const std::string& familyName,
                        Natural settlementDays,
                        const Currency& currency,
@@ -115,12 +126,20 @@ namespace QuantLib {
         /*!
             This method calculates the compounded rate for the index over the specified
             date range, using historical fixings stored in the index's time series.
+
+            \param fromFixingDate The start date of the fixing period.
+            \param toFixingDate The end date of the fixing period.
+            \return The compounded rate over the specified date range, or `Null<Rate>()` if any fixings are missing.
         */
         Rate compoundedFixings(const Date& fromFixingDate, const Date& toFixingDate);
         //! Computes the compounded factor over a given date range
         /*!
             This method calculates the compounded factor for the index over the specified
             date range, using historical fixings stored in the index's time series.
+
+            \param fromFixingDate The start date of the fixing period.
+            \param toFixingDate The end date of the fixing period.
+            \return The compounded factor over the specified date range, or `Null<Real>()` if any fixings are missing.
         */
         Real compoundedFactor(const Date& fromFixingDate, const Date& toFixingDate);
       protected:

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -119,6 +119,7 @@ set(QL_TEST_SOURCES
     operators.cpp
     optimizers.cpp
     optionletstripper.cpp
+    overnightindex.cpp
     overnightindexedcoupon.cpp
     overnightindexedswap.cpp
     pagodaoption.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -120,6 +120,7 @@ QL_TEST_SRCS = \
 	operators.cpp \
 	optimizers.cpp \
 	optionletstripper.cpp \
+	overnightindex.cpp \
 	overnightindexedcoupon.cpp \
 	overnightindexedswap.cpp \
 	pagodaoption.cpp \

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -58,7 +58,7 @@ ext::shared_ptr<IborIndex> makeIndex(std::vector<Date> dates, const std::vector<
 
     RelinkableHandle<YieldTermStructure> termStructure;
 
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
 
     Date todaysDate =
         index->fixingCalendar().adjust(Date(4,September,2005));

--- a/test-suite/overnightindex.cpp
+++ b/test-suite/overnightindex.cpp
@@ -87,8 +87,7 @@ struct CommonVars {
     }
 
 
-BOOST_AUTO_TEST_CASE(testCompoundedIndex) {
-    // Setup
+BOOST_AUTO_TEST_CASE(testCompoundedIndex1m) {
     CommonVars vars;
     Date today(22, April, 2025);
     Settings::instance().evaluationDate() = today;
@@ -96,16 +95,69 @@ BOOST_AUTO_TEST_CASE(testCompoundedIndex) {
     Calendar calendar = TARGET();
     DayCounter dayCounter = Actual360();
 
-    // Test compounded fixings
     Date fromFixingDate(14, February, 2025);
     Date toFixingDate(14, March, 2025);
 
     Rate compoundedRate = vars.estr->compoundedFixings(fromFixingDate, toFixingDate);
 
-    // Expected compounded rate calculation
-    Real expectedRate = 0.026489361171;
+    Rate expectedRate = 0.026489361171;
 
-    // Assert
+    CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedRate, expectedRate, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testCompoundedIndex2m) {
+    CommonVars vars;
+    Date today(22, April, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    DayCounter dayCounter = Actual360();
+
+    Date fromFixingDate(14, February, 2025);
+    Date toFixingDate(14, April, 2025);
+
+    Rate compoundedRate = vars.estr->compoundedFixings(fromFixingDate, toFixingDate);
+
+    Rate expectedRate = 0.02530656552467557;
+
+    CHECK_OIS_RATE_RESULT("OIS Rate over two months: ", compoundedRate, expectedRate, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeBefore) {
+    CommonVars vars;
+    Date today(22, April, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    DayCounter dayCounter = Actual360();
+
+    Date fromFixingDate(11, February, 2025);
+    Date toFixingDate(11, March, 2025);
+
+    Rate compoundedRate = vars.estr->compoundedFixings(fromFixingDate, toFixingDate);
+
+    // Expected Null<Rate>
+    Rate expectedRate = Null<Rate>();
+
+    CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedRate, expectedRate, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeAfter) {
+    CommonVars vars;
+    Date today(22, April, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    DayCounter dayCounter = Actual360();
+
+    Date fromFixingDate(22, March, 2025);
+    Date toFixingDate(22, April, 2025);
+
+    Rate compoundedRate = vars.estr->compoundedFixings(fromFixingDate, toFixingDate);
+
+    // Expected Null<Rate>
+    Rate expectedRate = Null<Rate>();
+
     CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedRate, expectedRate, 1e-12);
 }
 

--- a/test-suite/overnightindex.cpp
+++ b/test-suite/overnightindex.cpp
@@ -1,0 +1,114 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2025 StatPro Italia srl
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+#include "toplevelfixture.hpp"
+#include "utilities.hpp"
+#include <ql/indexes/iborindex.hpp>
+#include <ql/indexes/ibor/estr.hpp>
+#include <ql/settings.hpp>
+#include <ql/time/calendars/all.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <iomanip>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(OvernightIndexTest)
+
+struct CommonVars {
+    Date today;
+    ext::shared_ptr<OvernightIndex> estr;
+    RelinkableHandle<YieldTermStructure> forecastCurve;
+
+    CommonVars(const Date& evaluationDate) {
+        today = evaluationDate;
+
+        Settings::instance().evaluationDate() = today;
+
+        estr = ext::make_shared<Estr>(forecastCurve);
+
+        
+        std::vector<Date> pastDates = {
+            Date(14, February, 2025), Date(17, February, 2025), Date(18, February, 2025), Date(19, February, 2025), Date(20, February, 2025),
+            Date(21, February, 2025), Date(24, February, 2025), Date(25, February, 2025), Date(26, February, 2025), Date(27, February, 2025),
+            Date(28, February, 2025), Date(3, March, 2025),     Date(4, March, 2025),     Date(5, March, 2025),     Date(6, March, 2025),
+            Date(7, March, 2025),     Date(10, March, 2025),    Date(11, March, 2025),    Date(12, March, 2025),    Date(13, March, 2025),
+            Date(14, March, 2025),    Date(17, March, 2025),    Date(18, March, 2025),    Date(19, March, 2025),    Date(20, March, 2025),
+            Date(21, March, 2025),    Date(24, March, 2025),    Date(25, March, 2025),    Date(26, March, 2025),    Date(27, March, 2025),
+            Date(28, March, 2025),    Date(31, March, 2025),    Date(1, April, 2025),     Date(2, April, 2025),     Date(3, April, 2025),
+            Date(4, April, 2025),     Date(7, April, 2025),     Date(8, April, 2025),     Date(9, April, 2025),     Date(10, April, 2025),
+            Date(11, April, 2025),    Date(14, April, 2025),    Date(15, April, 2025),    Date(16, April, 2025),    Date(17, April, 2025)
+        };
+
+        std::vector<Rate> pastRates = {
+            0.02666, 0.02665, 0.02666, 0.02665, 0.02667,
+            0.02666, 0.02666, 0.02666, 0.02665, 0.02666,
+            0.02658, 0.02663, 0.02664, 0.02664, 0.02666,
+            0.02665, 0.02663, 0.02663, 0.02412, 0.02413,
+            0.02417, 0.02417, 0.02417, 0.02416, 0.02417,
+            0.02417, 0.02418, 0.02418, 0.02417, 0.02417,
+            0.02417, 0.02415, 0.02420, 0.02417, 0.02416,
+            0.02415, 0.02414, 0.02415, 0.02415, 0.02416,
+            0.02416, 0.02417, 0.02416, 0.02418, 0.02417
+        };
+
+        TimeSeries<Real> ts(pastDates.begin(), pastDates.end(), pastRates.begin());
+        estr->addFixings(ts);
+    }
+
+    CommonVars() : CommonVars(Date(23, November, 2021)) {}
+};
+
+#define CHECK_OIS_RATE_RESULT(what, calculated, expected, tolerance)   \
+    if (std::fabs(calculated-expected) > tolerance) { \
+        BOOST_ERROR("Failed to reproduce " what ":" \
+                    << "\n    expected:   " << std::setprecision(12) << expected \
+                    << "\n    calculated: " << std::setprecision(12) << calculated \
+                    << "\n    error:      " << std::setprecision(12) << std::fabs(calculated-expected)); \
+    }
+
+
+BOOST_AUTO_TEST_CASE(testCompoundedIndex) {
+    // Setup
+    CommonVars vars;
+    Date today(22, April, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    DayCounter dayCounter = Actual360();
+
+    // Test compounded fixings
+    Date fromFixingDate(14, February, 2025);
+    Date toFixingDate(14, March, 2025);
+
+    Rate compoundedRate = vars.estr->compoundedFixings(fromFixingDate, toFixingDate);
+
+    // Expected compounded rate calculation
+    Real expectedRate = 0.026489361171;
+
+    // Assert
+    CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedRate, expectedRate, 1e-12);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/overnightindex.cpp
+++ b/test-suite/overnightindex.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2025 StatPro Italia srl
+ Copyright (C) 2025 Paolo D'Elia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/overnightindex.cpp
+++ b/test-suite/overnightindex.cpp
@@ -88,6 +88,8 @@ struct CommonVars {
 
 
 BOOST_AUTO_TEST_CASE(testCompoundedIndex1m) {
+    BOOST_TEST_MESSAGE("Testing 1m rate for past overnight-indexed coupon...");
+
     CommonVars vars;
     Date today(22, April, 2025);
     Settings::instance().evaluationDate() = today;
@@ -106,6 +108,8 @@ BOOST_AUTO_TEST_CASE(testCompoundedIndex1m) {
 }
 
 BOOST_AUTO_TEST_CASE(testCompoundedIndex2m) {
+    BOOST_TEST_MESSAGE("Testing 2m rate for past overnight-indexed coupon...");
+
     CommonVars vars;
     Date today(22, April, 2025);
     Settings::instance().evaluationDate() = today;
@@ -124,6 +128,8 @@ BOOST_AUTO_TEST_CASE(testCompoundedIndex2m) {
 }
 
 BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeBefore) {
+    BOOST_TEST_MESSAGE("Testing compounded fixings for a date range partially before available fixings...");
+
     CommonVars vars;
     Date today(22, April, 2025);
     Settings::instance().evaluationDate() = today;
@@ -143,6 +149,8 @@ BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeBefore) {
 }
 
 BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeAfter) {
+    BOOST_TEST_MESSAGE("Testing compounded fixings for a date range partially after available fixings...");
+
     CommonVars vars;
     Date today(22, April, 2025);
     Settings::instance().evaluationDate() = today;
@@ -159,6 +167,26 @@ BOOST_AUTO_TEST_CASE(testCompoundedIndexOutOfRangeAfter) {
     Rate expectedRate = Null<Rate>();
 
     CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedRate, expectedRate, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE(testCompoundedFactor) {
+    BOOST_TEST_MESSAGE("Testing compoundFactor at the end of available fixings...");
+
+    CommonVars vars;
+    Date today(22, April, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    DayCounter dayCounter = Actual360();
+
+    Date fromFixingDate(14, February, 2025);
+    Date toFixingDate(17, March, 2025);
+
+    Real compoundedFactor = vars.estr->compoundedFactor(fromFixingDate, toFixingDate);
+
+    Real expectedCompounedFactor = 1.002262115288;
+
+    CHECK_OIS_RATE_RESULT("OIS Rate over a month", compoundedFactor, expectedCompounedFactor, 1e-12);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -104,7 +104,8 @@ struct CommonVars {
             0.0009
         };
 
-        sofr->addFixings(pastDates.begin(), pastDates.end(), pastRates.begin());
+        TimeSeries<Real> ts(pastDates.begin(), pastDates.end(), pastRates.begin());
+        sofr->addFixings(ts);
     }
 
     CommonVars() : CommonVars(Date(23, November, 2021)) {}

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -136,6 +136,21 @@ BOOST_AUTO_TEST_CASE(testPastCouponRate) {
     CHECK_OIS_COUPON_RESULT("coupon amount", pastCoupon->amount(), expectedAmount, 1e-8);
 }
 
+BOOST_AUTO_TEST_CASE(testPastCouponRateThroughIndex) {
+    BOOST_TEST_MESSAGE("Testing rate for past overnight-indexed coupon through compundFactor in index...");
+
+    CommonVars vars;
+
+    // coupon entirely in the past
+    auto pastCoupon = vars.makeCoupon(Date(1, July, 2019),
+                                      Date(1, August, 2019));
+
+    Rate expectedRate = 0.024537253424;
+    Real expectedAmount = vars.notional * expectedRate * 31.0/360;
+    CHECK_OIS_COUPON_RESULT("coupon rate", pastCoupon->rate(), expectedRate, 1e-12);
+    CHECK_OIS_COUPON_RESULT("coupon amount", pastCoupon->amount(), expectedAmount, 1e-8);
+}
+
 BOOST_AUTO_TEST_CASE(testCurrentCouponRate) {
     BOOST_TEST_MESSAGE("Testing rate for current overnight-indexed coupon...");
 

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -764,6 +764,7 @@
     <ClCompile Include="operators.cpp" />
     <ClCompile Include="optimizers.cpp" />
     <ClCompile Include="optionletstripper.cpp" />
+    <ClCompile Include="overnightindex.cpp" />
     <ClCompile Include="overnightindexedcoupon.cpp" />
     <ClCompile Include="overnightindexedswap.cpp" />
     <ClCompile Include="pagodaoption.cpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -311,6 +311,9 @@
     <ClCompile Include="optionletstripper.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="overnightindex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="overnightindexedcoupon.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Added a compoundIndex attribute in the `OvernightIndex` to keep track of the past fixings and speed up the calculation of compounded fixings for Seasoned OIS Swap as described in #1653.

Changes in the PR include:
- Made the `OvernightIndex` Lazy, so the compounded index is calculated on demand.
	- Added support for computing compounded fixings and factors over a given date range in the `OvernightIndex` class, with new methods `compoundedFixings` and `compoundedFactor`. These methods leverage historical fixings to calculate rates and factors efficiently. 
- Refactoring of the `averageRate` code in `CompoundingOvernightIndexedCouponPricer` by extracting logic for handling past, today, and future fixings into separate private methods (handlePastFixings, handleTodayFixing, handleFutureFixings) to improve code readability and maintainability.