### PR TITLE
Deprecate day-counter argument in z-spread functions

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -1144,7 +1144,6 @@ namespace QuantLib {
     Real CashFlows::npv(const Leg& leg,
                         const ext::shared_ptr<YieldTermStructure>& discountCurve,
                         Spread zSpread,
-                        const DayCounter& dc,
                         Compounding comp,
                         Frequency freq,
                         const ext::optional<bool>& includeSettlementDateFlows,
@@ -1173,10 +1172,22 @@ namespace QuantLib {
                    settlementDate, npvDate);
     }
 
+    Real CashFlows::npv(const Leg& leg,
+                        const ext::shared_ptr<YieldTermStructure>& discountCurve,
+                        Spread zSpread,
+                        const DayCounter&,
+                        Compounding comp,
+                        Frequency freq,
+                        const ext::optional<bool>& includeSettlementDateFlows,
+                        Date settlementDate,
+                        Date npvDate) {
+        return CashFlows::npv(leg, discountCurve, zSpread, comp, freq,
+                              includeSettlementDateFlows, settlementDate, npvDate);
+    }
+
     Spread CashFlows::zSpread(const Leg& leg,
                               Real npv,
                               const ext::shared_ptr<YieldTermStructure>& discount,
-                              const DayCounter& dayCounter,
                               Compounding compounding,
                               Frequency frequency,
                               const ext::optional<bool>& includeSettlementDateFlows,
@@ -1209,6 +1220,23 @@ namespace QuantLib {
         solver.setMaxEvaluations(maxIterations);
         Real step = 0.01;
         return solver.solve(objFunction, accuracy, guess, step);
+    }
+
+    Spread CashFlows::zSpread(const Leg& leg,
+                              Real npv,
+                              const ext::shared_ptr<YieldTermStructure>& discount,
+                              const DayCounter&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              const ext::optional<bool>& includeSettlementDateFlows,
+                              Date settlementDate,
+                              Date npvDate,
+                              Real accuracy,
+                              Size maxIterations,
+                              Rate guess) {
+        return CashFlows::zSpread(leg, npv, discount, compounding, frequency,
+                                  includeSettlementDateFlows, settlementDate, npvDate,
+                                  accuracy, maxIterations, guess);
     }
 
 }

--- a/ql/cashflows/cashflows.hpp
+++ b/ql/cashflows/cashflows.hpp
@@ -399,10 +399,21 @@ namespace QuantLib {
         //@{
         //! NPV of the cash flows.
         /*! The NPV is the sum of the cash flows, each discounted
-            according to the z-spreaded term structure.  The result
-            is affected by the choice of the z-spread compounding
-            and the relative frequency and day counter.
+            according to the z-spreaded term structure.  The spread
+            is expressed in terms of the underlying curve's day counter.
         */
+        static Real npv(const Leg& leg,
+                        const ext::shared_ptr<YieldTermStructure>& discount,
+                        Spread zSpread,
+                        Compounding compounding,
+                        Frequency frequency,
+                        const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                        Date settlementDate = Date(),
+                        Date npvDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
         static Real npv(const Leg& leg,
                         const ext::shared_ptr<YieldTermStructure>& discount,
                         Spread zSpread,
@@ -413,6 +424,21 @@ namespace QuantLib {
                         Date settlementDate = Date(),
                         Date npvDate = Date());
         //! implied Z-spread.
+        static Spread zSpread(const Leg& leg,
+                              Real npv,
+                              const ext::shared_ptr<YieldTermStructure>&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              const ext::optional<bool>& includeSettlementDateFlows = ext::nullopt,
+                              Date settlementDate = Date(),
+                              Date npvDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
         static Spread zSpread(const Leg& leg,
                               Real npv,
                               const ext::shared_ptr<YieldTermStructure>&,

--- a/ql/pricingengines/bond/bondfunctions.cpp
+++ b/ql/pricingengines/bond/bondfunctions.cpp
@@ -488,20 +488,28 @@ namespace QuantLib {
     Real BondFunctions::cleanPrice(const Bond& bond,
                                    const ext::shared_ptr<YieldTermStructure>& d,
                                    Spread zSpread,
-                                   const DayCounter& dc,
                                    Compounding comp,
                                    Frequency freq,
                                    Date settlement) {
         if (settlement == Date())
             settlement = bond.settlementDate();
 
-        return dirtyPrice(bond, d, zSpread, dc, comp, freq, settlement) - bond.accruedAmount(settlement);
+        return dirtyPrice(bond, d, zSpread, comp, freq, settlement) - bond.accruedAmount(settlement);
+    }
+
+    Real BondFunctions::cleanPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter&,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        return BondFunctions::cleanPrice(bond, d, zSpread, comp, freq, settlement);
     }
 
     Real BondFunctions::dirtyPrice(const Bond& bond,
                                    const ext::shared_ptr<YieldTermStructure>& d,
                                    Spread zSpread,
-                                   const DayCounter& dc,
                                    Compounding comp,
                                    Frequency freq,
                                    Date settlement) {
@@ -513,16 +521,25 @@ namespace QuantLib {
                    " (maturity being " << bond.maturityDate() << ")");
 
         Real dirtyPrice = CashFlows::npv(bond.cashflows(), d,
-                                         zSpread, dc, comp, freq,
+                                         zSpread, comp, freq,
                                          false, settlement) *
             100.0 / bond.notional(settlement);
         return dirtyPrice;
     }
 
+    Real BondFunctions::dirtyPrice(const Bond& bond,
+                                   const ext::shared_ptr<YieldTermStructure>& d,
+                                   Spread zSpread,
+                                   const DayCounter&,
+                                   Compounding comp,
+                                   Frequency freq,
+                                   Date settlement) {
+        return BondFunctions::dirtyPrice(bond, d, zSpread, comp, freq, settlement);
+    }
+
     Spread BondFunctions::zSpread(const Bond& bond,
                                   Bond::Price price,
                                   const ext::shared_ptr<YieldTermStructure>& d,
-                                  const DayCounter& dayCounter,
                                   Compounding compounding,
                                   Frequency frequency,
                                   Date settlement,
@@ -545,8 +562,22 @@ namespace QuantLib {
         return CashFlows::zSpread(bond.cashflows(),
                                   dirtyPrice,
                                   d,
-                                  dayCounter, compounding, frequency,
+                                  compounding, frequency,
                                   false, settlement, settlement,
                                   accuracy, maxIterations, guess);
+    }
+
+    Spread BondFunctions::zSpread(const Bond& bond,
+                                  Bond::Price price,
+                                  const ext::shared_ptr<YieldTermStructure>& d,
+                                  const DayCounter&,
+                                  Compounding compounding,
+                                  Frequency frequency,
+                                  Date settlement,
+                                  Real accuracy,
+                                  Size maxIterations,
+                                  Rate guess) {
+        return BondFunctions::zSpread(bond, price, d, compounding, frequency,
+                                      settlement, accuracy, maxIterations, guess);
     }
 }

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -233,6 +233,16 @@ namespace QuantLib {
         static Real cleanPrice(const Bond& bond,
                                const ext::shared_ptr<YieldTermStructure>& discount,
                                Spread zSpread,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
+        static Real cleanPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
@@ -240,10 +250,33 @@ namespace QuantLib {
         static Real dirtyPrice(const Bond& bond,
                                const ext::shared_ptr<YieldTermStructure>& discount,
                                Spread zSpread,
+                               Compounding compounding,
+                               Frequency frequency,
+                               Date settlementDate = Date());
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
+        static Real dirtyPrice(const Bond& bond,
+                               const ext::shared_ptr<YieldTermStructure>& discount,
+                               Spread zSpread,
                                const DayCounter& dayCounter,
                                Compounding compounding,
                                Frequency frequency,
                                Date settlementDate = Date());
+        static Spread zSpread(const Bond& bond,
+                              Bond::Price price,
+                              const ext::shared_ptr<YieldTermStructure>&,
+                              Compounding compounding,
+                              Frequency frequency,
+                              Date settlementDate = Date(),
+                              Real accuracy = 1.0e-10,
+                              Size maxIterations = 100,
+                              Rate guess = 0.0);
+        /*! \deprecated Use the overload without a day counter.
+                        Deprecated in version 1.42.
+        */
+        [[deprecated("Use the overload without a day counter")]]
         static Spread zSpread(const Bond& bond,
                               Bond::Price price,
                               const ext::shared_ptr<YieldTermStructure>&,

--- a/ql/termstructures/yield/zerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/zerospreadedtermstructure.hpp
@@ -143,7 +143,6 @@ namespace QuantLib {
     }
 
     inline Rate ZeroSpreadedTermStructure::zeroYieldImpl(Time t) const {
-        // to be fixed: user-defined daycounter should be used
         InterestRate zeroRate =
             originalCurve_->zeroRate(t, comp_, freq_, true);
         InterestRate spreadedRate(zeroRate + spread_->value(),

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -1513,7 +1513,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YC...
     Real fixedBondCleanPrice1 = BondFunctions::cleanPrice(
          *fixedBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          fixedBondSettlementDate1);
     Real tolerance = 1.0e-13;
     Real error1 = std::fabs(fixedBondImpliedValue1-fixedBondCleanPrice1);
@@ -1550,7 +1550,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real fixedBondCleanPrice2 = BondFunctions::cleanPrice(
          *fixedBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          fixedBondSettlementDate2);
     Real error3 = std::fabs(fixedBondImpliedValue2-fixedBondCleanPrice2);
     if (error3>tolerance) {
@@ -1592,7 +1592,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real floatingBondCleanPrice1 = BondFunctions::cleanPrice(
         *floatingBond1, *vars.termStructure, vars.spread,
-        Actual365Fixed(), vars.compounding, Semiannual,
+        vars.compounding, Semiannual,
         fixedBondSettlementDate1);
     Real error5 = std::fabs(floatingBondImpliedValue1-floatingBondCleanPrice1);
     if (error5>tolerance) {
@@ -1633,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real floatingBondCleanPrice2 = BondFunctions::cleanPrice(
         *floatingBond2, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
+        vars.spread, vars.compounding, Semiannual,
         fixedBondSettlementDate1);
     Real error7 = std::fabs(floatingBondImpliedValue2-floatingBondCleanPrice2);
     if (error7>tolerance) {
@@ -1674,7 +1674,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real cmsBondCleanPrice1 = BondFunctions::cleanPrice(
         *cmsBond1, *vars.termStructure, vars.spread,
-        Actual365Fixed(), vars.compounding, Annual,
+        vars.compounding, Annual,
         cmsBondSettlementDate1);
     Real error9 = std::fabs(cmsBondImpliedValue1-cmsBondCleanPrice1);
     if (error9>tolerance) {
@@ -1714,7 +1714,7 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real cmsBondCleanPrice2 = BondFunctions::cleanPrice(
          *cmsBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          cmsBondSettlementDate2);
     Real error11 = std::fabs(cmsBondImpliedValue2-cmsBondCleanPrice2);
     if (error11>tolerance) {
@@ -1746,7 +1746,6 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
         BondFunctions::cleanPrice(*zeroCpnBond1,
                               *vars.termStructure,
                               vars.spread,
-                              Actual365Fixed(),
                               vars.compounding, Annual,
                               zeroCpnBondSettlementDate1);
     Real error13 = std::fabs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1);
@@ -1780,7 +1779,6 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
         BondFunctions::cleanPrice(*zeroCpnBond2,
                               *vars.termStructure,
                               vars.spread,
-                              Actual365Fixed(),
                               vars.compounding, Annual,
                               zeroCpnBondSettlementDate2);
     Real error15 = std::fabs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2);
@@ -2701,7 +2699,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real fixedBondCleanPrice1 = BondFunctions::cleanPrice(
          *fixedBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          fixedBondSettlementDate1);
     Real tolerance = 1.0e-13;
     Real error1 = std::fabs(fixedBondImpliedValue1-fixedBondCleanPrice1);
@@ -2745,7 +2743,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
 
     Real fixedBondCleanPrice2 = BondFunctions::cleanPrice(
          *fixedBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          fixedBondSettlementDate2);
     Real error3 = std::fabs(fixedBondImpliedValue2-fixedBondCleanPrice2);
     if (error3>tolerance) {
@@ -2792,7 +2790,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real floatingBondCleanPrice1 = BondFunctions::cleanPrice(
         *floatingBond1, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
+        vars.spread, vars.compounding, Semiannual,
         fixedBondSettlementDate1);
     Real error5 = std::fabs(floatingBondImpliedValue1-floatingBondCleanPrice1);
     if (error5>tolerance) {
@@ -2840,7 +2838,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real floatingBondCleanPrice2 = BondFunctions::cleanPrice(
         *floatingBond2, *vars.termStructure,
-        vars.spread, Actual365Fixed(), vars.compounding, Semiannual,
+        vars.spread, vars.compounding, Semiannual,
         fixedBondSettlementDate1);
     Real error7 = std::fabs(floatingBondImpliedValue2-floatingBondCleanPrice2);
     if (error7>tolerance) {
@@ -2888,7 +2886,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real cmsBondCleanPrice1 = BondFunctions::cleanPrice(
          *cmsBond1, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          cmsBondSettlementDate1);
     Real error9 = std::fabs(cmsBondImpliedValue1-cmsBondCleanPrice1);
     if (error9>tolerance) {
@@ -2934,7 +2932,7 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     // bond's frequency + coumpounding and daycounter of the YieldCurve
     Real cmsBondCleanPrice2 = BondFunctions::cleanPrice(
          *cmsBond2, *vars.termStructure, vars.spread,
-         Actual365Fixed(), vars.compounding, Annual,
+         vars.compounding, Annual,
          cmsBondSettlementDate2);
     Real error11 = std::fabs(cmsBondImpliedValue2-cmsBondCleanPrice2);
     if (error11>tolerance) {
@@ -2969,7 +2967,6 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         BondFunctions::cleanPrice(*zeroCpnBond1,
                               *vars.termStructure,
                               vars.spread,
-                              Actual365Fixed(),
                               vars.compounding, Annual,
                               zeroCpnBondSettlementDate1);
     Real error13 = std::fabs(zeroCpnBondImpliedValue1-zeroCpnBondCleanPrice1);
@@ -3006,7 +3003,6 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         BondFunctions::cleanPrice(*zeroCpnBond2,
                               *vars.termStructure,
                               vars.spread,
-                              Actual365Fixed(),
                               vars.compounding, Annual,
                               zeroCpnBondSettlementDate2);
     Real error15 = std::fabs(zeroCpnBondImpliedValue2-zeroCpnBondCleanPrice2);

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -321,18 +321,17 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                             // Clean price
                             Bond::Price price = {
                                 BondFunctions::cleanPrice(bond, *discountCurve,
-                                                          spread, bondDayCount, n,
-                                                          frequency),
+                                                          spread, n, frequency),
                                 Bond::Price::Clean
                             };
                             Spread calculated = BondFunctions::zSpread(
-                                bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
+                                bond, price, *discountCurve, n, frequency, Date(),
                                 tolerance, maxEvaluations);
 
                             if (std::fabs(spread - calculated) > tolerance) {
                                 // the difference might not matter
                                 Real price2 = BondFunctions::cleanPrice(
-                                    bond, *discountCurve, calculated, bondDayCount, n, frequency);
+                                    bond, *discountCurve, calculated, n, frequency);
                                 if (std::fabs(price.amount() - price2) / price.amount() > tolerance) {
                                     BOOST_ERROR("\nZ-spread recalculation failed:"
                                                 "\n    issue:     " << issue <<
@@ -351,18 +350,18 @@ BOOST_AUTO_TEST_CASE(testZspread) {
                             // Dirty price
                             price = {
                                 BondFunctions::dirtyPrice(bond, *discountCurve, spread,
-                                                          bondDayCount, n, frequency),
+                                                          n, frequency),
                                 Bond::Price::Dirty
                             };
 
                             calculated = BondFunctions::zSpread(
-                                bond, price, *discountCurve, bondDayCount, n, frequency, Date(),
+                                bond, price, *discountCurve, n, frequency, Date(),
                                 tolerance, maxEvaluations);
 
                             if (std::fabs(spread - calculated) > tolerance) {
                                 // the difference might not matter
                                 Real price2 = BondFunctions::dirtyPrice(
-                                    bond, *discountCurve, calculated, bondDayCount, n, frequency);
+                                    bond, *discountCurve, calculated, n, frequency);
                                 if (std::fabs(price.amount() - price2) / price.amount() > tolerance) {
                                     BOOST_ERROR("\nZ-spread recalculation failed:"
                                                 "\n    issue:        " << issue <<


### PR DESCRIPTION
Since commit 5cb1bffa0 ("Remove day counter argument from spreaded
curves"), `ZeroSpreadedTermStructure` ignores the day counter it is
given and always delegates to the underlying curve's.  However, the
higher-level APIs still exposed a `DayCounter` parameter that had
silently become a no-op:

- `CashFlows::npv()` (z-spread overload)
- `CashFlows::zSpread()`
- `BondFunctions::cleanPrice()`, `dirtyPrice()`, `zSpread()` (z-spread overloads)

This adds new primary overloads without the `DayCounter` argument and
marks the old signatures `[[deprecated]]` (version 1.42), following the
same pattern used in 5cb1bffa0 for `ZeroSpreadedTermStructure` itself.
Internal callers in the test suite are updated accordingly.

Fixes #2278.