### PR TITLE
Check for negative rates in Barone-Adesi-Whaley engine

### DIFF
--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -42,6 +42,11 @@ namespace QuantLib {
         DiscountFactor dividendDiscount,
         Real variance, Real tolerance) {
 
+        QL_REQUIRE(riskFreeDiscount <= 1.0,
+                   "the Barone-Adesi-Whaley approximation is not applicable "
+                   "with negative interest rates "
+                   "(risk-free discount factor: " << riskFreeDiscount << ")");
+
         // Calculation of seed value, Si
         Real n= 2.0*std::log(dividendDiscount/riskFreeDiscount)/(variance);
         Real m=-2.0*std::log(riskFreeDiscount)/(variance);

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -2254,6 +2254,49 @@ BOOST_AUTO_TEST_CASE(testFdEarliestExerciseDate) {
         "full=" << fullPrice << " 6M=" << midPrice);
 }
 
+BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyNegativeRates) {
+
+    BOOST_TEST_MESSAGE("Testing Barone-Adesi-Whaley engine with negative rates...");
+
+    // Issue #1291: BAW crashes with a cryptic error when rates are negative.
+    // Verify that it now throws a clear error message instead.
+
+    Date today = Date::todaysDate();
+    DayCounter dc = Actual360();
+
+    auto spot = ext::make_shared<SimpleQuote>(36.0);
+    auto qRate = ext::make_shared<SimpleQuote>(0.0);
+    auto rRate = ext::make_shared<SimpleQuote>(-0.012);
+    auto vol = ext::make_shared<SimpleQuote>(0.20);
+
+    auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot),
+        Handle<YieldTermStructure>(flatRate(today, qRate, dc)),
+        Handle<YieldTermStructure>(flatRate(today, rRate, dc)),
+        Handle<BlackVolTermStructure>(flatVol(today, vol, dc)));
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 40.0);
+    Date exDate = today + Period(1, Years);
+    auto exercise = ext::make_shared<AmericanExercise>(today, exDate);
+
+    VanillaOption option(payoff, exercise);
+    option.setPricingEngine(
+        ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess));
+
+    BOOST_CHECK_EXCEPTION(option.NPV(), Error,
+                          ExpectedErrorMessage("negative interest rates"));
+
+    // also verify with a call and positive dividends
+    auto callPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 40.0);
+    qRate->setValue(0.06);
+    VanillaOption callOption(callPayoff, exercise);
+    callOption.setPricingEngine(
+        ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess));
+
+    BOOST_CHECK_EXCEPTION(callOption.NPV(), Error,
+                          ExpectedErrorMessage("negative interest rates"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- The Barone-Adesi-Whaley approximation diverges with negative interest rates: the Newton-Raphson seed in `criticalPrice()` overflows, producing a cryptic "forward + displacement must be positive" error from `blackFormula()`
- Root cause: with `riskFreeDiscount > 1`, the parameter `m = -2*log(riskFreeDiscount)/variance` becomes negative, corrupting the quadratic roots and causing the critical price `Si` to diverge (observed values: `-1.43e+15`)
- Add a `QL_REQUIRE` check at the top of `criticalPrice()` that rejects `riskFreeDiscount > 1.0` with a clear diagnostic
- This also protects `JuQuadraticApproximationEngine`, which calls `criticalPrice()` directly

Closes #1291.

## Test plan
- New `testBaroneAdesiWhaleyNegativeRates` covers both Put (reporter's case: S=36, K=40, r=-1.2%, q=0%, vol=20%) and Call (with q=6%) paths through `criticalPrice()`
- Existing BAW tests pass unchanged, including the `r=0, q=0` edge case
- Full test suite passes with no regressions
- Smoke-tested with positive, zero, negative, and very-small-negative rates