### PR TITLE
Cleanup includes in interpolated curves

### DIFF
--- a/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
@@ -29,7 +29,6 @@
 #include <ql/termstructures/inflationtermstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
-#include <ql/math/comparison.hpp>
 #include <utility>
 
 namespace QuantLib {

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -28,7 +28,6 @@
 #include <ql/termstructures/inflationtermstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
-#include <ql/math/comparison.hpp>
 #include <utility>
 
 namespace QuantLib {

--- a/ql/termstructures/interpolatedcurve.hpp
+++ b/ql/termstructures/interpolatedcurve.hpp
@@ -24,6 +24,7 @@
 #ifndef quantlib_interpolated_curve_hpp
 #define quantlib_interpolated_curve_hpp
 
+#include <ql/math/comparison.hpp>
 #include <ql/math/interpolation.hpp>
 #include <ql/time/date.hpp>
 #include <ql/time/daycounter.hpp>

--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -30,7 +30,6 @@
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/math/interpolations/loginterpolation.hpp>
-#include <ql/math/comparison.hpp>
 #include <utility>
 
 namespace QuantLib {

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -29,7 +29,6 @@
 #include <ql/termstructures/yield/forwardstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/math/interpolations/backwardflatinterpolation.hpp>
-#include <ql/math/comparison.hpp>
 #include <utility>
 
 namespace QuantLib {

--- a/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
+++ b/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
@@ -26,8 +26,6 @@
 #ifndef quantlib_zero_curve_simple_hpp
 #define quantlib_zero_curve_simple_hpp
 
-#include <ql/math/comparison.hpp>
-#include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/utilities/dataformatters.hpp>

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -30,7 +30,6 @@
 #include <ql/termstructures/interpolatedcurve.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/interestrate.hpp>
-#include <ql/math/comparison.hpp>
 #include <ql/utilities/dataformatters.hpp>
 #include <utility>
 


### PR DESCRIPTION
Include ql/math/comparison.hpp in interpolatedcurve.hpp, where it is actually used, instead of in the files that include interpolatedcurve.hpp.