### PR TITLE
update latestRelevantDate of swap RateHelpers with exogenous discount…

### DIFF
--- a/ql/cashflows/couponpricer.hpp
+++ b/ql/cashflows/couponpricer.hpp
@@ -137,12 +137,12 @@ namespace QuantLib {
         Real optionletRate(Option::Type optionType, Real effStrike) const;
 
         virtual Rate adjustedFixing(Rate fixing = Null<Rate>()) const;
-
-        Real discount_;
+        Real discount() const;
 
       private:
         const TimingAdjustment timingAdjustment_;
         const Handle<Quote> correlation_;
+        mutable Real discount_ = Null<Real>();
     };
 
     //! base pricer for vanilla CMS coupons
@@ -208,8 +208,7 @@ namespace QuantLib {
 
     inline Real BlackIborCouponPricer::swapletPrice() const {
         // past or future fixing is managed in InterestRateIndex::fixing()
-        QL_REQUIRE(discount_ != Null<Rate>(), "no forecast curve provided");
-        return swapletRate() * accrualPeriod_ * discount_;
+        return swapletRate() * accrualPeriod_ * discount();
     }
 
     inline Rate BlackIborCouponPricer::swapletRate() const {
@@ -217,8 +216,7 @@ namespace QuantLib {
     }
 
     inline Real BlackIborCouponPricer::capletPrice(Rate effectiveCap) const {
-        QL_REQUIRE(discount_ != Null<Rate>(), "no forecast curve provided");
-        return capletRate(effectiveCap) * accrualPeriod_ * discount_;
+        return capletRate(effectiveCap) * accrualPeriod_ * discount();
     }
 
     inline Rate BlackIborCouponPricer::capletRate(Rate effectiveCap) const {
@@ -227,8 +225,7 @@ namespace QuantLib {
 
     inline
     Real BlackIborCouponPricer::floorletPrice(Rate effectiveFloor) const {
-        QL_REQUIRE(discount_ != Null<Rate>(), "no forecast curve provided");
-        return floorletRate(effectiveFloor) * accrualPeriod_ * discount_;
+        return floorletRate(effectiveFloor) * accrualPeriod_ * discount();
     }
 
     inline

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -168,8 +168,8 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<OvernightIndexedCoupon>(swap_->overnightLeg().back())->fixingDate();
         Date fixingEndDate =
             overnightIndex_->maturityDate(overnightIndex_->valueDate(lastFixingDate));
-        latestRelevantDate_ = latestDate_ = std::max({maturityDate_, lastPaymentDate, fixingEndDate});
-
+        latestRelevantDate_ = latestDate_ =
+            discountHandle_.empty() ? std::max(lastPaymentDate, fixingEndDate) : fixingEndDate;
         switch (pillarChoice_) {
           case Pillar::MaturityDate:
             pillarDate_ = maturityDate_;

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -565,10 +565,12 @@ namespace QuantLib {
         earliestDate_ = swap_->startDate();
         maturityDate_ = swap_->maturityDate();
 
-        ext::shared_ptr<IborCoupon> lastCoupon =
-            ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg().back());
-        latestRelevantDate_ = std::max(maturityDate_, lastCoupon->fixingEndDate());
-
+        Date lastPaymentDate = std::max(swap_->floatingLeg().back()->date(),
+                                        swap_->fixedLeg().back()->date());
+        Date fixingEndDate =
+            ext::dynamic_pointer_cast<IborCoupon>(swap_->floatingLeg().back())->fixingEndDate();
+        latestRelevantDate_ = latestDate_ =
+            discountHandle_.empty() ? std::max(lastPaymentDate, fixingEndDate) : fixingEndDate;
         switch (pillarChoice_) {
           case Pillar::MaturityDate:
             pillarDate_ = maturityDate_;


### PR DESCRIPTION
…Curve

If the provided discountCurve is exogenous, the latestRelevantDate for a fixed floating swap RateHelper should be the latest date of the projected fixings, as the termstructure being built is only used for projection. If the discountCurve is the same as the projection curve the latestRelevantDate should be the maximum of the latest payment date and the latest date of the projected fixings, taking into account that this curve will be used for both discounting and projection.

Improve error handling in BlackIborCouponPricer so that a paymentDate beyond the maxDate of the provided termstructure does not throw if discount_ is not needed