### PR TITLE
Added asymmetric payment frequency support for cross-currency basis swap rate helpers

### DIFF
--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -276,13 +276,15 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
-      paymentFrequency_(paymentFrequency) {
+      paymentFrequency_(paymentFrequency),
+      quoteCcyPaymentFrequency_(quoteCcyPaymentFrequency) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 
@@ -293,8 +295,10 @@ namespace QuantLib {
         baseCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_, convention_,
                                            endOfMonth_, baseCcyIdx_, paymentFrequency_, paymentLag_);
 
+        Frequency effectiveQuoteCcyFreq = (quoteCcyPaymentFrequency_ == NoFrequency)
+            ? paymentFrequency_ : quoteCcyPaymentFrequency_;
         quoteCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                            convention_, endOfMonth_, quoteCcyIdx_, paymentFrequency_, paymentLag_);
+                                            convention_, endOfMonth_, quoteCcyIdx_, effectiveQuoteCcyFreq, paymentLag_);
 
         initializeDatesFromLegs(baseCcyIborLeg_, quoteCcyIborLeg_);
     }
@@ -322,7 +326,8 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -335,7 +340,8 @@ namespace QuantLib {
                                            isFxBaseCurrencyCollateralCurrency,
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
-                                           paymentLag) {}
+                                           paymentLag,
+                                           quoteCcyPaymentFrequency) {}
 
     Real ConstNotionalCrossCurrencyBasisSwapRateHelper::impliedQuote() const {
         QL_REQUIRE(!termStructureHandle_.empty(), "term structure not set");
@@ -374,7 +380,8 @@ namespace QuantLib {
         bool isBasisOnFxBaseCurrencyLeg,
         bool isFxBaseCurrencyLegResettable,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -387,7 +394,8 @@ namespace QuantLib {
                                            isFxBaseCurrencyCollateralCurrency,
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
-                                           paymentLag),
+                                           paymentLag,
+                                           quoteCcyPaymentFrequency),
       isFxBaseCurrencyLegResettable_(isFxBaseCurrencyLegResettable) {}
 
     Real MtMCrossCurrencyBasisSwapRateHelper::impliedQuote() const {

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -64,16 +64,16 @@ namespace QuantLib {
                          BusinessDayConvention convention,
                          bool endOfMonth,
                          const ext::shared_ptr<IborIndex>& idx,
-                         Frequency paymentFrequency,
+                         ext::optional<Frequency> paymentFrequency,
                          Integer paymentLag) {
             auto overnightIndex = ext::dynamic_pointer_cast<OvernightIndex>(idx);
 
             Period freqPeriod;
-            if (paymentFrequency == NoFrequency) {
+            if (!paymentFrequency) {
                 QL_REQUIRE(!overnightIndex, "Require payment frequency for overnight indices.");
                 freqPeriod = idx->tenor();
             } else {
-                freqPeriod = Period(paymentFrequency);
+                freqPeriod = Period(*paymentFrequency);
             }
 
             Schedule sch = legSchedule(evaluationDate, tenor, freqPeriod, fixingDays, calendar,
@@ -256,9 +256,9 @@ namespace QuantLib {
         Handle<YieldTermStructure> collateralCurve,
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
-        Frequency paymentFrequency,
+        ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        Frequency quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCcyPaymentFrequency)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
@@ -276,8 +276,8 @@ namespace QuantLib {
         baseCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_, convention_,
                                            endOfMonth_, baseCcyIdx_, paymentFrequency_, paymentLag_);
 
-        Frequency effectiveQuoteCcyFreq = (quoteCcyPaymentFrequency_ == NoFrequency)
-            ? paymentFrequency_ : quoteCcyPaymentFrequency_;
+        ext::optional<Frequency> effectiveQuoteCcyFreq =
+            quoteCcyPaymentFrequency_ ? quoteCcyPaymentFrequency_ : paymentFrequency_;
         quoteCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_,
                                             convention_, endOfMonth_, quoteCcyIdx_, effectiveQuoteCcyFreq, paymentLag_);
 
@@ -306,9 +306,9 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& collateralCurve,
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
-        Frequency paymentFrequency,
+        ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        Frequency quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -360,9 +360,9 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
         bool isFxBaseCurrencyLegResettable,
-        Frequency paymentFrequency,
+        ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        Frequency quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -271,14 +271,14 @@ namespace QuantLib {
         bool isBasisOnFxBaseCurrencyLeg,
         ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        ext::optional<Frequency> quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCurrencyPaymentFrequency)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
       paymentFrequency_(normalizedPaymentFrequency(paymentFrequency)),
-      quoteCcyPaymentFrequency_(normalizedPaymentFrequency(quoteCcyPaymentFrequency)) {
+      quoteCcyPaymentFrequency_(normalizedPaymentFrequency(quoteCurrencyPaymentFrequency)) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 
@@ -289,6 +289,9 @@ namespace QuantLib {
         baseCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_, convention_,
                                            endOfMonth_, baseCcyIdx_, paymentFrequency_, paymentLag_);
 
+        // If no quote-currency payment frequency was given, fall back to the
+        // base-currency payment frequency (which may itself be unset, in which
+        // case the quote-currency leg uses its own index tenor).
         ext::optional<Frequency> effectiveQuoteCcyFreq =
             quoteCcyPaymentFrequency_ ? quoteCcyPaymentFrequency_ : paymentFrequency_;
         quoteCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_,
@@ -321,7 +324,7 @@ namespace QuantLib {
         bool isBasisOnFxBaseCurrencyLeg,
         ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        ext::optional<Frequency> quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCurrencyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -335,7 +338,7 @@ namespace QuantLib {
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
                                            paymentLag,
-                                           quoteCcyPaymentFrequency) {}
+                                           quoteCurrencyPaymentFrequency) {}
 
     Real ConstNotionalCrossCurrencyBasisSwapRateHelper::impliedQuote() const {
         QL_REQUIRE(!termStructureHandle_.empty(), "term structure not set");
@@ -375,7 +378,7 @@ namespace QuantLib {
         bool isFxBaseCurrencyLegResettable,
         ext::optional<Frequency> paymentFrequency,
         Integer paymentLag,
-        ext::optional<Frequency> quoteCcyPaymentFrequency)
+        ext::optional<Frequency> quoteCurrencyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -389,7 +392,7 @@ namespace QuantLib {
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
                                            paymentLag,
-                                           quoteCcyPaymentFrequency),
+                                           quoteCurrencyPaymentFrequency),
       isFxBaseCurrencyLegResettable_(isFxBaseCurrencyLegResettable) {}
 
     Real MtMCrossCurrencyBasisSwapRateHelper::impliedQuote() const {

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -257,13 +257,15 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
-      paymentFrequency_(paymentFrequency) {
+      paymentFrequency_(paymentFrequency),
+      quoteCcyPaymentFrequency_(quoteCcyPaymentFrequency) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 
@@ -274,8 +276,10 @@ namespace QuantLib {
         baseCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_, convention_,
                                            endOfMonth_, baseCcyIdx_, paymentFrequency_, paymentLag_);
 
+        Frequency effectiveQuoteCcyFreq = (quoteCcyPaymentFrequency_ == NoFrequency)
+            ? paymentFrequency_ : quoteCcyPaymentFrequency_;
         quoteCcyIborLeg_ = buildFloatingLeg(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                            convention_, endOfMonth_, quoteCcyIdx_, paymentFrequency_, paymentLag_);
+                                            convention_, endOfMonth_, quoteCcyIdx_, effectiveQuoteCcyFreq, paymentLag_);
 
         initializeDatesFromLegs(baseCcyIborLeg_, quoteCcyIborLeg_);
     }
@@ -303,7 +307,8 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency,
         bool isBasisOnFxBaseCurrencyLeg,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -316,7 +321,8 @@ namespace QuantLib {
                                            isFxBaseCurrencyCollateralCurrency,
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
-                                           paymentLag) {}
+                                           paymentLag,
+                                           quoteCcyPaymentFrequency) {}
 
     Real ConstNotionalCrossCurrencyBasisSwapRateHelper::impliedQuote() const {
         QL_REQUIRE(!termStructureHandle_.empty(), "term structure not set");
@@ -355,7 +361,8 @@ namespace QuantLib {
         bool isBasisOnFxBaseCurrencyLeg,
         bool isFxBaseCurrencyLegResettable,
         Frequency paymentFrequency,
-        Integer paymentLag)
+        Integer paymentLag,
+        Frequency quoteCcyPaymentFrequency)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -368,7 +375,8 @@ namespace QuantLib {
                                            isFxBaseCurrencyCollateralCurrency,
                                            isBasisOnFxBaseCurrencyLeg,
                                            paymentFrequency,
-                                           paymentLag),
+                                           paymentLag,
+                                           quoteCcyPaymentFrequency),
       isFxBaseCurrencyLegResettable_(isFxBaseCurrencyLegResettable) {}
 
     Real MtMCrossCurrencyBasisSwapRateHelper::impliedQuote() const {

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -34,6 +34,19 @@ namespace QuantLib {
 
         constexpr double sample_fixed_rate = 0.01;
 
+        // Treat an explicitly-passed NoFrequency the same as an unset (nullopt)
+        // payment frequency.  Before these parameters were migrated to
+        // ext::optional<Frequency>, NoFrequency was the sentinel meaning "derive
+        // the schedule from the index tenor".  Normalizing it here preserves that
+        // behavior and keeps the stored optional either empty or holding an
+        // actual frequency, so the rest of the code can treat the two cases
+        // identically.
+        ext::optional<Frequency> normalizedPaymentFrequency(ext::optional<Frequency> frequency) {
+            if (frequency && *frequency == NoFrequency)
+                return ext::nullopt;
+            return frequency;
+        }
+
         Schedule legSchedule(const Date& evaluationDate,
                              const Period& tenor,
                              const Period& frequency,
@@ -264,8 +277,8 @@ namespace QuantLib {
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
-      paymentFrequency_(paymentFrequency),
-      quoteCcyPaymentFrequency_(quoteCcyPaymentFrequency) {
+      paymentFrequency_(normalizedPaymentFrequency(paymentFrequency)),
+      quoteCcyPaymentFrequency_(normalizedPaymentFrequency(quoteCcyPaymentFrequency)) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -76,7 +76,8 @@ namespace QuantLib {
                                              bool isFxBaseCurrencyCollateralCurrency,
                                              bool isBasisOnFxBaseCurrencyLeg,
                                              Frequency paymentFrequency = NoFrequency,
-                                             Integer paymentLag = 0);
+                                             Integer paymentLag = 0,
+                                             Frequency quoteCcyPaymentFrequency = NoFrequency);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -87,6 +88,7 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency_;
         bool isBasisOnFxBaseCurrencyLeg_;
         Frequency paymentFrequency_;
+        Frequency quoteCcyPaymentFrequency_;
 
         Leg baseCcyIborLeg_;
         Leg quoteCcyIborLeg_;
@@ -131,7 +133,8 @@ namespace QuantLib {
             bool isFxBaseCurrencyCollateralCurrency,
             bool isBasisOnFxBaseCurrencyLeg,
             Frequency paymentFrequency = NoFrequency,
-            Integer paymentLag = 0);
+            Integer paymentLag = 0,
+            Frequency quoteCcyPaymentFrequency = NoFrequency);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -170,7 +173,8 @@ namespace QuantLib {
                                             bool isBasisOnFxBaseCurrencyLeg,
                                             bool isFxBaseCurrencyLegResettable,
                                             Frequency paymentFrequency = NoFrequency,
-                                            Integer paymentLag = 0);
+                                            Integer paymentLag = 0,
+                                            Frequency quoteCcyPaymentFrequency = NoFrequency);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -77,7 +77,8 @@ namespace QuantLib {
                                              bool isFxBaseCurrencyCollateralCurrency,
                                              bool isBasisOnFxBaseCurrencyLeg,
                                              Frequency paymentFrequency = NoFrequency,
-                                             Integer paymentLag = 0);
+                                             Integer paymentLag = 0,
+                                             Frequency quoteCcyPaymentFrequency = NoFrequency);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -88,6 +89,7 @@ namespace QuantLib {
         bool isFxBaseCurrencyCollateralCurrency_;
         bool isBasisOnFxBaseCurrencyLeg_;
         Frequency paymentFrequency_;
+        Frequency quoteCcyPaymentFrequency_;
 
         Leg baseCcyIborLeg_;
         Leg quoteCcyIborLeg_;
@@ -132,7 +134,8 @@ namespace QuantLib {
             bool isFxBaseCurrencyCollateralCurrency,
             bool isBasisOnFxBaseCurrencyLeg,
             Frequency paymentFrequency = NoFrequency,
-            Integer paymentLag = 0);
+            Integer paymentLag = 0,
+            Frequency quoteCcyPaymentFrequency = NoFrequency);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -171,7 +174,8 @@ namespace QuantLib {
                                             bool isBasisOnFxBaseCurrencyLeg,
                                             bool isFxBaseCurrencyLegResettable,
                                             Frequency paymentFrequency = NoFrequency,
-                                            Integer paymentLag = 0);
+                                            Integer paymentLag = 0,
+                                            Frequency quoteCcyPaymentFrequency = NoFrequency);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -27,6 +27,7 @@
 
 #include <ql/termstructures/yield/ratehelpers.hpp>
 #include <ql/instruments/constnotionalcrosscurrencyfixedvsfloatingswap.hpp>
+#include <ql/optional.hpp>
 
 namespace QuantLib {
 
@@ -76,9 +77,9 @@ namespace QuantLib {
                                              Handle<YieldTermStructure> collateralCurve,
                                              bool isFxBaseCurrencyCollateralCurrency,
                                              bool isBasisOnFxBaseCurrencyLeg,
-                                             Frequency paymentFrequency = NoFrequency,
+                                             ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                              Integer paymentLag = 0,
-                                             Frequency quoteCcyPaymentFrequency = NoFrequency);
+                                             ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -88,8 +89,8 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> quoteCcyIdx_;
         bool isFxBaseCurrencyCollateralCurrency_;
         bool isBasisOnFxBaseCurrencyLeg_;
-        Frequency paymentFrequency_;
-        Frequency quoteCcyPaymentFrequency_;
+        ext::optional<Frequency> paymentFrequency_;
+        ext::optional<Frequency> quoteCcyPaymentFrequency_;
 
         Leg baseCcyIborLeg_;
         Leg quoteCcyIborLeg_;
@@ -133,9 +134,9 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& collateralCurve,
             bool isFxBaseCurrencyCollateralCurrency,
             bool isBasisOnFxBaseCurrencyLeg,
-            Frequency paymentFrequency = NoFrequency,
+            ext::optional<Frequency> paymentFrequency = ext::nullopt,
             Integer paymentLag = 0,
-            Frequency quoteCcyPaymentFrequency = NoFrequency);
+            ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -173,9 +174,9 @@ namespace QuantLib {
                                             bool isFxBaseCurrencyCollateralCurrency,
                                             bool isBasisOnFxBaseCurrencyLeg,
                                             bool isFxBaseCurrencyLegResettable,
-                                            Frequency paymentFrequency = NoFrequency,
+                                            ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                             Integer paymentLag = 0,
-                                            Frequency quoteCcyPaymentFrequency = NoFrequency);
+                                            ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -79,7 +79,7 @@ namespace QuantLib {
                                              bool isBasisOnFxBaseCurrencyLeg,
                                              ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                              Integer paymentLag = 0,
-                                             ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
+                                             ext::optional<Frequency> quoteCurrencyPaymentFrequency = ext::nullopt);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -122,6 +122,19 @@ namespace QuantLib {
     */
     class ConstNotionalCrossCurrencyBasisSwapRateHelper : public CrossCurrencyBasisSwapRateHelperBase {
       public:
+        /*! \param paymentFrequency
+                payment frequency of the base-currency leg; if left unset (the
+                default) the schedule is derived from the base-currency index tenor.
+            \param paymentLag
+                payment lag, in days, applied to both legs (default: 0).
+            \param quoteCurrencyPaymentFrequency
+                payment frequency of the quote-currency leg; if left unset (the
+                default) it defaults to \c paymentFrequency, and if that is unset as
+                well the schedule is derived from the quote-currency index tenor.
+
+            In both frequency parameters, \c NoFrequency is accepted as a synonym for
+            an unset (null) value.
+        */
         ConstNotionalCrossCurrencyBasisSwapRateHelper(
             const Handle<Quote>& basis,
             const Period& tenor,
@@ -136,7 +149,7 @@ namespace QuantLib {
             bool isBasisOnFxBaseCurrencyLeg,
             ext::optional<Frequency> paymentFrequency = ext::nullopt,
             Integer paymentLag = 0,
-            ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
+            ext::optional<Frequency> quoteCurrencyPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -162,6 +175,19 @@ namespace QuantLib {
     */
     class MtMCrossCurrencyBasisSwapRateHelper : public CrossCurrencyBasisSwapRateHelperBase {
       public:
+        /*! \param paymentFrequency
+                payment frequency of the base-currency leg; if left unset (the
+                default) the schedule is derived from the base-currency index tenor.
+            \param paymentLag
+                payment lag, in days, applied to both legs (default: 0).
+            \param quoteCurrencyPaymentFrequency
+                payment frequency of the quote-currency leg; if left unset (the
+                default) it defaults to \c paymentFrequency, and if that is unset as
+                well the schedule is derived from the quote-currency index tenor.
+
+            In both frequency parameters, \c NoFrequency is accepted as a synonym for
+            an unset (null) value.
+        */
         MtMCrossCurrencyBasisSwapRateHelper(const Handle<Quote>& basis,
                                             const Period& tenor,
                                             Natural fixingDays,
@@ -176,7 +202,7 @@ namespace QuantLib {
                                             bool isFxBaseCurrencyLegResettable,
                                             ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                             Integer paymentLag = 0,
-                                            ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt);
+                                            ext::optional<Frequency> quoteCurrencyPaymentFrequency = ext::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -115,7 +115,8 @@ struct CommonVars {
                             bool isFxBaseCurrencyLegResettable,
                             Frequency paymentFrequency = NoFrequency,
                             Integer paymentLag = 0,
-                            bool useOvernightIndex = false) const {
+                            bool useOvernightIndex = false,
+                            Frequency quoteCcyPaymentFrequency = NoFrequency) const {
         Handle<Quote> quoteHandle(ext::make_shared<SimpleQuote>(q.basis * basisPoint));
         Period tenor(q.n, q.units);
         ext::shared_ptr<IborIndex> baseIndex, quoteIndex;
@@ -130,7 +131,8 @@ struct CommonVars {
         return ext::shared_ptr<RateHelper>(new MtMCrossCurrencyBasisSwapRateHelper(
                 quoteHandle, tenor, instrumentSettlementDays, calendar, businessConvention, endOfMonth,
             baseIndex, quoteIndex, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag));
+                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag,
+                quoteCcyPaymentFrequency));
     }
 
     std::vector<ext::shared_ptr<RateHelper> >
@@ -141,14 +143,16 @@ struct CommonVars {
                                   bool isFxBaseCurrencyLegResettable,
                                   Frequency paymentFrequency = NoFrequency,
                                   Integer paymentLag = 0,
-                                  bool useOvernightQuoteIndex = false) const {
+                                  bool useOvernightQuoteIndex = false,
+                                  Frequency quoteCcyPaymentFrequency = NoFrequency) const {
         std::vector<ext::shared_ptr<RateHelper> > instruments;
         instruments.reserve(xccyData.size());
         for (const auto& i : xccyData) {
             instruments.push_back(resettingXccyRateHelper(
                     i, collateralHandle, isFxBaseCurrencyCollateralCurrency,
                     isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable,
-                    paymentFrequency, paymentLag, useOvernightQuoteIndex));
+                    paymentFrequency, paymentLag, useOvernightQuoteIndex,
+                    quoteCcyPaymentFrequency));
         }
 
         return instruments;
@@ -311,7 +315,8 @@ void testResettingCrossCurrencySwaps(bool isFxBaseCurrencyCollateralCurrency,
                                      bool isFxBaseCurrencyLegResettable,
                                      Frequency paymentFrequency = NoFrequency,
                                      Integer paymentLag = 0,
-                                     bool useOvernightIndex = false) {
+                                     bool useOvernightIndex = false,
+                                     Frequency quoteCcyPaymentFrequency = NoFrequency) {
 
     CommonVars vars;
 
@@ -322,7 +327,7 @@ void testResettingCrossCurrencySwaps(bool isFxBaseCurrencyCollateralCurrency,
         vars.buildResettingXccyRateHelpers(
             vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
             isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag,
-            useOvernightIndex);
+            useOvernightIndex, quoteCcyPaymentFrequency);
 
     std::vector<ext::shared_ptr<RateHelper> > constNotionalInstruments =
         vars.buildConstantNotionalXccyRateHelpers(vars.basisData, collateralHandle,
@@ -461,6 +466,19 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithArbitraryFreq) {
     testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
                                     isFxBaseCurrencyLegResettable,
                                     Weekly);
+}
+
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithAsymmetricFrequencies) {
+    BOOST_TEST_MESSAGE(
+        "Testing resetting basis swaps with different payment frequencies per leg...");
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isFxBaseCurrencyLegResettable = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+
+    testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
+                                    isFxBaseCurrencyLegResettable, Semiannual, 0, false,
+                                    Quarterly);
 }
 
 BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithPaymentLag) {

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -482,6 +482,60 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithAsymmetricFrequencies) {
                                     Quarterly);
 }
 
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsTreatNoFrequencyAsUnset) {
+    BOOST_TEST_MESSAGE(
+        "Testing that an explicit NoFrequency reproduces the default payment frequency...");
+
+    CommonVars vars;
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+    bool isFxBaseCurrencyLegResettable = false;
+
+    Handle<YieldTermStructure> collateralHandle = vars.quoteCcyIdxHandle;
+
+    // Default (unset) payment frequencies: the schedule is derived from the
+    // index tenor on both legs.
+    std::vector<ext::shared_ptr<RateHelper> > defaultInstruments =
+        vars.buildResettingXccyRateHelpers(
+            vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, ext::nullopt, 0, false,
+            ext::nullopt);
+
+    // An explicit NoFrequency on both legs must behave identically.  Before
+    // NoFrequency was normalized to nullopt it built a single-period schedule
+    // (Period(NoFrequency) has zero length, which Schedule maps to the Zero
+    // date-generation rule), silently changing the result instead of using the
+    // index tenor.
+    std::vector<ext::shared_ptr<RateHelper> > noFrequencyInstruments =
+        vars.buildResettingXccyRateHelpers(
+            vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, NoFrequency, 0, false,
+            NoFrequency);
+
+    ext::shared_ptr<YieldTermStructure> defaultCurve(new PiecewiseYieldCurve<Discount, LogLinear>(
+        vars.curveSettlementDt, defaultInstruments, vars.dayCount));
+    defaultCurve->enableExtrapolation();
+
+    ext::shared_ptr<YieldTermStructure> noFrequencyCurve(new PiecewiseYieldCurve<Discount, LogLinear>(
+        vars.curveSettlementDt, noFrequencyInstruments, vars.dayCount));
+    noFrequencyCurve->enableExtrapolation();
+
+    Real tolerance = 1.0e-12;
+    for (Size i = 0; i < vars.basisData.size(); ++i) {
+        Date maturity = defaultInstruments[i]->maturityDate();
+        Rate defaultZero = defaultCurve->zeroRate(maturity, vars.dayCount, Continuous);
+        Rate noFrequencyZero = noFrequencyCurve->zeroRate(maturity, vars.dayCount, Continuous);
+
+        if (std::fabs(defaultZero - noFrequencyZero) > tolerance)
+            BOOST_ERROR("explicit NoFrequency does not match the default payment frequency\n"
+                        << std::setprecision(16)
+                        << "    zero with default frequency:    " << defaultZero << "\n"
+                        << "    zero with explicit NoFrequency:    " << noFrequencyZero << "\n"
+                        << "    maturity:    " << maturity << "\n");
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithPaymentLag) {
     BOOST_TEST_MESSAGE(
         "Testing resetting basis swaps with collateral in quote ccy and basis in base ccy...");

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -536,6 +536,57 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsTreatNoFrequencyAsUnset) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testResettingBasisSwapsQuoteFrequencyDefaultsToBase) {
+    BOOST_TEST_MESSAGE(
+        "Testing that an unset quote-currency payment frequency defaults to the base frequency...");
+
+    CommonVars vars;
+
+    bool isFxBaseCurrencyCollateralCurrency = false;
+    bool isBasisOnFxBaseCurrencyLeg = true;
+    bool isFxBaseCurrencyLegResettable = false;
+
+    Handle<YieldTermStructure> collateralHandle = vars.quoteCcyIdxHandle;
+
+    Frequency baseFrequency = Semiannual;
+
+    // Quote-currency frequency left unset: it must fall back to the base frequency.
+    std::vector<ext::shared_ptr<RateHelper> > fallbackInstruments =
+        vars.buildResettingXccyRateHelpers(
+            vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, baseFrequency, 0, false,
+            ext::nullopt);
+
+    // Quote-currency frequency set explicitly to the base frequency: same result.
+    std::vector<ext::shared_ptr<RateHelper> > explicitInstruments =
+        vars.buildResettingXccyRateHelpers(
+            vars.basisData, collateralHandle, isFxBaseCurrencyCollateralCurrency,
+            isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, baseFrequency, 0, false,
+            baseFrequency);
+
+    ext::shared_ptr<YieldTermStructure> fallbackCurve(new PiecewiseYieldCurve<Discount, LogLinear>(
+        vars.curveSettlementDt, fallbackInstruments, vars.dayCount));
+    fallbackCurve->enableExtrapolation();
+
+    ext::shared_ptr<YieldTermStructure> explicitCurve(new PiecewiseYieldCurve<Discount, LogLinear>(
+        vars.curveSettlementDt, explicitInstruments, vars.dayCount));
+    explicitCurve->enableExtrapolation();
+
+    Real tolerance = 1.0e-12;
+    for (Size i = 0; i < vars.basisData.size(); ++i) {
+        Date maturity = fallbackInstruments[i]->maturityDate();
+        Rate fallbackZero = fallbackCurve->zeroRate(maturity, vars.dayCount, Continuous);
+        Rate explicitZero = explicitCurve->zeroRate(maturity, vars.dayCount, Continuous);
+
+        if (std::fabs(fallbackZero - explicitZero) > tolerance)
+            BOOST_ERROR("unset quote-currency frequency does not default to the base frequency\n"
+                        << std::setprecision(16)
+                        << "    zero with quote frequency unset:    " << fallbackZero << "\n"
+                        << "    zero with quote frequency = base:    " << explicitZero << "\n"
+                        << "    maturity:    " << maturity << "\n");
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithPaymentLag) {
     BOOST_TEST_MESSAGE(
         "Testing resetting basis swaps with collateral in quote ccy and basis in base ccy...");

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -23,6 +23,7 @@
 #include <ql/indexes/ibor/sofr.hpp>
 #include <ql/pricingengines/vanilla/all.hpp>
 #include <ql/experimental/termstructures/crosscurrencyratehelpers.hpp>
+#include <ql/optional.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
 #include <ql/indexes/ibor/usdlibor.hpp>
 #include <ql/cashflows/iborcoupon.hpp>
@@ -113,10 +114,10 @@ struct CommonVars {
                             bool isFxBaseCurrencyCollateralCurrency,
                             bool isBasisOnFxBaseCurrencyLeg,
                             bool isFxBaseCurrencyLegResettable,
-                            Frequency paymentFrequency = NoFrequency,
+                            ext::optional<Frequency> paymentFrequency = ext::nullopt,
                             Integer paymentLag = 0,
                             bool useOvernightIndex = false,
-                            Frequency quoteCcyPaymentFrequency = NoFrequency) const {
+                            ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt) const {
         Handle<Quote> quoteHandle(ext::make_shared<SimpleQuote>(q.basis * basisPoint));
         Period tenor(q.n, q.units);
         ext::shared_ptr<IborIndex> baseIndex, quoteIndex;
@@ -141,10 +142,10 @@ struct CommonVars {
                                   bool isFxBaseCurrencyCollateralCurrency,
                                   bool isBasisOnFxBaseCurrencyLeg,
                                   bool isFxBaseCurrencyLegResettable,
-                                  Frequency paymentFrequency = NoFrequency,
+                                  ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                   Integer paymentLag = 0,
                                   bool useOvernightQuoteIndex = false,
-                                  Frequency quoteCcyPaymentFrequency = NoFrequency) const {
+                                  ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt) const {
         std::vector<ext::shared_ptr<RateHelper> > instruments;
         instruments.reserve(xccyData.size());
         for (const auto& i : xccyData) {
@@ -313,10 +314,10 @@ void testConstantNotionalCrossCurrencySwapsNPV(bool isFxBaseCurrencyCollateralCu
 void testResettingCrossCurrencySwaps(bool isFxBaseCurrencyCollateralCurrency,
                                      bool isBasisOnFxBaseCurrencyLeg,
                                      bool isFxBaseCurrencyLegResettable,
-                                     Frequency paymentFrequency = NoFrequency,
+                                     ext::optional<Frequency> paymentFrequency = ext::nullopt,
                                      Integer paymentLag = 0,
                                      bool useOvernightIndex = false,
-                                     Frequency quoteCcyPaymentFrequency = NoFrequency) {
+                                     ext::optional<Frequency> quoteCcyPaymentFrequency = ext::nullopt) {
 
     CommonVars vars;
 
@@ -490,7 +491,7 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithPaymentLag) {
     bool isBasisOnFxBaseCurrencyLeg = true;
 
     testResettingCrossCurrencySwaps(isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
-                                    isFxBaseCurrencyLegResettable, NoFrequency, 2);
+                                    isFxBaseCurrencyLegResettable, ext::nullopt, 2);
 }
 
 BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithOvernightIndex) {
@@ -515,7 +516,7 @@ BOOST_AUTO_TEST_CASE(testResettingBasisSwapsWithOvernightIndexException) {
 
     BOOST_CHECK_THROW(testResettingCrossCurrencySwaps(
                           isFxBaseCurrencyCollateralCurrency, isBasisOnFxBaseCurrencyLeg,
-                          isFxBaseCurrencyLegResettable, NoFrequency, 0, true),
+                          isFxBaseCurrencyLegResettable, ext::nullopt, 0, true),
         Error);
 }
 


### PR DESCRIPTION
Added a `quoteCcyPaymentFrequency` parameter to the cross-currency basis swap rate helpers so the two legs can have different payment frequencies (e.g., 6M base / 3M quote for INR/USD basis).

The new parameter defaults to `NoFrequency`, which falls back to the shared paymentFrequency, so there shouldn't be any impact on existing code. Also added a test for the asymmetric case.

Fixes #2428