### PR TITLE
Deprecate `growthOnly` parameter in CPI bond and helper

### DIFF
--- a/ql/instruments/bonds/cpibond.cpp
+++ b/ql/instruments/bonds/cpibond.cpp
@@ -33,6 +33,29 @@
 
 namespace QuantLib {
 
+    QL_DEPRECATED_DISABLE_WARNING
+
+    CPIBond::CPIBond(Natural settlementDays,
+                     Real faceAmount,
+                     Real baseCPI,
+                     const Period& observationLag,
+                     ext::shared_ptr<ZeroInflationIndex> cpiIndex,
+                     CPI::InterpolationType observationInterpolation,
+                     Schedule schedule,
+                     const std::vector<Rate>& fixedRate,
+                     const DayCounter& accrualDayCounter,
+                     BusinessDayConvention paymentConvention,
+                     const Date& issueDate,
+                     const Calendar& paymentCalendar,
+                     const Period& exCouponPeriod,
+                     const Calendar& exCouponCalendar,
+                     const BusinessDayConvention exCouponConvention,
+                     bool exCouponEndOfMonth)
+    : CPIBond(settlementDays, faceAmount, false, baseCPI, observationLag, cpiIndex,
+              observationInterpolation, schedule, fixedRate, accrualDayCounter,
+              paymentConvention, issueDate, paymentCalendar, exCouponPeriod,
+              exCouponCalendar, exCouponConvention, exCouponEndOfMonth) {}
+
     CPIBond::CPIBond(Natural settlementDays,
                      Real faceAmount,
                      bool growthOnly,
@@ -59,7 +82,6 @@ namespace QuantLib {
 
         maturityDate_ = schedule.endDate();
 
-        // a CPIleg know about zero legs and inclusion of base inflation notional
         cashflows_ = CPILeg(std::move(schedule), cpiIndex_,
                             baseCPI_, observationLag_)
             .withNotionals(faceAmount)
@@ -85,4 +107,7 @@ namespace QuantLib {
             registerWith(*i);
         }
     }
+
+    QL_DEPRECATED_ENABLE_WARNING
+
 }

--- a/ql/instruments/bonds/cpibond.hpp
+++ b/ql/instruments/bonds/cpibond.hpp
@@ -44,6 +44,27 @@ namespace QuantLib {
       public:
         CPIBond(Natural settlementDays,
                 Real faceAmount,
+                Real baseCPI,
+                const Period& observationLag,
+                ext::shared_ptr<ZeroInflationIndex> cpiIndex,
+                CPI::InterpolationType observationInterpolation,
+                Schedule schedule,
+                const std::vector<Rate>& coupons,
+                const DayCounter& accrualDayCounter,
+                BusinessDayConvention paymentConvention = ModifiedFollowing,
+                const Date& issueDate = Date(),
+                const Calendar& paymentCalendar = Calendar(),
+                const Period& exCouponPeriod = Period(),
+                const Calendar& exCouponCalendar = Calendar(),
+                BusinessDayConvention exCouponConvention = Unadjusted,
+                bool exCouponEndOfMonth = false);
+
+        /*! \deprecated Use the overload without the growthOnly parameter.
+                        Deprecated in version 1.40.
+        */
+        [[deprecated("Use the overload without the growthOnly parameter")]]
+        CPIBond(Natural settlementDays,
+                Real faceAmount,
                 bool growthOnly,
                 Real baseCPI,
                 const Period& observationLag,

--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -78,8 +78,6 @@ namespace QuantLib {
     }
 
 
-    QL_DEPRECATED_DISABLE_WARNING
-
     FixedRateBondHelper::FixedRateBondHelper(
                                     const Handle<Quote>& price,
                                     Natural settlementDays,
@@ -104,8 +102,6 @@ namespace QuantLib {
                                                  exCouponConvention, exCouponEndOfMonth),
                  priceType) {}
 
-    QL_DEPRECATED_ENABLE_WARNING
-
     void FixedRateBondHelper::accept(AcyclicVisitor& v) {
         auto* v1 = dynamic_cast<Visitor<FixedRateBondHelper>*>(&v);
         if (v1 != nullptr)
@@ -116,6 +112,31 @@ namespace QuantLib {
 
 
     QL_DEPRECATED_DISABLE_WARNING
+
+    CPIBondHelper::CPIBondHelper(
+                            const Handle<Quote>& price,
+                            Natural settlementDays,
+                            Real faceAmount,
+                            Real baseCPI,
+                            const Period& observationLag,
+                            const ext::shared_ptr<ZeroInflationIndex>& cpiIndex,
+                            CPI::InterpolationType observationInterpolation,
+                            Schedule schedule,
+                            const std::vector<Rate>& fixedRate,
+                            const DayCounter& accrualDayCounter,
+                            BusinessDayConvention paymentConvention,
+                            const Date& issueDate,
+                            const Calendar& paymentCalendar,
+                            const Period& exCouponPeriod,
+                            const Calendar& exCouponCalendar,
+                            const BusinessDayConvention exCouponConvention,
+                            bool exCouponEndOfMonth,
+                            const Bond::Price::Type priceType)
+    : CPIBondHelper(price, settlementDays, faceAmount, false, baseCPI, observationLag,
+                    cpiIndex, observationInterpolation, std::move(schedule), fixedRate,
+                    accrualDayCounter, paymentConvention, issueDate, paymentCalendar,
+                    exCouponPeriod, exCouponCalendar, exCouponConvention, exCouponEndOfMonth,
+                    priceType) {}
 
     CPIBondHelper::CPIBondHelper(
                             const Handle<Quote>& price,
@@ -138,11 +159,12 @@ namespace QuantLib {
                             bool exCouponEndOfMonth,
                             const Bond::Price::Type priceType)
     : BondHelper(price,
-                 ext::make_shared<CPIBond>(settlementDays, faceAmount, growthOnly, baseCPI,
+                 // make_shared and deprecation interfere; restore later
+                 ext::shared_ptr<Bond>(new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI,
                                            observationLag, cpiIndex, observationInterpolation,
                                            std::move(schedule), fixedRate, accrualDayCounter, paymentConvention,
                                            issueDate, paymentCalendar, exCouponPeriod, exCouponCalendar,
-                                           exCouponConvention, exCouponEndOfMonth),
+                                           exCouponConvention, exCouponEndOfMonth)),
                  priceType) {}
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/termstructures/yield/bondhelpers.hpp
+++ b/ql/termstructures/yield/bondhelpers.hpp
@@ -103,6 +103,29 @@ namespace QuantLib {
         CPIBondHelper(const Handle<Quote>& price,
                       Natural settlementDays,
                       Real faceAmount,
+                      Real baseCPI,
+                      const Period& observationLag,
+                      const ext::shared_ptr<ZeroInflationIndex>& cpiIndex,
+                      CPI::InterpolationType observationInterpolation,
+                      Schedule schedule,
+                      const std::vector<Rate>& fixedRate,
+                      const DayCounter& accrualDayCounter,
+                      BusinessDayConvention paymentConvention = Following,
+                      const Date& issueDate = Date(),
+                      const Calendar& paymentCalendar = Calendar(),
+                      const Period& exCouponPeriod = Period(),
+                      const Calendar& exCouponCalendar = Calendar(),
+                      BusinessDayConvention exCouponConvention = Unadjusted,
+                      bool exCouponEndOfMonth = false,
+                      Bond::Price::Type priceType = Bond::Price::Clean);
+
+        /*! \deprecated Use the overload without the growthOnly parameter.
+                        Deprecated in version 1.40.
+        */
+        [[deprecated("Use the overload without the growthOnly parameter")]]
+        CPIBondHelper(const Handle<Quote>& price,
+                      Natural settlementDays,
+                      Real faceAmount,
                       bool growthOnly,
                       Real baseCPI,
                       const Period& observationLag,

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -173,7 +173,6 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
     Period contractObservationLag = Period(3,Months);
     CPI::InterpolationType observationInterpolation = CPI::Flat;
     Natural settlementDays = 3;
-    bool growthOnly = false;
 
     Real baseCPI = 206.1;
     // set the schedules
@@ -186,7 +185,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
                       .withConvention(Unadjusted)
                       .backwards();
 
-    CPIBond bond(settlementDays, notional, growthOnly,
+    CPIBond bond(settlementDays, notional,
                  baseCPI, contractObservationLag, fixedIndex,
                  observationInterpolation, fixedSchedule,
                  fixedRates, fixedDayCount, fixedPaymentConvention);

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
     Period contractObservationLag = Period(3,Months);
     CPI::InterpolationType observationInterpolation = CPI::Flat;
     Natural settlementDays = 3;
-    bool growthOnly = true;
+    bool growthOnly = false;
 
     Real baseCPI = 206.1;
     // set the schedules
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
     auto engine = ext::make_shared<DiscountingBondEngine>(common.yTS);
     bond.setPricingEngine(engine);
 
-    Real storedPrice = 384.71666770;
+    Real storedPrice = 396.45920973;
     Real calculated = bond.dirtyPrice();
     Real tolerance = 1.0e-8;
     if (std::fabs(calculated-storedPrice) > tolerance) {
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
                    << "\n  calculated: " << calculated);
     }
 
-    storedPrice = 383.04297558;
+    storedPrice = 394.78551761;
     calculated = bond.cleanPrice();
     if (std::fabs(calculated-storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(testCPILegWithoutBaseCPI) {
     Period contractObservationLag = Period(3, Months);
     CPI::InterpolationType observationInterpolation = CPI::Flat;
     Natural settlementDays = 3;
-    bool growthOnly = true;
+    bool growthOnly = false;
     Real baseCPI = 206.1;
     // set the schedules
     Date baseDate(1, July, 2007);
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(testCPILegWithoutBaseCPI) {
                    << "\n clean npv of leg with explicit baseCPI: " << cleanPriceWithBaseCPI);
     }
     // Compare to expected price
-    Real storedPrice = 383.04297558;
+    Real storedPrice = 394.78551761;
     if (std::fabs(cleanPriceWithBaseDate - storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
                    << std::fixed << std::setprecision(12) << "\n  expected:   " << storedPrice

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -409,11 +409,9 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
 
     CommonVars common;
 
-    // ZeroInflationSwap aka CPISwap
-
     Swap::Type type = Swap::Payer;
     Real nominal = 1000000.0;
-    bool subtractInflationNominal = true;
+    bool subtractInflationNominal = false;
     // float+spread leg
     Spread spread = 0.0;
     DayCounter floatDayCount = Actual365Fixed();
@@ -480,7 +478,7 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
     // now do the bond equivalent
     std::vector<Rate> fixedRates(1,fixedRate);
     Natural settlementDays = 1;// cannot be zero!
-    bool growthOnly = true;
+    bool growthOnly = false;
     CPIBond cpiB(settlementDays, nominal, growthOnly,
                  baseCPI, contractObservationLag, fixedIndex,
                  observationInterpolation, fixedSchedule,

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -237,6 +237,12 @@ struct CommonVars {
         // make sure that the index has the latest zero inflation term structure
         hcpi.linkTo(pCPIts);
     }
+
+    // teardown
+    ~CommonVars() {
+        // break circular references and allow curves to be destroyed
+        hcpi.reset();
+    }
 };
 
 
@@ -346,9 +352,6 @@ BOOST_AUTO_TEST_CASE(consistency) {
 
     QL_REQUIRE(diff<max_diff,
                "failed stored consistency value test, ratio = " << diff);
-
-    // remove circular refernce
-    common.hcpi.reset();
 }
 
 BOOST_AUTO_TEST_CASE(zciisconsistency) {
@@ -400,8 +403,6 @@ BOOST_AUTO_TEST_CASE(zciisconsistency) {
     for (Size i=0; i<2; i++) {
         QL_REQUIRE(fabs(cS.legNPV(i)-zciis.legNPV(i))<1e-3,"zciis leg does not equal CPISwap leg");
     }
-    // remove circular refernce
-    common.hcpi.reset();
 }
 
 BOOST_AUTO_TEST_CASE(cpibondconsistency) {
@@ -478,8 +479,7 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
     // now do the bond equivalent
     std::vector<Rate> fixedRates(1,fixedRate);
     Natural settlementDays = 1;// cannot be zero!
-    bool growthOnly = false;
-    CPIBond cpiB(settlementDays, nominal, growthOnly,
+    CPIBond cpiB(settlementDays, nominal,
                  baseCPI, contractObservationLag, fixedIndex,
                  observationInterpolation, fixedSchedule,
                  fixedRates, fixedDayCount, fixedPaymentConvention);
@@ -488,8 +488,6 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
     cpiB.setPricingEngine(dbe);
 
     QL_REQUIRE(fabs(cpiB.NPV() - zisV.legNPV(0))<1e-5,"cpi bond does not equal equivalent cpi swap leg");
-    // remove circular reference
-    common.hcpi.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
It was probably added because CPICashFlow allows it, and that in turn because it was needed for CPI swaps.  But it doesn't seem to make sense for CPI bonds.