### PR TITLE
Make unexpected types in quote variant a compile-time error

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1874,6 +1874,7 @@
     <ClInclude Include="ql\utilities\observablevalue.hpp" />
     <ClInclude Include="ql\utilities\steppingiterator.hpp" />
     <ClInclude Include="ql\utilities\tracing.hpp" />
+    <ClInclude Include="ql\utilities\variants.hpp" />
     <ClInclude Include="ql\utilities\vectors.hpp" />
     <ClInclude Include="ql\any.hpp" />
     <ClInclude Include="ql\auto_link.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2286,6 +2286,9 @@
     <ClInclude Include="ql\utilities\tracing.hpp">
       <Filter>utilities</Filter>
     </ClInclude>
+    <ClInclude Include="ql\utilities\variants.hpp">
+      <Filter>utilities</Filter>
+    </ClInclude>
     <ClInclude Include="ql\utilities\vectors.hpp">
       <Filter>utilities</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2241,6 +2241,7 @@ set(QL_HEADERS
     utilities/observablevalue.hpp
     utilities/steppingiterator.hpp
     utilities/tracing.hpp
+    utilities/variants.hpp
     utilities/vectors.hpp
     version.hpp
     volatilitymodel.hpp

--- a/ql/quote.cpp
+++ b/ql/quote.cpp
@@ -20,20 +20,15 @@
 #include <ql/quote.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/errors.hpp>
+#include <ql/utilities/variants.hpp>
 
 namespace QuantLib {
 
     Handle<Quote> handleFromVariant(const std::variant<Real, Handle<Quote>>& value) {
         return std::visit(
-            [](const auto& x) -> Handle<Quote> {
-                using T = std::decay_t<decltype(x)>;
-                if constexpr (std::is_same_v<T, Real>) {
-                    return makeQuoteHandle(x);
-                } else if constexpr (std::is_same_v<T, Handle<Quote>>) {
-                    return x;
-                } else {
-                    QL_FAIL("Unexpected type in quote variant");
-                }
+            detail::variant_visitor{
+                [](Real x) -> Handle<Quote> { return makeQuoteHandle(x); },
+                [](const Handle<Quote>& x) { return x; }
             },
             value);
     }

--- a/ql/utilities/Makefile.am
+++ b/ql/utilities/Makefile.am
@@ -8,10 +8,11 @@ this_include_HEADERS = \
     dataformatters.hpp \
     dataparsers.hpp \
     null.hpp \
-	null_deleter.hpp \
+    null_deleter.hpp \
     observablevalue.hpp \
     steppingiterator.hpp \
     tracing.hpp \
+    variants.hpp \
     vectors.hpp
 
 cpp_files = \

--- a/ql/utilities/all.hpp
+++ b/ql/utilities/all.hpp
@@ -9,5 +9,6 @@
 #include <ql/utilities/observablevalue.hpp>
 #include <ql/utilities/steppingiterator.hpp>
 #include <ql/utilities/tracing.hpp>
+#include <ql/utilities/variants.hpp>
 #include <ql/utilities/vectors.hpp>
 

--- a/ql/utilities/variants.hpp
+++ b/ql/utilities/variants.hpp
@@ -1,0 +1,19 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef quantlib_utilities_variants_hpp
+#define quantlib_utilities_variants_hpp
+
+namespace QuantLib::detail {
+
+    // Helper type for use with std::visit.
+    template <class... Ts>
+    struct variant_visitor : Ts... {
+        using Ts::operator()...;
+    };
+
+    template <class... Ts>
+    variant_visitor(Ts...) -> variant_visitor<Ts...>;
+
+}
+
+#endif


### PR DESCRIPTION
Simplify usage of std::visit using a helper visitor type as shown in https://en.cppreference.com/w/cpp/utility/variant/visit2

This also catches unknown types at compile-time instead of run-time even on older compilers.