### PR TITLE
Add `operator==` to `FdmLinearOpIterator`

### DIFF
--- a/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
+++ b/ql/methods/finitedifferences/operators/fdmlinearopiterator.hpp
@@ -63,6 +63,10 @@ namespace QuantLib {
             return *this;
         }
 
+        bool operator==(const FdmLinearOpIterator& iterator) const {
+            return index_ == iterator.index_;
+        }
+
         bool operator!=(const FdmLinearOpIterator& iterator) const {
             return index_ != iterator.index_;
         }


### PR DESCRIPTION
`FdmLinearOpIterator` defines `operator!=` but not `operator==`. Needed for C++20 conformance (rewrite rules synthesize `!=` from `==`, not the reverse) and standard iterator concepts.