### PR TITLE
Make all interpolation implementations final

### DIFF
--- a/ql/experimental/barrieroption/vannavolgainterpolation.hpp
+++ b/ql/experimental/barrieroption/vannavolgainterpolation.hpp
@@ -79,7 +79,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class VannaVolgaInterpolationImpl
+        class VannaVolgaInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             VannaVolgaInterpolationImpl(const I1& xBegin, const I1& xEnd,

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -337,7 +337,7 @@ namespace QuantLib {
 
     namespace detail {
         template <class I1, class I2>
-        class LinearFlatInterpolationImpl
+        class LinearFlatInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             LinearFlatInterpolationImpl(const I1& xBegin, const I1& xEnd,

--- a/ql/math/interpolations/backwardflatinterpolation.hpp
+++ b/ql/math/interpolations/backwardflatinterpolation.hpp
@@ -67,7 +67,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class BackwardFlatInterpolationImpl
+        class BackwardFlatInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             BackwardFlatInterpolationImpl(const I1& xBegin, const I1& xEnd,

--- a/ql/math/interpolations/forwardflatinterpolation.hpp
+++ b/ql/math/interpolations/forwardflatinterpolation.hpp
@@ -67,7 +67,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class ForwardFlatInterpolationImpl
+        class ForwardFlatInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             ForwardFlatInterpolationImpl(const I1& xBegin, const I1& xEnd,

--- a/ql/math/interpolations/kernelinterpolation.hpp
+++ b/ql/math/interpolations/kernelinterpolation.hpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2, class Kernel>
-        class KernelInterpolationImpl
+        class KernelInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             KernelInterpolationImpl(const I1& xBegin,

--- a/ql/math/interpolations/lagrangeinterpolation.hpp
+++ b/ql/math/interpolations/lagrangeinterpolation.hpp
@@ -41,7 +41,7 @@ namespace QuantLib {
         };
 
         template <class I1, class I2>
-        class LagrangeInterpolationImpl
+        class LagrangeInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2>,
               public UpdatedYInterpolation {
 

--- a/ql/math/interpolations/linearinterpolation.hpp
+++ b/ql/math/interpolations/linearinterpolation.hpp
@@ -68,7 +68,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class LinearInterpolationImpl
+        class LinearInterpolationImpl final
             : public Interpolation::templateImpl<I1,I2> {
           public:
             LinearInterpolationImpl(const I1& xBegin, const I1& xEnd,

--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -350,7 +350,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class LogInterpolationImpl
+        class LogInterpolationImpl final
             : public Interpolation::templateImpl<I1, I2> {
           public:
             template <class Interpolator>

--- a/ql/math/interpolations/mixedinterpolation.hpp
+++ b/ql/math/interpolations/mixedinterpolation.hpp
@@ -205,7 +205,7 @@ namespace QuantLib {
     namespace detail {
 
         template <class I1, class I2>
-        class MixedInterpolationImpl
+        class MixedInterpolationImpl final
             : public Interpolation::templateImpl<I1, I2> {
           public:
             template <class Interpolator1, class Interpolator2>


### PR DESCRIPTION
Possibly breaking change, but these implementations are in the `details` namespace and not to be relied upon.