### PR TITLE
Add Singapore public holidays for 2025

### DIFF
--- a/ql/time/calendars/singapore.cpp
+++ b/ql/time/calendars/singapore.cpp
@@ -217,6 +217,20 @@ namespace QuantLib {
                 || (d == 31 && m == October))
                 return false;
         }
+        
+        // https://api2.sgx.com/sites/default/files/2025-07/DT%20Trading%20Calendar%202025%20%28updated%2031%20Jul%202025%29.pdf
+        if (y == 2025)
+        {
+            if (// Chinese New Year
+                ((d == 29 || d == 30) && m == January)
+                // Hari Raya Puasa
+                || (d == 31 && m == March)
+                // Vesak Poya Day
+                || (d == 12 && m == May)
+                // Deepavali
+                || (d == 20 && m == October))
+                return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
**Summary**
This PR adds the official Singapore public holidays for 2025 to the Singapore calendar implementation in QuantLib.

**Changes Made**

- Added 2025 holiday dates to ql/time/calendars/singapore.cpp
- Updated the calendar implementation to recognize the following Singapore public holidays for 2025:
- Chinese New Year: January 29-30, 2025 (Wednesday-Thursday)
- Hari Raya Puasa (Eid al-Fitr): March 31, 2025
- Vesak Day: May 12, 2025
- Deepavali: October 20, 2025

**Implementation Details**

- Follows the existing pattern used for previous years (2019-2024)
- Added year-specific block for 2025 holidays in the isBusinessDay method
- Includes reference to SGX trading calendar documentation