### PR TITLE
Avoid repeated calls to `Interpolation::update()`

### DIFF
--- a/ql/experimental/credit/interpolatedaffinehazardratecurve.hpp
+++ b/ql/experimental/credit/interpolatedaffinehazardratecurve.hpp
@@ -436,7 +436,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, dates_[0], dayCounter());
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
     #endif

--- a/ql/math/interpolation.hpp
+++ b/ql/math/interpolation.hpp
@@ -29,8 +29,9 @@
 #include <ql/math/interpolations/extrapolation.hpp>
 #include <ql/math/comparison.hpp>
 #include <ql/errors.hpp>
-#include <vector>
 #include <algorithm>
+#include <type_traits>
+#include <vector>
 
 namespace QuantLib {
 
@@ -159,6 +160,23 @@ namespace QuantLib {
         friend class MixedLinearCubicInterpolation;
     };
 
+    namespace detail {
+
+        template <class Interpolator, class I1, class I2>
+        Interpolation interpolateWithoutUpdate(const Interpolator& interpolator,
+                                               const I1& xBegin,
+                                               const I1& xEnd,
+                                               const I2& yBegin) {
+            if constexpr (std::is_invocable_v<decltype(&Interpolator::template interpolate<I1, I2>),
+                                              const Interpolator&,
+                                              const I1&, const I1&, const I2&, bool>) {
+                return interpolator.interpolate(xBegin, xEnd, yBegin, false);
+            } else {
+                return interpolator.interpolate(xBegin, xEnd, yBegin);
+            }
+        }
+
+    }
 }
 
 #endif

--- a/ql/math/interpolations/abcdinterpolation.hpp
+++ b/ql/math/interpolations/abcdinterpolation.hpp
@@ -172,7 +172,8 @@ namespace QuantLib {
                           const ext::shared_ptr<EndCriteria>& endCriteria
                               = ext::shared_ptr<EndCriteria>(),
                           const ext::shared_ptr<OptimizationMethod>& optMethod
-                              = ext::shared_ptr<OptimizationMethod>()) {
+                              = ext::shared_ptr<OptimizationMethod>(),
+                          bool update = true) {
 
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::AbcdInterpolationImpl<I1,I2>(xBegin, xEnd, yBegin,
@@ -182,7 +183,8 @@ namespace QuantLib {
                                                      vegaWeighted,
                                                      endCriteria,
                                                      optMethod));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
         //! \name Inspectors
         //@{
@@ -225,13 +227,13 @@ namespace QuantLib {
           optMethod_(std::move(optMethod)) {}
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin, bool update = true) const {
             return AbcdInterpolation(xBegin, xEnd, yBegin,
                                      a_, b_, c_, d_,
                                      aIsFixed_, bIsFixed_,
                                      cIsFixed_, dIsFixed_,
                                      vegaWeighted_,
-                                     endCriteria_, optMethod_);
+                                     endCriteria_, optMethod_, update);
         }
         static const bool global = true;
         static const Size requiredPoints = 2;

--- a/ql/math/interpolations/backwardflatinterpolation.hpp
+++ b/ql/math/interpolations/backwardflatinterpolation.hpp
@@ -43,11 +43,12 @@ namespace QuantLib {
         /*! \pre the \f$ x \f$ values must be sorted. */
         template <class I1, class I2>
         BackwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) {
+                                  const I2& yBegin, bool update = true) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::BackwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
                                                              yBegin));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -57,8 +58,8 @@ namespace QuantLib {
       public:
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return BackwardFlatInterpolation(xBegin, xEnd, yBegin);
+                                  const I2& yBegin, bool update = true) const {
+            return BackwardFlatInterpolation(xBegin, xEnd, yBegin, update);
         }
         static const bool global = false;
         static const Size requiredPoints = 1;

--- a/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -59,8 +59,8 @@ namespace QuantLib {
                                     const I2& yBegin, Real quadraticity,
                                     Real monotonicity, bool forcePositive,
                                     bool flatFinalPeriod = false,
-                                    const helper_map& preExistingHelpers =
-                                                               helper_map()) {
+                                    const helper_map& preExistingHelpers = {},
+                                    bool update = true) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(
                    new detail::ConvexMonotoneImpl<I1,I2>(xBegin,
                                                          xEnd,
@@ -70,10 +70,11 @@ namespace QuantLib {
                                                          forcePositive,
                                                          flatFinalPeriod,
                                                          preExistingHelpers));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
 
-        ConvexMonotoneInterpolation(Interpolation& interp)
+        explicit ConvexMonotoneInterpolation(const Interpolation& interp)
         : Interpolation(interp) {}
 
         std::map<Real, ext::shared_ptr<detail::SectionHelper> >
@@ -98,12 +99,14 @@ namespace QuantLib {
 
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin, bool update = true) const {
             return ConvexMonotoneInterpolation<I1,I2>(xBegin, xEnd, yBegin,
                                                       quadraticity_,
                                                       monotonicity_,
                                                       forcePositive_,
-                                                      false);
+                                                      false,
+                                                      {},
+                                                      update);
         }
 
         template <class I1, class I2>

--- a/ql/math/interpolations/cubicinterpolation.hpp
+++ b/ql/math/interpolations/cubicinterpolation.hpp
@@ -167,7 +167,8 @@ namespace QuantLib {
                            CubicInterpolation::BoundaryCondition leftCond,
                            Real leftConditionValue,
                            CubicInterpolation::BoundaryCondition rightCond,
-                           Real rightConditionValue) {
+                           Real rightConditionValue,
+                           bool update = true) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::CubicInterpolationImpl<I1,I2>(xBegin, xEnd, yBegin,
                                                       da,
@@ -176,7 +177,8 @@ namespace QuantLib {
                                                       leftConditionValue,
                                                       rightCond,
                                                       rightConditionValue));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
         const std::vector<Real>& primitiveConstants() const {
             return baseImpl().primitiveConst_;
@@ -351,11 +353,12 @@ namespace QuantLib {
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin,
                                   const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin,
+                                  bool update = true) const {
             return CubicInterpolation(xBegin, xEnd, yBegin,
                                       da_, monotonic_,
                                       leftType_, leftValue_,
-                                      rightType_, rightValue_);
+                                      rightType_, rightValue_, update);
         }
         static const bool global = true;
         static const Size requiredPoints = 2;

--- a/ql/math/interpolations/forwardflatinterpolation.hpp
+++ b/ql/math/interpolations/forwardflatinterpolation.hpp
@@ -43,11 +43,12 @@ namespace QuantLib {
         /*! \pre the \f$ x \f$ values must be sorted. */
         template <class I1, class I2>
         ForwardFlatInterpolation(const I1& xBegin, const I1& xEnd,
-                                 const I2& yBegin) {
+                                 const I2& yBegin, bool update = true) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::ForwardFlatInterpolationImpl<I1,I2>(xBegin, xEnd,
                                                             yBegin));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -57,8 +58,8 @@ namespace QuantLib {
       public:
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return ForwardFlatInterpolation(xBegin, xEnd, yBegin);
+                                  const I2& yBegin, bool update = true) const {
+            return ForwardFlatInterpolation(xBegin, xEnd, yBegin, update);
         }
         static const bool global = false;
         static const Size requiredPoints = 2;

--- a/ql/math/interpolations/linearinterpolation.hpp
+++ b/ql/math/interpolations/linearinterpolation.hpp
@@ -44,11 +44,12 @@ namespace QuantLib {
         /*! \pre the \f$ x \f$ values must be sorted. */
         template <class I1, class I2>
         LinearInterpolation(const I1& xBegin, const I1& xEnd,
-                            const I2& yBegin) {
+                            const I2& yBegin, bool update = true) {
             impl_ = ext::shared_ptr<Interpolation::Impl>(new
                 detail::LinearInterpolationImpl<I1,I2>(xBegin, xEnd,
                                                        yBegin));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -58,8 +59,8 @@ namespace QuantLib {
       public:
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return LinearInterpolation(xBegin, xEnd, yBegin);
+                                  const I2& yBegin, bool update = true) const {
+            return LinearInterpolation(xBegin, xEnd, yBegin, update);
         }
         static const bool global = false;
         static const Size requiredPoints = 2;

--- a/ql/math/interpolations/loginterpolation.hpp
+++ b/ql/math/interpolations/loginterpolation.hpp
@@ -46,10 +46,11 @@ namespace QuantLib {
         /*! \pre the \f$ x \f$ values must be sorted. */
         template <class I1, class I2>
         LogLinearInterpolation(const I1& xBegin, const I1& xEnd,
-                               const I2& yBegin) {
+                               const I2& yBegin, bool update = true) {
             impl_ = ext::make_shared<detail::LogInterpolationImpl<I1, I2>>(
                 xBegin, xEnd, yBegin, Linear());
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -59,8 +60,8 @@ namespace QuantLib {
       public:
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
-            return LogLinearInterpolation(xBegin, xEnd, yBegin);
+                                  const I2& yBegin, bool update = true) const {
+            return LogLinearInterpolation(xBegin, xEnd, yBegin, update);
         }
         static const bool global = false;
         static const Size requiredPoints = 2;
@@ -79,13 +80,15 @@ namespace QuantLib {
                               CubicInterpolation::BoundaryCondition leftC,
                               Real leftConditionValue,
                               CubicInterpolation::BoundaryCondition rightC,
-                              Real rightConditionValue) {
+                              Real rightConditionValue,
+                              bool update = true) {
             impl_ = ext::make_shared<detail::LogInterpolationImpl<I1, I2>>(
                 xBegin, xEnd, yBegin,
                 Cubic(da, monotonic,
                       leftC, leftConditionValue,
                       rightC, rightConditionValue));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -106,11 +109,11 @@ namespace QuantLib {
           leftValue_(leftConditionValue), rightValue_(rightConditionValue) {}
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin, bool update = true) const {
             return LogCubicInterpolation(xBegin, xEnd, yBegin,
                                          da_, monotonic_,
                                          leftType_, leftValue_,
-                                         rightType_, rightValue_);
+                                         rightType_, rightValue_, update);
         }
         static const bool global = true;
         static const Size requiredPoints = 2;
@@ -254,13 +257,15 @@ namespace QuantLib {
                                          CubicInterpolation::BoundaryCondition leftC,
                                          Real leftConditionValue,
                                          CubicInterpolation::BoundaryCondition rightC,
-                                         Real rightConditionValue) {
+                                         Real rightConditionValue,
+                                         bool update = true) {
             impl_ = ext::make_shared<detail::LogInterpolationImpl<I1, I2>>(
                 xBegin, xEnd, yBegin,
                 MixedLinearCubic(n, behavior, da, monotonic,
                                  leftC, leftConditionValue,
                                  rightC, rightConditionValue));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -283,12 +288,13 @@ namespace QuantLib {
           leftValue_(leftConditionValue), rightValue_(rightConditionValue) {}
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin, bool update = true) const {
             return LogMixedLinearCubicInterpolation(xBegin, xEnd, yBegin,
                                                     n_, behavior_,
                                                     da_, monotonic_,
                                                     leftType_, leftValue_,
-                                                    rightType_, rightValue_);
+                                                    rightType_, rightValue_,
+                                                    update);
         }
         static const bool global = true;
         static const Size requiredPoints = 3;
@@ -367,9 +373,8 @@ namespace QuantLib {
             : Interpolation::templateImpl<I1, I2>(xBegin, xEnd, yBegin,
                                                   Interpolator::requiredPoints),
               logY_(xEnd-xBegin) {
-                interpolation_ = factory.interpolate(this->xBegin_,
-                                                     this->xEnd_,
-                                                     logY_.begin());
+                interpolation_ = detail::interpolateWithoutUpdate(
+                    factory, this->xBegin_, this->xEnd_, logY_.begin());
             }
             void update() override {
                 for (Size i=0; i<logY_.size(); ++i) {

--- a/ql/math/interpolations/mixedinterpolation.hpp
+++ b/ql/math/interpolations/mixedinterpolation.hpp
@@ -68,7 +68,8 @@ namespace QuantLib {
                                       CubicInterpolation::BoundaryCondition leftC,
                                       Real leftConditionValue,
                                       CubicInterpolation::BoundaryCondition rightC,
-                                      Real rightConditionValue) {
+                                      Real rightConditionValue,
+                                      bool update = true) {
             bool matchDerivatives = leftC == CubicInterpolation::FirstDerivative &&
                                     leftConditionValue == Null<Real>();
             QL_REQUIRE(!matchDerivatives || behavior == MixedInterpolation::SplitRanges,
@@ -86,7 +87,8 @@ namespace QuantLib {
                       leftC, leftConditionValue,
                       rightC, rightConditionValue),
                 std::move(switchFn));
-            impl_->update();
+            if (update)
+                impl_->update();
         }
     };
 
@@ -109,12 +111,13 @@ namespace QuantLib {
           leftValue_(leftConditionValue), rightValue_(rightConditionValue) {}
         template <class I1, class I2>
         Interpolation interpolate(const I1& xBegin, const I1& xEnd,
-                                  const I2& yBegin) const {
+                                  const I2& yBegin, bool update = true) const {
             return MixedLinearCubicInterpolation(xBegin, xEnd,
                                                  yBegin, n_, behavior_,
                                                  da_, monotonic_,
                                                  leftType_, leftValue_,
-                                                 rightType_, rightValue_);
+                                                 rightType_, rightValue_,
+                                                 update);
         }
         // fix below
         static const bool global = true;
@@ -243,20 +246,16 @@ namespace QuantLib {
 
                 switch (behavior) {
                   case MixedInterpolation::ShareRanges:
-                    interpolation1_ = factory1.interpolate(this->xBegin_,
-                                                           this->xEnd_,
-                                                           this->yBegin_);
-                    interpolation2_ = factory2.interpolate(this->xBegin_,
-                                                           this->xEnd_,
-                                                           this->yBegin_);
+                    interpolation1_ = detail::interpolateWithoutUpdate(
+                        factory1, this->xBegin_, this->xEnd_, this->yBegin_);
+                    interpolation2_ = detail::interpolateWithoutUpdate(
+                        factory2, this->xBegin_, this->xEnd_, this->yBegin_);
                     break;
                   case MixedInterpolation::SplitRanges:
-                    interpolation1_ = factory1.interpolate(this->xBegin_,
-                                                           this->xBegin2_ + 1,
-                                                           this->yBegin_);
-                    interpolation2_ = factory2.interpolate(this->xBegin2_,
-                                                           this->xEnd_,
-                                                           this->yBegin_ + n);
+                    interpolation1_ = detail::interpolateWithoutUpdate(
+                        factory1, this->xBegin_, this->xBegin2_ + 1, this->yBegin_);
+                    interpolation2_ = detail::interpolateWithoutUpdate(
+                        factory2, this->xBegin2_, this->xEnd_, this->yBegin_ + n);
                     break;
                   default:
                     QL_FAIL("unknown mixed-interpolation behavior: " << behavior);

--- a/ql/termstructures/credit/interpolateddefaultdensitycurve.hpp
+++ b/ql/termstructures/credit/interpolateddefaultdensitycurve.hpp
@@ -261,7 +261,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, dates_[0], dayCounter);
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/ql/termstructures/credit/interpolatedhazardratecurve.hpp
+++ b/ql/termstructures/credit/interpolatedhazardratecurve.hpp
@@ -260,7 +260,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, dates_[0], dayCounter());
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
+++ b/ql/termstructures/credit/interpolatedsurvivalprobabilitycurve.hpp
@@ -271,7 +271,6 @@ namespace QuantLib {
         }
 
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp
@@ -120,7 +120,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, referenceDate, dayCounter);
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
     template <class Interpolator>

--- a/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp
@@ -111,7 +111,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, referenceDate, dayCounter);
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
     template <class Interpolator>

--- a/ql/termstructures/iterativebootstrap.hpp
+++ b/ql/termstructures/iterativebootstrap.hpp
@@ -296,18 +296,17 @@ namespace detail {
                 if (!validData) {
                     try { // extend interpolation a point at a time
                           // including the pillar to be boostrapped
-                        ts_->interpolation_ = ts_->interpolator_.interpolate(
-                            times.begin(), times.begin()+i+1, data.begin());
+                        ts_->interpolation_ = detail::interpolateWithoutUpdate(
+                            ts_->interpolator_, times.begin(), times.begin()+i+1, data.begin());
                     } catch (...) {
                         if (!Interpolator::global)
                             throw; // no chance to fix it in a later iteration
 
                         // otherwise use Linear while the target
                         // interpolation is not usable yet
-                        ts_->interpolation_ = Linear().interpolate(
-                            times.begin(), times.begin()+i+1, data.begin());
+                        ts_->interpolation_ = detail::interpolateWithoutUpdate(
+                            Linear(), times.begin(), times.begin()+i+1, data.begin());
                     }
-                    ts_->interpolation_.update();
                 }
 
                 const auto& helper = ts_->instruments_[j];

--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
@@ -150,7 +150,8 @@ namespace QuantLib {
                                     vols_.begin(),
                                     CubicInterpolation::Spline, false,
                                     CubicInterpolation::SecondDerivative, 0.0,
-                                    CubicInterpolation::SecondDerivative, 0.0);
+                                    CubicInterpolation::SecondDerivative, 0.0,
+                                    false);
     }
 
     void CapFloorTermVolCurve::update()

--- a/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvariancecurve.hpp
@@ -70,7 +70,6 @@ namespace QuantLib {
         void setInterpolation(const Interpolator& i = Interpolator()) {
             varianceCurve_ = i.interpolate(times_.begin(), times_.end(),
                                            variances_.begin());
-            varianceCurve_.update();
             notifyObservers();
         }
         //@}

--- a/ql/termstructures/yield/discountcurve.hpp
+++ b/ql/termstructures/yield/discountcurve.hpp
@@ -256,7 +256,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, dates_[0], dayCounter());
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/ql/termstructures/yield/forwardcurve.hpp
+++ b/ql/termstructures/yield/forwardcurve.hpp
@@ -250,7 +250,6 @@ namespace QuantLib {
 
         this->setupTimes(dates_, dates_[0], dayCounter());
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
+++ b/ql/termstructures/yield/interpolatedsimplezerocurve.hpp
@@ -186,7 +186,6 @@ template <class T> void InterpolatedSimpleZeroCurve<T>::initialize() {
 
     this->setupTimes(dates_, dates_[0], dayCounter());
     this->setupInterpolation();
-    this->interpolation_.update();
 }
 
 } // namespace QuantLib

--- a/ql/termstructures/yield/piecewiseforwardspreadedtermstructure.hpp
+++ b/ql/termstructures/yield/piecewiseforwardspreadedtermstructure.hpp
@@ -108,6 +108,8 @@ namespace QuantLib {
         registerWith(originalCurve_);
         for (auto& spread : spreads_)
             registerWith(spread);
+        interpolator_ = detail::interpolateWithoutUpdate(
+            factory_, times_.begin(), times_.end(), spreadValues_.begin());
         if (!originalCurve_.empty())
             updateInterpolation();
     }
@@ -163,9 +165,9 @@ namespace QuantLib {
     inline Spread
     InterpolatedPiecewiseForwardSpreadedTermStructure<T>::calcSpread(Time t) const {
         if (t <= times_.front()) {
-            return spreads_.front()->value();
+            return spreadValues_.front();
         } else if (t >= times_.back()) {
-            return spreads_.back()->value();
+            return spreadValues_.back();
         } else {
             return interpolator_(t, true);
         }
@@ -178,11 +180,11 @@ namespace QuantLib {
             return calcSpread(0.0);
 
         Real integral;
-        if (t <= this->times_.back()) {
-            integral = this->interpolator_.primitive(t, true);
+        if (t <= times_.back()) {
+            integral = interpolator_.primitive(t, true);
         } else {
-            integral = this->interpolator_.primitive(this->times_.back(), true)
-                     + this->spreads_.back()->value() * (t - this->times_.back());
+            integral = interpolator_.primitive(times_.back(), true)
+                     + spreadValues_.back() * (t - times_.back());
         }
         return integral/t;
     }
@@ -208,9 +210,7 @@ namespace QuantLib {
             times_[i] = timeFromReference(dates_[i]);
             spreadValues_[i] = spreads_[i]->value();
         }
-        interpolator_ = factory_.interpolate(times_.begin(),
-                                             times_.end(),
-                                             spreadValues_.begin());
+        interpolator_.update();
     }
 
 }

--- a/ql/termstructures/yield/piecewisezerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/piecewisezerospreadedtermstructure.hpp
@@ -120,6 +120,8 @@ namespace QuantLib {
         registerWith(originalCurve_);
         for (auto& spread : spreads_)
             registerWith(spread);
+        interpolator_ = detail::interpolateWithoutUpdate(
+            factory_, times_.begin(), times_.end(), spreadValues_.begin());
         if (!originalCurve_.empty())
             updateInterpolation();
     }
@@ -181,9 +183,9 @@ namespace QuantLib {
     inline Spread
     InterpolatedPiecewiseZeroSpreadedTermStructure<T>::calcSpread(Time t) const {
         if (t <= times_.front()) {
-            return spreads_.front()->value();
+            return spreadValues_.front();
         } else if (t >= times_.back()) {
-            return spreads_.back()->value();
+            return spreadValues_.back();
         } else {
             return interpolator_(t, true);
         }
@@ -210,9 +212,7 @@ namespace QuantLib {
             times_[i] = timeFromReference(dates_[i]);
             spreadValues_[i] = spreads_[i]->value();
         }
-        interpolator_ = factory_.interpolate(times_.begin(),
-                                             times_.end(),
-                                             spreadValues_.begin());
+        interpolator_.update();
     }
 
 }

--- a/ql/termstructures/yield/spreaddiscountcurve.hpp
+++ b/ql/termstructures/yield/spreaddiscountcurve.hpp
@@ -100,6 +100,9 @@ namespace QuantLib {
         }
 
         registerWith(baseCurve_);
+        this->times_.resize(dates_.size());
+        this->interpolation_ = detail::interpolateWithoutUpdate(
+            this->interpolator_, this->times_.begin(), this->times_.end(), this->data_.begin());
         if (!baseCurve_.empty())
             updateInterpolation();
     }
@@ -218,7 +221,6 @@ namespace QuantLib {
         auto dc = dayCounter();
         if (prevDayCount_ != dc) {
             this->setupTimes(dates_, dates_[0], dc);
-            this->setupInterpolation();
             this->interpolation_.update();
             prevDayCount_ = dc;
         }

--- a/ql/termstructures/yield/zerocurve.hpp
+++ b/ql/termstructures/yield/zerocurve.hpp
@@ -273,7 +273,6 @@ namespace QuantLib {
         }
 
         this->setupInterpolation();
-        this->interpolation_.update();
     }
 
 }

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -54,6 +54,7 @@
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
+using QuantLib::detail::interpolateWithoutUpdate;
 
 BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
 
@@ -237,6 +238,76 @@ Real lagrangeTestFct(Real x) {
     return std::fabs(x) + 0.5*x - x*x;
 }
 
+template <class I1, class I2>
+class TestInterpolationImpl final : public Interpolation::templateImpl<I1, I2> {
+  public:
+    TestInterpolationImpl(const I1& xBegin, const I1& xEnd, const I2& yBegin)
+    : Interpolation::templateImpl<I1, I2>(xBegin, xEnd, yBegin) {}
+
+    void update() override {
+        updateCalls_++;
+    }
+    Real value(Real x) const override {
+        return updateCalls_;
+    }
+    Real primitive(Real x) const override {
+        return 0;
+    }
+    Real derivative(Real x) const override {
+        return 0;
+    }
+    Real secondDerivative(Real x) const override {
+        return 0;
+    }
+  private:
+    int updateCalls_ = 0;
+};
+
+class TestInterpolation : public Interpolation {
+  public:
+    template <class I1, class I2>
+    TestInterpolation(const I1& xBegin, const I1& xEnd,
+                      const I2& yBegin, bool update = true) {
+        impl_ = ext::make_shared<TestInterpolationImpl<I1, I2>>(xBegin, xEnd, yBegin);
+        if (update)
+            impl_->update();
+    }
+};
+
+class TestInterpOld {
+  public:
+    template <class I1, class I2>
+    Interpolation interpolate(const I1& xBegin,
+                              const I1& xEnd,
+                              const I2& yBegin) const {
+        return TestInterpolation(xBegin, xEnd, yBegin);
+    }
+};
+
+class TestInterpNew {
+  public:
+    template <class I1, class I2>
+    Interpolation interpolate(const I1& xBegin,
+                              const I1& xEnd,
+                              const I2& yBegin,
+                              bool update = true) const {
+        return TestInterpolation(xBegin, xEnd, yBegin, update);
+    }
+};
+
+BOOST_AUTO_TEST_CASE(testInterpolateWithoutUpdate) {
+    std::vector<Real> x, y;
+    x = xRange(-2.0, 2.0, 4);
+    y = parabolic(x);
+    auto interp = interpolateWithoutUpdate(TestInterpOld(), x.begin(), x.end(), y.begin());
+    BOOST_CHECK_EQUAL(interp(0), 1);
+    interp.update();
+    BOOST_CHECK_EQUAL(interp(0), 2);
+    interp = interpolateWithoutUpdate(TestInterpNew(), x.begin(), x.end(), y.begin());
+    BOOST_CHECK_EQUAL(interp(0), 0);
+    interp.update();
+    BOOST_CHECK_EQUAL(interp(0), 1);
+}
 
 /* See J. M. Hyman, "Accurate monotonicity preserving cubic interpolation"
    SIAM J. of Scientific and Statistical Computing, v. 4, 1983, pp. 645-654.
@@ -277,7 +348,6 @@ BOOST_AUTO_TEST_CASE(testSplineErrorOnGaussianValues) {
                              CubicInterpolation::Spline, false,
                              CubicInterpolation::NotAKnot, Null<Real>(),
                              CubicInterpolation::NotAKnot, Null<Real>());
-        f.update();
         Real result = std::sqrt(integral(make_error_function(f), -1.7, 1.9));
         result /= scaleFactor;
         if (std::fabs(result-tabulatedErrors[i]) > toleranceOnTabErr[i])
@@ -291,7 +361,6 @@ BOOST_AUTO_TEST_CASE(testSplineErrorOnGaussianValues) {
                                CubicInterpolation::Spline, true,
                                CubicInterpolation::NotAKnot, Null<Real>(),
                                CubicInterpolation::NotAKnot, Null<Real>());
-        f.update();
         result = std::sqrt(integral(make_error_function(f), -1.7, 1.9));
         result /= scaleFactor;
         if (std::fabs(result-tabulatedMCErrors[i]) > toleranceOnTabMCErr[i])
@@ -328,7 +397,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnGaussianValues) {
                              CubicInterpolation::Spline, false,
                              CubicInterpolation::NotAKnot, Null<Real>(),
                              CubicInterpolation::NotAKnot, Null<Real>());
-        f.update();
         checkValues("Not-a-knot spline", f,
                     x.begin(), x.end(), y.begin());
         checkNotAKnotCondition("Not-a-knot spline", f);
@@ -350,7 +418,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnGaussianValues) {
                                CubicInterpolation::Spline, true,
                                CubicInterpolation::NotAKnot, Null<Real>(),
                                CubicInterpolation::NotAKnot, Null<Real>());
-        f.update();
         checkValues("MC not-a-knot spline", f,
                     x.begin(), x.end(), y.begin());
         // good performance
@@ -401,7 +468,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                                     CubicInterpolation::Spline, false,
                                     CubicInterpolation::SecondDerivative, 0.0,
                                     CubicInterpolation::SecondDerivative, 0.0);
-    f.update();
     checkValues("Natural spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     check2ndDerivativeValue("Natural spline", f,
@@ -425,7 +491,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                            CubicInterpolation::Spline, false,
                            CubicInterpolation::FirstDerivative, 0.0,
                            CubicInterpolation::FirstDerivative, 0.0);
-    f.update();
     checkValues("Clamped spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     check1stDerivativeValue("Clamped spline", f,
@@ -448,7 +513,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                            CubicInterpolation::Spline, false,
                            CubicInterpolation::NotAKnot, Null<Real>(),
                            CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("Not-a-knot spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     checkNotAKnotCondition("Not-a-knot spline", f);
@@ -469,7 +533,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::SecondDerivative, 0.0,
                            CubicInterpolation::SecondDerivative, 0.0);
-    f.update();
     checkValues("MC natural spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     // good performance
@@ -488,7 +551,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::FirstDerivative, 0.0,
                            CubicInterpolation::FirstDerivative, 0.0);
-    f.update();
     checkValues("MC clamped spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     check1stDerivativeValue("MC clamped spline", f,
@@ -511,7 +573,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnRPN15AValues) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::NotAKnot, Null<Real>(),
                            CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("MC not-a-knot spline", f,
                 std::begin(RPN15A_x), std::end(RPN15A_x), std::begin(RPN15A_y));
     // good performance
@@ -550,7 +611,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnGenericValues) {
                          generic_natural_y2[0],
                          CubicInterpolation::SecondDerivative,
                          generic_natural_y2[n-1]);
-    f.update();
     checkValues("Natural spline", f,
                 std::begin(generic_x), std::end(generic_x), std::begin(generic_y));
     // cached second derivative
@@ -574,7 +634,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnGenericValues) {
                     CubicInterpolation::Spline, false,
                     CubicInterpolation::FirstDerivative, y1a,
                     CubicInterpolation::FirstDerivative, y1b);
-    f.update();
     checkValues("Clamped spline", f,
                 std::begin(generic_x), std::end(generic_x), std::begin(generic_y));
     check1stDerivativeValue("Clamped spline", f,
@@ -589,7 +648,6 @@ BOOST_AUTO_TEST_CASE(testSplineOnGenericValues) {
                            CubicInterpolation::Spline, false,
                            CubicInterpolation::NotAKnot, Null<Real>(),
                            CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("Not-a-knot spline", f,
                 std::begin(generic_x), std::end(generic_x), std::begin(generic_y));
     checkNotAKnotCondition("Not-a-knot spline", f);
@@ -622,7 +680,6 @@ BOOST_AUTO_TEST_CASE(testSimmetricEndConditions) {
                          CubicInterpolation::Spline, false,
                          CubicInterpolation::NotAKnot, Null<Real>(),
                          CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("Not-a-knot spline", f,
                 x.begin(), x.end(), y.begin());
     checkNotAKnotCondition("Not-a-knot spline", f);
@@ -634,7 +691,6 @@ BOOST_AUTO_TEST_CASE(testSimmetricEndConditions) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::NotAKnot, Null<Real>(),
                            CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("MC not-a-knot spline", f,
                 x.begin(), x.end(), y.begin());
     checkSymmetry("MC not-a-knot spline", f, x[0]);
@@ -656,7 +712,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                          CubicInterpolation::Spline, false,
                          CubicInterpolation::NotAKnot, Null<Real>(),
                          CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("Not-a-knot spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("Not-a-knot spline", f,
@@ -674,7 +729,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                            CubicInterpolation::Spline, false,
                            CubicInterpolation::FirstDerivative,  4.0,
                            CubicInterpolation::FirstDerivative, -4.0);
-    f.update();
     checkValues("Clamped spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("Clamped spline", f,
@@ -692,7 +746,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                            CubicInterpolation::Spline, false,
                            CubicInterpolation::SecondDerivative, -2.0,
                            CubicInterpolation::SecondDerivative, -2.0);
-    f.update();
     checkValues("SecondDerivative spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("SecondDerivative spline", f,
@@ -709,7 +762,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::NotAKnot, Null<Real>(),
                            CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     checkValues("MC Not-a-knot spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("MC Not-a-knot spline", f,
@@ -727,7 +779,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::FirstDerivative,  4.0,
                            CubicInterpolation::FirstDerivative, -4.0);
-    f.update();
     checkValues("MC Clamped spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("MC Clamped spline", f,
@@ -745,7 +796,6 @@ BOOST_AUTO_TEST_CASE(testDerivativeEndConditions) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::SecondDerivative, -2.0,
                            CubicInterpolation::SecondDerivative, -2.0);
-    f.update();
     checkValues("MC SecondDerivative spline", f,
                 x.begin(), x.end(), y.begin());
     check1stDerivativeValue("MC SecondDerivative spline", f,
@@ -782,7 +832,6 @@ BOOST_AUTO_TEST_CASE(testNonRestrictiveHymanFilter) {
                          CubicInterpolation::Spline, true,
                          CubicInterpolation::NotAKnot, Null<Real>(),
                          CubicInterpolation::NotAKnot, Null<Real>());
-    f.update();
     interpolated = f(zero);
     if (std::fabs(interpolated-expected)>1e-15) {
         BOOST_ERROR("MC not-a-knot spline"
@@ -799,7 +848,6 @@ BOOST_AUTO_TEST_CASE(testNonRestrictiveHymanFilter) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::FirstDerivative,  4.0,
                            CubicInterpolation::FirstDerivative, -4.0);
-    f.update();
     interpolated = f(zero);
     if (std::fabs(interpolated-expected)>1e-15) {
         BOOST_ERROR("MC clamped spline"
@@ -816,7 +864,6 @@ BOOST_AUTO_TEST_CASE(testNonRestrictiveHymanFilter) {
                            CubicInterpolation::Spline, true,
                            CubicInterpolation::SecondDerivative, -2.0,
                            CubicInterpolation::SecondDerivative, -2.0);
-    f.update();
     interpolated = f(zero);
     if (std::fabs(interpolated-expected)>1e-15) {
         BOOST_ERROR("MC SecondDerivative spline"
@@ -936,8 +983,7 @@ BOOST_AUTO_TEST_CASE(testAsFunctor) {
     const Real x[] = { 0.0, 1.0, 2.0, 3.0, 4.0 };
     const Real y[] = { 5.0, 4.0, 3.0, 2.0, 1.0 };
 
-   Interpolation f = LinearInterpolation(std::begin(x), std::end(x), std::begin(y));
-    f.update();
+    Interpolation f = LinearInterpolation(std::begin(x), std::end(x), std::begin(y));
 
     const Real x2[] = { -2.0, -1.0, 0.0, 1.0, 3.0, 4.0, 5.0, 6.0, 7.0 };
     Size N = std::size(x2);
@@ -985,7 +1031,6 @@ BOOST_AUTO_TEST_CASE(testFritschButland) {
     for (Size i=0; i<3; ++i) {
 
         Interpolation f = FritschButlandCubic(std::begin(x), std::end(x), std::begin(y[i]));
-        f.update();
 
         for (Size j=0; j<4; ++j) {
             Real left_knot = x[j];
@@ -1016,7 +1061,6 @@ BOOST_AUTO_TEST_CASE(testBackwardFlat) {
     const Real y[] = { 5.0, 4.0, 3.0, 2.0, 1.0 };
 
     Interpolation f = BackwardFlatInterpolation(std::begin(x), std::end(x), std::begin(y));
-    f.update();
 
     Size N = std::size(x);
     Size i;
@@ -1134,7 +1178,6 @@ BOOST_AUTO_TEST_CASE(testForwardFlat) {
     const Real y[] = { 5.0, 4.0, 3.0, 2.0, 1.0 };
 
     Interpolation f = ForwardFlatInterpolation(std::begin(x), std::end(x), std::begin(y));
-    f.update();
 
     Size N = std::size(x);
     Size i;
@@ -1257,7 +1300,6 @@ BOOST_AUTO_TEST_CASE(testMixedLinearCubicMatchDerivatives) {
         CubicInterpolation::Spline, false,
         CubicInterpolation::FirstDerivative, Null<Real>(),
         CubicInterpolation::SecondDerivative, 0.0);
-    f.update();
 
     Real tolerance = 1.0e-12;
     Real eps = tolerance / 10;
@@ -1535,7 +1577,6 @@ BOOST_AUTO_TEST_CASE(testKernelInterpolation) {
                                   1e-6
 #endif
             );
-            f.update();
 
             for (Size dIt=0; dIt< deltaGrid.size(); ++dIt) {
                 expectedVal=currY[dIt];
@@ -1576,7 +1617,6 @@ BOOST_AUTO_TEST_CASE(testKernelInterpolation) {
         // Build interpolation according to original grid + y-values
         KernelInterpolation f(deltaGrid.begin(), deltaGrid.end(),
                               currY.begin(), myKernel);
-        f.update();
 
         // test values at test Grid
         for (Size dIt=0; dIt< testDeltaGrid.size(); ++dIt) {


### PR DESCRIPTION
Add a flag (defaulting to true) for whether to run update when the
interpolation is constructed. This matches the current behavior of most
interpolations. Pass update=false when we don't need this, because we
will call update later. In particular, do this in composite
interpolations (log and mixed) and bootstrappers where we currently call
update multiple times unnecessarily (usually all but the last call are
before the data for the interpolation is set).

Note that:
1. Interpolations that do not support the new update argument are called
   without it.
2. Interpolations are assumed to call update during construction when
   not passed update=false. This is true for most current interpolations
   except XABR. Since XABR is not used in interpolated curves, this is
   out of scope for this PR.
3. Interpolation2D implementations used a different convention and never
   called update in constructors, so they are also out of scope for the
   change.
4. GlobalBootstrap currently has an issue where for rates-based traits
   it calls methods that use interpolation (zeroRate and forwardRate)
   without updating it first. This will be addressed in a separate PR.

Fixes #2447