### PR TITLE
Avoid warning when copying a partially initialized struct

### DIFF
--- a/ql/models/shortrate/onefactormodels/markovfunctional.hpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.hpp
@@ -262,12 +262,12 @@ namespace QuantLib {
             Period tenor_;
             std::vector<Date> paymentDates_;
             std::vector<Real> yearFractions_;
-            Real atm_;
-            Real annuity_;
+            Real atm_ = Null<Real>();
+            Real annuity_ = Null<Real>();
             ext::shared_ptr<SmileSection> smileSection_;
             ext::shared_ptr<SmileSection> rawSmileSection_;
-            Real minRateDigital_;
-            Real maxRateDigital_;
+            Real minRateDigital_ = Null<Real>();
+            Real maxRateDigital_ = Null<Real>();
         };
 
 // utility macro to write messages to the model outputs


### PR DESCRIPTION
The uninitialized values are filled in after the copy is made.

The warning only appeared at `-O3` optimization level and when selecting C++20 or above.