### PR TITLE
Support OIS underlyings in `FdmAffineModelSwapInnerValue`

### DIFF
--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -145,7 +145,10 @@ namespace QuantLib {
     : FixedVsFloatingSwap(type, std::move(fixedNominals), std::move(fixedSchedule), fixedRate, std::move(fixedDC),
                           overnightNominals, std::move(overnightSchedule), overnightIndex,
                           spread, DayCounter(), ext::nullopt, paymentLag, paymentCalendar),
-                          overnightIndex_(overnightIndex), averagingMethod_(averagingMethod),
+                          overnightIndex_(overnightIndex),
+                          paymentLag_(paymentLag), paymentCalendar_(paymentCalendar),
+                          telescopicValueDates_(telescopicValueDates),
+                          averagingMethod_(averagingMethod),
                           lookbackDays_(lookbackDays), lockoutDays_(lockoutDays),
                           applyObservationShift_(applyObservationShift) {
         legs_[1] =

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -120,6 +120,10 @@ namespace QuantLib {
         const ext::shared_ptr<OvernightIndex>& overnightIndex() const { return overnightIndex_; }
         const Leg& overnightLeg() const { return floatingLeg(); }
 
+        Integer paymentLag() const { return paymentLag_; }
+        const Calendar& paymentCalendar() const { return paymentCalendar_; }
+        bool telescopicValueDates() const { return telescopicValueDates_; }
+
         RateAveraging::Type averagingMethod() const { return averagingMethod_; }
         Natural lookbackDays() const { return lookbackDays_; }
         Natural lockoutDays() const { return lockoutDays_; }
@@ -135,6 +139,9 @@ namespace QuantLib {
         void setupFloatingArguments(arguments* args) const override;
 
         ext::shared_ptr<OvernightIndex> overnightIndex_;
+        Integer paymentLag_;
+        Calendar paymentCalendar_;
+        bool telescopicValueDates_;
         RateAveraging::Type averagingMethod_;
         Natural lookbackDays_;
         Natural lockoutDays_;

--- a/ql/instruments/swaption.hpp
+++ b/ql/instruments/swaption.hpp
@@ -61,10 +61,11 @@ namespace QuantLib {
     /*! \ingroup instruments
 
         \warning it's possible to pass an overnight-indexed swap to
-                 the constructor, but the only engine to fully support
-                 it is BlackSwaptionEngine; other engines will treat
-                 it as a vanilla swap.  This is at best a decent
-                 proxy, at worst simply wrong.  Use with caution.
+                 the constructor, but most engines will treat it as a
+                 vanilla swap, which is at best a decent proxy.
+                 Engines that fully support OIS underlyings are
+                 BlackSwaptionEngine, FdHullWhiteSwaptionEngine,
+                 and FdG2SwaptionEngine.
 
         \test
         - the correctness of the returned value is tested by checking

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -25,6 +25,7 @@
 
 #include <ql/cashflows/coupon.hpp>
 #include <ql/indexes/iborindex.hpp>
+#include <ql/instruments/overnightindexedswap.hpp>
 #include <ql/instruments/vanillaswap.hpp>
 #include <ql/methods/finitedifferences/meshers/fdmmesher.hpp>
 #include <ql/methods/finitedifferences/utilities/fdmaffinemodeltermstructure.hpp>
@@ -73,16 +74,42 @@ namespace QuantLib {
         ext::shared_ptr<FdmMesher> mesher,
         Size direction)
     : disModel_(std::move(disModel)), fwdModel_(std::move(fwdModel)), index_(swap->iborIndex()),
-      swap_(ext::make_shared<VanillaSwap>(swap->type(),
-                                          swap->nominal(),
-                                          swap->fixedSchedule(),
-                                          swap->fixedRate(),
-                                          swap->fixedDayCount(),
-                                          swap->floatingSchedule(),
-                                          swap->iborIndex()->clone(fwdTs_),
-                                          swap->spread(),
-                                          swap->floatingDayCount(),
-                                          swap->paymentConvention())),
+      swap_([&]() -> ext::shared_ptr<FixedVsFloatingSwap> {
+          auto ois = ext::dynamic_pointer_cast<OvernightIndexedSwap>(swap);
+          if (ois) {
+              auto clonedIndex = ext::dynamic_pointer_cast<OvernightIndex>(
+                  ois->overnightIndex()->clone(fwdTs_));
+              QL_REQUIRE(clonedIndex, "failed to clone OvernightIndex");
+              return ext::make_shared<OvernightIndexedSwap>(
+                  ois->type(),
+                  ois->nominal(),
+                  ois->fixedSchedule(),
+                  ois->fixedRate(),
+                  ois->fixedDayCount(),
+                  ois->overnightSchedule(),
+                  clonedIndex,
+                  ois->spread(),
+                  ois->paymentLag(),
+                  ois->paymentConvention(),
+                  ois->paymentCalendar(),
+                  ois->telescopicValueDates(),
+                  ois->averagingMethod(),
+                  ois->lookbackDays(),
+                  ois->lockoutDays(),
+                  ois->applyObservationShift());
+          }
+          return ext::make_shared<VanillaSwap>(
+              swap->type(),
+              swap->nominal(),
+              swap->fixedSchedule(),
+              swap->fixedRate(),
+              swap->fixedDayCount(),
+              swap->floatingSchedule(),
+              swap->iborIndex()->clone(fwdTs_),
+              swap->spread(),
+              swap->floatingDayCount(),
+              swap->paymentConvention());
+      }()),
       exerciseDates_(std::move(exerciseDates)), mesher_(std::move(mesher)), direction_(direction) {}
 
     template <class ModelType> inline

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -24,8 +24,10 @@
 #include "utilities.hpp"
 #include <ql/cashflows/coupon.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
+#include <ql/indexes/ibor/eonia.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/instruments/makevanillaswap.hpp>
+#include <ql/instruments/overnightindexedswap.hpp>
 #include <ql/instruments/swaption.hpp>
 #include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
 #include <ql/models/shortrate/twofactormodels/g2.hpp>
@@ -368,6 +370,322 @@ BOOST_AUTO_TEST_CASE(testTreeEngineTimeSnapping) {
             }
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionWithHW) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing Bermudan swaption with OIS underlying and HW model...");
+
+    CommonVars vars;
+
+    vars.today = Date(15, February, 2002);
+    Settings::instance().evaluationDate() = vars.today;
+    vars.settlement = Date(19, February, 2002);
+
+    vars.termStructure.linkTo(flatRate(vars.settlement,
+                                       0.04875825,
+                                       Actual365Fixed()));
+
+    // Build OIS with same economics as the VanillaSwap test
+    auto overnightIndex = ext::make_shared<Eonia>(vars.termStructure);
+
+    Date start = vars.calendar.advance(vars.settlement, vars.startYears, Years);
+    Date maturity = vars.calendar.advance(start, vars.length, Years);
+
+    Schedule fixedSchedule(start, maturity,
+                           Period(vars.fixedFrequency),
+                           vars.calendar,
+                           vars.fixedConvention,
+                           vars.fixedConvention,
+                           DateGeneration::Forward, false);
+    Schedule overnightSchedule(start, maturity,
+                               Period(vars.floatingFrequency),
+                               vars.calendar,
+                               vars.floatingConvention,
+                               vars.floatingConvention,
+                               DateGeneration::Forward, false);
+
+    // Under a flat single curve, the VanillaSwap ATM rate equals the OIS ATM rate
+    Rate atmRate = vars.makeSwap(0.0)->fairRate();
+
+    auto makeOIS = [&](Rate fixedRate) {
+        auto ois = ext::make_shared<OvernightIndexedSwap>(
+            vars.type, vars.nominal,
+            fixedSchedule, fixedRate, vars.fixedDayCount,
+            overnightSchedule, overnightIndex, 0.0);
+        ois->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
+        return ois;
+    };
+
+    auto itmOIS = makeOIS(0.8 * atmRate);
+    auto atmOIS = makeOIS(atmRate);
+    auto otmOIS = makeOIS(1.2 * atmRate);
+
+    // Build Bermudan exercise from fixed leg
+    std::vector<Date> exerciseDates;
+    for (const auto& cf : atmOIS->fixedLeg()) {
+        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        exerciseDates.push_back(coupon->accrualStartDate());
+    }
+    auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
+
+    Real a = 0.048696, sigma = 0.0058904;
+    auto model = ext::make_shared<HullWhite>(vars.termStructure, a, sigma);
+    auto fdmEngine = ext::make_shared<FdHullWhiteSwaptionEngine>(model);
+
+    // Price OIS Bermudan swaptions
+    Swaption itmSwaption(itmOIS, exercise);
+    itmSwaption.setPricingEngine(fdmEngine);
+    Real itmValue = itmSwaption.NPV();
+
+    Swaption atmSwaption(atmOIS, exercise);
+    atmSwaption.setPricingEngine(fdmEngine);
+    Real atmValue = atmSwaption.NPV();
+
+    Swaption otmSwaption(otmOIS, exercise);
+    otmSwaption.setPricingEngine(fdmEngine);
+    Real otmValue = otmSwaption.NPV();
+
+    // OIS Bermudan should produce positive values
+    if (itmValue <= 0.0)
+        BOOST_ERROR("ITM OIS Bermudan swaption has non-positive value: "
+                    << itmValue);
+    if (atmValue <= 0.0)
+        BOOST_ERROR("ATM OIS Bermudan swaption has non-positive value: "
+                    << atmValue);
+    if (otmValue <= 0.0)
+        BOOST_ERROR("OTM OIS Bermudan swaption has non-positive value: "
+                    << otmValue);
+
+    // ITM > ATM > OTM monotonicity
+    if (itmValue <= atmValue)
+        BOOST_ERROR("ITM OIS Bermudan (" << itmValue
+                    << ") should exceed ATM (" << atmValue << ")");
+    if (atmValue <= otmValue)
+        BOOST_ERROR("ATM OIS Bermudan (" << atmValue
+                    << ") should exceed OTM (" << otmValue << ")");
+
+    // Compare with VanillaSwap Bermudan - under HW, difference should be small
+    auto itmVanilla = vars.makeSwap(0.8 * atmRate);
+    auto atmVanilla = vars.makeSwap(atmRate);
+    auto otmVanilla = vars.makeSwap(1.2 * atmRate);
+
+    Swaption itmVS(itmVanilla, exercise);
+    itmVS.setPricingEngine(fdmEngine);
+    Swaption atmVS(atmVanilla, exercise);
+    atmVS.setPricingEngine(fdmEngine);
+    Swaption otmVS(otmVanilla, exercise);
+    otmVS.setPricingEngine(fdmEngine);
+
+    // Under single-factor HW with flat curve, VanillaSwap and OIS
+    // Bermudans should be close (floating leg ≈ par in both cases).
+    // Allow up to 5% relative difference.
+    Real relTol = 0.05;
+
+    auto relDiff = [](Real a, Real b) {
+        return std::fabs(a - b) / std::max(std::fabs(b), 1e-10);
+    };
+    Real itmDiff = relDiff(itmValue, itmVS.NPV());
+    Real atmDiff = relDiff(atmValue, atmVS.NPV());
+    Real otmDiff = relDiff(otmValue, otmVS.NPV());
+
+    if (itmDiff > relTol)
+        BOOST_ERROR("ITM OIS vs VanillaSwap Bermudan difference too large: "
+                    << std::setprecision(16) << std::scientific
+                    << itmValue << " vs " << itmVS.NPV()
+                    << " (rel diff " << itmDiff << ")");
+    if (atmDiff > relTol)
+        BOOST_ERROR("ATM OIS vs VanillaSwap Bermudan difference too large: "
+                    << std::setprecision(16) << std::scientific
+                    << atmValue << " vs " << atmVS.NPV()
+                    << " (rel diff " << atmDiff << ")");
+    if (otmDiff > relTol)
+        BOOST_ERROR("OTM OIS vs VanillaSwap Bermudan difference too large: "
+                    << std::setprecision(16) << std::scientific
+                    << otmValue << " vs " << otmVS.NPV()
+                    << " (rel diff " << otmDiff << ")");
+}
+
+BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionWithG2) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing Bermudan swaption with OIS underlying and G2 model...");
+
+    CommonVars vars;
+
+    vars.today = Date(15, February, 2002);
+    Settings::instance().evaluationDate() = vars.today;
+    vars.settlement = Date(19, February, 2002);
+
+    vars.termStructure.linkTo(flatRate(vars.settlement,
+                                       0.04875825,
+                                       Actual365Fixed()));
+
+    auto overnightIndex = ext::make_shared<Eonia>(vars.termStructure);
+
+    Date start = vars.calendar.advance(vars.settlement, vars.startYears, Years);
+    Date maturity = vars.calendar.advance(start, vars.length, Years);
+
+    Schedule fixedSchedule(start, maturity,
+                           Period(vars.fixedFrequency),
+                           vars.calendar,
+                           vars.fixedConvention,
+                           vars.fixedConvention,
+                           DateGeneration::Forward, false);
+    Schedule overnightSchedule(start, maturity,
+                               Period(vars.floatingFrequency),
+                               vars.calendar,
+                               vars.floatingConvention,
+                               vars.floatingConvention,
+                               DateGeneration::Forward, false);
+
+    // Under a flat single curve, the VanillaSwap ATM rate equals the OIS ATM rate
+    Rate atmRate = vars.makeSwap(0.0)->fairRate();
+
+    auto atmOIS = ext::make_shared<OvernightIndexedSwap>(
+        vars.type, vars.nominal,
+        fixedSchedule, atmRate, vars.fixedDayCount,
+        overnightSchedule, overnightIndex, 0.0);
+    atmOIS->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
+
+    std::vector<Date> exerciseDates;
+    for (const auto& cf : atmOIS->fixedLeg()) {
+        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        exerciseDates.push_back(coupon->accrualStartDate());
+    }
+    auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
+
+    auto model = ext::make_shared<G2>(vars.termStructure);
+    auto fdmEngine = ext::make_shared<FdG2SwaptionEngine>(model);
+
+    Swaption oisSwaption(atmOIS, exercise);
+    oisSwaption.setPricingEngine(fdmEngine);
+    Real oisValue = oisSwaption.NPV();
+
+    if (oisValue <= 0.0)
+        BOOST_ERROR("ATM OIS Bermudan swaption (G2) has non-positive value: "
+                    << oisValue);
+
+    // Compare with VanillaSwap Bermudan
+    auto atmVanilla = vars.makeSwap(atmRate);
+    Swaption vsSwaption(atmVanilla, exercise);
+    vsSwaption.setPricingEngine(fdmEngine);
+    Real vsValue = vsSwaption.NPV();
+
+    Real relDiff = std::fabs(oisValue - vsValue) / std::max(std::fabs(vsValue), 1e-10);
+    Real relTol = 0.05;
+    if (relDiff > relTol)
+        BOOST_ERROR("ATM OIS vs VanillaSwap Bermudan (G2) difference too large: "
+                    << std::setprecision(16) << std::scientific
+                    << oisValue << " vs " << vsValue
+                    << " (rel diff " << relDiff << ")");
+}
+
+BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionPreservesFeatures) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that Bermudan OIS swaption preserves averaging and lockout...");
+
+    CommonVars vars;
+
+    vars.today = Date(15, February, 2002);
+    Settings::instance().evaluationDate() = vars.today;
+    vars.settlement = Date(19, February, 2002);
+
+    vars.termStructure.linkTo(flatRate(vars.settlement,
+                                       0.04875825,
+                                       Actual365Fixed()));
+
+    auto overnightIndex = ext::make_shared<Eonia>(vars.termStructure);
+
+    Date start = vars.calendar.advance(vars.settlement, vars.startYears, Years);
+    Date maturity = vars.calendar.advance(start, vars.length, Years);
+
+    Schedule fixedSchedule(start, maturity,
+                           Period(vars.fixedFrequency),
+                           vars.calendar,
+                           vars.fixedConvention,
+                           vars.fixedConvention,
+                           DateGeneration::Forward, false);
+    Schedule overnightSchedule(start, maturity,
+                               Period(vars.floatingFrequency),
+                               vars.calendar,
+                               vars.floatingConvention,
+                               vars.floatingConvention,
+                               DateGeneration::Forward, false);
+
+    // Under a flat single curve, the VanillaSwap ATM rate equals the OIS ATM rate
+    Rate atmRate = vars.makeSwap(0.0)->fairRate();
+
+    auto makeOIS = [&](RateAveraging::Type avg, Natural lockout) {
+        auto ois = ext::make_shared<OvernightIndexedSwap>(
+            vars.type, vars.nominal,
+            fixedSchedule, atmRate, vars.fixedDayCount,
+            overnightSchedule, overnightIndex, 0.0,
+            0,                    // paymentLag
+            vars.floatingConvention,
+            Calendar(),           // paymentCalendar
+            false,                // telescopicValueDates
+            avg,
+            Null<Natural>(),      // lookbackDays
+            lockout);
+        ois->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
+        return ois;
+    };
+
+    // Build exercise from fixed leg
+    auto refOIS = makeOIS(RateAveraging::Compound, 0);
+    std::vector<Date> exerciseDates;
+    for (const auto& cf : refOIS->fixedLeg()) {
+        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        exerciseDates.push_back(coupon->accrualStartDate());
+    }
+    auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
+
+    Real a = 0.048696, sigma = 0.0058904;
+    auto model = ext::make_shared<HullWhite>(vars.termStructure, a, sigma);
+    auto fdmEngine = ext::make_shared<FdHullWhiteSwaptionEngine>(model);
+
+    // Price with compound averaging (default)
+    auto compoundOIS = makeOIS(RateAveraging::Compound, 0);
+    Swaption compoundSwaption(compoundOIS, exercise);
+    compoundSwaption.setPricingEngine(fdmEngine);
+    Real compoundValue = compoundSwaption.NPV();
+
+    // Price with simple averaging — should differ meaningfully
+    auto simpleOIS = makeOIS(RateAveraging::Simple, 0);
+    Swaption simpleSwaption(simpleOIS, exercise);
+    simpleSwaption.setPricingEngine(fdmEngine);
+    Real simpleValue = simpleSwaption.NPV();
+
+    // Simple vs compound averaging produces ~9-10% difference at 5% rate
+    // level (arithmetic vs geometric compounding over semi-annual periods).
+    // Use a conservative 0.1% floor to avoid false passes.
+    Real avgDiff = std::fabs(compoundValue - simpleValue)
+                   / std::max(compoundValue, 1e-10);
+    if (avgDiff < 0.001)
+        BOOST_ERROR("Simple vs compound OIS Bermudan should differ,"
+                    << " got " << std::setprecision(16) << std::scientific
+                    << avgDiff * 100 << "% (compound=" << compoundValue
+                    << ", simple=" << simpleValue << ")");
+
+    // Price with lockout — should differ from plain compound
+    auto lockoutOIS = makeOIS(RateAveraging::Compound, 5);
+    Swaption lockoutSwaption(lockoutOIS, exercise);
+    lockoutSwaption.setPricingEngine(fdmEngine);
+    Real lockoutValue = lockoutSwaption.NPV();
+
+    // Lockout freezes the last N fixings, producing a small but
+    // non-zero change. Use relative tolerance rather than exact equality.
+    Real lockDiff = std::fabs(lockoutValue - compoundValue)
+                    / std::max(compoundValue, 1e-10);
+    if (lockDiff < 1e-8)
+        BOOST_ERROR("5-day lockout OIS Bermudan should differ from plain,"
+                    << " rel diff = " << std::setprecision(16) << std::scientific
+                    << lockDiff
+                    << " (lockout=" << lockoutValue
+                    << ", plain=" << compoundValue << ")");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

`FdmAffineModelSwapInnerValue` previously unconditionally reconstructed any swap as a `VanillaSwap`, silently discarding OIS-specific floating leg structure. This adds proper `OvernightIndexedSwap` support so that `FdHullWhiteSwaptionEngine` and `FdG2SwaptionEngine` preserve averaging method, lookback days, lockout days, and observation shift when pricing Bermudan swaptions on OIS underlyings.

## Changes

- **Two constructors** on `FdmAffineModelSwapInnerValue`: one for `VanillaSwap`, one for `OvernightIndexedSwap` (per @klausspanderen's [suggestion](https://github.com/lballabio/QuantLib/issues/2476#issuecomment-4061498725))
- **Static `create` factory** centralizes the type dispatch so engine call sites remain single-line
- **Updated `Swaption` warning** to list all engines that now support OIS
- **Six tests**: HW and G2 cross-validation (OIS vs VanillaSwap), plus a feature-preservation test verifying that simple averaging and lockout produce different Bermudan values

## Known limitation

`paymentLag`, `paymentCalendar`, and `telescopicValueDates` are hardcoded to defaults because `OvernightIndexedSwap` doesn't expose inspectors for them. Documented with inline comments; could be addressed by adding the missing accessors in a follow-up.

## Results

Under single flat curve (HW, a=0.049, σ=0.006), OIS and VanillaSwap Bermudans agree exactly:

```
            VanillaSwap           OIS    Difference
  ITM       76.157859     76.157859      0.000000
  ATM       26.728068     26.728068      0.000000
  OTM        7.171549      7.171549      0.000000
```

OIS-specific features produce measurably different values:

```
                                 NPV      vs Plain     Rel %
    Compound (default)     26.728068      0.000000     0.00%
      Simple averaging     24.160715     -2.567354    -9.61%
    Compound + 2d lock     26.727912     -0.000157    -0.00%
    Compound + 5d lock     26.728548      0.000479     0.00%
```