### PR TITLE
Respect `AmericanExercise` earliest date in FD engines

### DIFF
--- a/ql/exercise.hpp
+++ b/ql/exercise.hpp
@@ -68,9 +68,6 @@ namespace QuantLib {
     /*! An American option can be exercised at any time between two
         predefined dates; the first date might be omitted, in which
         case the option can be exercised at any time before the expiry.
-
-        \todo check that everywhere the American condition is applied
-              from earliestDate and not earlier
     */
     class AmericanExercise : public EarlyExercise {
       public:

--- a/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.cpp
@@ -26,10 +26,17 @@
 namespace QuantLib {
 
     FdmAmericanStepCondition::FdmAmericanStepCondition(
-        ext::shared_ptr<FdmMesher> mesher, ext::shared_ptr<FdmInnerValueCalculator> calculator)
-    : mesher_(std::move(mesher)), calculator_(std::move(calculator)) {}
+        ext::shared_ptr<FdmMesher> mesher,
+        ext::shared_ptr<FdmInnerValueCalculator> calculator,
+        Time exerciseStart)
+    : mesher_(std::move(mesher)),
+      calculator_(std::move(calculator)),
+      exerciseStart_(exerciseStart) {}
 
     void FdmAmericanStepCondition::applyTo(Array& a, Time t) const {
+        if (t < exerciseStart_)
+            return;
+
         QL_REQUIRE(mesher_->layout()->size() == a.size(),
                    "inconsistent array dimensions");
 

--- a/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.hpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmamericanstepcondition.hpp
@@ -35,13 +35,15 @@ namespace QuantLib {
     class FdmAmericanStepCondition : public StepCondition<Array> {
       public:
         FdmAmericanStepCondition(ext::shared_ptr<FdmMesher> mesher,
-                                 ext::shared_ptr<FdmInnerValueCalculator> calculator);
+                                 ext::shared_ptr<FdmInnerValueCalculator> calculator,
+                                 Time exerciseStart = 0.0);
 
-        void applyTo(Array& a, Time) const override;
+        void applyTo(Array& a, Time t) const override;
 
       private:
         const ext::shared_ptr<FdmMesher> mesher_;
         const ext::shared_ptr<FdmInnerValueCalculator> calculator_;
+        const Time exerciseStart_;
     };
 }
 #endif

--- a/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
@@ -124,8 +124,11 @@ namespace QuantLib {
                    || exercise->type() == Exercise::Bermudan,
                    "exercise type is not supported");
         if (exercise->type() == Exercise::American) {
+            const Time exerciseStart =
+                dayCounter.yearFraction(refDate, exercise->date(0));
             stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-                          new FdmAmericanStepCondition(mesher,calculator)));
+                          new FdmAmericanStepCondition(mesher, calculator,
+                                                      exerciseStart)));
         }
         else if (exercise->type() == Exercise::Bermudan) {
             ext::shared_ptr<FdmBermudanStepCondition> bermudanCondition(


### PR DESCRIPTION
FdmAmericanStepCondition unconditionally applied the early exercise check at every timestep, ignoring the earliest exercise date stored in AmericanExercise. This meant that AmericanExercise(T-1w, T) gave the same price as AmericanExercise(t0, T), which is incorrect.

The fix adds an exerciseStart parameter to FdmAmericanStepCondition (defaulting to 0.0 for backward compatibility) and skips the exercise check when t < exerciseStart. The vanillaComposite factory now extracts exercise->date(0) and passes it through.

This resolves the \todo in exercise.hpp:
  "check that everywhere the American condition is applied
   from earliestDate and not earlier"