### PR TITLE
Remove dangling unreachable break clauses

### DIFF
--- a/ql/experimental/finitedifferences/fdmvppstepconditionfactory.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstepconditionfactory.cpp
@@ -83,7 +83,6 @@ namespace QuantLib {
               return ext::shared_ptr<FdmVPPStepCondition>(
                   new FdmVPPStartLimitStepCondition(params, args_.nStarts,
                           mesh, fuel, spark));
-              break;
           default:
             QL_FAIL("vpp type is not supported");
         }

--- a/ql/experimental/processes/extendedblackscholesprocess.cpp
+++ b/ql/experimental/processes/extendedblackscholesprocess.cpp
@@ -57,11 +57,9 @@ namespace QuantLib {
             return apply(x0, drift(t0, x0)*dt
                            + 0.5*std::pow(diffusion(t0, x0),2)*(dw*dw-1)*dt
                            + diffusion(t0,x0)*std::sqrt(dt)*dw);
-            break;
           case Euler:
             // Usual Euler scheme
             return apply(expectation(t0,x0,dt), stdDeviation(t0,x0,dt)*dw);
-            break;
           case PredictorCorrector:
             // Predictor-Corrector scheme with equal weighting
             predictor =
@@ -84,7 +82,6 @@ namespace QuantLib {
             corrector =
                 apply(x0,driftterm*dt+diffusionterm*std::sqrt(dt)*dw);
             return corrector;
-            break;
           default:
             QL_FAIL("unknown discretization scheme");
         }

--- a/ql/experimental/processes/extendedornsteinuhlenbeckprocess.cpp
+++ b/ql/experimental/processes/extendedornsteinuhlenbeckprocess.cpp
@@ -87,7 +87,6 @@ namespace QuantLib {
           case MidPoint:
             return ouProcess_->expectation(t0, x0, dt)
                     + b_(t0+0.5*dt)*(1.0 - std::exp(-speed_*dt));
-            break;
           case Trapezodial:
             {
               const Time t = t0+dt;
@@ -99,13 +98,11 @@ namespace QuantLib {
               return ouProcess_->expectation(t0, x0, dt)
                     + bt-ex*bu - (bt-bu)/(speed_*dt)*(1-ex);
             }
-            break;
           case GaussLobatto:
               return ouProcess_->expectation(t0, x0, dt)
                   + speed_*std::exp(-speed_*(t0+dt))
                   * GaussLobattoIntegral(100000, intEps_)(integrand(b_, speed_),
                                                           t0, t0+dt);
-            break;
           default:
             QL_FAIL("unknown discretization scheme");
         }

--- a/ql/instruments/overnightindexfuture.cpp
+++ b/ql/instruments/overnightindexfuture.cpp
@@ -124,10 +124,8 @@ namespace QuantLib {
         switch (averagingMethod_) {
           case RateAveraging::Simple:
             return averagedRate();
-            break;
           case RateAveraging::Compound:
             return compoundedRate();
-            break;
           default:
               QL_FAIL("unknown compounding convention (" << Integer(averagingMethod_) << ")");
         }

--- a/ql/models/equity/hestonslvfdmmodel.cpp
+++ b/ql/models/equity/hestonslvfdmmodel.cpp
@@ -89,7 +89,6 @@ namespace QuantLib {
                     return ext::make_shared<Concentrating1dMesher>(
                         lowerBound, upperBound, vGrid, cPoints, 1e-8);
                   }
-                break;
                 case FdmSquareRootFwdOp::Plain:
                   {
                       const Real v0Center = v0;
@@ -103,7 +102,6 @@ namespace QuantLib {
                       return ext::make_shared<Concentrating1dMesher>(
                           lowerBound, upperBound, vGrid, cPoints, 1e-8);
                   }
-                break;
                 case FdmSquareRootFwdOp::Power:
                 {
                     const Real v0Center = v0;
@@ -117,7 +115,6 @@ namespace QuantLib {
                     return ext::make_shared<Concentrating1dMesher>(
                         lowerBound, upperBound, vGrid, cPoints, 1e-8);
                 }
-                break;
                 default:
                     QL_FAIL("transformation type is not implemented");
             }

--- a/ql/pricingengines/barrier/analyticpartialtimebarrieroptionengine.cpp
+++ b/ql/pricingengines/barrier/analyticpartialtimebarrieroptionengine.cpp
@@ -48,13 +48,10 @@ namespace QuantLib {
             switch (barrierRange) {
               case PartialBarrier::Start:
                 return CA(1, barrier, strike, r, q);
-                break;
               case PartialBarrier::EndB1:
                 return CoB1(barrier, strike, r, q);
-                break;
               case PartialBarrier::EndB2:
                 return CoB2(Barrier::DownOut, barrier, strike, r, q);
-                break;
               default:
                 QL_FAIL("invalid barrier range");
             }
@@ -64,7 +61,6 @@ namespace QuantLib {
             switch (barrierRange) {
               case PartialBarrier::Start:
                 return CIA(1, barrier, strike, r, q);
-                break;
               case PartialBarrier::EndB1:
               case PartialBarrier::EndB2:
                 QL_FAIL("Down-and-in partial-time end barrier is not implemented");
@@ -77,13 +73,10 @@ namespace QuantLib {
             switch (barrierRange) {
               case PartialBarrier::Start:
                 return CA(-1, barrier, strike, r, q);
-                break;
               case PartialBarrier::EndB1:
                 return CoB1(barrier, strike, r, q);
-                break;
               case PartialBarrier::EndB2:
                 return CoB2(Barrier::UpOut, barrier, strike, r, q);
-                break;
               default:
                 QL_FAIL("invalid barrier range");
             }
@@ -93,7 +86,6 @@ namespace QuantLib {
               switch (barrierRange) {
                 case PartialBarrier::Start:
                   return CIA(-1, barrier, strike, r, q);
-                  break;
                 case PartialBarrier::EndB1:
                 case PartialBarrier::EndB2:
                   QL_FAIL("Up-and-in partial-time end barrier is not implemented");


### PR DESCRIPTION
Greetings, I found these minor code-smells working with static analyzers on the Quantlib.

These changes shouldn't affect functionality, whilst improving a bit of the readability. I have reviewed some of the code and seems like you don't have a defined style for break clauses, so I think these changes might help homogenize the code.

The rationale behind these changes are that there shouldn't be unreachable code:

- MISRA C:2012, 2.1 - A project shall not contain unreachable code

- CWE - [CWE-561 - Dead Code](https://cwe.mitre.org/data/definitions/561)

- [CERT, MSC12-C.](https://wiki.sei.cmu.edu/confluence/x/5dUxBQ) - Detect and remove code that has no effect or is never executed

Thank you for your time and for reviewing this change.