### PR TITLE
Fixed misspelling in output of example

### DIFF
--- a/Examples/Gaussian1dModels/Gaussian1dModels.cpp
+++ b/Examples/Gaussian1dModels/Gaussian1dModels.cpp
@@ -151,7 +151,7 @@ int main(int, char *[]) {
             << "\nWe assume a multicurve setup, for simplicity with flat yield "
                "\nterm structures. The discounting curve is an Eonia curve at"
                "\na level of " << oisLevel
-            << " and the forwarding curve is an Euribior 6m curve"
+            << " and the forwarding curve is an Euribor 6m curve"
             << "\nat a level of " << forward6mLevel << std::endl;
 
         Real volLevel = 0.20;


### PR DESCRIPTION
tested [Gaussian1dModels.cpp](https://github.com/BabarZKhan/QuantLib/blob/master/Examples/Gaussian1dModels/Gaussian1dModels.cpp) example for my own understanding. Found one very trivial typo. Fixed it for my better clarity.