### PR TITLE
Deprecate retrieval of lagged rates from inflation term structures

### DIFF
--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -194,8 +194,7 @@ namespace QuantLib {
             // work in terms of maturity-of-instruments
             // so ask for rate with observation lag
             Period p = (obsLag == Period(-1, Days)) ? observationLag() : obsLag;
-            // Third parameter = force linear interpolation of yoy
-            return yoy_->yoyRate(d, p, false, extrapolate);
+            return yoy_->yoyRate(d - p, extrapolate);
         }
         //@}
 

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -226,7 +226,7 @@ namespace QuantLib {
         std::pair<Date, Date> fixingPeriod = inflationPeriod(fixingDate, frequency_);
 
         Date firstDateInPeriod = fixingPeriod.first;
-        Rate Z1 = zeroInflation_->zeroRate(firstDateInPeriod, Period(0,Days), false);
+        Rate Z1 = zeroInflation_->zeroRate(firstDateInPeriod, false);
         Time t1 = inflationYearFraction(frequency_, false, zeroInflation_->dayCounter(),
                                         baseDate, firstDateInPeriod);
         return baseFixing * std::pow(1.0 + Z1, t1);
@@ -381,7 +381,7 @@ namespace QuantLib {
             std::pair<Date,Date> fixingPeriod = inflationPeriod(fixingDate, frequency_);
             d = fixingPeriod.first;
         }
-        return yoyInflation_->yoyRate(d,0*Days);
+        return yoyInflation_->yoyRate(d);
     }
 
     ext::shared_ptr<YoYInflationIndex> YoYInflationIndex::clone(

--- a/ql/pricingengines/inflation/inflationcapfloorengines.cpp
+++ b/ql/pricingengines/inflation/inflationcapfloorengines.cpp
@@ -78,7 +78,7 @@ namespace QuantLib {
                 // This also means that we do not need the coupon to have
                 // a pricing engine to return the swaplet rate and then
                 // the adjusted fixing in the instrument.
-                forwards[i] = yoyTS->yoyRate(arguments_.fixingDates[i],Period(0,Days));
+                forwards[i] = yoyTS->yoyRate(arguments_.fixingDates[i]);
                 Rate forward = forwards[i];
 
                 Date fixingDate = arguments_.fixingDates[i];

--- a/ql/termstructures/inflationtermstructure.cpp
+++ b/ql/termstructures/inflationtermstructure.cpp
@@ -131,6 +131,12 @@ namespace QuantLib {
                                    const ext::shared_ptr<Seasonality>& seasonality)
     : InflationTermStructure(settlementDays, calendar, baseDate, frequency, dayCounter, seasonality) {}
 
+    Rate ZeroInflationTermStructure::zeroRate(const Date &d, bool extrapolate) const {
+        QL_DEPRECATED_DISABLE_WARNING
+        return zeroRate(d, Period(0, Days), false, extrapolate);
+        QL_DEPRECATED_ENABLE_WARNING
+    }
+
     Rate ZeroInflationTermStructure::zeroRate(const Date &d, const Period& instObsLag,
                                               bool forceLinearInterpolation,
                                               bool extrapolate) const {
@@ -242,6 +248,12 @@ namespace QuantLib {
     }
 
     QL_DEPRECATED_ENABLE_WARNING
+
+    Rate YoYInflationTermStructure::yoyRate(const Date &d, bool extrapolate) const {
+        QL_DEPRECATED_DISABLE_WARNING
+        return yoyRate(d, Period(0, Days), false, extrapolate);
+        QL_DEPRECATED_ENABLE_WARNING
+    }
 
     Rate YoYInflationTermStructure::yoyRate(const Date &d, const Period& instObsLag,
                                             bool forceLinearInterpolation,

--- a/ql/termstructures/inflationtermstructure.hpp
+++ b/ql/termstructures/inflationtermstructure.hpp
@@ -144,18 +144,23 @@ namespace QuantLib {
         //! \name Inspectors
         //@{
         //! zero-coupon inflation rate.
-        /*! Essentially the fair rate for a zero-coupon inflation swap
-            (by definition), i.e. the zero term structure uses yearly
-            compounding, which is assumed for ZCIIS instrument quotes.
+        /*! The zero term structure uses yearly compounding, which is
+            assumed for ZCIIS instrument quotes.
 
-            \note by default you get the same as lag and interpolation
-            as the term structure.
-            If you want to get predictions of RPI/CPI/etc then use an
-            index.
+            If you want to get predictions of RPI/CPI/etc. use the
+            corresponding index instead; if you need a ZCIIS rate,
+            retrieve it from the instrument.
         */
-        Rate zeroRate(const Date& d, const Period& instObsLag = Period(-1,Days),
+        Rate zeroRate(const Date& d, bool extrapolate = false) const;
+
+        /*! \deprecated Use the overload without a lag instead.
+                        Deprecated in version 1.41.
+        */
+        [[deprecated("Use the overload without a lag instead")]]
+        Rate zeroRate(const Date& d, const Period& instObsLag,
                       bool forceLinearInterpolation = false,
                       bool extrapolate = false) const;
+
         //! zero-coupon inflation rate.
         /*! \warning Since inflation is highly linked to dates (lags,
                      interpolation, months for seasonality, etc) this
@@ -242,14 +247,20 @@ namespace QuantLib {
         //! \name Inspectors
         //@{
         //! year-on-year inflation rate.
-        /*! The forceLinearInterpolation parameter is relative to the
-            frequency of the TS.
-
-            \note this is not the year-on-year swap (YYIIS) rate.
+        /*! This does not return the year-on-year swap (YYIIS) rate.
+            If you need that rate, retrieve it from the corresponding
+            instrument instead.
         */
-        Rate yoyRate(const Date& d, const Period& instObsLag = Period(-1,Days),
+        Rate yoyRate(const Date& d, bool extrapolate = false) const;
+
+        /*! \deprecated Use the overload without a lag instead.
+                        Deprecated in version 1.41.
+        */
+        [[deprecated("Use the overload without a lag instead")]]
+        Rate yoyRate(const Date& d, const Period& instObsLag,
                      bool forceLinearInterpolation = false,
                      bool extrapolate = false) const;
+
         //! year-on-year inflation rate.
         /*! \warning Since inflation is highly linked to dates (lags,
                      interpolation, months for seasonality, etc) this

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     Date bd = hz->baseDate();
     Real bf = ii->fixing(bd);
     for (const auto& d : testIndex) {
-        Real z = hz->zeroRate(d, Period(0, Days));
+        Real z = hz->zeroRate(d);
         Real t = hz->dayCounter().yearFraction(bd, inflationPeriod(d, ii->frequency()).first);
         Real calc = bf * std::pow(1+z, t);
         if (t<=0)


### PR DESCRIPTION
No longer needed since the lag is managed by the coupons.