### PR TITLE
Fixing naming and styles in pull request #2315 (perpetual futures)

### DIFF
--- a/ql/pricingengines/futures/discountingperpetualfuturesengine.hpp
+++ b/ql/pricingengines/futures/discountingperpetualfuturesengine.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
             const Array fundingRates,
             const Array interestRateDiffs,
             const InterpolationType fundingInterpType = PiecewiseConstant,
-            const Real maxT_ = 60.);
+            const Real maxT = 60.);
         void calculate() const override;
         Handle<YieldTermStructure> domesticDiscountCurve() const { return domesticDiscountCurve_; }
         Handle<YieldTermStructure> foreignDiscountCurve() const { return foreignDiscountCurve_; }

--- a/test-suite/perpetualfutures.cpp
+++ b/test-suite/perpetualfutures.cpp
@@ -35,19 +35,19 @@ BOOST_AUTO_TEST_SUITE(PerpetualFuturesTests)
 
 #undef REPORT_FAILURE
 #define REPORT_FAILURE(greekName, payoffType, fundingType, fundingFreq, s, r, q, k, iDiff, today, \
-                       expected, calculated, relError, tolerance)                               \
-    BOOST_FAIL(payoffType                                                                    \
-               << " perpetual futures with " << fundingType << " funding type:\n"  \
-               << "    spot value:                      " << s << "\n"                                      \
-               << "    risk-free rate:                  " << r << "\n"                            \
-               << "    asset yield:                     " << q << "\n"                            \
-               << "    funding rate:                    " << k << "\n"                            \
-               << "    interest rate differential:      " << iDiff << "\n"                       \
-               << "    funding frequency:               " << fundingFreq << "\n"                       \
-               << "    reference date:                  " << today << "\n"                                  \
-               << "    expected   " << greekName << ": " << expected << "\n"                 \
-               << "    calculated " << greekName << ": " << calculated << "\n"               \
-               << "    rel error: " << relError << "\n"                                  \
+                       expected, calculated, relError, tolerance) \
+    BOOST_FAIL(payoffType \
+               << " perpetual futures with " << fundingType << " funding type:\n" \
+               << "    spot value:                      " << s << "\n" \
+               << "    risk-free rate:                  " << r << "\n" \
+               << "    asset yield:                     " << q << "\n" \
+               << "    funding rate:                    " << k << "\n" \
+               << "    interest rate differential:      " << iDiff << "\n" \
+               << "    funding frequency:               " << fundingFreq << "\n" \
+               << "    reference date:                  " << today << "\n" \
+               << "    expected   " << greekName << ": " << expected << "\n" \
+               << "    calculated " << greekName << ": " << calculated << "\n" \
+               << "    rel error: " << relError << "\n" \
                << "    tolerance: " << tolerance << "\n");
 
 struct PerpetualFuturesData {


### PR DESCRIPTION
Apologies but found a naming error in the last pull request #2315 (`maxT_` → `maxT` in a parameter of a constructor).