### PR TITLE
Fix first-period regularity check in `Schedule` backwards date generation

### DIFF
--- a/ql/time/schedule.cpp
+++ b/ql/time/schedule.cpp
@@ -217,7 +217,10 @@ namespace QuantLib {
                         (calendar_.adjust(dates_.back(),convention)!=
                          calendar_.adjust(firstDate_,convention))) {
                         dates_.push_back(firstDate_);
-                        isRegular_.push_back(false);
+                        isRegular_.push_back(
+                            nullCalendar.advance(dates_[dates_.size()-2],
+                                -1*(*tenor_), convention, *endOfMonth_) ==
+                            firstDate_);
                     }
                     break;
                 } else {
@@ -235,7 +238,10 @@ namespace QuantLib {
             if (calendar_.adjust(dates_.back(),convention)!=
                 calendar_.adjust(effectiveDate,convention)) {
                 dates_.push_back(effectiveDate);
-                isRegular_.push_back(false);
+                isRegular_.push_back(
+                    nullCalendar.advance(dates_[dates_.size()-2],
+                        -1*(*tenor_), convention, *endOfMonth_) ==
+                    effectiveDate);
             }
 	    std::reverse(dates_.begin(), dates_.end());
 	    std::reverse(isRegular_.begin(), isRegular_.end());
@@ -308,7 +314,10 @@ namespace QuantLib {
                         (calendar_.adjust(dates_.back(),convention)!=
                          calendar_.adjust(nextToLastDate_,convention))) {
                         dates_.push_back(nextToLastDate_);
-                        isRegular_.push_back(false);
+                        isRegular_.push_back(
+                            nullCalendar.advance(dates_[dates_.size()-2],
+                                1*(*tenor_), convention, *endOfMonth_) ==
+                            nextToLastDate_);
                     }
                     break;
                 } else {

--- a/test-suite/schedule.cpp
+++ b/test-suite/schedule.cpp
@@ -1226,6 +1226,72 @@ BOOST_AUTO_TEST_CASE(testTruncation) {
     BOOST_CHECK(t.isRegular().front() == true);
 }
 
+BOOST_AUTO_TEST_CASE(testBackwardRegularFirstPeriodWithFirstDate) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that Backward schedule marks regular first period correctly "
+        "when firstDate is provided...");
+
+    // Reproduces issue #405: Backward generation with firstDate and
+    // endOfMonth incorrectly marked the first period as irregular even
+    // when effectiveDate + tenor == firstDate.
+
+    NullCalendar calendar;
+
+    // Regular first period: Sep 30 + 6M = Mar 31 (with endOfMonth)
+    Schedule backward(
+        Date(30, September, 2017),   // effectiveDate
+        Date(30, September, 2024),   // terminationDate
+        Period(Semiannual),
+        calendar, Unadjusted, Unadjusted,
+        DateGeneration::Backward, true,
+        Date(31, March, 2018));      // firstDate
+
+    // First period should be regular
+    BOOST_CHECK_MESSAGE(backward.isRegular(1),
+        "First period should be regular (effectiveDate + 6M == firstDate)");
+
+    // Forward generation should agree
+    Schedule forward(
+        Date(30, September, 2017),
+        Date(30, September, 2024),
+        Period(Semiannual),
+        calendar, Unadjusted, Unadjusted,
+        DateGeneration::Forward, true,
+        Date(31, March, 2018));
+
+    BOOST_CHECK_MESSAGE(forward.isRegular(1),
+        "Forward first period should also be regular");
+
+    // Genuinely irregular first period: effective date does NOT align
+    // with firstDate by one tenor
+    Schedule irregular(
+        Date(3, September, 2017),    // effectiveDate (not end-of-month)
+        Date(30, September, 2024),
+        Period(Semiannual),
+        calendar, Unadjusted, Unadjusted,
+        DateGeneration::Backward, true,
+        Date(31, March, 2018));
+
+    BOOST_CHECK_MESSAGE(!irregular.isRegular(1),
+        "First period should be irregular (effectiveDate + 6M != firstDate)");
+
+    // Forward nextToLastDate: off-grid nextToLastDate triggers
+    // the insertion path and should be marked irregular
+    Schedule forwardNTLIrreg(
+        Date(30, September, 2017),
+        Date(30, September, 2024),
+        Period(Semiannual),
+        calendar, Unadjusted, Unadjusted,
+        DateGeneration::Forward, true,
+        Date(),
+        Date(15, March, 2024));        // off-grid, not one tenor from neighbors
+
+    Size n = forwardNTLIrreg.size();
+    BOOST_CHECK_MESSAGE(!forwardNTLIrreg.isRegular(n - 2),
+        "Period ending at off-grid nextToLastDate should be irregular");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Fix unconditional `isRegular_ = false` marking when inserting `firstDate` and `effectiveDate` in Backward date generation, and `nextToLastDate` in Forward date generation
- Compute regularity by checking whether the inserted date is exactly one tenor from its neighbor, matching the pattern already used in the Forward `firstDate` case
- Add test covering regular and irregular first periods with Backward generation, and irregular `nextToLastDate` with Forward generation

Before the fix, the original reporter's example produced a wrong first coupon of 1.0567 instead of 1.0625, because the first period was falsely marked irregular and `FixedRateLeg` computed a synthetic reference period for `ActualActual::Bond` day counting.

## Test plan

- [ ] Existing Schedule and Bond tests pass
- [ ] New test `testBackwardRegularFirstPeriodWithFirstDate` verifies:
  - Backward + firstDate: regular first period correctly detected
  - Forward agrees with Backward on regularity
  - Genuinely irregular first period still marked false
  - Off-grid Forward nextToLastDate correctly marked irregular