### PR TITLE
Add `smileSection(...)` methods to `BlackVolTermStructure`

### DIFF
--- a/ql/shared_ptr.hpp
+++ b/ql/shared_ptr.hpp
@@ -43,6 +43,7 @@ namespace QuantLib::ext {
         using std::static_pointer_cast;          // NOLINT(misc-unused-using-decls)
         using std::dynamic_pointer_cast;         // NOLINT(misc-unused-using-decls)
         using std::enable_shared_from_this;      // NOLINT(misc-unused-using-decls)
+        using std::bad_weak_ptr;                 // NOLINT(misc-unused-using-decls)
         #else
         using boost::shared_ptr;                 // NOLINT(misc-unused-using-decls)
         using boost::weak_ptr;                   // NOLINT(misc-unused-using-decls)
@@ -50,6 +51,7 @@ namespace QuantLib::ext {
         using boost::static_pointer_cast;        // NOLINT(misc-unused-using-decls)
         using boost::dynamic_pointer_cast;       // NOLINT(misc-unused-using-decls)
         using boost::enable_shared_from_this;    // NOLINT(misc-unused-using-decls)
+        using boost::bad_weak_ptr;               // NOLINT(misc-unused-using-decls)
         #endif
 
     }

--- a/ql/termstructures/volatility/equityfx/blackvolsurfacedelta.cpp
+++ b/ql/termstructures/volatility/equityfx/blackvolsurfacedelta.cpp
@@ -2,6 +2,7 @@
  Copyright (C) 2019 Quaternion Risk Management Ltd
  Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
  Copyright (C) 2025 Paolo D'Elia
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -206,7 +207,7 @@ namespace QuantLib {
         return blackVolSmile(timeFromReference(d));
     }
 
-    Real BlackVolatilitySurfaceDelta::forward(Time t) const {
+    Real BlackVolatilitySurfaceDelta::atmLevel(Time t) const {
         return spot_->value() * foreignTS_->discount(t) / domesticTS_->discount(t); // TODO
     }
 
@@ -221,7 +222,7 @@ namespace QuantLib {
                 return interpolators_[putDeltas_.size()]->blackVol(tme, Null<Real>(), true);
             } else {
                 // set strike to be fwd and we will return ATMF
-                strike = forward(tme);
+                strike = atmLevel(tme);
             }
         }
         return blackVolSmile(tme)->volatility(strike);

--- a/ql/termstructures/volatility/equityfx/blackvolsurfacedelta.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvolsurfacedelta.hpp
@@ -2,6 +2,7 @@
  Copyright (C) 2019 Quaternion Risk Management Ltd
  Copyright (C) 2022 Skandinaviska Enskilda Banken AB (publ)
  Copyright (C) 2025 Paolo D'Elia
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -111,6 +112,11 @@ namespace QuantLib {
         Real minStrike() const override { return 0; }
         Real maxStrike() const override { return QL_MAX_REAL; }
         //@}
+        //! \name BlackVolTermStructure interface
+        //@{
+        //! at-the-money level (forward) at time t
+        Real atmLevel(Time t) const override;
+        //@}
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
@@ -187,9 +193,6 @@ namespace QuantLib {
         DeltaVolQuote::AtmType longTermAtmType_;
         DeltaVolQuote::DeltaType longTermAtmDeltaType_;
         Real switchTime_;
-
-        // calculate forward for time $t$
-        Real forward(Time t) const;
     };
 
     // inline definitions

--- a/ql/termstructures/volatility/equityfx/blackvoltermstructure.cpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltermstructure.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2002, 2003 Ferdinando Ametrano
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -18,8 +19,32 @@
 */
 
 #include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
+#include <ql/termstructures/volatility/smilesection.hpp>
 
 namespace QuantLib {
+
+    namespace {
+
+        class BlackVolSmileSectionAdapter : public SmileSection {
+          public:
+            BlackVolSmileSectionAdapter(
+                ext::shared_ptr<const BlackVolTermStructure> vol,
+                Time t)
+            : SmileSection(t, vol->dayCounter()), vol_(std::move(vol)) {}
+            Real minStrike() const override { return vol_->minStrike(); }
+            Real maxStrike() const override { return vol_->maxStrike(); }
+            Real atmLevel() const override {
+                return vol_->atmLevel(exerciseTime());
+            }
+          protected:
+            Volatility volatilityImpl(Rate strike) const override {
+                return vol_->blackVol(exerciseTime(), strike, true);
+            }
+          private:
+            ext::shared_ptr<const BlackVolTermStructure> vol_;
+        };
+
+    }
 
     BlackVolTermStructure::BlackVolTermStructure(BusinessDayConvention bdc,
                                                  const DayCounter& dc)
@@ -150,5 +175,22 @@ namespace QuantLib {
                                                     BusinessDayConvention bdc,
                                                     const DayCounter& dc)
     : BlackVolTermStructure(settlementDays, cal, bdc, dc) {}
+
+    ext::shared_ptr<SmileSection>
+    BlackVolTermStructure::smileSectionImpl(Time t) const {
+        try {
+            return ext::make_shared<BlackVolSmileSectionAdapter>(
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+                ext::dynamic_pointer_cast<const BlackVolTermStructure>(
+                    shared_from_this()),
+#else
+                shared_from_this(),
+#endif
+                t);
+        } catch (const ext::bad_weak_ptr&) {
+            QL_FAIL("smileSection() requires the BlackVolTermStructure "
+                    "to be held by a shared_ptr");
+        }
+    }
 
 }

--- a/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2002, 2003 Ferdinando Ametrano
  Copyright (C) 2003, 2004, 2005, 2006 StatPro Italia srl
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -30,14 +31,24 @@
 
 namespace QuantLib {
 
+    class SmileSection;
+
     //! Black-volatility term structure
     /*! This abstract class defines the interface of concrete
         Black-volatility term structures which will be derived from
         this one.
 
         Volatilities are assumed to be expressed on an annual basis.
+
+        Instances are expected to be held by \c shared_ptr; the default
+        \c smileSectionImpl() adapter uses \c shared_from_this() to keep
+        the surface alive for as long as the returned SmileSection.
     */
-    class BlackVolTermStructure : public VolatilityTermStructure {
+    class BlackVolTermStructure : public VolatilityTermStructure
+#ifndef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+                                  , public ext::enable_shared_from_this<BlackVolTermStructure>
+#endif
+    {
       public:
         /*! \name Constructors
             See the TermStructure documentation for issues regarding
@@ -102,6 +113,17 @@ namespace QuantLib {
                                   Real strike,
                                   bool extrapolate = false) const;
         //@}
+        //! \name Smile
+        //@{
+        //! at-the-money level at time t, or \c Null<Real>() if not known
+        virtual Real atmLevel(Time t) const { return Null<Real>(); }
+        //! returns the smile for a given option date
+        ext::shared_ptr<SmileSection> smileSection(const Date& maturity,
+                                                   bool extrapolate = false) const;
+        //! returns the smile for a given option time
+        ext::shared_ptr<SmileSection> smileSection(Time maturity,
+                                                   bool extrapolate = false) const;
+        //@}
         //! \name Visitability
         //@{
         virtual void accept(AcyclicVisitor&);
@@ -119,6 +141,14 @@ namespace QuantLib {
         virtual Real blackVarianceImpl(Time t, Real strike) const = 0;
         //! Black volatility calculation
         virtual Volatility blackVolImpl(Time t, Real strike) const = 0;
+        /*! Smile section calculation.  The default implementation wraps
+            the vol surface into a SmileSection adapter that holds a
+            \c shared_ptr to \c *this (via \c shared_from_this()), so the
+            surface stays alive for the lifetime of the returned section.
+            Derived classes with a native smile representation can override
+            to return self-contained objects.
+        */
+        virtual ext::shared_ptr<SmileSection> smileSectionImpl(Time t) const;
         //@}
     };
 
@@ -246,6 +276,20 @@ namespace QuantLib {
         checkRange(t, extrapolate);
         checkStrike(strike, extrapolate);
         return blackVarianceImpl(t, strike);
+    }
+
+    inline ext::shared_ptr<SmileSection>
+    BlackVolTermStructure::smileSection(const Date& d,
+                                         bool extrapolate) const {
+        checkRange(d, extrapolate);
+        return smileSectionImpl(timeFromReference(d));
+    }
+
+    inline ext::shared_ptr<SmileSection>
+    BlackVolTermStructure::smileSection(Time t,
+                                         bool extrapolate) const {
+        checkRange(t, extrapolate);
+        return smileSectionImpl(t);
     }
 
     inline void BlackVolTermStructure::accept(AcyclicVisitor& v) {

--- a/ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.cpp
+++ b/ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2026 Rich Amaya
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -18,6 +19,7 @@
 */
 
 #include <ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.hpp>
+#include <ql/math/comparison.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/termstructures/volatility/interpolatedsmilesection.hpp>
 #include <ql/utilities/null.hpp>
@@ -155,6 +157,14 @@ namespace QuantLib {
 
         return ext::make_shared<PiecewiseBlackVarianceSurface>(
             referenceDate, dates, std::move(sections), dc);
+    }
+
+    ext::shared_ptr<SmileSection>
+    PiecewiseBlackVarianceSurface::smileSectionImpl(Time t) const {
+        auto it = std::lower_bound(times_.begin(), times_.end(), t);
+        if (it != times_.end() && close_enough(t, *it))
+            return smileSections_[std::distance(times_.begin(), it)];
+        return BlackVarianceTermStructure::smileSectionImpl(t);
     }
 
     void PiecewiseBlackVarianceSurface::accept(AcyclicVisitor& v) {

--- a/ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.hpp
+++ b/ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2026 Rich Amaya
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -76,6 +77,7 @@ namespace QuantLib {
 
       protected:
         Real blackVarianceImpl(Time t, Real strike) const override;
+        ext::shared_ptr<SmileSection> smileSectionImpl(Time t) const override;
 
       private:
         Real sectionVariance(Size i, Real strike) const;

--- a/test-suite/blackvolsurfacedelta.cpp
+++ b/test-suite/blackvolsurfacedelta.cpp
@@ -2,6 +2,7 @@
  Copyright (C) 2019 Quaternion Risk Management Ltd
  Copyright (C) 2020 Skandinaviska Enskilda Banken AB (publ)
  Copyright (C) 2025 Paolo D'Elia
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -21,11 +22,13 @@
 #include "utilities.hpp"
 #include <boost/make_shared.hpp>
 #include <boost/test/unit_test.hpp>
+#include <ql/pricingengines/blackformula.hpp>
 #include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/equityfx/blackvolsurfacedelta.hpp>
+#include <ql/termstructures/volatility/smilesection.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actualactual.hpp>
-#include <ql/termstructures/volatility/equityfx/blackvolsurfacedelta.hpp>
 
 using namespace boost::unit_test_framework;
 using namespace QuantLib;
@@ -291,6 +294,63 @@ BOOST_AUTO_TEST_CASE(testSmileInterpolation) {
     QL_CHECK_CLOSE(smile->volatility(smile->minStrike() - 0.5), 0.0, 1e-8);
     QL_CHECK_CLOSE(smile->volatility(smile->maxStrike() + 0.5), 0.0, 1e-8);
 
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionWithAtmLevel) {
+    BOOST_TEST_MESSAGE(
+        "Testing SmileSection from a vol surface that overrides "
+        "atmLevel(Time)...");
+
+    // BlackVolatilitySurfaceDelta carries spot + yield curves and overrides
+    // atmLevel(Time), so the SmileSection returned by smileSection() has a
+    // usable atmLevel() and its optionPrice() works without throwing.
+
+    Date refDate(1, January, 2010);
+    Settings::instance().evaluationDate() = refDate;
+    DayCounter dc = ActualActual(ActualActual::ISDA);
+
+    std::vector<Date> dates = {Date(1, January, 2011), Date(1, January, 2012)};
+    std::vector<Real> putDeltas = {-0.25};
+    std::vector<Real> callDeltas = {0.25};
+    Matrix volMatrix(2, 2, 0.10);
+
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(1.0));
+    Handle<YieldTermStructure> dts(
+        ext::make_shared<FlatForward>(refDate, 0.011, dc));
+    Handle<YieldTermStructure> fts(
+        ext::make_shared<FlatForward>(refDate, 0.012, dc));
+
+    auto surface = ext::make_shared<BlackVolatilitySurfaceDelta>(
+        refDate, dates, putDeltas, callDeltas, false, volMatrix,
+        dc, TARGET(), spot, dts, fts);
+
+    Date maturity(1, July, 2011);
+    auto smile = surface->smileSection(maturity);
+
+    // atmLevel matches spot * df_q / df_r (FX-style forward)
+    Real expectedFwd = spot->value()
+                     * fts->discount(maturity) / dts->discount(maturity);
+    Real atm = smile->atmLevel();
+    Real tolerance = 1.0e-12;
+    if (std::fabs(atm - expectedFwd) > tolerance)
+        BOOST_FAIL("smile atmLevel mismatch"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    calculated: " << atm
+                   << "\n    expected  : " << expectedFwd);
+
+    // optionPrice() works (without the atmLevel(Time) override it would
+    // throw a QL_REQUIRE) and matches the Black formula at the forward.
+    DiscountFactor df = dts->discount(maturity);
+    Real callPrice = smile->optionPrice(expectedFwd, Option::Call, df);
+    Time T = surface->timeFromReference(maturity);
+    Volatility vol = smile->volatility(expectedFwd);
+    Real expectedCall = blackFormula(Option::Call, expectedFwd, expectedFwd,
+                                      vol * std::sqrt(T), df);
+    if (std::fabs(callPrice - expectedCall) > tolerance)
+        BOOST_FAIL("smile optionPrice mismatch"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    calculated: " << callPrice
+                   << "\n    expected  : " << expectedCall);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/piecewiseblackvariancesurface.cpp
+++ b/test-suite/piecewiseblackvariancesurface.cpp
@@ -36,6 +36,7 @@
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
 #include <ql/termstructures/volatility/equityfx/localvolsurface.hpp>
+#include <ql/termstructures/volatility/smilesection.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <cmath>
@@ -1104,6 +1105,124 @@ BOOST_AUTO_TEST_CASE(testLocalVolFdPricingFromSabrSmiles) {
             }
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionFromBlackVolSurface) {
+    BOOST_TEST_MESSAGE(
+        "Testing SmileSection extraction from BlackVolTermStructure...");
+
+    Date today(15, January, 2026);
+    Settings::instance().evaluationDate() = today;
+    DayCounter dc = Actual365Fixed();
+
+    // 1. Vol-native surface (default adapter path)
+    // BlackConstantVol has no native SmileSection — the base class
+    // adapter wraps blackVol() into a SmileSection on the fly.
+    Volatility flatVol = 0.20;
+    auto constVol = ext::make_shared<BlackConstantVol>(today, NullCalendar(),
+                                                       flatVol, dc);
+
+    Date maturity = today + 1*Years;
+    auto smile = constVol->smileSection(maturity);
+
+    Real tolerance = 1.0e-12;
+    for (Real strike : {80.0, 100.0, 120.0}) {
+        Volatility v = smile->volatility(strike);
+        if (std::fabs(v - flatVol) > tolerance)
+            BOOST_FAIL("vol-native: failed to reproduce flat vol"
+                       << std::fixed << std::setprecision(12)
+                       << "\n    strike:     " << strike
+                       << "\n    expected:   " << flatVol
+                       << "\n    calculated: " << v);
+    }
+
+    // 2. Smile-native surface, at a stored tenor (override path)
+    // PiecewiseBlackVarianceSurface stores SmileSection objects and
+    // overrides smileSectionImpl() to return them directly at stored tenors.
+    Date d1 = today + 6*Months;
+    Date d2 = today + 1*Years;
+    std::vector<Real> strikes = {80.0, 90.0, 100.0, 110.0, 120.0};
+    std::vector<Real> vols1 = {0.30, 0.25, 0.20, 0.22, 0.28};
+    std::vector<Real> vols2 = {0.28, 0.23, 0.19, 0.21, 0.26};
+    Time T1 = dc.yearFraction(today, d1);
+    Time T2 = dc.yearFraction(today, d2);
+    Real sqrtT1 = std::sqrt(T1);
+    Real sqrtT2 = std::sqrt(T2);
+
+    std::vector<Real> stdDevs1, stdDevs2;
+    for (auto v : vols1)
+        stdDevs1.push_back(v * sqrtT1);
+    for (auto v : vols2)
+        stdDevs2.push_back(v * sqrtT2);
+
+    auto section1 = ext::make_shared<InterpolatedSmileSection<Linear>>(
+        d1, strikes, stdDevs1, 100.0, dc, Linear(), today);
+    auto section2 = ext::make_shared<InterpolatedSmileSection<Linear>>(
+        d2, strikes, stdDevs2, 100.0, dc, Linear(), today);
+    auto surface = ext::make_shared<PiecewiseBlackVarianceSurface>(
+        today, std::vector<Date>{d1, d2},
+        std::vector<ext::shared_ptr<SmileSection>>{section1, section2}, dc);
+
+    // At a stored tenor: should return the same SmileSection object (pointer equality)
+    auto smile1 = surface->smileSection(d1);
+    if (smile1.get() != section1.get())
+        BOOST_FAIL("at stored tenor: smileSection(d1) did not return "
+                   "the stored SmileSection (pointer mismatch)");
+
+    auto smile2 = surface->smileSection(d2);
+    if (smile2.get() != section2.get())
+        BOOST_FAIL("at stored tenor: smileSection(d2) did not return "
+                   "the stored SmileSection (pointer mismatch)");
+
+    // At a stored tenor: volatilities should match exactly
+    for (Size i = 0; i < strikes.size(); ++i) {
+        Volatility surfaceVol = surface->blackVol(d1, strikes[i]);
+        Volatility sectionVol = smile1->volatility(strikes[i]);
+        if (std::fabs(surfaceVol - sectionVol) > tolerance)
+            BOOST_FAIL("at stored tenor: vol mismatch"
+                       << std::fixed << std::setprecision(12)
+                       << "\n    strike:      " << strikes[i]
+                       << "\n    surface vol: " << surfaceVol
+                       << "\n    section vol: " << sectionVol);
+    }
+
+    // 3. Smile-native surface, between tenors (adapter fallback path)
+    // Between stored tenors, smileSectionImpl() falls back to the
+    // default adapter which queries blackVol() per strike.
+    Date dMid = today + 9*Months;
+    auto smileMid = surface->smileSection(dMid);
+
+    // Between tenors: should NOT be either stored section (it's an adapter)
+    if (smileMid.get() == section1.get() || smileMid.get() == section2.get())
+        BOOST_FAIL("between tenors: smileSection(dMid) should not "
+                   "return a stored SmileSection");
+
+    // Between tenors: adapter should reproduce blackVol() at each strike
+    for (Size i = 0; i < strikes.size(); ++i) {
+        Volatility surfaceVol = surface->blackVol(dMid, strikes[i]);
+        Volatility sectionVol = smileMid->volatility(strikes[i]);
+        if (std::fabs(surfaceVol - sectionVol) > tolerance)
+            BOOST_FAIL("between tenors: vol mismatch"
+                       << std::fixed << std::setprecision(12)
+                       << "\n    strike:      " << strikes[i]
+                       << "\n    surface vol: " << surfaceVol
+                       << "\n    section vol: " << sectionVol);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRequiresSharedPtr) {
+    BOOST_TEST_MESSAGE(
+        "Testing smileSection() throws on stack-allocated surface...");
+
+    Date today(15, January, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    // Stack-allocated surface: smileSection() should throw, not crash with UB.
+    BlackConstantVol surface(today, NullCalendar(), 0.20, Actual365Fixed());
+    BOOST_CHECK_EXCEPTION(
+        surface.smileSection(today + 1 * Years), QuantLib::Error,
+        ExpectedErrorMessage(
+            "requires the BlackVolTermStructure to be held by a shared_ptr"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR proposes adding `smileSection(Date/Time)` to `BlackVolTermStructure`, making EQ/FX vol surfaces in line with the IR ones (`OptionletVolatilityStructure`, `SwaptionVolatilityStructure`).

- Public non-virtual `smileSection()`
- Protected virtual `smileSectionImpl(Time)` provides a default adapter that wraps `blackVol()` into a `SmileSection`
- All existing derived classes would get a working `smileSection()` with no code changes

Unlike the IR vol structures where `smileSectionImpl` is pure virtual, the default adapter here means vol-native classes (`BlackConstantVol`, `HestonBlackVolSurface`, etc.) would work out of the box. Smile-native classes can override for efficiency: `PiecewiseBlackVarianceSurface` does so in this PR, returning its stored `SmileSection` directly at stored tenors. `BlackVolatilitySurfaceDelta` is another candidate: its existing `blackVolSmile()` methods are functionally equivalent to `smileSection()` and could be refactored to override `smileSectionImpl()` in a follow-up.

**Motivation:** From the discussions in #2443, #2478, and #2368, and increasing use of `SmileSection` for EQ/FX vol surfaces (`PiecewiseBlackVarianceSurface` and `BlackVolatilitySurfaceDelta`), the base class not returning them felt like a gap (there was no way to get a `SmileSection` from a `PiecewiseBlackVarianceSurface` and users needing one from any other `BlackVolTermStructure` would have to write their own adapter each time). Happy to adjust and would love to hear your thoughts on this.

**Tests:** default adapter (BlackConstantVol), override at stored tenor with pointer equality (PiecewiseBlackVarianceSurface), adapter fallback between tenors. Full suite passes.
