### PR TITLE
Cleaned up extra semicolon in output loops

### DIFF
--- a/Examples/LatentModel/LatentModel.cpp
+++ b/Examples/LatentModel/LatentModel.cpp
@@ -258,9 +258,8 @@ int main(int, char* []) {
         cout << endl;
         for(Size iName1=0; iName1 <theBskt->size(); iName1++) {
             for(Size iName2=0; iName2 <theBskt->size(); iName2++)
-                cout << 
-                    correlsTlm[iName1][iName2] << " , ";
-                cout << endl;
+                cout << correlsTlm[iName1][iName2] << " , ";
+            cout << endl;
         }
         cout << endl;
         for(Size iName1=0; iName1 <theBskt->size(); iName1++) {
@@ -276,9 +275,8 @@ int main(int, char* []) {
         cout << endl;
         for(Size iName1=0; iName1 <theBskt->size(); iName1++) {
             for(Size iName2=0; iName2 <theBskt->size(); iName2++)
-                cout << 
-                    correlsTrand[iName1][iName2] << " , ";
-                cout << endl;
+                cout << correlsTrand[iName1][iName2] << " , ";
+            cout << endl;
         }
 
         return 0;


### PR DESCRIPTION
While testing and understanding basic usage of a Latent variable model, I found some extra semicolons in nested loops.  Yes, it is syntactically valid but serves no purpose. 