### PR TITLE
Add `fixingConvention` parameter to `FloatingRateCoupon`

### DIFF
--- a/ql/cashflows/capflooredcoupon.cpp
+++ b/ql/cashflows/capflooredcoupon.cpp
@@ -39,7 +39,8 @@ namespace QuantLib {
                          underlying->referencePeriodEnd(),
                          underlying->dayCounter(),
                          underlying->isInArrears(),
-                         underlying->exCouponDate()),
+                         underlying->exCouponDate(),
+                         underlying->fixingConvention()),
       underlying_(underlying) {
 
         if (gearing_ > 0) {

--- a/ql/cashflows/capflooredcoupon.hpp
+++ b/ql/cashflows/capflooredcoupon.hpp
@@ -117,11 +117,13 @@ namespace QuantLib {
                   const Date& refPeriodEnd = Date(),
                   const DayCounter& dayCounter = DayCounter(),
                   bool isInArrears = false,
-                  const Date& exCouponDate = Date())
+                  const Date& exCouponDate = Date(),
+                  BusinessDayConvention fixingConvention = Preceding)
         : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
             IborCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
                        index, gearing, spread, refPeriodStart, refPeriodEnd,
-                       dayCounter, isInArrears, exCouponDate)), cap, floor) {}
+                       dayCounter, isInArrears, exCouponDate,
+                       fixingConvention)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredIborCoupon>*>(&v);
@@ -149,11 +151,13 @@ namespace QuantLib {
                   const Date& refPeriodEnd = Date(),
                   const DayCounter& dayCounter = DayCounter(),
                   bool isInArrears = false,
-                  const Date& exCouponDate = Date())
+                  const Date& exCouponDate = Date(),
+                  BusinessDayConvention fixingConvention = Preceding)
         : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
             CmsCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
                       index, gearing, spread, refPeriodStart, refPeriodEnd,
-                      dayCounter, isInArrears, exCouponDate)), cap, floor) {}
+                      dayCounter, isInArrears, exCouponDate,
+                      fixingConvention)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsCoupon>*>(&v);

--- a/ql/cashflows/cmscoupon.cpp
+++ b/ql/cashflows/cmscoupon.cpp
@@ -38,11 +38,13 @@ namespace QuantLib {
                          const Date& refPeriodEnd,
                          const DayCounter& dayCounter,
                          bool isInArrears,
-                         const Date& exCouponDate)
+                         const Date& exCouponDate,
+                         BusinessDayConvention fixingConvention)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          fixingDays, swapIndex, gearing, spread,
                          refPeriodStart, refPeriodEnd,
-                         dayCounter, isInArrears, exCouponDate),
+                         dayCounter, isInArrears, exCouponDate,
+                         fixingConvention),
       swapIndex_(swapIndex) {}
 
     void CmsCoupon::accept(AcyclicVisitor& v) {
@@ -139,6 +141,11 @@ namespace QuantLib {
         return *this;
     }
 
+    CmsLeg& CmsLeg::withFixingConvention(BusinessDayConvention convention) {
+        fixingConvention_ = convention;
+        return *this;
+    }
+
     CmsLeg& CmsLeg::withExCouponPeriod(
                                 const Period& period,
                                 const Calendar& cal,
@@ -158,7 +165,8 @@ namespace QuantLib {
                          caps_, floors_, inArrears_, zeroPayments_,
                          0, Calendar(),
                          exCouponPeriod_, exCouponCalendar_,
-                         exCouponAdjustment_, exCouponEndOfMonth_);
+                         exCouponAdjustment_, exCouponEndOfMonth_,
+                         fixingConvention_);
    }
 
 }

--- a/ql/cashflows/cmscoupon.hpp
+++ b/ql/cashflows/cmscoupon.hpp
@@ -50,7 +50,8 @@ namespace QuantLib {
                   const Date& refPeriodEnd = Date(),
                   const DayCounter& dayCounter = DayCounter(),
                   bool isInArrears = false,
-                  const Date& exCouponDate = Date());
+                  const Date& exCouponDate = Date(),
+                  BusinessDayConvention fixingConvention = Preceding);
         //! \name Inspectors
         //@{
         const ext::shared_ptr<SwapIndex>& swapIndex() const {
@@ -86,6 +87,7 @@ namespace QuantLib {
         CmsLeg& withFloors(const std::vector<Rate>& floors);
         CmsLeg& inArrears(bool flag = true);
         CmsLeg& withZeroPayments(bool flag = true);
+        CmsLeg& withFixingConvention(BusinessDayConvention);
         CmsLeg& withExCouponPeriod(const Period&,
                                    const Calendar&,
                                    BusinessDayConvention,
@@ -102,6 +104,7 @@ namespace QuantLib {
         std::vector<Spread> spreads_;
         std::vector<Rate> caps_, floors_;
         bool inArrears_ = false, zeroPayments_ = false;
+        BusinessDayConvention fixingConvention_ = Preceding;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_ = Following;

--- a/ql/cashflows/floatingratecoupon.cpp
+++ b/ql/cashflows/floatingratecoupon.cpp
@@ -42,11 +42,13 @@ namespace QuantLib {
                                            const Date& refPeriodEnd,
                                            DayCounter dayCounter,
                                            bool isInArrears,
-                                           const Date& exCouponDate)
+                                           const Date& exCouponDate,
+                                           BusinessDayConvention fixingConvention)
     : Coupon(paymentDate, nominal, startDate, endDate, refPeriodStart, refPeriodEnd, exCouponDate),
       index_(index), dayCounter_(std::move(dayCounter)),
       fixingDays_(fixingDays == Null<Natural>() ? (index ? index->fixingDays() : 0) : fixingDays),
-      gearing_(gearing), spread_(spread), isInArrears_(isInArrears) {
+      gearing_(gearing), spread_(spread), isInArrears_(isInArrears),
+      fixingConvention_(fixingConvention) {
         QL_REQUIRE(index_, "no index provided");
         QL_REQUIRE(gearing_!=0, "Null gearing not allowed");
 
@@ -80,7 +82,7 @@ namespace QuantLib {
         // if isInArrears_ fix at the end of period
         Date refDate = isInArrears_ ? accrualEndDate_ : accrualStartDate_;
         return index_->fixingCalendar().advance(refDate,
-            -static_cast<Integer>(fixingDays_), Days, Preceding);
+            -static_cast<Integer>(fixingDays_), Days, fixingConvention_);
     }
 
     Rate FloatingRateCoupon::rate() const {

--- a/ql/cashflows/floatingratecoupon.hpp
+++ b/ql/cashflows/floatingratecoupon.hpp
@@ -32,6 +32,7 @@
 #include <ql/cashflows/coupon.hpp>
 #include <ql/patterns/visitor.hpp>
 #include <ql/patterns/lazyobject.hpp>
+#include <ql/time/businessdayconvention.hpp>
 #include <ql/time/daycounter.hpp>
 #include <ql/handle.hpp>
 
@@ -56,7 +57,8 @@ namespace QuantLib {
                            const Date& refPeriodEnd = Date(),
                            DayCounter dayCounter = DayCounter(),
                            bool isInArrears = false,
-                           const Date& exCouponDate = Date());
+                           const Date& exCouponDate = Date(),
+                           BusinessDayConvention fixingConvention = Preceding);
 
         //! \name LazyObject interface
         //@{
@@ -95,6 +97,8 @@ namespace QuantLib {
         virtual Rate adjustedFixing() const;
         //! whether or not the coupon fixes in arrears
         bool isInArrears() const { return isInArrears_; }
+        //! business day convention used for fixing date calculation
+        BusinessDayConvention fixingConvention() const { return fixingConvention_; }
         //@}
 
         //! \name Visitability
@@ -113,6 +117,7 @@ namespace QuantLib {
         Real gearing_;
         Spread spread_;
         bool isInArrears_;
+        BusinessDayConvention fixingConvention_;
         ext::shared_ptr<FloatingRateCouponPricer> pricer_;
         mutable Real rate_;
     };

--- a/ql/cashflows/iborcoupon.cpp
+++ b/ql/cashflows/iborcoupon.cpp
@@ -44,11 +44,13 @@ namespace QuantLib {
                            const Date& refPeriodEnd,
                            const DayCounter& dayCounter,
                            bool isInArrears,
-                           const Date& exCouponDate)
+                           const Date& exCouponDate,
+                           BusinessDayConvention fixingConvention)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          fixingDays, iborIndex, gearing, spread,
                          refPeriodStart, refPeriodEnd,
-                         dayCounter, isInArrears, exCouponDate),
+                         dayCounter, isInArrears, exCouponDate,
+                         fixingConvention),
       iborIndex_(iborIndex) {
         fixingDate_ = FloatingRateCoupon::fixingDate();
     }
@@ -257,6 +259,11 @@ namespace QuantLib {
         return *this;
 	}
 
+    IborLeg& IborLeg::withFixingConvention(BusinessDayConvention convention) {
+        fixingConvention_ = convention;
+        return *this;
+    }
+
     IborLeg& IborLeg::withIndexedCoupons(ext::optional<bool> b) {
         useIndexedCoupons_ = b;
         return *this;
@@ -273,7 +280,8 @@ namespace QuantLib {
                          schedule_, notionals_, index_, paymentDayCounter_,
                          paymentAdjustment_, fixingDays_, gearings_, spreads_,
                          caps_, floors_, inArrears_, zeroPayments_, paymentLag_, paymentCalendar_, 
-			             exCouponPeriod_, exCouponCalendar_, exCouponAdjustment_, exCouponEndOfMonth_);
+			             exCouponPeriod_, exCouponCalendar_, exCouponAdjustment_, exCouponEndOfMonth_,
+			             fixingConvention_);
 
         if (caps_.empty() && floors_.empty() && !inArrears_) {
             ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(

--- a/ql/cashflows/iborcoupon.hpp
+++ b/ql/cashflows/iborcoupon.hpp
@@ -52,7 +52,8 @@ namespace QuantLib {
                    const Date& refPeriodEnd = Date(),
                    const DayCounter& dayCounter = DayCounter(),
                    bool isInArrears = false,
-                   const Date& exCouponDate = Date());
+                   const Date& exCouponDate = Date(),
+                   BusinessDayConvention fixingConvention = Preceding);
         //! \name Inspectors
         //@{
         const ext::shared_ptr<IborIndex>& iborIndex() const { return iborIndex_; }
@@ -157,6 +158,7 @@ namespace QuantLib {
                                     const Calendar&,
                                     BusinessDayConvention,
                                     bool endOfMonth = false);
+        IborLeg& withFixingConvention(BusinessDayConvention);
         IborLeg& withIndexedCoupons(ext::optional<bool> b = true);
         IborLeg& withAtParCoupons(bool b = true);
         operator Leg() const;
@@ -174,6 +176,7 @@ namespace QuantLib {
         std::vector<Spread> spreads_;
         std::vector<Rate> caps_, floors_;
         bool inArrears_ = false, zeroPayments_ = false;
+        BusinessDayConvention fixingConvention_ = Preceding;
         Period exCouponPeriod_;
         Calendar exCouponCalendar_;
         BusinessDayConvention exCouponAdjustment_ = Unadjusted;

--- a/ql/experimental/coupons/cmsspreadcoupon.cpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.cpp
@@ -29,11 +29,12 @@ namespace QuantLib {
         const ext::shared_ptr<SwapSpreadIndex> &index, Real gearing,
         Spread spread, const Date &refPeriodStart,
         const Date &refPeriodEnd,
-        const DayCounter &dayCounter, bool isInArrears, const Date &exCouponDate)
+        const DayCounter &dayCounter, bool isInArrears, const Date &exCouponDate,
+        BusinessDayConvention fixingConvention)
         : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                              fixingDays, index, gearing, spread,
                              refPeriodStart, refPeriodEnd, dayCounter,
-                             isInArrears, exCouponDate),
+                             isInArrears, exCouponDate, fixingConvention),
           index_(index) {}
 
     void CmsSpreadCoupon::accept(AcyclicVisitor &v) {

--- a/ql/experimental/coupons/cmsspreadcoupon.hpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.hpp
@@ -52,7 +52,8 @@ namespace QuantLib {
                   const Date& refPeriodEnd = Date(),
                   const DayCounter& dayCounter = DayCounter(),
                   bool isInArrears = false,
-                  const Date& exCouponDate = Date());
+                  const Date& exCouponDate = Date(),
+                  BusinessDayConvention fixingConvention = Preceding);
         //! \name Inspectors
         //@{
         const ext::shared_ptr<SwapSpreadIndex>& swapSpreadIndex() const {
@@ -84,11 +85,13 @@ namespace QuantLib {
                   const Date& refPeriodEnd = Date(),
                   const DayCounter& dayCounter = DayCounter(),
                   bool isInArrears = false,
-                  const Date& exCouponDate = Date())
+                  const Date& exCouponDate = Date(),
+                  BusinessDayConvention fixingConvention = Preceding)
         : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
             CmsSpreadCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
                       index, gearing, spread, refPeriodStart, refPeriodEnd,
-                      dayCounter, isInArrears, exCouponDate)), cap, floor) {}
+                      dayCounter, isInArrears, exCouponDate,
+                      fixingConvention)), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsSpreadCoupon>*>(&v);

--- a/ql/instruments/bonds/floatingratebond.cpp
+++ b/ql/instruments/bonds/floatingratebond.cpp
@@ -45,7 +45,8 @@ namespace QuantLib {
                            const Period& exCouponPeriod,
                            const Calendar& exCouponCalendar,
                            const BusinessDayConvention exCouponConvention,
-                           bool exCouponEndOfMonth)
+                           bool exCouponEndOfMonth,
+                           BusinessDayConvention fixingConvention)
     : Bond(settlementDays, schedule.calendar(), issueDate) {
 
         maturityDate_ = schedule.endDate();
@@ -60,7 +61,8 @@ namespace QuantLib {
             .withCaps(caps)
             .withFloors(floors)
             .inArrears(inArrears)
-            .withExCouponPeriod(exCouponPeriod, exCouponCalendar, exCouponConvention, exCouponEndOfMonth);
+            .withExCouponPeriod(exCouponPeriod, exCouponCalendar, exCouponConvention, exCouponEndOfMonth)
+            .withFixingConvention(fixingConvention);
 
         addRedemptionsToCashflows(std::vector<Real>(1, redemption));
 

--- a/ql/instruments/bonds/floatingratebond.hpp
+++ b/ql/instruments/bonds/floatingratebond.hpp
@@ -58,7 +58,8 @@ namespace QuantLib {
                          const Period& exCouponPeriod = Period(),
                          const Calendar& exCouponCalendar = Calendar(),
                          BusinessDayConvention exCouponConvention = Unadjusted,
-                         bool exCouponEndOfMonth = false);
+                         bool exCouponEndOfMonth = false,
+                         BusinessDayConvention fixingConvention = Preceding);
     };
 
 }


### PR DESCRIPTION
Closes #2015.

Adds a configurable `fixingConvention` parameter (defaulting to `Preceding`) to `FloatingRateCoupon` and threads it through the class hierarchy, replacing the hardcoded `Preceding` in `fixingDate()`.

**Changes across 14 files:**
- `FloatingRateCoupon`: new member, constructor parameter, accessor, used in `fixingDate()`
- Coupon subclasses (`IborCoupon`, `CmsCoupon`, `CmsSpreadCoupon`, `CappedFlooredCoupon` and variants): pass through to parent
- `FloatingLeg` template in `cashflowvectors.hpp`: uses `if constexpr` with `std::is_constructible_v` to detect whether the coupon type accepts `fixingConvention`, so custom coupon types without the parameter continue to compile unchanged
- Leg builders (`IborLeg`, `CmsLeg`): `withFixingConvention()` builder method
- `FloatingRateBond`: constructor parameter, forwarded via `IborLeg`

All defaults are `Preceding`, so this is fully backward-compatible — both at the API level (default arguments) and at the template level (`if constexpr` fallback).

**Test:** Australian-calendar bond with quarterly unadjusted schedule (Westpac Capital Notes 5 example from #2015). Verifies that `Following` convention resolves a Saturday accrual start to the following Monday, while `Preceding` resolves to the prior Friday.

```
Accrual Start         Fixing (Preceding)    Fixing (Following)
----------------------------------------------------------------
March 22nd, 2024      March 22nd, 2024      March 22nd, 2024
June 22nd, 2024       June 21st, 2024       June 24th, 2024      <-- differs
September 22nd, 2024  September 20th, 2024  September 23rd, 2024  <-- differs
```