### PR TITLE
Use double for constexpr to maintain AAD compatibility

### DIFF
--- a/ql/math/rounding.cpp
+++ b/ql/math/rounding.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
 
     static inline Real fast_pow10(Integer precision) {
         // Providing support for truncating up to 16 decimal places after dot
-        constexpr static Real pow10_lut[0x20] = {
+        constexpr static double pow10_lut[0x20] = {
             1.0E0,  1.0E1,  1.0E2,  1.0E3,  1.0E4,  1.0E5,
             1.0E6,  1.0E7,  1.0E8,  1.0E9,  1.0E10, 1.0E11,
             1.0E12, 1.0E13, 1.0E14, 1.0E15, 1.0E16


### PR DESCRIPTION
To allow `Real` to be types other than `double`, including AAD active datatypes, which might not have a `constexpr` constructor, this uses `double` explicitly for the power of 10 lookup table. 

As the table is `constexpr`, this comes at no cost and will also work well with non-double `Real` datatypes.

Note: This fixes the [QuantLib-Risks-Cpp pipeline](https://github.com/auto-differentiation/QuantLib-Risks-Cpp/actions/workflows/ci.yaml) using AAD.