### PR TITLE
Refactor LocalBootstrap's PenaltyFunction

### DIFF
--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -28,7 +28,6 @@
 
 #include <ql/patterns/lazyobject.hpp>
 #include <ql/termstructures/iterativebootstrap.hpp>
-#include <ql/termstructures/localbootstrap.hpp>
 #include <ql/termstructures/yield/bootstraptraits.hpp>
 #include <utility>
 
@@ -183,7 +182,6 @@ namespace QuantLib {
         // it would increase the complexity---which is high enough
         // already.
         friend class Bootstrap<this_curve>;
-        friend class PenaltyFunction<this_curve>;
         Bootstrap<this_curve> bootstrap_;
     };
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -41,6 +41,7 @@
 #include <ql/quotes/simplequote.hpp>
 #include <ql/termstructures/globalbootstrap.hpp>
 #include <ql/termstructures/globalbootstrapvars.hpp>
+#include <ql/termstructures/localbootstrap.hpp>
 #include <ql/termstructures/yield/bondhelpers.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/termstructures/yield/oisratehelper.hpp>


### PR DESCRIPTION
So that it does not pollute global namespace and does not need to be a friend of PiecewiseYieldCurve.