### PR TITLE
Add date adjustment rules for 30/365

### DIFF
--- a/ql/time/daycounters/thirty365.cpp
+++ b/ql/time/daycounters/thirty365.cpp
@@ -27,6 +27,11 @@ namespace QuantLib {
         Integer mm1 = d1.month(), mm2 = d2.month();
         Year yy1 = d1.year(), yy2 = d2.year();
 
+        // date adjustment rules as in ISO 20022
+        // see https://www.iso20022.org/15022/uhb/mt565-16-field-22f.htm
+        if (dd1 == 31) { dd1 = 30; }
+        if (dd2 == 31) { dd2 = 30; }
+
         return 360*(yy2-yy1) + 30*(mm2-mm1) + (dd2-dd1);
     }
 


### PR DESCRIPTION
I noticed end-of-month interest in the 30/365 day count convention didn't seem quite right.

```python
# March 31 -> April 30
>>> ql.Thirty365().yearFraction(ql.Date(31, 3, 2025), ql.Date(30, 4, 2025)) * 365
29.000000000000004  # was expecting 30 days of interest, month-to-month

# September 30 -> March 31
>>> ql.Thirty365().yearFraction(ql.Date(30, 9, 2024), ql.Date(31, 3, 2025)) * 365
181.0  # was expecting 180 days

# March 30 -> March 31
>>> ql.Thirty365().yearFraction(ql.Date(30, 3, 2025), ql.Date(31, 3, 2025)) * 365
1.0  # was expecting no interest to accrue beyond the 30th
```

Here, I'm following [ISO 20022](https://www.iso20022.org/15022/uhb/mt565-16-field-22f.htm) (emphasis mine):
> 30/365: Method whereby interest is calculated based on a 30-day month in a way similar to the 30/360 (basic rule) and a 365-day year. Accrued interest to a value date on the last day of a month shall be the same as to the 30th calendar day of the same month, except for February. **This means that a 31st is assumed to be a 30th and the 28 Feb (or 29 Feb for a leap year) is assumed to be a 28th (or 29th).**

Contrast this with their discussion of 30/360 (emphasis mine):
> This means that a 31st is assumed to be a 30th **if the period started on a 30th or a 31st** and the 28 Feb (or 29 Feb for a leap year) is assumed to be a 28th (or 29th)

As such, I'm basically using the ISDA implementation from 30/360 without the February adjustments.

This is subtle, so please let me know if you have any objections or if the dropping of the date adjustments was intentional.