### PR TITLE
Deprecate day-counter argument in z-spread functions

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -65,17 +65,15 @@ namespace QuantLib {
 
     bool CashFlows::isExpired(const Leg& leg,
                               const ext::optional<bool>& includeSettlementDateFlows,
-                              Date settlementDate)
-    {
+                              Date settlementDate) {
         if (leg.empty())
             return true;
 
         if (settlementDate == Date())
             settlementDate = Settings::instance().evaluationDate();
 
-        for (Size i=leg.size(); i>0; --i)
-            if (!leg[i-1]->hasOccurred(settlementDate,
-                                       includeSettlementDateFlows))
+        for (Size i = leg.size(); i > 0; --i)
+            if (!leg[i - 1]->hasOccurred(settlementDate, includeSettlementDateFlows))
                 return false;
         return true;
     }
@@ -91,8 +89,8 @@ namespace QuantLib {
             settlementDate = Settings::instance().evaluationDate();
 
         Leg::const_reverse_iterator i;
-        for (i = leg.rbegin(); i<leg.rend(); ++i) {
-            if ( (*i)->hasOccurred(settlementDate, includeSettlementDateFlows) )
+        for (i = leg.rbegin(); i < leg.rend(); ++i) {
+            if ((*i)->hasOccurred(settlementDate, includeSettlementDateFlows))
                 return i;
         }
         return leg.rend();
@@ -109,8 +107,8 @@ namespace QuantLib {
             settlementDate = Settings::instance().evaluationDate();
 
         Leg::const_iterator i;
-        for (i = leg.begin(); i<leg.end(); ++i) {
-            if ( ! (*i)->hasOccurred(settlementDate, includeSettlementDateFlows) )
+        for (i = leg.begin(); i < leg.end(); ++i) {
+            if (!(*i)->hasOccurred(settlementDate, includeSettlementDateFlows))
                 return i;
         }
         return leg.end();
@@ -122,7 +120,7 @@ namespace QuantLib {
         Leg::const_reverse_iterator cf;
         cf = previousCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
-        if (cf==leg.rend())
+        if (cf == leg.rend())
             return {};
 
         return (*cf)->date();
@@ -134,7 +132,7 @@ namespace QuantLib {
         Leg::const_iterator cf;
         cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
-        if (cf==leg.end())
+        if (cf == leg.end())
             return {};
 
         return (*cf)->date();
@@ -146,12 +144,12 @@ namespace QuantLib {
         Leg::const_reverse_iterator cf;
         cf = previousCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
-        if (cf==leg.rend())
+        if (cf == leg.rend())
             return Real();
 
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
-        for (; cf<leg.rend() && (*cf)->date()==paymentDate; ++cf)
+        for (; cf < leg.rend() && (*cf)->date() == paymentDate; ++cf)
             result += (*cf)->amount();
         return result;
     }
@@ -162,12 +160,12 @@ namespace QuantLib {
         Leg::const_iterator cf;
         cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
 
-        if (cf==leg.end())
+        if (cf == leg.end())
             return Real();
 
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf)
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf)
             result += (*cf)->amount();
         return result;
     }
@@ -175,10 +173,10 @@ namespace QuantLib {
     // Coupon utility functions
     namespace {
 
-        template<typename Iter>
-        Rate aggregateRate(Iter first,
-                           const Iter& last) {
-            if (first==last) return 0.0;
+        template <typename Iter>
+        Rate aggregateRate(Iter first, const Iter& last) {
+            if (first == last)
+                return 0.0;
 
             Date paymentDate = (*first)->date();
             bool firstCouponFound = false;
@@ -186,15 +184,14 @@ namespace QuantLib {
             Time accrualPeriod = 0.0;
             DayCounter dc;
             Rate result = 0.0;
-            for (; first<last && (*first)->date()==paymentDate; ++first) {
+            for (; first < last && (*first)->date() == paymentDate; ++first) {
                 ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*first);
                 if (cp) {
                     if (firstCouponFound) {
-                        QL_REQUIRE(nominal       == cp->nominal() &&
-                                   accrualPeriod == cp->accrualPeriod() &&
-                                   dc            == cp->dayCounter(),
-                                   "cannot aggregate two different coupons on "
-                                   << paymentDate);
+                        QL_REQUIRE(nominal == cp->nominal() &&
+                                       accrualPeriod == cp->accrualPeriod() &&
+                                       dc == cp->dayCounter(),
+                                   "cannot aggregate two different coupons on " << paymentDate);
                     } else {
                         firstCouponFound = true;
                         nominal = cp->nominal();
@@ -204,8 +201,7 @@ namespace QuantLib {
                     result += cp->rate();
                 }
             }
-            QL_ENSURE(firstCouponFound,
-                      "no coupon paid at cashflow date " << paymentDate);
+            QL_ENSURE(firstCouponFound, "no coupon paid at cashflow date " << paymentDate);
             return result;
         }
 
@@ -232,10 +228,11 @@ namespace QuantLib {
                             const ext::optional<bool>& includeSettlementDateFlows,
                             Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0.0;
+        if (cf == leg.end())
+            return 0.0;
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->nominal();
@@ -247,11 +244,11 @@ namespace QuantLib {
                                      const ext::optional<bool>& includeSettlementDateFlows,
                                      Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end())
+        if (cf == leg.end())
             return {};
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accrualStartDate();
@@ -263,11 +260,11 @@ namespace QuantLib {
                                    const ext::optional<bool>& includeSettlementDateFlows,
                                    Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end())
+        if (cf == leg.end())
             return {};
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accrualEndDate();
@@ -279,11 +276,11 @@ namespace QuantLib {
                                          const ext::optional<bool>& includeSettlementDateFlows,
                                          Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end())
+        if (cf == leg.end())
             return {};
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->referencePeriodStart();
@@ -295,11 +292,11 @@ namespace QuantLib {
                                        const ext::optional<bool>& includeSettlementDateFlows,
                                        Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end())
+        if (cf == leg.end())
             return {};
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->referencePeriodEnd();
@@ -311,10 +308,11 @@ namespace QuantLib {
                                   const ext::optional<bool>& includeSettlementDateFlows,
                                   Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0;
+        if (cf == leg.end())
+            return 0;
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accrualPeriod();
@@ -326,10 +324,11 @@ namespace QuantLib {
                                              const ext::optional<bool>& includeSettlementDateFlows,
                                              Date settlementDate) {
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0;
+        if (cf == leg.end())
+            return 0;
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accrualDays();
@@ -344,10 +343,11 @@ namespace QuantLib {
             settlementDate = Settings::instance().evaluationDate();
 
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0;
+        if (cf == leg.end())
+            return 0;
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accruedPeriod(settlementDate);
@@ -362,10 +362,11 @@ namespace QuantLib {
             settlementDate = Settings::instance().evaluationDate();
 
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0;
+        if (cf == leg.end())
+            return 0;
 
         Date paymentDate = (*cf)->date();
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 return cp->accruedDays(settlementDate);
@@ -380,11 +381,12 @@ namespace QuantLib {
             settlementDate = Settings::instance().evaluationDate();
 
         auto cf = nextCashFlow(leg, includeSettlementDateFlows, settlementDate);
-        if (cf==leg.end()) return 0.0;
+        if (cf == leg.end())
+            return 0.0;
 
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
-        for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
+        for (; cf < leg.end() && (*cf)->date() == paymentDate; ++cf) {
             ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
             if (cp != nullptr)
                 result += cp->accruedAmount(settlementDate);
@@ -402,17 +404,15 @@ namespace QuantLib {
             explicit BPSCalculator(const YieldTermStructure& discountCurve)
             : discountCurve_(discountCurve) {}
             void visit(Coupon& c) override {
-                Real bps = c.nominal() *
-                           c.accrualPeriod() *
-                           discountCurve_.discount(c.date());
+                Real bps = c.nominal() * c.accrualPeriod() * discountCurve_.discount(c.date());
                 bps_ += bps;
             }
             void visit(CashFlow& cf) override {
-                nonSensNPV_ += cf.amount() * 
-                               discountCurve_.discount(cf.date());
+                nonSensNPV_ += cf.amount() * discountCurve_.discount(cf.date());
             }
             Real bps() const { return bps_; }
             Real nonSensNPV() const { return nonSensNPV_; }
+
           private:
             const YieldTermStructure& discountCurve_;
             Real bps_ = 0.0, nonSensNPV_ = 0.0;
@@ -443,7 +443,7 @@ namespace QuantLib {
                 totalNPV += i->amount() * discountCurve.discount(i->date());
         }
 
-        return totalNPV/discountCurve.discount(npvDate);
+        return totalNPV / discountCurve.discount(npvDate);
     }
 
     Real CashFlows::bps(const Leg& leg,
@@ -466,7 +466,7 @@ namespace QuantLib {
                 !i->tradingExCoupon(settlementDate))
                 i->accept(calc);
         }
-        return basisPoint_*calc.bps()/discountCurve.discount(npvDate);
+        return basisPoint_ * calc.bps() / discountCurve.discount(npvDate);
     }
 
     std::pair<Real, Real> CashFlows::npvbps(const Leg& leg,
@@ -478,7 +478,7 @@ namespace QuantLib {
         Real bps = 0.0;
 
         if (leg.empty()) {
-            return { npv, bps };
+            return {npv, bps};
         }
 
         if (settlementDate == Date())
@@ -489,8 +489,7 @@ namespace QuantLib {
 
         for (const auto& i : leg) {
             CashFlow& cf = *i;
-            if (!cf.hasOccurred(settlementDate,
-                                includeSettlementDateFlows) &&
+            if (!cf.hasOccurred(settlementDate, includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
                 ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(i);
                 Real df = discountCurve.discount(cf.date());
@@ -503,7 +502,7 @@ namespace QuantLib {
         npv /= d;
         bps = basisPoint_ * bps / d;
 
-        return { npv, bps };
+        return {npv, bps};
     }
 
     Rate CashFlows::atmRate(const Leg& leg,
@@ -525,29 +524,27 @@ namespace QuantLib {
         BPSCalculator calc(discountCurve);
         for (const auto& i : leg) {
             CashFlow& cf = *i;
-            if (!cf.hasOccurred(settlementDate,
-                                includeSettlementDateFlows) &&
+            if (!cf.hasOccurred(settlementDate, includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
-                npv += cf.amount() *
-                       discountCurve.discount(cf.date());
+                npv += cf.amount() * discountCurve.discount(cf.date());
                 cf.accept(calc);
             }
         }
 
-        if (targetNpv==Null<Real>())
+        if (targetNpv == Null<Real>())
             targetNpv = npv - calc.nonSensNPV();
         else {
             targetNpv *= discountCurve.discount(npvDate);
             targetNpv -= calc.nonSensNPV();
         }
 
-        if (targetNpv==0.0)
+        if (targetNpv == 0.0)
             return 0.0;
 
         Real bps = calc.bps();
-        QL_REQUIRE(bps!=0.0, "null bps: impossible atm rate");
+        QL_REQUIRE(bps != 0.0, "null bps: impossible atm rate");
 
-        return targetNpv/bps;
+        return targetNpv / bps;
     }
 
     // IRR utility functions
@@ -564,15 +561,15 @@ namespace QuantLib {
                 return -1;
         }
 
-        // helper fucntion used to calculate Time-To-Discount for each stage when calculating discount factor stepwisely
+        // helper fucntion used to calculate Time-To-Discount for each stage when calculating
+        // discount factor stepwisely
         Time getStepwiseDiscountTime(const ext::shared_ptr<QuantLib::CashFlow>& cashFlow,
                                      const DayCounter& dc,
                                      Date npvDate,
                                      Date lastDate) {
             Date cashFlowDate = cashFlow->date();
             Date refStartDate, refEndDate;
-            ext::shared_ptr<Coupon> coupon =
-                    ext::dynamic_pointer_cast<Coupon>(cashFlow);
+            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(cashFlow);
             if (coupon != nullptr) {
                 refStartDate = coupon->referencePeriodStart();
                 refEndDate = coupon->referencePeriodEnd();
@@ -580,22 +577,21 @@ namespace QuantLib {
                 if (lastDate == npvDate) {
                     // we don't have a previous coupon date,
                     // so we fake it
-                    refStartDate = cashFlowDate - 1*Years;
-                } else  {
+                    refStartDate = cashFlowDate - 1 * Years;
+                } else {
                     refStartDate = lastDate;
                 }
                 refEndDate = cashFlowDate;
             }
 
             if ((coupon != nullptr) && lastDate != coupon->accrualStartDate()) {
-                Time couponPeriod = dc.yearFraction(coupon->accrualStartDate(),
-                                                cashFlowDate, refStartDate, refEndDate);
-                Time accruedPeriod = dc.yearFraction(coupon->accrualStartDate(),
-                                                lastDate, refStartDate, refEndDate);
+                Time couponPeriod = dc.yearFraction(coupon->accrualStartDate(), cashFlowDate,
+                                                    refStartDate, refEndDate);
+                Time accruedPeriod =
+                    dc.yearFraction(coupon->accrualStartDate(), lastDate, refStartDate, refEndDate);
                 return couponPeriod - accruedPeriod;
             } else {
-                return dc.yearFraction(lastDate, cashFlowDate,
-                                       refStartDate, refEndDate);
+                return dc.yearFraction(lastDate, cashFlowDate, refStartDate, refEndDate);
             }
         }
 
@@ -636,7 +632,7 @@ namespace QuantLib {
             }
             if (P == 0.0) // no cashflows
                 return 0.0;
-            return dPdy/P;
+            return dPdy / P;
         }
 
         Real modifiedDuration(const Leg& leg,
@@ -673,37 +669,37 @@ namespace QuantLib {
                 DiscountFactor B = y.discountFactor(t);
                 P += c * B;
                 switch (y.compounding()) {
-                  case Simple:
-                    dPdy -= c * B*B * t;
-                    break;
-                  case Compounded:
-                    dPdy -= c * t * B/(1+r/N);
-                    break;
-                  case Continuous:
-                    dPdy -= c * B * t;
-                    break;
-                  case SimpleThenCompounded:
-                    if (t<=1.0/N)
-                        dPdy -= c * B*B * t;
-                    else
-                        dPdy -= c * t * B/(1+r/N);
-                    break;
-                  case CompoundedThenSimple:
-                    if (t>1.0/N)
-                        dPdy -= c * B*B * t;
-                    else
-                        dPdy -= c * t * B/(1+r/N);
-                    break;
-                  default:
-                    QL_FAIL("unknown compounding convention (" <<
-                            Integer(y.compounding()) << ")");
+                    case Simple:
+                        dPdy -= c * B * B * t;
+                        break;
+                    case Compounded:
+                        dPdy -= c * t * B / (1 + r / N);
+                        break;
+                    case Continuous:
+                        dPdy -= c * B * t;
+                        break;
+                    case SimpleThenCompounded:
+                        if (t <= 1.0 / N)
+                            dPdy -= c * B * B * t;
+                        else
+                            dPdy -= c * t * B / (1 + r / N);
+                        break;
+                    case CompoundedThenSimple:
+                        if (t > 1.0 / N)
+                            dPdy -= c * B * B * t;
+                        else
+                            dPdy -= c * t * B / (1 + r / N);
+                        break;
+                    default:
+                        QL_FAIL("unknown compounding convention (" << Integer(y.compounding())
+                                                                   << ")");
                 }
                 lastDate = i->date();
             }
 
             if (P == 0.0) // no cashflows
                 return 0.0;
-            return -dPdy/P; // reverse derivative sign
+            return -dPdy / P; // reverse derivative sign
         }
 
         Real macaulayDuration(const Leg& leg,
@@ -712,18 +708,15 @@ namespace QuantLib {
                               Date settlementDate,
                               Date npvDate) {
 
-            QL_REQUIRE(y.compounding() == Compounded,
-                       "compounded rate required");
+            QL_REQUIRE(y.compounding() == Compounded, "compounded rate required");
 
-            return (1.0+y.rate()/Integer(y.frequency())) *
-                modifiedDuration(leg, y,
-                                 includeSettlementDateFlows,
-                                 settlementDate, npvDate);
+            return (1.0 + y.rate() / Integer(y.frequency())) *
+                   modifiedDuration(leg, y, includeSettlementDateFlows, settlementDate, npvDate);
         }
 
         struct CashFlowLater {
-            bool operator()(const ext::shared_ptr<CashFlow> &c,
-                            const ext::shared_ptr<CashFlow> &d) {
+            bool operator()(const ext::shared_ptr<CashFlow>& c,
+                            const ext::shared_ptr<CashFlow>& d) {
                 return c->date() > d->date();
             }
         };
@@ -753,17 +746,15 @@ namespace QuantLib {
 
     Real CashFlows::IrrFinder::operator()(Rate y) const {
         InterestRate yield(y, dayCounter_, compounding_, frequency_);
-        Real NPV = CashFlows::npv(leg_, yield,
-                                  includeSettlementDateFlows_,
-                                  settlementDate_, npvDate_);
+        Real NPV =
+            CashFlows::npv(leg_, yield, includeSettlementDateFlows_, settlementDate_, npvDate_);
         return npv_ - NPV;
     }
 
     Real CashFlows::IrrFinder::derivative(Rate y) const {
         InterestRate yield(y, dayCounter_, compounding_, frequency_);
-        return modifiedDuration(leg_, yield,
-                                includeSettlementDateFlows_,
-                                settlementDate_, npvDate_);
+        return modifiedDuration(leg_, yield, includeSettlementDateFlows_, settlementDate_,
+                                npvDate_);
     }
 
     void CashFlows::IrrFinder::checkSign() const {
@@ -771,8 +762,7 @@ namespace QuantLib {
         // flows of the opposite sign have been specified (otherwise
         // IRR is nonsensical.)
 
-        Integer lastSign = sign(Real(-npv_)),
-                signChanges = 0;
+        Integer lastSign = sign(Real(-npv_)), signChanges = 0;
         for (const auto& i : leg_) {
             if (!i->hasOccurred(settlementDate_, includeSettlementDateFlows_) &&
                 !i->tradingExCoupon(settlementDate_)) {
@@ -784,9 +774,8 @@ namespace QuantLib {
                     lastSign = thisSign;
             }
         }
-        QL_REQUIRE(signChanges > 0,
-                   "the given cash flows cannot result in the given market "
-                   "price due to their sign");
+        QL_REQUIRE(signChanges > 0, "the given cash flows cannot result in the given market "
+                                    "price due to their sign");
 
         /* The following is commented out due to the lack of a QL_WARN macro
         if (signChanges > 1) {    // Danger of non-unique solution
@@ -824,8 +813,7 @@ namespace QuantLib {
             npvDate = settlementDate;
 
 #if defined(QL_EXTRA_SAFETY_CHECKS)
-        QL_REQUIRE(std::adjacent_find(leg.begin(), leg.end(),
-                                      CashFlowLater()) == leg.end(),
+        QL_REQUIRE(std::adjacent_find(leg.begin(), leg.end(), CashFlowLater()) == leg.end(),
                    "cashflows must be sorted in ascending order w.r.t. their payment dates");
 #endif
 
@@ -860,8 +848,7 @@ namespace QuantLib {
                         const ext::optional<bool>& includeSettlementDateFlows,
                         Date settlementDate,
                         Date npvDate) {
-        return npv(leg, InterestRate(yield, dc, comp, freq),
-                   includeSettlementDateFlows,
+        return npv(leg, InterestRate(yield, dc, comp, freq), includeSettlementDateFlows,
                    settlementDate, npvDate);
     }
 
@@ -880,11 +867,9 @@ namespace QuantLib {
         if (npvDate == Date())
             npvDate = settlementDate;
 
-        FlatForward flatRate(settlementDate, yield.rate(), yield.dayCounter(),
-                             yield.compounding(), yield.frequency());
-        return bps(leg, flatRate,
-                   includeSettlementDateFlows,
-                   settlementDate, npvDate);
+        FlatForward flatRate(settlementDate, yield.rate(), yield.dayCounter(), yield.compounding(),
+                             yield.frequency());
+        return bps(leg, flatRate, includeSettlementDateFlows, settlementDate, npvDate);
     }
 
     Real CashFlows::bps(const Leg& leg,
@@ -895,8 +880,7 @@ namespace QuantLib {
                         const ext::optional<bool>& includeSettlementDateFlows,
                         Date settlementDate,
                         Date npvDate) {
-        return bps(leg, InterestRate(yield, dc, comp, freq),
-                   includeSettlementDateFlows,
+        return bps(leg, InterestRate(yield, dc, comp, freq), includeSettlementDateFlows,
                    settlementDate, npvDate);
     }
 
@@ -913,10 +897,8 @@ namespace QuantLib {
                           Rate guess) {
         NewtonSafe solver;
         solver.setMaxEvaluations(maxIterations);
-        return CashFlows::yield<NewtonSafe>(solver, leg, npv, dayCounter,
-                                            compounding, frequency,
-                                            includeSettlementDateFlows,
-                                            settlementDate, npvDate,
+        return CashFlows::yield<NewtonSafe>(solver, leg, npv, dayCounter, compounding, frequency,
+                                            includeSettlementDateFlows, settlementDate, npvDate,
                                             accuracy, guess);
     }
 
@@ -938,20 +920,17 @@ namespace QuantLib {
             npvDate = settlementDate;
 
         switch (type) {
-          case Duration::Simple:
-            return simpleDuration(leg, rate,
-                                  includeSettlementDateFlows,
-                                  settlementDate, npvDate);
-          case Duration::Modified:
-            return modifiedDuration(leg, rate,
-                                    includeSettlementDateFlows,
-                                    settlementDate, npvDate);
-          case Duration::Macaulay:
-            return macaulayDuration(leg, rate,
-                                    includeSettlementDateFlows,
-                                    settlementDate, npvDate);
-          default:
-            QL_FAIL("unknown duration type");
+            case Duration::Simple:
+                return simpleDuration(leg, rate, includeSettlementDateFlows, settlementDate,
+                                      npvDate);
+            case Duration::Modified:
+                return modifiedDuration(leg, rate, includeSettlementDateFlows, settlementDate,
+                                        npvDate);
+            case Duration::Macaulay:
+                return macaulayDuration(leg, rate, includeSettlementDateFlows, settlementDate,
+                                        npvDate);
+            default:
+                QL_FAIL("unknown duration type");
         }
     }
 
@@ -964,9 +943,7 @@ namespace QuantLib {
                              const ext::optional<bool>& includeSettlementDateFlows,
                              Date settlementDate,
                              Date npvDate) {
-        return duration(leg, InterestRate(yield, dc, comp, freq),
-                        type,
-                        includeSettlementDateFlows,
+        return duration(leg, InterestRate(yield, dc, comp, freq), type, includeSettlementDateFlows,
                         settlementDate, npvDate);
     }
 
@@ -1005,30 +982,29 @@ namespace QuantLib {
             DiscountFactor B = y.discountFactor(t);
             P += c * B;
             switch (y.compounding()) {
-              case Simple:
-                d2Pdy2 += c * 2.0*B*B*B*t*t;
-                break;
-              case Compounded:
-                d2Pdy2 += c * B*t*(N*t+1)/(N*(1+r/N)*(1+r/N));
-                break;
-              case Continuous:
-                d2Pdy2 += c * B*t*t;
-                break;
-              case SimpleThenCompounded:
-                if (t<=1.0/N)
-                    d2Pdy2 += c * 2.0*B*B*B*t*t;
-                else
-                    d2Pdy2 += c * B*t*(N*t+1)/(N*(1+r/N)*(1+r/N));
-                break;
-              case CompoundedThenSimple:
-                if (t>1.0/N)
-                    d2Pdy2 += c * 2.0*B*B*B*t*t;
-                else
-                    d2Pdy2 += c * B*t*(N*t+1)/(N*(1+r/N)*(1+r/N));
-                break;
-              default:
-                QL_FAIL("unknown compounding convention (" <<
-                        Integer(y.compounding()) << ")");
+                case Simple:
+                    d2Pdy2 += c * 2.0 * B * B * B * t * t;
+                    break;
+                case Compounded:
+                    d2Pdy2 += c * B * t * (N * t + 1) / (N * (1 + r / N) * (1 + r / N));
+                    break;
+                case Continuous:
+                    d2Pdy2 += c * B * t * t;
+                    break;
+                case SimpleThenCompounded:
+                    if (t <= 1.0 / N)
+                        d2Pdy2 += c * 2.0 * B * B * B * t * t;
+                    else
+                        d2Pdy2 += c * B * t * (N * t + 1) / (N * (1 + r / N) * (1 + r / N));
+                    break;
+                case CompoundedThenSimple:
+                    if (t > 1.0 / N)
+                        d2Pdy2 += c * 2.0 * B * B * B * t * t;
+                    else
+                        d2Pdy2 += c * B * t * (N * t + 1) / (N * (1 + r / N) * (1 + r / N));
+                    break;
+                default:
+                    QL_FAIL("unknown compounding convention (" << Integer(y.compounding()) << ")");
             }
             lastDate = i->date();
         }
@@ -1037,7 +1013,7 @@ namespace QuantLib {
             // no cashflows
             return 0.0;
 
-        return d2Pdy2/P;
+        return d2Pdy2 / P;
     }
 
 
@@ -1049,8 +1025,7 @@ namespace QuantLib {
                               const ext::optional<bool>& includeSettlementDateFlows,
                               Date settlementDate,
                               Date npvDate) {
-        return convexity(leg, InterestRate(yield, dc, comp, freq),
-                         includeSettlementDateFlows,
+        return convexity(leg, InterestRate(yield, dc, comp, freq), includeSettlementDateFlows,
                          settlementDate, npvDate);
     }
 
@@ -1068,24 +1043,19 @@ namespace QuantLib {
         if (npvDate == Date())
             npvDate = settlementDate;
 
-        Real npv = CashFlows::npv(leg, y,
-                                  includeSettlementDateFlows,
-                                  settlementDate, npvDate);
-        Real modifiedDuration = CashFlows::duration(leg, y,
-                                                    Duration::Modified,
-                                                    includeSettlementDateFlows,
-                                                    settlementDate, npvDate);
-        Real convexity = CashFlows::convexity(leg, y,
-                                              includeSettlementDateFlows,
-                                              settlementDate, npvDate);
-        Real delta = -modifiedDuration*npv;
-        Real gamma = (convexity/100.0)*npv;
+        Real npv = CashFlows::npv(leg, y, includeSettlementDateFlows, settlementDate, npvDate);
+        Real modifiedDuration = CashFlows::duration(
+            leg, y, Duration::Modified, includeSettlementDateFlows, settlementDate, npvDate);
+        Real convexity =
+            CashFlows::convexity(leg, y, includeSettlementDateFlows, settlementDate, npvDate);
+        Real delta = -modifiedDuration * npv;
+        Real gamma = (convexity / 100.0) * npv;
 
         Real shift = 0.0001;
         delta *= shift;
-        gamma *= shift*shift;
+        gamma *= shift * shift;
 
-        return delta + 0.5*gamma;
+        return delta + 0.5 * gamma;
     }
 
     Real CashFlows::basisPointValue(const Leg& leg,
@@ -1096,8 +1066,7 @@ namespace QuantLib {
                                     const ext::optional<bool>& includeSettlementDateFlows,
                                     Date settlementDate,
                                     Date npvDate) {
-        return basisPointValue(leg, InterestRate(yield, dc, comp, freq),
-                               includeSettlementDateFlows,
+        return basisPointValue(leg, InterestRate(yield, dc, comp, freq), includeSettlementDateFlows,
                                settlementDate, npvDate);
     }
 
@@ -1115,16 +1084,12 @@ namespace QuantLib {
         if (npvDate == Date())
             npvDate = settlementDate;
 
-        Real npv = CashFlows::npv(leg, y,
-                                  includeSettlementDateFlows,
-                                  settlementDate, npvDate);
-        Real modifiedDuration = CashFlows::duration(leg, y,
-                                                    Duration::Modified,
-                                                    includeSettlementDateFlows,
-                                                    settlementDate, npvDate);
+        Real npv = CashFlows::npv(leg, y, includeSettlementDateFlows, settlementDate, npvDate);
+        Real modifiedDuration = CashFlows::duration(
+            leg, y, Duration::Modified, includeSettlementDateFlows, settlementDate, npvDate);
 
         Real shift = 0.01;
-        return (1.0/(-npv*modifiedDuration))*shift;
+        return (1.0 / (-npv * modifiedDuration)) * shift;
     }
 
     Real CashFlows::yieldValueBasisPoint(const Leg& leg,
@@ -1136,15 +1101,13 @@ namespace QuantLib {
                                          Date settlementDate,
                                          Date npvDate) {
         return yieldValueBasisPoint(leg, InterestRate(yield, dc, comp, freq),
-                                    includeSettlementDateFlows,
-                                    settlementDate, npvDate);
+                                    includeSettlementDateFlows, settlementDate, npvDate);
     }
 
     // Z-spread utility functions
     Real CashFlows::npv(const Leg& leg,
                         const ext::shared_ptr<YieldTermStructure>& discountCurve,
                         Spread zSpread,
-                        const DayCounter& dc,
                         Compounding comp,
                         Frequency freq,
                         const ext::optional<bool>& includeSettlementDateFlows,
@@ -1161,22 +1124,30 @@ namespace QuantLib {
             npvDate = settlementDate;
 
         Handle<YieldTermStructure> discountCurveHandle(discountCurve);
-        Handle<Quote> zSpreadQuoteHandle(ext::shared_ptr<Quote>(new
-            SimpleQuote(zSpread)));
+        Handle<Quote> zSpreadQuoteHandle(ext::shared_ptr<Quote>(new SimpleQuote(zSpread)));
 
-        ZeroSpreadedTermStructure spreadedCurve(discountCurveHandle,
-                                                zSpreadQuoteHandle,
-                                                comp, freq);
+        ZeroSpreadedTermStructure spreadedCurve(discountCurveHandle, zSpreadQuoteHandle, comp,
+                                                freq);
 
-        return npv(leg, spreadedCurve,
-                   includeSettlementDateFlows,
-                   settlementDate, npvDate);
+        return npv(leg, spreadedCurve, includeSettlementDateFlows, settlementDate, npvDate);
+    }
+
+    Real CashFlows::npv(const Leg& leg,
+                        const ext::shared_ptr<YieldTermStructure>& discountCurve,
+                        Spread zSpread,
+                        const DayCounter&,
+                        Compounding comp,
+                        Frequency freq,
+                        const ext::optional<bool>& includeSettlementDateFlows,
+                        Date settlementDate,
+                        Date npvDate) {
+        return CashFlows::npv(leg, discountCurve, zSpread, comp, freq, includeSettlementDateFlows,
+                              settlementDate, npvDate);
     }
 
     Spread CashFlows::zSpread(const Leg& leg,
                               Real npv,
                               const ext::shared_ptr<YieldTermStructure>& discount,
-                              const DayCounter& dayCounter,
                               Compounding compounding,
                               Frequency frequency,
                               const ext::optional<bool>& includeSettlementDateFlows,
@@ -1194,13 +1165,11 @@ namespace QuantLib {
 
         auto zSpreadQuote = ext::make_shared<SimpleQuote>();
         ZeroSpreadedTermStructure spreadedCurve(Handle<YieldTermStructure>(discount),
-                                                Handle<Quote>(zSpreadQuote),
-                                                compounding,
+                                                Handle<Quote>(zSpreadQuote), compounding,
                                                 frequency);
         auto objFunction = [&](Rate zSpread) {
             zSpreadQuote->setValue(zSpread);
-            Real NPV = CashFlows::npv(leg, spreadedCurve,
-                                      includeSettlementDateFlows,
+            Real NPV = CashFlows::npv(leg, spreadedCurve, includeSettlementDateFlows,
                                       settlementDate, npvDate);
             return npv - NPV;
         };
@@ -1209,6 +1178,23 @@ namespace QuantLib {
         solver.setMaxEvaluations(maxIterations);
         Real step = 0.01;
         return solver.solve(objFunction, accuracy, guess, step);
+    }
+
+    Spread CashFlows::zSpread(const Leg& leg,
+                              Real npv,
+                              const ext::shared_ptr<YieldTermStructure>& discount,
+                              const DayCounter&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              const ext::optional<bool>& includeSettlementDateFlows,
+                              Date settlementDate,
+                              Date npvDate,
+                              Real accuracy,
+                              Size maxIterations,
+                              Rate guess) {
+        return CashFlows::zSpread(leg, npv, discount, compounding, frequency,
+                                  includeSettlementDateFlows, settlementDate, npvDate, accuracy,
+                                  maxIterations, guess);
     }
 
 }

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -27,8 +27,8 @@
 #ifndef quantlib_cashflows_hpp
 #define quantlib_cashflows_hpp
 
-#include <ql/cashflows/duration.hpp>
 #include <ql/cashflow.hpp>
+#include <ql/cashflows/duration.hpp>
 #include <ql/interestrate.hpp>
 #include <ql/shared_ptr.hpp>
 
@@ -53,6 +53,7 @@ namespace QuantLib {
 
             Real operator()(Rate y) const;
             Real derivative(Rate y) const;
+
           private:
             void checkSign() const;
 
@@ -64,6 +65,7 @@ namespace QuantLib {
             ext::optional<bool> includeSettlementDateFlows_;
             Date settlementDate_, npvDate_;
         };
+
       public:
         CashFlows() = delete;
         CashFlows(CashFlows&&) = delete;
@@ -122,10 +124,9 @@ namespace QuantLib {
                        const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
                        Date settlementDate = Date());
 
-        static Real
-        nominal(const Leg& leg,
-                const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                Date settlementDate = Date());
+        static Real nominal(const Leg& leg,
+                            const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                            Date settlementDate = Date());
         static Date
         accrualStartDate(const Leg& leg,
                          const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
@@ -191,11 +192,12 @@ namespace QuantLib {
         /*! The NPV and BPS of the cash flows calculated
             together for performance reason
         */
-        static std::pair<Real, Real> npvbps(const Leg& leg,
-                                            const YieldTermStructure& discountCurve,
-                                            const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                                            Date settlementDate = Date(),
-                                            Date npvDate = Date());
+        static std::pair<Real, Real>
+        npvbps(const Leg& leg,
+               const YieldTermStructure& discountCurve,
+               const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+               Date settlementDate = Date(),
+               Date npvDate = Date());
 
         //! At-the-money rate of the cash flows.
         /*! The result is the fixed rate for which a fixed rate cash flow
@@ -285,10 +287,9 @@ namespace QuantLib {
                           Date npvDate = Date(),
                           Real accuracy = 1.0e-10,
                           Rate guess = 0.05) {
-            IrrFinder objFunction(leg, npv, dayCounter, compounding,
-                                  frequency, includeSettlementDateFlows,
-                                  settlementDate, npvDate);
-            return solver.solve(objFunction, accuracy, guess, guess/10.0);
+            IrrFinder objFunction(leg, npv, dayCounter, compounding, frequency,
+                                  includeSettlementDateFlows, settlementDate, npvDate);
+            return solver.solve(objFunction, accuracy, guess, guess / 10.0);
         }
 
         //! Cash-flow duration.
@@ -357,38 +358,42 @@ namespace QuantLib {
         /*! Obtained by setting dy = 0.0001 in the 2nd-order Taylor
             series expansion.
         */
-        static Real basisPointValue(const Leg& leg,
-                                    const InterestRate& yield,
-                                    const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                                    Date settlementDate = Date(),
-                                    Date npvDate = Date());
-        static Real basisPointValue(const Leg& leg,
-                                    Rate yield,
-                                    const DayCounter& dayCounter,
-                                    Compounding compounding,
-                                    Frequency frequency,
-                                    const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                                    Date settlementDate = Date(),
-                                    Date npvDate = Date());
+        static Real
+        basisPointValue(const Leg& leg,
+                        const InterestRate& yield,
+                        const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                        Date settlementDate = Date(),
+                        Date npvDate = Date());
+        static Real
+        basisPointValue(const Leg& leg,
+                        Rate yield,
+                        const DayCounter& dayCounter,
+                        Compounding compounding,
+                        Frequency frequency,
+                        const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                        Date settlementDate = Date(),
+                        Date npvDate = Date());
 
         //! Yield value of a basis point
         /*! The yield value of a one basis point change in price is
             the derivative of the yield with respect to the price
             multiplied by 0.01
         */
-        static Real yieldValueBasisPoint(const Leg& leg,
-                                         const InterestRate& yield,
-                                         const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                                         Date settlementDate = Date(),
-                                         Date npvDate = Date());
-        static Real yieldValueBasisPoint(const Leg& leg,
-                                         Rate yield,
-                                         const DayCounter& dayCounter,
-                                         Compounding compounding,
-                                         Frequency frequency,
-                                         const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
-                                         Date settlementDate = Date(),
-                                         Date npvDate = Date());
+        static Real
+        yieldValueBasisPoint(const Leg& leg,
+                             const InterestRate& yield,
+                             const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                             Date settlementDate = Date(),
+                             Date npvDate = Date());
+        static Real
+        yieldValueBasisPoint(const Leg& leg,
+                             Rate yield,
+                             const DayCounter& dayCounter,
+                             Compounding compounding,
+                             Frequency frequency,
+                             const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                             Date settlementDate = Date(),
+                             Date npvDate = Date());
         //@}
 
         //! \name Z-spread functions
@@ -399,10 +404,21 @@ namespace QuantLib {
         //@{
         //! NPV of the cash flows.
         /*! The NPV is the sum of the cash flows, each discounted
-            according to the z-spreaded term structure.  The result
-            is affected by the choice of the z-spread compounding
-            and the relative frequency and day counter.
+            according to the z-spreaded term structure.  The spread
+            is expressed in terms of the underlying curve's day counter.
         */
+        static Real npv(const Leg& leg,
+                        const ext::shared_ptr<YieldTermStructure>& discount,
+                        Spread zSpread,
+                        Compounding compounding,
+                        Frequency frequency,
+                        const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                        Date settlementDate = Date(),
+                        Date npvDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
         static Real npv(const Leg& leg,
                         const ext::shared_ptr<YieldTermStructure>& discount,
                         Spread zSpread,
@@ -416,6 +432,21 @@ namespace QuantLib {
         static Spread zSpread(const Leg& leg,
                               Real npv,
                               const ext::shared_ptr<YieldTermStructure>&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                              Date settlementDate = Date(),
+                              Date npvDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
+        static Spread zSpread(const Leg& leg,
+                              Real npv,
+                              const ext::shared_ptr<YieldTermStructure>&,
                               const DayCounter& dayCounter,
                               Compounding compounding,
                               Frequency frequency,
@@ -426,7 +457,6 @@ namespace QuantLib {
                               Size maxIterations = 100,
                               Rate guess = 0.0);
         //@}
-
     };
 
 }

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -36,204 +36,167 @@ namespace QuantLib {
         return CashFlows::maturityDate(bond.cashflows());
     }
 
-    bool BondFunctions::isTradable(const Bond& bond,
-                                   Date settlement) {
+    bool BondFunctions::isTradable(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return bond.notional(settlement)!=0.0;
+        return bond.notional(settlement) != 0.0;
     }
 
-    Leg::const_reverse_iterator
-    BondFunctions::previousCashFlow(const Bond& bond,
-                                    Date settlement) {
+    Leg::const_reverse_iterator BondFunctions::previousCashFlow(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::previousCashFlow(bond.cashflows(),
-                                           false, settlement);
+        return CashFlows::previousCashFlow(bond.cashflows(), false, settlement);
     }
 
-    Leg::const_iterator BondFunctions::nextCashFlow(const Bond& bond,
-                                                    Date settlement) {
+    Leg::const_iterator BondFunctions::nextCashFlow(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::nextCashFlow(bond.cashflows(),
-                                       false, settlement);
+        return CashFlows::nextCashFlow(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::previousCashFlowDate(const Bond& bond,
-                                             Date settlement) {
+    Date BondFunctions::previousCashFlowDate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::previousCashFlowDate(bond.cashflows(),
-                                               false, settlement);
+        return CashFlows::previousCashFlowDate(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::nextCashFlowDate(const Bond& bond,
-                                         Date settlement) {
+    Date BondFunctions::nextCashFlowDate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::nextCashFlowDate(bond.cashflows(),
-                                           false, settlement);
+        return CashFlows::nextCashFlowDate(bond.cashflows(), false, settlement);
     }
 
-    Real BondFunctions::previousCashFlowAmount(const Bond& bond,
-                                               Date settlement) {
+    Real BondFunctions::previousCashFlowAmount(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::previousCashFlowAmount(bond.cashflows(),
-                                                 false, settlement);
+        return CashFlows::previousCashFlowAmount(bond.cashflows(), false, settlement);
     }
 
-    Real BondFunctions::nextCashFlowAmount(const Bond& bond,
-                                           Date settlement) {
+    Real BondFunctions::nextCashFlowAmount(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::nextCashFlowAmount(bond.cashflows(),
-                                             false, settlement);
+        return CashFlows::nextCashFlowAmount(bond.cashflows(), false, settlement);
     }
 
-    Rate BondFunctions::previousCouponRate(const Bond& bond,
-                                           Date settlement) {
+    Rate BondFunctions::previousCouponRate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::previousCouponRate(bond.cashflows(),
-                                             false, settlement);
+        return CashFlows::previousCouponRate(bond.cashflows(), false, settlement);
     }
 
-    Rate BondFunctions::nextCouponRate(const Bond& bond,
-                                       Date settlement) {
+    Rate BondFunctions::nextCouponRate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return CashFlows::nextCouponRate(bond.cashflows(),
-                                         false, settlement);
+        return CashFlows::nextCouponRate(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::accrualStartDate(const Bond& bond,
-                                         Date settlement) {
+    Date BondFunctions::accrualStartDate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accrualStartDate(bond.cashflows(),
-                                           false, settlement);
+        return CashFlows::accrualStartDate(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::accrualEndDate(const Bond& bond,
-                                       Date settlement) {
+    Date BondFunctions::accrualEndDate(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accrualEndDate(bond.cashflows(),
-                                         false, settlement);
+        return CashFlows::accrualEndDate(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::referencePeriodStart(const Bond& bond,
-                                             Date settlement) {
+    Date BondFunctions::referencePeriodStart(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::referencePeriodStart(bond.cashflows(),
-                                               false, settlement);
+        return CashFlows::referencePeriodStart(bond.cashflows(), false, settlement);
     }
 
-    Date BondFunctions::referencePeriodEnd(const Bond& bond,
-                                           Date settlement) {
+    Date BondFunctions::referencePeriodEnd(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::referencePeriodEnd(bond.cashflows(),
-                                             false, settlement);
+        return CashFlows::referencePeriodEnd(bond.cashflows(), false, settlement);
     }
 
-    Time BondFunctions::accrualPeriod(const Bond& bond,
-                                      Date settlement) {
+    Time BondFunctions::accrualPeriod(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accrualPeriod(bond.cashflows(),
-                                        false, settlement);
+        return CashFlows::accrualPeriod(bond.cashflows(), false, settlement);
     }
 
-    Date::serial_type BondFunctions::accrualDays(const Bond& bond,
-                                                 Date settlement) {
+    Date::serial_type BondFunctions::accrualDays(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accrualDays(bond.cashflows(),
-                                      false, settlement);
+        return CashFlows::accrualDays(bond.cashflows(), false, settlement);
     }
 
-    Time BondFunctions::accruedPeriod(const Bond& bond,
-                                      Date settlement) {
+    Time BondFunctions::accruedPeriod(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accruedPeriod(bond.cashflows(),
-                                        false, settlement);
+        return CashFlows::accruedPeriod(bond.cashflows(), false, settlement);
     }
 
-    Date::serial_type BondFunctions::accruedDays(const Bond& bond,
-                                                 Date settlement) {
+    Date::serial_type BondFunctions::accruedDays(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::accruedDays(bond.cashflows(),
-                                      false, settlement);
+        return CashFlows::accruedDays(bond.cashflows(), false, settlement);
     }
 
-    Real BondFunctions::accruedAmount(const Bond& bond,
-                                      Date settlement) {
+    Real BondFunctions::accruedAmount(const Bond& bond, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         if (!BondFunctions::isTradable(bond, settlement))
             return 0.0;
 
-        return CashFlows::accruedAmount(bond.cashflows(),
-                                        false, settlement) *
-            100.0 / bond.notional(settlement);
+        return CashFlows::accruedAmount(bond.cashflows(), false, settlement) * 100.0 /
+               bond.notional(settlement);
     }
-
 
 
     Real BondFunctions::cleanPrice(const Bond& bond,
@@ -252,29 +215,25 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " settlement date (maturity being " <<
-                   bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " settlement date (maturity being "
+                                      << bond.maturityDate() << ")");
 
-        Real dirtyPrice = CashFlows::npv(bond.cashflows(), discountCurve,
-                                         false, settlement) *
-            100.0 / bond.notional(settlement);
+        Real dirtyPrice = CashFlows::npv(bond.cashflows(), discountCurve, false, settlement) *
+                          100.0 / bond.notional(settlement);
         return dirtyPrice;
     }
 
-    Real BondFunctions::bps(const Bond& bond,
-                            const YieldTermStructure& discountCurve,
-                            Date settlement) {
+    Real
+    BondFunctions::bps(const Bond& bond, const YieldTermStructure& discountCurve, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::bps(bond.cashflows(), discountCurve,
-                              false, settlement) *
-            100.0 / bond.notional(settlement);
+        return CashFlows::bps(bond.cashflows(), discountCurve, false, settlement) * 100.0 /
+               bond.notional(settlement);
     }
 
     Rate BondFunctions::atmRate(const Bond& bond,
@@ -285,8 +244,8 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
         Real npv = Null<Real>();
         if (price.isValid()) {
@@ -296,16 +255,12 @@ namespace QuantLib {
 
             Real currentNotional = bond.notional(settlement);
             npv = dirtyPrice / 100.0 * currentNotional;
-
         }
-        return CashFlows::atmRate(bond.cashflows(), discountCurve,
-                                  false, settlement, settlement,
+        return CashFlows::atmRate(bond.cashflows(), discountCurve, false, settlement, settlement,
                                   npv);
     }
 
-    Real BondFunctions::cleanPrice(const Bond& bond,
-                                   const InterestRate& yield,
-                                   Date settlement) {
+    Real BondFunctions::cleanPrice(const Bond& bond, const InterestRate& yield, Date settlement) {
         return dirtyPrice(bond, yield, settlement) - bond.accruedAmount(settlement);
     }
 
@@ -319,19 +274,16 @@ namespace QuantLib {
         return cleanPrice(bond, y, settlement);
     }
 
-    Real BondFunctions::dirtyPrice(const Bond& bond,
-                                   const InterestRate& yield,
-                                   Date settlement) {
+    Real BondFunctions::dirtyPrice(const Bond& bond, const InterestRate& yield, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        Real dirtyPrice = CashFlows::npv(bond.cashflows(), yield,
-                                         false, settlement) *
-            100.0 / bond.notional(settlement);
+        Real dirtyPrice = CashFlows::npv(bond.cashflows(), yield, false, settlement) * 100.0 /
+                          bond.notional(settlement);
         return dirtyPrice;
     }
 
@@ -345,19 +297,16 @@ namespace QuantLib {
         return dirtyPrice(bond, y, settlement);
     }
 
-    Real BondFunctions::bps(const Bond& bond,
-                            const InterestRate& yield,
-                            Date settlement) {
+    Real BondFunctions::bps(const Bond& bond, const InterestRate& yield, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::bps(bond.cashflows(), yield,
-                              false, settlement) *
-            100.0 / bond.notional(settlement);
+        return CashFlows::bps(bond.cashflows(), yield, false, settlement) * 100.0 /
+               bond.notional(settlement);
     }
 
     Real BondFunctions::bps(const Bond& bond,
@@ -381,9 +330,8 @@ namespace QuantLib {
                               Rate guess) {
         NewtonSafe solver;
         solver.setMaxEvaluations(maxIterations);
-        return yield<NewtonSafe>(solver, bond, price, dayCounter,
-                                 compounding, frequency, settlement,
-                                 accuracy, guess);
+        return yield<NewtonSafe>(solver, bond, price, dayCounter, compounding, frequency,
+                                 settlement, accuracy, guess);
     }
 
     Time BondFunctions::duration(const Bond& bond,
@@ -394,12 +342,10 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::duration(bond.cashflows(), yield,
-                                   type,
-                                   false, settlement);
+        return CashFlows::duration(bond.cashflows(), yield, type, false, settlement);
     }
 
     Time BondFunctions::duration(const Bond& bond,
@@ -413,18 +359,15 @@ namespace QuantLib {
         return duration(bond, y, type, settlement);
     }
 
-    Real BondFunctions::convexity(const Bond& bond,
-                                  const InterestRate& yield,
-                                  Date settlement) {
+    Real BondFunctions::convexity(const Bond& bond, const InterestRate& yield, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::convexity(bond.cashflows(), yield,
-                                    false, settlement);
+        return CashFlows::convexity(bond.cashflows(), yield, false, settlement);
     }
 
     Real BondFunctions::convexity(const Bond& bond,
@@ -437,25 +380,23 @@ namespace QuantLib {
         return convexity(bond, y, settlement);
     }
 
-    Real BondFunctions::basisPointValue(const Bond& bond,
-                                        const InterestRate& yield,
-                                        Date settlement) {
+    Real
+    BondFunctions::basisPointValue(const Bond& bond, const InterestRate& yield, Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::basisPointValue(bond.cashflows(), yield,
-                                          false, settlement);
+        return CashFlows::basisPointValue(bond.cashflows(), yield, false, settlement);
     }
 
     Real BondFunctions::basisPointValue(const Bond& bond,
-                              Rate yield,
-                              const DayCounter& dayCounter,
-                              Compounding compounding,
-                              Frequency frequency,
+                                        Rate yield,
+                                        const DayCounter& dayCounter,
+                                        Compounding compounding,
+                                        Frequency frequency,
                                         Date settlement) {
         InterestRate y(yield, dayCounter, compounding, frequency);
         return basisPointValue(bond, y, settlement);
@@ -468,11 +409,10 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        return CashFlows::yieldValueBasisPoint(bond.cashflows(), yield,
-                                               false, settlement);
+        return CashFlows::yieldValueBasisPoint(bond.cashflows(), yield, false, settlement);
     }
 
     Real BondFunctions::yieldValueBasisPoint(const Bond& bond,
@@ -488,20 +428,29 @@ namespace QuantLib {
     Real BondFunctions::cleanPrice(const Bond& bond,
                                    const ext::shared_ptr<YieldTermStructure>& d,
                                    Spread zSpread,
-                                   const DayCounter& dc,
                                    Compounding comp,
                                    Frequency freq,
                                    Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return dirtyPrice(bond, d, zSpread, dc, comp, freq, settlement) - bond.accruedAmount(settlement);
+        return dirtyPrice(bond, d, zSpread, comp, freq, settlement) -
+               bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::cleanPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter&,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        return BondFunctions::cleanPrice(bond, d, zSpread, comp, freq, settlement);
     }
 
     Real BondFunctions::dirtyPrice(const Bond& bond,
                                    const ext::shared_ptr<YieldTermStructure>& d,
                                    Spread zSpread,
-                                   const DayCounter& dc,
                                    Compounding comp,
                                    Frequency freq,
                                    Date settlement) {
@@ -509,20 +458,28 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        Real dirtyPrice = CashFlows::npv(bond.cashflows(), d,
-                                         zSpread, dc, comp, freq,
-                                         false, settlement) *
-            100.0 / bond.notional(settlement);
+        Real dirtyPrice =
+            CashFlows::npv(bond.cashflows(), d, zSpread, comp, freq, false, settlement) * 100.0 /
+            bond.notional(settlement);
         return dirtyPrice;
+    }
+
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter&,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        return BondFunctions::dirtyPrice(bond, d, zSpread, comp, freq, settlement);
     }
 
     Spread BondFunctions::zSpread(const Bond& bond,
                                   Bond::Price price,
                                   const ext::shared_ptr<YieldTermStructure>& d,
-                                  const DayCounter& dayCounter,
                                   Compounding compounding,
                                   Frequency frequency,
                                   Date settlement,
@@ -533,20 +490,29 @@ namespace QuantLib {
             settlement = bond.settlementDate();
 
         QL_REQUIRE(BondFunctions::isTradable(bond, settlement),
-                   "non tradable at " << settlement <<
-                   " (maturity being " << bond.maturityDate() << ")");
+                   "non tradable at " << settlement << " (maturity being " << bond.maturityDate()
+                                      << ")");
 
-        Real dirtyPrice =
-            price.amount() +
-            (price.type() == Bond::Price::Clean ? bond.accruedAmount(settlement) : 0);
+        Real dirtyPrice = price.amount() +
+                          (price.type() == Bond::Price::Clean ? bond.accruedAmount(settlement) : 0);
 
         dirtyPrice /= 100.0 / bond.notional(settlement);
 
-        return CashFlows::zSpread(bond.cashflows(),
-                                  dirtyPrice,
-                                  d,
-                                  dayCounter, compounding, frequency,
-                                  false, settlement, settlement,
-                                  accuracy, maxIterations, guess);
+        return CashFlows::zSpread(bond.cashflows(), dirtyPrice, d, compounding, frequency, false,
+                                  settlement, settlement, accuracy, maxIterations, guess);
+    }
+
+    Spread BondFunctions::zSpread(const Bond& bond,
+                                  Bond::Price price,
+                                  const ext::shared_ptr<YieldTermStructure>& d,
+                                  const DayCounter&,
+                                  Compounding compounding,
+                                  Frequency frequency,
+                                  Date settlement,
+                                  Real accuracy,
+                                  Size maxIterations,
+                                  Rate guess) {
+        return BondFunctions::zSpread(bond, price, d, compounding, frequency, settlement, accuracy,
+                                      maxIterations, guess);
     }
 }

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -27,11 +27,11 @@
 #ifndef quantlib_bond_functions_hpp
 #define quantlib_bond_functions_hpp
 
+#include <ql/cashflow.hpp>
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/duration.hpp>
-#include <ql/cashflow.hpp>
-#include <ql/interestrate.hpp>
 #include <ql/instruments/bond.hpp>
+#include <ql/interestrate.hpp>
 #include <ql/shared_ptr.hpp>
 
 namespace QuantLib {
@@ -56,51 +56,33 @@ namespace QuantLib {
         //@{
         static Date startDate(const Bond& bond);
         static Date maturityDate(const Bond& bond);
-        static bool isTradable(const Bond& bond,
-                               Date settlementDate = Date());
+        static bool isTradable(const Bond& bond, Date settlementDate = Date());
         //@}
 
         //! \name CashFlow inspectors
         //@{
-        static Leg::const_reverse_iterator
-        previousCashFlow(const Bond& bond,
-                         Date refDate = Date());
-        static Leg::const_iterator nextCashFlow(const Bond& bond,
-                                                Date refDate = Date());
-        static Date previousCashFlowDate(const Bond& bond,
-                                         Date refDate = Date());
-        static Date nextCashFlowDate(const Bond& bond,
-                                     Date refDate = Date());
-        static Real previousCashFlowAmount(const Bond& bond,
-                                           Date refDate = Date());
-        static Real nextCashFlowAmount(const Bond& bond,
-                                       Date refDate = Date());
+        static Leg::const_reverse_iterator previousCashFlow(const Bond& bond,
+                                                            Date refDate = Date());
+        static Leg::const_iterator nextCashFlow(const Bond& bond, Date refDate = Date());
+        static Date previousCashFlowDate(const Bond& bond, Date refDate = Date());
+        static Date nextCashFlowDate(const Bond& bond, Date refDate = Date());
+        static Real previousCashFlowAmount(const Bond& bond, Date refDate = Date());
+        static Real nextCashFlowAmount(const Bond& bond, Date refDate = Date());
         //@}
 
         //! \name Coupon inspectors
         //@{
-        static Rate previousCouponRate(const Bond& bond,
-                                       Date settlementDate = Date());
-        static Rate nextCouponRate(const Bond& bond,
-                                   Date settlementDate = Date());
-        static Date accrualStartDate(const Bond& bond,
-                                     Date settlementDate = Date());
-        static Date accrualEndDate(const Bond& bond,
-                                   Date settlementDate = Date());
-        static Date referencePeriodStart(const Bond& bond,
-                                         Date settlementDate = Date());
-        static Date referencePeriodEnd(const Bond& bond,
-                                       Date settlementDate = Date());
-        static Time accrualPeriod(const Bond& bond,
-                                  Date settlementDate = Date());
-        static Date::serial_type accrualDays(const Bond& bond,
-                                             Date settlementDate = Date());
-        static Time accruedPeriod(const Bond& bond,
-                                  Date settlementDate = Date());
-        static Date::serial_type accruedDays(const Bond& bond,
-                                             Date settlementDate = Date());
-        static Real accruedAmount(const Bond& bond,
-                                  Date settlementDate = Date());
+        static Rate previousCouponRate(const Bond& bond, Date settlementDate = Date());
+        static Rate nextCouponRate(const Bond& bond, Date settlementDate = Date());
+        static Date accrualStartDate(const Bond& bond, Date settlementDate = Date());
+        static Date accrualEndDate(const Bond& bond, Date settlementDate = Date());
+        static Date referencePeriodStart(const Bond& bond, Date settlementDate = Date());
+        static Date referencePeriodEnd(const Bond& bond, Date settlementDate = Date());
+        static Time accrualPeriod(const Bond& bond, Date settlementDate = Date());
+        static Date::serial_type accrualDays(const Bond& bond, Date settlementDate = Date());
+        static Time accruedPeriod(const Bond& bond, Date settlementDate = Date());
+        static Date::serial_type accruedDays(const Bond& bond, Date settlementDate = Date());
+        static Real accruedAmount(const Bond& bond, Date settlementDate = Date());
         //@}
 
         //! \name YieldTermStructure functions
@@ -123,27 +105,23 @@ namespace QuantLib {
 
         //! \name Yield (a.k.a. Internal Rate of Return, i.e. IRR) functions
         //@{
-        static Real cleanPrice(const Bond& bond,
-                               const InterestRate& yield,
-                               Date settlementDate = Date());
+        static Real
+        cleanPrice(const Bond& bond, const InterestRate& yield, Date settlementDate = Date());
         static Real cleanPrice(const Bond& bond,
                                Rate yield,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
-        static Real dirtyPrice(const Bond& bond,
-                               const InterestRate& yield,
-                               Date settlementDate = Date());
+        static Real
+        dirtyPrice(const Bond& bond, const InterestRate& yield, Date settlementDate = Date());
         static Real dirtyPrice(const Bond& bond,
                                Rate yield,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
-        static Real bps(const Bond& bond,
-                        const InterestRate& yield,
-                        Date settlementDate = Date());
+        static Real bps(const Bond& bond, const InterestRate& yield, Date settlementDate = Date());
         static Real bps(const Bond& bond,
                         Rate yield,
                         const DayCounter& dayCounter,
@@ -173,8 +151,8 @@ namespace QuantLib {
                 settlementDate = bond.settlementDate();
 
             QL_REQUIRE(BondFunctions::isTradable(bond, settlementDate),
-                       "non tradable at " << settlementDate <<
-                       " (maturity being " << bond.maturityDate() << ")");
+                       "non tradable at " << settlementDate << " (maturity being "
+                                          << bond.maturityDate() << ")");
 
             Real amount = price.amount();
 
@@ -184,33 +162,30 @@ namespace QuantLib {
             amount /= 100.0 / bond.notional(settlementDate);
 
             return CashFlows::yield<Solver>(solver, bond.cashflows(), amount, dayCounter,
-                                            compounding,
-                                            frequency, false, settlementDate,
+                                            compounding, frequency, false, settlementDate,
                                             settlementDate, accuracy, guess);
         }
         static Time duration(const Bond& bond,
                              const InterestRate& yield,
                              Duration::Type type = Duration::Modified,
-                             Date settlementDate = Date() );
+                             Date settlementDate = Date());
         static Time duration(const Bond& bond,
                              Rate yield,
                              const DayCounter& dayCounter,
                              Compounding compounding,
                              Frequency frequency,
                              Duration::Type type = Duration::Modified,
-                             Date settlementDate = Date() );
-        static Real convexity(const Bond& bond,
-                              const InterestRate& yield,
-                              Date settlementDate = Date());
+                             Date settlementDate = Date());
+        static Real
+        convexity(const Bond& bond, const InterestRate& yield, Date settlementDate = Date());
         static Real convexity(const Bond& bond,
                               Rate yield,
                               const DayCounter& dayCounter,
                               Compounding compounding,
                               Frequency frequency,
                               Date settlementDate = Date());
-        static Real basisPointValue(const Bond& bond,
-                                    const InterestRate& yield,
-                                    Date settlementDate = Date());
+        static Real
+        basisPointValue(const Bond& bond, const InterestRate& yield, Date settlementDate = Date());
         static Real basisPointValue(const Bond& bond,
                                     Rate yield,
                                     const DayCounter& dayCounter,
@@ -233,6 +208,16 @@ namespace QuantLib {
         static Real cleanPrice(const Bond& bond,
                                const ext::shared_ptr<YieldTermStructure>& discount,
                                Spread zSpread,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
+        static Real cleanPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
@@ -240,10 +225,33 @@ namespace QuantLib {
         static Real dirtyPrice(const Bond& bond,
                                const ext::shared_ptr<YieldTermStructure>& discount,
                                Spread zSpread,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
+        static Real dirtyPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
+        static Spread zSpread(const Bond& bond,
+                              Bond::Price price,
+                              const ext::shared_ptr<YieldTermStructure>&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              Date settlementDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
         static Spread zSpread(const Bond& bond,
                               Bond::Price price,
                               const ext::shared_ptr<YieldTermStructure>&,
@@ -255,7 +263,6 @@ namespace QuantLib {
                               Size maxIterations = 100,
                               Rate guess = 0.0);
         //@}
-
     };
 
 }

--- a/ql/termstructures/yield/zerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/zerospreadedtermstructure.hpp
@@ -79,6 +79,7 @@ namespace QuantLib {
         //! returns the spreaded forward rate
         /* This method must disappear should the spread become a curve */
         Rate forwardImpl(Time) const;
+
       private:
         Handle<YieldTermStructure> originalCurve_;
         Handle<Quote> spread_;
@@ -143,19 +144,14 @@ namespace QuantLib {
     }
 
     inline Rate ZeroSpreadedTermStructure::zeroYieldImpl(Time t) const {
-        // to be fixed: user-defined daycounter should be used
-        InterestRate zeroRate =
-            originalCurve_->zeroRate(t, comp_, freq_, true);
-        InterestRate spreadedRate(zeroRate + spread_->value(),
-                                  zeroRate.dayCounter(),
-                                  zeroRate.compounding(),
-                                  zeroRate.frequency());
+        InterestRate zeroRate = originalCurve_->zeroRate(t, comp_, freq_, true);
+        InterestRate spreadedRate(zeroRate + spread_->value(), zeroRate.dayCounter(),
+                                  zeroRate.compounding(), zeroRate.frequency());
         return spreadedRate.equivalentRate(Continuous, NoFrequency, t);
     }
 
     inline Rate ZeroSpreadedTermStructure::forwardImpl(Time t) const {
-        return originalCurve_->forwardRate(t, t, comp_, freq_, true)
-            + spread_->value();
+        return originalCurve_->forwardRate(t, t, comp_, freq_, true) + spread_->value();
     }
 
 }

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -19,41 +19,41 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
-#include <ql/time/schedule.hpp>
+#include <ql/cashflows/cashflows.hpp>
+#include <ql/cashflows/cmscoupon.hpp>
+#include <ql/cashflows/conundrumpricer.hpp>
+#include <ql/cashflows/couponpricer.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/cashflows/iborcoupon.hpp>
+#include <ql/cashflows/simplecashflow.hpp>
+#include <ql/index.hpp>
+#include <ql/indexes/ibor/estr.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/swapindex.hpp>
 #include <ql/instruments/assetswap.hpp>
 #include <ql/instruments/bond.hpp>
+#include <ql/instruments/bonds/cmsratebond.hpp>
 #include <ql/instruments/bonds/fixedratebond.hpp>
 #include <ql/instruments/bonds/floatingratebond.hpp>
-#include <ql/instruments/bonds/cmsratebond.hpp>
 #include <ql/instruments/bonds/zerocouponbond.hpp>
-#include <ql/index.hpp>
+#include <ql/pricingengines/bond/bondfunctions.hpp>
+#include <ql/pricingengines/bond/discountingbondengine.hpp>
+#include <ql/pricingengines/swap/discountingswapengine.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/optionlet/constantoptionletvol.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionconstantvol.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionvolcube.hpp>
+#include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/time/calendars/target.hpp>
-#include <ql/time/daycounters/thirty360.hpp>
-#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
 #include <ql/time/daycounters/simpledaycounter.hpp>
-#include <ql/indexes/ibor/euribor.hpp>
-#include <ql/indexes/ibor/estr.hpp>
-#include <ql/indexes/swapindex.hpp>
-#include <ql/cashflows/fixedratecoupon.hpp>
-#include <ql/cashflows/iborcoupon.hpp>
-#include <ql/cashflows/cmscoupon.hpp>
-#include <ql/cashflows/couponpricer.hpp>
-#include <ql/cashflows/conundrumpricer.hpp>
-#include <ql/termstructures/volatility/optionlet/constantoptionletvol.hpp>
-#include <ql/termstructures/volatility/swaption/swaptionconstantvol.hpp>
-#include <ql/termstructures/volatility/swaption/swaptionvolmatrix.hpp>
-#include <ql/termstructures/volatility/swaption/swaptionvolcube.hpp>
+#include <ql/time/daycounters/thirty360.hpp>
+#include <ql/time/schedule.hpp>
 #include <ql/utilities/dataformatters.hpp>
-#include <ql/cashflows/cashflows.hpp>
-#include <ql/cashflows/simplecashflow.hpp>
-#include <ql/pricingengines/bond/discountingbondengine.hpp>
-#include <ql/pricingengines/bond/bondfunctions.hpp>
-#include <ql/pricingengines/swap/discountingswapengine.hpp>
-#include <ql/quotes/simplequote.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -82,38 +82,31 @@ struct CommonVars {
         compounding = Continuous;
         Frequency fixedFrequency = Annual;
         Frequency floatingFrequency = Semiannual;
-        iborIndex = ext::shared_ptr<IborIndex>(
-                     new Euribor(Period(floatingFrequency), termStructure));
+        iborIndex =
+            ext::shared_ptr<IborIndex>(new Euribor(Period(floatingFrequency), termStructure));
         Calendar calendar = iborIndex->fixingCalendar();
         swapIndex = ext::make_shared<SwapIndex>(
-                "EuriborSwapIsdaFixA", 10*Years, swapSettlementDays,
-                              iborIndex->currency(), calendar,
-                              Period(fixedFrequency), fixedConvention,
-                              iborIndex->dayCounter(), iborIndex);
+            "EuriborSwapIsdaFixA", 10 * Years, swapSettlementDays, iborIndex->currency(), calendar,
+            Period(fixedFrequency), fixedConvention, iborIndex->dayCounter(), iborIndex);
         spread = 0.0;
         nonnullspread = 0.003;
-        Date today(24,April,2007);
+        Date today(24, April, 2007);
         Settings::instance().evaluationDate() = today;
 
         termStructure.linkTo(flatRate(today, 0.05, Actual365Fixed()));
         pricer = ext::shared_ptr<IborCouponPricer>(new BlackIborCouponPricer);
         Handle<SwaptionVolatilityStructure> swaptionVolatilityStructure(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    ConstantSwaptionVolatility(today, NullCalendar(),Following,
-                                               0.2, Actual365Fixed())));
-        Handle<Quote> meanReversionQuote(ext::shared_ptr<Quote>(new
-                SimpleQuote(0.01)));
-        cmspricer = ext::shared_ptr<CmsCouponPricer>(new
-                AnalyticHaganPricer(swaptionVolatilityStructure,
-                                    GFunctionFactory::Standard,
-                                    meanReversionQuote));
+            ext::shared_ptr<SwaptionVolatilityStructure>(new ConstantSwaptionVolatility(
+                today, NullCalendar(), Following, 0.2, Actual365Fixed())));
+        Handle<Quote> meanReversionQuote(ext::shared_ptr<Quote>(new SimpleQuote(0.01)));
+        cmspricer = ext::shared_ptr<CmsCouponPricer>(new AnalyticHaganPricer(
+            swaptionVolatilityStructure, GFunctionFactory::Standard, meanReversionQuote));
     }
 };
 
 
 BOOST_AUTO_TEST_CASE(testConsistency) {
-    BOOST_TEST_MESSAGE(
-                 "Testing consistency between fair price and fair spread...");
+    BOOST_TEST_MESSAGE("Testing consistency between fair price and fair spread...");
 
     CommonVars vars;
 
@@ -123,35 +116,21 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Schedule bondSchedule(Date(4,January,2005),
-                          Date(4,January,2037),
-                          Period(Annual), bondCalendar,
-                          Unadjusted, Unadjusted,
-                          DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> bond(new
-        FixedRateBond(settlementDays, vars.faceAmount,
-                      bondSchedule,
-                      std::vector<Rate>(1, 0.04),
-                      ActualActual(ActualActual::ISDA),
-                      Following,
-                      100.0, Date(4,January,2005)));
+    Schedule bondSchedule(Date(4, January, 2005), Date(4, January, 2037), Period(Annual),
+                          bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward, false);
+    ext::shared_ptr<Bond> bond(new FixedRateBond(
+        settlementDays, vars.faceAmount, bondSchedule, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
 
     bool payFixedRate = true;
     Real bondPrice = 95.0;
 
     bool isPar = true;
-    AssetSwap parAssetSwap(payFixedRate,
-                         bond, bondPrice,
-                         vars.iborIndex, vars.spread,
-                         Schedule(),
-                         vars.iborIndex->dayCounter(),
-                         isPar);
+    AssetSwap parAssetSwap(payFixedRate, bond, bondPrice, vars.iborIndex, vars.spread, Schedule(),
+                           vars.iborIndex->dayCounter(), isPar);
 
-    ext::shared_ptr<PricingEngine> swapEngine(new
-        DiscountingSwapEngine(vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              Settings::instance().evaluationDate()));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(
+        vars.termStructure, true, bond->settlementDate(), Settings::instance().evaluationDate()));
 
     parAssetSwap.setPricingEngine(swapEngine);
     Real fairCleanPrice = parAssetSwap.fairCleanPrice();
@@ -159,517 +138,379 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
 
     Real tolerance = 1.0e-13;
 
-    AssetSwap assetSwap2(payFixedRate,
-                         bond, fairCleanPrice,
-                         vars.iborIndex, vars.spread,
-                         Schedule(),
-                         vars.iborIndex->dayCounter(),
-                         isPar);
+    AssetSwap assetSwap2(payFixedRate, bond, fairCleanPrice, vars.iborIndex, vars.spread,
+                         Schedule(), vars.iborIndex->dayCounter(), isPar);
     assetSwap2.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap2.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap2.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap2.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap2.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap2.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap2.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap2.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap2.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairSpread() - vars.spread)>tolerance) {
+    if (std::fabs(assetSwap2.fairSpread() - vars.spread) > tolerance) {
         BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread "
-                   "at zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap2.fairSpread() <<
-                   "\n  NPV:          " << assetSwap2.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   "at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap2.fairSpread() << "\n  NPV:          "
+                   << assetSwap2.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-    AssetSwap assetSwap3(payFixedRate,
-                         bond, bondPrice,
-                         vars.iborIndex, fairSpread,
-                         Schedule(),
-                         vars.iborIndex->dayCounter(),
-                         isPar);
+    AssetSwap assetSwap3(payFixedRate, bond, bondPrice, vars.iborIndex, fairSpread, Schedule(),
+                         vars.iborIndex->dayCounter(), isPar);
     assetSwap3.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap3.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap3.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap3.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap3.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap3.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap3.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap3.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap3.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairSpread() - fairSpread)>tolerance) {
+    if (std::fabs(assetSwap3.fairSpread() - fairSpread) > tolerance) {
         BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at"
-                   " zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap3.fairSpread() <<
-                   "\n  NPV:          " << assetSwap3.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   " zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap3.fairSpread() << "\n  NPV:          "
+                   << assetSwap3.NPV() << "\n  tolerance:    " << tolerance);
     }
 
     // let's change the npv date
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              bond->settlementDate()));
+    swapEngine = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(
+        vars.termStructure, true, bond->settlementDate(), bond->settlementDate()));
 
     parAssetSwap.setPricingEngine(swapEngine);
     // fair clean price and fair spread should not change
-    if (std::fabs(parAssetSwap.fairCleanPrice() - fairCleanPrice)>tolerance) {
-        BOOST_FAIL("\npar asset swap fair clean price changed with NpvDate:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n expected clean price: " << fairCleanPrice <<
-                   "\n fair clean price:     "<<parAssetSwap.fairCleanPrice()<<
-                   "\n tolerance:            " << tolerance);
+    if (std::fabs(parAssetSwap.fairCleanPrice() - fairCleanPrice) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair clean price changed with NpvDate:"
+                   << std::fixed << std::setprecision(4) << "\n expected clean price: "
+                   << fairCleanPrice << "\n fair clean price:     " << parAssetSwap.fairCleanPrice()
+                   << "\n tolerance:            " << tolerance);
     }
-    if (std::fabs(parAssetSwap.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread changed with NpvDate:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  expected spread: " << fairSpread <<
-                   "\n  fair spread:     " << parAssetSwap.fairSpread() <<
-                   "\n  tolerance:       " << tolerance);
+    if (std::fabs(parAssetSwap.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread changed with NpvDate:"
+                   << std::fixed << std::setprecision(4) << "\n  expected spread: " << fairSpread
+                   << "\n  fair spread:     " << parAssetSwap.fairSpread()
+                   << "\n  tolerance:       " << tolerance);
     }
 
-    assetSwap2 = AssetSwap(payFixedRate,
-                           bond, fairCleanPrice,
-                           vars.iborIndex, vars.spread,
-                           Schedule(),
-                           vars.iborIndex->dayCounter(),
-                           isPar);
+    assetSwap2 = AssetSwap(payFixedRate, bond, fairCleanPrice, vars.iborIndex, vars.spread,
+                           Schedule(), vars.iborIndex->dayCounter(), isPar);
     assetSwap2.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap2.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap2.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap2.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap2.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap2.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap2.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap2.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap2.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairSpread() - vars.spread)>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap2.fairSpread() <<
-                   "\n  NPV:          " << assetSwap2.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap2.fairSpread() - vars.spread) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap2.fairSpread() << "\n  NPV:          "
+                   << assetSwap2.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-    assetSwap3 = AssetSwap(payFixedRate,
-                           bond, bondPrice,
-                           vars.iborIndex, fairSpread,
-                           Schedule(),
-                           vars.iborIndex->dayCounter(),
-                           isPar);
+    assetSwap3 = AssetSwap(payFixedRate, bond, bondPrice, vars.iborIndex, fairSpread, Schedule(),
+                           vars.iborIndex->dayCounter(), isPar);
     assetSwap3.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap3.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap3.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap3.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap3.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap3.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap3.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap3.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap3.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap3.fairSpread() <<
-                   "\n  NPV:          " << assetSwap3.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap3.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap3.fairSpread() << "\n  NPV:          "
+                   << assetSwap3.NPV() << "\n  tolerance:    " << tolerance);
     }
 
     // using overnight index
 
     auto overnight = ext::make_shared<Estr>(vars.termStructure);
-    Schedule overnightSchedule(bond->settlementDate(),
-                               bond->maturityDate(),
-                               6 * Months,
-                               overnight->fixingCalendar(),
-                               overnight->businessDayConvention(),
-                               overnight->businessDayConvention(),
-                               DateGeneration::Backward,
-                               false);
+    Schedule overnightSchedule(bond->settlementDate(), bond->maturityDate(), 6 * Months,
+                               overnight->fixingCalendar(), overnight->businessDayConvention(),
+                               overnight->businessDayConvention(), DateGeneration::Backward, false);
 
-    parAssetSwap = AssetSwap(payFixedRate,
-                             bond, bondPrice,
-                             overnight, vars.spread,
-                             overnightSchedule,
-                             overnight->dayCounter(),
-                             isPar);
+    parAssetSwap = AssetSwap(payFixedRate, bond, bondPrice, overnight, vars.spread,
+                             overnightSchedule, overnight->dayCounter(), isPar);
 
     swapEngine = ext::make_shared<DiscountingSwapEngine>(
-                              vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              Settings::instance().evaluationDate());
+        vars.termStructure, true, bond->settlementDate(), Settings::instance().evaluationDate());
 
     parAssetSwap.setPricingEngine(swapEngine);
     fairCleanPrice = parAssetSwap.fairCleanPrice();
     fairSpread = parAssetSwap.fairSpread();
 
-    assetSwap2 = AssetSwap(payFixedRate,
-                           bond, fairCleanPrice,
-                           overnight, vars.spread,
-                           overnightSchedule,
-                           overnight->dayCounter(),
-                           isPar);
+    assetSwap2 = AssetSwap(payFixedRate, bond, fairCleanPrice, overnight, vars.spread,
+                           overnightSchedule, overnight->dayCounter(), isPar);
     assetSwap2.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap2.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap2.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap2.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap2.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap2.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap2.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap2.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap2.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap2.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap2.fairSpread() - vars.spread)>tolerance) {
+    if (std::fabs(assetSwap2.fairSpread() - vars.spread) > tolerance) {
         BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread "
-                   "at zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap2.fairSpread() <<
-                   "\n  NPV:          " << assetSwap2.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   "at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap2.fairSpread() << "\n  NPV:          "
+                   << assetSwap2.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-    assetSwap3 = AssetSwap(payFixedRate,
-                           bond, bondPrice,
-                           overnight, fairSpread,
-                           overnightSchedule,
-                           overnight->dayCounter(),
-                           isPar);
+    assetSwap3 = AssetSwap(payFixedRate, bond, bondPrice, overnight, fairSpread, overnightSchedule,
+                           overnight->dayCounter(), isPar);
     assetSwap3.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap3.NPV())>tolerance) {
-        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap3.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap3.NPV()) > tolerance) {
+        BOOST_FAIL("\npar asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap3.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap3.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\npar asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap3.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap3.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap3.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap3.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap3.fairSpread() - fairSpread)>tolerance) {
+    if (std::fabs(assetSwap3.fairSpread() - fairSpread) > tolerance) {
         BOOST_FAIL("\npar asset swap fair spread doesn't equal input spread at"
-                   " zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap3.fairSpread() <<
-                   "\n  NPV:          " << assetSwap3.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   " zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap3.fairSpread() << "\n  NPV:          "
+                   << assetSwap3.NPV() << "\n  tolerance:    " << tolerance);
     }
 
 
     // now market asset swap
 
     isPar = false;
-    AssetSwap mktAssetSwap(payFixedRate,
-                           bond, bondPrice,
-                           vars.iborIndex, vars.spread,
-                           Schedule(),
-                           vars.iborIndex->dayCounter(),
-                           isPar);
+    AssetSwap mktAssetSwap(payFixedRate, bond, bondPrice, vars.iborIndex, vars.spread, Schedule(),
+                           vars.iborIndex->dayCounter(), isPar);
 
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              Settings::instance().evaluationDate()));
+    swapEngine = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(
+        vars.termStructure, true, bond->settlementDate(), Settings::instance().evaluationDate()));
 
     mktAssetSwap.setPricingEngine(swapEngine);
     fairCleanPrice = mktAssetSwap.fairCleanPrice();
     fairSpread = mktAssetSwap.fairSpread();
 
-    AssetSwap assetSwap4(payFixedRate,
-                         bond, fairCleanPrice,
-                         vars.iborIndex, vars.spread,
-                         Schedule(),
-                         vars.iborIndex->dayCounter(),
-                         isPar);
+    AssetSwap assetSwap4(payFixedRate, bond, fairCleanPrice, vars.iborIndex, vars.spread,
+                         Schedule(), vars.iborIndex->dayCounter(), isPar);
     assetSwap4.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap4.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap4.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap4.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap4.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap4.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap4.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap4.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap4.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairSpread() - vars.spread)>tolerance) {
+    if (std::fabs(assetSwap4.fairSpread() - vars.spread) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread"
-                   " at zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap4.fairSpread() <<
-                   "\n  NPV:          " << assetSwap4.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   " at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap4.fairSpread() << "\n  NPV:          "
+                   << assetSwap4.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-    AssetSwap assetSwap5(payFixedRate,
-                         bond, bondPrice,
-                         vars.iborIndex, fairSpread,
-                         Schedule(),
-                         vars.iborIndex->dayCounter(),
-                         isPar);
+    AssetSwap assetSwap5(payFixedRate, bond, bondPrice, vars.iborIndex, fairSpread, Schedule(),
+                         vars.iborIndex->dayCounter(), isPar);
     assetSwap5.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap5.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap5.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap5.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap5.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap5.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap5.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap5.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap5.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap5.fairSpread() <<
-                   "\n  NPV:          " << assetSwap5.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap5.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap5.fairSpread() << "\n  NPV:          "
+                   << assetSwap5.NPV() << "\n  tolerance:    " << tolerance);
     }
 
     // let's change the npv date
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              bond->settlementDate()));
+    swapEngine = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(
+        vars.termStructure, true, bond->settlementDate(), bond->settlementDate()));
 
     mktAssetSwap.setPricingEngine(swapEngine);
     // fair clean price and fair spread should not change
-    if (std::fabs(mktAssetSwap.fairCleanPrice() - fairCleanPrice)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair clean price changed with NpvDate:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  expected clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << mktAssetSwap.fairCleanPrice() <<
-                   "\n  tolerance:         " << tolerance);
+    if (std::fabs(mktAssetSwap.fairCleanPrice() - fairCleanPrice) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair clean price changed with NpvDate:"
+                   << std::fixed << std::setprecision(4) << "\n  expected clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << mktAssetSwap.fairCleanPrice()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(mktAssetSwap.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread changed with NpvDate:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  expected spread: " << fairSpread <<
-                   "\n  fair spread:  " << mktAssetSwap.fairSpread() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(mktAssetSwap.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread changed with NpvDate:"
+                   << std::fixed << std::setprecision(4) << "\n  expected spread: " << fairSpread
+                   << "\n  fair spread:  " << mktAssetSwap.fairSpread()
+                   << "\n  tolerance:    " << tolerance);
     }
 
-    assetSwap4 = AssetSwap(payFixedRate,
-                           bond, fairCleanPrice,
-                           vars.iborIndex, vars.spread,
-                           Schedule(),
-                           vars.iborIndex->dayCounter(),
-                           isPar);
+    assetSwap4 = AssetSwap(payFixedRate, bond, fairCleanPrice, vars.iborIndex, vars.spread,
+                           Schedule(), vars.iborIndex->dayCounter(), isPar);
     assetSwap4.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap4.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap4.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap4.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap4.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap4.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap4.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap4.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap4.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairSpread() - vars.spread)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap4.fairSpread() <<
-                   "\n  NPV:          " << assetSwap4.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap4.fairSpread() - vars.spread) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap4.fairSpread() << "\n  NPV:          "
+                   << assetSwap4.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-     assetSwap5 = AssetSwap(payFixedRate,
-                            bond, bondPrice,
-                            vars.iborIndex, fairSpread,
-                            Schedule(),
-                            vars.iborIndex->dayCounter(),
-                            isPar);
+    assetSwap5 = AssetSwap(payFixedRate, bond, bondPrice, vars.iborIndex, fairSpread, Schedule(),
+                           vars.iborIndex->dayCounter(), isPar);
     assetSwap5.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap5.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap5.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap5.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap5.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap5.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap5.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap5.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap5.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap5.fairSpread() <<
-                   "\n  NPV:          " << assetSwap5.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap5.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap5.fairSpread() << "\n  NPV:          "
+                   << assetSwap5.NPV() << "\n  tolerance:    " << tolerance);
     }
 
     // using overnight index
 
-    mktAssetSwap = AssetSwap(payFixedRate,
-                             bond, bondPrice,
-                             overnight, vars.spread,
-                             overnightSchedule,
-                             overnight->dayCounter(),
-                             isPar);
+    mktAssetSwap = AssetSwap(payFixedRate, bond, bondPrice, overnight, vars.spread,
+                             overnightSchedule, overnight->dayCounter(), isPar);
 
     swapEngine = ext::make_shared<DiscountingSwapEngine>(
-                              vars.termStructure,
-                              true,
-                              bond->settlementDate(),
-                              Settings::instance().evaluationDate());
+        vars.termStructure, true, bond->settlementDate(), Settings::instance().evaluationDate());
 
     mktAssetSwap.setPricingEngine(swapEngine);
     fairCleanPrice = mktAssetSwap.fairCleanPrice();
     fairSpread = mktAssetSwap.fairSpread();
 
-    assetSwap4 = AssetSwap(payFixedRate,
-                           bond, fairCleanPrice,
-                           overnight, vars.spread,
-                           overnightSchedule,
-                           overnight->dayCounter(),
-                           isPar);
+    assetSwap4 = AssetSwap(payFixedRate, bond, fairCleanPrice, overnight, vars.spread,
+                           overnightSchedule, overnight->dayCounter(), isPar);
     assetSwap4.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap4.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  clean price:      " << bondPrice <<
-                   "\n  fair clean price: " << fairCleanPrice <<
-                   "\n  NPV:              " << assetSwap4.NPV() <<
-                   "\n  tolerance:        " << tolerance);
+    if (std::fabs(assetSwap4.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair clean price doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  clean price:      " << bondPrice
+                   << "\n  fair clean price: " << fairCleanPrice << "\n  NPV:              "
+                   << assetSwap4.NPV() << "\n  tolerance:        " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice)>tolerance) {
+    if (std::fabs(assetSwap4.fairCleanPrice() - fairCleanPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << fairCleanPrice <<
-                   "\n  fair clean price:  " << assetSwap4.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap4.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: "
+                   << fairCleanPrice << "\n  fair clean price:  " << assetSwap4.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap4.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap4.fairSpread() - vars.spread)>tolerance) {
+    if (std::fabs(assetSwap4.fairSpread() - vars.spread) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread"
-                   " at zero NPV: " << std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << vars.spread <<
-                   "\n  fair spread:  " << assetSwap4.fairSpread() <<
-                   "\n  NPV:          " << assetSwap4.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+                   " at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << vars.spread
+                   << "\n  fair spread:  " << assetSwap4.fairSpread() << "\n  NPV:          "
+                   << assetSwap4.NPV() << "\n  tolerance:    " << tolerance);
     }
 
-    assetSwap5 = AssetSwap(payFixedRate,
-                           bond, bondPrice,
-                           overnight, fairSpread,
-                           overnightSchedule,
-                           overnight->dayCounter(),
-                           isPar);
+    assetSwap5 = AssetSwap(payFixedRate, bond, bondPrice, overnight, fairSpread, overnightSchedule,
+                           overnight->dayCounter(), isPar);
     assetSwap5.setPricingEngine(swapEngine);
-    if (std::fabs(assetSwap5.NPV())>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  spread:      " << vars.spread <<
-                   "\n  fair spread: " << fairSpread <<
-                   "\n  NPV:         " << assetSwap5.NPV() <<
-                   "\n  tolerance:   " << tolerance);
+    if (std::fabs(assetSwap5.NPV()) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't zero the NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  spread:      " << vars.spread
+                   << "\n  fair spread: " << fairSpread << "\n  NPV:         " << assetSwap5.NPV()
+                   << "\n  tolerance:   " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice)>tolerance) {
+    if (std::fabs(assetSwap5.fairCleanPrice() - bondPrice) > tolerance) {
         BOOST_FAIL("\nmarket asset swap fair clean price doesn't equal input "
-                   "clean price at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input clean price: " << bondPrice <<
-                   "\n  fair clean price:  " << assetSwap5.fairCleanPrice() <<
-                   "\n  NPV:               " << assetSwap5.NPV() <<
-                   "\n  tolerance:         " << tolerance);
+                   "clean price at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input clean price: " << bondPrice
+                   << "\n  fair clean price:  " << assetSwap5.fairCleanPrice()
+                   << "\n  NPV:               " << assetSwap5.NPV()
+                   << "\n  tolerance:         " << tolerance);
     }
-    if (std::fabs(assetSwap5.fairSpread() - fairSpread)>tolerance) {
-        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: " <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  input spread: " << fairSpread <<
-                   "\n  fair spread:  " << assetSwap5.fairSpread() <<
-                   "\n  NPV:          " << assetSwap5.NPV() <<
-                   "\n  tolerance:    " << tolerance);
+    if (std::fabs(assetSwap5.fairSpread() - fairSpread) > tolerance) {
+        BOOST_FAIL("\nmarket asset swap fair spread doesn't equal input spread at zero NPV: "
+                   << std::fixed << std::setprecision(4) << "\n  input spread: " << fairSpread
+                   << "\n  fair spread:  " << assetSwap5.fairSpread() << "\n  NPV:          "
+                   << assetSwap5.NPV() << "\n  tolerance:    " << tolerance);
     }
 }
 
@@ -692,31 +533,20 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Schedule fixedBondSchedule1(Date(4,January,2005),
-                                Date(4,January,2037),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(
-                         new FixedRateBond(settlementDays, vars.faceAmount,
-                                           fixedBondSchedule1,
-                                           std::vector<Rate>(1, 0.04),
-                                           ActualActual(ActualActual::ISDA),
-                                           Following,
-                                           100.0, Date(4,January,2005)));
+    Schedule fixedBondSchedule1(Date(4, January, 2005), Date(4, January, 2037), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond1(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule1, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                            new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
-    AssetSwap fixedBondAssetSwap1(payFixedRate,
-                                  fixedBond1, fixedBondPrice1,
-                                  vars.iborIndex, vars.spread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap1(payFixedRate, fixedBond1, fixedBondPrice1, vars.iborIndex,
+                                  vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice();
@@ -729,312 +559,237 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
     // curve set up, which we do not test here.
     Real tolerance2 = usingAtParCoupons ? 1.0e-13 : 1.0e-2;
 
-    Real error1 = std::fabs(fixedBondAssetSwapPrice1-fixedBondPrice1);
+    Real error1 = std::fabs(fixedBondAssetSwapPrice1 - fixedBondPrice1);
 
-    if (error1>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for fixed bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  bond's clean price:    " << fixedBondPrice1 <<
-                    "\n  asset swap fair price: " << fixedBondAssetSwapPrice1 <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                 " << error1 <<
-                    "\n  tolerance:             " << tolerance2);
+    if (error1 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << fixedBondPrice1
+                   << "\n  asset swap fair price: " << fixedBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
 
-    Schedule fixedBondSchedule2(Date(5,February,2005),
-                                Date(5,February,2019),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(
-                         new FixedRateBond(settlementDays, vars.faceAmount,
-                                           fixedBondSchedule2,
-                                           std::vector<Rate>(1, 0.05),
-                                           Thirty360(Thirty360::BondBasis),
-                                           Following,
-                                           100.0, Date(5,February,2005)));
+    Schedule fixedBondSchedule2(Date(5, February, 2005), Date(5, February, 2019), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond2(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule2, std::vector<Rate>(1, 0.05),
+        Thirty360(Thirty360::BondBasis), Following, 100.0, Date(5, February, 2005)));
 
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondPrice2 = fixedBond2->cleanPrice();
-    AssetSwap fixedBondAssetSwap2(payFixedRate,
-                                  fixedBond2, fixedBondPrice2,
-                                  vars.iborIndex, vars.spread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap2(payFixedRate, fixedBond2, fixedBondPrice2, vars.iborIndex,
+                                  vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice();
-    Real error2 = std::fabs(fixedBondAssetSwapPrice2-fixedBondPrice2);
+    Real error2 = std::fabs(fixedBondAssetSwapPrice2 - fixedBondPrice2);
 
-    if (error2>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << fixedBondPrice2 <<
-                   "\n  asset swap fair price: " << fixedBondAssetSwapPrice2 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error2 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error2 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << fixedBondPrice2
+                   << "\n  asset swap fair price: " << fixedBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error2
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
 
-    Schedule floatingBondSchedule1(Date(29,September,2003),
-                                   Date(29,September,2013),
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Schedule floatingBondSchedule1(Date(29, September, 2003), Date(29, September, 2013),
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(
-                      new FloatingRateBond(settlementDays, vars.faceAmount,
-                                           floatingBondSchedule1,
-                                           vars.iborIndex, Actual360(),
-                                           Following, fixingDays,
-                                           std::vector<Real>(1,1),
-                                           std::vector<Spread>(1,0.0056),
-                                           std::vector<Rate>(),
-                                           std::vector<Rate>(),
-                                           inArrears,
-                                           100.0, Date(29,September,2003)));
+    ext::shared_ptr<Bond> floatingBond1(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule1, vars.iborIndex, Actual360(),
+        Following, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0056),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(29, September, 2003)));
 
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondPrice1 = floatingBond1->cleanPrice();
-    AssetSwap floatingBondAssetSwap1(payFixedRate,
-                                     floatingBond1, floatingBondPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap floatingBondAssetSwap1(payFixedRate, floatingBond1, floatingBondPrice1,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap1.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice();
-    Real error3 = std::fabs(floatingBondAssetSwapPrice1-floatingBondPrice1);
+    Real error3 = std::fabs(floatingBondAssetSwapPrice1 - floatingBondPrice1);
 
-    if (error3>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for floater:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << floatingBondPrice1 <<
-                   "\n  asset swap fair price: " << floatingBondAssetSwapPrice1 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error3 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error3 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for floater:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << floatingBondPrice1
+                   << "\n  asset swap fair price: " << floatingBondAssetSwapPrice1
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error3 << "\n  tolerance:             " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
 
-    Schedule floatingBondSchedule2(Date(24,September,2004),
-                                   Date(24,September,2018),
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(
-                      new FloatingRateBond(settlementDays, vars.faceAmount,
-                                           floatingBondSchedule2,
-                                           vars.iborIndex, Actual360(),
-                                           ModifiedFollowing, fixingDays,
-                                           std::vector<Real>(1,1),
-                                           std::vector<Spread>(1,0.0025),
-                                           std::vector<Rate>(),
-                                           std::vector<Rate>(),
-                                           inArrears,
-                                           100.0, Date(24,September,2004)));
+    Schedule floatingBondSchedule2(Date(24, September, 2004), Date(24, September, 2018),
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
+    ext::shared_ptr<Bond> floatingBond2(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule2, vars.iborIndex, Actual360(),
+        ModifiedFollowing, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0025),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(24, September, 2004)));
 
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
-    Real currentCoupon=0.04013+0.0025;
-    Rate floatingCurrentCoupon= floatingBond2->nextCouponRate();
-    Real error4= std::fabs(floatingCurrentCoupon-currentCoupon);
-    if (error4>tolerance) {
-        BOOST_FAIL("wrong current coupon is returned for floater bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's calculated current coupon:      " <<
-                   currentCoupon <<
-                   "\n  current coupon asked to the bond: " <<
-                   floatingCurrentCoupon <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error4 <<
-                   "\n  tolerance:             " << tolerance);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
+    Real currentCoupon = 0.04013 + 0.0025;
+    Rate floatingCurrentCoupon = floatingBond2->nextCouponRate();
+    Real error4 = std::fabs(floatingCurrentCoupon - currentCoupon);
+    if (error4 > tolerance) {
+        BOOST_FAIL("wrong current coupon is returned for floater bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's calculated current coupon:      " << currentCoupon
+                   << "\n  current coupon asked to the bond: " << floatingCurrentCoupon
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error4 << "\n  tolerance:             " << tolerance);
     }
 
     Real floatingBondPrice2 = floatingBond2->cleanPrice();
-    AssetSwap floatingBondAssetSwap2(payFixedRate,
-                                     floatingBond2, floatingBondPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap floatingBondAssetSwap2(payFixedRate, floatingBond2, floatingBondPrice2,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap2.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice();
-    Real error5 = std::fabs(floatingBondAssetSwapPrice2-floatingBondPrice2);
+    Real error5 = std::fabs(floatingBondAssetSwapPrice2 - floatingBondPrice2);
 
-    if (error5>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for floater:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << floatingBondPrice2 <<
-                   "\n  asset swap fair price: " << floatingBondAssetSwapPrice2 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error5 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error5 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for floater:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << floatingBondPrice2
+                   << "\n  asset swap fair price: " << floatingBondAssetSwapPrice2
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error5 << "\n  tolerance:             " << tolerance2);
     }
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
 
-    Schedule cmsBondSchedule1(Date(22,August,2005),
-                              Date(22,August,2020),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(
-                          new CmsRateBond(settlementDays, vars.faceAmount,
-                                          cmsBondSchedule1,
-                                          vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                                          Following, fixingDays,
-                                          std::vector<Real>(1,1.0),
-                                          std::vector<Spread>(1,0.0),
-                                          std::vector<Rate>(1,0.055),
-                                          std::vector<Rate>(1,0.025),
-                                          inArrears,
-                                          100.0, Date(22,August,2005)));
+    Schedule cmsBondSchedule1(Date(22, August, 2005), Date(22, August, 2020), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond1(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule1, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 1.0),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(1, 0.055), std::vector<Rate>(1, 0.025),
+        inArrears, 100.0, Date(22, August, 2005)));
 
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondPrice1 = cmsBond1->cleanPrice();
-    AssetSwap cmsBondAssetSwap1(payFixedRate,
-                                cmsBond1, cmsBondPrice1,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
-                                parAssetSwap);
+    AssetSwap cmsBondAssetSwap1(payFixedRate, cmsBond1, cmsBondPrice1, vars.iborIndex, vars.spread,
+                                Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice();
-    Real error6 = std::fabs(cmsBondAssetSwapPrice1-cmsBondPrice1);
+    Real error6 = std::fabs(cmsBondAssetSwapPrice1 - cmsBondPrice1);
 
-    if (error6>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for cms bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << cmsBondPrice1 <<
-                   "\n  asset swap fair price: " << cmsBondAssetSwapPrice1 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error6 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error6 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << cmsBondPrice1
+                   << "\n  asset swap fair price: " << cmsBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error6
+                   << "\n  tolerance:             " << tolerance2);
     }
 
-     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-     // maturity occurs on a business day
+    // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+    // maturity occurs on a business day
 
-    Schedule cmsBondSchedule2(Date(06,May,2005),
-                              Date(06,May,2015),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                    Following, fixingDays,
-                    std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
-                    std::vector<Rate>(), std::vector<Rate>(),
-                    inArrears,
-                    100.0, Date(06,May,2005)));
+    Schedule cmsBondSchedule2(Date(06, May, 2005), Date(06, May, 2015), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond2(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule2, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 0.84),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0,
+        Date(06, May, 2005)));
 
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondPrice2 = cmsBond2->cleanPrice();
-    AssetSwap cmsBondAssetSwap2(payFixedRate,
-                                cmsBond2, cmsBondPrice2,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
-                                parAssetSwap);
+    AssetSwap cmsBondAssetSwap2(payFixedRate, cmsBond2, cmsBondPrice2, vars.iborIndex, vars.spread,
+                                Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondAssetSwap2.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice();
-    Real error7 = std::fabs(cmsBondAssetSwapPrice2-cmsBondPrice2);
+    Real error7 = std::fabs(cmsBondAssetSwapPrice2 - cmsBondPrice2);
 
-    if (error7>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for cms bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << cmsBondPrice2 <<
-                   "\n  asset swap fair price: " << cmsBondAssetSwapPrice2 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error7 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error7 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << cmsBondPrice2
+                   << "\n  asset swap fair price: " << cmsBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(20,December,2015),
-                       Following,
-                       100.0, Date(19,December,1985)));
+    ext::shared_ptr<Bond> zeroCpnBond1(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(20, December, 2015),
+                           Following, 100.0, Date(19, December, 1985)));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice1 = zeroCpnBond1->cleanPrice();
-    AssetSwap zeroCpnAssetSwap1(payFixedRate,
-                                zeroCpnBond1, zeroCpnBondPrice1,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondPrice1, vars.iborIndex,
+                                vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     zeroCpnAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice1 = zeroCpnAssetSwap1.fairCleanPrice();
-    Real error8 = std::fabs(cmsBondAssetSwapPrice1-cmsBondPrice1);
+    Real error8 = std::fabs(cmsBondAssetSwapPrice1 - cmsBondPrice1);
 
-    if (error8>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:    " << zeroCpnBondPrice1 <<
-                   "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice1 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error8 <<
-                   "\n  tolerance:             " << tolerance2);
+    if (error8 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << zeroCpnBondPrice1
+                   << "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error8
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(17,February,2028),
-                       Following,
-                       100.0, Date(17,February,1998)));
+    ext::shared_ptr<Bond> zeroCpnBond2(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(17, February, 2028),
+                           Following, 100.0, Date(17, February, 1998)));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
-    AssetSwap zeroCpnAssetSwap2(payFixedRate,
-                                zeroCpnBond2, zeroCpnBondPrice2,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondPrice2, vars.iborIndex,
+                                vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     zeroCpnAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice2 = zeroCpnAssetSwap2.fairCleanPrice();
-    Real error9 = std::fabs(cmsBondAssetSwapPrice2-cmsBondPrice2);
+    Real error9 = std::fabs(cmsBondAssetSwapPrice2 - cmsBondPrice2);
 
-    if (error9>tolerance2) {
-        BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  bond's clean price:      " << zeroCpnBondPrice2 <<
-                   "\n  asset swap fair price:   " << zeroCpnBondAssetSwapPrice2 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                   " << error9 <<
-                   "\n  tolerance:               " << tolerance2);
+    if (error9 > tolerance2) {
+        BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:      " << zeroCpnBondPrice2
+                   << "\n  asset swap fair price:   " << zeroCpnBondAssetSwapPrice2
+                   << std::scientific << std::setprecision(2) << "\n  error:                   "
+                   << error9 << "\n  tolerance:               " << tolerance2);
     }
 }
 
@@ -1059,38 +814,26 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Schedule fixedBondSchedule1(Date(4,January,2005),
-                                Date(4,January,2037),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
-                      std::vector<Rate>(1, 0.04),
-                      ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005)));
+    Schedule fixedBondSchedule1(Date(4, January, 2005), Date(4, January, 2037), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond1(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule1, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                            new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
-    Real fixedBondMktPrice1 = 89.22 ; // market price observed on 7th June 2007
-    Real fixedBondMktFullPrice1=fixedBondMktPrice1+fixedBond1->accruedAmount();
-    AssetSwap fixedBondParAssetSwap1(payFixedRate,
-                                     fixedBond1, fixedBondMktPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    Real fixedBondMktPrice1 = 89.22; // market price observed on 7th June 2007
+    Real fixedBondMktFullPrice1 = fixedBondMktPrice1 + fixedBond1->accruedAmount();
+    AssetSwap fixedBondParAssetSwap1(payFixedRate, fixedBond1, fixedBondMktPrice1, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      parAssetSwap);
     fixedBondParAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondParAssetSwapSpread1 = fixedBondParAssetSwap1.fairSpread();
-    AssetSwap fixedBondMktAssetSwap1(payFixedRate,
-                                     fixedBond1, fixedBondMktPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondMktAssetSwap1(payFixedRate, fixedBond1, fixedBondMktPrice1, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      mktAssetSwap);
     fixedBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondMktAssetSwapSpread1 = fixedBondMktAssetSwap1.fairSpread();
@@ -1098,381 +841,283 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
     // see comment above
     Real tolerance2 = usingAtParCoupons ? 1.0e-13 : 1.0e-4;
 
-    Real error1 =
-        std::fabs(fixedBondMktAssetSwapSpread1-
-                  100*fixedBondParAssetSwapSpread1/fixedBondMktFullPrice1);
+    Real error1 = std::fabs(fixedBondMktAssetSwapSpread1 -
+                            100 * fixedBondParAssetSwapSpread1 / fixedBondMktFullPrice1);
 
-    if (error1>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(fixedBondMktAssetSwapSpread1) <<
-                   "\n  par ASW spread:    " << io::rate(fixedBondParAssetSwapSpread1) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error1 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error1 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(fixedBondMktAssetSwapSpread1)
+                   << "\n  par ASW spread:    " << io::rate(fixedBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error1
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
 
-    Schedule fixedBondSchedule2(Date(5,February,2005),
-                                Date(5,February,2019),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
-                      std::vector<Rate>(1, 0.05),
-                      Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+    Schedule fixedBondSchedule2(Date(5, February, 2005), Date(5, February, 2019), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond2(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule2, std::vector<Rate>(1, 0.05),
+        Thirty360(Thirty360::BondBasis), Following, 100.0, Date(5, February, 2005)));
 
     fixedBond2->setPricingEngine(bondEngine);
 
-    Real fixedBondMktPrice2 = 99.98 ; // market price observed on 7th June 2007
-    Real fixedBondMktFullPrice2=fixedBondMktPrice2+fixedBond2->accruedAmount();
-    AssetSwap fixedBondParAssetSwap2(payFixedRate,
-                                     fixedBond2, fixedBondMktPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    Real fixedBondMktPrice2 = 99.98; // market price observed on 7th June 2007
+    Real fixedBondMktFullPrice2 = fixedBondMktPrice2 + fixedBond2->accruedAmount();
+    AssetSwap fixedBondParAssetSwap2(payFixedRate, fixedBond2, fixedBondMktPrice2, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      parAssetSwap);
     fixedBondParAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondParAssetSwapSpread2 = fixedBondParAssetSwap2.fairSpread();
-    AssetSwap fixedBondMktAssetSwap2(payFixedRate,
-                                     fixedBond2, fixedBondMktPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondMktAssetSwap2(payFixedRate, fixedBond2, fixedBondMktPrice2, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      mktAssetSwap);
     fixedBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondMktAssetSwapSpread2 = fixedBondMktAssetSwap2.fairSpread();
-    Real error2 =
-        std::fabs(fixedBondMktAssetSwapSpread2-
-                  100*fixedBondParAssetSwapSpread2/fixedBondMktFullPrice2);
+    Real error2 = std::fabs(fixedBondMktAssetSwapSpread2 -
+                            100 * fixedBondParAssetSwapSpread2 / fixedBondMktFullPrice2);
 
-    if (error2>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(fixedBondMktAssetSwapSpread2) <<
-                   "\n  par ASW spread:    " << io::rate(fixedBondParAssetSwapSpread2) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error2 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error2 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(fixedBondMktAssetSwapSpread2)
+                   << "\n  par ASW spread:    " << io::rate(fixedBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error2
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
 
-    Schedule floatingBondSchedule1(Date(29,September,2003),
-                                   Date(29,September,2013),
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Schedule floatingBondSchedule1(Date(29, September, 2003), Date(29, September, 2013),
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule1,
-                         vars.iborIndex, Actual360(),
-                         Following, fixingDays,
-                         std::vector<Real>(1,1), std::vector<Spread>(1,0.0056),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(29,September,2003)));
+    ext::shared_ptr<Bond> floatingBond1(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule1, vars.iborIndex, Actual360(),
+        Following, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0056),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(29, September, 2003)));
 
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     // market price observed on 7th June 2007
-    Real floatingBondMktPrice1 = 101.64 ;
-    Real floatingBondMktFullPrice1 =
-        floatingBondMktPrice1+floatingBond1->accruedAmount();
-    AssetSwap floatingBondParAssetSwap1(payFixedRate,
-                                        floatingBond1, floatingBondMktPrice1,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        parAssetSwap);
+    Real floatingBondMktPrice1 = 101.64;
+    Real floatingBondMktFullPrice1 = floatingBondMktPrice1 + floatingBond1->accruedAmount();
+    AssetSwap floatingBondParAssetSwap1(payFixedRate, floatingBond1, floatingBondMktPrice1,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondParAssetSwap1.setPricingEngine(swapEngine);
-    Real floatingBondParAssetSwapSpread1 =
-        floatingBondParAssetSwap1.fairSpread();
-    AssetSwap floatingBondMktAssetSwap1(payFixedRate,
-                                        floatingBond1, floatingBondMktPrice1,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        mktAssetSwap);
+    Real floatingBondParAssetSwapSpread1 = floatingBondParAssetSwap1.fairSpread();
+    AssetSwap floatingBondMktAssetSwap1(payFixedRate, floatingBond1, floatingBondMktPrice1,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), mktAssetSwap);
     floatingBondMktAssetSwap1.setPricingEngine(swapEngine);
-    Real floatingBondMktAssetSwapSpread1 =
-        floatingBondMktAssetSwap1.fairSpread();
-    Real error3 =
-        std::fabs(floatingBondMktAssetSwapSpread1-
-                  100*floatingBondParAssetSwapSpread1/floatingBondMktFullPrice1);
+    Real floatingBondMktAssetSwapSpread1 = floatingBondMktAssetSwap1.fairSpread();
+    Real error3 = std::fabs(floatingBondMktAssetSwapSpread1 -
+                            100 * floatingBondParAssetSwapSpread1 / floatingBondMktFullPrice1);
 
-    if (error3>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for floating bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(floatingBondMktAssetSwapSpread1) <<
-                   "\n  par ASW spread:    " << io::rate(floatingBondParAssetSwapSpread1) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error3 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error3 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for floating bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(floatingBondMktAssetSwapSpread1)
+                   << "\n  par ASW spread:    " << io::rate(floatingBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error3
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
 
-    Schedule floatingBondSchedule2(Date(24,September,2004),
-                                   Date(24,September,2018),
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule2,
-                         vars.iborIndex, Actual360(),
-                         ModifiedFollowing, fixingDays,
-                         std::vector<Real>(1,1), std::vector<Spread>(1,0.0025),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(24,September,2004)));
+    Schedule floatingBondSchedule2(Date(24, September, 2004), Date(24, September, 2018),
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
+    ext::shared_ptr<Bond> floatingBond2(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule2, vars.iborIndex, Actual360(),
+        ModifiedFollowing, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0025),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(24, September, 2004)));
 
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
     // market price observed on 7th June 2007
-    Real floatingBondMktPrice2 = 101.248 ;
-    Real floatingBondMktFullPrice2 =
-        floatingBondMktPrice2+floatingBond2->accruedAmount();
-    AssetSwap floatingBondParAssetSwap2(payFixedRate,
-                                        floatingBond2, floatingBondMktPrice2,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        parAssetSwap);
+    Real floatingBondMktPrice2 = 101.248;
+    Real floatingBondMktFullPrice2 = floatingBondMktPrice2 + floatingBond2->accruedAmount();
+    AssetSwap floatingBondParAssetSwap2(payFixedRate, floatingBond2, floatingBondMktPrice2,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondParAssetSwap2.setPricingEngine(swapEngine);
-    Spread floatingBondParAssetSwapSpread2 =
-        floatingBondParAssetSwap2.fairSpread();
-    AssetSwap floatingBondMktAssetSwap2(payFixedRate,
-                                        floatingBond2, floatingBondMktPrice2,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        mktAssetSwap);
+    Spread floatingBondParAssetSwapSpread2 = floatingBondParAssetSwap2.fairSpread();
+    AssetSwap floatingBondMktAssetSwap2(payFixedRate, floatingBond2, floatingBondMktPrice2,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), mktAssetSwap);
     floatingBondMktAssetSwap2.setPricingEngine(swapEngine);
-    Real floatingBondMktAssetSwapSpread2 =
-        floatingBondMktAssetSwap2.fairSpread();
-    Real error4 =
-        std::fabs(floatingBondMktAssetSwapSpread2-
-                  100*floatingBondParAssetSwapSpread2/floatingBondMktFullPrice2);
+    Real floatingBondMktAssetSwapSpread2 = floatingBondMktAssetSwap2.fairSpread();
+    Real error4 = std::fabs(floatingBondMktAssetSwapSpread2 -
+                            100 * floatingBondParAssetSwapSpread2 / floatingBondMktFullPrice2);
 
-    if (error4>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for floating bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(floatingBondMktAssetSwapSpread2) <<
-                   "\n  par ASW spread:    " << io::rate(floatingBondParAssetSwapSpread2) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error4 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error4 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for floating bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(floatingBondMktAssetSwapSpread2)
+                   << "\n  par ASW spread:    " << io::rate(floatingBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error4
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
 
-    Schedule cmsBondSchedule1(Date(22,August,2005),
-                              Date(22,August,2020),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                    Following, fixingDays,
-                    std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
-                    std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
-                    inArrears,
-                    100.0, Date(22,August,2005)));
+    Schedule cmsBondSchedule1(Date(22, August, 2005), Date(22, August, 2020), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond1(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule1, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 1.0),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(1, 0.055), std::vector<Rate>(1, 0.025),
+        inArrears, 100.0, Date(22, August, 2005)));
 
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
-    Real cmsBondMktPrice1 = 88.45 ; // market price observed on 7th June 2007
-    Real cmsBondMktFullPrice1 = cmsBondMktPrice1+cmsBond1->accruedAmount();
-    AssetSwap cmsBondParAssetSwap1(payFixedRate,
-                                   cmsBond1, cmsBondMktPrice1,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
+    Real cmsBondMktPrice1 = 88.45; // market price observed on 7th June 2007
+    Real cmsBondMktFullPrice1 = cmsBondMktPrice1 + cmsBond1->accruedAmount();
+    AssetSwap cmsBondParAssetSwap1(payFixedRate, cmsBond1, cmsBondMktPrice1, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    parAssetSwap);
     cmsBondParAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondParAssetSwapSpread1 = cmsBondParAssetSwap1.fairSpread();
-    AssetSwap cmsBondMktAssetSwap1(payFixedRate,
-                                   cmsBond1, cmsBondMktPrice1,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondMktAssetSwap1(payFixedRate, cmsBond1, cmsBondMktPrice1, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    mktAssetSwap);
     cmsBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondMktAssetSwapSpread1 = cmsBondMktAssetSwap1.fairSpread();
-    Real error5 =
-        std::fabs(cmsBondMktAssetSwapSpread1-
-                  100*cmsBondParAssetSwapSpread1/cmsBondMktFullPrice1);
+    Real error5 = std::fabs(cmsBondMktAssetSwapSpread1 -
+                            100 * cmsBondParAssetSwapSpread1 / cmsBondMktFullPrice1);
 
-    if (error5>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for cms bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(cmsBondMktAssetSwapSpread1) <<
-                   "\n  par ASW spread:    " << io::rate(cmsBondParAssetSwapSpread1) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error5 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error5 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(cmsBondMktAssetSwapSpread1)
+                   << "\n  par ASW spread:    " << io::rate(cmsBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error5
+                   << "\n  tolerance:         " << tolerance2);
     }
 
-     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-     // maturity occurs on a business day
+    // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+    // maturity occurs on a business day
 
-    Schedule cmsBondSchedule2(Date(06,May,2005),
-                              Date(06,May,2015),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                    Following, fixingDays,
-                    std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
-                    std::vector<Rate>(), std::vector<Rate>(),
-                    inArrears,
-                    100.0, Date(06,May,2005)));
+    Schedule cmsBondSchedule2(Date(06, May, 2005), Date(06, May, 2015), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond2(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule2, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 0.84),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0,
+        Date(06, May, 2005)));
 
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
-    Real cmsBondMktPrice2 = 94.08 ; // market price observed on 7th June 2007
-    Real cmsBondMktFullPrice2 = cmsBondMktPrice2+cmsBond2->accruedAmount();
-    AssetSwap cmsBondParAssetSwap2(payFixedRate,
-                                   cmsBond2, cmsBondMktPrice2,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
+    Real cmsBondMktPrice2 = 94.08; // market price observed on 7th June 2007
+    Real cmsBondMktFullPrice2 = cmsBondMktPrice2 + cmsBond2->accruedAmount();
+    AssetSwap cmsBondParAssetSwap2(payFixedRate, cmsBond2, cmsBondMktPrice2, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    parAssetSwap);
     cmsBondParAssetSwap2.setPricingEngine(swapEngine);
     Spread cmsBondParAssetSwapSpread2 = cmsBondParAssetSwap2.fairSpread();
-    AssetSwap cmsBondMktAssetSwap2(payFixedRate,
-                                   cmsBond2, cmsBondMktPrice2,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondMktAssetSwap2(payFixedRate, cmsBond2, cmsBondMktPrice2, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    mktAssetSwap);
     cmsBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real cmsBondMktAssetSwapSpread2 = cmsBondMktAssetSwap2.fairSpread();
-    Real error6 =
-        std::fabs(cmsBondMktAssetSwapSpread2-
-                  100*cmsBondParAssetSwapSpread2/cmsBondMktFullPrice2);
+    Real error6 = std::fabs(cmsBondMktAssetSwapSpread2 -
+                            100 * cmsBondParAssetSwapSpread2 / cmsBondMktFullPrice2);
 
-    if (error6>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for cms bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(cmsBondMktAssetSwapSpread2) <<
-                   "\n  par ASW spread:    " << io::rate(cmsBondParAssetSwapSpread2) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error6 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error6 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(cmsBondMktAssetSwapSpread2)
+                   << "\n  par ASW spread:    " << io::rate(cmsBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error6
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(20,December,2015),
-                       Following,
-                       100.0, Date(19,December,1985)));
+    ext::shared_ptr<Bond> zeroCpnBond1(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(20, December, 2015),
+                           Following, 100.0, Date(19, December, 1985)));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // market price observed on 12th June 2007
-    Real zeroCpnBondMktPrice1 = 70.436 ;
-    Real zeroCpnBondMktFullPrice1 =
-        zeroCpnBondMktPrice1+zeroCpnBond1->accruedAmount();
-    AssetSwap zeroCpnBondParAssetSwap1(payFixedRate,zeroCpnBond1,
-                                       zeroCpnBondMktPrice1,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    Real zeroCpnBondMktPrice1 = 70.436;
+    Real zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1 + zeroCpnBond1->accruedAmount();
+    AssetSwap zeroCpnBondParAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondMktPrice1,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondParAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondParAssetSwapSpread1 = zeroCpnBondParAssetSwap1.fairSpread();
-    AssetSwap zeroCpnBondMktAssetSwap1(payFixedRate,zeroCpnBond1,
-                                       zeroCpnBondMktPrice1,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       mktAssetSwap);
+    AssetSwap zeroCpnBondMktAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondMktPrice1,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), mktAssetSwap);
     zeroCpnBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondMktAssetSwapSpread1 = zeroCpnBondMktAssetSwap1.fairSpread();
-    Real error7 =
-        std::fabs(zeroCpnBondMktAssetSwapSpread1-
-                  100*zeroCpnBondParAssetSwapSpread1/zeroCpnBondMktFullPrice1);
+    Real error7 = std::fabs(zeroCpnBondMktAssetSwapSpread1 -
+                            100 * zeroCpnBondParAssetSwapSpread1 / zeroCpnBondMktFullPrice1);
 
-    if (error7>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(zeroCpnBondMktAssetSwapSpread1) <<
-                   "\n  par ASW spread:    " << io::rate(zeroCpnBondParAssetSwapSpread1) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error7 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error7 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(zeroCpnBondMktAssetSwapSpread1)
+                   << "\n  par ASW spread:    " << io::rate(zeroCpnBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error7
+                   << "\n  tolerance:         " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(17,February,2028),
-                       Following,
-                       100.0, Date(17,February,1998)));
+    ext::shared_ptr<Bond> zeroCpnBond2(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(17, February, 2028),
+                           Following, 100.0, Date(17, February, 1998)));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
 
     // market price observed on 12th June 2007
-    Real zeroCpnBondMktPrice2 = 35.160 ;
-    Real zeroCpnBondMktFullPrice2 =
-        zeroCpnBondMktPrice2+zeroCpnBond2->accruedAmount();
-    AssetSwap zeroCpnBondParAssetSwap2(payFixedRate,zeroCpnBond2,
-                                       zeroCpnBondMktPrice2,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    Real zeroCpnBondMktPrice2 = 35.160;
+    Real zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2 + zeroCpnBond2->accruedAmount();
+    AssetSwap zeroCpnBondParAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondMktPrice2,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondParAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondParAssetSwapSpread2 = zeroCpnBondParAssetSwap2.fairSpread();
-    AssetSwap zeroCpnBondMktAssetSwap2(payFixedRate,zeroCpnBond2,
-                                       zeroCpnBondMktPrice2,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       mktAssetSwap);
+    AssetSwap zeroCpnBondMktAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondMktPrice2,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), mktAssetSwap);
     zeroCpnBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondMktAssetSwapSpread2 = zeroCpnBondMktAssetSwap2.fairSpread();
-    Real error8 =
-        std::fabs(zeroCpnBondMktAssetSwapSpread2-
-                  100*zeroCpnBondParAssetSwapSpread2/zeroCpnBondMktFullPrice2);
+    Real error8 = std::fabs(zeroCpnBondMktAssetSwapSpread2 -
+                            100 * zeroCpnBondParAssetSwapSpread2 / zeroCpnBondMktFullPrice2);
 
-    if (error8>tolerance2) {
-        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market ASW spread: " << io::rate(zeroCpnBondMktAssetSwapSpread2) <<
-                   "\n  par ASW spread:    " << io::rate(zeroCpnBondParAssetSwapSpread2) <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:             " << error8 <<
-                   "\n  tolerance:         " << tolerance2);
+    if (error8 > tolerance2) {
+        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market ASW spread: " << io::rate(zeroCpnBondMktAssetSwapSpread2)
+                   << "\n  par ASW spread:    " << io::rate(zeroCpnBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:             " << error8
+                   << "\n  tolerance:         " << tolerance2);
     }
 }
 
@@ -1492,307 +1137,242 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // Fixed bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Schedule fixedBondSchedule1(Date(4,January,2005),
-                                Date(4,January,2037),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
-                      std::vector<Rate>(1, 0.04),
-                      ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005)));
+    Schedule fixedBondSchedule1(Date(4, January, 2005), Date(4, January, 2037), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond1(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule1, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue1 = fixedBond1->cleanPrice();
-    Date fixedBondSettlementDate1= fixedBond1->settlementDate();
+    Date fixedBondSettlementDate1 = fixedBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YC...
-    Real fixedBondCleanPrice1 = BondFunctions::cleanPrice(
-         *fixedBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         fixedBondSettlementDate1);
+    Real fixedBondCleanPrice1 =
+        BondFunctions::cleanPrice(*fixedBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, fixedBondSettlementDate1);
     Real tolerance = 1.0e-13;
-    Real error1 = std::fabs(fixedBondImpliedValue1-fixedBondCleanPrice1);
-    if (error1>tolerance) {
-        BOOST_FAIL("wrong clean price for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market asset swap spread: " <<
-                   fixedBondImpliedValue1 <<
-                   "\n  par asset swap spread: " << fixedBondCleanPrice1 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error1 <<
-                   "\n  tolerance:             " << tolerance);
+    Real error1 = std::fabs(fixedBondImpliedValue1 - fixedBondCleanPrice1);
+    if (error1 > tolerance) {
+        BOOST_FAIL("wrong clean price for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << fixedBondImpliedValue1
+                   << "\n  par asset swap spread: " << fixedBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
 
-    Schedule fixedBondSchedule2(Date(5,February,2005),
-                                Date(5,February,2019),
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
-                      std::vector<Rate>(1, 0.05),
-                      Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+    Schedule fixedBondSchedule2(Date(5, February, 2005), Date(5, February, 2019), Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
+    ext::shared_ptr<Bond> fixedBond2(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule2, std::vector<Rate>(1, 0.05),
+        Thirty360(Thirty360::BondBasis), Following, 100.0, Date(5, February, 2005)));
 
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue2 = fixedBond2->cleanPrice();
-    Date fixedBondSettlementDate2= fixedBond2->settlementDate();
+    Date fixedBondSettlementDate2 = fixedBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real fixedBondCleanPrice2 = BondFunctions::cleanPrice(
-         *fixedBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         fixedBondSettlementDate2);
-    Real error3 = std::fabs(fixedBondImpliedValue2-fixedBondCleanPrice2);
-    if (error3>tolerance) {
-        BOOST_FAIL("wrong clean price for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market asset swap spread: " <<
-                   fixedBondImpliedValue2 <<
-                   "\n  par asset swap spread: " << fixedBondCleanPrice2 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error3 <<
-                   "\n  tolerance:             " << tolerance);
+    Real fixedBondCleanPrice2 =
+        BondFunctions::cleanPrice(*fixedBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, fixedBondSettlementDate2);
+    Real error3 = std::fabs(fixedBondImpliedValue2 - fixedBondCleanPrice2);
+    if (error3 > tolerance) {
+        BOOST_FAIL("wrong clean price for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << fixedBondImpliedValue2
+                   << "\n  par asset swap spread: " << fixedBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error3
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
 
-    Schedule floatingBondSchedule1(Date(29,September,2003),
-                                   Date(29,September,2013),
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Schedule floatingBondSchedule1(Date(29, September, 2003), Date(29, September, 2013),
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule1,
-                         vars.iborIndex, Actual360(),
-                         Following, fixingDays,
-                         std::vector<Real>(1,1), std::vector<Spread>(1,0.0056),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(29,September,2003)));
+    ext::shared_ptr<Bond> floatingBond1(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule1, vars.iborIndex, Actual360(),
+        Following, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0056),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(29, September, 2003)));
 
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondImpliedValue1 = floatingBond1->cleanPrice();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real floatingBondCleanPrice1 = BondFunctions::cleanPrice(
-        *floatingBond1, *vars.termStructure, vars.spread,
-        Actual365Fixed(), vars.compounding, Semiannual,
-        fixedBondSettlementDate1);
-    Real error5 = std::fabs(floatingBondImpliedValue1-floatingBondCleanPrice1);
-    if (error5>tolerance) {
-        BOOST_FAIL("wrong clean price for fixed bond:" <<
-                   std::fixed << std::setprecision(4) <<
-                   "\n  market asset swap spread: " <<
-                   floatingBondImpliedValue1 <<
-                   "\n  par asset swap spread: " << floatingBondCleanPrice1 <<
-                   std::scientific << std::setprecision(2) <<
-                   "\n  error:                 " << error5 <<
-                   "\n  tolerance:             " << tolerance);
+    Real floatingBondCleanPrice1 =
+        BondFunctions::cleanPrice(*floatingBond1, *vars.termStructure, vars.spread,
+                                  vars.compounding, Semiannual, fixedBondSettlementDate1);
+    Real error5 = std::fabs(floatingBondImpliedValue1 - floatingBondCleanPrice1);
+    if (error5 > tolerance) {
+        BOOST_FAIL("wrong clean price for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << floatingBondImpliedValue1
+                   << "\n  par asset swap spread: " << floatingBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error5
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
 
-    Schedule floatingBondSchedule2(Date(24,September,2004),
-                                   Date(24,September,2018),
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule2,
-                         vars.iborIndex, Actual360(),
-                         ModifiedFollowing, fixingDays,
-                         std::vector<Real>(1,1), std::vector<Spread>(1,0.0025),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(24,September,2004)));
+    Schedule floatingBondSchedule2(Date(24, September, 2004), Date(24, September, 2018),
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
+    ext::shared_ptr<Bond> floatingBond2(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule2, vars.iborIndex, Actual360(),
+        ModifiedFollowing, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0025),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(24, September, 2004)));
 
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
     Real floatingBondImpliedValue2 = floatingBond2->cleanPrice();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real floatingBondCleanPrice2 = BondFunctions::cleanPrice(
-        *floatingBond2, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
-        fixedBondSettlementDate1);
-    Real error7 = std::fabs(floatingBondImpliedValue2-floatingBondCleanPrice2);
-    if (error7>tolerance) {
+    Real floatingBondCleanPrice2 =
+        BondFunctions::cleanPrice(*floatingBond2, *vars.termStructure, vars.spread,
+                                  vars.compounding, Semiannual, fixedBondSettlementDate1);
+    Real error7 = std::fabs(floatingBondImpliedValue2 - floatingBondCleanPrice2);
+    if (error7 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " <<
-                    floatingBondImpliedValue2
-                    << "\n  par asset swap spread: " << floatingBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error7
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << floatingBondImpliedValue2
+                   << "\n  par asset swap spread: " << floatingBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance);
     }
 
     //// CMS bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     //// maturity doesn't occur on a business day
 
-    Schedule cmsBondSchedule1(Date(22,August,2005),
-                              Date(22,August,2020),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                    Following, fixingDays,
-                    std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
-                    std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
-                    inArrears,
-                    100.0, Date(22,August,2005)));
+    Schedule cmsBondSchedule1(Date(22, August, 2005), Date(22, August, 2020), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond1(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule1, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 1.0),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(1, 0.055), std::vector<Rate>(1, 0.025),
+        inArrears, 100.0, Date(22, August, 2005)));
 
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondImpliedValue1 = cmsBond1->cleanPrice();
-    Date cmsBondSettlementDate1= cmsBond1->settlementDate();
+    Date cmsBondSettlementDate1 = cmsBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real cmsBondCleanPrice1 = BondFunctions::cleanPrice(
-        *cmsBond1, *vars.termStructure, vars.spread,
-        Actual365Fixed(), vars.compounding, Annual,
-        cmsBondSettlementDate1);
-    Real error9 = std::fabs(cmsBondImpliedValue1-cmsBondCleanPrice1);
-    if (error9>tolerance) {
+    Real cmsBondCleanPrice1 =
+        BondFunctions::cleanPrice(*cmsBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, cmsBondSettlementDate1);
+    Real error9 = std::fabs(cmsBondImpliedValue1 - cmsBondCleanPrice1);
+    if (error9 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " << cmsBondImpliedValue1
-                    << "\n  par asset swap spread: " << cmsBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error9
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << cmsBondImpliedValue1
+                   << "\n  par asset swap spread: " << cmsBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error9
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
     // maturity occurs on a business day
 
-    Schedule cmsBondSchedule2(Date(06,May,2005),
-                              Date(06,May,2015),
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                    vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                    Following, fixingDays,
-                    std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
-                    std::vector<Rate>(), std::vector<Rate>(),
-                    inArrears,
-                    100.0, Date(06,May,2005)));
+    Schedule cmsBondSchedule2(Date(06, May, 2005), Date(06, May, 2015), Period(Annual),
+                              bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                              false);
+    ext::shared_ptr<Bond> cmsBond2(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule2, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 0.84),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0,
+        Date(06, May, 2005)));
 
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondImpliedValue2 = cmsBond2->cleanPrice();
-    Date cmsBondSettlementDate2= cmsBond2->settlementDate();
+    Date cmsBondSettlementDate2 = cmsBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real cmsBondCleanPrice2 = BondFunctions::cleanPrice(
-         *cmsBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         cmsBondSettlementDate2);
-    Real error11 = std::fabs(cmsBondImpliedValue2-cmsBondCleanPrice2);
-    if (error11>tolerance) {
+    Real cmsBondCleanPrice2 =
+        BondFunctions::cleanPrice(*cmsBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, cmsBondSettlementDate2);
+    Real error11 = std::fabs(cmsBondImpliedValue2 - cmsBondCleanPrice2);
+    if (error11 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " << cmsBondImpliedValue2
-                    << "\n  par asset swap spread: " << cmsBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error11
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << cmsBondImpliedValue2
+                   << "\n  par asset swap spread: " << cmsBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error11
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(20,December,2015),
-                       Following,
-                       100.0, Date(19,December,1985)));
+    ext::shared_ptr<Bond> zeroCpnBond1(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(20, December, 2015),
+                           Following, 100.0, Date(19, December, 1985)));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue1 = zeroCpnBond1->cleanPrice();
-    Date zeroCpnBondSettlementDate1= zeroCpnBond1->settlementDate();
+    Date zeroCpnBondSettlementDate1 = zeroCpnBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real zeroCpnBondCleanPrice1 =
-        BondFunctions::cleanPrice(*zeroCpnBond1,
-                              *vars.termStructure,
-                              vars.spread,
-                              Actual365Fixed(),
-                              vars.compounding, Annual,
-                              zeroCpnBondSettlementDate1);
-    Real error13 = std::fabs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1);
-    if (error13>tolerance) {
+        BondFunctions::cleanPrice(*zeroCpnBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, zeroCpnBondSettlementDate1);
+    Real error13 = std::fabs(zeroCpnBondImpliedValue1 - zeroCpnBondCleanPrice1);
+    if (error13 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  zero cpn implied value: " <<
-                    zeroCpnBondImpliedValue1
-                    << "\n  zero cpn price: " << zeroCpnBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error13
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  zero cpn implied value: " << zeroCpnBondImpliedValue1
+                   << "\n  zero cpn price: " << zeroCpnBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error13
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                       Date(17,February,2028),
-                       Following,
-                       100.0, Date(17,February,1998)));
+    ext::shared_ptr<Bond> zeroCpnBond2(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(17, February, 2028),
+                           Following, 100.0, Date(17, February, 1998)));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue2 = zeroCpnBond2->cleanPrice();
-    Date zeroCpnBondSettlementDate2= zeroCpnBond2->settlementDate();
+    Date zeroCpnBondSettlementDate2 = zeroCpnBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real zeroCpnBondCleanPrice2 =
-        BondFunctions::cleanPrice(*zeroCpnBond2,
-                              *vars.termStructure,
-                              vars.spread,
-                              Actual365Fixed(),
-                              vars.compounding, Annual,
-                              zeroCpnBondSettlementDate2);
-    Real error15 = std::fabs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2);
-    if (error15>tolerance) {
+        BondFunctions::cleanPrice(*zeroCpnBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, zeroCpnBondSettlementDate2);
+    Real error15 = std::fabs(zeroCpnBondImpliedValue2 - zeroCpnBondCleanPrice2);
+    if (error15 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  zero cpn implied value: " <<
-                    zeroCpnBondImpliedValue2
-                    << "\n  zero cpn price: " << zeroCpnBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error15
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  zero cpn implied value: " << zeroCpnBondImpliedValue2
+                   << "\n  zero cpn price: " << zeroCpnBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error15
+                   << "\n  tolerance:             " << tolerance);
     }
 }
 
@@ -1815,373 +1395,304 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
 
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
-    Date fixedBondStartDate1 = Date(4,January,2005);
-    Date fixedBondMaturityDate1 = Date(4,January,2037);
-    Schedule fixedBondSchedule1(fixedBondStartDate1,
-                                fixedBondMaturityDate1,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate1 = Date(4, January, 2005);
+    Date fixedBondMaturityDate1 = Date(4, January, 2037);
+    Schedule fixedBondSchedule1(fixedBondStartDate1, fixedBondMaturityDate1, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg1 = FixedRateLeg(fixedBondSchedule1)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
-    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                    Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
+    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following);
+    fixedBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption1)));
+    ext::shared_ptr<Bond> fixedBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate1, fixedBondStartDate1,
+                                              fixedBondLeg1));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
-    AssetSwap fixedBondAssetSwap1(payFixedRate,
-                                  fixedBond1, fixedBondPrice1,
-                                  vars.iborIndex, vars.spread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap1(payFixedRate, fixedBond1, fixedBondPrice1, vars.iborIndex,
+                                  vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice();
     Real tolerance = 1.0e-13;
 
     // see comment above
-    Real tolerance2 = usingAtParCoupons? 1.0e-13 : 1.0e-2;
+    Real tolerance2 = usingAtParCoupons ? 1.0e-13 : 1.0e-2;
 
-    Real error1 = std::fabs(fixedBondAssetSwapPrice1-fixedBondPrice1);
+    Real error1 = std::fabs(fixedBondAssetSwapPrice1 - fixedBondPrice1);
 
-    if (error1>tolerance2) {
+    if (error1 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << fixedBondPrice1
-                    << "\n  asset swap fair price: " << fixedBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error1
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << fixedBondPrice1
+                   << "\n  asset swap fair price: " << fixedBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
-    Date fixedBondStartDate2 = Date(5,February,2005);
-    Date fixedBondMaturityDate2 = Date(5,February,2019);
-    Schedule fixedBondSchedule2(fixedBondStartDate2,
-                                fixedBondMaturityDate2,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate2 = Date(5, February, 2005);
+    Date fixedBondMaturityDate2 = Date(5, February, 2019);
+    Schedule fixedBondSchedule2(fixedBondStartDate2, fixedBondMaturityDate2, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg2 = FixedRateLeg(fixedBondSchedule2)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
-    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
-                                                    Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
+    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following);
+    fixedBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption2)));
+    ext::shared_ptr<Bond> fixedBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate2, fixedBondStartDate2,
+                                              fixedBondLeg2));
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondPrice2 = fixedBond2->cleanPrice();
-    AssetSwap fixedBondAssetSwap2(payFixedRate,
-                                  fixedBond2, fixedBondPrice2,
-                                  vars.iborIndex, vars.spread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap2(payFixedRate, fixedBond2, fixedBondPrice2, vars.iborIndex,
+                                  vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice();
-    Real error2 = std::fabs(fixedBondAssetSwapPrice2-fixedBondPrice2);
+    Real error2 = std::fabs(fixedBondAssetSwapPrice2 - fixedBondPrice2);
 
-    if (error2>tolerance2) {
+    if (error2 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << fixedBondPrice2
-                    << "\n  asset swap fair price: " << fixedBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error2
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << fixedBondPrice2
+                   << "\n  asset swap fair price: " << fixedBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error2
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
-    Date floatingBondStartDate1 = Date(29,September,2003);
-    Date floatingBondMaturityDate1 = Date(29,September,2013);
-    Schedule floatingBondSchedule1(floatingBondStartDate1,
-                                   floatingBondMaturityDate1,
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Date floatingBondStartDate1 = Date(29, September, 2003);
+    Date floatingBondMaturityDate1 = Date(29, September, 2013);
+    Schedule floatingBondSchedule1(floatingBondStartDate1, floatingBondMaturityDate1,
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
     Leg floatingBondLeg1 = IborLeg(floatingBondSchedule1, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0056)
-        .inArrears(inArrears);
-    Date floatingbondRedemption1 =
-        bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0056)
+                               .inArrears(inArrears);
+    Date floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following);
+    floatingBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption1)));
+    ext::shared_ptr<Bond> floatingBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate1, floatingBondStartDate1,
+                                                 floatingBondLeg1));
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondPrice1 = floatingBond1->cleanPrice();
-    AssetSwap floatingBondAssetSwap1(payFixedRate,
-                                     floatingBond1, floatingBondPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap floatingBondAssetSwap1(payFixedRate, floatingBond1, floatingBondPrice1,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap1.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice();
-    Real error3 = std::fabs(floatingBondAssetSwapPrice1-floatingBondPrice1);
+    Real error3 = std::fabs(floatingBondAssetSwapPrice1 - floatingBondPrice1);
 
-    if (error3>tolerance2) {
+    if (error3 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for floater:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << floatingBondPrice1
-                    << "\n  asset swap fair price: " <<
-                    floatingBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error3
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << floatingBondPrice1
+                   << "\n  asset swap fair price: " << floatingBondAssetSwapPrice1
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error3 << "\n  tolerance:             " << tolerance2);
     }
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
-    Date floatingBondStartDate2 = Date(24,September,2004);
-    Date floatingBondMaturityDate2 = Date(24,September,2018);
-    Schedule floatingBondSchedule2(floatingBondStartDate2,
-                                   floatingBondMaturityDate2,
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
+    Date floatingBondStartDate2 = Date(24, September, 2004);
+    Date floatingBondMaturityDate2 = Date(24, September, 2018);
+    Schedule floatingBondSchedule2(floatingBondStartDate2, floatingBondMaturityDate2,
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
     Leg floatingBondLeg2 = IborLeg(floatingBondSchedule2, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withPaymentAdjustment(ModifiedFollowing)
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0025)
-        .inArrears(inArrears);
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withPaymentAdjustment(ModifiedFollowing)
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0025)
+                               .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+    floatingBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption2)));
+    ext::shared_ptr<Bond> floatingBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate2, floatingBondStartDate2,
+                                                 floatingBondLeg2));
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
-    Real currentCoupon=0.04013+0.0025;
-    Rate floatingCurrentCoupon= floatingBond2->nextCouponRate();
-    Real error4= std::fabs(floatingCurrentCoupon-currentCoupon);
-    if (error4>tolerance) {
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
+    Real currentCoupon = 0.04013 + 0.0025;
+    Rate floatingCurrentCoupon = floatingBond2->nextCouponRate();
+    Real error4 = std::fabs(floatingCurrentCoupon - currentCoupon);
+    if (error4 > tolerance) {
         BOOST_FAIL("wrong current coupon is returned for floater bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's calculated current coupon:      " <<
-                    currentCoupon
-                    << "\n  current coupon asked to the bond: " <<
-                    floatingCurrentCoupon
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error4
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's calculated current coupon:      " << currentCoupon
+                   << "\n  current coupon asked to the bond: " << floatingCurrentCoupon
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error4 << "\n  tolerance:             " << tolerance);
     }
 
     Real floatingBondPrice2 = floatingBond2->cleanPrice();
-    AssetSwap floatingBondAssetSwap2(payFixedRate,
-                                     floatingBond2, floatingBondPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap floatingBondAssetSwap2(payFixedRate, floatingBond2, floatingBondPrice2,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap2.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice();
-    Real error5 = std::fabs(floatingBondAssetSwapPrice2-floatingBondPrice2);
+    Real error5 = std::fabs(floatingBondAssetSwapPrice2 - floatingBondPrice2);
 
-    if (error5>tolerance2) {
+    if (error5 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for floater:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << floatingBondPrice2
-                    << "\n  asset swap fair price: " <<
-                    floatingBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error5
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << floatingBondPrice2
+                   << "\n  asset swap fair price: " << floatingBondAssetSwapPrice2
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error5 << "\n  tolerance:             " << tolerance2);
     }
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
-    Date cmsBondStartDate1 = Date(22,August,2005);
-    Date cmsBondMaturityDate1 = Date(22,August,2020);
-    Schedule cmsBondSchedule1(cmsBondStartDate1,
-                              cmsBondMaturityDate1,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate1 = Date(22, August, 2005);
+    Date cmsBondMaturityDate1 = Date(22, August, 2020);
+    Schedule cmsBondSchedule1(cmsBondStartDate1, cmsBondMaturityDate1, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withCaps(0.055)
-        .withFloors(0.025)
-        .inArrears(inArrears);
-    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
-                                                  Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withCaps(0.055)
+                          .withFloors(0.025)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following);
+    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption1)));
+    ext::shared_ptr<Bond> cmsBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondPrice1 = cmsBond1->cleanPrice();
-    AssetSwap cmsBondAssetSwap1(payFixedRate,
-                                cmsBond1, cmsBondPrice1,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
-                                parAssetSwap);
+    AssetSwap cmsBondAssetSwap1(payFixedRate, cmsBond1, cmsBondPrice1, vars.iborIndex, vars.spread,
+                                Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice();
-    Real error6 = std::fabs(cmsBondAssetSwapPrice1-cmsBondPrice1);
+    Real error6 = std::fabs(cmsBondAssetSwapPrice1 - cmsBondPrice1);
 
-    if (error6>tolerance2) {
+    if (error6 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << cmsBondPrice1
-                    << "\n  asset swap fair price: " << cmsBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error6
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << cmsBondPrice1
+                   << "\n  asset swap fair price: " << cmsBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error6
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
     // maturity occurs on a business day
-    Date cmsBondStartDate2 = Date(06,May,2005);
-    Date cmsBondMaturityDate2 = Date(06,May,2015);
-    Schedule cmsBondSchedule2(cmsBondStartDate2,
-                              cmsBondMaturityDate2,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate2 = Date(06, May, 2005);
+    Date cmsBondMaturityDate2 = Date(06, May, 2015);
+    Schedule cmsBondSchedule2(cmsBondStartDate2, cmsBondMaturityDate2, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withGearings(0.84)
-        .inArrears(inArrears);
-    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                  Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withGearings(0.84)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following);
+    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption2)));
+    ext::shared_ptr<Bond> cmsBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondPrice2 = cmsBond2->cleanPrice();
-    AssetSwap cmsBondAssetSwap2(payFixedRate,
-                                cmsBond2, cmsBondPrice2,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
-                                parAssetSwap);
+    AssetSwap cmsBondAssetSwap2(payFixedRate, cmsBond2, cmsBondPrice2, vars.iborIndex, vars.spread,
+                                Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondAssetSwap2.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice();
-    Real error7 = std::fabs(cmsBondAssetSwapPrice2-cmsBondPrice2);
+    Real error7 = std::fabs(cmsBondAssetSwapPrice2 - cmsBondPrice2);
 
-    if (error7>tolerance2) {
+    if (error7 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << cmsBondPrice2
-                    << "\n  asset swap fair price: " << cmsBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error7
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << cmsBondPrice2
+                   << "\n  asset swap fair price: " << cmsBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
-    Date zeroCpnBondStartDate1 = Date(19,December,1985);
-    Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
-    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                      Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Date zeroCpnBondStartDate1 = Date(19, December, 1985);
+    Date zeroCpnBondMaturityDate1 = Date(20, December, 2015);
+    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following);
+    Leg zeroCpnBondLeg1 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    ext::shared_ptr<Bond> zeroCpnBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate1, zeroCpnBondStartDate1,
+                                                zeroCpnBondLeg1));
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice1 = zeroCpnBond1->cleanPrice();
-    AssetSwap zeroCpnAssetSwap1(payFixedRate,
-                                zeroCpnBond1, zeroCpnBondPrice1,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondPrice1, vars.iborIndex,
+                                vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     zeroCpnAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice1 = zeroCpnAssetSwap1.fairCleanPrice();
-    Real error8 = std::fabs(zeroCpnBondAssetSwapPrice1-zeroCpnBondPrice1);
+    Real error8 = std::fabs(zeroCpnBondAssetSwapPrice1 - zeroCpnBondPrice1);
 
-    if (error8>tolerance2) {
+    if (error8 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << zeroCpnBondPrice1
-                    << "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error8
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << zeroCpnBondPrice1
+                   << "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error8
+                   << "\n  tolerance:             " << tolerance2);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
-    Date zeroCpnBondStartDate2 = Date(17,February,1998);
-    Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
-    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                      Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Date zeroCpnBondStartDate2 = Date(17, February, 1998);
+    Date zeroCpnBondMaturityDate2 = Date(17, February, 2028);
+    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following);
+    Leg zeroCpnBondLeg2 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    ext::shared_ptr<Bond> zeroCpnBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate2, zeroCpnBondStartDate2,
+                                                zeroCpnBondLeg2));
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
-    AssetSwap zeroCpnAssetSwap2(payFixedRate,
-                                zeroCpnBond2, zeroCpnBondPrice2,
-                                vars.iborIndex, vars.spread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondPrice2, vars.iborIndex,
+                                vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     zeroCpnAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice2 = zeroCpnAssetSwap2.fairCleanPrice();
-    Real error9 = std::fabs(zeroCpnBondAssetSwapPrice2-zeroCpnBondPrice2);
+    Real error9 = std::fabs(zeroCpnBondAssetSwapPrice2 - zeroCpnBondPrice2);
 
-    if (error9>tolerance2) {
+    if (error9 > tolerance2) {
         BOOST_FAIL("wrong zero spread asset swap price for zero cpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  bond's clean price:    " << zeroCpnBondPrice2
-                    << "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error9
-                    << "\n  tolerance:             " << tolerance2);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  bond's clean price:    " << zeroCpnBondPrice2
+                   << "\n  asset swap fair price: " << zeroCpnBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error9
+                   << "\n  tolerance:             " << tolerance2);
     }
 }
 
@@ -2205,45 +1716,33 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Date fixedBondStartDate1 = Date(4,January,2005);
-    Date fixedBondMaturityDate1 = Date(4,January,2037);
-    Schedule fixedBondSchedule1(fixedBondStartDate1,
-                                fixedBondMaturityDate1,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate1 = Date(4, January, 2005);
+    Date fixedBondMaturityDate1 = Date(4, January, 2037);
+    Schedule fixedBondSchedule1(fixedBondStartDate1, fixedBondMaturityDate1, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg1 = FixedRateLeg(fixedBondSchedule1)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
-    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                    Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
+    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following);
+    fixedBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption1)));
+    ext::shared_ptr<Bond> fixedBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate1, fixedBondStartDate1,
+                                              fixedBondLeg1));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
-    Real fixedBondMktPrice1 = 89.22 ; // market price observed on 7th June 2007
-    Real fixedBondMktFullPrice1=fixedBondMktPrice1+fixedBond1->accruedAmount();
-    AssetSwap fixedBondParAssetSwap1(payFixedRate,
-                                     fixedBond1, fixedBondMktPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    Real fixedBondMktPrice1 = 89.22; // market price observed on 7th June 2007
+    Real fixedBondMktFullPrice1 = fixedBondMktPrice1 + fixedBond1->accruedAmount();
+    AssetSwap fixedBondParAssetSwap1(payFixedRate, fixedBond1, fixedBondMktPrice1, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      parAssetSwap);
     fixedBondParAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondParAssetSwapSpread1 = fixedBondParAssetSwap1.fairSpread();
-    AssetSwap fixedBondMktAssetSwap1(payFixedRate,
-                                     fixedBond1, fixedBondMktPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondMktAssetSwap1(payFixedRate, fixedBond1, fixedBondMktPrice1, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      mktAssetSwap);
     fixedBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondMktAssetSwapSpread1 = fixedBondMktAssetSwap1.fairSpread();
@@ -2251,410 +1750,320 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
     // see comment above
     Real tolerance2 = usingAtParCoupons ? 1.0e-13 : 1.0e-4;
 
-    Real error1 =
-        std::fabs(fixedBondMktAssetSwapSpread1-
-                  100*fixedBondParAssetSwapSpread1/fixedBondMktFullPrice1);
+    Real error1 = std::fabs(fixedBondMktAssetSwapSpread1 -
+                            100 * fixedBondParAssetSwapSpread1 / fixedBondMktFullPrice1);
 
-    if (error1>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for fixed bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(fixedBondMktAssetSwapSpread1) <<
-                    "\n  par asset swap spread:    " << io::rate(fixedBondParAssetSwapSpread1) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error1 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error1 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(fixedBondMktAssetSwapSpread1)
+                   << "\n  par asset swap spread:    " << io::rate(fixedBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error1 << "\n  tolerance:                " << tolerance2);
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
 
-    Date fixedBondStartDate2 = Date(5,February,2005);
-    Date fixedBondMaturityDate2 = Date(5,February,2019);
-    Schedule fixedBondSchedule2(fixedBondStartDate2,
-                                fixedBondMaturityDate2,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate2 = Date(5, February, 2005);
+    Date fixedBondMaturityDate2 = Date(5, February, 2019);
+    Schedule fixedBondSchedule2(fixedBondStartDate2, fixedBondMaturityDate2, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg2 = FixedRateLeg(fixedBondSchedule2)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
-    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
-                                                    Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
+    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following);
+    fixedBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption2)));
+    ext::shared_ptr<Bond> fixedBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate2, fixedBondStartDate2,
+                                              fixedBondLeg2));
     fixedBond2->setPricingEngine(bondEngine);
 
-    Real fixedBondMktPrice2 = 99.98 ; // market price observed on 7th June 2007
-    Real fixedBondMktFullPrice2=fixedBondMktPrice2+fixedBond2->accruedAmount();
-    AssetSwap fixedBondParAssetSwap2(payFixedRate,
-                                     fixedBond2, fixedBondMktPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    Real fixedBondMktPrice2 = 99.98; // market price observed on 7th June 2007
+    Real fixedBondMktFullPrice2 = fixedBondMktPrice2 + fixedBond2->accruedAmount();
+    AssetSwap fixedBondParAssetSwap2(payFixedRate, fixedBond2, fixedBondMktPrice2, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      parAssetSwap);
     fixedBondParAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondParAssetSwapSpread2 = fixedBondParAssetSwap2.fairSpread();
-    AssetSwap fixedBondMktAssetSwap2(payFixedRate,
-                                     fixedBond2, fixedBondMktPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondMktAssetSwap2(payFixedRate, fixedBond2, fixedBondMktPrice2, vars.iborIndex,
+                                     vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                      mktAssetSwap);
     fixedBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondMktAssetSwapSpread2 = fixedBondMktAssetSwap2.fairSpread();
-    Real error2 =
-        std::fabs(fixedBondMktAssetSwapSpread2-
-                  100*fixedBondParAssetSwapSpread2/fixedBondMktFullPrice2);
+    Real error2 = std::fabs(fixedBondMktAssetSwapSpread2 -
+                            100 * fixedBondParAssetSwapSpread2 / fixedBondMktFullPrice2);
 
-    if (error2>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for fixed bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(fixedBondMktAssetSwapSpread2) <<
-                    "\n  par asset swap spread:    " << io::rate(fixedBondParAssetSwapSpread2) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error2 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error2 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for fixed bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(fixedBondMktAssetSwapSpread2)
+                   << "\n  par asset swap spread:    " << io::rate(fixedBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error2 << "\n  tolerance:                " << tolerance2);
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
 
-    Date floatingBondStartDate1 = Date(29,September,2003);
-    Date floatingBondMaturityDate1 = Date(29,September,2013);
-    Schedule floatingBondSchedule1(floatingBondStartDate1,
-                                   floatingBondMaturityDate1,
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Date floatingBondStartDate1 = Date(29, September, 2003);
+    Date floatingBondMaturityDate1 = Date(29, September, 2013);
+    Schedule floatingBondSchedule1(floatingBondStartDate1, floatingBondMaturityDate1,
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
     Leg floatingBondLeg1 = IborLeg(floatingBondSchedule1, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0056)
-        .inArrears(inArrears);
-    Date floatingbondRedemption1 =
-        bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0056)
+                               .inArrears(inArrears);
+    Date floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following);
+    floatingBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption1)));
+    ext::shared_ptr<Bond> floatingBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate1, floatingBondStartDate1,
+                                                 floatingBondLeg1));
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     // market price observed on 7th June 2007
-    Real floatingBondMktPrice1 = 101.64 ;
-    Real floatingBondMktFullPrice1 =
-        floatingBondMktPrice1+floatingBond1->accruedAmount();
-    AssetSwap floatingBondParAssetSwap1(payFixedRate,
-                                        floatingBond1, floatingBondMktPrice1,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        parAssetSwap);
+    Real floatingBondMktPrice1 = 101.64;
+    Real floatingBondMktFullPrice1 = floatingBondMktPrice1 + floatingBond1->accruedAmount();
+    AssetSwap floatingBondParAssetSwap1(payFixedRate, floatingBond1, floatingBondMktPrice1,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondParAssetSwap1.setPricingEngine(swapEngine);
-    Real floatingBondParAssetSwapSpread1 =
-        floatingBondParAssetSwap1.fairSpread();
-    AssetSwap floatingBondMktAssetSwap1(payFixedRate,
-                                        floatingBond1, floatingBondMktPrice1,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        mktAssetSwap);
+    Real floatingBondParAssetSwapSpread1 = floatingBondParAssetSwap1.fairSpread();
+    AssetSwap floatingBondMktAssetSwap1(payFixedRate, floatingBond1, floatingBondMktPrice1,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), mktAssetSwap);
     floatingBondMktAssetSwap1.setPricingEngine(swapEngine);
-    Real floatingBondMktAssetSwapSpread1 =
-        floatingBondMktAssetSwap1.fairSpread();
-    Real error3 =
-        std::fabs(floatingBondMktAssetSwapSpread1-
-                  100*floatingBondParAssetSwapSpread1/floatingBondMktFullPrice1);
+    Real floatingBondMktAssetSwapSpread1 = floatingBondMktAssetSwap1.fairSpread();
+    Real error3 = std::fabs(floatingBondMktAssetSwapSpread1 -
+                            100 * floatingBondParAssetSwapSpread1 / floatingBondMktFullPrice1);
 
-    if (error3>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for floating bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(floatingBondMktAssetSwapSpread1) <<
-                    "\n  par asset swap spread:    " << io::rate(floatingBondParAssetSwapSpread1) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error3 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error3 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for floating bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(floatingBondMktAssetSwapSpread1)
+                   << "\n  par asset swap spread:    " << io::rate(floatingBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error3 << "\n  tolerance:                " << tolerance2);
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
 
-    Date floatingBondStartDate2 = Date(24,September,2004);
-    Date floatingBondMaturityDate2 = Date(24,September,2018);
-    Schedule floatingBondSchedule2(floatingBondStartDate2,
-                                   floatingBondMaturityDate2,
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
+    Date floatingBondStartDate2 = Date(24, September, 2004);
+    Date floatingBondMaturityDate2 = Date(24, September, 2018);
+    Schedule floatingBondSchedule2(floatingBondStartDate2, floatingBondMaturityDate2,
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
     Leg floatingBondLeg2 = IborLeg(floatingBondSchedule2, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withPaymentAdjustment(ModifiedFollowing)
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0025)
-        .inArrears(inArrears);
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withPaymentAdjustment(ModifiedFollowing)
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0025)
+                               .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+    floatingBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption2)));
+    ext::shared_ptr<Bond> floatingBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate2, floatingBondStartDate2,
+                                                 floatingBondLeg2));
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
     // market price observed on 7th June 2007
-    Real floatingBondMktPrice2 = 101.248 ;
-    Real floatingBondMktFullPrice2 =
-        floatingBondMktPrice2+floatingBond2->accruedAmount();
-    AssetSwap floatingBondParAssetSwap2(payFixedRate,
-                                        floatingBond2, floatingBondMktPrice2,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        parAssetSwap);
+    Real floatingBondMktPrice2 = 101.248;
+    Real floatingBondMktFullPrice2 = floatingBondMktPrice2 + floatingBond2->accruedAmount();
+    AssetSwap floatingBondParAssetSwap2(payFixedRate, floatingBond2, floatingBondMktPrice2,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondParAssetSwap2.setPricingEngine(swapEngine);
-    Spread floatingBondParAssetSwapSpread2 =
-        floatingBondParAssetSwap2.fairSpread();
-    AssetSwap floatingBondMktAssetSwap2(payFixedRate,
-                                        floatingBond2, floatingBondMktPrice2,
-                                        vars.iborIndex, vars.spread,
-                                        Schedule(),
-                                        vars.iborIndex->dayCounter(),
-                                        mktAssetSwap);
+    Spread floatingBondParAssetSwapSpread2 = floatingBondParAssetSwap2.fairSpread();
+    AssetSwap floatingBondMktAssetSwap2(payFixedRate, floatingBond2, floatingBondMktPrice2,
+                                        vars.iborIndex, vars.spread, Schedule(),
+                                        vars.iborIndex->dayCounter(), mktAssetSwap);
     floatingBondMktAssetSwap2.setPricingEngine(swapEngine);
-    Real floatingBondMktAssetSwapSpread2 =
-        floatingBondMktAssetSwap2.fairSpread();
-    Real error4 =
-        std::fabs(floatingBondMktAssetSwapSpread2-
-                  100*floatingBondParAssetSwapSpread2/floatingBondMktFullPrice2);
+    Real floatingBondMktAssetSwapSpread2 = floatingBondMktAssetSwap2.fairSpread();
+    Real error4 = std::fabs(floatingBondMktAssetSwapSpread2 -
+                            100 * floatingBondParAssetSwapSpread2 / floatingBondMktFullPrice2);
 
-    if (error4>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for floating bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(floatingBondMktAssetSwapSpread2) <<
-                    "\n  par asset swap spread:    " << io::rate(floatingBondParAssetSwapSpread2) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error4 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error4 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for floating bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(floatingBondMktAssetSwapSpread2)
+                   << "\n  par asset swap spread:    " << io::rate(floatingBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error4 << "\n  tolerance:                " << tolerance2);
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
 
-    Date cmsBondStartDate1 = Date(22,August,2005);
-    Date cmsBondMaturityDate1 = Date(22,August,2020);
-    Schedule cmsBondSchedule1(cmsBondStartDate1,
-                              cmsBondMaturityDate1,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate1 = Date(22, August, 2005);
+    Date cmsBondMaturityDate1 = Date(22, August, 2020);
+    Schedule cmsBondSchedule1(cmsBondStartDate1, cmsBondMaturityDate1, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withCaps(0.055)
-        .withFloors(0.025)
-        .inArrears(inArrears);
-    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
-                                                  Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withCaps(0.055)
+                          .withFloors(0.025)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following);
+    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption1)));
+    ext::shared_ptr<Bond> cmsBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
-    Real cmsBondMktPrice1 = 88.45 ; // market price observed on 7th June 2007
-    Real cmsBondMktFullPrice1 = cmsBondMktPrice1+cmsBond1->accruedAmount();
-    AssetSwap cmsBondParAssetSwap1(payFixedRate,
-                                   cmsBond1, cmsBondMktPrice1,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
+    Real cmsBondMktPrice1 = 88.45; // market price observed on 7th June 2007
+    Real cmsBondMktFullPrice1 = cmsBondMktPrice1 + cmsBond1->accruedAmount();
+    AssetSwap cmsBondParAssetSwap1(payFixedRate, cmsBond1, cmsBondMktPrice1, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    parAssetSwap);
     cmsBondParAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondParAssetSwapSpread1 = cmsBondParAssetSwap1.fairSpread();
-    AssetSwap cmsBondMktAssetSwap1(payFixedRate,
-                                   cmsBond1, cmsBondMktPrice1,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondMktAssetSwap1(payFixedRate, cmsBond1, cmsBondMktPrice1, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    mktAssetSwap);
     cmsBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondMktAssetSwapSpread1 = cmsBondMktAssetSwap1.fairSpread();
-    Real error5 =
-        std::fabs(cmsBondMktAssetSwapSpread1-
-                  100*cmsBondParAssetSwapSpread1/cmsBondMktFullPrice1);
+    Real error5 = std::fabs(cmsBondMktAssetSwapSpread1 -
+                            100 * cmsBondParAssetSwapSpread1 / cmsBondMktFullPrice1);
 
-    if (error5>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for cms bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(cmsBondMktAssetSwapSpread1) <<
-                    "\n  par asset swap spread:    " << io::rate(cmsBondParAssetSwapSpread1) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error5 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error5 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(cmsBondMktAssetSwapSpread1)
+                   << "\n  par asset swap spread:    " << io::rate(cmsBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error5 << "\n  tolerance:                " << tolerance2);
 
-     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-     // maturity occurs on a business day
+    // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+    // maturity occurs on a business day
 
-    Date cmsBondStartDate2 = Date(06,May,2005);
-    Date cmsBondMaturityDate2 = Date(06,May,2015);
-    Schedule cmsBondSchedule2(cmsBondStartDate2,
-                              cmsBondMaturityDate2,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate2 = Date(06, May, 2005);
+    Date cmsBondMaturityDate2 = Date(06, May, 2015);
+    Schedule cmsBondSchedule2(cmsBondStartDate2, cmsBondMaturityDate2, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withGearings(0.84)
-        .inArrears(inArrears);
-    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                  Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withGearings(0.84)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following);
+    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption2)));
+    ext::shared_ptr<Bond> cmsBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
-    Real cmsBondMktPrice2 = 94.08 ; // market price observed on 7th June 2007
-    Real cmsBondMktFullPrice2 = cmsBondMktPrice2+cmsBond2->accruedAmount();
-    AssetSwap cmsBondParAssetSwap2(payFixedRate,
-                                   cmsBond2, cmsBondMktPrice2,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
+    Real cmsBondMktPrice2 = 94.08; // market price observed on 7th June 2007
+    Real cmsBondMktFullPrice2 = cmsBondMktPrice2 + cmsBond2->accruedAmount();
+    AssetSwap cmsBondParAssetSwap2(payFixedRate, cmsBond2, cmsBondMktPrice2, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    parAssetSwap);
     cmsBondParAssetSwap2.setPricingEngine(swapEngine);
     Spread cmsBondParAssetSwapSpread2 = cmsBondParAssetSwap2.fairSpread();
-    AssetSwap cmsBondMktAssetSwap2(payFixedRate,
-                                   cmsBond2, cmsBondMktPrice2,
-                                   vars.iborIndex, vars.spread,
-                                   Schedule(),
-                                   vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondMktAssetSwap2(payFixedRate, cmsBond2, cmsBondMktPrice2, vars.iborIndex,
+                                   vars.spread, Schedule(), vars.iborIndex->dayCounter(),
                                    mktAssetSwap);
     cmsBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real cmsBondMktAssetSwapSpread2 = cmsBondMktAssetSwap2.fairSpread();
-    Real error6 =
-        std::fabs(cmsBondMktAssetSwapSpread2-
-                  100*cmsBondParAssetSwapSpread2/cmsBondMktFullPrice2);
+    Real error6 = std::fabs(cmsBondMktAssetSwapSpread2 -
+                            100 * cmsBondParAssetSwapSpread2 / cmsBondMktFullPrice2);
 
-    if (error6>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for cms bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(cmsBondMktAssetSwapSpread2) <<
-                    "\n  par asset swap spread:    " << io::rate(cmsBondParAssetSwapSpread2) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error6 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error6 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for cms bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(cmsBondMktAssetSwapSpread2)
+                   << "\n  par asset swap spread:    " << io::rate(cmsBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error6 << "\n  tolerance:                " << tolerance2);
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    Date zeroCpnBondStartDate1 = Date(19,December,1985);
-    Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
-    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                      Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Date zeroCpnBondStartDate1 = Date(19, December, 1985);
+    Date zeroCpnBondMaturityDate1 = Date(20, December, 2015);
+    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following);
+    Leg zeroCpnBondLeg1 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    ext::shared_ptr<Bond> zeroCpnBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate1, zeroCpnBondStartDate1,
+                                                zeroCpnBondLeg1));
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // market price observed on 12th June 2007
-    Real zeroCpnBondMktPrice1 = 70.436 ;
-    Real zeroCpnBondMktFullPrice1 =
-        zeroCpnBondMktPrice1+zeroCpnBond1->accruedAmount();
-    AssetSwap zeroCpnBondParAssetSwap1(payFixedRate,zeroCpnBond1,
-                                       zeroCpnBondMktPrice1,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    Real zeroCpnBondMktPrice1 = 70.436;
+    Real zeroCpnBondMktFullPrice1 = zeroCpnBondMktPrice1 + zeroCpnBond1->accruedAmount();
+    AssetSwap zeroCpnBondParAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondMktPrice1,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondParAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondParAssetSwapSpread1 = zeroCpnBondParAssetSwap1.fairSpread();
-    AssetSwap zeroCpnBondMktAssetSwap1(payFixedRate,zeroCpnBond1,
-                                       zeroCpnBondMktPrice1,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       mktAssetSwap);
+    AssetSwap zeroCpnBondMktAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondMktPrice1,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), mktAssetSwap);
     zeroCpnBondMktAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondMktAssetSwapSpread1 = zeroCpnBondMktAssetSwap1.fairSpread();
-    Real error7 =
-        std::fabs(zeroCpnBondMktAssetSwapSpread1-
-                  100*zeroCpnBondParAssetSwapSpread1/zeroCpnBondMktFullPrice1);
+    Real error7 = std::fabs(zeroCpnBondMktAssetSwapSpread1 -
+                            100 * zeroCpnBondParAssetSwapSpread1 / zeroCpnBondMktFullPrice1);
 
-    if (error7>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(zeroCpnBondMktAssetSwapSpread1) <<
-                    "\n  par asset swap spread:    " << io::rate(zeroCpnBondParAssetSwapSpread1) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error7 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error7 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(zeroCpnBondMktAssetSwapSpread1)
+                   << "\n  par asset swap spread:    " << io::rate(zeroCpnBondParAssetSwapSpread1)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error7 << "\n  tolerance:                " << tolerance2);
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    Date zeroCpnBondStartDate2 = Date(17,February,1998);
-    Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
-    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                      Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Date zeroCpnBondStartDate2 = Date(17, February, 1998);
+    Date zeroCpnBondMaturityDate2 = Date(17, February, 2028);
+    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following);
+    Leg zeroCpnBondLeg2 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    ext::shared_ptr<Bond> zeroCpnBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate2, zeroCpnBondStartDate2,
+                                                zeroCpnBondLeg2));
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
     // market price observed on 12th June 2007
-    Real zeroCpnBondMktPrice2 = 35.160 ;
-    Real zeroCpnBondMktFullPrice2 =
-        zeroCpnBondMktPrice2+zeroCpnBond2->accruedAmount();
-    AssetSwap zeroCpnBondParAssetSwap2(payFixedRate,zeroCpnBond2,
-                                       zeroCpnBondMktPrice2,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    Real zeroCpnBondMktPrice2 = 35.160;
+    Real zeroCpnBondMktFullPrice2 = zeroCpnBondMktPrice2 + zeroCpnBond2->accruedAmount();
+    AssetSwap zeroCpnBondParAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondMktPrice2,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondParAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondParAssetSwapSpread2 = zeroCpnBondParAssetSwap2.fairSpread();
-    AssetSwap zeroCpnBondMktAssetSwap2(payFixedRate,zeroCpnBond2,
-                                       zeroCpnBondMktPrice2,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       mktAssetSwap);
+    AssetSwap zeroCpnBondMktAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondMktPrice2,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), mktAssetSwap);
     zeroCpnBondMktAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondMktAssetSwapSpread2 = zeroCpnBondMktAssetSwap2.fairSpread();
-    Real error8 =
-        std::fabs(zeroCpnBondMktAssetSwapSpread2-
-                  100*zeroCpnBondParAssetSwapSpread2/zeroCpnBondMktFullPrice2);
+    Real error8 = std::fabs(zeroCpnBondMktAssetSwapSpread2 -
+                            100 * zeroCpnBondParAssetSwapSpread2 / zeroCpnBondMktFullPrice2);
 
-    if (error8>tolerance2)
-        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:" <<
-                    std::fixed << std::setprecision(4) <<
-                    "\n  market asset swap spread: " << io::rate(zeroCpnBondMktAssetSwapSpread2) <<
-                    "\n  par asset swap spread:    " << io::rate(zeroCpnBondParAssetSwapSpread2) <<
-                    std::scientific << std::setprecision(2) <<
-                    "\n  error:                    " << error8 <<
-                    "\n  tolerance:                " << tolerance2);
+    if (error8 > tolerance2)
+        BOOST_FAIL("wrong asset swap spreads for zero cpn bond:"
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << io::rate(zeroCpnBondMktAssetSwapSpread2)
+                   << "\n  par asset swap spread:    " << io::rate(zeroCpnBondParAssetSwapSpread2)
+                   << std::scientific << std::setprecision(2) << "\n  error:                    "
+                   << error8 << "\n  tolerance:                " << tolerance2);
 }
 
 
@@ -2673,352 +2082,295 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
 
-    Date fixedBondStartDate1 = Date(4,January,2005);
-    Date fixedBondMaturityDate1 = Date(4,January,2037);
-    Schedule fixedBondSchedule1(fixedBondStartDate1,
-                                fixedBondMaturityDate1,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate1 = Date(4, January, 2005);
+    Date fixedBondMaturityDate1 = Date(4, January, 2037);
+    Schedule fixedBondSchedule1(fixedBondStartDate1, fixedBondMaturityDate1, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg1 = FixedRateLeg(fixedBondSchedule1)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
-    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                    Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(new
-        DiscountingBondEngine(vars.termStructure));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
+    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following);
+    fixedBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption1)));
+    ext::shared_ptr<Bond> fixedBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate1, fixedBondStartDate1,
+                                              fixedBondLeg1));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue1 = fixedBond1->cleanPrice();
-    Date fixedBondSettlementDate1= fixedBond1->settlementDate();
+    Date fixedBondSettlementDate1 = fixedBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real fixedBondCleanPrice1 = BondFunctions::cleanPrice(
-         *fixedBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         fixedBondSettlementDate1);
+    Real fixedBondCleanPrice1 =
+        BondFunctions::cleanPrice(*fixedBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, fixedBondSettlementDate1);
     Real tolerance = 1.0e-13;
-    Real error1 = std::fabs(fixedBondImpliedValue1-fixedBondCleanPrice1);
-    if (error1>tolerance) {
+    Real error1 = std::fabs(fixedBondImpliedValue1 - fixedBondCleanPrice1);
+    if (error1 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: "
-                    << fixedBondImpliedValue1
-                    << "\n  par asset swap spread: " << fixedBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error1
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << fixedBondImpliedValue1
+                   << "\n  par asset swap spread: " << fixedBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
 
-    Date fixedBondStartDate2 = Date(5,February,2005);
-    Date fixedBondMaturityDate2 = Date(5,February,2019);
-    Schedule fixedBondSchedule2(fixedBondStartDate2,
-                                fixedBondMaturityDate2,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate2 = Date(5, February, 2005);
+    Date fixedBondMaturityDate2 = Date(5, February, 2019);
+    Schedule fixedBondSchedule2(fixedBondStartDate2, fixedBondMaturityDate2, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg2 = FixedRateLeg(fixedBondSchedule2)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
-    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
-                                                    Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
+    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following);
+    fixedBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption2)));
+    ext::shared_ptr<Bond> fixedBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate2, fixedBondStartDate2,
+                                              fixedBondLeg2));
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue2 = fixedBond2->cleanPrice();
-    Date fixedBondSettlementDate2= fixedBond2->settlementDate();
+    Date fixedBondSettlementDate2 = fixedBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
 
-    Real fixedBondCleanPrice2 = BondFunctions::cleanPrice(
-         *fixedBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         fixedBondSettlementDate2);
-    Real error3 = std::fabs(fixedBondImpliedValue2-fixedBondCleanPrice2);
-    if (error3>tolerance) {
+    Real fixedBondCleanPrice2 =
+        BondFunctions::cleanPrice(*fixedBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, fixedBondSettlementDate2);
+    Real error3 = std::fabs(fixedBondImpliedValue2 - fixedBondCleanPrice2);
+    if (error3 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: "
-                    << fixedBondImpliedValue2
-                    << "\n  par asset swap spread: " << fixedBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error3
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << fixedBondImpliedValue2
+                   << "\n  par asset swap spread: " << fixedBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error3
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
 
-    Date floatingBondStartDate1 = Date(29,September,2003);
-    Date floatingBondMaturityDate1 = Date(29,September,2013);
-    Schedule floatingBondSchedule1(floatingBondStartDate1,
-                                   floatingBondMaturityDate1,
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Date floatingBondStartDate1 = Date(29, September, 2003);
+    Date floatingBondMaturityDate1 = Date(29, September, 2013);
+    Schedule floatingBondSchedule1(floatingBondStartDate1, floatingBondMaturityDate1,
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
     Leg floatingBondLeg1 = IborLeg(floatingBondSchedule1, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0056)
-        .inArrears(inArrears);
-    Date floatingbondRedemption1 =
-        bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0056)
+                               .inArrears(inArrears);
+    Date floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following);
+    floatingBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption1)));
+    ext::shared_ptr<Bond> floatingBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate1, floatingBondStartDate1,
+                                                 floatingBondLeg1));
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondImpliedValue1 = floatingBond1->cleanPrice();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real floatingBondCleanPrice1 = BondFunctions::cleanPrice(
-        *floatingBond1, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
-        fixedBondSettlementDate1);
-    Real error5 = std::fabs(floatingBondImpliedValue1-floatingBondCleanPrice1);
-    if (error5>tolerance) {
+    Real floatingBondCleanPrice1 =
+        BondFunctions::cleanPrice(*floatingBond1, *vars.termStructure, vars.spread,
+                                  vars.compounding, Semiannual, fixedBondSettlementDate1);
+    Real error5 = std::fabs(floatingBondImpliedValue1 - floatingBondCleanPrice1);
+    if (error5 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " <<
-                    floatingBondImpliedValue1
-                    << "\n  par asset swap spread: " << floatingBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error5
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << floatingBondImpliedValue1
+                   << "\n  par asset swap spread: " << floatingBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error5
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
 
-    Date floatingBondStartDate2 = Date(24,September,2004);
-    Date floatingBondMaturityDate2 = Date(24,September,2018);
-    Schedule floatingBondSchedule2(floatingBondStartDate2,
-                                   floatingBondMaturityDate2,
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
+    Date floatingBondStartDate2 = Date(24, September, 2004);
+    Date floatingBondMaturityDate2 = Date(24, September, 2018);
+    Schedule floatingBondSchedule2(floatingBondStartDate2, floatingBondMaturityDate2,
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
     Leg floatingBondLeg2 = IborLeg(floatingBondSchedule2, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withPaymentAdjustment(ModifiedFollowing)
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0025)
-        .inArrears(inArrears);
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withPaymentAdjustment(ModifiedFollowing)
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0025)
+                               .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+    floatingBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption2)));
+    ext::shared_ptr<Bond> floatingBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate2, floatingBondStartDate2,
+                                                 floatingBondLeg2));
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
     Real floatingBondImpliedValue2 = floatingBond2->cleanPrice();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real floatingBondCleanPrice2 = BondFunctions::cleanPrice(
-        *floatingBond2, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
-        fixedBondSettlementDate1);
-    Real error7 = std::fabs(floatingBondImpliedValue2-floatingBondCleanPrice2);
-    if (error7>tolerance) {
+    Real floatingBondCleanPrice2 =
+        BondFunctions::cleanPrice(*floatingBond2, *vars.termStructure, vars.spread,
+                                  vars.compounding, Semiannual, fixedBondSettlementDate1);
+    Real error7 = std::fabs(floatingBondImpliedValue2 - floatingBondCleanPrice2);
+    if (error7 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " <<
-                    floatingBondImpliedValue2
-                    << "\n  par asset swap spread: " << floatingBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error7
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << floatingBondImpliedValue2
+                   << "\n  par asset swap spread: " << floatingBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
 
-    Date cmsBondStartDate1 = Date(22,August,2005);
-    Date cmsBondMaturityDate1 = Date(22,August,2020);
-    Schedule cmsBondSchedule1(cmsBondStartDate1,
-                              cmsBondMaturityDate1,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate1 = Date(22, August, 2005);
+    Date cmsBondMaturityDate1 = Date(22, August, 2020);
+    Schedule cmsBondSchedule1(cmsBondStartDate1, cmsBondMaturityDate1, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withCaps(0.055)
-        .withFloors(0.025)
-        .inArrears(inArrears);
-    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
-                                                  Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withCaps(0.055)
+                          .withFloors(0.025)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following);
+    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption1)));
+    ext::shared_ptr<Bond> cmsBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondImpliedValue1 = cmsBond1->cleanPrice();
-    Date cmsBondSettlementDate1= cmsBond1->settlementDate();
+    Date cmsBondSettlementDate1 = cmsBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real cmsBondCleanPrice1 = BondFunctions::cleanPrice(
-         *cmsBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         cmsBondSettlementDate1);
-    Real error9 = std::fabs(cmsBondImpliedValue1-cmsBondCleanPrice1);
-    if (error9>tolerance) {
+    Real cmsBondCleanPrice1 =
+        BondFunctions::cleanPrice(*cmsBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, cmsBondSettlementDate1);
+    Real error9 = std::fabs(cmsBondImpliedValue1 - cmsBondCleanPrice1);
+    if (error9 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " << cmsBondImpliedValue1
-                    << "\n  par asset swap spread: " << cmsBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error9
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << cmsBondImpliedValue1
+                   << "\n  par asset swap spread: " << cmsBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error9
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
     // maturity occurs on a business day
 
-    Date cmsBondStartDate2 = Date(06,May,2005);
-    Date cmsBondMaturityDate2 = Date(06,May,2015);
-    Schedule cmsBondSchedule2(cmsBondStartDate2,
-                              cmsBondMaturityDate2,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate2 = Date(06, May, 2005);
+    Date cmsBondMaturityDate2 = Date(06, May, 2015);
+    Schedule cmsBondSchedule2(cmsBondStartDate2, cmsBondMaturityDate2, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withGearings(0.84)
-        .inArrears(inArrears);
-    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                  Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withGearings(0.84)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following);
+    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption2)));
+    ext::shared_ptr<Bond> cmsBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondImpliedValue2 = cmsBond2->cleanPrice();
-    Date cmsBondSettlementDate2= cmsBond2->settlementDate();
+    Date cmsBondSettlementDate2 = cmsBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
-    Real cmsBondCleanPrice2 = BondFunctions::cleanPrice(
-         *cmsBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
-         cmsBondSettlementDate2);
-    Real error11 = std::fabs(cmsBondImpliedValue2-cmsBondCleanPrice2);
-    if (error11>tolerance) {
+    Real cmsBondCleanPrice2 =
+        BondFunctions::cleanPrice(*cmsBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, cmsBondSettlementDate2);
+    Real error11 = std::fabs(cmsBondImpliedValue2 - cmsBondCleanPrice2);
+    if (error11 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  market asset swap spread: " << cmsBondImpliedValue2
-                    << "\n  par asset swap spread: " << cmsBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error11
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  market asset swap spread: " << cmsBondImpliedValue2
+                   << "\n  par asset swap spread: " << cmsBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error11
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    Date zeroCpnBondStartDate1 = Date(19,December,1985);
-    Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
-    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                      Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Date zeroCpnBondStartDate1 = Date(19, December, 1985);
+    Date zeroCpnBondMaturityDate1 = Date(20, December, 2015);
+    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following);
+    Leg zeroCpnBondLeg1 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    ext::shared_ptr<Bond> zeroCpnBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate1, zeroCpnBondStartDate1,
+                                                zeroCpnBondLeg1));
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue1 = zeroCpnBond1->cleanPrice();
-    Date zeroCpnBondSettlementDate1= zeroCpnBond1->settlementDate();
+    Date zeroCpnBondSettlementDate1 = zeroCpnBond1->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real zeroCpnBondCleanPrice1 =
-        BondFunctions::cleanPrice(*zeroCpnBond1,
-                              *vars.termStructure,
-                              vars.spread,
-                              Actual365Fixed(),
-                              vars.compounding, Annual,
-                              zeroCpnBondSettlementDate1);
-    Real error13 = std::fabs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1);
-    if (error13>tolerance) {
+        BondFunctions::cleanPrice(*zeroCpnBond1, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, zeroCpnBondSettlementDate1);
+    Real error13 = std::fabs(zeroCpnBondImpliedValue1 - zeroCpnBondCleanPrice1);
+    if (error13 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  zero cpn implied value: " <<
-                    zeroCpnBondImpliedValue1
-                    << "\n  zero cpn price: " << zeroCpnBondCleanPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error13
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  zero cpn implied value: " << zeroCpnBondImpliedValue1
+                   << "\n  zero cpn price: " << zeroCpnBondCleanPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error13
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    Date zeroCpnBondStartDate2 = Date(17,February,1998);
-    Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
-    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                      Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Date zeroCpnBondStartDate2 = Date(17, February, 1998);
+    Date zeroCpnBondMaturityDate2 = Date(17, February, 2028);
+    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following);
+    Leg zeroCpnBondLeg2 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    ext::shared_ptr<Bond> zeroCpnBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate2, zeroCpnBondStartDate2,
+                                                zeroCpnBondLeg2));
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue2 = zeroCpnBond2->cleanPrice();
-    Date zeroCpnBondSettlementDate2= zeroCpnBond2->settlementDate();
+    Date zeroCpnBondSettlementDate2 = zeroCpnBond2->settlementDate();
     // standard market conventions:
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real zeroCpnBondCleanPrice2 =
-        BondFunctions::cleanPrice(*zeroCpnBond2,
-                              *vars.termStructure,
-                              vars.spread,
-                              Actual365Fixed(),
-                              vars.compounding, Annual,
-                              zeroCpnBondSettlementDate2);
-    Real error15 = std::fabs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2);
-    if (error15>tolerance) {
+        BondFunctions::cleanPrice(*zeroCpnBond2, *vars.termStructure, vars.spread, vars.compounding,
+                                  Annual, zeroCpnBondSettlementDate2);
+    Real error15 = std::fabs(zeroCpnBondImpliedValue2 - zeroCpnBondCleanPrice2);
+    if (error15 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  zero cpn implied value: " <<
-                    zeroCpnBondImpliedValue2
-                    << "\n  zero cpn price: " << zeroCpnBondCleanPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error15
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  zero cpn implied value: " << zeroCpnBondImpliedValue2
+                   << "\n  zero cpn price: " << zeroCpnBondCleanPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error15
+                   << "\n  tolerance:             " << tolerance);
     }
 }
 
@@ -3036,547 +2388,437 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
 
     // Fixed Underlying bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
-    Date fixedBondStartDate1 = Date(4,January,2005);
-    Date fixedBondMaturityDate1 = Date(4,January,2037);
-    Schedule fixedBondSchedule1(fixedBondStartDate1,
-                                fixedBondMaturityDate1,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate1 = Date(4, January, 2005);
+    Date fixedBondMaturityDate1 = Date(4, January, 2037);
+    Schedule fixedBondSchedule1(fixedBondStartDate1, fixedBondMaturityDate1, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg1 = FixedRateLeg(fixedBondSchedule1)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
-    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                    Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
+    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following);
+    fixedBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(new
-        DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<Bond> fixedBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate1, fixedBondStartDate1,
+                                              fixedBondLeg1));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
-                      std::vector<Rate>(1, 0.04),
-                      ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005) ));
+    ext::shared_ptr<Bond> fixedSpecializedBond1(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule1, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
     fixedSpecializedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondTheoValue1 = fixedBond1->cleanPrice();
     Real fixedSpecializedBondTheoValue1 = fixedSpecializedBond1->cleanPrice();
     Real tolerance = 1.0e-13;
-    Real error1 = std::fabs(fixedBondTheoValue1-fixedSpecializedBondTheoValue1);
-    if (error1>tolerance) {
+    Real error1 = std::fabs(fixedBondTheoValue1 - fixedSpecializedBondTheoValue1);
+    if (error1 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  specialized fixed rate bond's theo clean price: "
-                    << fixedBondTheoValue1
-                    << "\n  generic equivalent bond's theo clean price: "
-                    << fixedSpecializedBondTheoValue1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error1
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  specialized fixed rate bond's theo clean price: " << fixedBondTheoValue1
+                   << "\n  generic equivalent bond's theo clean price: "
+                   << fixedSpecializedBondTheoValue1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real fixedBondTheoDirty1 = fixedBondTheoValue1+fixedBond1->accruedAmount();
-    Real fixedSpecializedTheoDirty1 = fixedSpecializedBondTheoValue1+
-                                  fixedSpecializedBond1->accruedAmount();
-    Real error2 = std::fabs(fixedBondTheoDirty1-fixedSpecializedTheoDirty1);
-    if (error2>tolerance) {
+    Real fixedBondTheoDirty1 = fixedBondTheoValue1 + fixedBond1->accruedAmount();
+    Real fixedSpecializedTheoDirty1 =
+        fixedSpecializedBondTheoValue1 + fixedSpecializedBond1->accruedAmount();
+    Real error2 = std::fabs(fixedBondTheoDirty1 - fixedSpecializedTheoDirty1);
+    if (error2 > tolerance) {
         BOOST_FAIL("wrong dirty price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  specialized fixed rate bond's theo dirty price: "
-                    << fixedBondTheoDirty1
-                    << "\n  generic equivalent bond's theo dirty price: "
-                    << fixedSpecializedTheoDirty1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error2
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  specialized fixed rate bond's theo dirty price: " << fixedBondTheoDirty1
+                   << "\n  generic equivalent bond's theo dirty price: "
+                   << fixedSpecializedTheoDirty1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error2
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Fixed Underlying bond (Isin: IT0006527060 IBRD 5 02/05/19)
     // maturity occurs on a business day
-    Date fixedBondStartDate2 = Date(5,February,2005);
-    Date fixedBondMaturityDate2 = Date(5,February,2019);
-    Schedule fixedBondSchedule2(fixedBondStartDate2,
-                                fixedBondMaturityDate2,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate2 = Date(5, February, 2005);
+    Date fixedBondMaturityDate2 = Date(5, February, 2019);
+    Schedule fixedBondSchedule2(fixedBondStartDate2, fixedBondMaturityDate2, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg2 = FixedRateLeg(fixedBondSchedule2)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
-    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
-                                                    Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
+    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following);
+    fixedBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption2)));
 
     // generic bond
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    ext::shared_ptr<Bond> fixedBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate2, fixedBondStartDate2,
+                                              fixedBondLeg2));
     fixedBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond2(new
-         FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
-                      std::vector<Rate>(1, 0.05),
-                      Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+    ext::shared_ptr<Bond> fixedSpecializedBond2(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule2, std::vector<Rate>(1, 0.05),
+        Thirty360(Thirty360::BondBasis), Following, 100.0, Date(5, February, 2005)));
     fixedSpecializedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondTheoValue2 = fixedBond2->cleanPrice();
     Real fixedSpecializedBondTheoValue2 = fixedSpecializedBond2->cleanPrice();
 
-    Real error3 = std::fabs(fixedBondTheoValue2-fixedSpecializedBondTheoValue2);
-    if (error3>tolerance) {
+    Real error3 = std::fabs(fixedBondTheoValue2 - fixedSpecializedBondTheoValue2);
+    if (error3 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  specialized fixed rate bond's theo clean price: "
-                    << fixedBondTheoValue2
-                    << "\n  generic equivalent bond's theo clean price: "
-                    << fixedSpecializedBondTheoValue2
-                    << "\n  error:                 " << error3
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  specialized fixed rate bond's theo clean price: " << fixedBondTheoValue2
+                   << "\n  generic equivalent bond's theo clean price: "
+                   << fixedSpecializedBondTheoValue2 << "\n  error:                 " << error3
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real fixedBondTheoDirty2 = fixedBondTheoValue2+
-                               fixedBond2->accruedAmount();
-    Real fixedSpecializedBondTheoDirty2 = fixedSpecializedBondTheoValue2+
-                                      fixedSpecializedBond2->accruedAmount();
+    Real fixedBondTheoDirty2 = fixedBondTheoValue2 + fixedBond2->accruedAmount();
+    Real fixedSpecializedBondTheoDirty2 =
+        fixedSpecializedBondTheoValue2 + fixedSpecializedBond2->accruedAmount();
 
-    Real error4 = std::fabs(fixedBondTheoDirty2-fixedSpecializedBondTheoDirty2);
-    if (error4>tolerance) {
+    Real error4 = std::fabs(fixedBondTheoDirty2 - fixedSpecializedBondTheoDirty2);
+    if (error4 > tolerance) {
         BOOST_FAIL("wrong dirty price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  specialized fixed rate bond's dirty clean price: "
-                    << fixedBondTheoDirty2
-                    << "\n  generic equivalent bond's theo dirty price: "
-                    << fixedSpecializedBondTheoDirty2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error4
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  specialized fixed rate bond's dirty clean price: " << fixedBondTheoDirty2
+                   << "\n  generic equivalent bond's theo dirty price: "
+                   << fixedSpecializedBondTheoDirty2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error4
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN Underlying bond (Isin: IT0003543847 ISPIM 0 09/29/13)
     // maturity doesn't occur on a business day
-    Date floatingBondStartDate1 = Date(29,September,2003);
-    Date floatingBondMaturityDate1 = Date(29,September,2013);
-    Schedule floatingBondSchedule1(floatingBondStartDate1,
-                                   floatingBondMaturityDate1,
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    Date floatingBondStartDate1 = Date(29, September, 2003);
+    Date floatingBondMaturityDate1 = Date(29, September, 2013);
+    Schedule floatingBondSchedule1(floatingBondStartDate1, floatingBondMaturityDate1,
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
     Leg floatingBondLeg1 = IborLeg(floatingBondSchedule1, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0056)
-        .inArrears(inArrears);
-    Date floatingbondRedemption1 =
-        bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0056)
+                               .inArrears(inArrears);
+    Date floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following);
+    floatingBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+    ext::shared_ptr<Bond> floatingBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate1, floatingBondStartDate1,
+                                                 floatingBondLeg1));
     floatingBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond1(new
-           FloatingRateBond(settlementDays, vars.faceAmount,
-                            floatingBondSchedule1,
-                            vars.iborIndex, Actual360(),
-                            Following, fixingDays,
-                            std::vector<Real>(1,1),
-                            std::vector<Spread>(1,0.0056),
-                            std::vector<Rate>(), std::vector<Rate>(),
-                            inArrears,
-                            100.0, Date(29,September,2003)));
+    ext::shared_ptr<Bond> floatingSpecializedBond1(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule1, vars.iborIndex, Actual360(),
+        Following, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0056),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(29, September, 2003)));
     floatingSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
     setCouponPricer(floatingSpecializedBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondTheoValue1 = floatingBond1->cleanPrice();
-    Real floatingSpecializedBondTheoValue1 =
-        floatingSpecializedBond1->cleanPrice();
+    Real floatingSpecializedBondTheoValue1 = floatingSpecializedBond1->cleanPrice();
 
-    Real error5 = std::fabs(floatingBondTheoValue1-
-                            floatingSpecializedBondTheoValue1);
-    if (error5>tolerance) {
+    Real error5 = std::fabs(floatingBondTheoValue1 - floatingSpecializedBondTheoValue1);
+    if (error5 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic fixed rate bond's theo clean price: "
-                    << floatingBondTheoValue1
-                    << "\n  equivalent specialized bond's theo clean price: "
-                    << floatingSpecializedBondTheoValue1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error5
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic fixed rate bond's theo clean price: " << floatingBondTheoValue1
+                   << "\n  equivalent specialized bond's theo clean price: "
+                   << floatingSpecializedBondTheoValue1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error5
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real floatingBondTheoDirty1 = floatingBondTheoValue1+
-                                  floatingBond1->accruedAmount();
+    Real floatingBondTheoDirty1 = floatingBondTheoValue1 + floatingBond1->accruedAmount();
     Real floatingSpecializedBondTheoDirty1 =
-        floatingSpecializedBondTheoValue1+
-        floatingSpecializedBond1->accruedAmount();
-    Real error6 = std::fabs(floatingBondTheoDirty1-
-                            floatingSpecializedBondTheoDirty1);
-    if (error6>tolerance) {
+        floatingSpecializedBondTheoValue1 + floatingSpecializedBond1->accruedAmount();
+    Real error6 = std::fabs(floatingBondTheoDirty1 - floatingSpecializedBondTheoDirty1);
+    if (error6 > tolerance) {
         BOOST_FAIL("wrong dirty price for frn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic frn bond's dirty clean price: "
-                    << floatingBondTheoDirty1
-                    << "\n  equivalent specialized bond's theo dirty price: "
-                    << floatingSpecializedBondTheoDirty1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error6
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic frn bond's dirty clean price: " << floatingBondTheoDirty1
+                   << "\n  equivalent specialized bond's theo dirty price: "
+                   << floatingSpecializedBondTheoDirty1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error6
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // FRN Underlying bond (Isin: XS0090566539 COE 0 09/24/18)
     // maturity occurs on a business day
-    Date floatingBondStartDate2 = Date(24,September,2004);
-    Date floatingBondMaturityDate2 = Date(24,September,2018);
-    Schedule floatingBondSchedule2(floatingBondStartDate2,
-                                   floatingBondMaturityDate2,
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
+    Date floatingBondStartDate2 = Date(24, September, 2004);
+    Date floatingBondMaturityDate2 = Date(24, September, 2018);
+    Schedule floatingBondSchedule2(floatingBondStartDate2, floatingBondMaturityDate2,
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
     Leg floatingBondLeg2 = IborLeg(floatingBondSchedule2, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withPaymentAdjustment(ModifiedFollowing)
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0025)
-        .inArrears(inArrears);
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withPaymentAdjustment(ModifiedFollowing)
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0025)
+                               .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
+    floatingBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+    ext::shared_ptr<Bond> floatingBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate2, floatingBondStartDate2,
+                                                 floatingBondLeg2));
     floatingBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule2,
-                         vars.iborIndex, Actual360(),
-                         ModifiedFollowing, fixingDays,
-                         std::vector<Real>(1,1),
-                         std::vector<Spread>(1,0.0025),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(24,September,2004)));
+    ext::shared_ptr<Bond> floatingSpecializedBond2(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule2, vars.iborIndex, Actual360(),
+        ModifiedFollowing, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0025),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(24, September, 2004)));
     floatingSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
     setCouponPricer(floatingSpecializedBond2->cashflows(), vars.pricer);
 
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
 
     Real floatingBondTheoValue2 = floatingBond2->cleanPrice();
-    Real floatingSpecializedBondTheoValue2 =
-        floatingSpecializedBond2->cleanPrice();
+    Real floatingSpecializedBondTheoValue2 = floatingSpecializedBond2->cleanPrice();
 
-    Real error7 =
-        std::fabs(floatingBondTheoValue2-floatingSpecializedBondTheoValue2);
-    if (error7>tolerance) {
+    Real error7 = std::fabs(floatingBondTheoValue2 - floatingSpecializedBondTheoValue2);
+    if (error7 > tolerance) {
         BOOST_FAIL("wrong clean price for floater bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic floater bond's theo clean price: "
-                    << floatingBondTheoValue2
-                    << "\n  equivalent specialized bond's theo clean price: "
-                    << floatingSpecializedBondTheoValue2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error7
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic floater bond's theo clean price: " << floatingBondTheoValue2
+                   << "\n  equivalent specialized bond's theo clean price: "
+                   << floatingSpecializedBondTheoValue2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real floatingBondTheoDirty2 = floatingBondTheoValue2+
-                                  floatingBond2->accruedAmount();
-    Real floatingSpecializedTheoDirty2 = floatingSpecializedBondTheoValue2+
-                                     floatingSpecializedBond2->accruedAmount();
+    Real floatingBondTheoDirty2 = floatingBondTheoValue2 + floatingBond2->accruedAmount();
+    Real floatingSpecializedTheoDirty2 =
+        floatingSpecializedBondTheoValue2 + floatingSpecializedBond2->accruedAmount();
 
-    Real error8 =
-        std::fabs(floatingBondTheoDirty2-floatingSpecializedTheoDirty2);
-    if (error8>tolerance) {
+    Real error8 = std::fabs(floatingBondTheoDirty2 - floatingSpecializedTheoDirty2);
+    if (error8 > tolerance) {
         BOOST_FAIL("wrong dirty price for floater bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic floater bond's theo dirty price: "
-                    << floatingBondTheoDirty2
-                    << "\n  equivalent specialized  bond's theo dirty price: "
-                    << floatingSpecializedTheoDirty2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error8
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic floater bond's theo dirty price: " << floatingBondTheoDirty2
+                   << "\n  equivalent specialized  bond's theo dirty price: "
+                   << floatingSpecializedTheoDirty2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error8
+                   << "\n  tolerance:             " << tolerance);
     }
 
 
     // CMS Underlying bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
-    Date cmsBondStartDate1 = Date(22,August,2005);
-    Date cmsBondMaturityDate1 = Date(22,August,2020);
-    Schedule cmsBondSchedule1(cmsBondStartDate1,
-                              cmsBondMaturityDate1,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate1 = Date(22, August, 2005);
+    Date cmsBondMaturityDate1 = Date(22, August, 2020);
+    Schedule cmsBondSchedule1(cmsBondStartDate1, cmsBondMaturityDate1, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withCaps(0.055)
-        .withFloors(0.025)
-        .inArrears(inArrears);
-    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
-                                                  Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withCaps(0.055)
+                          .withFloors(0.025)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following);
+    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption1)));
     // generic cms bond
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    ext::shared_ptr<Bond> cmsBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
     cmsBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                Following, fixingDays,
-                std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
-                std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
-                inArrears,
-                100.0, Date(22,August,2005)));
+    ext::shared_ptr<Bond> cmsSpecializedBond1(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule1, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 1.0),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(1, 0.055), std::vector<Rate>(1, 0.025),
+        inArrears, 100.0, Date(22, August, 2005)));
     cmsSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
     setCouponPricer(cmsSpecializedBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondTheoValue1 = cmsBond1->cleanPrice();
     Real cmsSpecializedBondTheoValue1 = cmsSpecializedBond1->cleanPrice();
-    Real error9 = std::fabs(cmsBondTheoValue1-cmsSpecializedBondTheoValue1);
-    if (error9>tolerance) {
+    Real error9 = std::fabs(cmsBondTheoValue1 - cmsSpecializedBondTheoValue1);
+    if (error9 > tolerance) {
         BOOST_FAIL("wrong clean price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic cms bond's theo clean price: "
-                    << cmsBondTheoValue1
-                    <<  "\n  equivalent specialized bond's theo clean price: "
-                    << cmsSpecializedBondTheoValue1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error9
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic cms bond's theo clean price: " << cmsBondTheoValue1
+                   << "\n  equivalent specialized bond's theo clean price: "
+                   << cmsSpecializedBondTheoValue1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error9
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real cmsBondTheoDirty1 = cmsBondTheoValue1+cmsBond1->accruedAmount();
-    Real cmsSpecializedBondTheoDirty1 = cmsSpecializedBondTheoValue1+
-                                    cmsSpecializedBond1->accruedAmount();
-    Real error10 = std::fabs(cmsBondTheoDirty1-cmsSpecializedBondTheoDirty1);
-    if (error10>tolerance) {
+    Real cmsBondTheoDirty1 = cmsBondTheoValue1 + cmsBond1->accruedAmount();
+    Real cmsSpecializedBondTheoDirty1 =
+        cmsSpecializedBondTheoValue1 + cmsSpecializedBond1->accruedAmount();
+    Real error10 = std::fabs(cmsBondTheoDirty1 - cmsSpecializedBondTheoDirty1);
+    if (error10 > tolerance) {
         BOOST_FAIL("wrong dirty price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n generic cms bond's theo dirty price: "
-                    << cmsBondTheoDirty1
-                    << "\n  specialized cms bond's theo dirty price: "
-                    << cmsSpecializedBondTheoDirty1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error10
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n generic cms bond's theo dirty price: " << cmsBondTheoDirty1
+                   << "\n  specialized cms bond's theo dirty price: "
+                   << cmsSpecializedBondTheoDirty1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error10
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // CMS Underlying bond (Isin: XS0218766664 ISPIM 0 5/6/15)
     // maturity occurs on a business day
-    Date cmsBondStartDate2 = Date(06,May,2005);
-    Date cmsBondMaturityDate2 = Date(06,May,2015);
-    Schedule cmsBondSchedule2(cmsBondStartDate2,
-                              cmsBondMaturityDate2,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate2 = Date(06, May, 2005);
+    Date cmsBondMaturityDate2 = Date(06, May, 2015);
+    Schedule cmsBondSchedule2(cmsBondStartDate2, cmsBondMaturityDate2, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withGearings(0.84)
-        .inArrears(inArrears);
-    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                  Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withGearings(0.84)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following);
+    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    ext::shared_ptr<Bond> cmsBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
     cmsBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                Following, fixingDays,
-                std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
-                std::vector<Rate>(), std::vector<Rate>(),
-                inArrears,
-                100.0, Date(06,May,2005)));
+    ext::shared_ptr<Bond> cmsSpecializedBond2(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule2, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 0.84),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0,
+        Date(06, May, 2005)));
     cmsSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
     setCouponPricer(cmsSpecializedBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondTheoValue2 = cmsBond2->cleanPrice();
     Real cmsSpecializedBondTheoValue2 = cmsSpecializedBond2->cleanPrice();
 
-    Real error11 = std::fabs(cmsBondTheoValue2-cmsSpecializedBondTheoValue2);
-    if (error11>tolerance) {
+    Real error11 = std::fabs(cmsBondTheoValue2 - cmsSpecializedBondTheoValue2);
+    if (error11 > tolerance) {
         BOOST_FAIL("wrong clean price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic cms bond's theo clean price: "
-                    << cmsBondTheoValue2
-                    << "\n  cms bond's theo clean price: "
-                    << cmsSpecializedBondTheoValue2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error11
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic cms bond's theo clean price: " << cmsBondTheoValue2
+                   << "\n  cms bond's theo clean price: " << cmsSpecializedBondTheoValue2
+                   << std::scientific << std::setprecision(2) << "\n  error:                 "
+                   << error11 << "\n  tolerance:             " << tolerance);
     }
-    Real cmsBondTheoDirty2 = cmsBondTheoValue2+cmsBond2->accruedAmount();
+    Real cmsBondTheoDirty2 = cmsBondTheoValue2 + cmsBond2->accruedAmount();
     Real cmsSpecializedBondTheoDirty2 =
-        cmsSpecializedBondTheoValue2+cmsSpecializedBond2->accruedAmount();
-    Real error12 = std::fabs(cmsBondTheoDirty2-cmsSpecializedBondTheoDirty2);
-    if (error12>tolerance) {
+        cmsSpecializedBondTheoValue2 + cmsSpecializedBond2->accruedAmount();
+    Real error12 = std::fabs(cmsBondTheoDirty2 - cmsSpecializedBondTheoDirty2);
+    if (error12 > tolerance) {
         BOOST_FAIL("wrong dirty price for cms bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic cms bond's dirty price: "
-                    << cmsBondTheoDirty2
-                    << "\n  specialized cms bond's theo dirty price: "
-                    << cmsSpecializedBondTheoDirty2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error12
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4) << "\n  generic cms bond's dirty price: "
+                   << cmsBondTheoDirty2 << "\n  specialized cms bond's theo dirty price: "
+                   << cmsSpecializedBondTheoDirty2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error12
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
-    Date zeroCpnBondStartDate1 = Date(19,December,1985);
-    Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
-    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                      Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    Date zeroCpnBondStartDate1 = Date(19, December, 1985);
+    Date zeroCpnBondMaturityDate1 = Date(20, December, 2015);
+    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following);
+    Leg zeroCpnBondLeg1 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    ext::shared_ptr<Bond> zeroCpnBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate1, zeroCpnBondStartDate1,
+                                                zeroCpnBondLeg1));
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                  Date(20,December,2015),
-                  Following,
-                  100.0, Date(19,December,1985)));
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(20, December, 2015),
+                           Following, 100.0, Date(19, December, 1985)));
     zeroCpnSpecializedBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondTheoValue1 = zeroCpnBond1->cleanPrice();
-    Real zeroCpnSpecializedBondTheoValue1 =
-        zeroCpnSpecializedBond1->cleanPrice();
+    Real zeroCpnSpecializedBondTheoValue1 = zeroCpnSpecializedBond1->cleanPrice();
 
-    Real error13 =
-        std::fabs(zeroCpnBondTheoValue1-zeroCpnSpecializedBondTheoValue1);
-    if (error13>tolerance) {
+    Real error13 = std::fabs(zeroCpnBondTheoValue1 - zeroCpnSpecializedBondTheoValue1);
+    if (error13 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zero bond's clean price: "
-                    << zeroCpnBondTheoValue1
-                    << "\n  specialized zero bond's clean price: "
-                    << zeroCpnSpecializedBondTheoValue1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error13
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4) << "\n  generic zero bond's clean price: "
+                   << zeroCpnBondTheoValue1 << "\n  specialized zero bond's clean price: "
+                   << zeroCpnSpecializedBondTheoValue1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error13
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real zeroCpnBondTheoDirty1 = zeroCpnBondTheoValue1+
-                                 zeroCpnBond1->accruedAmount();
+    Real zeroCpnBondTheoDirty1 = zeroCpnBondTheoValue1 + zeroCpnBond1->accruedAmount();
     Real zeroCpnSpecializedBondTheoDirty1 =
-        zeroCpnSpecializedBondTheoValue1+
-        zeroCpnSpecializedBond1->accruedAmount();
-    Real error14 =
-        std::fabs(zeroCpnBondTheoDirty1-zeroCpnSpecializedBondTheoDirty1);
-    if (error14>tolerance) {
+        zeroCpnSpecializedBondTheoValue1 + zeroCpnSpecializedBond1->accruedAmount();
+    Real error14 = std::fabs(zeroCpnBondTheoDirty1 - zeroCpnSpecializedBondTheoDirty1);
+    if (error14 > tolerance) {
         BOOST_FAIL("wrong dirty price for zero bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zerocpn bond's dirty price: "
-                    << zeroCpnBondTheoDirty1
-                    << "\n  specialized zerocpn bond's clean price: "
-                    << zeroCpnSpecializedBondTheoDirty1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error14
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zerocpn bond's dirty price: " << zeroCpnBondTheoDirty1
+                   << "\n  specialized zerocpn bond's clean price: "
+                   << zeroCpnSpecializedBondTheoDirty1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error14
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
-    Date zeroCpnBondStartDate2 = Date(17,February,1998);
-    Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
-    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                      Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    Date zeroCpnBondStartDate2 = Date(17, February, 1998);
+    Date zeroCpnBondMaturityDate2 = Date(17, February, 2028);
+    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following);
+    Leg zeroCpnBondLeg2 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zerocpbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    ext::shared_ptr<Bond> zeroCpnBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate2, zeroCpnBondStartDate2,
+                                                zeroCpnBondLeg2));
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                   Date(17,February,2028),
-                   Following,
-                   100.0, Date(17,February,1998)));
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(17, February, 2028),
+                           Following, 100.0, Date(17, February, 1998)));
     zeroCpnSpecializedBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondTheoValue2 = zeroCpnBond2->cleanPrice();
-    Real zeroCpnSpecializedBondTheoValue2 =
-        zeroCpnSpecializedBond2->cleanPrice();
+    Real zeroCpnSpecializedBondTheoValue2 = zeroCpnSpecializedBond2->cleanPrice();
 
-    Real error15 =
-        std::fabs(zeroCpnBondTheoValue2 -zeroCpnSpecializedBondTheoValue2);
-    if (error15>tolerance) {
+    Real error15 = std::fabs(zeroCpnBondTheoValue2 - zeroCpnSpecializedBondTheoValue2);
+    if (error15 > tolerance) {
         BOOST_FAIL("wrong clean price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zerocpn bond's clean price: "
-                    << zeroCpnBondTheoValue2
-                    << "\n  specialized zerocpn bond's clean price: "
-                    << zeroCpnSpecializedBondTheoValue2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error15
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zerocpn bond's clean price: " << zeroCpnBondTheoValue2
+                   << "\n  specialized zerocpn bond's clean price: "
+                   << zeroCpnSpecializedBondTheoValue2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error15
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real zeroCpnBondTheoDirty2 = zeroCpnBondTheoValue2+
-                                 zeroCpnBond2->accruedAmount();
+    Real zeroCpnBondTheoDirty2 = zeroCpnBondTheoValue2 + zeroCpnBond2->accruedAmount();
 
     Real zeroCpnSpecializedBondTheoDirty2 =
-        zeroCpnSpecializedBondTheoValue2+
-        zeroCpnSpecializedBond2->accruedAmount();
+        zeroCpnSpecializedBondTheoValue2 + zeroCpnSpecializedBond2->accruedAmount();
 
-    Real error16 =
-        std::fabs(zeroCpnBondTheoDirty2-zeroCpnSpecializedBondTheoDirty2);
-    if (error16>tolerance) {
+    Real error16 = std::fabs(zeroCpnBondTheoDirty2 - zeroCpnSpecializedBondTheoDirty2);
+    if (error16 > tolerance) {
         BOOST_FAIL("wrong dirty price for zero coupon bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zerocpn bond's dirty price: "
-                    << zeroCpnBondTheoDirty2
-                    << "\n  specialized zerocpn bond's dirty price: "
-                    << zeroCpnSpecializedBondTheoDirty2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error16
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zerocpn bond's dirty price: " << zeroCpnBondTheoDirty2
+                   << "\n  specialized zerocpn bond's dirty price: "
+                   << zeroCpnSpecializedBondTheoDirty2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error16
+                   << "\n  tolerance:             " << tolerance);
     }
 }
 
@@ -3597,814 +2839,578 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
 
     // Fixed bond (Isin: DE0001135275 DBR 4 01/04/37)
     // maturity doesn't occur on a business day
-    Date fixedBondStartDate1 = Date(4,January,2005);
-    Date fixedBondMaturityDate1 = Date(4,January,2037);
-    Schedule fixedBondSchedule1(fixedBondStartDate1,
-                                fixedBondMaturityDate1,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate1 = Date(4, January, 2005);
+    Date fixedBondMaturityDate1 = Date(4, January, 2037);
+    Schedule fixedBondSchedule1(fixedBondStartDate1, fixedBondMaturityDate1, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg1 = FixedRateLeg(fixedBondSchedule1)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
-    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
-                                                    Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
+    Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1, Following);
+    fixedBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<Bond> fixedBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate1, fixedBondStartDate1,
+                                              fixedBondLeg1));
+    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> swapEngine(new DiscountingSwapEngine(vars.termStructure));
     fixedBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
-                      std::vector<Rate>(1, 0.04),
-                      ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005) ));
+    ext::shared_ptr<Bond> fixedSpecializedBond1(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule1, std::vector<Rate>(1, 0.04),
+        ActualActual(ActualActual::ISDA), Following, 100.0, Date(4, January, 2005)));
     fixedSpecializedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
     Real fixedSpecializedBondPrice1 = fixedSpecializedBond1->cleanPrice();
-    AssetSwap fixedBondAssetSwap1(payFixedRate,
-                                  fixedBond1, fixedBondPrice1,
-                                  vars.iborIndex, vars.nonnullspread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap1(payFixedRate, fixedBond1, fixedBondPrice1, vars.iborIndex,
+                                  vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap1.setPricingEngine(swapEngine);
-    AssetSwap fixedSpecializedBondAssetSwap1(payFixedRate,
-                                             fixedSpecializedBond1,
-                                             fixedSpecializedBondPrice1,
-                                             vars.iborIndex,
-                                             vars.nonnullspread,
-                                             Schedule(),
-                                             vars.iborIndex->dayCounter(),
-                                             parAssetSwap);
+    AssetSwap fixedSpecializedBondAssetSwap1(
+        payFixedRate, fixedSpecializedBond1, fixedSpecializedBondPrice1, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     fixedSpecializedBondAssetSwap1.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice1 = fixedBondAssetSwap1.fairCleanPrice();
-    Real fixedSpecializedBondAssetSwapPrice1 =
-        fixedSpecializedBondAssetSwap1.fairCleanPrice();
+    Real fixedSpecializedBondAssetSwapPrice1 = fixedSpecializedBondAssetSwap1.fairCleanPrice();
     Real tolerance = 1.0e-13;
-    Real error1 =
-        std::fabs(fixedBondAssetSwapPrice1-fixedSpecializedBondAssetSwapPrice1);
-    if (error1>tolerance) {
+    Real error1 = std::fabs(fixedBondAssetSwapPrice1 - fixedSpecializedBondAssetSwapPrice1);
+    if (error1 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  fixed rate bond's  clean price: "
-                    << fixedBondAssetSwapPrice1
-                    << "\n  equivalent specialized bond's clean price: "
-                    << fixedSpecializedBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error1
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  fixed rate bond's  clean price: " << fixedBondAssetSwapPrice1
+                   << "\n  equivalent specialized bond's clean price: "
+                   << fixedSpecializedBondAssetSwapPrice1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error1
+                   << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
-    Real fixedBondMktPrice1= 91.832;
-    AssetSwap fixedBondASW1(payFixedRate,
-                            fixedBond1, fixedBondMktPrice1,
-                            vars.iborIndex, vars.spread,
-                            Schedule(),
-                            vars.iborIndex->dayCounter(),
-                            parAssetSwap);
+    Real fixedBondMktPrice1 = 91.832;
+    AssetSwap fixedBondASW1(payFixedRate, fixedBond1, fixedBondMktPrice1, vars.iborIndex,
+                            vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     fixedBondASW1.setPricingEngine(swapEngine);
-    AssetSwap fixedSpecializedBondASW1(payFixedRate,
-                                       fixedSpecializedBond1,
-                                       fixedBondMktPrice1,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    AssetSwap fixedSpecializedBondASW1(payFixedRate, fixedSpecializedBond1, fixedBondMktPrice1,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     fixedSpecializedBondASW1.setPricingEngine(swapEngine);
     Real fixedBondASWSpread1 = fixedBondASW1.fairSpread();
     Real fixedSpecializedBondASWSpread1 = fixedSpecializedBondASW1.fairSpread();
-    Real error2 = std::fabs(fixedBondASWSpread1-fixedSpecializedBondASWSpread1);
-    if (error2>tolerance) {
+    Real error2 = std::fabs(fixedBondASWSpread1 - fixedSpecializedBondASWSpread1);
+    if (error2 > tolerance) {
         BOOST_FAIL("wrong asw spread  for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  fixed rate bond's  asw spread: "
-                    << fixedBondASWSpread1
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << fixedSpecializedBondASWSpread1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error2
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  fixed rate bond's  asw spread: " << fixedBondASWSpread1
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << fixedSpecializedBondASWSpread1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error2
+                   << "\n  tolerance:             " << tolerance);
     }
 
-     //Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
-     //maturity occurs on a business day
+    // Fixed bond (Isin: IT0006527060 IBRD 5 02/05/19)
+    // maturity occurs on a business day
 
-    Date fixedBondStartDate2 = Date(5,February,2005);
-    Date fixedBondMaturityDate2 = Date(5,February,2019);
-    Schedule fixedBondSchedule2(fixedBondStartDate2,
-                                fixedBondMaturityDate2,
-                                Period(Annual), bondCalendar,
-                                Unadjusted, Unadjusted,
-                                DateGeneration::Backward, false);
+    Date fixedBondStartDate2 = Date(5, February, 2005);
+    Date fixedBondMaturityDate2 = Date(5, February, 2019);
+    Schedule fixedBondSchedule2(fixedBondStartDate2, fixedBondMaturityDate2, Period(Annual),
+                                bondCalendar, Unadjusted, Unadjusted, DateGeneration::Backward,
+                                false);
     Leg fixedBondLeg2 = FixedRateLeg(fixedBondSchedule2)
-        .withNotionals(vars.faceAmount)
-        .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
-    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
-                                                    Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
+                            .withNotionals(vars.faceAmount)
+                            .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
+    Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2, Following);
+    fixedBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, fixedbondRedemption2)));
 
     // generic bond
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    ext::shared_ptr<Bond> fixedBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                              fixedBondMaturityDate2, fixedBondStartDate2,
+                                              fixedBondLeg2));
     fixedBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond2(new
-         FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
-                      std::vector<Rate>(1, 0.05),
-                      Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+    ext::shared_ptr<Bond> fixedSpecializedBond2(new FixedRateBond(
+        settlementDays, vars.faceAmount, fixedBondSchedule2, std::vector<Rate>(1, 0.05),
+        Thirty360(Thirty360::BondBasis), Following, 100.0, Date(5, February, 2005)));
     fixedSpecializedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondPrice2 = fixedBond2->cleanPrice();
     Real fixedSpecializedBondPrice2 = fixedSpecializedBond2->cleanPrice();
-    AssetSwap fixedBondAssetSwap2(payFixedRate,
-                                  fixedBond2, fixedBondPrice2,
-                                  vars.iborIndex, vars.nonnullspread,
-                                  Schedule(),
-                                  vars.iborIndex->dayCounter(),
+    AssetSwap fixedBondAssetSwap2(payFixedRate, fixedBond2, fixedBondPrice2, vars.iborIndex,
+                                  vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                   parAssetSwap);
     fixedBondAssetSwap2.setPricingEngine(swapEngine);
-    AssetSwap fixedSpecializedBondAssetSwap2(payFixedRate,
-                                             fixedSpecializedBond2,
-                                             fixedSpecializedBondPrice2,
-                                             vars.iborIndex,
-                                             vars.nonnullspread,
-                                             Schedule(),
-                                             vars.iborIndex->dayCounter(),
-                                             parAssetSwap);
+    AssetSwap fixedSpecializedBondAssetSwap2(
+        payFixedRate, fixedSpecializedBond2, fixedSpecializedBondPrice2, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     fixedSpecializedBondAssetSwap2.setPricingEngine(swapEngine);
     Real fixedBondAssetSwapPrice2 = fixedBondAssetSwap2.fairCleanPrice();
-    Real fixedSpecializedBondAssetSwapPrice2 =
-        fixedSpecializedBondAssetSwap2.fairCleanPrice();
+    Real fixedSpecializedBondAssetSwapPrice2 = fixedSpecializedBondAssetSwap2.fairCleanPrice();
 
-    Real error3 =
-        std::fabs(fixedBondAssetSwapPrice2-fixedSpecializedBondAssetSwapPrice2);
-    if (error3>tolerance) {
+    Real error3 = std::fabs(fixedBondAssetSwapPrice2 - fixedSpecializedBondAssetSwapPrice2);
+    if (error3 > tolerance) {
         BOOST_FAIL("wrong clean price for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  fixed rate bond's clean price: "
-                    << fixedBondAssetSwapPrice2
-                    << "\n  equivalent specialized  bond's clean price: "
-                    << fixedSpecializedBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error3
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  fixed rate bond's clean price: " << fixedBondAssetSwapPrice2
+                   << "\n  equivalent specialized  bond's clean price: "
+                   << fixedSpecializedBondAssetSwapPrice2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error3
+                   << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
-    Real fixedBondMktPrice2= 102.178;
-    AssetSwap fixedBondASW2(payFixedRate,
-                            fixedBond2, fixedBondMktPrice2,
-                            vars.iborIndex, vars.spread,
-                            Schedule(),
-                            vars.iborIndex->dayCounter(),
-                            parAssetSwap);
+    Real fixedBondMktPrice2 = 102.178;
+    AssetSwap fixedBondASW2(payFixedRate, fixedBond2, fixedBondMktPrice2, vars.iborIndex,
+                            vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     fixedBondASW2.setPricingEngine(swapEngine);
-    AssetSwap fixedSpecializedBondASW2(payFixedRate,
-                                       fixedSpecializedBond2,
-                                       fixedBondMktPrice2,
-                                       vars.iborIndex, vars.spread,
-                                       Schedule(),
-                                       vars.iborIndex->dayCounter(),
-                                       parAssetSwap);
+    AssetSwap fixedSpecializedBondASW2(payFixedRate, fixedSpecializedBond2, fixedBondMktPrice2,
+                                       vars.iborIndex, vars.spread, Schedule(),
+                                       vars.iborIndex->dayCounter(), parAssetSwap);
     fixedSpecializedBondASW2.setPricingEngine(swapEngine);
     Real fixedBondASWSpread2 = fixedBondASW2.fairSpread();
     Real fixedSpecializedBondASWSpread2 = fixedSpecializedBondASW2.fairSpread();
-    Real error4 = std::fabs(fixedBondASWSpread2-fixedSpecializedBondASWSpread2);
-    if (error4>tolerance) {
+    Real error4 = std::fabs(fixedBondASWSpread2 - fixedSpecializedBondASWSpread2);
+    if (error4 > tolerance) {
         BOOST_FAIL("wrong asw spread for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  fixed rate bond's  asw spread: "
-                    << fixedBondASWSpread2
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << fixedSpecializedBondASWSpread2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error4
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  fixed rate bond's  asw spread: " << fixedBondASWSpread2
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << fixedSpecializedBondASWSpread2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error4
+                   << "\n  tolerance:             " << tolerance);
     }
 
 
-    //FRN bond (Isin: IT0003543847 ISPIM 0 09/29/13)
-    //maturity doesn't occur on a business day
-    Date floatingBondStartDate1 = Date(29,September,2003);
-    Date floatingBondMaturityDate1 = Date(29,September,2013);
-    Schedule floatingBondSchedule1(floatingBondStartDate1,
-                                   floatingBondMaturityDate1,
-                                   Period(Semiannual), bondCalendar,
-                                   Unadjusted, Unadjusted,
+    // FRN bond (Isin: IT0003543847 ISPIM 0 09/29/13)
+    // maturity doesn't occur on a business day
+    Date floatingBondStartDate1 = Date(29, September, 2003);
+    Date floatingBondMaturityDate1 = Date(29, September, 2013);
+    Schedule floatingBondSchedule1(floatingBondStartDate1, floatingBondMaturityDate1,
+                                   Period(Semiannual), bondCalendar, Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
     Leg floatingBondLeg1 = IborLeg(floatingBondSchedule1, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0056)
-        .inArrears(inArrears);
-    Date floatingbondRedemption1 =
-        bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0056)
+                               .inArrears(inArrears);
+    Date floatingbondRedemption1 = bondCalendar.adjust(floatingBondMaturityDate1, Following);
+    floatingBondLeg1.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+    ext::shared_ptr<Bond> floatingBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate1, floatingBondStartDate1,
+                                                 floatingBondLeg1));
     floatingBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond1(new
-           FloatingRateBond(settlementDays, vars.faceAmount,
-                            floatingBondSchedule1,
-                            vars.iborIndex, Actual360(),
-                            Following, fixingDays,
-                            std::vector<Real>(1,1),
-                            std::vector<Spread>(1,0.0056),
-                            std::vector<Rate>(), std::vector<Rate>(),
-                            inArrears,
-                            100.0, Date(29,September,2003)));
+    ext::shared_ptr<Bond> floatingSpecializedBond1(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule1, vars.iborIndex, Actual360(),
+        Following, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0056),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(29, September, 2003)));
     floatingSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
     setCouponPricer(floatingSpecializedBond1->cashflows(), vars.pricer);
-    vars.iborIndex->addFixing(Date(27,March,2007), 0.0402);
+    vars.iborIndex->addFixing(Date(27, March, 2007), 0.0402);
     Real floatingBondPrice1 = floatingBond1->cleanPrice();
-    Real floatingSpecializedBondPrice1= floatingSpecializedBond1->cleanPrice();
-    AssetSwap floatingBondAssetSwap1(payFixedRate,
-                                     floatingBond1, floatingBondPrice1,
-                                     vars.iborIndex, vars.nonnullspread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    Real floatingSpecializedBondPrice1 = floatingSpecializedBond1->cleanPrice();
+    AssetSwap floatingBondAssetSwap1(payFixedRate, floatingBond1, floatingBondPrice1,
+                                     vars.iborIndex, vars.nonnullspread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap1.setPricingEngine(swapEngine);
-    AssetSwap floatingSpecializedBondAssetSwap1(payFixedRate,
-                                                floatingSpecializedBond1,
-                                                floatingSpecializedBondPrice1,
-                                                vars.iborIndex,
-                                                vars.nonnullspread,
-                                                Schedule(),
-                                                vars.iborIndex->dayCounter(),
-                                                parAssetSwap);
+    AssetSwap floatingSpecializedBondAssetSwap1(
+        payFixedRate, floatingSpecializedBond1, floatingSpecializedBondPrice1, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingSpecializedBondAssetSwap1.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice1 = floatingBondAssetSwap1.fairCleanPrice();
     Real floatingSpecializedBondAssetSwapPrice1 =
         floatingSpecializedBondAssetSwap1.fairCleanPrice();
 
-    Real error5 =
-        std::fabs(floatingBondAssetSwapPrice1-floatingSpecializedBondAssetSwapPrice1);
-    if (error5>tolerance) {
+    Real error5 = std::fabs(floatingBondAssetSwapPrice1 - floatingSpecializedBondAssetSwapPrice1);
+    if (error5 > tolerance) {
         BOOST_FAIL("wrong clean price for frnbond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic frn rate bond's clean price: "
-                    << floatingBondAssetSwapPrice1
-                    << "\n  equivalent specialized  bond's price: "
-                    << floatingSpecializedBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error5
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic frn rate bond's clean price: " << floatingBondAssetSwapPrice1
+                   << "\n  equivalent specialized  bond's price: "
+                   << floatingSpecializedBondAssetSwapPrice1 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error5
+                   << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
-    Real floatingBondMktPrice1= 101.33;
-    AssetSwap floatingBondASW1(payFixedRate,
-                               floatingBond1, floatingBondMktPrice1,
-                               vars.iborIndex, vars.spread,
-                               Schedule(),
-                               vars.iborIndex->dayCounter(),
-                               parAssetSwap);
+    Real floatingBondMktPrice1 = 101.33;
+    AssetSwap floatingBondASW1(payFixedRate, floatingBond1, floatingBondMktPrice1, vars.iborIndex,
+                               vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondASW1.setPricingEngine(swapEngine);
-    AssetSwap floatingSpecializedBondASW1(payFixedRate,
-                                          floatingSpecializedBond1,
-                                          floatingBondMktPrice1,
-                                          vars.iborIndex, vars.spread,
-                                          Schedule(),
-                                          vars.iborIndex->dayCounter(),
-                                          parAssetSwap);
+    AssetSwap floatingSpecializedBondASW1(payFixedRate, floatingSpecializedBond1,
+                                          floatingBondMktPrice1, vars.iborIndex, vars.spread,
+                                          Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingSpecializedBondASW1.setPricingEngine(swapEngine);
     Real floatingBondASWSpread1 = floatingBondASW1.fairSpread();
-    Real floatingSpecializedBondASWSpread1 =
-        floatingSpecializedBondASW1.fairSpread();
-    Real error6 =
-        std::fabs(floatingBondASWSpread1-floatingSpecializedBondASWSpread1);
-    if (error6>tolerance) {
+    Real floatingSpecializedBondASWSpread1 = floatingSpecializedBondASW1.fairSpread();
+    Real error6 = std::fabs(floatingBondASWSpread1 - floatingSpecializedBondASWSpread1);
+    if (error6 > tolerance) {
         BOOST_FAIL("wrong asw spread for fixed bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  frn rate bond's  asw spread: "
-                    << floatingBondASWSpread1
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << floatingSpecializedBondASWSpread1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error6
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  frn rate bond's  asw spread: " << floatingBondASWSpread1
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << floatingSpecializedBondASWSpread1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error6
+                   << "\n  tolerance:             " << tolerance);
     }
-    //FRN bond (Isin: XS0090566539 COE 0 09/24/18)
-    //maturity occurs on a business day
-    Date floatingBondStartDate2 = Date(24,September,2004);
-    Date floatingBondMaturityDate2 = Date(24,September,2018);
-    Schedule floatingBondSchedule2(floatingBondStartDate2,
-                                   floatingBondMaturityDate2,
-                                   Period(Semiannual), bondCalendar,
-                                   ModifiedFollowing, ModifiedFollowing,
-                                   DateGeneration::Backward, false);
+    // FRN bond (Isin: XS0090566539 COE 0 09/24/18)
+    // maturity occurs on a business day
+    Date floatingBondStartDate2 = Date(24, September, 2004);
+    Date floatingBondMaturityDate2 = Date(24, September, 2018);
+    Schedule floatingBondSchedule2(floatingBondStartDate2, floatingBondMaturityDate2,
+                                   Period(Semiannual), bondCalendar, ModifiedFollowing,
+                                   ModifiedFollowing, DateGeneration::Backward, false);
     Leg floatingBondLeg2 = IborLeg(floatingBondSchedule2, vars.iborIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Actual360())
-        .withPaymentAdjustment(ModifiedFollowing)
-        .withFixingDays(fixingDays)
-        .withSpreads(0.0025)
-        .inArrears(inArrears);
+                               .withNotionals(vars.faceAmount)
+                               .withPaymentDayCounter(Actual360())
+                               .withPaymentAdjustment(ModifiedFollowing)
+                               .withFixingDays(fixingDays)
+                               .withSpreads(0.0025)
+                               .inArrears(inArrears);
     Date floatingbondRedemption2 =
-        bondCalendar.adjust(floatingBondMaturityDate2,
-                            ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
+        bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
+    floatingBondLeg2.push_back(
+        ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, floatingbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+    ext::shared_ptr<Bond> floatingBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                 floatingBondMaturityDate2, floatingBondStartDate2,
+                                                 floatingBondLeg2));
     floatingBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
-                         floatingBondSchedule2,
-                         vars.iborIndex, Actual360(),
-                         ModifiedFollowing, fixingDays,
-                         std::vector<Real>(1,1),
-                         std::vector<Spread>(1,0.0025),
-                         std::vector<Rate>(), std::vector<Rate>(),
-                         inArrears,
-                         100.0, Date(24,September,2004)));
+    ext::shared_ptr<Bond> floatingSpecializedBond2(new FloatingRateBond(
+        settlementDays, vars.faceAmount, floatingBondSchedule2, vars.iborIndex, Actual360(),
+        ModifiedFollowing, fixingDays, std::vector<Real>(1, 1), std::vector<Spread>(1, 0.0025),
+        std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0, Date(24, September, 2004)));
     floatingSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
     setCouponPricer(floatingSpecializedBond2->cashflows(), vars.pricer);
 
-    vars.iborIndex->addFixing(Date(22,March,2007), 0.04013);
+    vars.iborIndex->addFixing(Date(22, March, 2007), 0.04013);
 
     Real floatingBondPrice2 = floatingBond2->cleanPrice();
-    Real floatingSpecializedBondPrice2= floatingSpecializedBond2->cleanPrice();
-    AssetSwap floatingBondAssetSwap2(payFixedRate,
-                                     floatingBond2, floatingBondPrice2,
-                                     vars.iborIndex, vars.nonnullspread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    Real floatingSpecializedBondPrice2 = floatingSpecializedBond2->cleanPrice();
+    AssetSwap floatingBondAssetSwap2(payFixedRate, floatingBond2, floatingBondPrice2,
+                                     vars.iborIndex, vars.nonnullspread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondAssetSwap2.setPricingEngine(swapEngine);
-    AssetSwap floatingSpecializedBondAssetSwap2(payFixedRate,
-                                                floatingSpecializedBond2,
-                                                floatingSpecializedBondPrice2,
-                                                vars.iborIndex,
-                                                vars.nonnullspread,
-                                                Schedule(),
-                                                vars.iborIndex->dayCounter(),
-                                                parAssetSwap);
+    AssetSwap floatingSpecializedBondAssetSwap2(
+        payFixedRate, floatingSpecializedBond2, floatingSpecializedBondPrice2, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingSpecializedBondAssetSwap2.setPricingEngine(swapEngine);
     Real floatingBondAssetSwapPrice2 = floatingBondAssetSwap2.fairCleanPrice();
     Real floatingSpecializedBondAssetSwapPrice2 =
         floatingSpecializedBondAssetSwap2.fairCleanPrice();
-    Real error7 =
-        std::fabs(floatingBondAssetSwapPrice2-floatingSpecializedBondAssetSwapPrice2);
-    if (error7>tolerance) {
+    Real error7 = std::fabs(floatingBondAssetSwapPrice2 - floatingSpecializedBondAssetSwapPrice2);
+    if (error7 > tolerance) {
         BOOST_FAIL("wrong clean price for frnbond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic frn rate bond's clean price: "
-                    << floatingBondAssetSwapPrice2
-                    << "\n  equivalent specialized frn  bond's price: "
-                    << floatingSpecializedBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error7
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic frn rate bond's clean price: " << floatingBondAssetSwapPrice2
+                   << "\n  equivalent specialized frn  bond's price: "
+                   << floatingSpecializedBondAssetSwapPrice2 << std::scientific
+                   << std::setprecision(2) << "\n  error:                 " << error7
+                   << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
     Real floatingBondMktPrice2 = 101.26;
-    AssetSwap floatingBondASW2(payFixedRate,
-                               floatingBond2, floatingBondMktPrice2,
-                               vars.iborIndex, vars.spread,
-                               Schedule(),
-                               vars.iborIndex->dayCounter(),
-                               parAssetSwap);
+    AssetSwap floatingBondASW2(payFixedRate, floatingBond2, floatingBondMktPrice2, vars.iborIndex,
+                               vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingBondASW2.setPricingEngine(swapEngine);
-    AssetSwap floatingSpecializedBondASW2(payFixedRate,
-                                          floatingSpecializedBond2,
-                                          floatingBondMktPrice2,
-                                          vars.iborIndex, vars.spread,
-                                          Schedule(),
-                                          vars.iborIndex->dayCounter(),
-                                          parAssetSwap);
+    AssetSwap floatingSpecializedBondASW2(payFixedRate, floatingSpecializedBond2,
+                                          floatingBondMktPrice2, vars.iborIndex, vars.spread,
+                                          Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     floatingSpecializedBondASW2.setPricingEngine(swapEngine);
     Real floatingBondASWSpread2 = floatingBondASW2.fairSpread();
-    Real floatingSpecializedBondASWSpread2 =
-        floatingSpecializedBondASW2.fairSpread();
-    Real error8 =
-        std::fabs(floatingBondASWSpread2-floatingSpecializedBondASWSpread2);
-    if (error8>tolerance) {
+    Real floatingSpecializedBondASWSpread2 = floatingSpecializedBondASW2.fairSpread();
+    Real error8 = std::fabs(floatingBondASWSpread2 - floatingSpecializedBondASWSpread2);
+    if (error8 > tolerance) {
         BOOST_FAIL("wrong asw spread for frn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  frn rate bond's  asw spread: "
-                    << floatingBondASWSpread2
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << floatingSpecializedBondASWSpread2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error8
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic  frn rate bond's  asw spread: " << floatingBondASWSpread2
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << floatingSpecializedBondASWSpread2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error8
+                   << "\n  tolerance:             " << tolerance);
     }
 
     // CMS bond (Isin: XS0228052402 CRDIT 0 8/22/20)
     // maturity doesn't occur on a business day
-    Date cmsBondStartDate1 = Date(22,August,2005);
-    Date cmsBondMaturityDate1 = Date(22,August,2020);
-    Schedule cmsBondSchedule1(cmsBondStartDate1,
-                              cmsBondMaturityDate1,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    Date cmsBondStartDate1 = Date(22, August, 2005);
+    Date cmsBondMaturityDate1 = Date(22, August, 2020);
+    Schedule cmsBondSchedule1(cmsBondStartDate1, cmsBondMaturityDate1, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg1 = CmsLeg(cmsBondSchedule1, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withCaps(0.055)
-        .withFloors(0.025)
-        .inArrears(inArrears);
-    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
-                                                  Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withCaps(0.055)
+                          .withFloors(0.025)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1, Following);
+    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption1)));
     // generic cms bond
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    ext::shared_ptr<Bond> cmsBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
     cmsBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
-                vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                Following, fixingDays,
-                std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
-                std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
-                inArrears,
-                100.0, Date(22,August,2005)));
+    ext::shared_ptr<Bond> cmsSpecializedBond1(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule1, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 1.0),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(1, 0.055), std::vector<Rate>(1, 0.025),
+        inArrears, 100.0, Date(22, August, 2005)));
     cmsSpecializedBond1->setPricingEngine(bondEngine);
 
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
     setCouponPricer(cmsSpecializedBond1->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(18,August,2006), 0.04158);
+    vars.swapIndex->addFixing(Date(18, August, 2006), 0.04158);
     Real cmsBondPrice1 = cmsBond1->cleanPrice();
     Real cmsSpecializedBondPrice1 = cmsSpecializedBond1->cleanPrice();
-    AssetSwap cmsBondAssetSwap1(payFixedRate,cmsBond1, cmsBondPrice1,
-                                vars.iborIndex, vars.nonnullspread,
-                                Schedule(),vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondAssetSwap1(payFixedRate, cmsBond1, cmsBondPrice1, vars.iborIndex,
+                                vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     cmsBondAssetSwap1.setPricingEngine(swapEngine);
-    AssetSwap cmsSpecializedBondAssetSwap1(payFixedRate,cmsSpecializedBond1,
-                                           cmsSpecializedBondPrice1,
-                                           vars.iborIndex,
-                                           vars.nonnullspread,
-                                           Schedule(),
-                                           vars.iborIndex->dayCounter(),
-                                           parAssetSwap);
+    AssetSwap cmsSpecializedBondAssetSwap1(
+        payFixedRate, cmsSpecializedBond1, cmsSpecializedBondPrice1, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsSpecializedBondAssetSwap1.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice1 = cmsBondAssetSwap1.fairCleanPrice();
-    Real cmsSpecializedBondAssetSwapPrice1 =
-        cmsSpecializedBondAssetSwap1.fairCleanPrice();
-    Real error9 =
-        std::fabs(cmsBondAssetSwapPrice1-cmsSpecializedBondAssetSwapPrice1);
-    if (error9>tolerance) {
+    Real cmsSpecializedBondAssetSwapPrice1 = cmsSpecializedBondAssetSwap1.fairCleanPrice();
+    Real error9 = std::fabs(cmsBondAssetSwapPrice1 - cmsSpecializedBondAssetSwapPrice1);
+    if (error9 > tolerance) {
         BOOST_FAIL("wrong clean price for cmsbond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic bond's clean price: "
-                    << cmsBondAssetSwapPrice1
-                    << "\n  equivalent specialized cms rate bond's price: "
-                    << cmsSpecializedBondAssetSwapPrice1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error9
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4) << "\n  generic bond's clean price: "
+                   << cmsBondAssetSwapPrice1 << "\n  equivalent specialized cms rate bond's price: "
+                   << cmsSpecializedBondAssetSwapPrice1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error9
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real cmsBondMktPrice1 = 87.02;// market executable price as of 4th sept 2007
-    AssetSwap cmsBondASW1(payFixedRate,
-                          cmsBond1, cmsBondMktPrice1,
-                          vars.iborIndex, vars.spread,
-                          Schedule(),
-                          vars.iborIndex->dayCounter(),
-                          parAssetSwap);
+    Real cmsBondMktPrice1 = 87.02; // market executable price as of 4th sept 2007
+    AssetSwap cmsBondASW1(payFixedRate, cmsBond1, cmsBondMktPrice1, vars.iborIndex, vars.spread,
+                          Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondASW1.setPricingEngine(swapEngine);
-    AssetSwap cmsSpecializedBondASW1(payFixedRate,
-                                     cmsSpecializedBond1,
-                                     cmsBondMktPrice1,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap cmsSpecializedBondASW1(payFixedRate, cmsSpecializedBond1, cmsBondMktPrice1,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     cmsSpecializedBondASW1.setPricingEngine(swapEngine);
     Real cmsBondASWSpread1 = cmsBondASW1.fairSpread();
     Real cmsSpecializedBondASWSpread1 = cmsSpecializedBondASW1.fairSpread();
-    Real error10 = std::fabs(cmsBondASWSpread1-cmsSpecializedBondASWSpread1);
-    if (error10>tolerance) {
+    Real error10 = std::fabs(cmsBondASWSpread1 - cmsSpecializedBondASWSpread1);
+    if (error10 > tolerance) {
         BOOST_FAIL("wrong asw spread for cm bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic cms rate bond's  asw spread: "
-                    << cmsBondASWSpread1
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << cmsSpecializedBondASWSpread1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error10
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic cms rate bond's  asw spread: " << cmsBondASWSpread1
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << cmsSpecializedBondASWSpread1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error10
+                   << "\n  tolerance:             " << tolerance);
     }
 
-      //CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
-      //maturity occurs on a business day
-    Date cmsBondStartDate2 = Date(06,May,2005);
-    Date cmsBondMaturityDate2 = Date(06,May,2015);
-    Schedule cmsBondSchedule2(cmsBondStartDate2,
-                              cmsBondMaturityDate2,
-                              Period(Annual), bondCalendar,
-                              Unadjusted, Unadjusted,
-                              DateGeneration::Backward, false);
+    // CMS bond (Isin: XS0218766664 ISPIM 0 5/6/15)
+    // maturity occurs on a business day
+    Date cmsBondStartDate2 = Date(06, May, 2005);
+    Date cmsBondMaturityDate2 = Date(06, May, 2015);
+    Schedule cmsBondSchedule2(cmsBondStartDate2, cmsBondMaturityDate2, Period(Annual), bondCalendar,
+                              Unadjusted, Unadjusted, DateGeneration::Backward, false);
     Leg cmsBondLeg2 = CmsLeg(cmsBondSchedule2, vars.swapIndex)
-        .withNotionals(vars.faceAmount)
-        .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
-        .withFixingDays(fixingDays)
-        .withGearings(0.84)
-        .inArrears(inArrears);
-    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
-                                                  Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
+                          .withNotionals(vars.faceAmount)
+                          .withPaymentDayCounter(Thirty360(Thirty360::BondBasis))
+                          .withFixingDays(fixingDays)
+                          .withGearings(0.84)
+                          .inArrears(inArrears);
+    Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2, Following);
+    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, cmsbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    ext::shared_ptr<Bond> cmsBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                            cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
     cmsBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
-                vars.swapIndex, Thirty360(Thirty360::BondBasis),
-                Following, fixingDays,
-                std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
-                std::vector<Rate>(), std::vector<Rate>(),
-                inArrears,
-                100.0, Date(06,May,2005)));
+    ext::shared_ptr<Bond> cmsSpecializedBond2(new CmsRateBond(
+        settlementDays, vars.faceAmount, cmsBondSchedule2, vars.swapIndex,
+        Thirty360(Thirty360::BondBasis), Following, fixingDays, std::vector<Real>(1, 0.84),
+        std::vector<Spread>(1, 0.0), std::vector<Rate>(), std::vector<Rate>(), inArrears, 100.0,
+        Date(06, May, 2005)));
     cmsSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
     setCouponPricer(cmsSpecializedBond2->cashflows(), vars.cmspricer);
-    vars.swapIndex->addFixing(Date(04,May,2006), 0.04217);
+    vars.swapIndex->addFixing(Date(04, May, 2006), 0.04217);
     Real cmsBondPrice2 = cmsBond2->cleanPrice();
     Real cmsSpecializedBondPrice2 = cmsSpecializedBond2->cleanPrice();
-    AssetSwap cmsBondAssetSwap2(payFixedRate,cmsBond2, cmsBondPrice2,
-                                vars.iborIndex, vars.nonnullspread,
-                                Schedule(),
-                                vars.iborIndex->dayCounter(),
+    AssetSwap cmsBondAssetSwap2(payFixedRate, cmsBond2, cmsBondPrice2, vars.iborIndex,
+                                vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                 parAssetSwap);
     cmsBondAssetSwap2.setPricingEngine(swapEngine);
-    AssetSwap cmsSpecializedBondAssetSwap2(payFixedRate,cmsSpecializedBond2,
-                                           cmsSpecializedBondPrice2,
-                                           vars.iborIndex,
-                                           vars.nonnullspread,
-                                           Schedule(),
-                                           vars.iborIndex->dayCounter(),
-                                           parAssetSwap);
+    AssetSwap cmsSpecializedBondAssetSwap2(
+        payFixedRate, cmsSpecializedBond2, cmsSpecializedBondPrice2, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsSpecializedBondAssetSwap2.setPricingEngine(swapEngine);
     Real cmsBondAssetSwapPrice2 = cmsBondAssetSwap2.fairCleanPrice();
-    Real cmsSpecializedBondAssetSwapPrice2 =
-        cmsSpecializedBondAssetSwap2.fairCleanPrice();
-    Real error11 =
-        std::fabs(cmsBondAssetSwapPrice2-cmsSpecializedBondAssetSwapPrice2);
-    if (error11>tolerance) {
+    Real cmsSpecializedBondAssetSwapPrice2 = cmsSpecializedBondAssetSwap2.fairCleanPrice();
+    Real error11 = std::fabs(cmsBondAssetSwapPrice2 - cmsSpecializedBondAssetSwapPrice2);
+    if (error11 > tolerance) {
         BOOST_FAIL("wrong clean price for cmsbond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic  bond's clean price: "
-                    << cmsBondAssetSwapPrice2
-                    << "\n  equivalent specialized cms rate bond's price: "
-                    << cmsSpecializedBondAssetSwapPrice2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error11
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4) << "\n  generic  bond's clean price: "
+                   << cmsBondAssetSwapPrice2 << "\n  equivalent specialized cms rate bond's price: "
+                   << cmsSpecializedBondAssetSwapPrice2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error11
+                   << "\n  tolerance:             " << tolerance);
     }
-    Real cmsBondMktPrice2 = 94.35;// market executable price as of 4th sept 2007
-    AssetSwap cmsBondASW2(payFixedRate,
-                          cmsBond2, cmsBondMktPrice2,
-                          vars.iborIndex, vars.spread,
-                          Schedule(),
-                          vars.iborIndex->dayCounter(),
-                          parAssetSwap);
+    Real cmsBondMktPrice2 = 94.35; // market executable price as of 4th sept 2007
+    AssetSwap cmsBondASW2(payFixedRate, cmsBond2, cmsBondMktPrice2, vars.iborIndex, vars.spread,
+                          Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     cmsBondASW2.setPricingEngine(swapEngine);
-    AssetSwap cmsSpecializedBondASW2(payFixedRate,
-                                     cmsSpecializedBond2,
-                                     cmsBondMktPrice2,
-                                     vars.iborIndex, vars.spread,
-                                     Schedule(),
-                                     vars.iborIndex->dayCounter(),
-                                     parAssetSwap);
+    AssetSwap cmsSpecializedBondASW2(payFixedRate, cmsSpecializedBond2, cmsBondMktPrice2,
+                                     vars.iborIndex, vars.spread, Schedule(),
+                                     vars.iborIndex->dayCounter(), parAssetSwap);
     cmsSpecializedBondASW2.setPricingEngine(swapEngine);
     Real cmsBondASWSpread2 = cmsBondASW2.fairSpread();
     Real cmsSpecializedBondASWSpread2 = cmsSpecializedBondASW2.fairSpread();
-    Real error12 = std::fabs(cmsBondASWSpread2-cmsSpecializedBondASWSpread2);
-    if (error12>tolerance) {
+    Real error12 = std::fabs(cmsBondASWSpread2 - cmsSpecializedBondASWSpread2);
+    if (error12 > tolerance) {
         BOOST_FAIL("wrong asw spread for cm bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic cms rate bond's  asw spread: "
-                    << cmsBondASWSpread2
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << cmsSpecializedBondASWSpread2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error12
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic cms rate bond's  asw spread: " << cmsBondASWSpread2
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << cmsSpecializedBondASWSpread2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error12
+                   << "\n  tolerance:             " << tolerance);
     }
 
 
-   //  Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
-   //  maturity doesn't occur on a business day
-    Date zeroCpnBondStartDate1 = Date(19,December,1985);
-    Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
-    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
-                                                      Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    //  Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
+    //  maturity doesn't occur on a business day
+    Date zeroCpnBondStartDate1 = Date(19, December, 1985);
+    Date zeroCpnBondMaturityDate1 = Date(20, December, 2015);
+    Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1, Following);
+    Leg zeroCpnBondLeg1 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    ext::shared_ptr<Bond> zeroCpnBond1(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate1, zeroCpnBondStartDate1,
+                                                zeroCpnBondLeg1));
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                  Date(20,December,2015),
-                  Following,
-                  100.0, Date(19,December,1985)));
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(20, December, 2015),
+                           Following, 100.0, Date(19, December, 1985)));
     zeroCpnSpecializedBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice1 = zeroCpnBond1->cleanPrice();
     Real zeroCpnSpecializedBondPrice1 = zeroCpnSpecializedBond1->cleanPrice();
-    AssetSwap zeroCpnBondAssetSwap1(payFixedRate,zeroCpnBond1,
-                                    zeroCpnBondPrice1,
-                                    vars.iborIndex, vars.nonnullspread,
-                                    Schedule(),
-                                    vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnBondAssetSwap1(payFixedRate, zeroCpnBond1, zeroCpnBondPrice1, vars.iborIndex,
+                                    vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                     parAssetSwap);
     zeroCpnBondAssetSwap1.setPricingEngine(swapEngine);
-    AssetSwap zeroCpnSpecializedBondAssetSwap1(payFixedRate,
-                                               zeroCpnSpecializedBond1,
-                                               zeroCpnSpecializedBondPrice1,
-                                               vars.iborIndex,
-                                               vars.nonnullspread,
-                                               Schedule(),
-                                               vars.iborIndex->dayCounter(),
-                                               parAssetSwap);
+    AssetSwap zeroCpnSpecializedBondAssetSwap1(
+        payFixedRate, zeroCpnSpecializedBond1, zeroCpnSpecializedBondPrice1, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnSpecializedBondAssetSwap1.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice1 = zeroCpnBondAssetSwap1.fairCleanPrice();
-    Real zeroCpnSpecializedBondAssetSwapPrice1 =
-        zeroCpnSpecializedBondAssetSwap1.fairCleanPrice();
-    Real error13 =
-        std::fabs(zeroCpnBondAssetSwapPrice1-zeroCpnSpecializedBondAssetSwapPrice1);
-    if (error13>tolerance) {
+    Real zeroCpnSpecializedBondAssetSwapPrice1 = zeroCpnSpecializedBondAssetSwap1.fairCleanPrice();
+    Real error13 = std::fabs(zeroCpnBondAssetSwapPrice1 - zeroCpnSpecializedBondAssetSwapPrice1);
+    if (error13 > tolerance) {
         BOOST_FAIL("wrong clean price for zerocpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zero cpn bond's clean price: "
-                    << zeroCpnBondAssetSwapPrice1
-                    << "\n  specialized equivalent bond's price: "
-                    << zeroCpnSpecializedBondAssetSwapPrice1
-                    << "\n  error:                 " << error13
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zero cpn bond's clean price: " << zeroCpnBondAssetSwapPrice1
+                   << "\n  specialized equivalent bond's price: "
+                   << zeroCpnSpecializedBondAssetSwapPrice1 << "\n  error:                 "
+                   << error13 << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
     Real zeroCpnBondMktPrice1 = 72.277;
-    AssetSwap zeroCpnBondASW1(payFixedRate,
-                              zeroCpnBond1,zeroCpnBondMktPrice1,
-                              vars.iborIndex, vars.spread,
-                              Schedule(),
-                              vars.iborIndex->dayCounter(),
-                              parAssetSwap);
+    AssetSwap zeroCpnBondASW1(payFixedRate, zeroCpnBond1, zeroCpnBondMktPrice1, vars.iborIndex,
+                              vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondASW1.setPricingEngine(swapEngine);
-    AssetSwap zeroCpnSpecializedBondASW1(payFixedRate,
-                                         zeroCpnSpecializedBond1,
-                                         zeroCpnBondMktPrice1,
-                                         vars.iborIndex, vars.spread,
-                                         Schedule(),
-                                         vars.iborIndex->dayCounter(),
-                                         parAssetSwap);
+    AssetSwap zeroCpnSpecializedBondASW1(payFixedRate, zeroCpnSpecializedBond1,
+                                         zeroCpnBondMktPrice1, vars.iborIndex, vars.spread,
+                                         Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnSpecializedBondASW1.setPricingEngine(swapEngine);
     Real zeroCpnBondASWSpread1 = zeroCpnBondASW1.fairSpread();
-    Real zeroCpnSpecializedBondASWSpread1 =
-        zeroCpnSpecializedBondASW1.fairSpread();
-    Real error14 =
-        std::fabs(zeroCpnBondASWSpread1-zeroCpnSpecializedBondASWSpread1);
-    if (error14>tolerance) {
+    Real zeroCpnSpecializedBondASWSpread1 = zeroCpnSpecializedBondASW1.fairSpread();
+    Real error14 = std::fabs(zeroCpnBondASWSpread1 - zeroCpnSpecializedBondASWSpread1);
+    if (error14 > tolerance) {
         BOOST_FAIL("wrong asw spread for zeroCpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zeroCpn bond's  asw spread: "
-                    << zeroCpnBondASWSpread1
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << zeroCpnSpecializedBondASWSpread1
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error14
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zeroCpn bond's  asw spread: " << zeroCpnBondASWSpread1
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << zeroCpnSpecializedBondASWSpread1 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error14
+                   << "\n  tolerance:             " << tolerance);
     }
 
 
-   //  Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
-   //  maturity doesn't occur on a business day
-    Date zeroCpnBondStartDate2 = Date(17,February,1998);
-    Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
-    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
-                                                      Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    //  Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
+    //  maturity doesn't occur on a business day
+    Date zeroCpnBondStartDate2 = Date(17, February, 1998);
+    Date zeroCpnBondMaturityDate2 = Date(17, February, 2028);
+    Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2, Following);
+    Leg zeroCpnBondLeg2 =
+        Leg(1, ext::shared_ptr<CashFlow>(new SimpleCashFlow(100.0, zerocpbondRedemption2)));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    ext::shared_ptr<Bond> zeroCpnBond2(new Bond(settlementDays, bondCalendar, vars.faceAmount,
+                                                zeroCpnBondMaturityDate2, zeroCpnBondStartDate2,
+                                                zeroCpnBondLeg2));
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
-                   Date(17,February,2028),
-                   Following,
-                   100.0, Date(17,February,1998)));
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(
+        new ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount, Date(17, February, 2028),
+                           Following, 100.0, Date(17, February, 1998)));
     zeroCpnSpecializedBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
     Real zeroCpnSpecializedBondPrice2 = zeroCpnSpecializedBond2->cleanPrice();
 
-    AssetSwap zeroCpnBondAssetSwap2(payFixedRate,zeroCpnBond2,
-                                    zeroCpnBondPrice2,
-                                    vars.iborIndex, vars.nonnullspread,
-                                    Schedule(),
-                                    vars.iborIndex->dayCounter(),
+    AssetSwap zeroCpnBondAssetSwap2(payFixedRate, zeroCpnBond2, zeroCpnBondPrice2, vars.iborIndex,
+                                    vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(),
                                     parAssetSwap);
     zeroCpnBondAssetSwap2.setPricingEngine(swapEngine);
-    AssetSwap zeroCpnSpecializedBondAssetSwap2(payFixedRate,
-                                               zeroCpnSpecializedBond2,
-                                               zeroCpnSpecializedBondPrice2,
-                                               vars.iborIndex,
-                                               vars.nonnullspread,
-                                               Schedule(),
-                                               vars.iborIndex->dayCounter(),
-                                               parAssetSwap);
+    AssetSwap zeroCpnSpecializedBondAssetSwap2(
+        payFixedRate, zeroCpnSpecializedBond2, zeroCpnSpecializedBondPrice2, vars.iborIndex,
+        vars.nonnullspread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnSpecializedBondAssetSwap2.setPricingEngine(swapEngine);
     Real zeroCpnBondAssetSwapPrice2 = zeroCpnBondAssetSwap2.fairCleanPrice();
-    Real zeroCpnSpecializedBondAssetSwapPrice2 =
-                               zeroCpnSpecializedBondAssetSwap2.fairCleanPrice();
-    Real error15 = std::fabs(zeroCpnBondAssetSwapPrice2
-                             -zeroCpnSpecializedBondAssetSwapPrice2);
-    if (error15>tolerance) {
+    Real zeroCpnSpecializedBondAssetSwapPrice2 = zeroCpnSpecializedBondAssetSwap2.fairCleanPrice();
+    Real error15 = std::fabs(zeroCpnBondAssetSwapPrice2 - zeroCpnSpecializedBondAssetSwapPrice2);
+    if (error15 > tolerance) {
         BOOST_FAIL("wrong clean price for zerocpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zero cpn bond's clean price: "
-                    << zeroCpnBondAssetSwapPrice2
-                    << "\n  equivalent specialized bond's price: "
-                    << zeroCpnSpecializedBondAssetSwapPrice2
-                    << "\n  error:                 " << error15
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zero cpn bond's clean price: " << zeroCpnBondAssetSwapPrice2
+                   << "\n  equivalent specialized bond's price: "
+                   << zeroCpnSpecializedBondAssetSwapPrice2 << "\n  error:                 "
+                   << error15 << "\n  tolerance:             " << tolerance);
     }
     // market executable price as of 4th sept 2007
     Real zeroCpnBondMktPrice2 = 72.277;
-    AssetSwap zeroCpnBondASW2(payFixedRate,
-                              zeroCpnBond2,zeroCpnBondMktPrice2,
-                              vars.iborIndex, vars.spread,
-                              Schedule(),
-                              vars.iborIndex->dayCounter(),
-                              parAssetSwap);
+    AssetSwap zeroCpnBondASW2(payFixedRate, zeroCpnBond2, zeroCpnBondMktPrice2, vars.iborIndex,
+                              vars.spread, Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnBondASW2.setPricingEngine(swapEngine);
-    AssetSwap zeroCpnSpecializedBondASW2(payFixedRate,
-                                         zeroCpnSpecializedBond2,
-                                         zeroCpnBondMktPrice2,
-                                         vars.iborIndex, vars.spread,
-                                         Schedule(),
-                                         vars.iborIndex->dayCounter(),
-                                         parAssetSwap);
+    AssetSwap zeroCpnSpecializedBondASW2(payFixedRate, zeroCpnSpecializedBond2,
+                                         zeroCpnBondMktPrice2, vars.iborIndex, vars.spread,
+                                         Schedule(), vars.iborIndex->dayCounter(), parAssetSwap);
     zeroCpnSpecializedBondASW2.setPricingEngine(swapEngine);
     Real zeroCpnBondASWSpread2 = zeroCpnBondASW2.fairSpread();
-    Real zeroCpnSpecializedBondASWSpread2 =
-        zeroCpnSpecializedBondASW2.fairSpread();
-    Real error16 =
-        std::fabs(zeroCpnBondASWSpread2-zeroCpnSpecializedBondASWSpread2);
-    if (error16>tolerance) {
+    Real zeroCpnSpecializedBondASWSpread2 = zeroCpnSpecializedBondASW2.fairSpread();
+    Real error16 = std::fabs(zeroCpnBondASWSpread2 - zeroCpnSpecializedBondASWSpread2);
+    if (error16 > tolerance) {
         BOOST_FAIL("wrong asw spread for zeroCpn bond:"
-                    << std::fixed << std::setprecision(4)
-                    << "\n  generic zeroCpn bond's  asw spread: "
-                    << zeroCpnBondASWSpread2
-                    << "\n  equivalent specialized bond's asw spread: "
-                    << zeroCpnSpecializedBondASWSpread2
-                    << std::scientific << std::setprecision(2)
-                    << "\n  error:                 " << error16
-                    << "\n  tolerance:             " << tolerance);
+                   << std::fixed << std::setprecision(4)
+                   << "\n  generic zeroCpn bond's  asw spread: " << zeroCpnBondASWSpread2
+                   << "\n  equivalent specialized bond's asw spread: "
+                   << zeroCpnSpecializedBondASWSpread2 << std::scientific << std::setprecision(2)
+                   << "\n  error:                 " << error16
+                   << "\n  tolerance:             " << tolerance);
     }
 }
 


### PR DESCRIPTION
Fixes #2278.

Since commit 5cb1bffa0 ("Remove day counter argument from spreaded curves"),
`ZeroSpreadedTermStructure` no longer uses the day counter it is given and
always delegates to the underlying curve's day counter.  However, the
higher-level APIs that build that structure internally still exposed a
`DayCounter` parameter that had become a no-op:

- `CashFlows::npv()` (z-spread overload)
- `CashFlows::zSpread()`
- `BondFunctions::cleanPrice()` (z-spread overload)
- `BondFunctions::dirtyPrice()` (z-spread overload)
- `BondFunctions::zSpread()`

This PR follows the same deprecation strategy as 5cb1bffa0:

- Add new primary overloads without the `DayCounter` argument.
- Mark the old signatures `[[deprecated("Use the overload without a day counter")]]` (deprecated in version 1.42).
- The deprecated overloads are one-line delegates to the new primaries (unnamed `const DayCounter&` parameter suppresses unused-variable warnings).
- Remove the stale `// to be fixed: user-defined daycounter should be used` comment from `zerospreadedtermstructure.hpp` (the design decision made in 5cb1bffa0 settled this).
- Update all internal callers in `test-suite/bonds.cpp` and `test-suite/assetswap.cpp`.

All existing tests pass.