### PR TITLE
Bring `MakeCreditDefaultSwap` up to date with CDS instrument

### DIFF
--- a/ql/instruments/makecds.cpp
+++ b/ql/instruments/makecds.cpp
@@ -25,19 +25,18 @@
 
 namespace QuantLib {
 
-    MakeCreditDefaultSwap::MakeCreditDefaultSwap(const Period &tenor,
-                                                 const Real couponRate)
-        : side_(Protection::Buyer), nominal_(1.0), tenor_(tenor),
-          couponTenor_(3 * Months), couponRate_(couponRate), upfrontRate_(0.0),
-          dayCounter_(Actual360()), lastPeriodDayCounter_(Actual360(true)),
-          rule_(DateGeneration::CDS), cashSettlementDays_(3) {}
+    MakeCreditDefaultSwap::MakeCreditDefaultSwap(const Period& tenor,
+                                                 Rate runningSpread)
+    : tenor_(tenor), runningSpread_(runningSpread) {}
 
-    MakeCreditDefaultSwap::MakeCreditDefaultSwap(const Date &termDate,
-                                                 const Real couponRate)
-        : side_(Protection::Buyer), nominal_(1.0), termDate_(termDate),
-          couponTenor_(3 * Months), couponRate_(couponRate), upfrontRate_(0.0),
-          dayCounter_(Actual360()), lastPeriodDayCounter_(Actual360(true)),
-          rule_(DateGeneration::CDS), cashSettlementDays_(3) {}
+    MakeCreditDefaultSwap::MakeCreditDefaultSwap(const Date& termDate,
+                                                 Rate runningSpread)
+    : termDate_(termDate), runningSpread_(runningSpread) {}
+
+    MakeCreditDefaultSwap::MakeCreditDefaultSwap(const Schedule& schedule,
+                                                 Rate runningSpread)
+    : schedule_(schedule), runningSpread_(runningSpread) {}
+
 
     MakeCreditDefaultSwap::operator CreditDefaultSwap() const {
         ext::shared_ptr<CreditDefaultSwap> swap = *this;
@@ -46,47 +45,51 @@ namespace QuantLib {
 
     MakeCreditDefaultSwap::operator ext::shared_ptr<CreditDefaultSwap>() const {
 
-        Date tradeDate = (tradeDate_ != Date()) ? tradeDate_ : Settings::instance().evaluationDate();
-        Date upfrontDate = WeekendsOnly().advance(tradeDate, cashSettlementDays_, Days);
+        Date tradeDate = tradeDate_ != Date() ? tradeDate_ : Settings::instance().evaluationDate();
+        Date upfrontDate = upfrontDate_ != Date() ? upfrontDate_ : WeekendsOnly().advance(tradeDate, cashSettlementDays_, Days);
 
-        Date protectionStart;
-        if (rule_ == DateGeneration::CDS2015 || rule_ == DateGeneration::CDS) {
-            protectionStart = tradeDate;
-        } else {
-            protectionStart = tradeDate + 1;
-        }
-
-        Date end;
-        if (tenor_) { // NOLINT(readability-implicit-bool-conversion)
-            if (rule_ == DateGeneration::CDS2015 || rule_ == DateGeneration::CDS || rule_ == DateGeneration::OldCDS) {
-                end = cdsMaturity(tradeDate, *tenor_, rule_);
+        Date protectionStart = protectionStart_;
+        if (protectionStart == Date()) {
+            if (schedule_) { // NOLINT(readability-implicit-bool-conversion)
+                protectionStart = schedule_->at(0);
             } else {
-                end = tradeDate + *tenor_;
+                if (rule_ == DateGeneration::CDS2015 || rule_ == DateGeneration::CDS) {
+                    protectionStart = tradeDate;
+                } else {
+                    protectionStart = tradeDate + 1;
+                }
             }
-        } else {
-            // we have two exclusive constructors; if we don't have a tenor, we have a term date
-            end = *termDate_; // NOLINT(bugprone-unchecked-optional-access)
         }
 
-        Schedule schedule(protectionStart, end, couponTenor_, WeekendsOnly(), Following,
-                          Unadjusted, rule_, false);
+        // schedule, tenor and term date come from different constructors; exactly one of them is not null.
+        Schedule schedule;
+        if (schedule_) { // NOLINT(readability-implicit-bool-conversion)
+            schedule = *schedule_;
+        } else {
+            Date end;
+            if (tenor_) { // NOLINT(readability-implicit-bool-conversion)
+                if (rule_ == DateGeneration::CDS2015 || rule_ == DateGeneration::CDS || rule_ == DateGeneration::OldCDS) {
+                    end = cdsMaturity(tradeDate, *tenor_, rule_);
+                } else {
+                    end = tradeDate + *tenor_;
+                }
+            } else {
+                end = *termDate_; // NOLINT(bugprone-unchecked-optional-access)
+            }
 
-        ext::shared_ptr<CreditDefaultSwap> cds =
-            ext::make_shared<CreditDefaultSwap>(
-                side_, nominal_, upfrontRate_, couponRate_, schedule, Following,
-                dayCounter_, true, true, protectionStart, upfrontDate,
-                ext::shared_ptr<Claim>(), lastPeriodDayCounter_, true, tradeDate, cashSettlementDays_);
+            schedule = Schedule(protectionStart, end, couponTenor_, WeekendsOnly(), convention_,
+                                Unadjusted, rule_, false);
+        }
+
+        auto cds = ext::make_shared<CreditDefaultSwap>(
+            side_, nominal_, upfrontRate_, runningSpread_, schedule, convention_,
+            dayCounter_, settlesAccrual_, paysAtDefaultTime_, protectionStart, upfrontDate,
+            claim_, lastPeriodDayCounter_, rebatesAccrual_, tradeDate, cashSettlementDays_);
 
         cds->setPricingEngine(engine_);
         return cds;
-
     }
 
-    MakeCreditDefaultSwap &
-    MakeCreditDefaultSwap::withUpfrontRate(Real upfrontRate) {
-        upfrontRate_ = upfrontRate;
-        return *this;
-    }
 
     MakeCreditDefaultSwap &
     MakeCreditDefaultSwap::withSide(Protection::Side side) {
@@ -100,25 +103,74 @@ namespace QuantLib {
     }
 
     MakeCreditDefaultSwap &
+    MakeCreditDefaultSwap::withUpfrontRate(Real upfrontRate) {
+        upfrontRate_ = upfrontRate;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap &
     MakeCreditDefaultSwap::withCouponTenor(Period couponTenor) {
         couponTenor_ = couponTenor;
         return *this;
     }
 
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withDateGenerationRule(DateGeneration::Rule rule) {
+        rule_ = rule;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withConvention(BusinessDayConvention convention) {
+        convention_ = convention;
+        return *this;
+    }
+
     MakeCreditDefaultSwap &
-    MakeCreditDefaultSwap::withDayCounter(DayCounter &dayCounter) {
+    MakeCreditDefaultSwap::withDayCounter(const DayCounter& dayCounter) {
         dayCounter_ = dayCounter;
         return *this;
     }
 
+    MakeCreditDefaultSwap &
+    MakeCreditDefaultSwap::settleAccrual(bool b) {
+        settlesAccrual_ = b;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap &
+    MakeCreditDefaultSwap::payAtDefaultTime(bool b) {
+        paysAtDefaultTime_ = b;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withProtectionStart(Date d) {
+        protectionStart_ = d;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withUpfrontDate(Date d) {
+        upfrontDate_ = d;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withClaim(ext::shared_ptr<Claim> claim) {
+        claim_ = claim;
+        return *this;
+    }
+
     MakeCreditDefaultSwap &MakeCreditDefaultSwap::withLastPeriodDayCounter(
-        DayCounter &lastPeriodDayCounter) {
+        const DayCounter& lastPeriodDayCounter) {
         lastPeriodDayCounter_ = lastPeriodDayCounter;
         return *this;
     }
 
-    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withDateGenerationRule(DateGeneration::Rule rule) {
-        rule_ = rule;
+    MakeCreditDefaultSwap &
+    MakeCreditDefaultSwap::rebateAccrual(bool b) {
+        rebatesAccrual_ = b;
+        return *this;
+    }
+
+    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withTradeDate(Date tradeDate) {
+        tradeDate_ = tradeDate;
         return *this;
     }
 
@@ -128,13 +180,8 @@ namespace QuantLib {
     }
 
     MakeCreditDefaultSwap &MakeCreditDefaultSwap::withPricingEngine(
-        const ext::shared_ptr<PricingEngine> &engine) {
+                               const ext::shared_ptr<PricingEngine> &engine) {
         engine_ = engine;
-        return *this;
-    }
-
-    MakeCreditDefaultSwap& MakeCreditDefaultSwap::withTradeDate(const Date& tradeDate) {
-        tradeDate_ = tradeDate;
         return *this;
     }
 

--- a/ql/instruments/makecds.hpp
+++ b/ql/instruments/makecds.hpp
@@ -26,6 +26,7 @@
 #define quantlib_makecds_hpp
 
 #include <ql/instruments/creditdefaultswap.hpp>
+#include <ql/time/daycounters/actual360.hpp>
 #include <ql/optional.hpp>
 
 namespace QuantLib {
@@ -36,38 +37,53 @@ namespace QuantLib {
     */
     class MakeCreditDefaultSwap {
       public:
-        MakeCreditDefaultSwap(const Period& tenor, Real couponRate);
-        MakeCreditDefaultSwap(const Date& termDate, Real couponRate);
+        MakeCreditDefaultSwap(const Period& tenor, Rate runningSpread);
+        MakeCreditDefaultSwap(const Date& termDate, Rate runningSpread);
+        MakeCreditDefaultSwap(const Schedule& schedule, Rate runningSpread);
 
         operator CreditDefaultSwap() const;
         operator ext::shared_ptr<CreditDefaultSwap>() const;
 
-        MakeCreditDefaultSwap& withUpfrontRate(Real);
         MakeCreditDefaultSwap& withSide(Protection::Side);
         MakeCreditDefaultSwap& withNominal(Real);
+        MakeCreditDefaultSwap& withUpfrontRate(Real);
         MakeCreditDefaultSwap& withCouponTenor(Period);
-        MakeCreditDefaultSwap& withDayCounter(DayCounter&);
-        MakeCreditDefaultSwap& withLastPeriodDayCounter(DayCounter&);
-        MakeCreditDefaultSwap& withDateGenerationRule(DateGeneration::Rule rule);
-        MakeCreditDefaultSwap& withCashSettlementDays(Natural cashSettlementDays);
+        MakeCreditDefaultSwap& withDateGenerationRule(DateGeneration::Rule);
+        MakeCreditDefaultSwap& withConvention(BusinessDayConvention);
+        MakeCreditDefaultSwap& withDayCounter(const DayCounter&);
+        MakeCreditDefaultSwap& settleAccrual(bool b = true);
+        MakeCreditDefaultSwap& payAtDefaultTime(bool b = true);
+        MakeCreditDefaultSwap& withProtectionStart(Date);
+        MakeCreditDefaultSwap& withUpfrontDate(Date);
+        MakeCreditDefaultSwap& withClaim(ext::shared_ptr<Claim>);
+        MakeCreditDefaultSwap& withLastPeriodDayCounter(const DayCounter&);
+        MakeCreditDefaultSwap& rebateAccrual(bool b = true);
+        MakeCreditDefaultSwap& withTradeDate(Date);
+        MakeCreditDefaultSwap& withCashSettlementDays(Natural);
 
         MakeCreditDefaultSwap& withPricingEngine(const ext::shared_ptr<PricingEngine>&);
 
-        MakeCreditDefaultSwap& withTradeDate(const Date& tradeDate);
-
       private:
-        Protection::Side side_;
-        Real nominal_;
         ext::optional<Period> tenor_;
         ext::optional<Date> termDate_;
-        Period couponTenor_;
-        Real couponRate_;
-        Real upfrontRate_;
-        DayCounter dayCounter_;
-        DayCounter lastPeriodDayCounter_;
-        DateGeneration::Rule rule_;
-        Natural cashSettlementDays_;
+        ext::optional<Schedule> schedule_;
+        Real runningSpread_;
+        Protection::Side side_ = Protection::Buyer;
+        Real nominal_ = 1.0;
+        Real upfrontRate_ = 0.0;
+        Period couponTenor_ = 3 * Months;
+        DateGeneration::Rule rule_ = DateGeneration::CDS;
+        BusinessDayConvention convention_ = Following;
+        DayCounter dayCounter_ = Actual360();
+        bool settlesAccrual_ = true;
+        bool paysAtDefaultTime_ = true;
+        Date protectionStart_;
+        Date upfrontDate_;
+        ext::shared_ptr<Claim> claim_;
+        DayCounter lastPeriodDayCounter_ = Actual360(true);
+        bool rebatesAccrual_ = true;
         Date tradeDate_;
+        Natural cashSettlementDays_ = 3;
 
         ext::shared_ptr<PricingEngine> engine_;
     };

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -19,6 +19,7 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include <ql/cashflows/fixedratecoupon.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/instruments/creditdefaultswap.hpp>
 #include <ql/instruments/makecds.hpp>
@@ -957,6 +958,123 @@ BOOST_AUTO_TEST_CASE(testIsdaCalculatorReconcileSingleWithIssueDateInThePast) {
 
     QL_CHECK_CLOSE(calculated_accrual, expected_accrual, tolerance);
 }
+
+BOOST_AUTO_TEST_CASE(testDefaultConventions) {
+    BOOST_TEST_MESSAGE("Testing default conventions for CDS factory class...");
+
+    Date today(6, March, 2026); // a Friday
+
+    Settings::instance().evaluationDate() = today;
+
+    ext::shared_ptr<CreditDefaultSwap> cds =
+        MakeCreditDefaultSwap(5 * Years, 0.01);
+
+    BOOST_CHECK_EQUAL(cds->runningSpread(), 0.01); // not actually a default
+
+    BOOST_CHECK_EQUAL(cds->notional(), 1.0);
+    BOOST_CHECK_EQUAL(*(cds->upfront()), 0.0);
+
+    BOOST_CHECK_EQUAL(cds->tradeDate(), today);
+    BOOST_CHECK_EQUAL(cds->cashSettlementDays(), 3U);
+    BOOST_CHECK_EQUAL(cds->upfrontPayment()->date(), today + 5); // 3 cash settlement days plus the weekend
+    BOOST_CHECK_EQUAL(cds->protectionStartDate(), today);
+    BOOST_CHECK_EQUAL(cds->protectionEndDate(), cdsMaturity(today, 5 * Years, DateGeneration::CDS));
+
+    BOOST_CHECK_EQUAL(cds->coupons().size(), 21U); // 5Y quarterly, modulo CDS conventions
+
+    BOOST_CHECK_EQUAL(cds->settlesAccrual(), true);
+    BOOST_CHECK_EQUAL(cds->paysAtDefaultTime(), true);
+    BOOST_CHECK_EQUAL(cds->rebatesAccrual(), true);
+
+    auto first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
+    auto last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+
+    BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/360");
+    BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/360 (inc)");
+
+    Date termDate = cdsMaturity(today, 3 * Years, DateGeneration::CDS2015);
+    cds = MakeCreditDefaultSwap(termDate, 0.01);
+    BOOST_CHECK_EQUAL(cds->protectionEndDate(), termDate);
+
+    termDate = cdsMaturity(today - 4, 10 * Years, DateGeneration::CDS2015);
+    Schedule schedule(today - 4, termDate, 3 * Months, WeekendsOnly(),
+                      Following, Unadjusted, DateGeneration::CDS2015, false);
+    cds = MakeCreditDefaultSwap(schedule, 0.01);
+    BOOST_CHECK_EQUAL(cds->protectionStartDate(), schedule.front());
+    BOOST_CHECK_EQUAL(cds->protectionEndDate(), schedule.back());
+
+    // override the defaults
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withNominal(10000.0)
+        .withUpfrontRate(0.02);
+
+    BOOST_CHECK_EQUAL(cds->notional(), 10000.0);
+    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
+    BOOST_CHECK_EQUAL(first->nominal(), 10000.0);
+
+    BOOST_CHECK_EQUAL(*(cds->upfront()), 0.02);
+    BOOST_CHECK_EQUAL(cds->upfrontPayment()->amount(), 200.0);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withCashSettlementDays(2);
+    BOOST_CHECK_EQUAL(cds->cashSettlementDays(), 2U);
+    BOOST_CHECK_EQUAL(cds->upfrontPayment()->date(), today + 4);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withCashSettlementDays(2)
+        .withUpfrontDate(today + 7);
+    BOOST_CHECK_EQUAL(cds->cashSettlementDays(), 2U);
+    BOOST_CHECK_EQUAL(cds->upfrontPayment()->date(), today + 7);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withProtectionStart(today + 2);
+    BOOST_CHECK_EQUAL(cds->protectionStartDate(), today + 2);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withCouponTenor(6 * Months);
+    BOOST_CHECK_EQUAL(cds->coupons().size(), 11U); // 5Y semiannually, modulo CDS conventions
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withTradeDate(today + 3);
+
+    BOOST_CHECK_EQUAL(cds->tradeDate(), today + 3);
+    BOOST_CHECK_EQUAL(cds->cashSettlementDays(), 3U);
+    BOOST_CHECK_EQUAL(cds->upfrontPayment()->date(), today + 6);
+    BOOST_CHECK_EQUAL(cds->protectionStartDate(), today + 3);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .settleAccrual(false);
+    BOOST_CHECK_EQUAL(cds->settlesAccrual(), false);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .payAtDefaultTime(false);
+    BOOST_CHECK_EQUAL(cds->paysAtDefaultTime(), false);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .rebateAccrual(false);
+    BOOST_CHECK_EQUAL(cds->rebatesAccrual(), false);
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withDayCounter(Actual365Fixed());
+
+    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
+    last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+
+    BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/365 (Fixed)");
+    BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/360 (inc)");
+
+    cds = MakeCreditDefaultSwap(5 * Years, 0.01)
+        .withLastPeriodDayCounter(Actual365Fixed());
+
+    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
+    last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+
+    BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/360");
+    BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/365 (Fixed)");
+
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Currently, the factory class can set just a few of the several constructor arguments of `CreditDefaultSwap`.  This change should let it cover the whole set.