### PR TITLE
Fix pillar assignment in inflation-curve bootstrap for `CPI::Linear`

### DIFF
--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -229,6 +229,10 @@ namespace QuantLib {
         Rate Z1 = zeroInflation_->zeroRate(firstDateInPeriod, false);
         Time t1 = inflationYearFraction(frequency_, false, zeroInflation_->dayCounter(),
                                         baseDate, firstDateInPeriod);
+        // During bootstrapping, extrapolated rates can temporarily go below -1.
+        // Guard against pow of a negative base with non-integer exponent.
+        if (Z1 <= -1.0)
+            return 0.0;
         return baseFixing * std::pow(1.0 + Z1, t1);
     }
 

--- a/ql/termstructures/inflation/inflationhelpers.hpp
+++ b/ql/termstructures/inflation/inflationhelpers.hpp
@@ -44,7 +44,9 @@ namespace QuantLib {
             BusinessDayConvention paymentConvention,
             DayCounter dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& zii,
-            CPI::InterpolationType observationInterpolation);
+            CPI::InterpolationType observationInterpolation,
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
 
         ZeroCouponInflationSwapHelper(
             const Handle<Quote>& quote,
@@ -55,7 +57,9 @@ namespace QuantLib {
             BusinessDayConvention paymentConvention,
             DayCounter dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& zii,
-            CPI::InterpolationType observationInterpolation);
+            CPI::InterpolationType observationInterpolation,
+            Pillar::Choice pillar = Pillar::LastRelevantDate,
+            Date customPillarDate = Date());
 
         /*! \deprecated Use the overload that does not take a nominal curve.
                         Deprecated in version 1.39.
@@ -89,6 +93,7 @@ namespace QuantLib {
         DayCounter dayCounter_;
         ext::shared_ptr<ZeroInflationIndex> zii_;
         CPI::InterpolationType observationInterpolation_;
+        Pillar::Choice pillarChoice_;
         ext::shared_ptr<ZeroCouponInflationSwap> zciis_;
         Handle<YieldTermStructure> nominalTermStructure_;
         RelinkableHandle<ZeroInflationTermStructure> termStructureHandle_;
@@ -103,7 +108,9 @@ namespace QuantLib {
             DayCounter dayCounter,
             const ext::shared_ptr<ZeroInflationIndex>& zii,
             CPI::InterpolationType observationInterpolation,
-            Handle<YieldTermStructure> nominalTermStructure);
+            Handle<YieldTermStructure> nominalTermStructure,
+            Pillar::Choice pillar,
+            Date customPillarDate);
     };
 
 
@@ -119,7 +126,9 @@ namespace QuantLib {
                                       DayCounter dayCounter,
                                       const ext::shared_ptr<YoYInflationIndex>& yii,
                                       CPI::InterpolationType interpolation,
-                                      Handle<YieldTermStructure> nominalTermStructure);
+                                      Handle<YieldTermStructure> nominalTermStructure,
+                                      Pillar::Choice pillar = Pillar::LastRelevantDate,
+                                      Date customPillarDate = Date());
 
         YearOnYearInflationSwapHelper(const Handle<Quote>& quote,
                                       const Period& swapObsLag,
@@ -130,7 +139,9 @@ namespace QuantLib {
                                       DayCounter dayCounter,
                                       const ext::shared_ptr<YoYInflationIndex>& yii,
                                       CPI::InterpolationType interpolation,
-                                      Handle<YieldTermStructure> nominalTermStructure);
+                                      Handle<YieldTermStructure> nominalTermStructure,
+                                      Pillar::Choice pillar = Pillar::LastRelevantDate,
+                                      Date customPillarDate = Date());
 
         void setTermStructure(YoYInflationTermStructure*) override;
         Real impliedQuote() const override;
@@ -149,6 +160,7 @@ namespace QuantLib {
         DayCounter dayCounter_;
         ext::shared_ptr<YoYInflationIndex> yii_;
         CPI::InterpolationType interpolation_;
+        Pillar::Choice pillarChoice_;
         ext::shared_ptr<YearOnYearInflationSwap> yyiis_;
         Handle<YieldTermStructure> nominalTermStructure_;
         RelinkableHandle<YoYInflationTermStructure> termStructureHandle_;

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -101,12 +101,20 @@ namespace QuantLib {
             if (i==1)
                 data[0] = level; // the first point is updated as well
         }
+        // transformation to add constraints to an unconstrained optimization
+        template <class C>
+        static Real transformDirect(Real x, Size, const C*) {
+            return x;
+        }
+        template <class C>
+        static Real transformInverse(Real x, Size, const C*) {
+            return x;
+        }
         // upper bound for convergence loop
-        // calibration is trivial, should be immediate
-        static Size maxIterations() { return 5; }
+        static Size maxIterations() { return 40; }
     };
 
-    //! Bootstrap traits to use for PiecewiseZeroInflationCurve
+    //! Bootstrap traits to use for PiecewiseYoYInflationCurve
     class YoYInflationTraits {
       public:
         // helper class
@@ -168,6 +176,15 @@ namespace QuantLib {
                                 Rate level,
                                 Size i) {
             data[i] = level;
+        }
+        // transformation to add constraints to an unconstrained optimization
+        template <class C>
+        static Real transformDirect(Real x, Size, const C*) {
+            return x;
+        }
+        template <class C>
+        static Real transformInverse(Real x, Size, const C*) {
+            return x;
         }
         // upper bound for convergence loop
         static Size maxIterations() { return 40; }

--- a/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
@@ -139,6 +139,8 @@ namespace QuantLib {
 
     template <class T>
     Date InterpolatedYoYInflationCurve<T>::maxDate() const {
+        if (this->maxDate_ != Date())
+            return this->maxDate_;
         return dates_.back();
     }
 

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -128,6 +128,8 @@ namespace QuantLib {
 
     template <class T>
     Date InterpolatedZeroInflationCurve<T>::maxDate() const {
+        if (this->maxDate_ != Date())
+            return this->maxDate_;
         return dates_.back();
     }
 


### PR DESCRIPTION
## Summary

Fixes #2454 — `PiecewiseZeroInflationCurve<Linear>` bootstrap fails with "root not bracketed" when evaluation dates fall near the start of the month, because the pillar is assigned to the right interpolation node which has negligible sensitivity at month-start.

Changes:

- **Weight-based pillar assignment**: For `CPI::Linear` helpers, assign the pillar to the node with the dominant interpolation weight. When the right-node weight is at most 0.5, use the left node as pillar. Uses `startDate_` (the swap effective date) rather than `maturity_` for the weight calculation so that all helpers sharing the same effective date switch LEFT/RIGHT in sync — avoiding collisions when consecutive helpers mature in months of different length (e.g. 28-day February vs 31-day March).

- **`Pillar::Choice` for inflation helpers**: Add `Pillar::Choice pillar` and `Date customPillarDate` parameters to `ZeroCouponInflationSwapHelper` and `YearOnYearInflationSwapHelper`, following the same pattern as `SwapRateHelper`. Default is `Pillar::LastRelevantDate` (backward-compatible).

- **Enable `GlobalBootstrap` for inflation curves**: Add identity `transformDirect`/`transformInverse` to `ZeroInflationTraits` and `YoYInflationTraits`. `PiecewiseZeroInflationCurve<Linear, GlobalBootstrap>` now compiles and works.

- **Prerequisite fixes**:
  - `forecastFixing`: guard against `pow(negative, non-integer)` → NaN during bootstrap
  - `maxDate()`: respect `maxDate_` override in interpolated inflation curves (needed by both bootstrap algorithms)
  - `maxIterations`: 5 → 40 for `ZeroInflationTraits` (was already 40 for YoY)

## Test plan

- [x] `testUsCpiLinearBootstrapAtMonthStart` — US CPI, CPI::Linear, T+2 settlement, 28/28
- [x] `testEuHicpFlatBootstrapAtMonthStart` — EU HICP, CPI::Flat, T+2, iterative + global, 28/28 each
- [x] `testUkRpiFlatBootstrapAtMonthStart` — UK RPI, CPI::Flat, T+0, iterative + global, 28/28 each
- [x] `testUsCpiLinearGlobalBootstrapAtMonthStart` — US CPI, CPI::Linear, T+2, GlobalBootstrap, 28/28
- [x] `testPillarCollisionWithDifferentMonthLengths` — T+0 with 13M helper, Feb+Mar, 59/59 (regression test for the `startDate_`-based weight fix; would fail on Feb 16 and Mar 16 without it)
- [x] All 6 inflation test suites pass (InflationTests, InflationCapFloor, InflationCapFlooredCoupon, InflationCPIBond, InflationCPICapFloor, InflationVol)