### PR TITLE
Fix default settlement logic in MakeOIS: SONIA=0, CORRA=1, others=2.

### DIFF
--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -24,6 +24,8 @@
 #include <ql/pricingengines/swap/discountingswapengine.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/schedule.hpp>
+#include <ql/indexes/ibor/sonia.hpp>
+#include <ql/indexes/ibor/corra.hpp>
 
 namespace QuantLib {
 
@@ -35,6 +37,7 @@ namespace QuantLib {
       forwardStart_(forwardStart),
       fixedCalendar_(overnightIndex->fixingCalendar()),
       overnightCalendar_(overnightIndex->fixingCalendar()),
+      settlementDays_(Null<Natural>()),
       fixedDayCount_(overnightIndex->dayCounter()) {}
 
     MakeOIS::operator OvernightIndexedSwap() const {
@@ -48,12 +51,23 @@ namespace QuantLib {
         if (effectiveDate_ != Date())
             startDate = effectiveDate_;
         else {
+            // settlement days: override if set, else fallback to default by index name
+            Natural settlementDays = settlementDays_;
+            if (settlementDays == Null<Natural>()) {
+                if (ext::dynamic_pointer_cast<Sonia>(overnightIndex_))
+                    settlementDays = 0;
+                else if (ext::dynamic_pointer_cast<Corra>(overnightIndex_))
+                    settlementDays = 1;
+                else
+                    settlementDays = 2;
+            }            
+
             Date refDate = Settings::instance().evaluationDate();
             // if the evaluation date is not a business day
             // then move to the next business day
             refDate = overnightCalendar_.adjust(refDate);
             Date spotDate = overnightCalendar_.advance(refDate,
-                                                       settlementDays_*Days);
+                                                       settlementDays*Days);
             startDate = spotDate+forwardStart_;
             if (forwardStart_.length()<0)
                 startDate = overnightCalendar_.adjust(startDate, Preceding);

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -45,6 +45,9 @@
 #include <ql/currencies/europe.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/utilities/dataformatters.hpp>
+#include <ql/indexes/ibor/sonia.hpp>
+#include <ql/indexes/ibor/eonia.hpp>
+#include <ql/indexes/ibor/corra.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -964,6 +967,37 @@ BOOST_AUTO_TEST_CASE(testNotifications) {
 
     if (!flag.isUp())
         BOOST_FAIL("OIS was not notified of curve change");
+}
+
+BOOST_AUTO_TEST_CASE(testMakeOISDefaultSettlementDays) {
+    BOOST_TEST_MESSAGE("Testing default settlement days in MakeOIS...");
+
+    Date today(12, May, 2025);
+    Settings::instance().evaluationDate() = today;
+
+    auto sonia = ext::make_shared<Sonia>();
+    auto corra = ext::make_shared<Corra>();
+    auto eonia = ext::make_shared<Eonia>();
+
+    // SONIA: 0-day settlement
+    {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, sonia, 0.01);
+        Date expected(12, May, 2025);
+        BOOST_CHECK_EQUAL(swap.startDate(), expected);
+    }
+    // CORRA: 1-day settlement
+    {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, corra, 0.01);
+        Date expected(13, May, 2025); 
+        BOOST_CHECK_EQUAL(swap.startDate(), expected);
+    }
+
+    // EONIA: 2-day settlement
+    {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, eonia, 0.01);
+        Date expected(14, May, 2025);
+        BOOST_CHECK_EQUAL(swap.startDate(), expected);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Applies default settlement days based on index type, keeps override behavior when .withSettlementDays() is used. Ensures expected behavior with testMakeOISDefaultSettlementDays