### PR TITLE
Skip degenerate periods in OvernightLeg when adjusted dates collapse

### DIFF
--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -599,9 +599,18 @@ namespace QuantLib {
                                                     << n << ")");
         }
 
+        const Calendar& fixCal = overnightIndex_->fixingCalendar();
+        BusinessDayConvention fixConv = overnightIndex_->businessDayConvention();
+
         for (Size i=0; i<n; ++i) {
             refStart = start = schedule_.date(i);
             refEnd   =   end = schedule_.date(i+1);
+
+            // Skip degenerate periods whose start and end collapse to the
+            // same business day under the overnight index's fixing calendar
+            // (e.g. a 1-day stub spanning Saturday-Sunday).
+            if (fixCal.adjust(start, fixConv) >= fixCal.adjust(end, fixConv))
+                continue;
 
             // If explicit payment dates provided, use them.
             if (!paymentDates_.empty()) {

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -1125,6 +1125,36 @@ BOOST_AUTO_TEST_CASE(testOvernightIndexedCouponPaymentBeforeAccrualEnd) {
     );
 }
 
+BOOST_AUTO_TEST_CASE(testOvernightLegDegeneratePeriod) {
+    BOOST_TEST_MESSAGE("Testing overnight leg with degenerate weekend stub period...");
+
+    Date today(1, March, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Handle<YieldTermStructure> h(
+        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+    ext::shared_ptr<OvernightIndex> sofr =
+        ext::make_shared<Sofr>(h);
+
+    // March 28, 2026 is a Saturday, March 30 is a Monday.
+    // The period [March 28, March 30] is degenerate: both dates
+    // adjust to Monday March 30 under the SOFR fixing calendar.
+    std::vector<Date> dates = {
+        Date(27, March, 2026),
+        Date(28, March, 2026),
+        Date(30, March, 2026),
+        Date(30, June, 2026)
+    };
+    Schedule schedule(dates);
+
+    Leg leg = OvernightLeg(schedule, sofr)
+        .withNotionals(10000.0)
+        .withPaymentDayCounter(Actual360());
+
+    // The degenerate period is skipped; 2 coupons instead of 3.
+    BOOST_CHECK_EQUAL(leg.size(), Size(2));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes #2496

## Summary

A 1-day stub spanning a weekend (e.g. Saturday to Sunday) can collapse
to the same business day under the overnight index's fixing calendar.
This causes `OvernightIndexedCoupon` to throw on the degenerate schedule,
and the exception unwind triggers use-after-free in `~FloatingRateCoupon`
(partially constructed coupon still registered as observer).

The fix adds a guard in `OvernightLeg::operator Leg()` that skips periods
whose adjusted start date is on or past the adjusted end date.

## Test plan

- Added test constructing a schedule with a Saturday-to-Monday degenerate
  stub and verifying the period is skipped without crashing