### PR TITLE
Inherit  ForwardRateStructure from ZeroYieldStructure

### DIFF
--- a/ql/termstructures/yield/forwardstructure.cpp
+++ b/ql/termstructures/yield/forwardstructure.cpp
@@ -24,7 +24,7 @@
 namespace QuantLib {
 
     ForwardRateStructure::ForwardRateStructure(const DayCounter& dc)
-    : YieldTermStructure(dc) {}
+    : ZeroYieldStructure(dc) {}
 
     ForwardRateStructure::ForwardRateStructure(
                                     const Date& refDate,
@@ -32,7 +32,7 @@ namespace QuantLib {
                                     const DayCounter& dc,
                                     const std::vector<Handle<Quote> >& jumps,
                                     const std::vector<Date>& jumpDates)
-    : YieldTermStructure(refDate, cal, dc, jumps, jumpDates) {}
+    : ZeroYieldStructure(refDate, cal, dc, jumps, jumpDates) {}
 
     ForwardRateStructure::ForwardRateStructure(
                                     Natural settlDays,
@@ -40,7 +40,7 @@ namespace QuantLib {
                                     const DayCounter& dc,
                                     const std::vector<Handle<Quote> >& jumps,
                                     const std::vector<Date>& jumpDates)
-    : YieldTermStructure(settlDays, cal, dc, jumps, jumpDates) {}
+    : ZeroYieldStructure(settlDays, cal, dc, jumps, jumpDates) {}
 
     Rate ForwardRateStructure::zeroYieldImpl(Time t) const {
         if (t == 0.0)

--- a/ql/termstructures/yield/forwardstructure.hpp
+++ b/ql/termstructures/yield/forwardstructure.hpp
@@ -26,14 +26,16 @@
 #ifndef quantlib_forward_structure_hpp
 #define quantlib_forward_structure_hpp
 
-#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/yield/zeroyieldstructure.hpp>
 
 namespace QuantLib {
 
     //! %Forward-rate term structure
     /*! This abstract class acts as an adapter to YieldTermStructure allowing
         the programmer to implement only the <tt>forwardImpl(Time)</tt> method
-        in derived classes.
+        in derived classes. However, it is strongly recommended to provide an
+        efficient implementation of <tt>zeroYieldImpl(Time)</tt> as well if
+        possible.
 
         Zero yields and discounts are calculated from forwards.
 
@@ -41,7 +43,7 @@ namespace QuantLib {
 
         \ingroup yieldtermstructures
     */
-    class ForwardRateStructure : public YieldTermStructure {
+    class ForwardRateStructure : public ZeroYieldStructure {
       public:
         /*! \name Constructors
             See the TermStructure documentation for issues regarding
@@ -85,28 +87,9 @@ namespace QuantLib {
                      Derived classes should override it if a more efficient
                      implementation is available.
         */
-        virtual Rate zeroYieldImpl(Time) const;
-        //@}
-
-        //! \name YieldTermStructure implementation
-        //@{
-        /*! Returns the discount factor for the given date calculating it
-            from the zero rate as \f$ d(t) = \exp \left( -z(t) t \right) \f$
-        */
-        DiscountFactor discountImpl(Time) const override;
+        Rate zeroYieldImpl(Time) const override;
         //@}
     };
-
-
-    // inline definitions
-
-    inline DiscountFactor ForwardRateStructure::discountImpl(Time t) const {
-        if (t == 0.0)     // this acts as a safe guard in cases where
-            return 1.0;   // zeroYieldImpl(0.0) would throw.
-
-        Rate r = zeroYieldImpl(t);
-        return DiscountFactor(std::exp(-r*t));
-    }
 
 }
 

--- a/ql/termstructures/yield/zerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/zerospreadedtermstructure.hpp
@@ -67,9 +67,6 @@ namespace QuantLib {
       protected:
         //! returns the spreaded zero yield rate
         Rate zeroYieldImpl(Time) const override;
-        //! returns the spreaded forward rate
-        /* This method must disappear should the spread become a curve */
-        Rate forwardImpl(Time) const;
       private:
         Handle<YieldTermStructure> originalCurve_;
         Handle<Quote> spread_;
@@ -138,11 +135,6 @@ namespace QuantLib {
                                   zeroRate.compounding(),
                                   zeroRate.frequency());
         return spreadedRate.equivalentRate(Continuous, NoFrequency, t);
-    }
-
-    inline Rate ZeroSpreadedTermStructure::forwardImpl(Time t) const {
-        return originalCurve_->forwardRate(t, t, comp_, freq_, true)
-            + spread_->value();
     }
 
 }


### PR DESCRIPTION
Instead of duplicating its code. This is effectively a public API because users are encouraged to override `zeroYieldImpl` with an efficient implementation.

Also, delete dead `forwardImpl` in ZeroSpreadedTermStructure. This method is never called because the class is not a ForwardRateStructure.