### PR TITLE
Add zero-coupon inflation helper that doesn't need a nominal curve

### DIFF
--- a/ql/termstructures/inflation/inflationhelpers.cpp
+++ b/ql/termstructures/inflation/inflationhelpers.cpp
@@ -29,6 +29,8 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     ZeroCouponInflationSwapHelper::ZeroCouponInflationSwapHelper(
         const Handle<Quote>& quote,
         const Period& swapObsLag,
@@ -90,6 +92,8 @@ namespace QuantLib {
         registerWith(Settings::instance().evaluationDate());
         registerWith(nominalTermStructure_);
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
 
 
     Real ZeroCouponInflationSwapHelper::impliedQuote() const {

--- a/ql/termstructures/inflation/inflationhelpers.hpp
+++ b/ql/termstructures/inflation/inflationhelpers.hpp
@@ -45,6 +45,10 @@ namespace QuantLib {
             ext::shared_ptr<ZeroInflationIndex> zii,
             CPI::InterpolationType observationInterpolation);
 
+        /*! \deprecated Use the overload that does not take a nominal curve.
+                        Deprecated in version 1.39.
+        */
+        [[deprecated("Use the overload that does not take a nominal curve.")]]
         ZeroCouponInflationSwapHelper(
             const Handle<Quote>& quote,
             const Period& swapObsLag,

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -482,6 +482,8 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
 }
 
 
+QL_DEPRECATED_DISABLE_WARNING
+
 BOOST_AUTO_TEST_CASE(testZeroTermStructureWithNominalCurve) {
     BOOST_TEST_MESSAGE("Testing zero inflation term structure passing nominal curve to helpers...");
 
@@ -538,8 +540,9 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructureWithNominalCurve) {
     Frequency frequency = Monthly;
 
     auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
-        return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, nominalTS);
+        return ext::shared_ptr<ZeroCouponInflationSwapHelper>(
+          new ZeroCouponInflationSwapHelper(
+            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, nominalTS));
     };
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
 
@@ -648,6 +651,8 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructureWithNominalCurve) {
     // remove circular refernce
     hz.reset();
 }
+
+QL_DEPRECATED_ENABLE_WARNING
 
 
 BOOST_AUTO_TEST_CASE(testSeasonalityCorrection) {
@@ -1713,7 +1718,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolationRegression) {
 
     auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
         return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, rpi, CPI::AsIndex, nominalTS);
+            quote, observationLag, maturity, calendar, bdc, dc, rpi, CPI::AsIndex);
     };
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
 

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -58,16 +58,15 @@ std::vector<ext::shared_ptr<Helper> > makeHelpers(
         const Period& observationLag,
         const Calendar& calendar,
         const BusinessDayConvention& bdc,
-        const DayCounter& dc,
-        const Handle<YieldTermStructure>& yTS) {
+        const DayCounter& dc) {
 
     std::vector<ext::shared_ptr<Helper> > instruments;
     for (Datum datum : iiData) {
         Date maturity = datum.date;
         Handle<Quote> quote(ext::shared_ptr<Quote>(
                                 new SimpleQuote(datum.rate/100.0)));
-        ext::shared_ptr<Helper> h(new ZeroCouponInflationSwapHelper(
-                quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex, yTS));
+        auto h = ext::make_shared<ZeroCouponInflationSwapHelper>(
+                quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex);
         instruments.push_back(h);
     }
     return instruments;
@@ -144,7 +143,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
 
         std::vector<ext::shared_ptr<Helper> > helpers =
             makeHelpers(zciisData, ii,
-                        observationLag, calendar, convention, dayCounter, yTS);
+                        observationLag, calendar, convention, dayCounter);
 
         Date baseDate = ii->lastFixingDate();
 

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -62,17 +62,15 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
         const ext::shared_ptr<I> &ii, const Period &observationLag,
         const Calendar &calendar,
         const BusinessDayConvention &bdc,
-        const DayCounter &dc,
-        const Handle<YieldTermStructure>& discountCurve) {
+        const DayCounter &dc) {
 
     std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
     for (Size i=0; i<N; i++) {
         Date maturity = iiData[i].date;
         Handle<Quote> quote(ext::shared_ptr<Quote>(
                                 new SimpleQuote(iiData[i].rate/100.0)));
-        ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(quote, observationLag, maturity,
-                                                                calendar, bdc, dc, ii,
-                                                                CPI::AsIndex, discountCurve));
+        auto anInstrument = ext::make_shared<U>(quote, observationLag, maturity,
+                                                calendar, bdc, dc, ii, CPI::AsIndex);
         instruments.push_back(anInstrument);
     }
 
@@ -239,12 +237,11 @@ struct CommonVars {
         }
 
         // now build the helpers ...
-        std::vector<ext::shared_ptr<BootstrapHelper<ZeroInflationTermStructure> > > helpers =
+        auto helpers =
             makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
             ZeroInflationIndex>(zciisData, zciisDataLength, ii,
                                 observationLag,
-                                calendar, convention, dcZCIIS,
-                                Handle<YieldTermStructure>(nominalTS));
+                                calendar, convention, dcZCIIS);
 
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -58,17 +58,16 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
         const ext::shared_ptr<I> &ii, const Period &observationLag,
         const Calendar &calendar,
         const BusinessDayConvention &bdc,
-        const DayCounter &dc,
-        const Handle<YieldTermStructure>& discountCurve) {
+        const DayCounter &dc) {
 
     std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
     for (Size i=0; i<N; i++) {
         Date maturity = iiData[i].date;
         Handle<Quote> quote(ext::shared_ptr<Quote>(
                                 new SimpleQuote(iiData[i].rate/100.0)));
-        ext::shared_ptr<BootstrapHelper<T> > anInstrument(new U(quote, observationLag, maturity,
-                                                                calendar, bdc, dc, ii,
-                                                                CPI::AsIndex, discountCurve));
+        auto anInstrument = ext::make_shared<U>(quote, observationLag, maturity,
+                                                calendar, bdc, dc, ii,
+                                                CPI::AsIndex);
         instruments.push_back(anInstrument);
     }
 
@@ -220,12 +219,11 @@ struct CommonVars {
         }
 
         // now build the helpers ...
-        std::vector<ext::shared_ptr<BootstrapHelper<ZeroInflationTermStructure> > > helpers =
+        auto helpers =
             makeHelpers<ZeroInflationTermStructure,ZeroCouponInflationSwapHelper,
             ZeroInflationIndex>(zciisData, zciisDataLength, ii,
                                 observationLag,
-                                calendar, convention, dcZCIIS,
-                                Handle<YieldTermStructure>(nominalTS));
+                                calendar, convention, dcZCIIS);
 
         // we can use historical or first ZCIIS for this
         // we know historical is WAY off market-implied, so use market implied flat.


### PR DESCRIPTION
Any nominal curve will result in the same inflation curve for zero-coupon bonds, because the two equal discount factors applied to the fixed and inflation coupons will cancel out in the calculation of the fair rate.