### PR TITLE
Use contract dates for fixed-leg year fraction in `ZeroCouponInflationSwap`

### DIFF
--- a/ql/instruments/zerocouponinflationswap.cpp
+++ b/ql/instruments/zerocouponinflationswap.cpp
@@ -89,10 +89,7 @@ namespace QuantLib {
         // At this point the index may not be able to forecast
         // i.e. do not want to force the existence of an inflation
         // term structure before allowing users to create instruments.
-        Real T =
-            inflationYearFraction(infIndex_->frequency(),
-                                  detail::CPI::isInterpolated(observationInterpolation_),
-                                  dayCounter_, baseDate_, obsDate_);
+        Real T = dayCounter_.yearFraction(startDate_, maturityDate_);
         // N.B. the -1.0 is because swaps only exchange growth, not notionals as well
         Real fixedAmount = nominal * (std::pow(1.0 + fixedRate, T) - 1.0);
 
@@ -130,10 +127,7 @@ namespace QuantLib {
 
         // +1 because the IndexedCashFlow has growthOnly=true
         Real growth = icf->amount() / icf->notional() + 1.0;
-        Real T =
-            inflationYearFraction(infIndex_->frequency(),
-                                  detail::CPI::isInterpolated(observationInterpolation_),
-                                  dayCounter_, baseDate_, obsDate_);
+        Real T = dayCounter_.yearFraction(startDate_, maturityDate_);
 
         return std::pow(growth,1.0/T) - 1.0;
 
@@ -155,10 +149,7 @@ namespace QuantLib {
 
         const Spread basisPoint = 1.0e-4;
         DiscountFactor df = payer_[0] * endDiscounts_[0];
-        Real T =
-            inflationYearFraction(infIndex_->frequency(),
-                                  detail::CPI::isInterpolated(observationInterpolation_),
-                                  dayCounter_, baseDate_, obsDate_);
+        Real T = dayCounter_.yearFraction(startDate_, maturityDate_);
 
         return df * nominal_ * (pow(1.0 + fixedRate_ + basisPoint, T) - pow(1.0 + fixedRate_, T));
     }

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
     auto engine = ext::make_shared<DiscountingBondEngine>(common.yTS);
     bond.setPricingEngine(engine);
 
-    Real storedPrice = 396.45920973;
+    Real storedPrice = 396.47045891;
     Real calculated = bond.dirtyPrice();
     Real tolerance = 1.0e-8;
     if (std::fabs(calculated-storedPrice) > tolerance) {
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(testCleanPrice) {
                    << "\n  calculated: " << calculated);
     }
 
-    storedPrice = 394.78551761;
+    storedPrice = 394.79676679;
     calculated = bond.cleanPrice();
     if (std::fabs(calculated-storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(testCPILegWithoutBaseCPI) {
                    << "\n clean npv of leg with explicit baseCPI: " << cleanPriceWithBaseCPI);
     }
     // Compare to expected price
-    Real storedPrice = 394.78551761;
+    Real storedPrice = 394.79676680;
     if (std::fabs(cleanPriceWithBaseDate - storedPrice) > tolerance) {
         BOOST_FAIL("failed to reproduce expected CPI-bond clean price"
                    << std::fixed << std::setprecision(12) << "\n  expected:   " << storedPrice

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE(consistency) {
                "failed manual inf leg NPV calc vs pricing engine: " <<
                testInfLegNPV << " vs " << zisV.legNPV(0));
 
-    Real diff = fabs(1-zisV.NPV()/4191660.0);
-    
+    Real diff = fabs(1-zisV.NPV()/4191797.54);
+
     Real max_diff = usingAtParCoupons ? 1e-5 : 3e-5;
 
     QL_REQUIRE(diff<max_diff,


### PR DESCRIPTION
## Summary

The fixed leg of a ZCIIS computes `N * [(1+K)^T - 1]` where T should be the contractual accrual period (per [OpenGamma, Section 3.1](https://quant.opengamma.io/Inflation-Curve-Construction-OpenGamma.pdf)). The previous code computed T via `inflationYearFraction()` using observation dates shifted by lag and snapped to inflation period boundaries — correct for inflation curve interpolation, but not for the fixed leg compounding exponent.

Replace `inflationYearFraction(baseDate_, obsDate_)` with `dayCounter_.yearFraction(startDate_, maturityDate_)` in the constructor, `fairRate()`, and `fixedLegBPS()`.

For standard instruments (Monthly frequency, whole-year tenors), the old and new values of T are identical. The cached test values in `inflationcpibond` and `inflationcpiswap` shift slightly because those tests use `ActualActual(ISDA)` where the observation-date snapping introduced small differences; the bootstrap round-trip is preserved.

Closes #2361.

## Breaking change note

Users who bootstrap inflation curves via `ZeroCouponInflationSwapHelper` will see small shifts in calibrated zero inflation rates (order of 1-3 bp) because the helper constructs `ZeroCouponInflationSwap` internally. The bootstrap still round-trips correctly — it calibrates to a marginally different internal T. Cached regression values against ZCIIS NPVs or CPI bond prices will need updating.

## Test plan
- [ ] All existing inflation tests pass with updated cached values
- [ ] Bootstrap round-trip preserved (NPV < tolerance)
- [ ] No new compiler warnings