### PR TITLE
Add `withExerciseCalendar` to `MakeSwaption`

### DIFF
--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -53,14 +53,16 @@ namespace QuantLib {
 
     MakeSwaption::operator ext::shared_ptr<Swaption>() const {
 
-        const Calendar& fixingCalendar = swapIndex_->fixingCalendar();
+        const Calendar& calendar = exerciseCalendar_.empty()
+            ? swapIndex_->fixingCalendar()
+            : exerciseCalendar_;
         Date refDate = Settings::instance().evaluationDate();
         // if the evaluation date is not a business day
         // then move to the next business day
-        refDate = fixingCalendar.adjust(refDate);
+        refDate = calendar.adjust(refDate);
         if (fixingDate_ == Date())
-            fixingDate_ = fixingCalendar.advance(refDate, optionTenor_,
-                                                 optionConvention_);
+            fixingDate_ = calendar.advance(refDate, optionTenor_,
+                                           optionConvention_);
         if (exerciseDate_ == Date()) {
             exercise_ = ext::shared_ptr<Exercise>(new
                 EuropeanExercise(fixingDate_));
@@ -162,6 +164,11 @@ namespace QuantLib {
 
     MakeSwaption& MakeSwaption::withExerciseDate(const Date& date) {
         exerciseDate_ = date;
+        return *this;
+    }
+
+    MakeSwaption& MakeSwaption::withExerciseCalendar(const Calendar& cal) {
+        exerciseCalendar_ = cal;
         return *this;
     }
 

--- a/ql/instruments/makeswaption.hpp
+++ b/ql/instruments/makeswaption.hpp
@@ -60,6 +60,7 @@ namespace QuantLib {
         MakeSwaption& withSettlementMethod(Settlement::Method settlementMethod);
         MakeSwaption& withOptionConvention(BusinessDayConvention bdc);
         MakeSwaption& withExerciseDate(const Date&);
+        MakeSwaption& withExerciseCalendar(const Calendar&);
         MakeSwaption& withUnderlyingType(Swap::Type type);
         MakeSwaption& withIndexedCoupons(const ext::optional<bool>& b = true);
         MakeSwaption& withAtParCoupons(bool b = true);
@@ -76,6 +77,7 @@ namespace QuantLib {
         BusinessDayConvention optionConvention_;
         mutable Date fixingDate_;
         Date exerciseDate_;
+        Calendar exerciseCalendar_;
         mutable ext::shared_ptr<Exercise> exercise_;
 
         Rate strike_;

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -27,8 +27,11 @@
 #include "utilities.hpp"
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/instruments/swaption.hpp>
+#include <ql/instruments/makeswaption.hpp>
 #include <ql/instruments/makevanillaswap.hpp>
 #include <ql/instruments/makeois.hpp>
+#include <ql/indexes/swap/euriborswap.hpp>
+#include <ql/time/calendars/unitedstates.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/termstructures/yield/zerospreadedtermstructure.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
@@ -1141,6 +1144,52 @@ BOOST_AUTO_TEST_CASE(testSwaptionDeltaInBachelierModel) {
     BOOST_TEST_MESSAGE("Testing swaption delta in Bachelier model...");
 
     checkSwaptionDelta<BachelierSwaptionEngine>(true);
+}
+
+BOOST_AUTO_TEST_CASE(testMakeSwaptionWithExerciseCalendar) {
+
+    BOOST_TEST_MESSAGE("Testing MakeSwaption with exercise calendar override...");
+
+    // Use a specific date where TARGET and US Settlement diverge:
+    // 1Y advance from Oct 9, 2015 gives Oct 10, 2016 (TARGET)
+    // vs Oct 11, 2016 (US), because Oct 10 is Columbus Day.
+    Date today(9, October, 2015);
+    Settings::instance().evaluationDate() = today;
+    RelinkableHandle<YieldTermStructure> termStructure;
+    termStructure.linkTo(flatRate(today, 0.05, Actual365Fixed()));
+
+    auto swapIndex = ext::make_shared<EuriborSwapIsdaFixA>(5*Years, termStructure);
+    Calendar targetCalendar = swapIndex->fixingCalendar();
+    Calendar usCalendar = UnitedStates(UnitedStates::Settlement);
+
+    // Default uses swap index's fixing calendar (TARGET)
+    Swaption defaultSwaption =
+        MakeSwaption(swapIndex, 1*Years, 0.05);
+    Date defaultExercise = defaultSwaption.exercise()->dates().front();
+
+    Date expected = targetCalendar.advance(
+        targetCalendar.adjust(today), 1*Years, ModifiedFollowing);
+    BOOST_CHECK_EQUAL(defaultExercise, expected);
+
+    // With custom calendar, exercise date differs
+    Swaption customSwaption =
+        MakeSwaption(swapIndex, 1*Years, 0.05)
+            .withExerciseCalendar(usCalendar);
+    Date customExercise = customSwaption.exercise()->dates().front();
+
+    Date expectedCustom = usCalendar.advance(
+        usCalendar.adjust(today), 1*Years, ModifiedFollowing);
+    BOOST_CHECK_EQUAL(customExercise, expectedCustom);
+    BOOST_CHECK_NE(customExercise, defaultExercise);
+
+    // Explicit withExerciseDate takes precedence over calendar
+    Date explicitDate = targetCalendar.advance(today, 6*Months);
+    Date fixingDate = targetCalendar.advance(today, 1*Years);
+    Swaption explicitSwaption =
+        MakeSwaption(swapIndex, fixingDate, 0.05)
+            .withExerciseCalendar(usCalendar)
+            .withExerciseDate(explicitDate);
+    BOOST_CHECK_EQUAL(explicitSwaption.exercise()->dates().front(), explicitDate);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Add `withExerciseCalendar(const Calendar&)` to `MakeSwaption`, allowing
  the calendar used for exercise/fixing date computation to be overridden
  independently of the swap index's fixing calendar
- Defaults to current behavior (`swapIndex->fixingCalendar()`) when not set
- Useful for cross-border swaptions where exercise dates follow a different
  calendar than the underlying rate's fixing calendar (e.g. ISDA Settlement
  Matrix overrides)

Closes #2469.

## Test plan
- [x] Default construction produces same exercise date as before
- [x] Custom calendar (US Settlement vs TARGET) produces correctly adjusted exercise date
- [x] `withExerciseDate()` takes precedence over calendar when both are set
- [x] All existing swaption tests pass