### PR TITLE
Allow creating PiecewiseZeroInflationCurve before baseDate is known

### DIFF
--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -76,11 +76,7 @@ namespace QuantLib {
         virtual Rate baseRate() const;
 
         //! minimum (base) date
-        /*! The last date for which we have information.
-
-            When not set directly (the recommended option), it is
-            calculated base on an observation lag relative to today.
-        */
+        /*! The last date for which we have information. */
         virtual Date baseDate() const;
 
         /*! \deprecated Do not use; inflation curves always have an explicit
@@ -117,8 +113,7 @@ namespace QuantLib {
 
         Frequency frequency_;
         mutable Rate baseRate_;
-
-      private:
+        // Can be set by subclasses that don't have baseDate available in constructors.
         Date baseDate_;
     };
 


### PR DESCRIPTION
QuantLib's yield curves can be created before fetching market data, which allows creating complex object graphs ahead of time and setting market data (quotes and fixings) at a later stage. We use this feature extensively in our code.

The new API for PiecewiseZeroInflationCurve does not offer the same flexibility, since it requires baseDate to be set at the curve creation time. BaseDate comes from inflation fixings, which means that the fixings have to be fetched before the curve can be created.

Add another constructor for PiecewiseZeroInflationCurve, which takes a function that returns the baseDate. This function will be called during the curve's bootstrap, and the result will be cached. This allows one to construct PiecewiseZeroInflationCurve first and fetch the fixings at a later stage.