### PR TITLE
Deprecate classes using Kruger with `monotonic=true`

### DIFF
--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -123,7 +123,10 @@ namespace QuantLib {
 
     // convenience classes
 
-    class DefaultLogCubic : public LogCubic {
+    /*! \deprecated Use KrugerLog instead.
+                    Deprecated in version 1.42.
+    */
+    class [[deprecated("Use KrugerLog instead")]] DefaultLogCubic : public LogCubic {
       public:
         DefaultLogCubic()
         : LogCubic(CubicInterpolation::Kruger) {}
@@ -300,7 +303,11 @@ namespace QuantLib {
 
     // convenience classes
     
-    class DefaultLogMixedLinearCubic : public LogMixedLinearCubic {
+    /*! \deprecated Use KrugerLogMixedLinearCubic instead.
+                    Deprecated in version 1.42.
+    */
+    class [[deprecated("Use KrugerLogMixedLinearCubic instead")]] DefaultLogMixedLinearCubic
+        : public LogMixedLinearCubic {
       public:
         explicit DefaultLogMixedLinearCubic(const Size n,
                                             MixedInterpolation::Behavior behavior

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1074,7 +1074,6 @@ BOOST_AUTO_TEST_CASE(testDefaultInstantiation) {
     PiecewiseYieldCurve<Discount, Linear> linear(vars.settlement, vars.instruments, Actual360());
     PiecewiseYieldCurve<Discount, LogLinear> log_linear(vars.settlement, vars.instruments, Actual360());
     PiecewiseYieldCurve<Discount, Cubic> cubic(vars.settlement, vars.instruments, Actual360());
-    PiecewiseYieldCurve<Discount, DefaultLogCubic> log_cubic(vars.settlement, vars.instruments, Actual360());
     PiecewiseYieldCurve<Discount, MonotonicLogCubic> monotonic_log_cubic(vars.settlement, vars.instruments, Actual360());
     PiecewiseYieldCurve<Discount, KrugerLog> kruger_log_cubic(vars.settlement, vars.instruments, Actual360());
     PiecewiseYieldCurve<ForwardRate, BackwardFlat> backward(vars.settlement, vars.instruments, Actual360());


### PR DESCRIPTION
That's probably a mistake caused by different defaults for monotonic between Cubic (defaults to false) and LogCubic (defaults to true). Since Kruger is naturally monotonic, it generally does not need a separate monotonic filter.

Also, the name "Default" for Kruger is fairly misleading.