### PR TITLE
AD Initializer List Fix

### DIFF
--- a/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmsimplestoragecondition.cpp
@@ -78,8 +78,8 @@ namespace QuantLib {
                 // bang-bang-wait strategy
                 Real currentValue = std::max({
                         a[iter.index()],
-                        buyPrice - price*maxInject,
-                        sellPrice + price*maxWithDraw
+                        Real(buyPrice - price*maxInject),
+                        Real(sellPrice + price*maxWithDraw)
                     });
 
                 // check if intermediate grid points give a better value


### PR DESCRIPTION
AD tools use lazy evaluation to optimise large expressions. For example:

```c++
xad::AReal<double> = 1.0 * 2.0;
```

is first of `BinaryExpr` type before becoming `AReal`. This works fine but causes issues for initializer lists. Here:

```c++
xad::AReal x = 1.0, y = 2.0, z = 3.0;
auto vec = max({x, y + z});
```

breaks because `x` is of type `AReal` and `y + z` is of type `BinaryExpr` and so the compiler can't resolve an overload for `max`. This PR fixes this by casting `y + z` (equivalent) to `Real` such that the compiler doesn't struggle with this resolve.