### PR TITLE
Revert #2410

### DIFF
--- a/ql/processes/gsrprocesscore.hpp
+++ b/ql/processes/gsrprocesscore.hpp
@@ -68,7 +68,7 @@ class GsrProcessCore {
     void flushCache() const;
 
   protected:
-    const Array times_, vols_, reversions_;
+    const Array &times_, &vols_, &reversions_;
 
   private:
     int lowerIndex(Time t) const;

--- a/test-suite/gsr.cpp
+++ b/test-suite/gsr.cpp
@@ -291,6 +291,8 @@ BOOST_AUTO_TEST_CASE(testGsrModel) {
                     << GsrJamNpv << ")");
 }
 
+/* To be re-enabled when we find a solution to #2408 that doesn't break calibration
+
 BOOST_AUTO_TEST_CASE(testGsrProcessWithPathGenerator) {
 
     BOOST_TEST_MESSAGE("Testing GSR process path generation...");
@@ -341,6 +343,7 @@ BOOST_AUTO_TEST_CASE(testGsrProcessWithPathGenerator) {
         }
     }
 }
+*/
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
The fix in #2410 avoids crashes but causes regressions in the calibration of the process; see the Gaussian1DModels example, which started printing model prices and vols that didn't match the market inputs.  We need to revisit this. 