### PR TITLE
Remove virtual destructor from `Extrapolator`

### DIFF
--- a/ql/math/interpolation.hpp
+++ b/ql/math/interpolation.hpp
@@ -116,7 +116,6 @@ namespace QuantLib {
         };
 
         Interpolation() = default;
-        ~Interpolation() override = default;
         bool empty() const { return !impl_; }
         Real operator()(Real x, bool allowExtrapolation = false) const {
             checkRange(x,allowExtrapolation);

--- a/ql/math/interpolations/chebyshevinterpolation.hpp
+++ b/ql/math/interpolations/chebyshevinterpolation.hpp
@@ -41,7 +41,6 @@ namespace QuantLib {
             Size n, const std::function<Real(Real)>& f,
             PointsType pointsType = SecondKind);
 
-        ~ChebyshevInterpolation() override = default;
         explicit ChebyshevInterpolation(const ChebyshevInterpolation&) = delete;
         explicit ChebyshevInterpolation(ChebyshevInterpolation&&) = delete;
         ChebyshevInterpolation& operator=(const ChebyshevInterpolation&) = delete;

--- a/ql/math/interpolations/extrapolation.hpp
+++ b/ql/math/interpolations/extrapolation.hpp
@@ -32,7 +32,6 @@ namespace QuantLib {
     class Extrapolator {
       public:
         Extrapolator() = default;
-        virtual ~Extrapolator() = default;
         //! \name modifiers
         //@{
         //! enable extrapolation in subsequent calls


### PR DESCRIPTION
It's not needed and adds unnecessary overhead to Interpolation classes.