### PR TITLE
  Fix potential dangling reference in MultiCubicSpline

### DIFF
--- a/ql/math/interpolations/multicubicspline.hpp
+++ b/ql/math/interpolations/multicubicspline.hpp
@@ -493,7 +493,7 @@ namespace QuantLib {
       private:
         const SplineGrid &grid_;
         const data_table &y_;
-        const std::vector<bool> &ae_;
+        const std::vector<bool> ae_;
         mutable return_type a_, b_, a2_, b2_;
         mutable output_data v_, v1_, v2_;
         mutable result_type res_;


### PR DESCRIPTION
This PR fixes issue #2183 by changing the 'ae_' member from a reference to a value type.

  The problem was that ae_ was declared as const std::vector<bool> &ae_ but initialized with a temporary default parameter `std::vector<bool>(20, false)`. This creates a dangling reference when the
   constructor is called without the third argument.

  **Changes:**
  - Changed const std::vector<bool> &ae_ to const std::vector<bool> ae_ in the private member section
  - This ensures the vector is properly copied into the object instead of holding a reference to a temporary

  **Testing:**
  - Existing tests continue to pass as the change is backward compatible
  - The fix eliminates potential undefined behavior when using default parameters