### PR TITLE
Consistent usage of `BOOST_ALL_NO_LIB` and `ql/auto_link.hpp`

### DIFF
--- a/ql/Makefile.am
+++ b/ql/Makefile.am
@@ -144,7 +144,7 @@ quantlib.hpp: Makefile.am
 	echo >> ${srcdir}/$@
 	echo "#include <ql/qldefines.hpp>" >> ${srcdir}/$@
 	echo "#include <ql/version.hpp>" >> ${srcdir}/$@
-	echo "#ifdef BOOST_MSVC" >> ${srcdir}/$@
+	echo "#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)" >> ${srcdir}/$@
 	echo "#  include <ql/auto_link.hpp>" >> ${srcdir}/$@
 	echo "#endif" >> ${srcdir}/$@
 	echo >> ${srcdir}/$@


### PR DESCRIPTION
This is a minor change to have the same guard around `#include <ql/auto_link.hpp>` in `ql/quantlib.hpp` as in other header files where it is included i.e. `#if !defined(BOOST_ALL_NO_LIB) && defined(BOOST_MSVC)`.

I didn't amend `ql/quantlib.hpp` accordingly as my understanding is that the `Update generated headers` workflow will do that.