### PR TITLE
Adjust Bessel K tolerance for catastrophic cancellation

### DIFF
--- a/test-suite/functions.cpp
+++ b/test-suite/functions.cpp
@@ -141,7 +141,8 @@ BOOST_AUTO_TEST_CASE(testModifiedBesselFunctions) {
         const Real expected_i = i[2];
         const Real expected_k = i[3];
         const Real tol_i = 5e4 * QL_EPSILON*std::fabs(expected_i);
-        const Real tol_k = 5e4 * QL_EPSILON*std::fabs(expected_k);
+        const Real tol_k = 5e4 * QL_EPSILON
+                           * std::max(std::fabs(expected_k), std::fabs(expected_i));
 
         const Real calculated_i = modifiedBesselFunction_i(nu, x);
         const Real calculated_k = modifiedBesselFunction_k(nu, x);
@@ -149,18 +150,24 @@ BOOST_AUTO_TEST_CASE(testModifiedBesselFunctions) {
         if (std::fabs(expected_i - calculated_i) > tol_i) {
             BOOST_ERROR("failed to reproduce modified Bessel "
                        << "function of first kind"
+                       << std::setprecision(16) << std::scientific
                        << "\n order     : " << nu
                        << "\n argument  : " << x
                        << "\n calculated: " << calculated_i
-                       << "\n expected  : " << expected_i);
+                       << "\n expected  : " << expected_i
+                       << "\n difference: " << std::fabs(expected_i - calculated_i)
+                       << "\n tolerance : " << tol_i);
         }
         if (std::fabs(expected_k - calculated_k) > tol_k) {
             BOOST_ERROR("failed to reproduce modified Bessel "
                        << "function of second kind"
+                       << std::setprecision(16) << std::scientific
                        << "\n order     : " << nu
                        << "\n argument  : " << x
                        << "\n calculated: " << calculated_k
-                       << "\n expected  : " << expected_k);
+                       << "\n expected  : " << expected_k
+                       << "\n difference: " << std::fabs(expected_k - calculated_k)
+                       << "\n tolerance : " << tol_k);
         }
     }
 


### PR DESCRIPTION
## Summary

- Scale `tol_k` by `max(|expected_k|, |expected_i|)` to account for error propagation from the cancellation-prone `K_nu` formula when `nu` is small
- Add `setprecision(16)` and show difference/tolerance in error messages

Fixes #2432.

## Details

`K_nu(x) = (π/2)·(I_{-ν} − I_ν)/sin(πν)` has condition number ~10,000 for `ν = 0.001`, amplifying normal rounding errors in `I_ν` into `K_ν`. The previous tolerance of `5e4·ε·|K|` gave only 2.2× headroom, causing platform-dependent failures.

Since the absolute error in `K` propagates from the `I` computation, the tolerance should scale with `max(|K|, |I|)` rather than `|K|` alone. This naturally loosens the tolerance for the cancellation-prone case while leaving well-conditioned cases (all others) unchanged.

## Test plan

- [x] `testModifiedBesselFunctions` passes
- [x] `testWeightedModifiedBesselFunctions` passes
- [x] Full `FunctionsTests` suite (7 tests) — no regressions