### PR TITLE
Allow crossed ranges in `holidayList` and `businessDayList` methods

### DIFF
--- a/ql/time/calendar.cpp
+++ b/ql/time/calendar.cpp
@@ -277,9 +277,6 @@ namespace QuantLib {
     std::vector<Date> Calendar::holidayList(
         const Date& from, const Date& to, bool includeWeekEnds) const {
 
-        QL_REQUIRE(to>=from, "'from' date ("
-            << from << ") must be equal to or earlier than 'to' date ("
-            << to << ")");
         std::vector<Date> result;
         for (Date d = from; d <= to; ++d) {
             if (isHoliday(d) && (includeWeekEnds || !isWeekend(d.weekday())))
@@ -291,9 +288,6 @@ namespace QuantLib {
     std::vector<Date> Calendar::businessDayList(
         const Date& from, const Date& to) const {
 
-        QL_REQUIRE(to>=from, "'from' date ("
-            << from << ") must be equal to or earlier than 'to' date ("
-            << to << ")");
         std::vector<Date> result;
         for (Date d = from; d <= to; ++d) {
             if (isBusinessDay(d))

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3831,15 +3831,20 @@ BOOST_AUTO_TEST_CASE(testDayLists) {
     Calendar germany = Germany();
     Date firstDate = Settings::instance().evaluationDate(), endDate = firstDate + 1 * Years;
 
-    // Test that same day holidayList and businessDayList does not throw an error
-    germany.holidayList(firstDate, firstDate, true);
-    germany.businessDayList(firstDate, firstDate);
+    // Test that a crossed range returns an empty vector
+    BOOST_CHECK_EQUAL(germany.holidayList(endDate, firstDate, true).size(), 0);
+    BOOST_CHECK_EQUAL(germany.businessDayList(endDate, firstDate).size(), 0);
+    // Test that the range is inclusive on both sides
+    BOOST_CHECK_EQUAL(germany.holidayList(firstDate, firstDate, true).size(),
+                      static_cast<size_t>(germany.isHoliday(firstDate)));
+    BOOST_CHECK_EQUAL(germany.businessDayList(firstDate, firstDate).size(),
+                      static_cast<size_t>(germany.isBusinessDay(firstDate)));
 
     std::vector<Date> holidays = germany.holidayList(firstDate, endDate, true);
     std::vector<Date> businessDays = germany.businessDayList(firstDate, endDate);
 
     auto it_holidays = holidays.begin(), it_businessDays = businessDays.begin();
-    for (Date d = firstDate; d < endDate; d++) {
+    for (Date d = firstDate; d <= endDate; d++) {
         if (it_holidays != holidays.end() && it_businessDays != businessDays.end() &&
             d == *it_holidays && d == *it_businessDays) {
             BOOST_FAIL("Date " << d << "is both holiday and business day.");


### PR DESCRIPTION
This should just return an empty vector instead of throwing an error.