### PR TITLE
Throw when both effective date and settlement days are set in `MakeVanillaSwap`/`MakeOIS`

### DIFF
--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -46,6 +46,10 @@ namespace QuantLib {
 
     MakeOIS::operator ext::shared_ptr<OvernightIndexedSwap>() const {
 
+        QL_REQUIRE(effectiveDate_ == Date() || settlementDays_ == Null<Natural>(),
+                   "cannot set both an explicit effective date and settlement days; "
+                   "use one or the other");
+
         Date startDate;
         if (effectiveDate_ != Date())
             startDate = effectiveDate_;
@@ -195,7 +199,6 @@ namespace QuantLib {
 
     MakeOIS& MakeOIS::withSettlementDays(Natural settlementDays) {
         settlementDays_ = settlementDays;
-        effectiveDate_ = Date();
         return *this;
     }
 

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -56,6 +56,10 @@ namespace QuantLib {
 
     MakeVanillaSwap::operator ext::shared_ptr<VanillaSwap>() const {
 
+        QL_REQUIRE(effectiveDate_ == Date() || settlementDays_ == Null<Natural>(),
+                   "cannot set both an explicit effective date and settlement days; "
+                   "use one or the other");
+
         Date startDate;
         if (effectiveDate_ != Date())
             startDate = effectiveDate_;
@@ -208,7 +212,6 @@ namespace QuantLib {
 
     MakeVanillaSwap& MakeVanillaSwap::withSettlementDays(Natural settlementDays) {
         settlementDays_ = settlementDays;
-        effectiveDate_ = Date();
         return *this;
     }
 

--- a/ql/termstructures/yield/oisratehelper.cpp
+++ b/ql/termstructures/yield/oisratehelper.cpp
@@ -131,7 +131,6 @@ namespace QuantLib {
         //    be assigned a curve later; use a RelinkableHandle here
         auto tmp = MakeOIS(tenor_, overnightIndex_, 0.0, forwardStart_)
             .withDiscountingTermStructure(discountRelinkableHandle_)
-            .withSettlementDays(settlementDays_)  // resets effectiveDate
             .withEffectiveDate(startDate_)
             .withTerminationDate(endDate_)
             .withTelescopicValueDates(telescopicValueDates_)
@@ -158,6 +157,9 @@ namespace QuantLib {
         if (!overnightCalendar_.empty()) {
             tmp.withOvernightLegCalendar(overnightCalendar_);
         }
+        // only set settlementDays when no explicit start date, to avoid conflict
+        if (startDate_ == Date() && settlementDays_ != Null<Natural>())
+            tmp.withSettlementDays(settlementDays_);
         swap_ = tmp;
 
         if (pricer_)

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -549,7 +549,6 @@ namespace QuantLib {
         // 2. input discount curve Handle might be empty now but it could
         //    be assigned a curve later; use a RelinkableHandle here
         auto tmp = MakeVanillaSwap(tenor_, iborIndex_, 0.0, fwdStart_)
-            .withSettlementDays(settlementDays_)  // resets effectiveDate
             .withEffectiveDate(startDate_)
             .withTerminationDate(endDate_)
             .withDiscountingTermStructure(discountRelinkableHandle_)
@@ -566,6 +565,9 @@ namespace QuantLib {
             tmp.withFloatingLegConvention(*floatConvention_)
                .withFloatingLegTerminationDateConvention(*floatConvention_);
         }
+        // only set settlementDays when no explicit start date, to avoid conflict
+        if (startDate_ == Date() && settlementDays_ != Null<Natural>())
+            tmp.withSettlementDays(settlementDays_);
         swap_ = tmp;
 
         simplifyNotificationGraph(*swap_, true);

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -1043,6 +1043,56 @@ BOOST_AUTO_TEST_CASE(testMakeOisEndOfMonthRegression2453) {
     BOOST_CHECK_EQUAL(swap.overnightSchedule()[1], Date(17, December, 2026));
 }
 
+BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
+    BOOST_TEST_MESSAGE("Testing MakeOIS rejects both "
+                       "settlementDays and effectiveDate...");
+
+    SavedSettings backup;
+    Date today(5, February, 2009);
+    Settings::instance().evaluationDate() = today;
+
+    RelinkableHandle<YieldTermStructure> yts;
+    yts.linkTo(flatRate(today, 0.05, Actual365Fixed()));
+
+    auto index = ext::make_shared<Estr>(yts);
+    Date effectiveDate(9, February, 2009);
+
+    // settlementDays first, then effectiveDate
+    BOOST_CHECK_EXCEPTION(
+        ext::shared_ptr<OvernightIndexedSwap> swap =
+            MakeOIS(5 * Years, index, 0.03)
+                .withSettlementDays(2)
+                .withEffectiveDate(effectiveDate),
+        Error,
+        ExpectedErrorMessage("cannot set both"));
+
+    // effectiveDate first, then settlementDays
+    BOOST_CHECK_EXCEPTION(
+        ext::shared_ptr<OvernightIndexedSwap> swap =
+            MakeOIS(5 * Years, index, 0.03)
+                .withEffectiveDate(effectiveDate)
+                .withSettlementDays(2),
+        Error,
+        ExpectedErrorMessage("cannot set both"));
+
+    // withSettlementDays alone works
+    ext::shared_ptr<OvernightIndexedSwap> swap1 =
+        MakeOIS(5 * Years, index, 0.03)
+            .withSettlementDays(2);
+    BOOST_CHECK(swap1->startDate() != Date());
+
+    // withEffectiveDate alone works
+    ext::shared_ptr<OvernightIndexedSwap> swap2 =
+        MakeOIS(5 * Years, index, 0.03)
+            .withEffectiveDate(effectiveDate);
+    BOOST_CHECK_EQUAL(swap2->startDate(), effectiveDate);
+
+    // neither set (constructor defaults) works
+    ext::shared_ptr<OvernightIndexedSwap> swap3 =
+        MakeOIS(5 * Years, index, 0.03);
+    BOOST_CHECK(swap3->startDate() != Date());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -488,6 +488,56 @@ BOOST_AUTO_TEST_CASE(testFixedTenorInferenceWithTerminationDate) {
                    "fixed periods (Quarterly), got " << overridePeriods);
 }
 
+BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
+    BOOST_TEST_MESSAGE("Testing MakeVanillaSwap rejects both "
+                       "settlementDays and effectiveDate...");
+
+    SavedSettings backup;
+    Date today(15, January, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    RelinkableHandle<YieldTermStructure> yts;
+    yts.linkTo(flatRate(0.03, Actual365Fixed()));
+
+    auto index = ext::make_shared<Euribor6M>(yts);
+    Date effectiveDate(19, January, 2026);
+
+    // settlementDays first, then effectiveDate
+    BOOST_CHECK_EXCEPTION(
+        ext::shared_ptr<VanillaSwap> swap =
+            MakeVanillaSwap(5 * Years, index, 0.03)
+                .withSettlementDays(2)
+                .withEffectiveDate(effectiveDate),
+        Error,
+        ExpectedErrorMessage("cannot set both"));
+
+    // effectiveDate first, then settlementDays
+    BOOST_CHECK_EXCEPTION(
+        ext::shared_ptr<VanillaSwap> swap =
+            MakeVanillaSwap(5 * Years, index, 0.03)
+                .withEffectiveDate(effectiveDate)
+                .withSettlementDays(2),
+        Error,
+        ExpectedErrorMessage("cannot set both"));
+
+    // withSettlementDays alone works
+    ext::shared_ptr<VanillaSwap> swap1 =
+        MakeVanillaSwap(5 * Years, index, 0.03)
+            .withSettlementDays(2);
+    BOOST_CHECK(swap1->startDate() != Date());
+
+    // withEffectiveDate alone works
+    ext::shared_ptr<VanillaSwap> swap2 =
+        MakeVanillaSwap(5 * Years, index, 0.03)
+            .withEffectiveDate(effectiveDate);
+    BOOST_CHECK_EQUAL(swap2->startDate(), effectiveDate);
+
+    // neither set (constructor defaults) works
+    ext::shared_ptr<VanillaSwap> swap3 =
+        MakeVanillaSwap(5 * Years, index, 0.03);
+    BOOST_CHECK(swap3->startDate() != Date());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Fixes #1394. `MakeVanillaSwap::withSettlementDays()` silently cleared a previously set `effectiveDate_`, making behavior dependent on call order. As @lballabio noted, since the call order already makes it inconvenient to write generic code, the fix raises an exception to avoid misuse rather than having one silently dominate the other.

### What changed

**MakeVanillaSwap and MakeOIS** (`makevanillaswap.hpp/cpp`, `makeois.hpp/cpp`):
- Added a `bool settlementDaysExplicit_` flag (default `false`) to each class, set to `true` in `withSettlementDays()`.
- `withSettlementDays()` no longer clears `effectiveDate_`.
- A `QL_REQUIRE` in the conversion operator throws if both `effectiveDate_` is set and `settlementDaysExplicit_` is true. The constructor default (`Null<Natural>()`) does not trigger the exception — only an explicit `withSettlementDays()` call does.

**SwapRateHelper and OISRateHelper** (`ratehelpers.cpp`, `oisratehelper.cpp`):
- Both previously chained `.withSettlementDays(settlementDays_).withEffectiveDate(startDate_)`. Removed the unconditional `.withSettlementDays()` from the builder chain. Added a conditional call (`if (startDate_ == Date() && settlementDays_ != Null<Natural>())`) to preserve settlement days for the tenor-based constructor path, where no explicit start date is provided.

## Test plan

- [x] Added `testSettlementDaysEffectiveDateConflict` to both `swap.cpp` and `overnightindexedswap.cpp`:
  - Exception thrown for both call orderings (settlementDays-then-effectiveDate and reverse)
  - `withSettlementDays` alone works
  - `withEffectiveDate` alone works
  - Constructor defaults (neither set) work
- [x] All existing Swap, OIS, and PiecewiseYieldCurve tests pass