### PR TITLE
Explicit return type for lambdas to work with expression templates

### DIFF
--- a/ql/pricingengines/futures/discountingperpetualfuturesengine.cpp
+++ b/ql/pricingengines/futures/discountingperpetualfuturesengine.cpp
@@ -201,7 +201,7 @@ namespace QuantLib {
             // continuous-time case
             TrapezoidIntegral<Default> integrator(1.e-6, 30);
             Real fundingRateXMax = fundingRateInterp.xMax();
-            auto expIRDiff = [&fundingRateInterp, &integrator, fundingRateXMax](Real s) {
+            auto expIRDiff = [&fundingRateInterp, &integrator, fundingRateXMax](Real s) -> Real {
                 if (s < fundingRateXMax) {
                     return exp(-integrator(fundingRateInterp, 0., s));
                 } else {
@@ -211,7 +211,7 @@ namespace QuantLib {
             };
 
             auto timeIntegrand = [fundingRateInterp, interestRateDiffInterp, integrator, expIRDiff,
-                                  effDomCurve, effForCurve](Real s) {
+                                  effDomCurve, effForCurve](Real s) -> Real {
                 return (fundingRateInterp(s) - interestRateDiffInterp(s)) * expIRDiff(s)
                        * effForCurve->discount(s) / effDomCurve->discount(s);
             };


### PR DESCRIPTION
This makes the lambda return types explicit, which is required in case `Real` is an expression template type (for example for AAD), as the return type would be inconsistent otherwise. 