### PR TITLE
Add optional forward parameter to SmileSection pricing methods

### DIFF
--- a/ql/experimental/volatility/noarbsabrsmilesection.cpp
+++ b/ql/experimental/volatility/noarbsabrsmilesection.cpp
@@ -57,19 +57,19 @@ void NoArbSabrSmileSection::init() {
 }
 
 Real NoArbSabrSmileSection::optionPrice(Rate strike, Option::Type type,
-                                        Real discount) const {
+                                        Real discount, Real) const {
     Real call = model_->optionPrice(strike);
     return discount *
            (type == Option::Call ? call : call - (forward_ - strike));
 }
 
 Real NoArbSabrSmileSection::digitalOptionPrice(Rate strike, Option::Type type,
-                                               Real discount, Real) const {
+                                               Real discount, Real, Real) const {
     Real call = model_->digitalOptionPrice(strike);
     return discount * (type == Option::Call ? call : 1.0 - call);
 }
 
-Real NoArbSabrSmileSection::density(Rate strike, Real discount, Real) const {
+Real NoArbSabrSmileSection::density(Rate strike, Real discount, Real, Real) const {
     return discount * model_->density(strike);
 }
 

--- a/ql/experimental/volatility/noarbsabrsmilesection.hpp
+++ b/ql/experimental/volatility/noarbsabrsmilesection.hpp
@@ -49,12 +49,15 @@ class NoArbSabrSmileSection : public SmileSection {
     Real maxStrike() const override { return QL_MAX_REAL; }
     Real atmLevel() const override { return forward_; }
     Real
-    optionPrice(Rate strike, Option::Type type = Option::Call, Real discount = 1.0) const override;
+    optionPrice(Rate strike, Option::Type type = Option::Call, Real discount = 1.0,
+                Real forward = Null<Real>()) const override;
     Real digitalOptionPrice(Rate strike,
                             Option::Type type = Option::Call,
                             Real discount = 1.0,
-                            Real gap = 1.0e-5) const override;
-    Real density(Rate strike, Real discount = 1.0, Real gap = 1.0E-4) const override;
+                            Real gap = 1.0e-5,
+                            Real forward = Null<Real>()) const override;
+    Real density(Rate strike, Real discount = 1.0, Real gap = 1.0E-4,
+                 Real forward = Null<Real>()) const override;
 
     ext::shared_ptr<NoArbSabrModel> model() { return model_; }
 

--- a/ql/termstructures/volatility/atmadjustedsmilesection.hpp
+++ b/ql/termstructures/volatility/atmadjustedsmilesection.hpp
@@ -48,24 +48,28 @@ namespace QuantLib {
 
         Real optionPrice(Rate strike,
                          Option::Type type = Option::Call,
-                         Real discount = 1.0) const override {
-            return source_->optionPrice(adjustedStrike(strike), type, discount);
+                         Real discount = 1.0,
+                         Real forward = Null<Real>()) const override {
+            return source_->optionPrice(adjustedStrike(strike), type, discount, forward);
         }
 
         Real digitalOptionPrice(Rate strike,
                                 Option::Type type = Option::Call,
                                 Real discount = 1.0,
-                                Real gap = 1.0e-5) const override {
+                                Real gap = 1.0e-5,
+                                Real forward = Null<Real>()) const override {
             return source_->digitalOptionPrice(adjustedStrike(strike), type,
-                                               discount, gap);
+                                               discount, gap, forward);
         }
 
-        Real vega(Rate strike, Real discount = 1.0) const override {
-            return source_->vega(adjustedStrike(strike), discount);
+        Real vega(Rate strike, Real discount = 1.0,
+                  Real forward = Null<Real>()) const override {
+            return source_->vega(adjustedStrike(strike), discount, forward);
         }
 
-        Real density(Rate strike, Real discount = 1.0, Real gap = 1.0E-4) const override {
-            return source_->density(adjustedStrike(strike), discount, gap);
+        Real density(Rate strike, Real discount = 1.0, Real gap = 1.0E-4,
+                     Real forward = Null<Real>()) const override {
+            return source_->density(adjustedStrike(strike), discount, gap, forward);
         }
 
       protected:

--- a/ql/termstructures/volatility/gaussian1dsmilesection.cpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.cpp
@@ -73,7 +73,7 @@ namespace QuantLib {
 Real Gaussian1dSmileSection::atmLevel() const { return atm_; }
 
 Real Gaussian1dSmileSection::optionPrice(Rate strike, Option::Type type,
-                                         Real discount) const {
+                                         Real discount, Real) const {
 
     if (swapIndex_ != nullptr) {
         Swaption s = MakeSwaption(swapIndex_, fixingDate_, strike)

--- a/ql/termstructures/volatility/gaussian1dsmilesection.hpp
+++ b/ql/termstructures/volatility/gaussian1dsmilesection.hpp
@@ -59,7 +59,8 @@ class Gaussian1dSmileSection : public SmileSection {
     Real maxStrike() const override { return QL_MAX_REAL; }
 
     Real atmLevel() const override;
-    Real optionPrice(Rate strike, Option::Type = Option::Call, Real discount = 1.0) const override;
+    Real optionPrice(Rate strike, Option::Type = Option::Call, Real discount = 1.0,
+                     Real forward = Null<Real>()) const override;
 
   protected:
     Real volatilityImpl(Rate strike) const override;

--- a/ql/termstructures/volatility/kahalesmilesection.cpp
+++ b/ql/termstructures/volatility/kahalesmilesection.cpp
@@ -224,7 +224,7 @@ namespace QuantLib {
     }
 
     Real KahaleSmileSection::optionPrice(Rate strike, Option::Type type,
-                                         Real discount) const {
+                                         Real discount, Real) const {
         // option prices are directly available, so implement this function
         // rather than use smileSection
         // standard implementation

--- a/ql/termstructures/volatility/kahalesmilesection.hpp
+++ b/ql/termstructures/volatility/kahalesmilesection.hpp
@@ -156,7 +156,8 @@ namespace QuantLib {
 
         Real optionPrice(Rate strike,
                          Option::Type type = Option::Call,
-                         Real discount = 1.0) const override;
+                         Real discount = 1.0,
+                         Real forward = Null<Real>()) const override;
 
       protected:
         Volatility volatilityImpl(Rate strike) const override;

--- a/ql/termstructures/volatility/smilesection.cpp
+++ b/ql/termstructures/volatility/smilesection.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Mario Pucci
  Copyright (C) 2013, 2015 Peter Caspers
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -71,10 +72,12 @@ namespace QuantLib {
 
     Real SmileSection::optionPrice(Rate strike,
                                    Option::Type type,
-                                   Real discount) const {
-        Real atm = atmLevel();
+                                   Real discount,
+                                   Real forward) const {
+        Real atm = forward != Null<Real>() ? forward : atmLevel();
         QL_REQUIRE(atm != Null<Real>(),
-                   "smile section must provide atm level to compute option price");
+                   "smile section must provide atm level "
+                   "or forward must be passed to compute option price");
         // if lognormal or shifted lognormal,
         // for strike at -shift, return option price even if outside
         // minstrike, maxstrike interval
@@ -88,28 +91,32 @@ namespace QuantLib {
     Real SmileSection::digitalOptionPrice(Rate strike,
                                           Option::Type type,
                                           Real discount,
-                                          Real gap) const {
+                                          Real gap,
+                                          Real forward) const {
         Real m = volatilityType() == ShiftedLognormal ? Real(-shift()) : -QL_MAX_REAL;
         Real kl = std::max(strike-gap/2.0,m);
         Real kr = kl+gap;
         return (type==Option::Call ? 1.0 : -1.0) *
-            (optionPrice(kl,type,discount)-optionPrice(kr,type,discount)) / gap;
+            (optionPrice(kl,type,discount,forward)-optionPrice(kr,type,discount,forward)) / gap;
     }
 
-    Real SmileSection::density(Rate strike, Real discount, Real gap) const {
+    Real SmileSection::density(Rate strike, Real discount, Real gap,
+                               Real forward) const {
         Real m = volatilityType() == ShiftedLognormal ? Real(-shift()) : -QL_MAX_REAL;
         Real kl = std::max(strike-gap/2.0,m);
         Real kr = kl+gap;
-        return (digitalOptionPrice(kl,Option::Call,discount,gap) -
-                digitalOptionPrice(kr,Option::Call,discount,gap)) / gap;
+        return (digitalOptionPrice(kl,Option::Call,discount,gap,forward) -
+                digitalOptionPrice(kr,Option::Call,discount,gap,forward)) / gap;
     }
 
-    Real SmileSection::vega(Rate strike, Real discount) const {
-        Real atm = atmLevel();
+    Real SmileSection::vega(Rate strike, Real discount,
+                            Real forward) const {
+        Real atm = forward != Null<Real>() ? forward : atmLevel();
         QL_REQUIRE(atm != Null<Real>(),
-                   "smile section must provide atm level to compute option vega");
+                   "smile section must provide atm level "
+                   "or forward must be passed to compute option vega");
         if (volatilityType() == ShiftedLognormal)
-            return blackFormulaVolDerivative(strike,atmLevel(),
+            return blackFormulaVolDerivative(strike,atm,
                                              sqrt(variance(strike)),
                                              exerciseTime(),discount,shift())*0.01;
         else

--- a/ql/termstructures/volatility/smilesection.hpp
+++ b/ql/termstructures/volatility/smilesection.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2006 Mario Pucci
  Copyright (C) 2013, 2015 Peter Caspers
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -67,16 +68,20 @@ namespace QuantLib {
         virtual const DayCounter& dayCounter() const { return dc_; }
         virtual Real optionPrice(Rate strike,
                                  Option::Type type = Option::Call,
-                                 Real discount=1.0) const;
+                                 Real discount=1.0,
+                                 Real forward=Null<Real>()) const;
         virtual Real digitalOptionPrice(Rate strike,
                                         Option::Type type = Option::Call,
                                         Real discount=1.0,
-                                        Real gap=1.0e-5) const;
+                                        Real gap=1.0e-5,
+                                        Real forward=Null<Real>()) const;
         virtual Real vega(Rate strike,
-                          Real discount=1.0) const;
+                          Real discount=1.0,
+                          Real forward=Null<Real>()) const;
         virtual Real density(Rate strike,
                              Real discount=1.0,
-                             Real gap=1.0E-4) const;
+                             Real gap=1.0E-4,
+                             Real forward=Null<Real>()) const;
         Volatility volatility(Rate strike, VolatilityType type, Real shift=0.0) const;
       protected:
         virtual void initializeExerciseTime() const;

--- a/ql/termstructures/volatility/zabrsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrsmilesection.hpp
@@ -62,7 +62,8 @@ template <typename Evaluation> class ZabrSmileSection : public SmileSection {
     Real maxStrike() const override { return QL_MAX_REAL; }
     Real atmLevel() const override { return model_->forward(); }
     Real
-    optionPrice(Rate strike, Option::Type type = Option::Call, Real discount = 1.0) const override {
+    optionPrice(Rate strike, Option::Type type = Option::Call, Real discount = 1.0,
+                Real forward = Null<Real>()) const override {
         return optionPrice(strike, type, discount, Evaluation());
     }
 

--- a/test-suite/interpolatedsmilesection.cpp
+++ b/test-suite/interpolatedsmilesection.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2025 Paolo D'Elia
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -19,7 +20,9 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <ql/termstructures/volatility/interpolatedsmilesection.hpp>
+#include <ql/termstructures/volatility/flatsmilesection.hpp>
 #include <ql/math/interpolations/linearinterpolation.hpp>
+#include <ql/pricingengines/blackformula.hpp>
 #include <ql/quotes/simplequote.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 
@@ -208,6 +211,82 @@ BOOST_AUTO_TEST_CASE(testErrorThrowingWhenNonSortedStrikes) {
         ),
         QuantLib::Error
     );
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(SmileSectionOptionalForward)
+
+BOOST_AUTO_TEST_CASE(testForwardAwareOptionPrice) {
+    BOOST_TEST_MESSAGE(
+        "Testing SmileSection methods with optional forward parameter...");
+
+    DayCounter dc = Actual365Fixed();
+    Volatility vol = 0.20;
+    Time T = 1.0;
+    Real forward = 100.0;
+    Real discount = 0.97;
+
+    // FlatSmileSection without atmLevel — simulates a forward-unaware smile
+    auto smile = ext::make_shared<FlatSmileSection>(T, vol, dc);
+
+    // The virtual optionPrice() without forward should fail (no atmLevel)
+    BOOST_CHECK_THROW(smile->optionPrice(100.0, Option::Call, discount),
+                      QuantLib::Error);
+
+    // With forward parameter it should work
+    Real tolerance = 1.0e-12;
+
+    // Compare against blackFormula directly
+    Real strike = 105.0;
+    Real stdDev = vol * std::sqrt(T);
+    Real expected = blackFormula(Option::Call, strike, forward,
+                                 stdDev, discount);
+    Real calculated = smile->optionPrice(strike, Option::Call,
+                                          discount, forward);
+
+    if (std::fabs(calculated - expected) > tolerance)
+        BOOST_FAIL("forward-aware optionPrice mismatch"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    expected:   " << expected
+                   << "\n    calculated: " << calculated);
+
+    // digitalOptionPrice with forward
+    Real gap = 1.0e-5;
+    Real digital = smile->digitalOptionPrice(strike, Option::Call,
+                                              discount, gap, forward);
+    if (digital <= 0.0 || digital > 1.0 / discount)
+        BOOST_FAIL("forward-aware digitalOptionPrice out of range"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    digital: " << digital);
+
+    // density with forward
+    Real dens = smile->density(strike, discount, 1.0e-4, forward);
+    if (dens <= 0.0)
+        BOOST_FAIL("forward-aware density should be positive"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    density: " << dens);
+
+    // vega with forward
+    Real v = smile->vega(strike, discount, forward);
+    if (v <= 0.0)
+        BOOST_FAIL("forward-aware vega should be positive"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    vega: " << v);
+
+    // Consistency: forward parameter should match atmLevel-based result
+    auto smileWithFwd = ext::make_shared<FlatSmileSection>(T, vol, dc,
+                                                            forward);
+    Real fromAtmLevel = smileWithFwd->optionPrice(strike, Option::Call,
+                                                   discount);
+    Real fromForward = smileWithFwd->optionPrice(strike, Option::Call,
+                                                  discount, forward);
+
+    if (std::fabs(fromAtmLevel - fromForward) > tolerance)
+        BOOST_FAIL("forward parameter inconsistent with atmLevel"
+                   << std::fixed << std::setprecision(12)
+                   << "\n    via atmLevel: " << fromAtmLevel
+                   << "\n    via forward:  " << fromForward);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR proposes adding an optional `forward` parameter (defaulting to `Null<Real>()`) to `SmileSection::optionPrice()`, `digitalOptionPrice()`, `vega()`, and `density()`.

Currently these methods rely on `atmLevel()` to obtain the forward, and fail at runtime if it returns `Null<Real>()`.

This works for IR smile sections which always know their forward, but equity/FX smile sections often don't. A `SmileSection` obtained from a `BlackVolTermStructure` (see #2487) or constructed from market data without a forward hits this `QL_REQUIRE` as soon as `optionPrice()` or `density()` is called.

The optional `forward` parameter lets callers provide the forward at the call site when the smile doesn't know it.

When `forward` is not passed (or passed as `Null<Real>()`), behavior is unchanged, `atmLevel()` is used as before. Fully backwards compatible.

All derived classes that override these methods (`NoArbSabrSmileSection`, `ZabrSmileSection`, `Gaussian1dSmileSection`, `KahaleSmileSection`, `AtmAdjustedSmileSection`) have been updated to match the new signatures. They ignore the `forward` parameter since they already know their forward via `atmLevel()`.

Note: for `digitalOptionPrice` and `density`, the `forward` parameter comes after `gap` to preserve backwards compatibility.

**Tests:** forward-aware calls on a forward-unaware `FlatSmileSection` produce correct prices (verified against `blackFormula`), and are consistent with `atmLevel`-based results on forward-aware smiles. Full suite passes.

@pcaspers, @lballabio, would appreciate your feedback on this, especially regarding the parameter ordering for `digitalOptionPrice` and `density` where `forward` comes after `gap`.
