### PR TITLE
Forward notifications after failed calculations in `LazyObject`

### DIFF
--- a/ql/patterns/lazyobject.hpp
+++ b/ql/patterns/lazyobject.hpp
@@ -128,7 +128,7 @@ namespace QuantLib {
         //@}
 
       protected:
-        mutable bool calculated_ = false, frozen_ = false, alwaysForward_;
+        mutable bool calculated_ = false, frozen_ = false, failed_ = false, alwaysForward_;
       private:
         bool updating_ = false;
         class UpdateChecker {  // NOLINT(cppcoreguidelines-special-member-functions)
@@ -203,12 +203,13 @@ namespace QuantLib {
         UpdateChecker checker(this);
 
         // forwards notifications only the first time
-        if (calculated_ || alwaysForward_) {
+        if (calculated_ || failed_ || alwaysForward_) {
             // set to false early
             // 1) to prevent infinite recursion
             // 2) otherways non-lazy observers would be served obsolete
             //    data because of calculated_ being still true
             calculated_ = false;
+            failed_ = false;
             // observers don't expect notifications from frozen objects
             if (!frozen_)
                 notifyObservers();
@@ -219,7 +220,7 @@ namespace QuantLib {
 
     inline void LazyObject::recalculate() {
         bool wasFrozen = frozen_;
-        calculated_ = frozen_ = false;
+        calculated_ = frozen_ = failed_ = false;
         try {
             calculate();
         } catch (...) {
@@ -258,8 +259,11 @@ namespace QuantLib {
                                   // case of bootstrapping
             try {
                 performCalculations();
+                failed_ = false;  // needed when calculate() is called
+                                  // directly after a prior failure
             } catch (...) {
                 calculated_ = false;
+                failed_ = true;
                 throw;
             }
         }

--- a/test-suite/lazyobject.cpp
+++ b/test-suite/lazyobject.cpp
@@ -199,6 +199,79 @@ BOOST_AUTO_TEST_CASE(testNotificationLoop) {
     s3->unregisterWithAll();
 }
 
+BOOST_AUTO_TEST_CASE(testNotificationAfterFailedCalculation) {
+
+    BOOST_TEST_MESSAGE("Testing that lazy objects forward notifications after a failed calculation...");
+
+    TearDown teardown;
+
+    LazyObject::Defaults::instance().forwardFirstNotificationOnly();
+
+    // a lazy object whose performCalculations() can be made to fail
+    class Failing : public LazyObject {
+        mutable bool fail_ = false;
+      public:
+        void failOnCalculation(bool b) { fail_ = b; }
+        void doCalculate() const { calculate(); }
+        void performCalculations() const override {
+            if (fail_)
+                QL_FAIL("intentional failure");
+        }
+    };
+
+    auto q = ext::make_shared<SimpleQuote>(0.0);
+    auto s = ext::make_shared<Failing>();
+    s->registerWith(q);
+
+    Flag f;
+    f.registerWith(s);
+
+    // successful calculation, then change => observer should be notified
+    s->doCalculate();
+    q->setValue(1.0);
+    if (!f.isUp())
+        BOOST_FAIL("Observer was not notified of change after successful calculation");
+
+    f.lower();
+
+    // failed calculation
+    s->failOnCalculation(true);
+    BOOST_CHECK_EXCEPTION(s->doCalculate(), Error,
+                          ExpectedErrorMessage("intentional failure"));
+
+    if (f.isUp())
+        BOOST_FAIL("Observer was notified by failed calculation itself");
+
+    // fix the object
+    s->failOnCalculation(false);
+
+    // change input => observer should be notified despite the prior failure
+    q->setValue(2.0);
+    if (!f.isUp())
+        BOOST_FAIL("Observer was not notified of change after failed calculation");
+
+    f.lower();
+
+    // verify it can actually recalculate now
+    BOOST_CHECK_NO_THROW(s->doCalculate());
+
+    if (f.isUp())
+        BOOST_FAIL("Observer was notified by successful recalculation itself");
+
+    // verify the "forward first only" contract is preserved:
+    // after recalculation, one notification should be forwarded...
+    q->setValue(3.0);
+    if (!f.isUp())
+        BOOST_FAIL("Observer was not notified of change after recovery");
+
+    f.lower();
+
+    // ...but a second change without recalculation should be discarded
+    q->setValue(4.0);
+    if (f.isUp())
+        BOOST_FAIL("Observer was notified of second change without recalculation");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- When `performCalculations()` throws, `LazyObject::update()` silently swallows subsequent notifications because `calculated_` is `false` and the forwarding condition is not met
- Add a `failed_` flag that ensures the next input change after a failed calculation is forwarded to observers
- Add test verifying notification after failure and preservation of forward-first-only semantics

Closes #395.

## Test plan
- New `testNotificationAfterFailedCalculation` covers: success→notify, fail→change→notify, recovery, and forward-first-only contract preservation
- All existing LazyObject tests pass
- Full test suite passes with no regressions