### PR TITLE
Add CustomIborIndex

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -829,6 +829,7 @@
     <ClInclude Include="ql\indexes\ibor\cdor.hpp" />
     <ClInclude Include="ql\indexes\ibor\chflibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\corra.hpp" />
+    <ClInclude Include="ql\indexes\ibor\custom.hpp" />
     <ClInclude Include="ql\indexes\ibor\destr.hpp" />
     <ClInclude Include="ql\indexes\ibor\dkklibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\eonia.hpp" />
@@ -2133,6 +2134,7 @@
     <ClCompile Include="ql\indexes\equityindex.cpp" />
     <ClCompile Include="ql\indexes\ibor\bibor.cpp" />
     <ClCompile Include="ql\indexes\ibor\corra.cpp" />
+    <ClCompile Include="ql\indexes\ibor\custom.cpp" />
     <ClCompile Include="ql\indexes\ibor\eonia.cpp" />
     <ClCompile Include="ql\indexes\ibor\estr.cpp" />
     <ClCompile Include="ql\indexes\ibor\euribor.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -639,6 +639,9 @@
     <ClInclude Include="ql\indexes\ibor\corra.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\ibor\custom.hpp">
+      <Filter>indexes\ibor</Filter>
+    </ClInclude>
     <ClInclude Include="ql\indexes\ibor\dkklibor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
@@ -4635,6 +4638,9 @@
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\corra.cpp">
+      <Filter>indexes\ibor</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\ibor\custom.cpp">
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\eonia.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -218,6 +218,7 @@ set(QL_SOURCES
     indexes/equityindex.cpp
     indexes/ibor/bibor.cpp
     indexes/ibor/corra.cpp
+    indexes/ibor/custom.cpp
     indexes/ibor/eonia.cpp
     indexes/ibor/estr.cpp
     indexes/ibor/euribor.cpp
@@ -1255,6 +1256,7 @@ set(QL_HEADERS
     indexes/ibor/cdor.hpp
     indexes/ibor/chflibor.hpp
     indexes/ibor/corra.hpp
+    indexes/ibor/custom.hpp
     indexes/ibor/destr.hpp
     indexes/ibor/dkklibor.hpp
     indexes/ibor/eonia.hpp

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -13,6 +13,7 @@ this_include_HEADERS = \
     cdor.hpp \
     chflibor.hpp \
     corra.hpp \
+    custom.hpp \
     destr.hpp \
     dkklibor.hpp \
     eonia.hpp \
@@ -47,6 +48,7 @@ this_include_HEADERS = \
 cpp_files = \
     bibor.cpp \
     corra.cpp \
+    custom.cpp \
     eonia.cpp \
     estr.cpp \
     euribor.cpp \

--- a/ql/indexes/ibor/all.hpp
+++ b/ql/indexes/ibor/all.hpp
@@ -10,6 +10,7 @@
 #include <ql/indexes/ibor/cdor.hpp>
 #include <ql/indexes/ibor/chflibor.hpp>
 #include <ql/indexes/ibor/corra.hpp>
+#include <ql/indexes/ibor/custom.hpp>
 #include <ql/indexes/ibor/destr.hpp>
 #include <ql/indexes/ibor/dkklibor.hpp>
 #include <ql/indexes/ibor/eonia.hpp>

--- a/ql/indexes/ibor/custom.cpp
+++ b/ql/indexes/ibor/custom.cpp
@@ -1,0 +1,50 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <ql/indexes/ibor/custom.hpp>
+
+namespace QuantLib {
+
+    CustomIborIndex::CustomIborIndex(const std::string& familyName,
+                                     const Period& tenor,
+                                     Natural settlementDays,
+                                     const Currency& currency,
+                                     const Calendar& fixingCalendar,
+                                     const Calendar& valueCalendar,
+                                     const Calendar& maturityCalendar,
+                                     BusinessDayConvention convention,
+                                     bool endOfMonth,
+                                     const DayCounter& dayCounter,
+                                     const Handle<YieldTermStructure>& h)
+    : IborIndex(familyName, tenor, settlementDays, currency, fixingCalendar,
+                convention, endOfMonth, dayCounter, h),
+      valueCalendar_(valueCalendar), maturityCalendar_(maturityCalendar) {}
+
+    Date CustomIborIndex::fixingDate(const Date& valueDate) const {
+        Date fixingDate = valueCalendar_.advance(valueDate,
+            -static_cast<Integer>(fixingDays_), Days);
+        return fixingCalendar().adjust(fixingDate, Preceding);
+    }
+
+    Date CustomIborIndex::valueDate(const Date& fixingDate) const {
+
+        QL_REQUIRE(isValidFixingDate(fixingDate),
+                   "Fixing date " << fixingDate << " is not valid");
+
+        Date d = valueCalendar_.advance(fixingDate, fixingDays_, Days);
+        return maturityCalendar_.adjust(d);
+    }
+
+    Date CustomIborIndex::maturityDate(const Date& valueDate) const {
+        return maturityCalendar_.advance(valueDate, tenor_, convention_,
+                                         endOfMonth_);
+    }
+
+    ext::shared_ptr<IborIndex> CustomIborIndex::clone(
+            const Handle<YieldTermStructure>& h) const {
+        return ext::make_shared<CustomIborIndex>(
+            familyName_, tenor_, fixingDays_, currency_, fixingCalendar(),
+            valueCalendar_, maturityCalendar_, convention_, endOfMonth_,
+            dayCounter_, h);
+    }
+
+}

--- a/ql/indexes/ibor/custom.hpp
+++ b/ql/indexes/ibor/custom.hpp
@@ -1,0 +1,63 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef quantlib_custom_ibor_hpp
+#define quantlib_custom_ibor_hpp
+
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    /*! LIBOR-like index that allows specifying custom calendars for value
+        and maturity dates calculations:
+
+        * valueDate() advances on the valueCalendar and adjusts on the
+         maturityCalendar.
+
+        * maturityDate() advances on the maturityCalendar.
+
+        * fixingDate() goes back on the valueCalendar.
+
+        Typical LIBOR indexes use:
+
+        * fixingCalendar = valueCalendar = UK, maturityCalendar =
+        JoinHolidays(UK, CurrencyCalendar) for non-EUR currencies.
+
+        * fixingCalendar = JoinHolidays(UK, TARGET), valueCalendar =
+        maturityCalendar = TARGET for EUR.
+    */
+    class CustomIborIndex : public IborIndex {
+      public:
+        CustomIborIndex(const std::string& familyName,
+                        const Period& tenor,
+                        Natural settlementDays,
+                        const Currency& currency,
+                        const Calendar& fixingCalendar,
+                        const Calendar& valueCalendar,
+                        const Calendar& maturityCalendar,
+                        BusinessDayConvention convention,
+                        bool endOfMonth,
+                        const DayCounter& dayCounter,
+                        const Handle<YieldTermStructure>& h = {});
+        //! \name InterestRateIndex interface
+        //@{
+        Date fixingDate(const Date& valueDate) const override;
+        Date valueDate(const Date& fixingDate) const override;
+        Date maturityDate(const Date& valueDate) const override;
+        // @}
+        //! \name IborIndex interface
+        //@{
+        ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        // @}
+        //! \name Other inspectors
+        //@{
+        Calendar valueCalendar() const { return valueCalendar_; }
+        Calendar maturityCalendar() const { return maturityCalendar_; }
+        // @}
+      private:
+        Calendar valueCalendar_;
+        Calendar maturityCalendar_;
+    };
+
+}
+
+#endif

--- a/ql/indexes/ibor/eurlibor.cpp
+++ b/ql/indexes/ibor/eurlibor.cpp
@@ -100,6 +100,10 @@ namespace QuantLib {
         return target_.advance(valueDate, tenor_, convention_, endOfMonth());
     }
 
+    ext::shared_ptr<IborIndex> EURLibor::clone(const Handle<YieldTermStructure>& h) const {
+        return ext::make_shared<EURLibor>(tenor(), h);
+    }
+
     DailyTenorEURLibor::DailyTenorEURLibor(Natural settlementDays,
                                            const Handle<YieldTermStructure>& h)
     : IborIndex("EURLibor", 1*Days,

--- a/ql/indexes/ibor/eurlibor.hpp
+++ b/ql/indexes/ibor/eurlibor.hpp
@@ -52,6 +52,10 @@ namespace QuantLib {
         Date valueDate(const Date& fixingDate) const override;
         Date maturityDate(const Date& valueDate) const override;
         // @}
+        //! \name IborIndex interface
+        //@{
+        ext::shared_ptr<IborIndex> clone(const Handle<YieldTermStructure>& h) const override;
+        // @}
       private:
         Calendar target_;
     };

--- a/ql/indexes/ibor/libor.cpp
+++ b/ql/indexes/ibor/libor.cpp
@@ -118,13 +118,13 @@ namespace QuantLib {
 
     ext::shared_ptr<IborIndex> Libor::clone(
                                   const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(new Libor(familyName(),
-                                                      tenor(),
-                                                      fixingDays(),
-                                                      currency(),
-                                                      financialCenterCalendar_,
-                                                      dayCounter(),
-                                                      h));
+        return ext::make_shared<Libor>(familyName(),
+                                       tenor(),
+                                       fixingDays(),
+                                       currency(),
+                                       financialCenterCalendar_,
+                                       dayCounter(),
+                                       h);
     }
 
 

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -20,7 +20,9 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <ql/indexes/bmaindex.hpp>
+#include <ql/indexes/ibor/custom.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
+#include <ql/time/calendars/bespokecalendar.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual360.hpp>
 #include <ql/utilities/dataformatters.hpp>
@@ -136,6 +138,60 @@ BOOST_AUTO_TEST_CASE(testTenorNormalization) {
         BOOST_ERROR("inconsistent maturity dates and tenors"
                     << "\n  maturity date for 6-days index: " << maturity6d
                     << "\n  maturity date for 7-days index: " << maturity7d);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testCustomIborIndex) {
+    BOOST_TEST_MESSAGE("Testing CustomIborIndex...");
+
+    auto fixCal = BespokeCalendar("Fixings");
+    fixCal.addHoliday(Date(8, January, 2025));
+
+    auto valCal = BespokeCalendar("Value");
+    valCal.addHoliday(Date(21, January, 2025));
+
+    auto matCal = BespokeCalendar("Maturity");
+    matCal.addHoliday(Date(7, January, 2025));
+    matCal.addHoliday(Date(15, January, 2025));
+    matCal.addHoliday(Date(23, April, 2025));
+    matCal.addHoliday(Date(30, April, 2025));
+
+    auto ibor = CustomIborIndex(
+        "Custom Ibor", 3*Months, 2, Currency(), fixCal, valCal, matCal,
+        ModifiedFollowing, true, Actual360()
+    );
+    auto iborClone = ibor.clone(Handle<YieldTermStructure>());
+
+    for (IborIndex* index : {static_cast<IborIndex*>(&ibor), iborClone.get()}) {
+        auto* as_custom = dynamic_cast<CustomIborIndex*>(index);
+        BOOST_CHECK_EQUAL(index->fixingCalendar(), fixCal);
+        BOOST_CHECK_EQUAL(as_custom->valueCalendar(), valCal);
+        BOOST_CHECK_EQUAL(as_custom->maturityCalendar(), matCal);
+
+        BOOST_CHECK_EXCEPTION(
+            index->valueDate(Date(8, January, 2025)), Error,
+            ExpectedErrorMessage("Fixing date January 8th, 2025 is not valid"));
+
+        BOOST_CHECK_EQUAL(index->valueDate(Date(7, January, 2025)),
+                          Date(9, January, 2025));
+        BOOST_CHECK_EQUAL(index->valueDate(Date(13, January, 2025)),
+                          Date(16, January, 2025));
+        BOOST_CHECK_EQUAL(index->valueDate(Date(20, January, 2025)),
+                          Date(23, January, 2025));
+
+        BOOST_CHECK_EQUAL(index->fixingDate(Date(23, January, 2025)),
+                          Date(20, January, 2025));
+        BOOST_CHECK_EQUAL(index->fixingDate(Date(16, January, 2025)),
+                          Date(14, January, 2025));
+        BOOST_CHECK_EQUAL(index->fixingDate(Date(10, January, 2025)),
+                          Date(7, January, 2025));
+
+        BOOST_CHECK_EQUAL(index->maturityDate(Date(23, January, 2025)),
+                          Date(24, April, 2025));
+        BOOST_CHECK_EQUAL(index->maturityDate(Date(30, January, 2025)),
+                          Date(29, April, 2025));
+        BOOST_CHECK_EQUAL(index->maturityDate(Date(28, February, 2025)),
+                          Date(31, May, 2025));
     }
 }
 


### PR DESCRIPTION
This is a LIBOR-like index that allows specifying custom calendars for value and maturity dates calculations. This is useful, for example, when using vendor calendars instead of the built-in ones.

Also, add missing EURLibor::clone().