### PR TITLE
Improvement to Latent model execution time

### DIFF
--- a/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
+++ b/ql/experimental/credit/defaultprobabilitylatentmodel.hpp
@@ -29,15 +29,15 @@ namespace QuantLib {
 
     /*! \brief Default event Latent Model.
 
-     This is a model for joint default events based on a generic Latent 
-      Model. It models solely the default events in a portfolio, not making any 
+     This is a model for joint default events based on a generic Latent
+      Model. It models solely the default events in a portfolio, not making any
       reference to severities, exposures, etc...
      An implicit correspondence is stablished between the variables modelled and
-     the names in the basket given by the basket and model variable access 
+     the names in the basket given by the basket and model variable access
      indices.
      The class is parametric on the Latent Model copula.
 
-     \todo Consider QL_REQUIRE(basket_, "No portfolio basket set.") test in 
+     \todo Consider QL_REQUIRE(basket_, "No portfolio basket set.") test in
      debug model only for performance reasons.
     */
     template<class copulaPolicy>
@@ -52,7 +52,7 @@ namespace QuantLib {
         using LatentModel<copulaPolicy>::cumulativeZ;
         using LatentModel<copulaPolicy>::integratedExpectedValue;// which one?
     protected:
-        // not a handle, the model doesnt keep any cached magnitudes, no need 
+        // not a handle, the model doesnt keep any cached magnitudes, no need
         //  for notifications, still...
         mutable ext::shared_ptr<Basket> basket_;
         ext::shared_ptr<LMIntegration> integration_;
@@ -60,7 +60,7 @@ namespace QuantLib {
         typedef typename copulaPolicy::initTraits initTraits;
     public:
         /*!
-        @param factorWeights Latent model independent factors weights for each 
+        @param factorWeights Latent model independent factors weights for each
             variable.
         @param integralType Integration type.
         @param ini Copula initialization if any.
@@ -71,7 +71,7 @@ namespace QuantLib {
             const std::vector<std::vector<Real> >& factorWeights,
             LatentModelIntegrationType::LatentModelIntegrationType integralType,
             const initTraits& ini = initTraits()
-            ) 
+            )
         : LatentModel<copulaPolicy>(factorWeights, ini),
           integration_(LatentModel<copulaPolicy>::IntegrationFactory::
             createLMIntegration(factorWeights[0].size(), integralType))
@@ -87,17 +87,17 @@ namespace QuantLib {
             createLMIntegration(1, integralType))
         { }
         /* \todo
-            Add other constructors as in LatentModel for ease of use. (less 
+            Add other constructors as in LatentModel for ease of use. (less
             dimensions, factors, etcc...)
         */
 
-        /* To interface with loss models. It is possible to change the basket 
+        /* To interface with loss models. It is possible to change the basket
         since there are no cached magnitudes.
         */
         void resetBasket(const ext::shared_ptr<Basket>& basket) const {
             basket_ = basket;
             // in the future change 'size' to 'liveSize'
-            QL_REQUIRE(basket_->size() == factorWeights_.size(), 
+            QL_REQUIRE(basket_->size() == factorWeights_.size(),
                 "Incompatible new basket and model sizes.");
         }
 
@@ -112,7 +112,7 @@ namespace QuantLib {
         cumulative inversion.
         */
         Probability conditionalDefaultProbability(Probability prob, Size iName,
-            const std::vector<Real>& mktFactors) const 
+            const std::vector<Real>& mktFactors) const
         {
             // we can be called from the outside (from an integrable loss model)
             //   but we are called often at integration points. This or
@@ -143,24 +143,24 @@ namespace QuantLib {
         Same intention as above but provides a performance opportunity, if the
         integration is along the market factors (as usually is) avoids computing
         the inverse of the probability on each call.
-        @param invCumYProb Inverse cumul of the unconditional probability of 
+        @param invCumYProb Inverse cumul of the unconditional probability of
           default, has to follow the same copula law for results to be coherent
         @param iName desired name.
         @param m Value of LM independent factors.
         */
-        Probability conditionalDefaultProbabilityInvP(Real invCumYProb, 
-            Size iName, 
+        Probability conditionalDefaultProbabilityInvP(Real invCumYProb,
+            Size iName,
             const std::vector<Real>& m) const {
-            Real sumMs = 
-                std::inner_product(factorWeights_[iName].begin(), 
+            Real sumMs =
+                std::inner_product(factorWeights_[iName].begin(),
                     factorWeights_[iName].end(), m.begin(), Real(0.));
-            Real res = cumulativeZ((invCumYProb - sumMs) / 
+            Real res = cumulativeZ((invCumYProb - sumMs) /
                     idiosyncFctrs_[iName] );
             #if defined(QL_EXTRA_SAFETY_CHECKS)
             QL_REQUIRE (res >= 0. && res <= 1.,
                         "conditional probability " << res << "out of range");
             #endif
-        
+
             return res;
         }
     protected:
@@ -177,7 +177,7 @@ namespace QuantLib {
         outside the call.
         */
         Probability conditionalDefaultProbability(const Date& date, Size iName,
-            const std::vector<Real>& mktFactors) const 
+            const std::vector<Real>& mktFactors) const
         {
             const ext::shared_ptr<Pool>& pool = basket_->pool();
             Probability pDefUncond =
@@ -186,15 +186,15 @@ namespace QuantLib {
                   ->defaultProbability(date);
             return conditionalDefaultProbability(pDefUncond, iName, mktFactors);
         }
-        /*! Conditional default probability product, intermediate step in the 
+        /*! Conditional default probability product, intermediate step in the
             correlation calculation.*/
-        Probability condProbProduct(Real invCumYProb1, Real invCumYProb2, 
-            Size iName1, Size iName2, 
+        Probability condProbProduct(Real invCumYProb1, Real invCumYProb2,
+            Size iName1, Size iName2,
             const std::vector<Real>& mktFactors) const {
-            return 
-                conditionalDefaultProbabilityInvP(invCumYProb1, iName1, 
+            return
+                conditionalDefaultProbabilityInvP(invCumYProb1, iName1,
                     mktFactors) *
-                conditionalDefaultProbabilityInvP(invCumYProb2, iName2, 
+                conditionalDefaultProbabilityInvP(invCumYProb2, iName2,
                     mktFactors);
         }
         //! Conditional probability of n default events or more.
@@ -205,7 +205,7 @@ namespace QuantLib {
         const ext::shared_ptr<LMIntegration>& integration() const override { return integration_; }
 
       public:
-        /*! Computes the unconditional probability of default of a given name. 
+        /*! Computes the unconditional probability of default of a given name.
         Trivial method for testing
         */
         Probability probOfDefault(Size iName, const Date& d) const {
@@ -223,15 +223,15 @@ namespace QuantLib {
                         inverseCumulativeY(pUncond, iName), iName, v1);
                 });
         }
-        /*! Pearsons' default probability correlation. 
+        /*! Pearsons' default probability correlation.
             Users should consider specialization on the copula type for specific
-            distributions since that might simplify the integrations, most 
+            distributions since that might simplify the integrations, most
             importantly if this is to be used in calibration of observations for
             factor coefficients as it is expensive to integrate directly.
         */
         Real defaultCorrelation(const Date& d, Size iNamei, Size iNamej) const;
 
-        /*! Returns the probaility of having a given or larger number of 
+        /*! Returns the probaility of having a given or larger number of
         defaults in the basket portfolio at a given time.
         */
         Probability probAtLeastNEvents(Size n, const Date& date) const {
@@ -246,8 +246,8 @@ namespace QuantLib {
     //---- Defines -----------------------------------------------------------
 
     template<class CP>
-    Real DefaultLatentModel<CP>::defaultCorrelation(const Date& d, 
-        Size iNamei, Size iNamej) const 
+    Real DefaultLatentModel<CP>::defaultCorrelation(const Date& d,
+        Size iNamei, Size iNamej) const
     {
         QL_REQUIRE(basket_, "No portfolio basket set.");
 
@@ -276,14 +276,14 @@ namespace QuantLib {
 
 
     template<class CP>
-    Real DefaultLatentModel<CP>::conditionalProbAtLeastNEvents(Size n, 
+    Real DefaultLatentModel<CP>::conditionalProbAtLeastNEvents(Size n,
         const Date& date,
         const std::vector<Real>& mktFactors) const {
             QL_REQUIRE(basket_, "No portfolio basket set.");
 
-            /* \todo 
+            /* \todo
             This algorithm traverses all permutations starting form the
-            lowest one. This is inneficient, there shouldnt be any need to 
+            lowest one. This is inneficient, there shouldnt be any need to
             go through the invalid ones. Use combinations of n elements.
 
             See integration in O'Kane for homogeneous ntds.
@@ -304,20 +304,28 @@ namespace QuantLib {
                     defaultProbability(date), i, mktFactors));
 
             Probability probNEventsOrMore = 0.;
-            for (auto mask = static_cast<BigNatural>(std::pow(2., (int)(n)) - 1); mask < limit;
-                 mask++) {
-                // cheap permutations
-                boost::dynamic_bitset<> bsetMask(poolSize, mask);
-                if(bsetMask.count() >= n) {
+            // cheap permutations
+            // dynamic_bitset (std::vector) memory manipulations moved out of the hot loop
+            auto mask = static_cast<BigNatural>((1 << (int)(n)) - 1);
+            boost::dynamic_bitset<> bsetMask(poolSize, mask);
+            auto bits_set = bsetMask.count();
+            auto increaseMask = [&]() {
+                for (Size i = 0; i < bsetMask.size(); i++) {
+                    if (bsetMask[i]) {bsetMask[i] = 0; bits_set--;}
+                    else {bsetMask[i] = 1; bits_set++; break;}
+                }
+            };
+            for (; mask < limit; mask++) {
+                if (bits_set >= n) {
                     Probability pConfig = 1;
-                    for(Size i=0; i<bsetMask.size(); i++)
-                        pConfig *= 
-                          (bsetMask[i] ? pDefCond[i] : (1.- pDefCond[i]));
+                    for (Size i = 0; i < bsetMask.size(); i++)
+                        pConfig *= (bsetMask[i] ? pDefCond[i] : (1. - pDefCond[i]));
                     probNEventsOrMore += pConfig;
                 }
+                increaseMask();
             }
             return probNEventsOrMore;
-        }
+    }
 
 
     // often used:


### PR DESCRIPTION
1. Improvement to Latent model execution time and the most heavy testGauss test/benchmark: boost::dynamic_bitset (std::vector) memory manipulations moved out of the hot loop. Times, for example:
<pre>
Before the improvement
NthToDefaultTests/testGauss  : 48.7896s
After the improvement
NthToDefaultTests/testGauss  : 27.3736s
</pre>
2. Trailing spaces removed.