### PR TITLE
Add constructors with fixed start and end dates for inflation swap helpers

### DIFF
--- a/ql/termstructures/inflation/inflationhelpers.hpp
+++ b/ql/termstructures/inflation/inflationhelpers.hpp
@@ -42,7 +42,18 @@ namespace QuantLib {
             const Date& maturity,
             Calendar calendar, // index may have null calendar as valid on every day
             BusinessDayConvention paymentConvention,
-            const DayCounter& dayCounter,
+            DayCounter dayCounter,
+            const ext::shared_ptr<ZeroInflationIndex>& zii,
+            CPI::InterpolationType observationInterpolation);
+
+        ZeroCouponInflationSwapHelper(
+            const Handle<Quote>& quote,
+            const Period& swapObsLag, // lag on swap observation of index
+            const Date& startDate,
+            const Date& endDate,
+            Calendar calendar, // index may have null calendar as valid on every day
+            BusinessDayConvention paymentConvention,
+            DayCounter dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& zii,
             CPI::InterpolationType observationInterpolation);
 
@@ -72,7 +83,7 @@ namespace QuantLib {
         void initializeDates() override;
 
         Period swapObsLag_;
-        Date maturity_;
+        Date startDate_, maturity_;
         Calendar calendar_;
         BusinessDayConvention paymentConvention_;
         DayCounter dayCounter_;
@@ -81,6 +92,18 @@ namespace QuantLib {
         ext::shared_ptr<ZeroCouponInflationSwap> zciis_;
         Handle<YieldTermStructure> nominalTermStructure_;
         RelinkableHandle<ZeroInflationTermStructure> termStructureHandle_;
+      private:
+        ZeroCouponInflationSwapHelper(
+            const Handle<Quote>& quote,
+            const Period& swapObsLag,
+            const Date& startDate,
+            const Date& endDate,
+            Calendar calendar,
+            BusinessDayConvention paymentConvention,
+            DayCounter dayCounter,
+            const ext::shared_ptr<ZeroInflationIndex>& zii,
+            CPI::InterpolationType observationInterpolation,
+            Handle<YieldTermStructure> nominalTermStructure);
     };
 
 
@@ -91,6 +114,17 @@ namespace QuantLib {
         YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
                                       const Period& swapObsLag,
                                       const Date& maturity,
+                                      Calendar calendar,
+                                      BusinessDayConvention paymentConvention,
+                                      DayCounter dayCounter,
+                                      const ext::shared_ptr<YoYInflationIndex>& yii,
+                                      CPI::InterpolationType interpolation,
+                                      Handle<YieldTermStructure> nominalTermStructure);
+
+        YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
+                                      const Period& swapObsLag,
+                                      const Date& startDate,
+                                      const Date& endDate,
                                       Calendar calendar,
                                       BusinessDayConvention paymentConvention,
                                       DayCounter dayCounter,
@@ -109,7 +143,7 @@ namespace QuantLib {
         void initializeDates() override;
 
         Period swapObsLag_;
-        Date maturity_;
+        Date startDate_, maturity_;
         Calendar calendar_;
         BusinessDayConvention paymentConvention_;
         DayCounter dayCounter_;


### PR DESCRIPTION
This allows to specify a start date for the swap different from the evaluation date (the assumption of the other constructor).