### PR TITLE
Enhance MakeOIS default settlement days test and use settlement days t+1 for CORRA

### DIFF
--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -54,10 +54,13 @@ namespace QuantLib {
             // settlement days: override if set, else fallback to default by index name
             Natural settlementDays = settlementDays_;
             if (settlementDays == Null<Natural>()) {
-                if (ext::dynamic_pointer_cast<Sonia>(overnightIndex_) 
-                    || ext::dynamic_pointer_cast<Corra>(overnightIndex_)) {
-                    settlementDays = 0;
-                } else {
+                if (ext::dynamic_pointer_cast<Sonia>(overnightIndex_)) {
+                    settlementDays = 0; 
+                }
+                else if (ext::dynamic_pointer_cast<Corra>(overnightIndex_)) {
+                    settlementDays = 1;
+                }
+                else {
                     settlementDays = 2;
                 }
             }            

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -48,6 +48,15 @@
 #include <ql/indexes/ibor/sonia.hpp>
 #include <ql/indexes/ibor/eonia.hpp>
 #include <ql/indexes/ibor/corra.hpp>
+#include <ql/indexes/ibor/tibor.hpp>
+#include <ql/indexes/ibor/aonia.hpp>
+#include <ql/indexes/ibor/tona.hpp>
+#include <ql/indexes/ibor/saron.hpp>
+#include <ql/indexes/ibor/nzocr.hpp>
+#include <ql/indexes/ibor/destr.hpp>
+#include <ql/indexes/ibor/swestr.hpp>
+#include <ql/indexes/ibor/kofr.hpp>
+#include <ql/indexes/ibor/mosprime.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -975,27 +984,58 @@ BOOST_AUTO_TEST_CASE(testMakeOISDefaultSettlementDays) {
     Date today(12, May, 2025);
     Settings::instance().evaluationDate() = today;
 
-    auto sonia = ext::make_shared<Sonia>();
-    auto corra = ext::make_shared<Corra>();
-    auto eonia = ext::make_shared<Eonia>();
+    // Create all overnight indices
+    std::vector<std::pair<std::string, ext::shared_ptr<OvernightIndex>>> indices = {
+        // 0-day settlement indices
+        {"SONIA", ext::make_shared<Sonia>()},
+        {"CORRA", ext::make_shared<Corra>()},
+        
+        // 2-day settlement indices
+        {"EONIA", ext::make_shared<Eonia>()},
+        {"ESTR", ext::make_shared<Estr>()},
+        {"FedFunds", ext::make_shared<FedFunds>()},
+        {"SOFR", ext::make_shared<Sofr>()},
+        {"AONIA", ext::make_shared<Aonia>()},
+        {"TONA", ext::make_shared<Tona>()},
+        {"SARON", ext::make_shared<Saron>()},
+        {"NZOCR", ext::make_shared<Nzocr>()},
+        {"DESTR", ext::make_shared<Destr>()},
+        {"SWESTR", ext::make_shared<Swestr>()},
+        {"KOFR", ext::make_shared<Kofr>()}
+    };
 
-    // SONIA: 0-day settlement
-    {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, sonia, 0.01);
-        Date expected(12, May, 2025);
+    // Test default settlement days
+    for (const auto& [name, index] : indices) {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, index, 0.01);
+        Date expected = (name == "SONIA" || name == "CORRA") ? 
+            today : // 0-day settlement
+            today + 2 * Days; // 2-day settlement
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
-    // CORRA: 0-day settlement
-    {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, corra, 0.01);
-        Date expected(12, May, 2025); 
+
+    // Test manual override
+    for (const auto& [name, index] : indices) {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, index, 0.01)
+                                        .withSettlementDays(1);
+        Date expected = today + 1 * Days;
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
 
-    // EONIA: 2-day settlement
+    // Test weekend handling
+    Date weekend(10, May, 2025); // Saturday
+    Settings::instance().evaluationDate() = weekend;
+
+    // Test 0-day settlement index on weekend
     {
-        OvernightIndexedSwap swap = MakeOIS(6 * Months, eonia, 0.01);
-        Date expected(14, May, 2025);
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[0].second, 0.01); // SONIA
+        Date expected(12, May, 2025); // Monday
+        BOOST_CHECK_EQUAL(swap.startDate(), expected);
+    }
+
+    // Test 2-day settlement index on weekend
+    {
+        OvernightIndexedSwap swap = MakeOIS(6 * Months, indices[2].second, 0.01); // EONIA
+        Date expected(14, May, 2025); // Wednesday
         BOOST_CHECK_EQUAL(swap.startDate(), expected);
     }
 }


### PR DESCRIPTION
This change addresses the second portion of #1695 by updating OISRateHelper to mirror the behavior introduced in MakeOIS. When settlementDays is unspecified, index-specific defaults are applied: 0 for SONIA and CORRA, 2 otherwise. This PR adds test coverage to confirm expected start dates under these defaults. It also includes two new assertions in testMakeOISDefaultSettlementDays to verify that manual settlement overrides continue to take precedence.