### PR TITLE
Patch a few vector initialisations for AD compatibility

### DIFF
--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -1165,8 +1165,8 @@ BOOST_AUTO_TEST_CASE(testCashDividendEuropeanEngineWithManyDividends) {
     );
 
     MersenneTwisterUniformRng rng(1234);
-    std::vector<Date> dividendDates({today + Period(-1, Months)});
-    std::vector<Real> dividendAmounts({1.0});
+    std::vector<Date> dividendDates = {today + Period(-1, Months)};
+    std::vector<Real> dividendAmounts = {Real(1.0)};
 
     const Size daysToMaturity = maturityDate - today;
     dividendDates.reserve(Size(daysToMaturity/2.8));


### PR DESCRIPTION
If `Real` is not `double`, the compiler has to choose between converting `{1.0}` to a `Real` for a value initializer, or converting it to a `size_t` for the size initializer. It favours the latter as it's a better match, which creates invalid code.

This PR fixes that.