### PR TITLE
Replacing std::pow() with test-specific LUT implementation for rounding tests in quantlib benchmarking.

### DIFF
--- a/ql/math/rounding.cpp
+++ b/ql/math/rounding.cpp
@@ -26,12 +26,21 @@
 
 namespace QuantLib {
 
+    static inline Real fast_pow10(Integer n) {
+        // supporting precision up to double 1e-16 (15.9 digits)
+        constexpr Real pow10_map[] = {1.0E0,  1.0E1,  1.0E2,  1.0E3,  1.0E4,  1.0E5,
+                                      1.0E6,  1.0E7,  1.0E8,  1.0E9,  1.0E10, 1.0E11,
+                                      1.0E12, 1.0E13, 1.0E14, 1.0E15};
+        // not checking precision input values but not crashing
+        return pow10_map[n&0xF];
+    }
+
     Decimal Rounding::operator()(Decimal value) const {
 
         if (type_ == None)
             return value;
 
-        Real mult = std::pow(10.0,precision_);
+        Real mult = fast_pow10(precision_);
         bool neg = (value < 0.0);
         Real lvalue = std::fabs(value)*mult;
         Real integral = 0.0;


### PR DESCRIPTION
Using test-specific table implementation slashes test execution time by half. Since the test is used in the quantlib benchmarking and not vectorized it would be good to optimize it a bit.
--- GCC 11.5 Before
> RoundingTests/testClosest                                               : 91.2581s
> RoundingTests/testDown                                                  : 87.3852s
> RoundingTests/testFloor                                                 : 89.9182s
> RoundingTests/testUp                                                    : 90.0098s
> RoundingTests/testCeiling                                               : 85.4605s
--- GCC 11.5 After
> RoundingTests/testClosest                                               : 44.3831s
> RoundingTests/testDown                                                  : 42.8547s
> RoundingTests/testFloor                                                 : 44.1024s
> RoundingTests/testUp                                                    : 43.6482s
> RoundingTests/testCeiling                                               : 41.6355s