### PR TITLE
Correct days in Thirty365 dayCount calculation

### DIFF
--- a/ql/time/daycounters/thirty365.cpp
+++ b/ql/time/daycounters/thirty365.cpp
@@ -27,7 +27,7 @@ namespace QuantLib {
         Integer mm1 = d1.month(), mm2 = d2.month();
         Year yy1 = d1.year(), yy2 = d2.year();
 
-        return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
+        return 365*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
     }
 
     Thirty365::Thirty365()


### PR DESCRIPTION
It seems the Thirty365 calculation actually uses 30/360 logic instead of using 365 as the number of days in the year.

I've changed that one value in `dayCount()` accordingly to fix it.