### PR TITLE
Add the double boundary case for QDFP and QD+ American Engine and analytical greeks for both

### DIFF
--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -27,8 +27,6 @@
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/qdfpamericanengine.hpp>
-#include <iostream>
-#include <utility>
 #ifndef QL_BOOST_HAS_TANH_SINH
 #    include <ql/math/integrals/gausslobattointegral.hpp>
 #endif
@@ -124,6 +122,10 @@ namespace QuantLib {
         using detail::computeTauHatSensitivities;
     }
 
+    struct FpParameterDerivatives {
+        Real dfv_dSigma, dfv_dR, dfv_dQ;
+    };
+
     class DqFpEquation {
       public:
         DqFpEquation(Rate _r,
@@ -143,6 +145,8 @@ namespace QuantLib {
 
         virtual std::pair<Real, Real> NDd(Real tau, Real b) const = 0;
         virtual std::tuple<Real, Real, Real> f(Real tau, Real b) const = 0;
+        virtual FpParameterDerivatives fDerivatives(
+            Real tau, Real b, Real N, Real D, Real fv) const = 0;
 
         virtual ~DqFpEquation() = default;
 
@@ -176,6 +180,8 @@ namespace QuantLib {
 
         std::pair<Real, Real> NDd(Real tau, Real b) const override;
         std::tuple<Real, Real, Real> f(Real tau, Real b) const override;
+        FpParameterDerivatives fDerivatives(
+            Real tau, Real b, Real N, Real D, Real fv) const override;
 
       private:
           const Real K;
@@ -192,6 +198,8 @@ namespace QuantLib {
 
         std::pair<Real, Real> NDd(Real tau, Real b) const override;
         std::tuple<Real, Real, Real> f(Real tau, Real b) const override;
+        FpParameterDerivatives fDerivatives(
+            Real tau, Real b, Real N, Real D, Real fv) const override;
 
       private:
           const Real K;
@@ -316,6 +324,203 @@ namespace QuantLib {
         return std::make_pair(Nd, Dd);
     }
 
+    FpParameterDerivatives DqFpEquation_A::fDerivatives(
+        Real tau, Real b, Real N, Real D, Real fv) const {
+
+        if (tau < squared(QL_EPSILON))
+            return {0.0, 0.0, 0.0};
+
+        const Real alpha = K * std::exp(-(r - q) * tau);
+        const Real v = vol * std::sqrt(tau);
+        const Real stv = std::sqrt(tau) / vol;
+        const Real sqrtTau = std::sqrt(tau);
+        const Real vol2 = vol * vol;
+        const auto [dp0, dm0] = d(tau, b / K);
+        const Real phi_dp0 = phi(dp0);
+        const Real phi_dm0 = phi(dm0);
+
+        // Lead terms for N = phi(dm0)/v + r*K3
+        // d[phi(d)/v]/dsigma = phi(d)*(d*d_other - 1)/(v*sigma)
+        // d[phi(d)/v]/dr = -d*phi(d)/sigma^2
+        // d[phi(d)/v]/dq = d*phi(d)/sigma^2
+        Real dNds = phi_dm0 * (dm0 * dp0 - 1) / (v * vol);
+        Real dNdr = -dm0 * phi_dm0 / vol2;
+        Real dNdq = dm0 * phi_dm0 / vol2;
+
+        // Lead terms for D = phi(dp0)/v + Phi(dp0) + q*K12
+        // d[Phi(dp0)]/dsigma = phi(dp0)*(-dm0/sigma)
+        // d[Phi(dp0)]/dr = phi(dp0)*sqrtTau/sigma
+        // d[Phi(dp0)]/dq = phi(dp0)*(-sqrtTau/sigma)
+        Real dDds = phi_dp0 * (dp0 * dm0 - 1) / (v * vol) + phi_dp0 * (-dm0 / vol);
+        Real dDdr = -dp0 * phi_dp0 / vol2 + phi_dp0 * sqrtTau / vol;
+        Real dDdq = dp0 * phi_dp0 / vol2 + phi_dp0 * (-sqrtTau / vol);
+
+        // Integral terms for K3 and K12 plus their parameter derivatives
+        Real K3_val = 0, K12_val = 0;
+        Real dK3ds = 0, dK12ds = 0;
+        Real dK3dr = 0, dK12dr = 0;
+        Real dK3dq = 0, dK12dq = 0;
+
+        if (!x_i.empty()) {
+            for (Integer i = x_i.size() - 1; i >= 0; --i) {
+                const Real y = x_i[i];
+                const Real m = 0.25 * tau * squared(1 + y);
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real phi_dp_m = phi(dp_m);
+                const Real phi_dm_m = phi(dm_m);
+                const Real Phi_dp_m = Phi(dp_m);
+                const Real exp_r = std::exp(r * (tau - m));
+                const Real exp_q = std::exp(q * (tau - m));
+                const Real sqrt_m = std::sqrt(std::max(0.0, m));
+                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+
+                K3_val += w_i[i] * stv * exp_r * phi_dm_m;
+                K12_val += w_i[i] * exp_q * (half_tau_yp1 * Phi_dp_m + stv * phi_dp_m);
+
+                // sigma: d/dsigma of stv*exp_r*phi(dm) = stv*exp_r*phi(dm)*(dm*dp-1)/sigma
+                dK3ds += w_i[i] * stv * exp_r * phi_dm_m * (dm_m * dp_m - 1) / vol;
+                // d/dsigma of exp_q*[...] = exp_q*phi(dp)*[-dm*half/(sigma) + stv*(dp*dm-1)/sigma]
+                dK12ds += w_i[i] * exp_q * phi_dp_m *
+                    (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
+
+                // r: d/dr of stv*exp(r*(tau-m))*phi(dm) via product+chain rule
+                dK3dr += w_i[i] * stv * exp_r * phi_dm_m *
+                    ((tau - m) - dm_m * sqrt_m / vol);
+                // K12 depends on r only through dp (exp_q independent of r)
+                dK12dr += w_i[i] * exp_q * phi_dp_m * (sqrt_m / vol) *
+                    (half_tau_yp1 - stv * dp_m);
+
+                // q: K3 depends on q only through dm (exp_r independent of q)
+                dK3dq += w_i[i] * stv * exp_r * phi_dm_m * dm_m * sqrt_m / vol;
+                // d/dq of exp(q*(tau-m))*[...]: both exp and dp depend on q
+                dK12dq += w_i[i] * exp_q *
+                    ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi_dp_m)
+                     + phi_dp_m * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
+            }
+        }
+        else {
+            const Real sqrtTwoPI = M_SQRT2 * M_SQRTPI;
+
+            K3_val = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(r * tau - r * m);
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return df * stv / sqrtTwoPI;
+                    else
+                        return 0.0;
+                }
+                return df * stv * phi(d(m, b / B(tau - m)).second);
+            }, -1, 1);
+
+            K12_val = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(q * tau - q * m);
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return df * stv / sqrtTwoPI;
+                    else
+                        return 0.0;
+                }
+                const Real dp = d(m, b / B(tau - m)).first;
+                return df * (0.5 * tau * (y + 1) * Phi(dp) + stv * phi(dp));
+            }, -1, 1);
+
+            // sigma derivative integrals
+            dK3ds = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(r * (tau - m));
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return -df * stv / (vol * sqrtTwoPI);
+                    return 0.0;
+                }
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                return stv * df * phi(dm_m) * (dm_m * dp_m - 1) / vol;
+            }, -1, 1);
+
+            dK12ds = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(q * (tau - m));
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return -df * stv / (vol * sqrtTwoPI);
+                    return 0.0;
+                }
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                return df * phi(dp_m) *
+                    (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
+            }, -1, 1);
+
+            // r derivative integrals
+            dK3dr = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(r * (tau - m));
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return df * stv * tau / sqrtTwoPI;
+                    return 0.0;
+                }
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real sqrt_m = std::sqrt(m);
+                return stv * df * phi(dm_m) * ((tau - m) - dm_m * sqrt_m / vol);
+            }, -1, 1);
+
+            dK12dr = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                if (y <= 5 * QL_EPSILON - 1)
+                    return 0.0;
+                const Real df = std::exp(q * (tau - m));
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real sqrt_m = std::sqrt(m);
+                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                return df * phi(dp_m) * (sqrt_m / vol) * (half_tau_yp1 - stv * dp_m);
+            }, -1, 1);
+
+            // q derivative integrals
+            dK3dq = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                if (y <= 5 * QL_EPSILON - 1)
+                    return 0.0;
+                const Real df = std::exp(r * (tau - m));
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real sqrt_m = std::sqrt(m);
+                return stv * df * phi(dm_m) * dm_m * sqrt_m / vol;
+            }, -1, 1);
+
+            dK12dq = (*integrator)([&, this](Real y) -> Real {
+                const Real m = 0.25 * tau * squared(1 + y);
+                const Real df = std::exp(q * (tau - m));
+                if (y <= 5 * QL_EPSILON - 1) {
+                    if (close_enough(b, B(tau - m)))
+                        return df * tau * stv / sqrtTwoPI;
+                    return 0.0;
+                }
+                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                const Real sqrt_m = std::sqrt(m);
+                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                const Real Phi_dp_m = Phi(dp_m);
+                return df * ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi(dp_m))
+                    + phi(dp_m) * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
+            }, -1, 1);
+        }
+
+        // Assemble using product rule: d(r*K3)/dr = K3 + r*dK3/dr, etc.
+        dNds += r * dK3ds;
+        dDds += q * dK12ds;
+        dNdr += K3_val + r * dK3dr;
+        dDdr += q * dK12dr;
+        dNdq += r * dK3dq;
+        dDdq += K12_val + q * dK12dq;
+
+        const Real D2 = D * D;
+        const Real dfv_ds = alpha * (dNds * D - N * dDds) / D2;
+        const Real dfv_dr = -tau * fv + alpha * (dNdr * D - N * dDdr) / D2;
+        const Real dfv_dq = tau * fv + alpha * (dNdq * D - N * dDdq) / D2;
+
+        return {dfv_ds, dfv_dr, dfv_dq};
+    }
 
     DqFpEquation_B::DqFpEquation_B(Real K,
                                    Rate _r,
@@ -405,6 +610,160 @@ namespace QuantLib {
             phi(dpm.second) / (b*vol*std::sqrt(tau)),
             phi(dpm.first)  / (b*vol*std::sqrt(tau))
         );
+    }
+
+    FpParameterDerivatives DqFpEquation_B::fDerivatives(
+        Real tau, Real b, Real N, Real D, Real fv) const {
+
+        if (tau < squared(QL_EPSILON))
+            return {0.0, 0.0, 0.0};
+
+        const Real alpha = K * std::exp(-(r - q) * tau);
+        const Real sqrtTau = std::sqrt(tau);
+        const auto [dp0, dm0] = d(tau, b / K);
+        const Real phi_dp0 = phi(dp0);
+        const Real phi_dm0 = phi(dm0);
+
+        // Lead terms: derivatives of Phi(d0) w.r.t. sigma, r, q
+        Real dNds = phi_dm0 * (-dp0 / vol);
+        Real dDds = phi_dp0 * (-dm0 / vol);
+        Real dNdr = phi_dm0 * (sqrtTau / vol);
+        Real dDdr = phi_dp0 * (sqrtTau / vol);
+        Real dNdq = phi_dm0 * (-sqrtTau / vol);
+        Real dDdq = phi_dp0 * (-sqrtTau / vol);
+
+        // Integral terms accumulated over quadrature nodes.
+        // ni = integral of exp(ru)*Phi(d-) du, needed for d(r*ni)/dr = ni + r*dni/dr
+        // di = integral of exp(qu)*Phi(d+) du, needed for d(q*di)/dq = di + q*ddi/dq
+        Real ni_val = 0, di_val = 0;
+        Real int_Nds = 0, int_Dds = 0;
+        Real int_Ndr = 0, int_Ddr = 0;
+        Real int_Ndq = 0, int_Ddq = 0;
+
+        if (!x_i.empty()) {
+            const Real c = 0.5 * tau;
+
+            for (Integer i = x_i.size() - 1; i >= 0; --i) {
+                const Real u = c * x_i[i] + c;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                const Real phi_dpu = phi(dpu);
+                const Real phi_dmu = phi(dmu);
+                const Real Phi_dmu = Phi(dmu);
+                const Real Phi_dpu = Phi(dpu);
+                const Real exp_ru = std::exp(r * u);
+                const Real exp_qu = std::exp(q * u);
+                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+
+                ni_val += w_i[i] * exp_ru * Phi_dmu;
+                di_val += w_i[i] * exp_qu * Phi_dpu;
+
+                // sigma: dd+/dsigma = -d-/sigma, dd-/dsigma = -d+/sigma
+                int_Nds += w_i[i] * exp_ru * phi_dmu * (-dpu / vol);
+                int_Dds += w_i[i] * exp_qu * phi_dpu * (-dmu / vol);
+
+                // r: dd/dr = sqrt(tau-u)/sigma for both d+ and d-
+                // Also u*Phi from d(exp(ru))/dr = u*exp(ru)
+                int_Ndr += w_i[i] * exp_ru * (u * Phi_dmu + phi_dmu * sqrt_s / vol);
+                int_Ddr += w_i[i] * exp_qu * phi_dpu * sqrt_s / vol;
+
+                // q: dd/dq = -sqrt(tau-u)/sigma for both d+ and d-
+                // Also u*Phi from d(exp(qu))/dq = u*exp(qu)
+                int_Ndq += w_i[i] * exp_ru * phi_dmu * (-sqrt_s / vol);
+                int_Ddq += w_i[i] * exp_qu * (u * Phi_dpu + phi_dpu * (-sqrt_s / vol));
+            }
+            ni_val *= c;
+            di_val *= c;
+
+            dNds += r * c * int_Nds;
+            dDds += q * c * int_Dds;
+            dNdr += ni_val + r * c * int_Ndr;
+            dDdr += q * c * int_Ddr;
+            dNdq += r * c * int_Ndq;
+            dDdq += di_val + q * c * int_Ddq;
+        }
+        else {
+            // Generic integrator path
+            ni_val = (*integrator)([&, this](Real u) -> Real {
+                const Real df = std::exp(r * u);
+                if (u >= tau * (1 - 5 * QL_EPSILON)) {
+                    if (close_enough(b, B(u)))
+                        return 0.5 * df;
+                    else
+                        return df * ((b < B(u) ? 0.0 : 1.0));
+                }
+                return df * Phi(d(tau - u, b / B(u)).second);
+            }, 0, tau);
+            di_val = (*integrator)([&, this](Real u) -> Real {
+                const Real df = std::exp(q * u);
+                if (u >= tau * (1 - 5 * QL_EPSILON)) {
+                    if (close_enough(b, B(u)))
+                        return 0.5 * df;
+                    else
+                        return df * ((b < B(u) ? 0.0 : 1.0));
+                }
+                return df * Phi(d(tau - u, b / B(u)).first);
+            }, 0, tau);
+
+            // sigma derivative integrals
+            const Real i_Nds = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                return std::exp(r * u) * phi(dmu) * (-dpu / vol);
+            }, 0, tau);
+            const Real i_Dds = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                return std::exp(q * u) * phi(dpu) * (-dmu / vol);
+            }, 0, tau);
+
+            // r derivative integrals
+            const Real i_Ndr = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                return std::exp(r * u) * (u * Phi(dmu) + phi(dmu) * sqrt_s / vol);
+            }, 0, tau);
+            const Real i_Ddr = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                return std::exp(q * u) * phi(dpu) * sqrt_s / vol;
+            }, 0, tau);
+
+            // q derivative integrals
+            const Real i_Ndq = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                return std::exp(r * u) * phi(dmu) * (-sqrt_s / vol);
+            }, 0, tau);
+            const Real i_Ddq = (*integrator)([&, this](Real u) -> Real {
+                if (u >= tau * (1 - 5 * QL_EPSILON))
+                    return 0.0;
+                const auto [dpu, dmu] = d(tau - u, b / B(u));
+                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                return std::exp(q * u) * (u * Phi(dpu) + phi(dpu) * (-sqrt_s / vol));
+            }, 0, tau);
+
+            dNds += r * i_Nds;
+            dDds += q * i_Dds;
+            dNdr += ni_val + r * i_Ndr;
+            dDdr += q * i_Ddr;
+            dNdq += r * i_Ndq;
+            dDdq += di_val + q * i_Ddq;
+        }
+
+        const Real D2 = D * D;
+        const Real dfv_ds = alpha * (dNds * D - N * dDds) / D2;
+        const Real dfv_dr = -tau * fv + alpha * (dNdr * D - N * dDdr) / D2;
+        const Real dfv_dq = tau * fv + alpha * (dNdq * D - N * dDdq) / D2;
+
+        return {dfv_ds, dfv_dr, dfv_dq};
     }
 
     QdFpAmericanEngine::QdFpAmericanEngine(
@@ -773,58 +1132,26 @@ namespace QuantLib {
             const Size nNodes = x.size();
             const Size m = nNodes - 1;
 
-            // Determine FP equation type consistently
-            const bool useFpA =
-                (fpEquation_ == FP_A || (fpEquation_ == Auto && std::abs(r - q) < 0.001));
-
-            // Use GaussLegendre for sensitivity equations to avoid
-            // GaussLobatto max-iteration failures with bumped parameters
-            auto makeSensEqn = [&](Rate r_, Rate q_,
-                                   Volatility vol_) -> ext::shared_ptr<DqFpEquation> {
-                auto sensInteg = ext::make_shared<GaussLegendreIntegrator>(25);
-                if (useFpA)
-                    return ext::shared_ptr<DqFpEquation>(
-                        new DqFpEquation_A(K, r_, q_, vol_, B, std::move(sensInteg)));
-                else
-                    return ext::shared_ptr<DqFpEquation>(
-                        new DqFpEquation_B(K, r_, q_, vol_, B, std::move(sensInteg)));
-            };
-
-            // Compute y_fp = h(G(B;p)) explicitly. This differs from y_orig
-            // by the FP residual; using y_orig in finite differences would
-            // amplify this residual by 1/eps, corrupting the sensitivities.
-            Array y_fp(nNodes);
+            // Step 1: dG/dp via analytical derivatives of the FP equation.
+            // h(fv) = log(fv/xmax)^2, h'(fv) = 2*log(fv/xmax)/fv
+            // dG/dp = h'(fv) * dfv/dp
+            Array y_fp(nNodes), g_sigma(m), g_r(m), g_q(m);
             y_fp[0] = 0.0;
             for (Size i = 1; i < nNodes; ++i) {
                 const Real tau = squared(x[i]);
-                y_fp[i] = h(std::get<2>(eqn->f(tau, B(tau))));
-            }
-
-            // Step 1: dG/dp -- central difference for O(eps^2) accuracy
-            const Real eps_sigma = vol * 1e-4;
-            const Real eps_r = std::max(std::abs(r), 1.0) * 1e-4;
-            const Real eps_q = std::max(std::abs(q), 1.0) * 1e-4;
-
-            const auto eqn_sv_up = makeSensEqn(r, q, vol + eps_sigma);
-            const auto eqn_sv_dn = makeSensEqn(r, q, vol - eps_sigma);
-            const auto eqn_rv_up = makeSensEqn(r + eps_r, q, vol);
-            const auto eqn_rv_dn = makeSensEqn(r - eps_r, q, vol);
-            const auto eqn_qv_up = makeSensEqn(r, q + eps_q, vol);
-            const auto eqn_qv_dn = makeSensEqn(r, q - eps_q, vol);
-
-            Array g_sigma(m), g_r(m), g_q(m);
-            for (Size i = 1; i < nNodes; ++i) {
-                const Real tau = squared(x[i]);
                 const Real b = B(tau);
-                g_sigma[i - 1] =
-                    (h(std::get<2>(eqn_sv_up->f(tau, b))) - h(std::get<2>(eqn_sv_dn->f(tau, b)))) /
-                    (2 * eps_sigma);
-                g_r[i - 1] =
-                    (h(std::get<2>(eqn_rv_up->f(tau, b))) - h(std::get<2>(eqn_rv_dn->f(tau, b)))) /
-                    (2 * eps_r);
-                g_q[i - 1] =
-                    (h(std::get<2>(eqn_qv_up->f(tau, b))) - h(std::get<2>(eqn_qv_dn->f(tau, b)))) /
-                    (2 * eps_q);
+                const auto [N_i, D_i, fv_i] = eqn->f(tau, b);
+                y_fp[i] = h(fv_i);
+
+                if (tau < squared(QL_EPSILON) || fv_i < QL_EPSILON) {
+                    g_sigma[i - 1] = g_r[i - 1] = g_q[i - 1] = 0.0;
+                } else {
+                    const auto derivs = eqn->fDerivatives(tau, b, N_i, D_i, fv_i);
+                    const Real hp = 2.0 * std::log(fv_i / xmax) / fv_i;
+                    g_sigma[i - 1] = hp * derivs.dfv_dSigma;
+                    g_r[i - 1] = hp * derivs.dfv_dR;
+                    g_q[i - 1] = hp * derivs.dfv_dQ;
+                }
             }
 
             // Step 2: Sensitivity FP iteration -- same contraction as boundary
@@ -942,43 +1269,25 @@ namespace QuantLib {
                 const Size nYNodes = xY.size();
                 const Size mY = nYNodes - 1;
 
-                // Y FP baseline values
-                Array y_fp_Y(nYNodes);
+                // Step 1 for Y: analytical dG_Y/dp
+                // h_y(fv) = log(fv/ymax)^2, h_y'(fv) = 2*log(fv/ymax)/fv
+                Array y_fp_Y(nYNodes), gY_sigma(mY), gY_r(mY), gY_q(mY);
                 y_fp_Y[0] = 0.0;
                 for (Size i = 1; i < nYNodes; ++i) {
                     const Real tau = squared(xY[i]);
-                    y_fp_Y[i] = h_y(std::get<2>(eqnY->f(tau, Y(tau))));
-                }
-
-                // Bumped FP equations for Y (always use FP_B for Y boundary)
-                auto makeSensEqnY = [&](Rate r_, Rate q_,
-                                        Volatility vol_) -> ext::shared_ptr<DqFpEquation> {
-                    auto sensInteg = ext::make_shared<GaussLegendreIntegrator>(25);
-                    return ext::shared_ptr<DqFpEquation>(
-                        new DqFpEquation_B(K, r_, q_, vol_, Y, std::move(sensInteg)));
-                };
-
-                const auto eqnY_sv_up = makeSensEqnY(r, q, vol + eps_sigma);
-                const auto eqnY_sv_dn = makeSensEqnY(r, q, vol - eps_sigma);
-                const auto eqnY_rv_up = makeSensEqnY(r + eps_r, q, vol);
-                const auto eqnY_rv_dn = makeSensEqnY(r - eps_r, q, vol);
-                const auto eqnY_qv_up = makeSensEqnY(r, q + eps_q, vol);
-                const auto eqnY_qv_dn = makeSensEqnY(r, q - eps_q, vol);
-
-                // dG_Y/dp via central difference
-                Array gY_sigma(mY), gY_r(mY), gY_q(mY);
-                for (Size i = 1; i < nYNodes; ++i) {
-                    const Real tau = squared(xY[i]);
                     const Real yt = Y(tau);
-                    gY_sigma[i - 1] = (h_y(std::get<2>(eqnY_sv_up->f(tau, yt))) -
-                                       h_y(std::get<2>(eqnY_sv_dn->f(tau, yt)))) /
-                                      (2 * eps_sigma);
-                    gY_r[i - 1] = (h_y(std::get<2>(eqnY_rv_up->f(tau, yt))) -
-                                   h_y(std::get<2>(eqnY_rv_dn->f(tau, yt)))) /
-                                  (2 * eps_r);
-                    gY_q[i - 1] = (h_y(std::get<2>(eqnY_qv_up->f(tau, yt))) -
-                                   h_y(std::get<2>(eqnY_qv_dn->f(tau, yt)))) /
-                                  (2 * eps_q);
+                    const auto [NY_i, DY_i, fvY_i] = eqnY->f(tau, yt);
+                    y_fp_Y[i] = h_y(fvY_i);
+
+                    if (tau < squared(QL_EPSILON) || fvY_i < QL_EPSILON) {
+                        gY_sigma[i - 1] = gY_r[i - 1] = gY_q[i - 1] = 0.0;
+                    } else {
+                        const auto derivs = eqnY->fDerivatives(tau, yt, NY_i, DY_i, fvY_i);
+                        const Real hp = 2.0 * std::log(fvY_i / ymax) / fvY_i;
+                        gY_sigma[i - 1] = hp * derivs.dfv_dSigma;
+                        gY_r[i - 1] = hp * derivs.dfv_dR;
+                        gY_q[i - 1] = hp * derivs.dfv_dQ;
+                    }
                 }
 
                 // Sensitivity FP iteration for Y

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -25,7 +25,6 @@
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/integrals/tanhsinhintegral.hpp>
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
-#include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/qdfpamericanengine.hpp>
 #include <utility>
@@ -118,116 +117,10 @@ namespace QuantLib {
 
 
     namespace {
-        // Critical volatility at which double-boundary boundaries merge.
-        // sigma_hat(tau) = |Phi^{-1}(e^{q*tau}) - Phi^{-1}(e^{r*tau})| / sqrt(tau)
-        Real sigmaHat(Rate r, Rate q, Time tau) {
-            if (tau < QL_EPSILON)
-                return QL_MAX_REAL;
-            const Real erT = std::exp(r * tau);
-            const Real eqT = std::exp(q * tau);
-            if (erT >= 1.0 || eqT >= 1.0)
-                return QL_MAX_REAL; // tau too small for FP; σ̂ → ∞ as τ → 0
-            const InverseCumulativeNormal PhiInv;
-            return std::abs(PhiInv(eqT) - PhiInv(erT)) / std::sqrt(tau);
-        }
-
-        // Derivatives of σ̂ at a given τ, for computing dτ̂/dp via IFT.
-        // Returns {σ̂'(τ), ∂σ̂/∂r, ∂σ̂/∂q} at the given τ.
-        struct SigmaHatDerivatives {
-            Real dSigmaHat_dTau; // σ̂'(τ)
-            Real dSigmaHat_dR;   // ∂σ̂/∂r at fixed τ
-            Real dSigmaHat_dQ;   // ∂σ̂/∂q at fixed τ
-        };
-
-        SigmaHatDerivatives sigmaHatDerivatives(Rate r, Rate q, Time tau) {
-            const Real sqrtTau = std::sqrt(tau);
-            const Real erT = std::exp(r * tau);
-            const Real eqT = std::exp(q * tau);
-
-            const InverseCumulativeNormal PhiInv;
-            const NormalDistribution phi;
-
-            const Real gr = PhiInv(erT);
-            const Real gq = PhiInv(eqT);
-            const Real N = gr - gq; // > 0 for q < r < 0
-            const Real sign = (N > 0) ? 1.0 : -1.0;
-
-            // φ(Φ⁻¹(x)) = pdf at the quantile
-            const Real phi_gr = phi(gr);
-            const Real phi_gq = phi(gq);
-
-            // g_α'(τ) = α·e^{ατ} / φ(g_α)
-            const Real gr_tau = r * erT / phi_gr;
-            const Real gq_tau = q * eqT / phi_gq;
-            const Real N_tau = gr_tau - gq_tau;
-
-            // σ̂(τ) = |N(τ)|/√τ → σ̂'(τ) = sign·[2τ·N'−N] / (2τ^{3/2})
-            const Real dSigmaHat_dTau = sign * (2 * tau * N_tau - N) / (2 * tau * sqrtTau);
-
-            // ∂σ̂/∂r = sign · (∂g_r/∂r) / √τ = sign · τ·e^{rτ}/φ(g_r) / √τ
-            const Real dSigmaHat_dR = sign * tau * erT / (phi_gr * sqrtTau);
-
-            // ∂σ̂/∂q = −sign · (∂g_q/∂q) / √τ = −sign · τ·e^{qτ}/φ(g_q) / √τ
-            const Real dSigmaHat_dQ = -sign * tau * eqT / (phi_gq * sqrtTau);
-
-            return {dSigmaHat_dTau, dSigmaHat_dR, dSigmaHat_dQ};
-        }
-
-        // Derivatives dτ̂/dp via IFT: σ̂(τ̂) = σ.
-        // dτ̂/dσ = 1/σ̂'(τ̂), dτ̂/dr = −(∂σ̂/∂r)/σ̂'(τ̂), dτ̂/dq = −(∂σ̂/∂q)/σ̂'(τ̂)
-        struct TauHatSensitivities {
-            Real dTauHat_dSigma;
-            Real dTauHat_dR;
-            Real dTauHat_dQ;
-        };
-
-        TauHatSensitivities computeTauHatSensitivities(Rate r, Rate q, Time tauHat) {
-            const auto d = sigmaHatDerivatives(r, q, tauHat);
-            const Real inv = 1.0 / d.dSigmaHat_dTau;
-            return {inv, -d.dSigmaHat_dR * inv, -d.dSigmaHat_dQ * inv};
-        }
-
-        // Find tau_hat where sigma_hat(r, q, tau_hat) = vol.
-        // sigma_hat decreases from ∞ (tau→0) to sigma* (tau→∞).
-        // If sigma_hat(T) > vol, boundaries exist throughout [0,T], return T.
-        // Otherwise solve sigma_hat(tau_hat) = vol; boundaries merge at tau_hat < T.
-        Time computeTauHat(Rate r, Rate q, Volatility vol, Time T) {
-            if (sigmaHat(r, q, T) > vol)
-                return T;
-            Brent solver;
-            solver.setMaxEvaluations(100);
-            return solver.solve([&](Real tau) { return sigmaHat(r, q, tau) - vol; }, 1e-10, 0.5 * T,
-                                QL_EPSILON, T);
-        }
-
-        struct QdAddOnSetup {
-            Real t, dr, dq, v, b_t, dp, dm;
-            bool valid;
-
-            QdAddOnSetup(Real z,
-                         Time T,
-                         Time tauTilde,
-                         Real S,
-                         Rate r,
-                         Rate q,
-                         Volatility vol,
-                         Real xmax,
-                         const Interpolation& q_z) {
-                t = z * z;
-                const Real qv = q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true);
-                b_t = xmax * std::exp(-std::sqrt(std::max(0.0, qv)));
-
-                dr = std::exp(-r * t);
-                dq = std::exp(-q * t);
-                v = vol * std::sqrt(t);
-
-                valid = (v >= QL_EPSILON && b_t > QL_EPSILON);
-                if (valid) {
-                    dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
-                    dm = dp - v;
-                }
-            }
-        };
+        using detail::QdAddOnSetup;
+        using detail::TauHatSensitivities;
+        using detail::computeTauHat;
+        using detail::computeTauHatSensitivities;
     }
 
     class DqFpEquation {
@@ -623,8 +516,8 @@ namespace QuantLib {
         // --- Upper boundary Y (double-boundary case only) ---
         ext::shared_ptr<ChebyshevInterpolation> interpY;
         Real ymax = 0.0;
-        std::function<Real(Real)> Y;   // Y(tau) → upper boundary value
-        std::function<Real(Real)> h_y; // h_y(fv) = log(fv/ymax)²
+        std::function<Real(Real)> Y;   // Y(tau) -> upper boundary value
+        std::function<Real(Real)> h_y; // h_y(fv) = log(fv/ymax)^2
         ext::shared_ptr<DqFpEquation> eqnY;
         Array xY, yY;
 
@@ -703,8 +596,8 @@ namespace QuantLib {
         const Real addOn = integrate(aov);
 
         // Y add-on: subtract upper boundary contribution.
-        // Y exists for time-to-expiry τ ∈ [0, τ̂], i.e. calendar time
-        // t ∈ [T−τ̂, T]. Integration variable z = √t.
+        // Y exists for time-to-expiry tau in [0, tauHat], i.e. calendar time
+        // t in [T-tauHat, T]. Integration variable z = sqrt(t).
         Real addOnY = 0.0;
         if (doubleBoundary && tauHat > QL_EPSILON) {
             const NormalDistribution phiY;
@@ -745,9 +638,9 @@ namespace QuantLib {
         // S < Y(0)=ymax: eq(16), V = K - S - addOnY
         // Otherwise: eq(12) with both boundaries, or exercise
         if (doubleBoundary && tauHat > QL_EPSILON) {
-            // Check if S is in the immediate exercise region at τ=T (now).
-            // Boundaries only exist for τ ≤ tauHat; at τ=T the exercise
-            // region is [Y(T), B(T)] if T ≤ tauHat, otherwise empty.
+            // Check if S is in the immediate exercise region at tau=T (now).
+            // Boundaries only exist for tau <= tauHat; at tau=T the exercise
+            // region is [Y(T), B(T)] if T <= tauHat, otherwise empty.
             if (T <= tauHat) {
                 const Real B_T = B(T);
                 const Real Y_T = Y(T);
@@ -852,7 +745,7 @@ namespace QuantLib {
         }
 
         // Analytical vega, rho, dividendRho via tangent linear FP iteration.
-        // dV/dp = ∂V/∂p|_B + ∫ (∂f/∂B)·(dB/dp) dz
+        // dV/dp = dV/dp|_B + integral (df/dB)*(dB/dp) dz
         // where dB/dp is obtained by differentiating the FP equation.
         {
             const Array y_orig(y);
@@ -886,7 +779,7 @@ namespace QuantLib {
                 y_fp[i] = h(std::get<2>(eqn->f(tau, B(tau))));
             }
 
-            // Step 1: ∂G/∂p — central difference for O(eps²) accuracy
+            // Step 1: dG/dp -- central difference for O(eps^2) accuracy
             const Real eps_sigma = vol * 1e-4;
             const Real eps_r = std::max(std::abs(r), 1.0) * 1e-4;
             const Real eps_q = std::max(std::abs(q), 1.0) * 1e-4;
@@ -913,7 +806,7 @@ namespace QuantLib {
                     (2 * eps_q);
             }
 
-            // Step 2: Sensitivity FP iteration — same contraction as boundary
+            // Step 2: Sensitivity FP iteration -- same contraction as boundary
             Array s_sigma(g_sigma), s_r(g_r), s_q(g_q);
             const Real eps_fd = std::sqrt(QL_EPSILON);
 
@@ -937,8 +830,8 @@ namespace QuantLib {
                 iterateSens(s_q, g_q);
             }
 
-            // Step 3: Convert dy/dp → dB/dp at nodes, then interpolate dB/dp
-            // dB = B · (-1/(2√y)) · dy avoids amplification by interpolating
+            // Step 3: Convert dy/dp -> dB/dp at nodes, then interpolate dB/dp
+            // dB = B * (-1/(2*sqrt(y))) * dy avoids amplification by interpolating
             // the smooth function dB/dp directly.
             auto makeBoundarySensInterp = [&](const Array& s_p) {
                 Array db_dp(nNodes);
@@ -960,15 +853,15 @@ namespace QuantLib {
             const auto si_r = makeBoundarySensInterp(s_r);
             const auto si_q = makeBoundarySensInterp(s_q);
 
-            // When τ̂ < T, dB/dp has two parts:
-            //  (a) FP sensitivity at fixed τ̂ (from the tangent-linear iteration)
-            //  (b) grid remapping: the Chebyshev coordinate z_c = 2√(τ/τ̂)−1
-            //      shifts when τ̂ changes with p.
-            //      dB_remap/dp = (∂B/∂z_c)·(∂z_c/∂τ̂)·(dτ̂/dp)
-            // For vega, |dτ̂/dσ| is small so (b) is negligible.
-            // For rho/divRho, |dτ̂/dr| ≈ 30×|dτ̂/dσ| so (b) is significant.
+            // When tauHat < T, dB/dp has two parts:
+            //  (a) FP sensitivity at fixed tauHat (from the tangent-linear iteration)
+            //  (b) grid remapping: the Chebyshev coordinate z_c = 2*sqrt(tau/tauHat)-1
+            //      shifts when tauHat changes with p.
+            //      dB_remap/dp = (dB/dz_c)*(dz_c/dtauHat)*(dtauHat/dp)
+            // For vega, |dtauHat/dsigma| is small so (b) is negligible.
+            // For rho/divRho, |dtauHat/dr| ~= 30x|dtauHat/dsigma| so (b) is significant.
 
-            // Compute τ̂ sensitivities (needed for grid remapping and Leibniz)
+            // Compute tauHat sensitivities (needed for grid remapping and Leibniz)
             const bool hasMerge = doubleBoundary && tauTilde < T - QL_EPSILON;
             TauHatSensitivities ths{0, 0, 0};
             if (hasMerge)
@@ -1049,7 +942,7 @@ namespace QuantLib {
                 const auto eqnY_qv_up = makeSensEqnY(r, q + eps_q, vol);
                 const auto eqnY_qv_dn = makeSensEqnY(r, q - eps_q, vol);
 
-                // ∂G_Y/∂p via central difference
+                // dG_Y/dp via central difference
                 Array gY_sigma(mY), gY_r(mY), gY_q(mY);
                 for (Size i = 1; i < nYNodes; ++i) {
                     const Real tau = squared(xY[i]);
@@ -1089,7 +982,7 @@ namespace QuantLib {
                     iterateSensY(sY_q, gY_q);
                 }
 
-                // Convert dy_Y/dp → dY/dp
+                // Convert dy_Y/dp -> dY/dp
                 auto makeYBoundarySensInterp = [&](const Array& s_p) {
                     Array dy_dp(nYNodes);
                     dy_dp[0] = 0.0;
@@ -1159,13 +1052,13 @@ namespace QuantLib {
             }
 
             // --- Leibniz boundary correction for vega/rho/divRho ---
-            // When τ̂ < T, the integration lower limit z₀ = √(T−τ̂) depends on
-            // σ, r, q through τ̂. By Leibniz rule: correction = [f_B(z₀)−f_Y(z₀)]·dτ̂/dp/(2z₀)
+            // When tauHat < T, the integration lower limit z0 = sqrt(T-tauHat) depends on
+            // sigma, r, q through tauHat. By Leibniz rule: correction = [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
             if (doubleBoundary && tauTilde < T - QL_EPSILON) {
                 const Real z0 = std::sqrt(T - tauHat);
                 const Real fB_z0 = aov(z0);
 
-                // Evaluate Y integrand at z₀
+                // Evaluate Y integrand at z0
                 Real fY_z0 = 0.0;
                 if (interpY) {
                     const Real t0 = z0 * z0;
@@ -1192,8 +1085,8 @@ namespace QuantLib {
             }
         }
 
-        // StrikeSensitivity add-on: total d/dK, using B ∝ K
-        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ∂dp/∂K = -1/(Kv)
+        // StrikeSensitivity add-on: total d/dK, using B proportional to K
+        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ddp/dK = -1/(Kv)
         const Real strikeSensAddOn = integrate([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
@@ -1204,7 +1097,7 @@ namespace QuantLib {
         });
         res.strikeSensitivity = bc.strikeSensitivity() + strikeSensAddOn;
 
-        // StrikeGamma add-on: d²f/dK²
+        // StrikeGamma add-on: d^2f/dK^2
         const Real strikeGammaAddOn = integrate([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
@@ -1216,8 +1109,8 @@ namespace QuantLib {
         res.strikeGamma = bc.strikeGamma() + strikeGammaAddOn;
 
         // --- Y boundary contributions to strikeSens, strikeGamma ---
-        // Y = K·r/q ∝ K, so dY/dK = r/q. The Y integrand also depends on K
-        // directly through the rK·dr·Φ(−d−) term. ∂dp/∂K = −1/(K·v).
+        // Y = K*r/q proportional to K, so dY/dK = r/q. The Y integrand also depends on K
+        // directly through the rK*dr*Phi(-d-) term. ddp/dK = -1/(K*v).
         if (doubleBoundary && tauHat > QL_EPSILON) {
             const Real strikeSensYAddOn = integrateY([&](Real z) -> Real {
                 const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
@@ -1239,7 +1132,7 @@ namespace QuantLib {
             res.strikeGamma -= strikeGammaYAddOn;
         }
 
-        // Theta: Leibniz rule → f(√T) / (2√T)
+        // Theta: Leibniz rule -> f(sqrt(T)) / (2*sqrt(T))
         const Real sqrtT = std::sqrt(T);
         res.theta = bc.theta(S, T) + aov(sqrtT) / (2 * sqrtT);
 

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -27,6 +27,7 @@
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/qdfpamericanengine.hpp>
+#include <iostream>
 #include <utility>
 #ifndef QL_BOOST_HAS_TANH_SINH
 #    include <ql/math/integrals/gausslobattointegral.hpp>
@@ -665,12 +666,32 @@ namespace QuantLib {
         } else {
             res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn - addOnY);
         }
+        // Greek add-on integrator: in the near-European regime (small early
+        // exercise premium) the Greek integrands are smooth O(1) functions
+        // while the value integrand is O(addOn). TanhSinh's adaptive
+        // refinement can over-probe the endpoints trying to resolve the
+        // smooth integrand to high relative precision. GaussLegendre with
+        // sufficient order handles this regime robustly. When the early
+        // exercise premium is material, TanhSinh's endpoint handling is
+        // appropriate for potential integrand singularities near tau->0.
+        const Real netAddOn = std::abs(addOn - addOnY);
+        const Real euroVal = std::max(QL_EPSILON, bc.value());
+        const bool useGaussLegendre = (netAddOn < 1e-4 * euroVal);
+
+        const auto glIntegrator = ext::make_shared<GaussLegendreIntegrator>(25);
+        const Real zLo = std::sqrt(T - tauTilde);
+        const Real zHi = std::sqrt(T);
+        auto integrateGreek = [&](const auto& f) {
+            if (useGaussLegendre)
+                return (*glIntegrator)(f, zLo, zHi);
+            return (*integrator)(f, zLo, zHi);
+        };
 
         const NormalDistribution phi;
         const CumulativeNormalDistribution Phi;
 
         // Delta add-on
-        const Real deltaAddOn = integrate([&](Real z) -> Real {
+        const Real deltaAddOn = integrateGreek([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
                 return 0.0;
@@ -681,7 +702,7 @@ namespace QuantLib {
         res.delta = bc.delta(S) + deltaAddOn;
 
         // Gamma add-on
-        const Real gammaAddOn = integrate([&](Real z) -> Real {
+        const Real gammaAddOn = integrateGreek([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
                 return 0.0;
@@ -875,7 +896,7 @@ namespace QuantLib {
             };
 
             // Vega add-on
-            const Real vegaAddOn = integrate([&](Real z) -> Real {
+            const Real vegaAddOn = integrateGreek([&](Real z) -> Real {
                 const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
                 if (!s.valid)
                     return 0.0;
@@ -888,7 +909,7 @@ namespace QuantLib {
             res.vega = bc.vega(T) + vegaAddOn;
 
             // Rho add-on
-            const Real rhoAddOn = integrate([&](Real z) -> Real {
+            auto rhoIntegrand = [&](Real z) -> Real {
                 const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
                 if (!s.valid)
                     return 0.0;
@@ -897,11 +918,12 @@ namespace QuantLib {
                 return 2 * z *
                        ((1 - r * s.t) * K * s.dr * Phi(-s.dm) - r * K * s.dr * phi(s.dm) * ddp_dr +
                         q * S * s.dq * phi(s.dp) * ddp_dr);
-            });
+            };
+            const Real rhoAddOn = integrateGreek(rhoIntegrand);
             res.rho = bc.rho(T) + rhoAddOn;
 
             // DividendRho add-on
-            const Real divRhoAddOn = integrate([&](Real z) -> Real {
+            auto divRhoIntegrand = [&](Real z) -> Real {
                 const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
                 if (!s.valid)
                     return 0.0;
@@ -910,7 +932,8 @@ namespace QuantLib {
                 return 2 * z *
                        (-r * K * s.dr * phi(s.dm) * ddp_dq - (1 - q * s.t) * S * s.dq * Phi(-s.dp) +
                         q * S * s.dq * phi(s.dp) * ddp_dq);
-            });
+            };
+            const Real divRhoAddOn = integrateGreek(divRhoIntegrand);
             res.dividendRho = bc.dividendRho(T) + divRhoAddOn;
 
             // --- Y boundary sensitivity for vega/rho/divRho ---
@@ -1088,7 +1111,7 @@ namespace QuantLib {
 
         // StrikeSensitivity add-on: total d/dK, using B proportional to K
         // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ddp/dK = -1/(Kv)
-        const Real strikeSensAddOn = integrate([&](Real z) -> Real {
+        const Real strikeSensAddOn = integrateGreek([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
                 return 0.0;
@@ -1099,7 +1122,7 @@ namespace QuantLib {
         res.strikeSensitivity = bc.strikeSensitivity() + strikeSensAddOn;
 
         // StrikeGamma add-on: d^2f/dK^2
-        const Real strikeGammaAddOn = integrate([&](Real z) -> Real {
+        const Real strikeGammaAddOn = integrateGreek([&](Real z) -> Real {
             const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
             if (!s.valid)
                 return 0.0;

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -145,8 +145,8 @@ namespace QuantLib {
 
         virtual std::pair<Real, Real> NDd(Real tau, Real b) const = 0;
         virtual std::tuple<Real, Real, Real> f(Real tau, Real b) const = 0;
-        virtual FpParameterDerivatives fDerivatives(
-            Real tau, Real b, Real N, Real D, Real fv) const = 0;
+        virtual FpParameterDerivatives
+        fDerivatives(Real tau, Real b, Real N, Real D, Real fv) const = 0;
 
         virtual ~DqFpEquation() = default;
 
@@ -180,8 +180,8 @@ namespace QuantLib {
 
         std::pair<Real, Real> NDd(Real tau, Real b) const override;
         std::tuple<Real, Real, Real> f(Real tau, Real b) const override;
-        FpParameterDerivatives fDerivatives(
-            Real tau, Real b, Real N, Real D, Real fv) const override;
+        FpParameterDerivatives
+        fDerivatives(Real tau, Real b, Real N, Real D, Real fv) const override;
 
       private:
           const Real K;
@@ -198,8 +198,8 @@ namespace QuantLib {
 
         std::pair<Real, Real> NDd(Real tau, Real b) const override;
         std::tuple<Real, Real, Real> f(Real tau, Real b) const override;
-        FpParameterDerivatives fDerivatives(
-            Real tau, Real b, Real N, Real D, Real fv) const override;
+        FpParameterDerivatives
+        fDerivatives(Real tau, Real b, Real N, Real D, Real fv) const override;
 
       private:
           const Real K;
@@ -324,8 +324,8 @@ namespace QuantLib {
         return std::make_pair(Nd, Dd);
     }
 
-    FpParameterDerivatives DqFpEquation_A::fDerivatives(
-        Real tau, Real b, Real N, Real D, Real fv) const {
+    FpParameterDerivatives
+    DqFpEquation_A::fDerivatives(Real tau, Real b, Real N, Real D, Real fv) const {
 
         if (tau < squared(QL_EPSILON))
             return {0.0, 0.0, 0.0};
@@ -381,129 +381,142 @@ namespace QuantLib {
                 dK3ds += w_i[i] * stv * exp_r * phi_dm_m * (dm_m * dp_m - 1) / vol;
                 // d/dsigma of exp_q*[...] = exp_q*phi(dp)*[-dm*half/(sigma) + stv*(dp*dm-1)/sigma]
                 dK12ds += w_i[i] * exp_q * phi_dp_m *
-                    (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
+                          (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
 
                 // r: d/dr of stv*exp(r*(tau-m))*phi(dm) via product+chain rule
-                dK3dr += w_i[i] * stv * exp_r * phi_dm_m *
-                    ((tau - m) - dm_m * sqrt_m / vol);
+                dK3dr += w_i[i] * stv * exp_r * phi_dm_m * ((tau - m) - dm_m * sqrt_m / vol);
                 // K12 depends on r only through dp (exp_q independent of r)
-                dK12dr += w_i[i] * exp_q * phi_dp_m * (sqrt_m / vol) *
-                    (half_tau_yp1 - stv * dp_m);
+                dK12dr += w_i[i] * exp_q * phi_dp_m * (sqrt_m / vol) * (half_tau_yp1 - stv * dp_m);
 
                 // q: K3 depends on q only through dm (exp_r independent of q)
                 dK3dq += w_i[i] * stv * exp_r * phi_dm_m * dm_m * sqrt_m / vol;
                 // d/dq of exp(q*(tau-m))*[...]: both exp and dp depend on q
                 dK12dq += w_i[i] * exp_q *
-                    ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi_dp_m)
-                     + phi_dp_m * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
+                          ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi_dp_m) +
+                           phi_dp_m * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
             }
-        }
-        else {
+        } else {
             const Real sqrtTwoPI = M_SQRT2 * M_SQRTPI;
 
-            K3_val = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(r * tau - r * m);
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return df * stv / sqrtTwoPI;
-                    else
-                        return 0.0;
-                }
-                return df * stv * phi(d(m, b / B(tau - m)).second);
-            }, -1, 1);
+            K3_val = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(r * tau - r * m);
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return df * stv / sqrtTwoPI;
+                        else
+                            return 0.0;
+                    }
+                    return df * stv * phi(d(m, b / B(tau - m)).second);
+                },
+                -1, 1);
 
-            K12_val = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(q * tau - q * m);
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return df * stv / sqrtTwoPI;
-                    else
-                        return 0.0;
-                }
-                const Real dp = d(m, b / B(tau - m)).first;
-                return df * (0.5 * tau * (y + 1) * Phi(dp) + stv * phi(dp));
-            }, -1, 1);
+            K12_val = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(q * tau - q * m);
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return df * stv / sqrtTwoPI;
+                        else
+                            return 0.0;
+                    }
+                    const Real dp = d(m, b / B(tau - m)).first;
+                    return df * (0.5 * tau * (y + 1) * Phi(dp) + stv * phi(dp));
+                },
+                -1, 1);
 
             // sigma derivative integrals
-            dK3ds = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(r * (tau - m));
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return -df * stv / (vol * sqrtTwoPI);
-                    return 0.0;
-                }
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                return stv * df * phi(dm_m) * (dm_m * dp_m - 1) / vol;
-            }, -1, 1);
+            dK3ds = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(r * (tau - m));
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return -df * stv / (vol * sqrtTwoPI);
+                        return 0.0;
+                    }
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    return stv * df * phi(dm_m) * (dm_m * dp_m - 1) / vol;
+                },
+                -1, 1);
 
-            dK12ds = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(q * (tau - m));
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return -df * stv / (vol * sqrtTwoPI);
-                    return 0.0;
-                }
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
-                return df * phi(dp_m) *
-                    (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
-            }, -1, 1);
+            dK12ds = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(q * (tau - m));
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return -df * stv / (vol * sqrtTwoPI);
+                        return 0.0;
+                    }
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                    return df * phi(dp_m) *
+                           (-dm_m * half_tau_yp1 / vol + stv * (dp_m * dm_m - 1) / vol);
+                },
+                -1, 1);
 
             // r derivative integrals
-            dK3dr = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(r * (tau - m));
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return df * stv * tau / sqrtTwoPI;
-                    return 0.0;
-                }
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                const Real sqrt_m = std::sqrt(m);
-                return stv * df * phi(dm_m) * ((tau - m) - dm_m * sqrt_m / vol);
-            }, -1, 1);
+            dK3dr = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(r * (tau - m));
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return df * stv * tau / sqrtTwoPI;
+                        return 0.0;
+                    }
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    const Real sqrt_m = std::sqrt(m);
+                    return stv * df * phi(dm_m) * ((tau - m) - dm_m * sqrt_m / vol);
+                },
+                -1, 1);
 
-            dK12dr = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                if (y <= 5 * QL_EPSILON - 1)
-                    return 0.0;
-                const Real df = std::exp(q * (tau - m));
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                const Real sqrt_m = std::sqrt(m);
-                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
-                return df * phi(dp_m) * (sqrt_m / vol) * (half_tau_yp1 - stv * dp_m);
-            }, -1, 1);
+            dK12dr = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    if (y <= 5 * QL_EPSILON - 1)
+                        return 0.0;
+                    const Real df = std::exp(q * (tau - m));
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    const Real sqrt_m = std::sqrt(m);
+                    const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                    return df * phi(dp_m) * (sqrt_m / vol) * (half_tau_yp1 - stv * dp_m);
+                },
+                -1, 1);
 
             // q derivative integrals
-            dK3dq = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                if (y <= 5 * QL_EPSILON - 1)
-                    return 0.0;
-                const Real df = std::exp(r * (tau - m));
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                const Real sqrt_m = std::sqrt(m);
-                return stv * df * phi(dm_m) * dm_m * sqrt_m / vol;
-            }, -1, 1);
+            dK3dq = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    if (y <= 5 * QL_EPSILON - 1)
+                        return 0.0;
+                    const Real df = std::exp(r * (tau - m));
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    const Real sqrt_m = std::sqrt(m);
+                    return stv * df * phi(dm_m) * dm_m * sqrt_m / vol;
+                },
+                -1, 1);
 
-            dK12dq = (*integrator)([&, this](Real y) -> Real {
-                const Real m = 0.25 * tau * squared(1 + y);
-                const Real df = std::exp(q * (tau - m));
-                if (y <= 5 * QL_EPSILON - 1) {
-                    if (close_enough(b, B(tau - m)))
-                        return df * tau * stv / sqrtTwoPI;
-                    return 0.0;
-                }
-                const auto [dp_m, dm_m] = d(m, b / B(tau - m));
-                const Real sqrt_m = std::sqrt(m);
-                const Real half_tau_yp1 = 0.5 * tau * (y + 1);
-                const Real Phi_dp_m = Phi(dp_m);
-                return df * ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi(dp_m))
-                    + phi(dp_m) * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
-            }, -1, 1);
+            dK12dq = (*integrator)(
+                [&, this](Real y) -> Real {
+                    const Real m = 0.25 * tau * squared(1 + y);
+                    const Real df = std::exp(q * (tau - m));
+                    if (y <= 5 * QL_EPSILON - 1) {
+                        if (close_enough(b, B(tau - m)))
+                            return df * tau * stv / sqrtTwoPI;
+                        return 0.0;
+                    }
+                    const auto [dp_m, dm_m] = d(m, b / B(tau - m));
+                    const Real sqrt_m = std::sqrt(m);
+                    const Real half_tau_yp1 = 0.5 * tau * (y + 1);
+                    const Real Phi_dp_m = Phi(dp_m);
+                    return df * ((tau - m) * (half_tau_yp1 * Phi_dp_m + stv * phi(dp_m)) +
+                                 phi(dp_m) * (sqrt_m / vol) * (-half_tau_yp1 + stv * dp_m));
+                },
+                -1, 1);
         }
 
         // Assemble using product rule: d(r*K3)/dr = K3 + r*dK3/dr, etc.
@@ -612,8 +625,8 @@ namespace QuantLib {
         );
     }
 
-    FpParameterDerivatives DqFpEquation_B::fDerivatives(
-        Real tau, Real b, Real N, Real D, Real fv) const {
+    FpParameterDerivatives
+    DqFpEquation_B::fDerivatives(Real tau, Real b, Real N, Real D, Real fv) const {
 
         if (tau < squared(QL_EPSILON))
             return {0.0, 0.0, 0.0};
@@ -680,75 +693,90 @@ namespace QuantLib {
             dDdr += q * c * int_Ddr;
             dNdq += r * c * int_Ndq;
             dDdq += di_val + q * c * int_Ddq;
-        }
-        else {
+        } else {
             // Generic integrator path
-            ni_val = (*integrator)([&, this](Real u) -> Real {
-                const Real df = std::exp(r * u);
-                if (u >= tau * (1 - 5 * QL_EPSILON)) {
-                    if (close_enough(b, B(u)))
-                        return 0.5 * df;
-                    else
-                        return df * ((b < B(u) ? 0.0 : 1.0));
-                }
-                return df * Phi(d(tau - u, b / B(u)).second);
-            }, 0, tau);
-            di_val = (*integrator)([&, this](Real u) -> Real {
-                const Real df = std::exp(q * u);
-                if (u >= tau * (1 - 5 * QL_EPSILON)) {
-                    if (close_enough(b, B(u)))
-                        return 0.5 * df;
-                    else
-                        return df * ((b < B(u) ? 0.0 : 1.0));
-                }
-                return df * Phi(d(tau - u, b / B(u)).first);
-            }, 0, tau);
+            ni_val = (*integrator)(
+                [&, this](Real u) -> Real {
+                    const Real df = std::exp(r * u);
+                    if (u >= tau * (1 - 5 * QL_EPSILON)) {
+                        if (close_enough(b, B(u)))
+                            return 0.5 * df;
+                        else
+                            return df * ((b < B(u) ? 0.0 : 1.0));
+                    }
+                    return df * Phi(d(tau - u, b / B(u)).second);
+                },
+                0, tau);
+            di_val = (*integrator)(
+                [&, this](Real u) -> Real {
+                    const Real df = std::exp(q * u);
+                    if (u >= tau * (1 - 5 * QL_EPSILON)) {
+                        if (close_enough(b, B(u)))
+                            return 0.5 * df;
+                        else
+                            return df * ((b < B(u) ? 0.0 : 1.0));
+                    }
+                    return df * Phi(d(tau - u, b / B(u)).first);
+                },
+                0, tau);
 
             // sigma derivative integrals
-            const Real i_Nds = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                return std::exp(r * u) * phi(dmu) * (-dpu / vol);
-            }, 0, tau);
-            const Real i_Dds = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                return std::exp(q * u) * phi(dpu) * (-dmu / vol);
-            }, 0, tau);
+            const Real i_Nds = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    return std::exp(r * u) * phi(dmu) * (-dpu / vol);
+                },
+                0, tau);
+            const Real i_Dds = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    return std::exp(q * u) * phi(dpu) * (-dmu / vol);
+                },
+                0, tau);
 
             // r derivative integrals
-            const Real i_Ndr = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
-                return std::exp(r * u) * (u * Phi(dmu) + phi(dmu) * sqrt_s / vol);
-            }, 0, tau);
-            const Real i_Ddr = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
-                return std::exp(q * u) * phi(dpu) * sqrt_s / vol;
-            }, 0, tau);
+            const Real i_Ndr = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                    return std::exp(r * u) * (u * Phi(dmu) + phi(dmu) * sqrt_s / vol);
+                },
+                0, tau);
+            const Real i_Ddr = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                    return std::exp(q * u) * phi(dpu) * sqrt_s / vol;
+                },
+                0, tau);
 
             // q derivative integrals
-            const Real i_Ndq = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
-                return std::exp(r * u) * phi(dmu) * (-sqrt_s / vol);
-            }, 0, tau);
-            const Real i_Ddq = (*integrator)([&, this](Real u) -> Real {
-                if (u >= tau * (1 - 5 * QL_EPSILON))
-                    return 0.0;
-                const auto [dpu, dmu] = d(tau - u, b / B(u));
-                const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
-                return std::exp(q * u) * (u * Phi(dpu) + phi(dpu) * (-sqrt_s / vol));
-            }, 0, tau);
+            const Real i_Ndq = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                    return std::exp(r * u) * phi(dmu) * (-sqrt_s / vol);
+                },
+                0, tau);
+            const Real i_Ddq = (*integrator)(
+                [&, this](Real u) -> Real {
+                    if (u >= tau * (1 - 5 * QL_EPSILON))
+                        return 0.0;
+                    const auto [dpu, dmu] = d(tau - u, b / B(u));
+                    const Real sqrt_s = std::sqrt(std::max(0.0, tau - u));
+                    return std::exp(q * u) * (u * Phi(dpu) + phi(dpu) * (-sqrt_s / vol));
+                },
+                0, tau);
 
             dNds += r * i_Nds;
             dDds += q * i_Dds;

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -1053,7 +1053,8 @@ namespace QuantLib {
 
             // --- Leibniz boundary correction for vega/rho/divRho ---
             // When tauHat < T, the integration lower limit z0 = sqrt(T-tauHat) depends on
-            // sigma, r, q through tauHat. By Leibniz rule: correction = [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
+            // sigma, r, q through tauHat. By Leibniz rule: correction =
+            // [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
             if (doubleBoundary && tauTilde < T - QL_EPSILON) {
                 const Real z0 = std::sqrt(T - tauHat);
                 const Real fB_z0 = aov(z0);

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -25,6 +25,7 @@
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/integrals/tanhsinhintegral.hpp>
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
+#include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/qdfpamericanengine.hpp>
 #include <utility>
@@ -115,6 +116,119 @@ namespace QuantLib {
 #endif
     }
 
+
+    namespace {
+        // Critical volatility at which double-boundary boundaries merge.
+        // sigma_hat(tau) = |Phi^{-1}(e^{q*tau}) - Phi^{-1}(e^{r*tau})| / sqrt(tau)
+        Real sigmaHat(Rate r, Rate q, Time tau) {
+            if (tau < QL_EPSILON)
+                return QL_MAX_REAL;
+            const Real erT = std::exp(r * tau);
+            const Real eqT = std::exp(q * tau);
+            if (erT >= 1.0 || eqT >= 1.0)
+                return QL_MAX_REAL; // tau too small for FP; σ̂ → ∞ as τ → 0
+            const InverseCumulativeNormal PhiInv;
+            return std::abs(PhiInv(eqT) - PhiInv(erT)) / std::sqrt(tau);
+        }
+
+        // Derivatives of σ̂ at a given τ, for computing dτ̂/dp via IFT.
+        // Returns {σ̂'(τ), ∂σ̂/∂r, ∂σ̂/∂q} at the given τ.
+        struct SigmaHatDerivatives {
+            Real dSigmaHat_dTau; // σ̂'(τ)
+            Real dSigmaHat_dR;   // ∂σ̂/∂r at fixed τ
+            Real dSigmaHat_dQ;   // ∂σ̂/∂q at fixed τ
+        };
+
+        SigmaHatDerivatives sigmaHatDerivatives(Rate r, Rate q, Time tau) {
+            const Real sqrtTau = std::sqrt(tau);
+            const Real erT = std::exp(r * tau);
+            const Real eqT = std::exp(q * tau);
+
+            const InverseCumulativeNormal PhiInv;
+            const NormalDistribution phi;
+
+            const Real gr = PhiInv(erT);
+            const Real gq = PhiInv(eqT);
+            const Real N = gr - gq; // > 0 for q < r < 0
+            const Real sign = (N > 0) ? 1.0 : -1.0;
+
+            // φ(Φ⁻¹(x)) = pdf at the quantile
+            const Real phi_gr = phi(gr);
+            const Real phi_gq = phi(gq);
+
+            // g_α'(τ) = α·e^{ατ} / φ(g_α)
+            const Real gr_tau = r * erT / phi_gr;
+            const Real gq_tau = q * eqT / phi_gq;
+            const Real N_tau = gr_tau - gq_tau;
+
+            // σ̂(τ) = |N(τ)|/√τ → σ̂'(τ) = sign·[2τ·N'−N] / (2τ^{3/2})
+            const Real dSigmaHat_dTau = sign * (2 * tau * N_tau - N) / (2 * tau * sqrtTau);
+
+            // ∂σ̂/∂r = sign · (∂g_r/∂r) / √τ = sign · τ·e^{rτ}/φ(g_r) / √τ
+            const Real dSigmaHat_dR = sign * tau * erT / (phi_gr * sqrtTau);
+
+            // ∂σ̂/∂q = −sign · (∂g_q/∂q) / √τ = −sign · τ·e^{qτ}/φ(g_q) / √τ
+            const Real dSigmaHat_dQ = -sign * tau * eqT / (phi_gq * sqrtTau);
+
+            return {dSigmaHat_dTau, dSigmaHat_dR, dSigmaHat_dQ};
+        }
+
+        // Derivatives dτ̂/dp via IFT: σ̂(τ̂) = σ.
+        // dτ̂/dσ = 1/σ̂'(τ̂), dτ̂/dr = −(∂σ̂/∂r)/σ̂'(τ̂), dτ̂/dq = −(∂σ̂/∂q)/σ̂'(τ̂)
+        struct TauHatSensitivities {
+            Real dTauHat_dSigma;
+            Real dTauHat_dR;
+            Real dTauHat_dQ;
+        };
+
+        TauHatSensitivities computeTauHatSensitivities(Rate r, Rate q, Time tauHat) {
+            const auto d = sigmaHatDerivatives(r, q, tauHat);
+            const Real inv = 1.0 / d.dSigmaHat_dTau;
+            return {inv, -d.dSigmaHat_dR * inv, -d.dSigmaHat_dQ * inv};
+        }
+
+        // Find tau_hat where sigma_hat(r, q, tau_hat) = vol.
+        // sigma_hat decreases from ∞ (tau→0) to sigma* (tau→∞).
+        // If sigma_hat(T) > vol, boundaries exist throughout [0,T], return T.
+        // Otherwise solve sigma_hat(tau_hat) = vol; boundaries merge at tau_hat < T.
+        Time computeTauHat(Rate r, Rate q, Volatility vol, Time T) {
+            if (sigmaHat(r, q, T) > vol)
+                return T;
+            Brent solver;
+            solver.setMaxEvaluations(100);
+            return solver.solve([&](Real tau) { return sigmaHat(r, q, tau) - vol; }, 1e-10, 0.5 * T,
+                                QL_EPSILON, T);
+        }
+
+        struct QdAddOnSetup {
+            Real t, dr, dq, v, b_t, dp, dm;
+            bool valid;
+
+            QdAddOnSetup(Real z,
+                         Time T,
+                         Time tauTilde,
+                         Real S,
+                         Rate r,
+                         Rate q,
+                         Volatility vol,
+                         Real xmax,
+                         const Interpolation& q_z) {
+                t = z * z;
+                const Real qv = q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true);
+                b_t = xmax * std::exp(-std::sqrt(std::max(0.0, qv)));
+
+                dr = std::exp(-r * t);
+                dq = std::exp(-q * t);
+                v = vol * std::sqrt(t);
+
+                valid = (v >= QL_EPSILON && b_t > QL_EPSILON);
+                if (valid) {
+                    dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
+                    dm = dp - v;
+                }
+            }
+        };
+    }
 
     class DqFpEquation {
       public:
@@ -426,25 +540,28 @@ namespace QuantLib {
         return scheme;
     }
 
-    Real QdFpAmericanEngine::calculatePut(
-            Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const {
+    detail::QdPutResults
+    QdFpAmericanEngine::calculatePut(Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const {
 
-        if (r < 0.0 && q < r)
-            QL_FAIL("double-boundary case q<r<0 for a put option is given");
+        const bool doubleBoundary = (r < 0.0 && q < r);
+        const Real tauHat = doubleBoundary ? computeTauHat(r, q, vol, T) : 0.0;
+        const Time tauTilde = doubleBoundary ? tauHat : T;
+
+        detail::QdPutResults res;
 
         const Real xmax =  QdPlusAmericanEngine::xMax(K, r, q);
         const Size n = iterationScheme_->getNumberOfChebyshevInterpolationNodes();
 
+        // --- Lower boundary B: computed over [0, tauTilde] ---
         const ext::shared_ptr<ChebyshevInterpolation> interp =
-            QdPlusAmericanEngine(
-                    process_, n+1, QdPlusAmericanEngine::Halley, 1e-8)
-                .getPutExerciseBoundary(S, K, r, q, vol, T);
+            QdPlusAmericanEngine(process_, n + 1, QdPlusAmericanEngine::Halley, 1e-8)
+                .getPutExerciseBoundary(S, K, r, q, vol, tauTilde);
 
         const Array z = interp->nodes();
-        const Array x = 0.5*std::sqrt(T)*(1.0+z);
+        const Array x = 0.5 * std::sqrt(tauTilde) * (1.0 + z);
 
-        const auto B = [xmax, T, &interp](Real tau) -> Real {
-            const Real z = 2*std::sqrt(std::abs(tau)/T)-1;
+        const auto B = [xmax, tauTilde, &interp](Real tau) -> Real {
+            const Real z = 2 * std::sqrt(std::abs(tau) / tauTilde) - 1;
             return xmax*std::exp(-std::sqrt(std::max(Real(0), (*interp)(z, true))));
         };
 
@@ -503,18 +620,631 @@ namespace QuantLib {
             interp->updateY(y);
         }
 
-        const detail::QdPlusAddOnValue aov(T, S, K, r, q, vol, xmax, interp);
-        const Real addOn =
-           (*iterationScheme_->getExerciseBoundaryToPriceIntegrator())(
-               aov, 0.0, std::sqrt(T));
+        // --- Upper boundary Y (double-boundary case only) ---
+        ext::shared_ptr<ChebyshevInterpolation> interpY;
+        Real ymax = 0.0;
+        std::function<Real(Real)> Y;   // Y(tau) → upper boundary value
+        std::function<Real(Real)> h_y; // h_y(fv) = log(fv/ymax)²
+        ext::shared_ptr<DqFpEquation> eqnY;
+        Array xY, yY;
 
-        const Real europeanValue = BlackCalculator(
-            Option::Put, K, S*std::exp((r-q)*T),
-            vol*std::sqrt(T), std::exp(-r*T)).value();
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            ymax = K * r / q;
+            const Real bAtTauHat = B(tauHat);
 
-        return std::max(europeanValue, 0.0) + std::max(0.0, addOn);
+            h_y = [ymax](Real fv) -> Real { return squared(std::log(fv / ymax)); };
+
+            // Initial guess: interpolate between Y(0)=ymax and B(tauHat)
+            interpY = ext::make_shared<ChebyshevInterpolation>(
+                n + 1,
+                [&](Real zz) -> Real {
+                    const Real tau = 0.25 * tauHat * squared(1 + zz);
+                    const Real frac = std::sqrt(tau / tauHat);
+                    const Real yGuess = ymax * (1 - frac) + bAtTauHat * frac;
+                    return h_y(std::max(QL_EPSILON, yGuess));
+                },
+                ChebyshevInterpolation::SecondKind);
+
+            Y = [ymax, tauHat, &interpY](Real tau) -> Real {
+                const Real z = 2 * std::sqrt(std::abs(tau) / tauHat) - 1;
+                return ymax * std::exp(-std::sqrt(std::max(Real(0), (*interpY)(z, true))));
+            };
+
+            // FP equation for Y: same DqFpEquation_B structure, Y as boundary
+            eqnY = ext::shared_ptr<DqFpEquation>(
+                new DqFpEquation_B(K, r, q, vol, Y, iterationScheme_->getFixedPointIntegrator()));
+
+            const Array zY = interpY->nodes();
+            xY = 0.5 * std::sqrt(tauHat) * (1.0 + zY);
+            yY = Array(xY.size());
+            yY[0] = 0.0;
+
+            // Jacobi-Newton steps for Y
+            for (Size k = 0; k < n_newton; ++k) {
+                for (Size i = 1; i < xY.size(); ++i) {
+                    const Real tau = squared(xY[i]);
+                    const Real yv = Y(tau);
+
+                    const auto results = eqnY->f(tau, yv);
+                    const Real N = std::get<0>(results);
+                    const Real D = std::get<1>(results);
+                    const Real fv = std::get<2>(results);
+
+                    if (tau < QL_EPSILON)
+                        yY[i] = h_y(fv);
+                    else {
+                        const auto ndd = eqnY->NDd(tau, yv);
+                        const Real Nd = std::get<0>(ndd);
+                        const Real Dd = std::get<1>(ndd);
+                        const Real fd = K * std::exp(-(r - q) * tau) * (Nd / D - Dd * N / (D * D));
+                        yY[i] = h_y(yv - (fv - yv) / (fd - 1));
+                    }
+                }
+                interpY->updateY(yY);
+            }
+
+            // Naive FP steps for Y
+            for (Size k = 0; k < n_fp; ++k) {
+                for (Size i = 1; i < xY.size(); ++i) {
+                    const Real tau = squared(xY[i]);
+                    yY[i] = h_y(std::get<2>(eqnY->f(tau, Y(tau))));
+                }
+                interpY->updateY(yY);
+            }
+        }
+
+        const detail::QdPlusAddOnValue aov(T, tauTilde, S, K, r, q, vol, xmax, interp);
+        const auto integrator = iterationScheme_->getExerciseBoundaryToPriceIntegrator();
+
+        auto integrate = [&](const auto& f) {
+            return (*integrator)(f, std::sqrt(T - tauTilde), std::sqrt(T));
+        };
+
+        const Real addOn = integrate(aov);
+
+        // Y add-on: subtract upper boundary contribution.
+        // Y exists for time-to-expiry τ ∈ [0, τ̂], i.e. calendar time
+        // t ∈ [T−τ̂, T]. Integration variable z = √t.
+        Real addOnY = 0.0;
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            const NormalDistribution phiY;
+            const CumulativeNormalDistribution PhiY;
+
+            addOnY = (*integrator)(
+                [&](Real z) -> Real {
+                    const Real t = z * z;
+                    const Real tau = T - t; // time-to-expiry
+                    if (tau < QL_EPSILON || tau > tauHat + QL_EPSILON)
+                        return 0.0;
+
+                    // Evaluate Y at time-to-expiry tau
+                    const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+                    const Real qv = (*interpY)(zc, true);
+                    const Real y_t = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+
+                    const Real dr_ = std::exp(-r * t);
+                    const Real dq_ = std::exp(-q * t);
+                    const Real v_ = vol * std::sqrt(t);
+
+                    if (v_ < QL_EPSILON || y_t < QL_EPSILON)
+                        return 0.0;
+
+                    const Real dp_ = std::log(S * dq_ / (y_t * dr_)) / v_ + 0.5 * v_;
+                    return 2 * z * (r * K * dr_ * PhiY(-(dp_ - v_)) - q * S * dq_ * PhiY(-dp_));
+                },
+                std::sqrt(std::max(0.0, T - tauHat)), std::sqrt(T));
+        }
+
+        const Real fwd = S * std::exp((r - q) * T);
+        const Real stdDev = vol * std::sqrt(T);
+        const Real df = std::exp(-r * T);
+        BlackCalculator bc(Option::Put, K, fwd, stdDev, df);
+
+        // Pricing formula depends on S location (paper step 6):
+        // S > B(0)=xmax: eq(15), only B add-on
+        // S < Y(0)=ymax: eq(16), V = K - S - addOnY
+        // Otherwise: eq(12) with both boundaries, or exercise
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            // Check if S is in the immediate exercise region at τ=T (now).
+            // Boundaries only exist for τ ≤ tauHat; at τ=T the exercise
+            // region is [Y(T), B(T)] if T ≤ tauHat, otherwise empty.
+            if (T <= tauHat) {
+                const Real B_T = B(T);
+                const Real Y_T = Y(T);
+                if (S >= Y_T && S <= B_T) {
+                    res.value = K - S;
+                    res.delta = -1.0;
+                    // gamma, vega, rho, divRho, theta all zero
+                    res.strikeSensitivity = 1.0;
+                    return res;
+                }
+            }
+            if (S >= xmax) {
+                // Eq (15): upper continuation region, only B
+                res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn);
+            } else if (S <= ymax) {
+                // Eq (16): lower continuation region
+                res.value = std::max(0.0, K - S - addOnY);
+            } else {
+                // Between ymax and xmax but outside [Y(T), B(T)]
+                res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn - addOnY);
+            }
+        } else {
+            res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn - addOnY);
+        }
+
+        const NormalDistribution phi;
+        const CumulativeNormalDistribution Phi;
+
+        // Delta add-on
+        const Real deltaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (-r * K * s.dr * phi(s.dm) / (S * s.v) - q * s.dq * Phi(-s.dp) +
+                    q * s.dq * phi(s.dp) / s.v);
+        });
+        res.delta = bc.delta(S) + deltaAddOn;
+
+        // Gamma add-on
+        const Real gammaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * K * s.dr * phi(s.dm) * s.dp / (S * S * s.v * s.v) -
+                    q * s.dq * phi(s.dp) * s.dm / (S * s.v * s.v));
+        });
+        res.gamma = bc.gamma(S) + gammaAddOn;
+
+        // --- Y boundary contributions to delta, gamma (double-boundary) ---
+        // The Y add-on uses the same integrand form as B but with the upper
+        // boundary y_t, and is subtracted from the total.
+        // Y boundary setup: evaluates Y at integration point z
+        auto yBoundarySetup =
+            [&](Real z) -> std::tuple<bool, Real, Real, Real, Real, Real, Real, Real> {
+            const Real t = z * z;
+            const Real tau = T - t;
+            if (tau < QL_EPSILON || tau > tauHat + QL_EPSILON)
+                return {false, 0, 0, 0, 0, 0, 0, 0};
+            const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+            const Real qv = (*interpY)(zc, true);
+            const Real y_t = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+            const Real dr_ = std::exp(-r * t);
+            const Real dq_ = std::exp(-q * t);
+            const Real v_ = vol * std::sqrt(t);
+            if (v_ < QL_EPSILON || y_t < QL_EPSILON)
+                return {false, 0, 0, 0, 0, 0, 0, 0};
+            const Real dp_ = std::log(S * dq_ / (y_t * dr_)) / v_ + 0.5 * v_;
+            const Real dm_ = dp_ - v_;
+            return {true, t, dr_, dq_, v_, y_t, dp_, dm_};
+        };
+
+        const Real zYlo = std::sqrt(std::max(0.0, T - tauHat));
+        const Real zYhi = std::sqrt(T);
+        auto integrateY = [&](const auto& f) -> Real {
+            if (!doubleBoundary || tauHat <= QL_EPSILON)
+                return 0.0;
+            return (*integrator)(f, zYlo, zYhi);
+        };
+
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            const Real deltaYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (-r * K * dr_ * phi(dm_) / (S * v_) - q * dq_ * Phi(-dp_) +
+                        q * dq_ * phi(dp_) / v_);
+            });
+            res.delta -= deltaYAddOn;
+
+            const Real gammaYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (r * K * dr_ * phi(dm_) * dp_ / (S * S * v_ * v_) -
+                        q * dq_ * phi(dp_) * dm_ / (S * v_ * v_));
+            });
+            res.gamma -= gammaYAddOn;
+        }
+
+        // Analytical vega, rho, dividendRho via tangent linear FP iteration.
+        // dV/dp = ∂V/∂p|_B + ∫ (∂f/∂B)·(dB/dp) dz
+        // where dB/dp is obtained by differentiating the FP equation.
+        {
+            const Array y_orig(y);
+            const Size nNodes = x.size();
+            const Size m = nNodes - 1;
+
+            // Determine FP equation type consistently
+            const bool useFpA =
+                (fpEquation_ == FP_A || (fpEquation_ == Auto && std::abs(r - q) < 0.001));
+
+            // Use GaussLegendre for sensitivity equations to avoid
+            // GaussLobatto max-iteration failures with bumped parameters
+            auto makeSensEqn = [&](Rate r_, Rate q_,
+                                   Volatility vol_) -> ext::shared_ptr<DqFpEquation> {
+                auto sensInteg = ext::make_shared<GaussLegendreIntegrator>(25);
+                if (useFpA)
+                    return ext::shared_ptr<DqFpEquation>(
+                        new DqFpEquation_A(K, r_, q_, vol_, B, std::move(sensInteg)));
+                else
+                    return ext::shared_ptr<DqFpEquation>(
+                        new DqFpEquation_B(K, r_, q_, vol_, B, std::move(sensInteg)));
+            };
+
+            // Compute y_fp = h(G(B;p)) explicitly. This differs from y_orig
+            // by the FP residual; using y_orig in finite differences would
+            // amplify this residual by 1/eps, corrupting the sensitivities.
+            Array y_fp(nNodes);
+            y_fp[0] = 0.0;
+            for (Size i = 1; i < nNodes; ++i) {
+                const Real tau = squared(x[i]);
+                y_fp[i] = h(std::get<2>(eqn->f(tau, B(tau))));
+            }
+
+            // Step 1: ∂G/∂p — central difference for O(eps²) accuracy
+            const Real eps_sigma = vol * 1e-4;
+            const Real eps_r = std::max(std::abs(r), 1.0) * 1e-4;
+            const Real eps_q = std::max(std::abs(q), 1.0) * 1e-4;
+
+            const auto eqn_sv_up = makeSensEqn(r, q, vol + eps_sigma);
+            const auto eqn_sv_dn = makeSensEqn(r, q, vol - eps_sigma);
+            const auto eqn_rv_up = makeSensEqn(r + eps_r, q, vol);
+            const auto eqn_rv_dn = makeSensEqn(r - eps_r, q, vol);
+            const auto eqn_qv_up = makeSensEqn(r, q + eps_q, vol);
+            const auto eqn_qv_dn = makeSensEqn(r, q - eps_q, vol);
+
+            Array g_sigma(m), g_r(m), g_q(m);
+            for (Size i = 1; i < nNodes; ++i) {
+                const Real tau = squared(x[i]);
+                const Real b = B(tau);
+                g_sigma[i - 1] =
+                    (h(std::get<2>(eqn_sv_up->f(tau, b))) - h(std::get<2>(eqn_sv_dn->f(tau, b)))) /
+                    (2 * eps_sigma);
+                g_r[i - 1] =
+                    (h(std::get<2>(eqn_rv_up->f(tau, b))) - h(std::get<2>(eqn_rv_dn->f(tau, b)))) /
+                    (2 * eps_r);
+                g_q[i - 1] =
+                    (h(std::get<2>(eqn_qv_up->f(tau, b))) - h(std::get<2>(eqn_qv_dn->f(tau, b)))) /
+                    (2 * eps_q);
+            }
+
+            // Step 2: Sensitivity FP iteration — same contraction as boundary
+            Array s_sigma(g_sigma), s_r(g_r), s_q(g_q);
+            const Real eps_fd = std::sqrt(QL_EPSILON);
+
+            auto iterateSens = [&](Array& s_p, const Array& g_p) {
+                Array y_pert(y_orig);
+                for (Size i = 1; i < nNodes; ++i)
+                    y_pert[i] = y_orig[i] + eps_fd * s_p[i - 1];
+                interp->updateY(y_pert);
+
+                for (Size i = 1; i < nNodes; ++i) {
+                    const Real tau = squared(x[i]);
+                    const Real b = B(tau);
+                    s_p[i - 1] = g_p[i - 1] + (h(std::get<2>(eqn->f(tau, b))) - y_fp[i]) / eps_fd;
+                }
+                interp->updateY(y_orig);
+            };
+
+            for (Size k = 0; k < n_fp; ++k) {
+                iterateSens(s_sigma, g_sigma);
+                iterateSens(s_r, g_r);
+                iterateSens(s_q, g_q);
+            }
+
+            // Step 3: Convert dy/dp → dB/dp at nodes, then interpolate dB/dp
+            // dB = B · (-1/(2√y)) · dy avoids amplification by interpolating
+            // the smooth function dB/dp directly.
+            auto makeBoundarySensInterp = [&](const Array& s_p) {
+                Array db_dp(nNodes);
+                db_dp[0] = 0.0;
+                for (Size i = 1; i < nNodes; ++i) {
+                    const Real yi = y_orig[i];
+                    if (yi < QL_EPSILON) {
+                        db_dp[i] = 0.0;
+                    } else {
+                        const Real Bi = B(squared(x[i]));
+                        db_dp[i] = Bi * (-1.0 / (2 * std::sqrt(yi))) * s_p[i - 1];
+                    }
+                }
+                return ext::make_shared<ChebyshevInterpolation>(db_dp,
+                                                                ChebyshevInterpolation::SecondKind);
+            };
+
+            const auto si_sigma = makeBoundarySensInterp(s_sigma);
+            const auto si_r = makeBoundarySensInterp(s_r);
+            const auto si_q = makeBoundarySensInterp(s_q);
+
+            // When τ̂ < T, dB/dp has two parts:
+            //  (a) FP sensitivity at fixed τ̂ (from the tangent-linear iteration)
+            //  (b) grid remapping: the Chebyshev coordinate z_c = 2√(τ/τ̂)−1
+            //      shifts when τ̂ changes with p.
+            //      dB_remap/dp = (∂B/∂z_c)·(∂z_c/∂τ̂)·(dτ̂/dp)
+            // For vega, |dτ̂/dσ| is small so (b) is negligible.
+            // For rho/divRho, |dτ̂/dr| ≈ 30×|dτ̂/dσ| so (b) is significant.
+
+            // Compute τ̂ sensitivities (needed for grid remapping and Leibniz)
+            const bool hasMerge = doubleBoundary && tauTilde < T - QL_EPSILON;
+            TauHatSensitivities ths{0, 0, 0};
+            if (hasMerge)
+                ths = computeTauHatSensitivities(r, q, tauHat);
+
+            // B boundary: FP sensitivity lookup
+            auto lookupDBdp = [&](Real t_val, const ChebyshevInterpolation& si) -> Real {
+                const Real tau = T - t_val;
+                const Real zc = 2 * std::sqrt(std::max(0.0, tau / tauTilde)) - 1;
+                return si(zc, true);
+            };
+
+            // Vega add-on
+            const Real vegaAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+                if (!s.valid)
+                    return 0.0;
+                const Real dBds = lookupDBdp(s.t, *si_sigma);
+                const Real ddp_ds = -s.dm / vol - dBds / (s.b_t * s.v);
+                const Real ddm_ds = -s.dp / vol - dBds / (s.b_t * s.v);
+                return 2 * z *
+                       (-r * K * s.dr * phi(s.dm) * ddm_ds + q * S * s.dq * phi(s.dp) * ddp_ds);
+            });
+            res.vega = bc.vega(T) + vegaAddOn;
+
+            // Rho add-on
+            const Real rhoAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+                if (!s.valid)
+                    return 0.0;
+                const Real dBdr = lookupDBdp(s.t, *si_r);
+                const Real ddp_dr = s.t / s.v - dBdr / (s.b_t * s.v);
+                return 2 * z *
+                       ((1 - r * s.t) * K * s.dr * Phi(-s.dm) - r * K * s.dr * phi(s.dm) * ddp_dr +
+                        q * S * s.dq * phi(s.dp) * ddp_dr);
+            });
+            res.rho = bc.rho(T) + rhoAddOn;
+
+            // DividendRho add-on
+            const Real divRhoAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+                if (!s.valid)
+                    return 0.0;
+                const Real dBdq = lookupDBdp(s.t, *si_q);
+                const Real ddp_dq = -s.t / s.v - dBdq / (s.b_t * s.v);
+                return 2 * z *
+                       (-r * K * s.dr * phi(s.dm) * ddp_dq - (1 - q * s.t) * S * s.dq * Phi(-s.dp) +
+                        q * S * s.dq * phi(s.dp) * ddp_dq);
+            });
+            res.dividendRho = bc.dividendRho(T) + divRhoAddOn;
+
+            // --- Y boundary sensitivity for vega/rho/divRho ---
+            if (doubleBoundary && tauHat > QL_EPSILON) {
+                const Array yY_orig(yY);
+                const Size nYNodes = xY.size();
+                const Size mY = nYNodes - 1;
+
+                // Y FP baseline values
+                Array y_fp_Y(nYNodes);
+                y_fp_Y[0] = 0.0;
+                for (Size i = 1; i < nYNodes; ++i) {
+                    const Real tau = squared(xY[i]);
+                    y_fp_Y[i] = h_y(std::get<2>(eqnY->f(tau, Y(tau))));
+                }
+
+                // Bumped FP equations for Y (always use FP_B for Y boundary)
+                auto makeSensEqnY = [&](Rate r_, Rate q_,
+                                        Volatility vol_) -> ext::shared_ptr<DqFpEquation> {
+                    auto sensInteg = ext::make_shared<GaussLegendreIntegrator>(25);
+                    return ext::shared_ptr<DqFpEquation>(
+                        new DqFpEquation_B(K, r_, q_, vol_, Y, std::move(sensInteg)));
+                };
+
+                const auto eqnY_sv_up = makeSensEqnY(r, q, vol + eps_sigma);
+                const auto eqnY_sv_dn = makeSensEqnY(r, q, vol - eps_sigma);
+                const auto eqnY_rv_up = makeSensEqnY(r + eps_r, q, vol);
+                const auto eqnY_rv_dn = makeSensEqnY(r - eps_r, q, vol);
+                const auto eqnY_qv_up = makeSensEqnY(r, q + eps_q, vol);
+                const auto eqnY_qv_dn = makeSensEqnY(r, q - eps_q, vol);
+
+                // ∂G_Y/∂p via central difference
+                Array gY_sigma(mY), gY_r(mY), gY_q(mY);
+                for (Size i = 1; i < nYNodes; ++i) {
+                    const Real tau = squared(xY[i]);
+                    const Real yt = Y(tau);
+                    gY_sigma[i - 1] = (h_y(std::get<2>(eqnY_sv_up->f(tau, yt))) -
+                                       h_y(std::get<2>(eqnY_sv_dn->f(tau, yt)))) /
+                                      (2 * eps_sigma);
+                    gY_r[i - 1] = (h_y(std::get<2>(eqnY_rv_up->f(tau, yt))) -
+                                   h_y(std::get<2>(eqnY_rv_dn->f(tau, yt)))) /
+                                  (2 * eps_r);
+                    gY_q[i - 1] = (h_y(std::get<2>(eqnY_qv_up->f(tau, yt))) -
+                                   h_y(std::get<2>(eqnY_qv_dn->f(tau, yt)))) /
+                                  (2 * eps_q);
+                }
+
+                // Sensitivity FP iteration for Y
+                Array sY_sigma(gY_sigma), sY_r(gY_r), sY_q(gY_q);
+
+                auto iterateSensY = [&](Array& s_p, const Array& g_p) {
+                    Array yY_pert(yY_orig);
+                    for (Size i = 1; i < nYNodes; ++i)
+                        yY_pert[i] = yY_orig[i] + eps_fd * s_p[i - 1];
+                    interpY->updateY(yY_pert);
+
+                    for (Size i = 1; i < nYNodes; ++i) {
+                        const Real tau = squared(xY[i]);
+                        const Real yt = Y(tau);
+                        s_p[i - 1] =
+                            g_p[i - 1] + (h_y(std::get<2>(eqnY->f(tau, yt))) - y_fp_Y[i]) / eps_fd;
+                    }
+                    interpY->updateY(yY_orig);
+                };
+
+                for (Size k = 0; k < n_fp; ++k) {
+                    iterateSensY(sY_sigma, gY_sigma);
+                    iterateSensY(sY_r, gY_r);
+                    iterateSensY(sY_q, gY_q);
+                }
+
+                // Convert dy_Y/dp → dY/dp
+                auto makeYBoundarySensInterp = [&](const Array& s_p) {
+                    Array dy_dp(nYNodes);
+                    dy_dp[0] = 0.0;
+                    for (Size i = 1; i < nYNodes; ++i) {
+                        const Real yi = yY_orig[i];
+                        if (yi < QL_EPSILON) {
+                            dy_dp[i] = 0.0;
+                        } else {
+                            const Real Yi = Y(squared(xY[i]));
+                            dy_dp[i] = Yi * (-1.0 / (2 * std::sqrt(yi))) * s_p[i - 1];
+                        }
+                    }
+                    return ext::make_shared<ChebyshevInterpolation>(
+                        dy_dp, ChebyshevInterpolation::SecondKind);
+                };
+
+                const auto siY_sigma = makeYBoundarySensInterp(sY_sigma);
+                const auto siY_r = makeYBoundarySensInterp(sY_r);
+                const auto siY_q = makeYBoundarySensInterp(sY_q);
+
+                // Y boundary: FP sensitivity lookup
+                auto lookupDYdp = [&](Real t_val, const ChebyshevInterpolation& si) -> Real {
+                    const Real tau = T - t_val;
+                    const Real zc =
+                        2 * std::sqrt(std::max(0.0, std::min(tau, tauHat)) / tauHat) - 1;
+                    return si(zc, true);
+                };
+
+                // Vega Y add-on (subtracted)
+                const Real vegaYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real dYds = lookupDYdp(t, *siY_sigma);
+                    const Real ddp_ds = -dm_ / vol - dYds / (y_t * v_);
+                    const Real ddm_ds = -dp_ / vol - dYds / (y_t * v_);
+                    return 2 * z *
+                           (-r * K * dr_ * phi(dm_) * ddm_ds + q * S * dq_ * phi(dp_) * ddp_ds);
+                });
+                res.vega -= vegaYAddOn;
+
+                // Rho Y add-on (subtracted)
+                const Real rhoYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real dYdr = lookupDYdp(t, *siY_r);
+                    const Real ddp_dr = t / v_ - dYdr / (y_t * v_);
+                    return 2 * z *
+                           ((1 - r * t) * K * dr_ * Phi(-dm_) - r * K * dr_ * phi(dm_) * ddp_dr +
+                            q * S * dq_ * phi(dp_) * ddp_dr);
+                });
+                res.rho -= rhoYAddOn;
+
+                // DividendRho Y add-on (subtracted)
+                const Real divRhoYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real dYdq = lookupDYdp(t, *siY_q);
+                    const Real ddp_dq = -t / v_ - dYdq / (y_t * v_);
+                    return 2 * z *
+                           (-r * K * dr_ * phi(dm_) * ddp_dq - (1 - q * t) * S * dq_ * Phi(-dp_) +
+                            q * S * dq_ * phi(dp_) * ddp_dq);
+                });
+                res.dividendRho -= divRhoYAddOn;
+            }
+
+            // --- Leibniz boundary correction for vega/rho/divRho ---
+            // When τ̂ < T, the integration lower limit z₀ = √(T−τ̂) depends on
+            // σ, r, q through τ̂. By Leibniz rule: correction = [f_B(z₀)−f_Y(z₀)]·dτ̂/dp/(2z₀)
+            if (doubleBoundary && tauTilde < T - QL_EPSILON) {
+                const Real z0 = std::sqrt(T - tauHat);
+                const Real fB_z0 = aov(z0);
+
+                // Evaluate Y integrand at z₀
+                Real fY_z0 = 0.0;
+                if (interpY) {
+                    const Real t0 = z0 * z0;
+                    const Real tau0 = T - t0;
+                    const Real zc = 2 * std::sqrt(std::min(tau0, tauHat) / tauHat) - 1;
+                    const Real qv = (*interpY)(zc, true);
+                    const Real y0 = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+                    const Real dr0 = std::exp(-r * t0);
+                    const Real dq0 = std::exp(-q * t0);
+                    const Real v0 = vol * std::sqrt(t0);
+                    if (v0 >= QL_EPSILON && y0 > QL_EPSILON) {
+                        const Real dp0 = std::log(S * dq0 / (y0 * dr0)) / v0 + 0.5 * v0;
+                        fY_z0 = 2 * z0 * (r * K * dr0 * Phi(-(dp0 - v0)) - q * S * dq0 * Phi(-dp0));
+                    }
+                }
+
+                const Real fNet = fB_z0 - fY_z0;
+                if (std::abs(fNet) > QL_EPSILON) {
+                    const Real leibnizFactor = fNet / (2 * z0);
+                    res.vega += leibnizFactor * ths.dTauHat_dSigma;
+                    res.rho += leibnizFactor * ths.dTauHat_dR;
+                    res.dividendRho += leibnizFactor * ths.dTauHat_dQ;
+                }
+            }
+        }
+
+        // StrikeSensitivity add-on: total d/dK, using B ∝ K
+        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ∂dp/∂K = -1/(Kv)
+        const Real strikeSensAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * s.dr * (Phi(-s.dm) + phi(s.dm) / s.v) -
+                    q * S * s.dq * phi(s.dp) / (K * s.v));
+        });
+        res.strikeSensitivity = bc.strikeSensitivity() + strikeSensAddOn;
+
+        // StrikeGamma add-on: d²f/dK²
+        const Real strikeGammaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *interp);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * s.dr * phi(s.dm) * s.dp / (K * s.v * s.v) -
+                    q * S * s.dq * phi(s.dp) * s.dm / (K * K * s.v * s.v));
+        });
+        res.strikeGamma = bc.strikeGamma() + strikeGammaAddOn;
+
+        // --- Y boundary contributions to strikeSens, strikeGamma ---
+        // Y = K·r/q ∝ K, so dY/dK = r/q. The Y integrand also depends on K
+        // directly through the rK·dr·Φ(−d−) term. ∂dp/∂K = −1/(K·v).
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            const Real strikeSensYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (r * dr_ * (Phi(-dm_) + phi(dm_) / v_) - q * S * dq_ * phi(dp_) / (K * v_));
+            });
+            res.strikeSensitivity -= strikeSensYAddOn;
+
+            const Real strikeGammaYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = yBoundarySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (r * dr_ * phi(dm_) * dp_ / (K * v_ * v_) -
+                        q * S * dq_ * phi(dp_) * dm_ / (K * K * v_ * v_));
+            });
+            res.strikeGamma -= strikeGammaYAddOn;
+        }
+
+        // Theta: Leibniz rule → f(√T) / (2√T)
+        const Real sqrtT = std::sqrt(T);
+        res.theta = bc.theta(S, T) + aov(sqrtT) / (2 * sqrtT);
+
+        return res;
     }
-
 }
 
 

--- a/ql/pricingengines/vanilla/qdfpamericanengine.hpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.hpp
@@ -132,8 +132,8 @@ namespace QuantLib {
         static ext::shared_ptr<QdFpIterationScheme> highPrecisionScheme();
 
       protected:
-        Real calculatePut(
-            Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const override;
+        detail::QdPutResults
+        calculatePut(Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const override;
 
       private:
         const ext::shared_ptr<QdFpIterationScheme> iterationScheme_;

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -808,12 +808,6 @@ namespace QuantLib {
                 const auto siY_r = makeYSensInterp(eps_r, 0, 0);
                 const auto siY_q = makeYSensInterp(0, eps_q, 0);
 
-                // df_Y/dY = 2z/(Y*v) * [rK*dr*phi(dm) - qS*dq*phi(dp)]
-                auto dfdy = [&](Real z, Real y_t, Real dr_, Real v_, Real dp_, Real dm_) -> Real {
-                    return 2 * z / (y_t * v_) *
-                           (r * K * dr_ * phi(dm_) - q * S * std::exp(-q * z * z) * phi(dp_));
-                };
-
                 auto lookupDYdp = [&](Real t_val, const ChebyshevInterpolation& si) -> Real {
                     const Real tau = T - t_val;
                     const Real zc =

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -32,7 +32,6 @@
 #include <ql/pricingengines/vanilla/qdplusamericanengine.hpp>
 #include <ql/utilities/null.hpp>
 #include <algorithm>
-#include <iostream>
 #ifndef QL_BOOST_HAS_TANH_SINH
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #endif
@@ -93,6 +92,140 @@ namespace QuantLib {
         Real xmin() const { return xMin; }
         Real xmax() const { return xMax; }
         Size evaluations() const { return nrEvaluations; }
+
+        // Analytical partial derivatives of eval w.r.t. sigma, r, q at fixed S.
+        // Returns {deval/dsigma, deval/dr, deval/dq}.
+        std::tuple<Real, Real, Real> parameterDerivatives(Real S) const {
+            if (S != sc)
+                preCalculate(S);
+
+            const Real sqrtTau = std::sqrt(tau);
+            const Real phi_dm = phi(dm);
+            const Real P = K - S - npv;
+
+            // --- constructor-level derivatives ---
+
+            // dr, dq
+            const Real dr_r = -tau * dr;
+            const Real dq_q = -tau * dq;
+
+            // ddr = r/(1-dr)
+            Real ddr_r;
+            if (std::abs(r * tau) > 1e-5)
+                ddr_r = ((1 - dr) - r * tau * dr) / squared(1 - dr);
+            else
+                ddr_r = 0.5 + r * tau / 6.0;
+
+            // omega = 2(r-q)/sigma^2
+            const Real omega_s = -2 * omega / sigma;
+            const Real omega_r = 2.0 / sigma2;
+            const Real omega_q = -2.0 / sigma2;
+
+            // D = (omega-1)^2 + 8*ddr/sigma^2, sqrtD = sqrt(D)
+            // Note: 2*lambda + omega - 1 = -sqrtD
+            const Real D = squared(omega - 1) + 8 * ddr / sigma2;
+            const Real sqrtD = std::sqrt(D);
+
+            const Real D_s = 2 * (omega - 1) * omega_s - 16 * ddr / (sigma2 * sigma);
+            const Real D_r = 2 * (omega - 1) * omega_r + 8 * ddr_r / sigma2;
+            const Real D_q = 2 * (omega - 1) * omega_q;
+
+            const Real sqrtD_s = D_s / (2 * sqrtD);
+            const Real sqrtD_r = D_r / (2 * sqrtD);
+            const Real sqrtD_q = D_q / (2 * sqrtD);
+
+            // lambda = 0.5*(-(omega-1) - sqrtD)
+            const Real lambda_s = 0.5 * (-omega_s - sqrtD_s);
+            const Real lambda_r = 0.5 * (-omega_r - sqrtD_r);
+            const Real lambda_q = 0.5 * (-omega_q - sqrtD_q);
+
+            // alpha = -2*dr/(sigma^2*sqrtD)
+            // Using quotient rule on num=-2*dr, den=sigma^2*sqrtD
+            const Real a_den = sigma2 * sqrtD;
+            const Real a_den2 = a_den * a_den;
+            const Real a_den_s = 2 * sigma * sqrtD + sigma2 * sqrtD_s;
+            const Real a_den_r = sigma2 * sqrtD_r;
+            const Real a_den_q = sigma2 * sqrtD_q;
+
+            const Real alpha_s = 2 * dr * a_den_s / a_den2;
+            const Real alpha_r = (-2 * dr_r * a_den + 2 * dr * a_den_r) / a_den2;
+            const Real alpha_q = 2 * dr * a_den_q / a_den2;
+
+            // lambdaPrime = 2*ddr^2/(sigma^2*sqrtD)
+            // Quotient rule: num=2*ddr^2, den=sigma^2*sqrtD (same den as alpha)
+            const Real lp_num = 2 * ddr * ddr;
+            const Real lp_num_r = 4 * ddr * ddr_r;
+
+            const Real lp_s = -lp_num * a_den_s / a_den2;
+            const Real lp_r = (lp_num_r * a_den - lp_num * a_den_r) / a_den2;
+            const Real lp_q = -lp_num * a_den_q / a_den2;
+
+            // beta = alpha*(ddr - lambdaPrime/sqrtD) - lambda
+            const Real lp_over_sqrtD = lambdaPrime / sqrtD;
+            const Real inner = ddr - lp_over_sqrtD;
+
+            const Real lpos_s = (lp_s * sqrtD - lambdaPrime * sqrtD_s) / D;
+            const Real lpos_r = (lp_r * sqrtD - lambdaPrime * sqrtD_r) / D;
+            const Real lpos_q = (lp_q * sqrtD - lambdaPrime * sqrtD_q) / D;
+
+            const Real inner_s = -lpos_s;
+            const Real inner_r = ddr_r - lpos_r;
+            const Real inner_q = -lpos_q;
+
+            const Real beta_s = alpha_s * inner + alpha * inner_s - lambda_s;
+            const Real beta_r = alpha_r * inner + alpha * inner_r - lambda_r;
+            const Real beta_q = alpha_q * inner + alpha * inner_q - lambda_q;
+
+            // --- preCalculate-level derivatives at fixed S ---
+
+            // dp, dm
+            const Real dp_s = -dm / sigma;
+            const Real dp_r = sqrtTau / sigma;
+            const Real dp_q = -sqrtTau / sigma;
+
+            const Real dm_s = -dp / sigma;
+            // dm_r = dp_r, dm_q = dp_q (since dm = dp - v and v is independent of r,q)
+
+            // Phi(-dp), Phi(-dm): d(Phi(-x))/dp = -phi(x)*dx/dp
+            const Real Phidp_s = -phi_dp * dp_s;
+            const Real Phidp_r = -phi_dp * dp_r;
+            const Real Phidp_q = -phi_dp * dp_q;
+
+            const Real Phidm_s = -phi_dm * dm_s;
+            const Real Phidm_r = -phi_dm * dp_r;
+            const Real Phidm_q = -phi_dm * dp_q;
+
+            // npv = dr*K*Phi_dm - S*dq*Phi_dp
+            const Real npv_s = K * dr * Phidm_s - S * dq * Phidp_s;
+            const Real npv_r = K * (dr_r * Phi_dm + dr * Phidm_r) - S * dq * Phidp_r;
+            const Real npv_q = K * dr * Phidm_q - S * (dq_q * Phi_dp + dq * Phidp_q);
+
+            // theta = r*K*dr*Phi_dm - q*S*dq*Phi_dp - sigma*S*dq*phi_dp/(2*sqrtTau)
+            const Real theta_s = r * K * dr * Phidm_s - q * S * dq * Phidp_s -
+                                 S * dq * phi_dp * (1 + dp * dm) / (2 * sqrtTau);
+            const Real theta_r = K * dr * (1 - r * tau) * Phi_dm + r * K * dr * Phidm_r -
+                                 q * S * dq * Phidp_r + S * dq * dp * phi_dp / 2;
+            const Real theta_q = r * K * dr * Phidm_q - S * dq * (1 - q * tau) * Phi_dp -
+                                 q * S * dq * Phidp_q - S * dq * phi_dp * dm / 2;
+
+            // --- assemble d(eval)/dp ---
+            // eval = (1-dq*Phi_dp)*S - beta*P + alpha*theta/dr
+            // d(eval)/dp = S*d(-dq*Phi_dp)/dp - d(beta)/dp*P + beta*d(npv)/dp
+            //            + [d(alpha)/dp*theta + alpha*d(theta)/dp]/dr
+            //            + alpha*theta*d(1/dr)/dp
+
+            const Real eval_s = S * (-dq * Phidp_s) - beta_s * P + beta * npv_s +
+                                (alpha_s * theta + alpha * theta_s) / dr;
+
+            // d(1/dr)/dr = tau/dr (since d(dr)/dr = -tau*dr)
+            const Real eval_r = S * (-dq * Phidp_r) - beta_r * P + beta * npv_r +
+                                (alpha_r * theta + alpha * theta_r) / dr + alpha * theta * tau / dr;
+
+            const Real eval_q = S * (-(dq_q * Phi_dp + dq * Phidp_q)) - beta_q * P + beta * npv_q +
+                                (alpha_q * theta + alpha * theta_q) / dr;
+
+            return {eval_s, eval_r, eval_q};
+        }
 
       private:
         void preCalculate(Real S) const {
@@ -688,40 +821,53 @@ namespace QuantLib {
         // The QdPlus boundary solves eval(B;p) = 0 at each tau.
         // By the IFT: dB/dp = -(deval/dp) / (deval/dB)
         {
-            const Real eps_sigma = vol * 1e-6;
-            const Real eps_r = std::max(std::abs(r), 1.0) * 1e-6;
-            const Real eps_q = std::max(std::abs(q), 1.0) * 1e-6;
+            // Build Chebyshev interpolations of dB/dp using analytical derivatives
+            auto makeBoundarySensInterps =
+                [&]() -> std::tuple<ext::shared_ptr<ChebyshevInterpolation>,
+                                    ext::shared_ptr<ChebyshevInterpolation>,
+                                    ext::shared_ptr<ChebyshevInterpolation>> {
+                const Array chebNodes = ChebyshevInterpolation::nodes(
+                    interpolationPoints_, ChebyshevInterpolation::SecondKind);
+                Array db_ds(interpolationPoints_);
+                Array db_dr(interpolationPoints_);
+                Array db_dq(interpolationPoints_);
 
-            // Build Chebyshev interpolations of dB/dp at each node
-            auto makeBoundarySensInterp =
-                [&](Real dr_, Real dq_, Real dvol_) -> ext::shared_ptr<ChebyshevInterpolation> {
-                const Real bump = (dvol_ != 0.0) ? dvol_ : ((dr_ != 0.0) ? dr_ : dq_);
-                return ext::make_shared<ChebyshevInterpolation>(
-                    interpolationPoints_,
-                    [&, dr_, dq_, dvol_, bump](Real z) -> Real {
-                        const Real tau = 0.25 * tauTilde * squared(1 + z);
-                        if (tau < QL_EPSILON)
-                            return 0.0;
+                for (Size i = 0; i < interpolationPoints_; ++i) {
+                    const Real z = chebNodes[i];
+                    const Real tau = 0.25 * tauTilde * squared(1 + z);
+                    if (tau < QL_EPSILON) {
+                        db_ds[i] = db_dr[i] = db_dq[i] = 0.0;
+                        continue;
+                    }
 
-                        const Real b = xmax * std::exp(-std::sqrt(std::max(0.0, (*q_z)(z, true))));
+                    const Real b = xmax * std::exp(-std::sqrt(std::max(0.0, (*q_z)(z, true))));
 
-                        const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
-                        const Real evalDeriv = eval0.derivative(b);
-                        if (std::abs(evalDeriv) < QL_EPSILON)
-                            return 0.0;
+                    const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
+                    const Real evalDeriv = eval0.derivative(b);
+                    if (std::abs(evalDeriv) < QL_EPSILON) {
+                        db_ds[i] = db_dr[i] = db_dq[i] = 0.0;
+                        continue;
+                    }
 
-                        const QdPlusBoundaryEvaluator evalBump(S, K, r + dr_, q + dq_, vol + dvol_,
-                                                               tau, T);
-                        const Real dEval = evalBump(b) / bump;
+                    const auto [dEval_ds, dEval_dr, dEval_dq] = eval0.parameterDerivatives(b);
 
-                        return -dEval / evalDeriv;
-                    },
-                    ChebyshevInterpolation::SecondKind);
+                    db_ds[i] = -dEval_ds / evalDeriv;
+                    db_dr[i] = -dEval_dr / evalDeriv;
+                    db_dq[i] = -dEval_dq / evalDeriv;
+                }
+
+                return {ext::make_shared<ChebyshevInterpolation>(
+                            db_ds, ChebyshevInterpolation::SecondKind),
+                        ext::make_shared<ChebyshevInterpolation>(
+                            db_dr, ChebyshevInterpolation::SecondKind),
+                        ext::make_shared<ChebyshevInterpolation>(
+                            db_dq, ChebyshevInterpolation::SecondKind)};
             };
 
-            const auto si_sigma = makeBoundarySensInterp(0, 0, eps_sigma);
-            const auto si_r = makeBoundarySensInterp(eps_r, 0, 0);
-            const auto si_q = makeBoundarySensInterp(0, eps_q, 0);
+            const auto bSensInterps = makeBoundarySensInterps();
+            const auto& si_sigma = std::get<0>(bSensInterps);
+            const auto& si_r = std::get<1>(bSensInterps);
+            const auto& si_q = std::get<2>(bSensInterps);
 
             // df/dB = 2z/(B*v) * [rK*dr*phi(dm) - qS*dq*phi(dp)]
             auto dfdb = [&](Real z, const detail::QdAddOnSetup& s) -> Real {
@@ -775,38 +921,55 @@ namespace QuantLib {
 
             // --- Y boundary contributions to vega, rho, divRho (double-boundary) ---
             if (doubleBoundary && tauHat > QL_EPSILON && interpY) {
-                // Build Y boundary sensitivity interpolations via IFT
-                auto makeYSensInterp = [&](Real dr_, Real dq_,
-                                           Real dvol_) -> ext::shared_ptr<ChebyshevInterpolation> {
-                    const Real bump = (dvol_ != 0.0) ? dvol_ : ((dr_ != 0.0) ? dr_ : dq_);
-                    return ext::make_shared<ChebyshevInterpolation>(
-                        interpolationPoints_,
-                        [&, dr_, dq_, dvol_, bump](Real zz) -> Real {
-                            const Real tau = 0.25 * tauHat * squared(1 + zz);
-                            if (tau < QL_EPSILON)
-                                return 0.0;
+                // Build Y boundary sensitivity interpolations using analytical derivatives
+                auto makeYSensInterps =
+                    [&]() -> std::tuple<ext::shared_ptr<ChebyshevInterpolation>,
+                                        ext::shared_ptr<ChebyshevInterpolation>,
+                                        ext::shared_ptr<ChebyshevInterpolation>> {
+                    const Array yChebNodes = ChebyshevInterpolation::nodes(
+                        interpolationPoints_, ChebyshevInterpolation::SecondKind);
+                    Array dy_ds(interpolationPoints_);
+                    Array dy_dr(interpolationPoints_);
+                    Array dy_dq(interpolationPoints_);
 
-                            const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
-                            const Real qv = (*interpY)(zc, true);
-                            const Real y = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+                    for (Size i = 0; i < interpolationPoints_; ++i) {
+                        const Real zz = yChebNodes[i];
+                        const Real tau = 0.25 * tauHat * squared(1 + zz);
+                        if (tau < QL_EPSILON) {
+                            dy_ds[i] = dy_dr[i] = dy_dq[i] = 0.0;
+                            continue;
+                        }
 
-                            const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
-                            const Real evalDeriv = eval0.derivative(y);
-                            if (std::abs(evalDeriv) < QL_EPSILON)
-                                return 0.0;
+                        const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+                        const Real qv = (*interpY)(zc, true);
+                        const Real y = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
 
-                            const QdPlusBoundaryEvaluator evalBump(S, K, r + dr_, q + dq_,
-                                                                   vol + dvol_, tau, T);
-                            const Real dEval = evalBump(y) / bump;
+                        const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
+                        const Real evalDeriv = eval0.derivative(y);
+                        if (std::abs(evalDeriv) < QL_EPSILON) {
+                            dy_ds[i] = dy_dr[i] = dy_dq[i] = 0.0;
+                            continue;
+                        }
 
-                            return -dEval / evalDeriv;
-                        },
-                        ChebyshevInterpolation::SecondKind);
+                        const auto [dEval_ds, dEval_dr, dEval_dq] = eval0.parameterDerivatives(y);
+
+                        dy_ds[i] = -dEval_ds / evalDeriv;
+                        dy_dr[i] = -dEval_dr / evalDeriv;
+                        dy_dq[i] = -dEval_dq / evalDeriv;
+                    }
+
+                    return {ext::make_shared<ChebyshevInterpolation>(
+                                dy_ds, ChebyshevInterpolation::SecondKind),
+                            ext::make_shared<ChebyshevInterpolation>(
+                                dy_dr, ChebyshevInterpolation::SecondKind),
+                            ext::make_shared<ChebyshevInterpolation>(
+                                dy_dq, ChebyshevInterpolation::SecondKind)};
                 };
 
-                const auto siY_sigma = makeYSensInterp(0, 0, eps_sigma);
-                const auto siY_r = makeYSensInterp(eps_r, 0, 0);
-                const auto siY_q = makeYSensInterp(0, eps_q, 0);
+                const auto ySensInterps = makeYSensInterps();
+                const auto& siY_sigma = std::get<0>(ySensInterps);
+                const auto& siY_r = std::get<1>(ySensInterps);
+                const auto& siY_q = std::get<2>(ySensInterps);
 
                 auto lookupDYdp = [&](Real t_val, const ChebyshevInterpolation& si) -> Real {
                     const Real tau = T - t_val;

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -122,16 +122,22 @@ namespace QuantLib {
     };
 
 
-    detail::QdPlusAddOnValue::QdPlusAddOnValue(
-        Time T, Real S, Real K, Rate r, Rate q, Volatility vol,
-        const Real xmax, ext::shared_ptr<Interpolation> q_z)
-    : T_(T), S_(S), K_(K), xmax_(xmax),
-      r_(r), q_(q), vol_(vol), q_z_(std::move(q_z)) {}
+    detail::QdPlusAddOnValue::QdPlusAddOnValue(Time T,
+                                               Time tauTilde,
+                                               Real S,
+                                               Real K,
+                                               Rate r,
+                                               Rate q,
+                                               Volatility vol,
+                                               const Real xmax,
+                                               ext::shared_ptr<Interpolation> q_z)
+    : T_(T), tauTilde_(tauTilde), S_(S), K_(K), xmax_(xmax), r_(r), q_(q), vol_(vol),
+      q_z_(std::move(q_z)) {}
 
 
     Real detail::QdPlusAddOnValue::operator()(Real z) const {
         const Real t = z*z;
-        const Real q = (*q_z_)(2*std::sqrt(std::max(0.0, T_-t)/T_) - 1, true);
+        const Real q = (*q_z_)(2 * std::sqrt(std::max(0.0, T_ - t) / tauTilde_) - 1, true);
         const Real b_t = xmax_*std::exp(-std::sqrt(std::max(0.0, q)));
 
         const Real dr = std::exp(-r_*t);
@@ -157,6 +163,93 @@ namespace QuantLib {
         return r;
     }
 
+
+    namespace {
+        Real sigmaHat(Rate r, Rate q, Time tau) {
+            if (tau < QL_EPSILON)
+                return QL_MAX_REAL;
+            const Real erT = std::exp(r * tau);
+            const Real eqT = std::exp(q * tau);
+            if (erT >= 1.0 || eqT >= 1.0)
+                return QL_MAX_REAL; // tau too small for FP; σ̂ → ∞ as τ → 0
+            const InverseCumulativeNormal PhiInv;
+            return std::abs(PhiInv(eqT) - PhiInv(erT)) / std::sqrt(tau);
+        }
+
+        // Derivatives of σ̂ at a given τ, for computing dτ̂/dp via IFT.
+        struct SigmaHatDerivatives {
+            Real dSigmaHat_dTau, dSigmaHat_dR, dSigmaHat_dQ;
+        };
+
+        SigmaHatDerivatives sigmaHatDerivatives(Rate r, Rate q, Time tau) {
+            const Real sqrtTau = std::sqrt(tau);
+            const Real erT = std::exp(r * tau);
+            const Real eqT = std::exp(q * tau);
+            const InverseCumulativeNormal PhiInv;
+            const NormalDistribution phi;
+            const Real gr = PhiInv(erT), gq = PhiInv(eqT);
+            const Real N = gr - gq;
+            const Real sign = (N > 0) ? 1.0 : -1.0;
+            const Real phi_gr = phi(gr), phi_gq = phi(gq);
+            const Real gr_tau = r * erT / phi_gr;
+            const Real gq_tau = q * eqT / phi_gq;
+            const Real N_tau = gr_tau - gq_tau;
+            return {sign * (2 * tau * N_tau - N) / (2 * tau * sqrtTau),
+                    sign * tau * erT / (phi_gr * sqrtTau), -sign * tau * eqT / (phi_gq * sqrtTau)};
+        }
+
+        struct TauHatSensitivities {
+            Real dTauHat_dSigma, dTauHat_dR, dTauHat_dQ;
+        };
+
+        TauHatSensitivities computeTauHatSensitivities(Rate r, Rate q, Time tauHat) {
+            const auto d = sigmaHatDerivatives(r, q, tauHat);
+            const Real inv = 1.0 / d.dSigmaHat_dTau;
+            return {inv, -d.dSigmaHat_dR * inv, -d.dSigmaHat_dQ * inv};
+        }
+
+        // sigma_hat decreases from ∞ (tau→0) to sigma* (tau→∞).
+        // If sigma_hat(T) > vol, boundaries exist throughout [0,T], return T.
+        // Otherwise solve sigma_hat(tau_hat) = vol; boundaries merge at tau_hat < T.
+        Time computeTauHat(Rate r, Rate q, Volatility vol, Time T) {
+            if (sigmaHat(r, q, T) > vol)
+                return T;
+            QuantLib::Brent solver;
+            solver.setMaxEvaluations(100);
+            return solver.solve([&](Real tau) { return sigmaHat(r, q, tau) - vol; }, 1e-10, 0.5 * T,
+                                QL_EPSILON, T);
+        }
+
+        // Common setup for all Greek integrand classes
+        struct QdAddOnSetup {
+            Real t, dr, dq, v, b_t, dp, dm;
+            bool valid;
+
+            QdAddOnSetup(Real z,
+                         Time T,
+                         Time tauTilde,
+                         Real S,
+                         Rate r,
+                         Rate q,
+                         Volatility vol,
+                         Real xmax,
+                         const Interpolation& q_z) {
+                t = z * z;
+                const Real qv = q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true);
+                b_t = xmax * std::exp(-std::sqrt(std::max(0.0, qv)));
+
+                dr = std::exp(-r * t);
+                dq = std::exp(-q * t);
+                v = vol * std::sqrt(t);
+
+                valid = (v >= QL_EPSILON && b_t > QL_EPSILON);
+                if (valid) {
+                    dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
+                    dm = dp - v;
+                }
+            }
+        };
+    }
 
     detail::QdPutCallParityEngine::QdPutCallParityEngine(
         ext::shared_ptr<GeneralizedBlackScholesProcess> process)
@@ -187,27 +280,70 @@ namespace QuantLib {
         QL_REQUIRE(K >= 0, "zero or positive strike is required");
         QL_REQUIRE(vol >= 0, "zero or positive volatility is required");
 
-        if (payoff->optionType() == Option::Put)
-            results_.value = calculatePutWithEdgeCases(S, K, r, q, vol, T);
-        else if (payoff->optionType() == Option::Call)
-            results_.value = calculatePutWithEdgeCases(K, S, q, r, vol, T);
-        else
+        if (payoff->optionType() == Option::Put) {
+            const auto res = calculatePutWithEdgeCases(S, K, r, q, vol, T);
+            results_.value = res.value;
+            results_.delta = res.delta;
+            results_.gamma = res.gamma;
+            results_.vega = res.vega;
+            results_.rho = res.rho;
+            results_.dividendRho = res.dividendRho;
+            results_.theta = res.theta;
+            results_.strikeSensitivity = res.strikeSensitivity;
+        } else if (payoff->optionType() == Option::Call) {
+            // Put-call symmetry: Call(S,K,r,q) = Put(K,S,q,r)
+            // Put is computed with S_put=K, K_put=S, r_put=q, q_put=r
+            const auto res = calculatePutWithEdgeCases(K, S, q, r, vol, T);
+            results_.value = res.value;
+            // delta_call = d/dS [Put(K,S,q,r)] = strikeSensitivity_put
+            results_.delta = res.strikeSensitivity;
+            // gamma_call = d²/dS² [Put(K,S,q,r)] = strikeGamma_put
+            results_.gamma = res.strikeGamma;
+            // vega is symmetric
+            results_.vega = res.vega;
+            // rho_call: r appears as q_put → rho_call = dividendRho_put
+            results_.rho = res.dividendRho;
+            // dividendRho_call: q appears as r_put → dividendRho_call = rho_put
+            results_.dividendRho = res.rho;
+            // theta is symmetric
+            results_.theta = res.theta;
+            // strikeSensitivity_call: K appears as S_put → delta_put
+            results_.strikeSensitivity = res.delta;
+        } else
             QL_FAIL("unknown option type");
     }
 
-    Real detail::QdPutCallParityEngine::calculatePutWithEdgeCases(
+    detail::QdPutResults detail::QdPutCallParityEngine::calculatePutWithEdgeCases(
         Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const {
 
+        QdPutResults res;
+
         if (close(K, 0.0))
-            return 0.0;
+            return res;
 
-        if (close(S, 0.0))
-            return std::max(K, K*std::exp(-r*T));
+        if (close(S, 0.0)) {
+            res.value = std::max(K, K * std::exp(-r * T));
+            return res;
+        }
 
-        if (r <= 0.0 && r <= q)
-            return std::max(0.0,
-                BlackCalculator(Option::Put, K, S*std::exp((r-q)*T),
-                                vol*std::sqrt(T), std::exp(-r*T)).value());
+        if (r <= 0.0 && r <= q) {
+            const Real fwd = S * std::exp((r - q) * T);
+            const Real stdDev = vol * std::sqrt(T);
+            const Real df = std::exp(-r * T);
+            BlackCalculator bc(Option::Put, K, fwd, stdDev, df);
+            res.value = std::max(0.0, bc.value());
+            if (res.value > 0.0) {
+                res.delta = bc.delta(S);
+                res.gamma = bc.gamma(S);
+                res.vega = bc.vega(T);
+                res.rho = bc.rho(T);
+                res.dividendRho = bc.dividendRho(T);
+                res.theta = bc.theta(S, T);
+                res.strikeSensitivity = bc.strikeSensitivity();
+                res.strikeGamma = bc.strikeGamma();
+            }
+            return res;
+        }
 
         if (close(vol, 0.0)) {
             const auto intrinsic = [&](Real t)  -> Real {
@@ -219,9 +355,10 @@ namespace QuantLib {
                 = close_enough(r, q)? QL_MAX_REAL : Real(std::log(r*K/(q*S))/(r-q));
 
             if (extremT > 0.0 && extremT < T)
-                return std::max({npv0, npvT, intrinsic(extremT)});
+                res.value = std::max({npv0, npvT, intrinsic(extremT)});
             else
-                return std::max(npv0, npvT);
+                res.value = std::max(npv0, npvT);
+            return res;
         }
 
         return calculatePut(S, K, r, q, vol, T);
@@ -332,7 +469,17 @@ namespace QuantLib {
                 while (!resultCloseEnough && eval.evaluations() < maxIter_);
 
                 if (!resultCloseEnough && !close(std::fabs(fx), 0.0)) {
-                    x = buildInSolver(eval, QuantLib::Brent(), S, K, 10*maxIter_, x);
+                    try {
+                        x = buildInSolver(eval, QuantLib::Brent(), S, K, 10 * maxIter_, x);
+                    } catch (...) {
+                        // For double-boundary case (q<r<0) with large τ,
+                        // boundary B→0 and solver may fail to bracket.
+                        // Return small fraction of xmax to keep interpolation stable.
+                        if (r < 0.0 && q < r)
+                            x = 0.01 * eval.xmax();
+                        else
+                            throw;
+                    }
                 }
             }
             break;
@@ -361,36 +508,447 @@ namespace QuantLib {
         );
     }
 
-    Real QdPlusAmericanEngine::calculatePut(
+    detail::QdPutResults QdPlusAmericanEngine::calculatePut(
         Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const {
 
-        if (r < 0.0 && q < r)
-            QL_FAIL("double-boundary case q<r<0 for a put option is given");
+        const bool doubleBoundary = (r < 0.0 && q < r);
+        const Real tauHat = doubleBoundary ? computeTauHat(r, q, vol, T) : 0.0;
+        const Time tauTilde = doubleBoundary ? tauHat : T;
 
-        const ext::shared_ptr<Interpolation> q_z
-            = getPutExerciseBoundary(S, K, r, q, vol, T);
+        detail::QdPutResults res;
+
+        // --- Lower boundary B: computed over [0, tauTilde] ---
+        const ext::shared_ptr<Interpolation> q_z =
+            getPutExerciseBoundary(S, K, r, q, vol, tauTilde);
 
         const Real xmax = xMax(K, r, q);
-        const detail::QdPlusAddOnValue aov(T, S, K, r, q, vol, xmax, q_z);
+        const detail::QdPlusAddOnValue aov(T, tauTilde, S, K, r, q, vol, xmax, q_z);
+
+        const NormalDistribution phi;
+        const CumulativeNormalDistribution Phi;
 
 #ifdef QL_BOOST_HAS_TANH_SINH
-        const Real addOn = TanhSinhIntegral(eps_)(aov, 0.0, std::sqrt(T));
+        auto integrate = [&](const auto& f) {
+            return TanhSinhIntegral(eps_)(f, std::sqrt(T - tauTilde), std::sqrt(T));
+        };
 #else
-        const Real addOn = GaussLobattoIntegral(100000, QL_MAX_REAL, 0.1*eps_)
-                (aov, 0.0, std::sqrt(T));
+        auto integrate = [&](const auto& f) {
+            return GaussLobattoIntegral(100000, QL_MAX_REAL, 0.1 * eps_)(f, std::sqrt(T - tauTilde),
+                                                                         std::sqrt(T));
+        };
 #endif
 
-        QL_REQUIRE(addOn > -10*eps_,
-            "negative early exercise value " << addOn);
+        const Real addOn = integrate(aov);
+        if (!doubleBoundary) {
+            QL_REQUIRE(addOn > -10 * eps_, "negative early exercise value " << addOn);
+        }
 
-        const Real europeanValue = std::max(
-            0.0,
-            BlackCalculator(
-                Option::Put, K,
-                S*std::exp((r-q)*T),
-                vol*std::sqrt(T), std::exp(-r*T)).value()
-        );
+        // --- Upper boundary Y (double-boundary case) ---
+        Real addOnY = 0.0;
+        ext::shared_ptr<ChebyshevInterpolation> interpY;
+        Real ymax = 0.0;
 
-        return europeanValue + std::max(0.0, addOn);
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            ymax = K * r / q;
+
+            // Compute Y boundary via QdPlus at each Chebyshev node.
+            // Y satisfies the same equation as B but converges to ymax < K.
+            // Use getPutExerciseBoundary but seeded from ymax.
+            // For simplicity, use a separate Chebyshev interpolation.
+            interpY = ext::make_shared<ChebyshevInterpolation>(
+                interpolationPoints_,
+                [&](Real zz) -> Real {
+                    const Real tau = 0.25 * tauHat * squared(1 + zz);
+                    if (tau < QL_EPSILON)
+                        return 0.0;
+
+                    // Solve boundary equation from ymax side
+                    const QdPlusBoundaryEvaluator eval(S, K, r, q, vol, tau, T);
+                    // Find root near ymax (the upper boundary)
+                    const Real xmin = QL_EPSILON * 1e4;
+                    try {
+                        QuantLib::Brent solver;
+                        solver.setMaxEvaluations(100);
+                        const Real yBound =
+                            solver.solve([&](Real x) { return eval(x); }, eps_, ymax, xmin,
+                                         std::min(ymax * 1.5, K * 0.99));
+                        return squared(std::log(yBound / ymax));
+                    } catch (...) {
+                        return 0.0;
+                    }
+                },
+                ChebyshevInterpolation::SecondKind);
+
+            // Y add-on: integrate over calendar time t ∈ [T-τ̂, T]
+            const Real zYlo = std::sqrt(std::max(0.0, T - tauHat));
+            const Real zYhi = std::sqrt(T);
+            auto yAddOnIntegrand = [&](Real z) -> Real {
+                const Real t = z * z;
+                const Real tau = T - t;
+                if (tau < QL_EPSILON || tau > tauHat + QL_EPSILON)
+                    return 0.0;
+
+                const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+                const Real qv = (*interpY)(zc, true);
+                const Real y_t = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+
+                const Real dr_ = std::exp(-r * t);
+                const Real dq_ = std::exp(-q * t);
+                const Real v_ = vol * std::sqrt(t);
+
+                if (v_ < QL_EPSILON || y_t < QL_EPSILON)
+                    return 0.0;
+
+                const Real dp_ = std::log(S * dq_ / (y_t * dr_)) / v_ + 0.5 * v_;
+                return 2 * z * (r * K * dr_ * Phi(-(dp_ - v_)) - q * S * dq_ * Phi(-dp_));
+            };
+#ifdef QL_BOOST_HAS_TANH_SINH
+            addOnY = TanhSinhIntegral(eps_)(yAddOnIntegrand, zYlo, zYhi);
+#else
+            addOnY =
+                GaussLobattoIntegral(100000, QL_MAX_REAL, 0.1 * eps_)(yAddOnIntegrand, zYlo, zYhi);
+#endif
+        }
+
+        const Real fwd = S * std::exp((r - q) * T);
+        const Real stdDev = vol * std::sqrt(T);
+        const Real df = std::exp(-r * T);
+        BlackCalculator bc(Option::Put, K, fwd, stdDev, df);
+
+        // Pricing formula depends on S location (paper step 6):
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            if (S >= xmax) {
+                // Eq (15): upper continuation region, only B
+                res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn);
+            } else if (S <= ymax) {
+                // Eq (16): lower continuation region
+                res.value = std::max(K - S, std::max(0.0, K - S - addOnY));
+            } else {
+                // Exercise region or general case eq (12)
+                const Real intrinsic = std::max(0.0, K - S);
+                const Real eqn12 = std::max(0.0, bc.value()) + std::max(0.0, addOn - addOnY);
+                res.value = std::max(intrinsic, eqn12);
+            }
+        } else {
+            res.value = std::max(0.0, bc.value()) + std::max(0.0, addOn - addOnY);
+        }
+
+        // Delta add-on (B boundary)
+        const Real deltaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (-r * K * s.dr * phi(s.dm) / (S * s.v) - q * s.dq * Phi(-s.dp) +
+                    q * s.dq * phi(s.dp) / s.v);
+        });
+        res.delta = bc.delta(S) + deltaAddOn;
+
+        // Gamma add-on (B boundary)
+        const Real gammaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * K * s.dr * phi(s.dm) * s.dp / (S * S * s.v * s.v) -
+                    q * s.dq * phi(s.dp) * s.dm / (S * s.v * s.v));
+        });
+        res.gamma = bc.gamma(S) + gammaAddOn;
+
+        // --- Y boundary contributions to delta, gamma (double-boundary) ---
+        auto ySetup = [&](Real z) -> std::tuple<bool, Real, Real, Real, Real, Real, Real, Real> {
+            const Real t = z * z;
+            const Real tau = T - t;
+            if (tau < QL_EPSILON || tau > tauHat + QL_EPSILON)
+                return {false, 0, 0, 0, 0, 0, 0, 0};
+            const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+            const Real qv = (*interpY)(zc, true);
+            const Real y_t = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+            const Real dr_ = std::exp(-r * t);
+            const Real dq_ = std::exp(-q * t);
+            const Real v_ = vol * std::sqrt(t);
+            if (v_ < QL_EPSILON || y_t < QL_EPSILON)
+                return {false, 0, 0, 0, 0, 0, 0, 0};
+            const Real dp_ = std::log(S * dq_ / (y_t * dr_)) / v_ + 0.5 * v_;
+            const Real dm_ = dp_ - v_;
+            return {true, t, dr_, dq_, v_, y_t, dp_, dm_};
+        };
+
+        const Real zYlo = std::sqrt(std::max(0.0, T - tauHat));
+        const Real zYhi = std::sqrt(T);
+        auto integrateY = [&](const auto& f) -> Real {
+            if (!doubleBoundary || tauHat <= QL_EPSILON)
+                return 0.0;
+#ifdef QL_BOOST_HAS_TANH_SINH
+            return TanhSinhIntegral(eps_)(f, zYlo, zYhi);
+#else
+            return GaussLobattoIntegral(100000, QL_MAX_REAL, 0.1 * eps_)(f, zYlo, zYhi);
+#endif
+        };
+
+        if (doubleBoundary && tauHat > QL_EPSILON) {
+            const Real deltaYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = ySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (-r * K * dr_ * phi(dm_) / (S * v_) - q * dq_ * Phi(-dp_) +
+                        q * dq_ * phi(dp_) / v_);
+            });
+            res.delta -= deltaYAddOn;
+
+            const Real gammaYAddOn = integrateY([&](Real z) -> Real {
+                const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = ySetup(z);
+                if (!valid)
+                    return 0.0;
+                return 2 * z *
+                       (r * K * dr_ * phi(dm_) * dp_ / (S * S * v_ * v_) -
+                        q * dq_ * phi(dp_) * dm_ / (S * v_ * v_));
+            });
+            res.gamma -= gammaYAddOn;
+        }
+
+        // Analytical vega, rho, dividendRho via implicit function theorem.
+        // The QdPlus boundary solves eval(B;p) = 0 at each τ.
+        // By the IFT: dB/dp = -(∂eval/∂p) / (∂eval/∂B)
+        {
+            const Real eps_sigma = vol * 1e-6;
+            const Real eps_r = std::max(std::abs(r), 1.0) * 1e-6;
+            const Real eps_q = std::max(std::abs(q), 1.0) * 1e-6;
+
+            // Build Chebyshev interpolations of dB/dp at each node
+            auto makeBoundarySensInterp =
+                [&](Real dr_, Real dq_, Real dvol_) -> ext::shared_ptr<ChebyshevInterpolation> {
+                const Real bump = (dvol_ != 0.0) ? dvol_ : ((dr_ != 0.0) ? dr_ : dq_);
+                return ext::make_shared<ChebyshevInterpolation>(
+                    interpolationPoints_,
+                    [&, dr_, dq_, dvol_, bump](Real z) -> Real {
+                        const Real tau = 0.25 * tauTilde * squared(1 + z);
+                        if (tau < QL_EPSILON)
+                            return 0.0;
+
+                        const Real b = xmax * std::exp(-std::sqrt(std::max(0.0, (*q_z)(z, true))));
+
+                        const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
+                        const Real evalDeriv = eval0.derivative(b);
+                        if (std::abs(evalDeriv) < QL_EPSILON)
+                            return 0.0;
+
+                        const QdPlusBoundaryEvaluator evalBump(S, K, r + dr_, q + dq_, vol + dvol_,
+                                                               tau, T);
+                        const Real dEval = evalBump(b) / bump;
+
+                        return -dEval / evalDeriv;
+                    },
+                    ChebyshevInterpolation::SecondKind);
+            };
+
+            const auto si_sigma = makeBoundarySensInterp(0, 0, eps_sigma);
+            const auto si_r = makeBoundarySensInterp(eps_r, 0, 0);
+            const auto si_q = makeBoundarySensInterp(0, eps_q, 0);
+
+            // ∂f/∂B = 2z/(B·v) · [rK·dr·φ(dm) − qS·dq·φ(dp)]
+            auto dfdb = [&](Real z, const QdAddOnSetup& s) -> Real {
+                return 2 * z / (s.b_t * s.v) *
+                       (r * K * s.dr * phi(s.dm) - q * S * s.dq * phi(s.dp));
+            };
+
+            // Lookup dB/dp from interpolation
+            auto lookupDBdp = [&](const QdAddOnSetup& s, const ChebyshevInterpolation& si) -> Real {
+                const Real zc = 2 * std::sqrt(std::max(0.0, T - s.t) / tauTilde) - 1;
+                return si(zc, true);
+            };
+
+            // Vega: ∂f/∂σ|_B + ∂f/∂B · dB/dσ
+            const Real vegaAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                if (!s.valid)
+                    return 0.0;
+                const Real partial = (2 * z / vol) * (r * K * s.dr * phi(s.dm) * s.dp -
+                                                      q * S * s.dq * phi(s.dp) * s.dm);
+                return partial + dfdb(z, s) * lookupDBdp(s, *si_sigma);
+            });
+            res.vega = bc.vega(T) + vegaAddOn;
+
+            // Rho: ∂f/∂r|_B + ∂f/∂B · dB/dr
+            const Real rhoAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                if (!s.valid)
+                    return 0.0;
+                const Real partial =
+                    2 * z *
+                    (K * s.dr * Phi(-s.dm) * (1 - r * s.t) -
+                     (s.t / s.v) * (r * K * s.dr * phi(s.dm) - q * S * s.dq * phi(s.dp)));
+                return partial + dfdb(z, s) * lookupDBdp(s, *si_r);
+            });
+            res.rho = bc.rho(T) + rhoAddOn;
+
+            // DividendRho: ∂f/∂q|_B + ∂f/∂B · dB/dq
+            const Real divRhoAddOn = integrate([&](Real z) -> Real {
+                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                if (!s.valid)
+                    return 0.0;
+                const Real partial =
+                    2 * z *
+                    (r * K * s.dr * phi(s.dm) * s.t / s.v - S * s.dq * Phi(-s.dp) * (1 - q * s.t) -
+                     q * S * s.dq * phi(s.dp) * s.t / s.v);
+                return partial + dfdb(z, s) * lookupDBdp(s, *si_q);
+            });
+            res.dividendRho = bc.dividendRho(T) + divRhoAddOn;
+
+            // --- Y boundary contributions to vega, rho, divRho (double-boundary) ---
+            if (doubleBoundary && tauHat > QL_EPSILON && interpY) {
+                // Build Y boundary sensitivity interpolations via IFT
+                auto makeYSensInterp = [&](Real dr_, Real dq_,
+                                           Real dvol_) -> ext::shared_ptr<ChebyshevInterpolation> {
+                    const Real bump = (dvol_ != 0.0) ? dvol_ : ((dr_ != 0.0) ? dr_ : dq_);
+                    return ext::make_shared<ChebyshevInterpolation>(
+                        interpolationPoints_,
+                        [&, dr_, dq_, dvol_, bump](Real zz) -> Real {
+                            const Real tau = 0.25 * tauHat * squared(1 + zz);
+                            if (tau < QL_EPSILON)
+                                return 0.0;
+
+                            const Real zc = 2 * std::sqrt(std::min(tau, tauHat) / tauHat) - 1;
+                            const Real qv = (*interpY)(zc, true);
+                            const Real y = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+
+                            const QdPlusBoundaryEvaluator eval0(S, K, r, q, vol, tau, T);
+                            const Real evalDeriv = eval0.derivative(y);
+                            if (std::abs(evalDeriv) < QL_EPSILON)
+                                return 0.0;
+
+                            const QdPlusBoundaryEvaluator evalBump(S, K, r + dr_, q + dq_,
+                                                                   vol + dvol_, tau, T);
+                            const Real dEval = evalBump(y) / bump;
+
+                            return -dEval / evalDeriv;
+                        },
+                        ChebyshevInterpolation::SecondKind);
+                };
+
+                const auto siY_sigma = makeYSensInterp(0, 0, eps_sigma);
+                const auto siY_r = makeYSensInterp(eps_r, 0, 0);
+                const auto siY_q = makeYSensInterp(0, eps_q, 0);
+
+                // ∂f_Y/∂Y = 2z/(Y·v) · [rK·dr·φ(dm) − qS·dq·φ(dp)]
+                auto dfdy = [&](Real z, Real y_t, Real dr_, Real v_, Real dp_, Real dm_) -> Real {
+                    return 2 * z / (y_t * v_) *
+                           (r * K * dr_ * phi(dm_) - q * S * std::exp(-q * z * z) * phi(dp_));
+                };
+
+                auto lookupDYdp = [&](Real t_val, const ChebyshevInterpolation& si) -> Real {
+                    const Real tau = T - t_val;
+                    const Real zc =
+                        2 * std::sqrt(std::max(0.0, std::min(tau, tauHat)) / tauHat) - 1;
+                    return si(zc, true);
+                };
+
+                // Subtract Y vega contribution
+                const Real vegaYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = ySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real partial = (2 * z / vol) * (r * K * dr_ * phi(dm_) * dp_ -
+                                                          q * S * dq_ * phi(dp_) * dm_);
+                    const Real dYds = lookupDYdp(t, *siY_sigma);
+                    const Real ddp_ds = -dm_ / vol - dYds / (y_t * v_);
+                    const Real ddm_ds = -dp_ / vol - dYds / (y_t * v_);
+                    return partial +
+                           2 * z *
+                               (-r * K * dr_ * phi(dm_) * ddm_ds + q * S * dq_ * phi(dp_) * ddp_ds);
+                });
+                res.vega -= vegaYAddOn;
+
+                // Subtract Y rho contribution
+                const Real rhoYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = ySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real dYdr = lookupDYdp(t, *siY_r);
+                    const Real ddp_dr = t / v_ - dYdr / (y_t * v_);
+                    return 2 * z *
+                           ((1 - r * t) * K * dr_ * Phi(-dm_) - r * K * dr_ * phi(dm_) * ddp_dr +
+                            q * S * dq_ * phi(dp_) * ddp_dr);
+                });
+                res.rho -= rhoYAddOn;
+
+                // Subtract Y divRho contribution
+                const Real divRhoYAddOn = integrateY([&](Real z) -> Real {
+                    const auto [valid, t, dr_, dq_, v_, y_t, dp_, dm_] = ySetup(z);
+                    if (!valid)
+                        return 0.0;
+                    const Real dYdq = lookupDYdp(t, *siY_q);
+                    const Real ddp_dq = -t / v_ - dYdq / (y_t * v_);
+                    return 2 * z *
+                           (-r * K * dr_ * phi(dm_) * ddp_dq - (1 - q * t) * S * dq_ * Phi(-dp_) +
+                            q * S * dq_ * phi(dp_) * ddp_dq);
+                });
+                res.dividendRho -= divRhoYAddOn;
+            }
+
+            // --- Leibniz boundary correction for vega/rho/divRho ---
+            // When τ̂ < T, the integration lower limit z₀ = √(T−τ̂) depends on
+            // σ, r, q through τ̂. By Leibniz rule: correction = [f_B(z₀)−f_Y(z₀)]·dτ̂/dp/(2z₀)
+            if (doubleBoundary && tauTilde < T - QL_EPSILON) {
+                const Real z0 = std::sqrt(T - tauHat);
+                const Real fB_z0 = aov(z0);
+
+                // Evaluate Y integrand at z₀
+                Real fY_z0 = 0.0;
+                if (interpY) {
+                    const Real t0 = z0 * z0;
+                    const Real tau0 = T - t0;
+                    const Real zc = 2 * std::sqrt(std::min(tau0, tauHat) / tauHat) - 1;
+                    const Real qv = (*interpY)(zc, true);
+                    const Real y0 = ymax * std::exp(-std::sqrt(std::max(0.0, qv)));
+                    const Real dr0 = std::exp(-r * t0);
+                    const Real dq0 = std::exp(-q * t0);
+                    const Real v0 = vol * std::sqrt(t0);
+                    if (v0 >= QL_EPSILON && y0 > QL_EPSILON) {
+                        const Real dp0 = std::log(S * dq0 / (y0 * dr0)) / v0 + 0.5 * v0;
+                        fY_z0 = 2 * z0 * (r * K * dr0 * Phi(-(dp0 - v0)) - q * S * dq0 * Phi(-dp0));
+                    }
+                }
+
+                const Real fNet = fB_z0 - fY_z0;
+                if (std::abs(fNet) > QL_EPSILON) {
+                    const auto ths = computeTauHatSensitivities(r, q, tauHat);
+                    const Real leibnizFactor = fNet / (2 * z0);
+                    res.vega += leibnizFactor * ths.dTauHat_dSigma;
+                    res.rho += leibnizFactor * ths.dTauHat_dR;
+                    res.dividendRho += leibnizFactor * ths.dTauHat_dQ;
+                }
+            }
+        }
+
+        // StrikeSensitivity add-on: total d/dK, using B ∝ K
+        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ∂dp/∂K = -1/(Kv)
+        const Real strikeSensAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * s.dr * (Phi(-s.dm) + phi(s.dm) / s.v) -
+                    q * S * s.dq * phi(s.dp) / (K * s.v));
+        });
+        res.strikeSensitivity = bc.strikeSensitivity() + strikeSensAddOn;
+
+        // StrikeGamma add-on: d²f/dK²
+        const Real strikeGammaAddOn = integrate([&](Real z) -> Real {
+            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            if (!s.valid)
+                return 0.0;
+            return 2 * z *
+                   (r * s.dr * phi(s.dm) * s.dp / (K * s.v * s.v) -
+                    q * S * s.dq * phi(s.dp) * s.dm / (K * K * s.v * s.v));
+        });
+        res.strikeGamma = bc.strikeGamma() + strikeGammaAddOn;
+
+        // Theta: Leibniz rule → f(√T) / (2√T)
+        const Real sqrtT = std::sqrt(T);
+        res.theta = bc.theta(S, T) + aov(sqrtT) / (2 * sqrtT);
+
+        return res;
     }
 }

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -164,91 +164,70 @@ namespace QuantLib {
     }
 
 
-    namespace {
-        Real sigmaHat(Rate r, Rate q, Time tau) {
-            if (tau < QL_EPSILON)
-                return QL_MAX_REAL;
-            const Real erT = std::exp(r * tau);
-            const Real eqT = std::exp(q * tau);
-            if (erT >= 1.0 || eqT >= 1.0)
-                return QL_MAX_REAL; // tau too small for FP; σ̂ → ∞ as τ → 0
-            const InverseCumulativeNormal PhiInv;
-            return std::abs(PhiInv(eqT) - PhiInv(erT)) / std::sqrt(tau);
+    Real detail::sigmaHat(Rate r, Rate q, Time tau) {
+        if (tau < QL_EPSILON)
+            return QL_MAX_REAL;
+        const Real erT = std::exp(r * tau);
+        const Real eqT = std::exp(q * tau);
+        if (erT >= 1.0 || eqT >= 1.0)
+            return QL_MAX_REAL;
+        const InverseCumulativeNormal PhiInv;
+        return std::abs(PhiInv(eqT) - PhiInv(erT)) / std::sqrt(tau);
+    }
+
+    detail::SigmaHatDerivatives detail::sigmaHatDerivatives(Rate r, Rate q, Time tau) {
+        const Real sqrtTau = std::sqrt(tau);
+        const Real erT = std::exp(r * tau);
+        const Real eqT = std::exp(q * tau);
+        const InverseCumulativeNormal PhiInv;
+        const NormalDistribution phi;
+        const Real gr = PhiInv(erT), gq = PhiInv(eqT);
+        const Real N = gr - gq;
+        const Real sign = (N > 0) ? 1.0 : -1.0;
+        const Real phi_gr = phi(gr), phi_gq = phi(gq);
+        const Real gr_tau = r * erT / phi_gr;
+        const Real gq_tau = q * eqT / phi_gq;
+        const Real N_tau = gr_tau - gq_tau;
+        return {sign * (2 * tau * N_tau - N) / (2 * tau * sqrtTau),
+                sign * tau * erT / (phi_gr * sqrtTau), -sign * tau * eqT / (phi_gq * sqrtTau)};
+    }
+
+    detail::TauHatSensitivities detail::computeTauHatSensitivities(Rate r, Rate q, Time tauHat) {
+        const auto d = sigmaHatDerivatives(r, q, tauHat);
+        const Real inv = 1.0 / d.dSigmaHat_dTau;
+        return {inv, -d.dSigmaHat_dR * inv, -d.dSigmaHat_dQ * inv};
+    }
+
+    Time detail::computeTauHat(Rate r, Rate q, Volatility vol, Time T) {
+        if (sigmaHat(r, q, T) > vol)
+            return T;
+        Brent solver;
+        solver.setMaxEvaluations(100);
+        return solver.solve([&](Real tau) { return sigmaHat(r, q, tau) - vol; }, 1e-10, 0.5 * T,
+                            QL_EPSILON, T);
+    }
+
+    detail::QdAddOnSetup::QdAddOnSetup(Real z,
+                                       Time T,
+                                       Time tauTilde,
+                                       Real S,
+                                       Rate r,
+                                       Rate q,
+                                       Volatility vol,
+                                       Real xmax,
+                                       const Interpolation& q_z)
+    : t(z * z),
+      dr(std::exp(-r * t)),
+      dq(std::exp(-q * t)),
+      v(vol * std::sqrt(t)),
+      b_t(xmax * std::exp(-std::sqrt(std::max(0.0,
+              q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true))))),
+      dp(0), dm(0),
+      valid(v >= QL_EPSILON && b_t > QL_EPSILON) {
+        if (valid) {
+            dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
+            dm = dp - v;
         }
-
-        // Derivatives of σ̂ at a given τ, for computing dτ̂/dp via IFT.
-        struct SigmaHatDerivatives {
-            Real dSigmaHat_dTau, dSigmaHat_dR, dSigmaHat_dQ;
-        };
-
-        SigmaHatDerivatives sigmaHatDerivatives(Rate r, Rate q, Time tau) {
-            const Real sqrtTau = std::sqrt(tau);
-            const Real erT = std::exp(r * tau);
-            const Real eqT = std::exp(q * tau);
-            const InverseCumulativeNormal PhiInv;
-            const NormalDistribution phi;
-            const Real gr = PhiInv(erT), gq = PhiInv(eqT);
-            const Real N = gr - gq;
-            const Real sign = (N > 0) ? 1.0 : -1.0;
-            const Real phi_gr = phi(gr), phi_gq = phi(gq);
-            const Real gr_tau = r * erT / phi_gr;
-            const Real gq_tau = q * eqT / phi_gq;
-            const Real N_tau = gr_tau - gq_tau;
-            return {sign * (2 * tau * N_tau - N) / (2 * tau * sqrtTau),
-                    sign * tau * erT / (phi_gr * sqrtTau), -sign * tau * eqT / (phi_gq * sqrtTau)};
-        }
-
-        struct TauHatSensitivities {
-            Real dTauHat_dSigma, dTauHat_dR, dTauHat_dQ;
-        };
-
-        TauHatSensitivities computeTauHatSensitivities(Rate r, Rate q, Time tauHat) {
-            const auto d = sigmaHatDerivatives(r, q, tauHat);
-            const Real inv = 1.0 / d.dSigmaHat_dTau;
-            return {inv, -d.dSigmaHat_dR * inv, -d.dSigmaHat_dQ * inv};
-        }
-
-        // sigma_hat decreases from ∞ (tau→0) to sigma* (tau→∞).
-        // If sigma_hat(T) > vol, boundaries exist throughout [0,T], return T.
-        // Otherwise solve sigma_hat(tau_hat) = vol; boundaries merge at tau_hat < T.
-        Time computeTauHat(Rate r, Rate q, Volatility vol, Time T) {
-            if (sigmaHat(r, q, T) > vol)
-                return T;
-            QuantLib::Brent solver;
-            solver.setMaxEvaluations(100);
-            return solver.solve([&](Real tau) { return sigmaHat(r, q, tau) - vol; }, 1e-10, 0.5 * T,
-                                QL_EPSILON, T);
-        }
-
-        // Common setup for all Greek integrand classes
-        struct QdAddOnSetup {
-            Real t, dr, dq, v, b_t, dp, dm;
-            bool valid;
-
-            QdAddOnSetup(Real z,
-                         Time T,
-                         Time tauTilde,
-                         Real S,
-                         Rate r,
-                         Rate q,
-                         Volatility vol,
-                         Real xmax,
-                         const Interpolation& q_z) {
-                t = z * z;
-                const Real qv = q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true);
-                b_t = xmax * std::exp(-std::sqrt(std::max(0.0, qv)));
-
-                dr = std::exp(-r * t);
-                dq = std::exp(-q * t);
-                v = vol * std::sqrt(t);
-
-                valid = (v >= QL_EPSILON && b_t > QL_EPSILON);
-                if (valid) {
-                    dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
-                    dm = dp - v;
-                }
-            }
-        };
     }
 
     detail::QdPutCallParityEngine::QdPutCallParityEngine(
@@ -297,17 +276,17 @@ namespace QuantLib {
             results_.value = res.value;
             // delta_call = d/dS [Put(K,S,q,r)] = strikeSensitivity_put
             results_.delta = res.strikeSensitivity;
-            // gamma_call = d²/dS² [Put(K,S,q,r)] = strikeGamma_put
+            // gamma_call = d^2/dS^2 [Put(K,S,q,r)] = strikeGamma_put
             results_.gamma = res.strikeGamma;
             // vega is symmetric
             results_.vega = res.vega;
-            // rho_call: r appears as q_put → rho_call = dividendRho_put
+            // rho_call: r appears as q_put -> rho_call = dividendRho_put
             results_.rho = res.dividendRho;
-            // dividendRho_call: q appears as r_put → dividendRho_call = rho_put
+            // dividendRho_call: q appears as r_put -> dividendRho_call = rho_put
             results_.dividendRho = res.rho;
             // theta is symmetric
             results_.theta = res.theta;
-            // strikeSensitivity_call: K appears as S_put → delta_put
+            // strikeSensitivity_call: K appears as S_put -> delta_put
             results_.strikeSensitivity = res.delta;
         } else
             QL_FAIL("unknown option type");
@@ -472,8 +451,8 @@ namespace QuantLib {
                     try {
                         x = buildInSolver(eval, QuantLib::Brent(), S, K, 10 * maxIter_, x);
                     } catch (...) {
-                        // For double-boundary case (q<r<0) with large τ,
-                        // boundary B→0 and solver may fail to bracket.
+                        // For double-boundary case (q<r<0) with large tau,
+                        // boundary B->0 and solver may fail to bracket.
                         // Return small fraction of xmax to keep interpolation stable.
                         if (r < 0.0 && q < r)
                             x = 0.01 * eval.xmax();
@@ -512,7 +491,7 @@ namespace QuantLib {
         Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const {
 
         const bool doubleBoundary = (r < 0.0 && q < r);
-        const Real tauHat = doubleBoundary ? computeTauHat(r, q, vol, T) : 0.0;
+        const Real tauHat = doubleBoundary ? detail::computeTauHat(r, q, vol, T) : 0.0;
         const Time tauTilde = doubleBoundary ? tauHat : T;
 
         detail::QdPutResults res;
@@ -579,7 +558,7 @@ namespace QuantLib {
                 },
                 ChebyshevInterpolation::SecondKind);
 
-            // Y add-on: integrate over calendar time t ∈ [T-τ̂, T]
+            // Y add-on: integrate over calendar time t in [T-tauHat, T]
             const Real zYlo = std::sqrt(std::max(0.0, T - tauHat));
             const Real zYhi = std::sqrt(T);
             auto yAddOnIntegrand = [&](Real z) -> Real {
@@ -635,7 +614,7 @@ namespace QuantLib {
 
         // Delta add-on (B boundary)
         const Real deltaAddOn = integrate([&](Real z) -> Real {
-            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
             if (!s.valid)
                 return 0.0;
             return 2 * z *
@@ -646,7 +625,7 @@ namespace QuantLib {
 
         // Gamma add-on (B boundary)
         const Real gammaAddOn = integrate([&](Real z) -> Real {
-            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
             if (!s.valid)
                 return 0.0;
             return 2 * z *
@@ -709,8 +688,8 @@ namespace QuantLib {
         }
 
         // Analytical vega, rho, dividendRho via implicit function theorem.
-        // The QdPlus boundary solves eval(B;p) = 0 at each τ.
-        // By the IFT: dB/dp = -(∂eval/∂p) / (∂eval/∂B)
+        // The QdPlus boundary solves eval(B;p) = 0 at each tau.
+        // By the IFT: dB/dp = -(deval/dp) / (deval/dB)
         {
             const Real eps_sigma = vol * 1e-6;
             const Real eps_r = std::max(std::abs(r), 1.0) * 1e-6;
@@ -747,21 +726,21 @@ namespace QuantLib {
             const auto si_r = makeBoundarySensInterp(eps_r, 0, 0);
             const auto si_q = makeBoundarySensInterp(0, eps_q, 0);
 
-            // ∂f/∂B = 2z/(B·v) · [rK·dr·φ(dm) − qS·dq·φ(dp)]
-            auto dfdb = [&](Real z, const QdAddOnSetup& s) -> Real {
+            // df/dB = 2z/(B*v) * [rK*dr*phi(dm) - qS*dq*phi(dp)]
+            auto dfdb = [&](Real z, const detail::QdAddOnSetup& s) -> Real {
                 return 2 * z / (s.b_t * s.v) *
                        (r * K * s.dr * phi(s.dm) - q * S * s.dq * phi(s.dp));
             };
 
             // Lookup dB/dp from interpolation
-            auto lookupDBdp = [&](const QdAddOnSetup& s, const ChebyshevInterpolation& si) -> Real {
+            auto lookupDBdp = [&](const detail::QdAddOnSetup& s, const ChebyshevInterpolation& si) -> Real {
                 const Real zc = 2 * std::sqrt(std::max(0.0, T - s.t) / tauTilde) - 1;
                 return si(zc, true);
             };
 
-            // Vega: ∂f/∂σ|_B + ∂f/∂B · dB/dσ
+            // Vega: df/dsigma|_B + df/dB * dB/dsigma
             const Real vegaAddOn = integrate([&](Real z) -> Real {
-                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
                 if (!s.valid)
                     return 0.0;
                 const Real partial = (2 * z / vol) * (r * K * s.dr * phi(s.dm) * s.dp -
@@ -770,9 +749,9 @@ namespace QuantLib {
             });
             res.vega = bc.vega(T) + vegaAddOn;
 
-            // Rho: ∂f/∂r|_B + ∂f/∂B · dB/dr
+            // Rho: df/dr|_B + df/dB * dB/dr
             const Real rhoAddOn = integrate([&](Real z) -> Real {
-                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
                 if (!s.valid)
                     return 0.0;
                 const Real partial =
@@ -783,9 +762,9 @@ namespace QuantLib {
             });
             res.rho = bc.rho(T) + rhoAddOn;
 
-            // DividendRho: ∂f/∂q|_B + ∂f/∂B · dB/dq
+            // DividendRho: df/dq|_B + df/dB * dB/dq
             const Real divRhoAddOn = integrate([&](Real z) -> Real {
-                const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+                const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
                 if (!s.valid)
                     return 0.0;
                 const Real partial =
@@ -831,7 +810,7 @@ namespace QuantLib {
                 const auto siY_r = makeYSensInterp(eps_r, 0, 0);
                 const auto siY_q = makeYSensInterp(0, eps_q, 0);
 
-                // ∂f_Y/∂Y = 2z/(Y·v) · [rK·dr·φ(dm) − qS·dq·φ(dp)]
+                // df_Y/dY = 2z/(Y*v) * [rK*dr*phi(dm) - qS*dq*phi(dp)]
                 auto dfdy = [&](Real z, Real y_t, Real dr_, Real v_, Real dp_, Real dm_) -> Real {
                     return 2 * z / (y_t * v_) *
                            (r * K * dr_ * phi(dm_) - q * S * std::exp(-q * z * z) * phi(dp_));
@@ -888,13 +867,13 @@ namespace QuantLib {
             }
 
             // --- Leibniz boundary correction for vega/rho/divRho ---
-            // When τ̂ < T, the integration lower limit z₀ = √(T−τ̂) depends on
-            // σ, r, q through τ̂. By Leibniz rule: correction = [f_B(z₀)−f_Y(z₀)]·dτ̂/dp/(2z₀)
+            // When tauHat < T, the integration lower limit z0 = sqrt(T-tauHat) depends on
+            // sigma, r, q through tauHat. By Leibniz rule: correction = [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
             if (doubleBoundary && tauTilde < T - QL_EPSILON) {
                 const Real z0 = std::sqrt(T - tauHat);
                 const Real fB_z0 = aov(z0);
 
-                // Evaluate Y integrand at z₀
+                // Evaluate Y integrand at z0
                 Real fY_z0 = 0.0;
                 if (interpY) {
                     const Real t0 = z0 * z0;
@@ -913,7 +892,7 @@ namespace QuantLib {
 
                 const Real fNet = fB_z0 - fY_z0;
                 if (std::abs(fNet) > QL_EPSILON) {
-                    const auto ths = computeTauHatSensitivities(r, q, tauHat);
+                    const auto ths = detail::computeTauHatSensitivities(r, q, tauHat);
                     const Real leibnizFactor = fNet / (2 * z0);
                     res.vega += leibnizFactor * ths.dTauHat_dSigma;
                     res.rho += leibnizFactor * ths.dTauHat_dR;
@@ -922,10 +901,10 @@ namespace QuantLib {
             }
         }
 
-        // StrikeSensitivity add-on: total d/dK, using B ∝ K
-        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ∂dp/∂K = -1/(Kv)
+        // StrikeSensitivity add-on: total d/dK, using B proportional to K
+        // dp = [log(S/K) - log(g) + (r-q)t]/v + v/2, so ddp/dK = -1/(Kv)
         const Real strikeSensAddOn = integrate([&](Real z) -> Real {
-            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
             if (!s.valid)
                 return 0.0;
             return 2 * z *
@@ -934,9 +913,9 @@ namespace QuantLib {
         });
         res.strikeSensitivity = bc.strikeSensitivity() + strikeSensAddOn;
 
-        // StrikeGamma add-on: d²f/dK²
+        // StrikeGamma add-on: d^2f/dK^2
         const Real strikeGammaAddOn = integrate([&](Real z) -> Real {
-            const QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
+            const detail::QdAddOnSetup s(z, T, tauTilde, S, r, q, vol, xmax, *q_z);
             if (!s.valid)
                 return 0.0;
             return 2 * z *
@@ -945,7 +924,7 @@ namespace QuantLib {
         });
         res.strikeGamma = bc.strikeGamma() + strikeGammaAddOn;
 
-        // Theta: Leibniz rule → f(√T) / (2√T)
+        // Theta: Leibniz rule -> f(sqrt(T)) / (2*sqrt(T))
         const Real sqrtT = std::sqrt(T);
         res.theta = bc.theta(S, T) + aov(sqrtT) / (2 * sqrtT);
 

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -20,18 +20,19 @@
 /*! \file qrplusamericanengine.cpp
 */
 
-#include <algorithm>
 #include <ql/exercise.hpp>
-#include <ql/utilities/null.hpp>
-#include <ql/math/functional.hpp>
 #include <ql/math/comparison.hpp>
-#include <ql/math/solvers1d/brent.hpp>
-#include <ql/math/solvers1d/ridder.hpp>
-#include <ql/math/solvers1d/newton.hpp>
+#include <ql/math/functional.hpp>
+#include <ql/math/integrals/tanhsinhintegral.hpp>
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
+#include <ql/math/solvers1d/brent.hpp>
+#include <ql/math/solvers1d/newton.hpp>
+#include <ql/math/solvers1d/ridder.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/vanilla/qdplusamericanengine.hpp>
-#include <ql/math/integrals/tanhsinhintegral.hpp>
+#include <ql/utilities/null.hpp>
+#include <algorithm>
+#include <iostream>
 #ifndef QL_BOOST_HAS_TANH_SINH
 #include <ql/math/integrals/gausslobattointegral.hpp>
 #endif

--- a/ql/pricingengines/vanilla/qdplusamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.cpp
@@ -216,14 +216,10 @@ namespace QuantLib {
                                        Volatility vol,
                                        Real xmax,
                                        const Interpolation& q_z)
-    : t(z * z),
-      dr(std::exp(-r * t)),
-      dq(std::exp(-q * t)),
-      v(vol * std::sqrt(t)),
-      b_t(xmax * std::exp(-std::sqrt(std::max(0.0,
-              q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true))))),
-      dp(0), dm(0),
-      valid(v >= QL_EPSILON && b_t > QL_EPSILON) {
+    : t(z * z), dr(std::exp(-r * t)), dq(std::exp(-q * t)), v(vol * std::sqrt(t)),
+      b_t(xmax * std::exp(-std::sqrt(std::max(
+                     0.0, q_z(2 * std::sqrt(std::max(0.0, T - t) / tauTilde) - 1, true))))),
+      dp(0), dm(0), valid(v >= QL_EPSILON && b_t > QL_EPSILON) {
         if (valid) {
             dp = std::log(S * dq / (b_t * dr)) / v + 0.5 * v;
             dm = dp - v;
@@ -733,7 +729,8 @@ namespace QuantLib {
             };
 
             // Lookup dB/dp from interpolation
-            auto lookupDBdp = [&](const detail::QdAddOnSetup& s, const ChebyshevInterpolation& si) -> Real {
+            auto lookupDBdp = [&](const detail::QdAddOnSetup& s,
+                                  const ChebyshevInterpolation& si) -> Real {
                 const Real zc = 2 * std::sqrt(std::max(0.0, T - s.t) / tauTilde) - 1;
                 return si(zc, true);
             };
@@ -868,7 +865,8 @@ namespace QuantLib {
 
             // --- Leibniz boundary correction for vega/rho/divRho ---
             // When tauHat < T, the integration lower limit z0 = sqrt(T-tauHat) depends on
-            // sigma, r, q through tauHat. By Leibniz rule: correction = [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
+            // sigma, r, q through tauHat. By Leibniz rule: correction =
+            // [f_B(z0)-f_Y(z0)]*dtauHat/dp/(2z0)
             if (doubleBoundary && tauTilde < T - QL_EPSILON) {
                 const Real z0 = std::sqrt(T - tauHat);
                 const Real fB_z0 = aov(z0);

--- a/ql/pricingengines/vanilla/qdplusamericanengine.hpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.hpp
@@ -83,6 +83,39 @@ namespace QuantLib {
             const ext::shared_ptr<Interpolation> q_z_;
             const CumulativeNormalDistribution Phi_;
         };
+
+        // Shared helpers for double-boundary American engines (QdFp, QdPlus)
+
+        Real sigmaHat(Rate r, Rate q, Time tau);
+
+        struct SigmaHatDerivatives {
+            Real dSigmaHat_dTau, dSigmaHat_dR, dSigmaHat_dQ;
+        };
+
+        SigmaHatDerivatives sigmaHatDerivatives(Rate r, Rate q, Time tau);
+
+        struct TauHatSensitivities {
+            Real dTauHat_dSigma, dTauHat_dR, dTauHat_dQ;
+        };
+
+        TauHatSensitivities computeTauHatSensitivities(Rate r, Rate q, Time tauHat);
+
+        Time computeTauHat(Rate r, Rate q, Volatility vol, Time T);
+
+        struct QdAddOnSetup {
+            Real t, dr, dq, v, b_t, dp, dm;
+            bool valid;
+
+            QdAddOnSetup(Real z,
+                         Time T,
+                         Time tauTilde,
+                         Real S,
+                         Rate r,
+                         Rate q,
+                         Volatility vol,
+                         Real xmax,
+                         const Interpolation& q_z);
+        };
     }
 
 

--- a/ql/pricingengines/vanilla/qdplusamericanengine.hpp
+++ b/ql/pricingengines/vanilla/qdplusamericanengine.hpp
@@ -37,6 +37,13 @@ namespace QuantLib {
 
     namespace detail {
 
+        struct QdPutResults {
+            Real value = 0.0;
+            Real delta = 0.0, gamma = 0.0;
+            Real vega = 0.0, rho = 0.0, dividendRho = 0.0, theta = 0.0;
+            Real strikeSensitivity = 0.0, strikeGamma = 0.0;
+        };
+
         class QdPutCallParityEngine: public VanillaOption::engine {
           public:
             explicit QdPutCallParityEngine(
@@ -45,19 +52,20 @@ namespace QuantLib {
             void calculate() const override;
 
           protected:
-            virtual Real calculatePut(
-                Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const = 0;
+            virtual QdPutResults
+            calculatePut(Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const = 0;
 
             const ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
 
           private:
-            Real calculatePutWithEdgeCases(
-               Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const;
+            QdPutResults
+            calculatePutWithEdgeCases(Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const;
         };
 
         class QdPlusAddOnValue {
           public:
             QdPlusAddOnValue(Time T,
+                             Time tauTilde,
                              Real S,
                              Real K,
                              Rate r,
@@ -68,7 +76,7 @@ namespace QuantLib {
 
             Real operator()(Real z) const;
           private:
-            const Time T_;
+            const Time T_, tauTilde_;
             const Real S_, K_, xmax_;
             const Rate r_, q_;
             const Volatility vol_;
@@ -110,8 +118,8 @@ namespace QuantLib {
         static Real xMax(Real K, Rate r, Rate q);
 
       protected:
-        Real calculatePut(
-            Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const override;
+        detail::QdPutResults
+        calculatePut(Real S, Real K, Rate r, Rate q, Volatility vol, Time T) const override;
 
       private:
         template <class Solver>

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -1576,7 +1576,7 @@ class QdFpGaussLobattoScheme: public QdFpIterationScheme {
 };
 
 
-BOOST_AUTO_TEST_CASE(testBulkQdFpAmericanEngine) {
+BOOST_AUTO_TEST_CASE(testBulkQdFpAmericanEngine, *precondition(if_speed(Fast))) {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden bulk examples...");
 
     // Examples are taken from
@@ -1684,7 +1684,7 @@ BOOST_AUTO_TEST_CASE(testBulkQdFpAmericanEngine) {
                 << "\n    tol     : " << tolMax);
 }
 
-BOOST_AUTO_TEST_CASE(testQdEngineWithLobattoIntegral) {
+BOOST_AUTO_TEST_CASE(testQdEngineWithLobattoIntegral, *precondition(if_speed(Fast))) {
     BOOST_TEST_MESSAGE("Testing Andersen, Lake and Offengenden "
                        "with high precision Gauss-Lobatto integration...");
 
@@ -2297,7 +2297,7 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyNegativeRates) {
                           ExpectedErrorMessage("negative interest rates"));
 }
 
-BOOST_AUTO_TEST_CASE(testQdAmericanGreeks) {
+BOOST_AUTO_TEST_CASE(testQdAmericanGreeks, *precondition(if_speed(Fast))) {
     BOOST_TEST_MESSAGE("Testing QD+ and QdFp American option greeks "
                        "against bump and revalue...");
 

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -2297,6 +2297,831 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyNegativeRates) {
                           ExpectedErrorMessage("negative interest rates"));
 }
 
+BOOST_AUTO_TEST_CASE(testQdAmericanGreeks) {
+    BOOST_TEST_MESSAGE("Testing QD+ and QdFp American option greeks "
+                       "against bump and revalue...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(1, June, 2022);
+    Settings::instance().evaluationDate() = today;
+
+    const auto spot = ext::make_shared<SimpleQuote>(100.0);
+    const auto rRate = ext::make_shared<SimpleQuote>(0.05);
+    const auto qRate = ext::make_shared<SimpleQuote>(0.03);
+    const auto vol = ext::make_shared<SimpleQuote>(0.25);
+
+    const auto bsProcess = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(flatRate(today, qRate, dc)),
+        Handle<YieldTermStructure>(flatRate(today, rRate, dc)),
+        Handle<BlackVolTermStructure>(flatVol(today, vol, dc)));
+
+    const Option::Type types[] = {Option::Put, Option::Call};
+    const Real strikes[] = {80.0, 100.0, 120.0};
+    const Real spots[] = {80.0, 100.0, 120.0};
+    const Rate rates[] = {0.02, 0.08};
+    const Rate divs[] = {0.0, 0.04, 0.10};
+    const Volatility vols[] = {0.15, 0.35};
+    const Integer maturities[] = {182, 365};
+
+    const Real tolDelta = 7.0e-4;
+    const Real tolGamma = 2.0e-4;
+
+    // Vega, rho, dividendRho now use analytical boundary sensitivity.
+    const Real tolVega = 7.0e-4;
+    const Real tolRho = 7.0e-4;
+    const Real tolDivRho = 7.0e-4;
+
+    using EngineSpec = std::pair<std::string, ext::shared_ptr<PricingEngine>>;
+    std::vector<EngineSpec> engines = {
+        {"QdPlus",
+         ext::make_shared<QdPlusAmericanEngine>(bsProcess, 8, QdPlusAmericanEngine::Halley, 1e-10)},
+        {"QdFpAccurate",
+         ext::make_shared<QdFpAmericanEngine>(bsProcess, QdFpAmericanEngine::accurateScheme())}};
+
+    for (const auto& [engineName, engine] : engines) {
+        // Both engines now compute analytical vega/rho/dividendRho
+        const bool testParamGreeks = true;
+
+        for (auto type : types) {
+            for (Real K : strikes) {
+                for (Integer mat : maturities) {
+                    const Date matDate = today + Period(mat, Days);
+                    const auto payoff = ext::make_shared<PlainVanillaPayoff>(type, K);
+                    const auto exercise = ext::make_shared<AmericanExercise>(today, matDate);
+                    VanillaOption option(payoff, exercise);
+                    option.setPricingEngine(engine);
+
+                    for (Real S : spots) {
+                        for (Rate r : rates) {
+                            for (Rate q : divs) {
+                                for (Volatility v : vols) {
+                                    spot->setValue(S);
+                                    rRate->setValue(r);
+                                    qRate->setValue(q);
+                                    vol->setValue(v);
+
+                                    const Real price = option.NPV();
+                                    if (price < S * 1e-5)
+                                        continue;
+
+                                    const Real anDelta = option.delta();
+                                    const Real anGamma = option.gamma();
+
+                                    // Delta and Gamma via spot bump
+                                    const Real du = S * 1e-4;
+                                    spot->setValue(S + du);
+                                    const Real pUp = option.NPV();
+                                    const Real dUp = option.delta();
+                                    spot->setValue(S - du);
+                                    const Real pDn = option.NPV();
+                                    const Real dDn = option.delta();
+                                    spot->setValue(S);
+
+                                    const Real fdDelta = (pUp - pDn) / (2 * du);
+                                    const Real fdGamma = (dUp - dDn) / (2 * du);
+
+                                    Real err = relativeError(fdDelta, anDelta, S);
+                                    if (err > tolDelta) {
+                                        BOOST_ERROR(engineName << " delta mismatch for " << type
+                                                               << " K=" << K << " S=" << S
+                                                               << " r=" << r << " q=" << q
+                                                               << " v=" << v << " T=" << mat << "d"
+                                                               << "\n    analytical: " << anDelta
+                                                               << "\n    FD:         " << fdDelta
+                                                               << "\n    rel error:  " << err);
+                                    }
+
+                                    err = relativeError(fdGamma, anGamma, S);
+                                    if (err > tolGamma) {
+                                        BOOST_ERROR(engineName << " gamma mismatch for " << type
+                                                               << " K=" << K << " S=" << S
+                                                               << " r=" << r << " q=" << q
+                                                               << " v=" << v << " T=" << mat << "d"
+                                                               << "\n    analytical: " << anGamma
+                                                               << "\n    FD:         " << fdGamma
+                                                               << "\n    rel error:  " << err);
+                                    }
+
+                                    if (!testParamGreeks)
+                                        continue;
+
+                                    const Real anVega = option.vega();
+                                    const Real anRho = option.rho();
+                                    const Real anDivRho = option.dividendRho();
+
+                                    // (logging moved after FD computation below)
+
+                                    // Vega via vol bump
+                                    const Real dv = v * 1e-4;
+                                    vol->setValue(v + dv);
+                                    const Real pVolUp = option.NPV();
+                                    vol->setValue(v - dv);
+                                    const Real pVolDn = option.NPV();
+                                    vol->setValue(v);
+
+                                    const Real fdVega = (pVolUp - pVolDn) / (2 * dv);
+                                    err = relativeError(fdVega, anVega, S);
+                                    if (err > tolVega) {
+                                        BOOST_ERROR(engineName << " vega mismatch for " << type
+                                                               << " K=" << K << " S=" << S
+                                                               << " r=" << r << " q=" << q
+                                                               << " v=" << v << " T=" << mat << "d"
+                                                               << "\n    analytical: " << anVega
+                                                               << "\n    FD:         " << fdVega
+                                                               << "\n    rel error:  " << err);
+                                    }
+
+                                    // Rho via rate bump
+                                    const Real dr = r * 1e-4;
+                                    rRate->setValue(r + dr);
+                                    const Real pRUp = option.NPV();
+                                    rRate->setValue(r - dr);
+                                    const Real pRDn = option.NPV();
+                                    rRate->setValue(r);
+
+                                    const Real fdRho = (pRUp - pRDn) / (2 * dr);
+                                    err = relativeError(fdRho, anRho, S);
+                                    if (err > tolRho) {
+                                        BOOST_ERROR(engineName << " rho mismatch for " << type
+                                                               << " K=" << K << " S=" << S
+                                                               << " r=" << r << " q=" << q
+                                                               << " v=" << v << " T=" << mat << "d"
+                                                               << "\n    analytical: " << anRho
+                                                               << "\n    FD:         " << fdRho
+                                                               << "\n    rel error:  " << err);
+                                    }
+
+                                    // DividendRho via dividend bump (skip q=0)
+                                    Real fdDivRho = 0.0;
+                                    if (q > QL_EPSILON) {
+                                        const Real dq = q * 1e-4;
+                                        qRate->setValue(q + dq);
+                                        const Real pQUp = option.NPV();
+                                        qRate->setValue(q - dq);
+                                        const Real pQDn = option.NPV();
+                                        qRate->setValue(q);
+
+                                        fdDivRho = (pQUp - pQDn) / (2 * dq);
+                                        err = relativeError(fdDivRho, anDivRho, S);
+                                        if (err > tolDivRho) {
+                                            BOOST_ERROR(engineName
+                                                        << " dividendRho mismatch for " << type
+                                                        << " K=" << K << " S=" << S << " r=" << r
+                                                        << " q=" << q << " v=" << v << " T=" << mat
+                                                        << "d"
+                                                        << "\n    analytical: " << anDivRho
+                                                        << "\n    FD:         " << fdDivRho
+                                                        << "\n    rel error:  " << err);
+                                        }
+                                    }
+
+                                    BOOST_TEST_MESSAGE(
+                                        engineName
+                                        << " " << type << " K=" << K << " S=" << S << " r=" << r
+                                        << " q=" << q << " v=" << v << " T=" << mat << "d"
+                                        << "\n  price=" << price << "\n  delta:  an=" << anDelta
+                                        << "  fd=" << fdDelta << "\n  gamma:  an=" << anGamma
+                                        << "  fd=" << fdGamma << "\n  vega:   an=" << anVega
+                                        << "  fd=" << fdVega << "\n  rho:    an=" << anRho
+                                        << "  fd=" << fdRho << "\n  divRho: an=" << anDivRho
+                                        << "  fd=" << fdDivRho);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testQdDoubleBoundary) {
+    BOOST_TEST_MESSAGE("Testing QD American engine double-boundary case (q<r<0)...");
+
+    const Date today = Date(15, March, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    // Parameters: q < r < 0
+    const Real S = 100.0;
+    const Real K = 100.0;
+    const Rate r = -0.02;
+    const Rate q = -0.05;
+    const Volatility vol = 0.20;
+    const Integer matDays = 365;
+    const Date matDate = today + matDays;
+
+    const auto spot = ext::make_shared<SimpleQuote>(S);
+    const auto rRate = ext::make_shared<SimpleQuote>(r);
+    const auto qRate = ext::make_shared<SimpleQuote>(q);
+    const auto sigma = ext::make_shared<SimpleQuote>(vol);
+
+    const auto rTS = flatRate(today, rRate, Actual365Fixed());
+    const auto qTS = flatRate(today, qRate, Actual365Fixed());
+    const auto volTS = flatVol(today, sigma, Actual365Fixed());
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
+        Handle<BlackVolTermStructure>(volTS));
+
+    const auto exercise = ext::make_shared<AmericanExercise>(matDate);
+    const auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, K);
+    VanillaOption option(payoff, exercise);
+
+    // Test QdPlus
+    option.setPricingEngine(ext::make_shared<QdPlusAmericanEngine>(process));
+    const Real qdPlusPrice = option.NPV();
+    BOOST_TEST_MESSAGE("  QdPlus price: " << qdPlusPrice);
+
+    // Test QdFp (accurate)
+    option.setPricingEngine(
+        ext::make_shared<QdFpAmericanEngine>(process, QdFpAmericanEngine::accurateScheme()));
+    const Real qdFpPrice = option.NPV();
+    BOOST_TEST_MESSAGE("  QdFpAccurate price: " << qdFpPrice);
+
+    // Sanity: price should be positive and reasonable
+    BOOST_CHECK_MESSAGE(qdFpPrice > 0.0, "QdFp price should be positive, got " << qdFpPrice);
+    BOOST_CHECK_MESSAGE(qdPlusPrice > 0.0, "QdPlus price should be positive, got " << qdPlusPrice);
+
+    // Compare against FD engine
+    option.setPricingEngine(ext::make_shared<FdBlackScholesVanillaEngine>(process, 200, 800));
+    const Real fdPrice = option.NPV();
+    BOOST_TEST_MESSAGE("  FD price: " << fdPrice);
+
+    // QdFp and QdPlus should agree reasonably with FD
+    Real diff = std::abs(qdFpPrice - fdPrice);
+    BOOST_CHECK_MESSAGE(diff < 0.05,
+                        "QdFp " << qdFpPrice << " vs FD " << fdPrice << " differ by " << diff);
+    diff = std::abs(qdPlusPrice - fdPrice);
+    BOOST_CHECK_MESSAGE(diff < 0.1,
+                        "QdPlus " << qdPlusPrice << " vs FD " << fdPrice << " differ by " << diff);
+
+    // Test with a call (r < q < 0, which maps to put double-boundary via parity)
+    const auto callPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, K);
+    VanillaOption callOption(callPayoff, exercise);
+    callOption.setPricingEngine(
+        ext::make_shared<QdFpAmericanEngine>(process, QdFpAmericanEngine::accurateScheme()));
+    const Real callPrice = callOption.NPV();
+    BOOST_TEST_MESSAGE("  Call price (r<q<0): " << callPrice);
+    BOOST_CHECK_MESSAGE(callPrice > 0.0, "Call price should be positive");
+
+    // Reference prices from Andersen-Lake "Fast American Option Pricing:
+    // The Double-Boundary Case", Table 3.
+    // Parameters: K=100, r=-1.2%, q=-1.6%, sigma=10%, S=101
+    // Benchmark computed with (m,n,l) = (64,128,257)
+    {
+        const Real S2 = 100.0;
+        const Real K2 = 100.0;
+        const Rate r2 = -0.012;
+        const Rate q2 = -0.016;
+        const Volatility vol2 = 0.10;
+
+        const auto spot2 = ext::make_shared<SimpleQuote>(S2);
+        const auto rRate2 = ext::make_shared<SimpleQuote>(r2);
+        const auto qRate2 = ext::make_shared<SimpleQuote>(q2);
+        const auto sigma2 = ext::make_shared<SimpleQuote>(vol2);
+
+        const auto rTS2 = flatRate(today, rRate2, Actual365Fixed());
+        const auto qTS2 = flatRate(today, qRate2, Actual365Fixed());
+        const auto volTS2 = flatVol(today, sigma2, Actual365Fixed());
+
+        const auto process2 = ext::make_shared<BlackScholesMertonProcess>(
+            Handle<Quote>(spot2), Handle<YieldTermStructure>(qTS2),
+            Handle<YieldTermStructure>(rTS2), Handle<BlackVolTermStructure>(volTS2));
+
+        struct TestCase {
+            Integer days;
+            Real reference; // n=16 benchmark from Table 3
+            Real fpTol;     // QdFp tolerance
+            Real qpTol;     // QdPlus tolerance
+        };
+        const TestCase cases[] = {
+            {45, 1.380533089, 1e-3, 0.01},
+            {90, 1.942381237, 1e-3, 0.01},
+            {180, 2.729267252, 1e-3, 0.01},
+            {360, 3.830520425, 1e-3, 0.01},
+            {3600, 12.189323541, 0.05, 0.1} // long-dated: harder case
+        };
+
+        for (const auto& tc : cases) {
+            const Date mat2 = today + tc.days;
+            const auto ex2 = ext::make_shared<AmericanExercise>(mat2);
+            const auto po2 = ext::make_shared<PlainVanillaPayoff>(Option::Put, K2);
+            VanillaOption opt2(po2, ex2);
+
+            opt2.setPricingEngine(ext::make_shared<QdFpAmericanEngine>(
+                process2, QdFpAmericanEngine::accurateScheme()));
+            const Real fpPrice = opt2.NPV();
+
+            opt2.setPricingEngine(ext::make_shared<QdPlusAmericanEngine>(process2));
+            const Real qpPrice = opt2.NPV();
+
+            const Real fpErr = std::abs(fpPrice - tc.reference);
+            const Real qpErr = std::abs(qpPrice - tc.reference);
+
+            BOOST_TEST_MESSAGE("  T=" << tc.days << "d: QdFp=" << fpPrice << " QdPlus=" << qpPrice
+                                      << " ref=" << tc.reference << " fpErr=" << fpErr
+                                      << " qpErr=" << qpErr);
+
+            BOOST_CHECK_MESSAGE(fpErr < tc.fpTol, "QdFp T=" << tc.days << "d: " << fpPrice
+                                                            << " vs ref " << tc.reference
+                                                            << " diff " << fpErr);
+
+            BOOST_CHECK_MESSAGE(qpErr < tc.qpTol, "QdPlus T=" << tc.days << "d: " << qpPrice
+                                                              << " vs ref " << tc.reference
+                                                              << " diff " << qpErr);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testQdDoubleBoundaryGreeks) {
+    BOOST_TEST_MESSAGE("Testing QD American engine double-boundary greeks "
+                       "against FD reference values...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(15, March, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const auto spot = ext::make_shared<SimpleQuote>(100.0);
+    const auto rRate = ext::make_shared<SimpleQuote>(-0.02);
+    const auto qRate = ext::make_shared<SimpleQuote>(-0.05);
+    const auto vol = ext::make_shared<SimpleQuote>(0.20);
+
+    const auto bsProcess = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(flatRate(today, qRate, dc)),
+        Handle<YieldTermStructure>(flatRate(today, rRate, dc)),
+        Handle<BlackVolTermStructure>(flatVol(today, vol, dc)));
+
+    struct RefCase {
+        Option::Type type;
+        Real K, S;
+        Rate r, q;
+        Volatility v;
+        Integer mat;
+        // FD reference values (from FdBlackScholesVanillaEngine 6400x25600)
+        Real price, delta, gamma, vega, rho, divRho;
+    };
+
+    // --- Generate FD reference values ---
+    // Uncomment the block below to regenerate reference values with the FD
+    // pricer.  The output is in C++ struct-initializer syntax that can be
+    // pasted directly into the refCases array.
+    //
+    // const auto fdEngine = ext::make_shared<FdBlackScholesVanillaEngine>(
+    //     bsProcess, 6400, 25600);
+    if (false) {
+        const auto fdEngine = ext::make_shared<FdBlackScholesVanillaEngine>(bsProcess, 6400, 25600);
+
+        struct GenCase {
+            Option::Type type;
+            Real K, S;
+            Rate r, q;
+            Volatility v;
+            Integer mat;
+        };
+        const GenCase gcases[] = {
+            // Double-boundary puts (q < r < 0) — 1y
+            {Option::Put, 100, 100, -0.02, -0.03, 0.25, 365},
+            {Option::Put, 100, 100, -0.02, -0.03, 0.10, 365},
+            {Option::Put, 100, 100, -0.02, -0.03, 0.40, 365},
+            {Option::Put, 100, 110, -0.02, -0.03, 0.25, 365},
+            {Option::Put, 100, 90, -0.02, -0.03, 0.25, 365},
+            {Option::Put, 100, 90, -0.02, -0.03, 0.40, 365},
+            {Option::Put, 100, 100, -0.02, -0.05, 0.25, 365},
+            {Option::Put, 100, 100, -0.02, -0.05, 0.10, 365},
+            {Option::Put, 100, 110, -0.02, -0.05, 0.25, 365},
+            {Option::Put, 100, 90, -0.02, -0.05, 0.25, 365},
+            {Option::Put, 100, 100, -0.01, -0.05, 0.25, 365},
+            {Option::Put, 100, 100, -0.01, -0.05, 0.10, 365},
+            // Double-boundary puts — 6m
+            {Option::Put, 100, 100, -0.02, -0.03, 0.25, 182},
+            {Option::Put, 100, 110, -0.02, -0.03, 0.25, 182},
+            {Option::Put, 100, 90, -0.02, -0.03, 0.25, 182},
+            {Option::Put, 100, 100, -0.02, -0.05, 0.25, 182},
+            // Double-boundary puts — 3m
+            {Option::Put, 100, 100, -0.02, -0.03, 0.25, 91},
+            {Option::Put, 100, 110, -0.02, -0.03, 0.25, 91},
+            {Option::Put, 100, 100, -0.02, -0.05, 0.25, 91},
+            // Double-boundary puts — 1m
+            {Option::Put, 100, 100, -0.02, -0.03, 0.25, 30},
+            {Option::Put, 100, 100, -0.02, -0.05, 0.25, 30},
+            // Double-boundary calls (r < q < 0) — 1y
+            {Option::Call, 100, 100, -0.03, -0.02, 0.25, 365},
+            {Option::Call, 100, 100, -0.03, -0.02, 0.10, 365},
+            {Option::Call, 100, 100, -0.03, -0.02, 0.40, 365},
+            {Option::Call, 100, 90, -0.03, -0.02, 0.25, 365},
+            {Option::Call, 100, 110, -0.03, -0.02, 0.25, 365},
+            {Option::Call, 100, 100, -0.05, -0.02, 0.25, 365},
+            {Option::Call, 100, 100, -0.05, -0.01, 0.25, 365},
+            // Double-boundary calls — 6m, 3m
+            {Option::Call, 100, 100, -0.03, -0.02, 0.25, 182},
+            {Option::Call, 100, 110, -0.03, -0.02, 0.25, 182},
+            {Option::Call, 100, 100, -0.03, -0.02, 0.25, 91},
+            {Option::Call, 100, 100, -0.05, -0.02, 0.25, 91},
+            // Single-boundary puts (r > 0) — 1y
+            {Option::Put, 100, 100, 0.05, 0.02, 0.25, 365},
+            {Option::Put, 100, 110, 0.05, 0.02, 0.25, 365},
+            {Option::Put, 100, 90, 0.05, 0.02, 0.25, 365},
+            {Option::Put, 100, 100, 0.05, 0.02, 0.10, 365},
+            {Option::Put, 100, 100, 0.05, 0.00, 0.25, 365},
+            // Single-boundary puts — shorter dated
+            {Option::Put, 100, 100, 0.05, 0.02, 0.25, 182},
+            {Option::Put, 100, 100, 0.05, 0.02, 0.25, 91},
+            // Single-boundary calls (q > 0) — 1y
+            {Option::Call, 100, 100, 0.02, 0.05, 0.25, 365},
+            {Option::Call, 100, 90, 0.02, 0.05, 0.25, 365},
+            {Option::Call, 100, 110, 0.02, 0.05, 0.25, 365},
+            {Option::Call, 100, 100, 0.02, 0.05, 0.10, 365},
+            // Single-boundary calls — shorter dated
+            {Option::Call, 100, 100, 0.02, 0.05, 0.25, 182},
+            {Option::Call, 100, 100, 0.02, 0.05, 0.25, 91},
+            // Immediate exercise: deep ITM puts with low vol in double-boundary
+            // S between Y(T) and B(T), option at intrinsic
+            {Option::Put, 110, 90, -0.02, -0.03, 0.10, 365},  // intrinsic=20
+            {Option::Put, 120, 90, -0.02, -0.03, 0.10, 365},  // intrinsic=30
+            {Option::Put, 110, 100, -0.02, -0.03, 0.10, 182}, // intrinsic=10
+            // Immediate exercise: deep ITM calls with low vol in double-boundary
+            {Option::Call, 90, 110, -0.03, -0.02, 0.10, 365}, // intrinsic=20
+            {Option::Call, 80, 110, -0.03, -0.02, 0.10, 365}, // intrinsic=30
+            {Option::Call, 90, 100, -0.03, -0.02, 0.10, 182}, // intrinsic=10
+        };
+
+        for (const auto& gc : gcases) {
+            spot->setValue(gc.S);
+            rRate->setValue(gc.r);
+            qRate->setValue(gc.q);
+            vol->setValue(gc.v);
+            const Date matDate = today + Period(gc.mat, Days);
+            VanillaOption opt(ext::make_shared<PlainVanillaPayoff>(gc.type, gc.K),
+                              ext::make_shared<AmericanExercise>(today, matDate));
+            opt.setPricingEngine(fdEngine);
+            const Real fdP = opt.NPV();
+            const Real fdDelta = opt.delta();
+
+            // Gamma via forward differences to avoid straddling exercise boundary kink
+            const Real h = gc.S * 5e-3;
+            spot->setValue(gc.S + h);
+            const Real fdP1 = opt.NPV();
+            spot->setValue(gc.S + 2 * h);
+            const Real fdP2 = opt.NPV();
+            spot->setValue(gc.S);
+            const Real fdGamma = (fdP2 - 2 * fdP1 + fdP) / (h * h);
+
+            // vega, rho, divRho via bump-and-revalue (FD engine doesn't provide them)
+            const Real dv = gc.v * 5e-5;
+            vol->setValue(gc.v + dv);
+            const Real fdVup = opt.NPV();
+            vol->setValue(gc.v - dv);
+            const Real fdVdn = opt.NPV();
+            vol->setValue(gc.v);
+            const Real fdVega = (fdVup - fdVdn) / (2 * dv);
+
+            const Real dr = std::max(std::abs(gc.r), 0.01) * 5e-5;
+            rRate->setValue(gc.r + dr);
+            const Real fdRup = opt.NPV();
+            rRate->setValue(gc.r - dr);
+            const Real fdRdn = opt.NPV();
+            rRate->setValue(gc.r);
+            const Real fdRho = (fdRup - fdRdn) / (2 * dr);
+
+            const Real dq = std::max(std::abs(gc.q), 0.01) * 5e-5;
+            qRate->setValue(gc.q + dq);
+            const Real fdQup = opt.NPV();
+            qRate->setValue(gc.q - dq);
+            const Real fdQdn = opt.NPV();
+            qRate->setValue(gc.q);
+            const Real fdDivRho = (fdQup - fdQdn) / (2 * dq);
+
+
+            const char* typeStr = (gc.type == Option::Put) ? "Option::Put" : "Option::Call";
+            std::cerr << std::setprecision(15) << "{" << typeStr << ", " << gc.K << ", " << gc.S
+                      << ", " << gc.r << ", " << gc.q << ", " << gc.v << ", " << gc.mat << ", "
+                      << fdP << ", " << fdDelta << ", " << fdGamma << ", " << fdVega << ", "
+                      << fdRho << ", " << fdDivRho << "},\n";
+        }
+    }
+
+    // --- QdFp profile sweep for analysis/plotting ---
+    // Produces CSV on stderr: spot sweep and vol sweep for interesting cases.
+    // Enable by changing if(false) to if(true).
+    if (false) {
+        const auto sweepEngine =
+            ext::make_shared<QdFpAmericanEngine>(bsProcess, QdFpAmericanEngine::accurateScheme());
+
+        struct SweepCase {
+            const char* label;
+            Option::Type type;
+            Real K;
+            Rate r, q;
+            Volatility v;
+            Integer mat;
+        };
+        const SweepCase sweepCases[] = {
+            // Double-boundary put, narrow gap
+            {"dbl_put_narrow_1y", Option::Put, 100, -0.02, -0.03, 0.25, 365},
+            // Double-boundary put, wide gap
+            {"dbl_put_wide_1y", Option::Put, 100, -0.01, -0.05, 0.25, 365},
+            // Double-boundary put, low vol
+            {"dbl_put_lowvol_1y", Option::Put, 100, -0.02, -0.03, 0.10, 365},
+            // Double-boundary call, narrow gap
+            {"dbl_call_narrow_1y", Option::Call, 100, -0.03, -0.02, 0.25, 365},
+            // Single-boundary put (standard)
+            {"sgl_put_1y", Option::Put, 100, 0.05, 0.02, 0.25, 365},
+            // Single-boundary call (standard)
+            {"sgl_call_1y", Option::Call, 100, 0.02, 0.05, 0.25, 365},
+            // Double-boundary put, short dated
+            {"dbl_put_narrow_3m", Option::Put, 100, -0.02, -0.03, 0.25, 91},
+        };
+
+        // Spot sweep: S from 70 to 130
+        std::cerr << "SPOT_SWEEP\n";
+        std::cerr << "label,type,K,r,q,v,T,S,price,delta,gamma,vega,rho,divRho\n";
+        for (const auto& sc : sweepCases) {
+            rRate->setValue(sc.r);
+            qRate->setValue(sc.q);
+            vol->setValue(sc.v);
+            const Date matDate = today + Period(sc.mat, Days);
+            VanillaOption opt(ext::make_shared<PlainVanillaPayoff>(sc.type, sc.K),
+                              ext::make_shared<AmericanExercise>(today, matDate));
+            opt.setPricingEngine(sweepEngine);
+
+            for (Real S = 70.0; S <= 130.01; S += 0.5) {
+                spot->setValue(S);
+                std::cerr << std::setprecision(10) << sc.label << ","
+                          << (sc.type == Option::Put ? "Put" : "Call") << "," << sc.K << "," << sc.r
+                          << "," << sc.q << "," << sc.v << "," << sc.mat << "," << S << ","
+                          << opt.NPV() << "," << opt.delta() << "," << opt.gamma() << ","
+                          << opt.vega() << "," << opt.rho() << "," << opt.dividendRho() << "\n";
+            }
+        }
+
+        // Vol sweep: vol from 0.05 to 0.60, at S=100 (ATM)
+        std::cerr << "VOL_SWEEP\n";
+        std::cerr << "label,type,K,r,q,S,T,v,price,delta,gamma,vega,rho,divRho\n";
+        spot->setValue(100.0);
+        for (const auto& sc : sweepCases) {
+            rRate->setValue(sc.r);
+            qRate->setValue(sc.q);
+            const Date matDate = today + Period(sc.mat, Days);
+            VanillaOption opt(ext::make_shared<PlainVanillaPayoff>(sc.type, sc.K),
+                              ext::make_shared<AmericanExercise>(today, matDate));
+            opt.setPricingEngine(sweepEngine);
+
+            for (Real v = 0.05; v <= 0.601; v += 0.01) {
+                vol->setValue(v);
+                std::cerr << std::setprecision(10) << sc.label << ","
+                          << (sc.type == Option::Put ? "Put" : "Call") << "," << sc.K << "," << sc.r
+                          << "," << sc.q << "," << 100.0 << "," << sc.mat << "," << v << ","
+                          << opt.NPV() << "," << opt.delta() << "," << opt.gamma() << ","
+                          << opt.vega() << "," << opt.rho() << "," << opt.dividendRho() << "\n";
+            }
+        }
+    }
+
+    // Reference values from FdBlackScholesVanillaEngine(6400, 25600)
+    // Greeks computed via bump-and-revalue with relative bump 5e-5;
+    // gamma via forward differences with 1% bump
+    const RefCase refCases[] = {
+        // Double-boundary puts (q < r < 0) — 1y
+        {Option::Put, 100, 100, -0.02, -0.03, 0.25, 365, 9.70634871891378, -0.449149920684487,
+         0.0161117554440651, 40.4325420979035, -49.7305992688268, 41.1211151464623},
+        {Option::Put, 100, 100, -0.02, -0.03, 0.10, 365, 3.64590769414805, -0.46308197469402,
+         0.0410550676300847, 40.250315494017, -39.5038269058734, 36.9498067658292},
+        {Option::Put, 100, 100, -0.02, -0.03, 0.40, 365, 15.7486419445511, -0.424784208456321,
+         0.00996385375447773, 40.0588527441403, -56.7279489578354, 41.3104383121995},
+        {Option::Put, 100, 110, -0.02, -0.03, 0.25, 365, 5.98553175979762, -0.301688245147016,
+         0.0126795572790804, 38.8968635008524, -36.2320249660541, 30.8933657583073},
+        {Option::Put, 100, 90, -0.02, -0.03, 0.25, 365, 15.0334199706047, -0.619782929211281,
+         0.0176593155826081, 35.6077802050692, -63.9089959948436, 50.5343370290253},
+        {Option::Put, 100, 90, -0.02, -0.03, 0.40, 365, 20.5097856412248, -0.531021556463035,
+         0.0113563975412735, 36.9452440279971, -66.7936644536127, 46.6584266689551},
+        {Option::Put, 100, 100, -0.02, -0.05, 0.25, 365, 8.96769519525504, -0.431009456915774,
+         0.0165866833616732, 40.178739903709, -40.5972343031635, 34.4303783752054},
+        {Option::Put, 100, 100, -0.02, -0.05, 0.10, 365, 3.00584702665286, -0.42862370829589,
+         0.0455937834869307, 38.6256212425273, -29.4683204513646, 27.8122341020648},
+        {Option::Put, 100, 110, -0.02, -0.05, 0.25, 365, 5.41728344849056, -0.284121602335388,
+         0.0125959168280032, 37.9000228735649, -30.7832070149949, 26.6704784220195},
+        {Option::Put, 100, 90, -0.02, -0.05, 0.25, 365, 14.1786059865793, -0.613485117553759,
+         0.0189719251641075, 35.4535320184368, -46.7986304437673, 38.5648085995172},
+        {Option::Put, 100, 100, -0.01, -0.05, 0.25, 365, 8.5775244406978, -0.422766145564709,
+         0.0169284840289876, 39.6985105058434, -37.6001141546567, 32.0620328562171},
+        {Option::Put, 100, 100, -0.01, -0.05, 0.10, 365, 2.73086268374839, -0.413720610385531,
+         0.0486380443455197, 37.2728131330824, -25.6433523100341, 24.2883307733699},
+        // Double-boundary puts — 6m
+        {Option::Put, 100, 100, -0.02, -0.03, 0.25, 182, 6.88245013988051, -0.459571993884531,
+         0.0226277275072029, 28.3276039322899, -23.1574223983344, 20.3778610785577},
+        {Option::Put, 100, 110, -0.02, -0.03, 0.25, 182, 3.32714702710883, -0.260035361689148,
+         0.0164402079842633, 25.3490088232766, -14.6094502806449, 13.1810888879258},
+        {Option::Put, 100, 90, -0.02, -0.03, 0.25, 182, 12.6665171459094, -0.695549959414845,
+         0.0228772144891679, 22.7242583986254, -30.460479361949, 25.7265516806863},
+        {Option::Put, 100, 100, -0.02, -0.05, 0.25, 182, 6.49974274749274, -0.448196661623547,
+         0.0231099790799085, 28.2493668472839, -20.4849502725146, 18.1828823528463},
+        // Double-boundary puts — 3m
+        {Option::Put, 100, 100, -0.02, -0.03, 0.25, 91, 4.89041800156482, -0.469903537558339,
+         0.0318721565007216, 19.971779320862, -11.3850989476028, 10.4051044903149},
+        {Option::Put, 100, 110, -0.02, -0.03, 0.25, 91, 1.63032027762322, -0.200570952600447,
+         0.0197055661359183, 15.4418621646535, -5.5134074191665, 5.15616616122057},
+        {Option::Put, 100, 100, -0.02, -0.05, 0.25, 91, 4.6918617119121, -0.461969567992806,
+         0.0323093103669798, 19.9382117095226, -10.3902374521958, 9.53693902854269},
+        // Double-boundary puts — 1m
+        {Option::Put, 100, 100, -0.02, -0.03, 0.25, 30, 2.82642347938117, -0.482150015914476,
+         0.0552272105490808, 11.4463475614812, -3.73157326682971, 3.54337625048847},
+        {Option::Put, 100, 100, -0.02, -0.05, 0.25, 30, 2.75782216780659, -0.475353754281258,
+         0.0555678417457734, 11.4374173679721, -3.50907097046438, 3.33810339538942},
+        // Double-boundary calls (r < q < 0) — 1y
+        {Option::Call, 100, 100, -0.03, -0.02, 0.25, 365, 9.70634873011048, 0.546213233339622,
+         0.0161360481654143, 40.4325433551378, 41.1229147404176, -49.7288653420469},
+        {Option::Call, 100, 100, -0.03, -0.02, 0.10, 365, 3.64590769656091, 0.499541011015061,
+         0.0415272830826794, 40.2503160227496, 36.9505014381488, -39.5032025357622},
+        {Option::Call, 100, 100, -0.03, -0.02, 0.40, 365, 15.7486420140371, 0.582270513785861,
+         0.00996997076028805, 40.0588648903799, 41.3132181685446, -56.7249055425378},
+        {Option::Call, 100, 90, -0.03, -0.02, 0.25, 365, 5.09237180265451, 0.376139931211938,
+         0.0171300729859175, 34.5692357397098, 26.8134783384018, -31.3576761667988},
+        {Option::Call, 100, 110, -0.03, -0.02, 0.25, 365, 15.9250060291346, 0.693617651239593,
+         0.0130709368607326, 39.9527729126703, 54.7552232556351, -68.9079981306406},
+        {Option::Call, 100, 100, -0.05, -0.02, 0.25, 365, 8.96769519428094, 0.520686297698953,
+         0.0166762734441974, 40.1787414146071, 34.4307732671467, -40.5957890068365},
+        {Option::Call, 100, 100, -0.05, -0.01, 0.25, 365, 8.57752442660377, 0.508541274188651,
+         0.0170692991195764, 39.6985270182881, 32.0625275094244, -37.5892976371972},
+        // Double-boundary calls — 6m, 3m
+        {Option::Call, 100, 100, -0.03, -0.02, 0.25, 182, 6.8824501339981, 0.528396395405936,
+         0.0226615696132306, 28.3275948875783, 20.3814311374728, -23.1530688106218},
+        {Option::Call, 100, 110, -0.03, -0.02, 0.25, 182, 13.2479893568667, 0.733849103769163,
+         0.0169356378709736, 25.9307127365815, 27.9541693301392, -32.9286216311786},
+        {Option::Call, 100, 100, -0.03, -0.02, 0.25, 91, 4.89041800481184, 0.518807645661719,
+         0.0319237737504672, 19.9717855024417, 10.4030494224953, -11.385761693905},
+        {Option::Call, 100, 100, -0.05, -0.02, 0.25, 91, 4.69186171081853, 0.508888162273453,
+         0.0324987619469468, 19.938211594237, 9.53599736206456, -10.3910036473032},
+        // Single-boundary puts (r > 0) — 1y
+        {Option::Put, 100, 100, 0.05, 0.02, 0.25, 365, 8.56516754564992, -0.417498564515722,
+         0.016621053064668, 38.1258099609028, -36.3853448671847, 30.9993555491772},
+        {Option::Put, 100, 110, 0.05, 0.02, 0.25, 365, 5.1448369208686, -0.272220115245049,
+         0.012285114453521, 35.9828294574172, -28.1767442595893, 24.4831557409952},
+        {Option::Put, 100, 90, 0.05, 0.02, 0.25, 365, 13.6591033384705, -0.605536555936136,
+         0.0201218681751941, 33.043132469075, -39.6804399354522, 32.9460442154428},
+        {Option::Put, 100, 100, 0.05, 0.02, 0.10, 365, 2.89533078318739, -0.419876864564183,
+         0.0462348707087603, 36.8729507430832, -27.2285744687295, 25.7224514195187},
+        {Option::Put, 100, 100, 0.05, 0.00, 0.25, 365, 7.97439342909439, -0.40864507977181,
+         0.0174773907560066, 37.8333182794321, -32.8126366699877, 28.1869264124879},
+        // Single-boundary puts — shorter dated
+        {Option::Put, 100, 100, 0.05, 0.02, 0.25, 182, 6.3451006584151, -0.440268624461285,
+         0.0230569802255474, 27.4990108782092, -19.2733765683073, 17.1454777162516},
+        {Option::Put, 100, 100, 0.05, 0.02, 0.25, 91, 4.63340476090454, -0.457492685608646,
+         0.0322213244793979, 19.6654315759659, -10.0445785371051, 9.2263260000891},
+        // Single-boundary calls (q > 0) — 1y
+        {Option::Call, 100, 100, 0.02, 0.05, 0.25, 365, 8.56516754429367, 0.503150128720948,
+         0.0167753673117801, 38.1258160767572, 30.9981308550533, -36.3857261145739},
+        {Option::Call, 100, 90, 0.02, 0.05, 0.25, 365, 4.36500082455977, 0.335802795618739,
+         0.0165962925640462, 31.8913772857243, 21.3099466472855, -24.4792960376827},
+        {Option::Call, 100, 110, 0.02, 0.05, 0.25, 365, 14.4286567619336, 0.665022320946486,
+         0.0148917716733521, 37.2554478762765, 36.4196035107511, -43.7517875827353},
+        {Option::Call, 100, 100, 0.02, 0.05, 0.10, 365, 2.89533078212857, 0.448830143007674,
+         0.0489020992523734, 36.8729543108071, 25.7220759454224, -27.228765929177},
+        // Single-boundary calls — shorter dated
+        {Option::Call, 100, 100, 0.02, 0.05, 0.25, 182, 6.34510064461839, 0.503719590713749,
+         0.0232471939003638, 27.4990190098379, 17.1415625969118, -19.2736572133256},
+        {Option::Call, 100, 100, 0.02, 0.05, 0.25, 91, 4.6334047598945, 0.503826710409155,
+         0.0324637591295414, 19.665433094822, 9.22713331830138, -10.0436372770574},
+        // Immediate exercise — double-boundary puts
+        {Option::Put, 110, 90, -0.02, -0.03, 0.10, 365, 20.0, -1.0, 0.0, 0.0, 0.0, 0.0},
+        {Option::Put, 120, 90, -0.02, -0.03, 0.10, 365, 30.0, -1.0, 0.0, 0.0, 0.0, 0.0},
+        {Option::Put, 110, 100, -0.02, -0.03, 0.10, 182, 10.1090129265466, -0.927921861900638,
+         0.0305232774434501, 9.63850817026213, -18.0582480115987, 16.6383846718077},
+        // Immediate exercise — double-boundary calls
+        {Option::Call, 90, 110, -0.03, -0.02, 0.10, 365, 20.0, 1.0, 0.0, 0.0, 0.0, 0.0},
+        {Option::Call, 80, 110, -0.03, -0.02, 0.10, 365, 30.0, 1.0, 0.0, 0.0, 0.0, 0.0},
+        {Option::Call, 90, 100, -0.03, -0.02, 0.10, 182, 10.0457853012681, 0.959112950493978,
+         0.0192937600670717, 5.99007261197215, 11.5121098674583, -12.5514394717641},
+    };
+
+    const auto fpEngine =
+        ext::make_shared<QdFpAmericanEngine>(bsProcess, QdFpAmericanEngine::accurateScheme());
+
+    // Tolerances: price and greeks vs FD reference
+    // FD reference: 6400x25600 grid, forward-difference gamma (1% bump),
+    // central-difference vega/rho/divRho (5e-5 relative bump)
+    const Real tolPrice = 5.0e-3;
+    const Real tolDelta = 2.0e-2;
+    const Real tolGamma = 5.0e-2;
+    const Real tolVega = 0.5;
+    const Real tolRho = 1.0;
+    const Real tolDivRho = 1.0;
+
+    for (const auto& rc : refCases) {
+        if (rc.price == 0.0)
+            continue; // skip placeholder
+
+        spot->setValue(rc.S);
+        rRate->setValue(rc.r);
+        qRate->setValue(rc.q);
+        vol->setValue(rc.v);
+        const Date matDate = today + Period(rc.mat, Days);
+        VanillaOption opt(ext::make_shared<PlainVanillaPayoff>(rc.type, rc.K),
+                          ext::make_shared<AmericanExercise>(today, matDate));
+        opt.setPricingEngine(fpEngine);
+
+        const Real price = opt.NPV();
+        const Real delta = opt.delta();
+        const Real gamma = opt.gamma();
+        const Real vega = opt.vega();
+        const Real rho = opt.rho();
+        const Real divRho = opt.dividendRho();
+
+        const char* typeStr = (rc.type == Option::Put) ? "Put" : "Call";
+
+        BOOST_TEST_MESSAGE(
+            std::fixed << std::setprecision(6) << typeStr << " K=" << rc.K << " S=" << rc.S
+                       << " r=" << rc.r << " q=" << rc.q << " v=" << rc.v << " T=" << rc.mat << "d"
+                       << "\n             " << std::setw(14) << "QdFp" << "  " << std::setw(14)
+                       << "FD ref" << "  " << std::setw(12) << "diff"
+                       << "\n  price:   " << std::setw(14) << price << "  " << std::setw(14)
+                       << rc.price << "  " << std::setw(12) << (price - rc.price) << "\n  delta:   "
+                       << std::setw(14) << delta << "  " << std::setw(14) << rc.delta << "  "
+                       << std::setw(12) << (delta - rc.delta) << "\n  gamma:   " << std::setw(14)
+                       << gamma << "  " << std::setw(14) << rc.gamma << "  " << std::setw(12)
+                       << (gamma - rc.gamma) << "\n  vega:    " << std::setw(14) << vega << "  "
+                       << std::setw(14) << rc.vega << "  " << std::setw(12) << (vega - rc.vega)
+                       << "\n  rho:     " << std::setw(14) << rho << "  " << std::setw(14) << rc.rho
+                       << "  " << std::setw(12) << (rho - rc.rho)
+                       << "\n  divRho:  " << std::setw(14) << divRho << "  " << std::setw(14)
+                       << rc.divRho << "  " << std::setw(12) << (divRho - rc.divRho));
+
+        if (std::abs(price - rc.price) > tolPrice) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: price " << price
+                                << " vs ref " << rc.price << " diff=" << (price - rc.price));
+        }
+        if (std::abs(delta - rc.delta) > tolDelta) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: delta " << delta
+                                << " vs ref " << rc.delta << " diff=" << (delta - rc.delta));
+        }
+        if (std::abs(gamma - rc.gamma) > tolGamma) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: gamma " << gamma
+                                << " vs ref " << rc.gamma << " diff=" << (gamma - rc.gamma));
+        }
+        if (std::abs(vega - rc.vega) > tolVega) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: vega " << vega
+                                << " vs ref " << rc.vega << " diff=" << (vega - rc.vega));
+        }
+        if (std::abs(rho - rc.rho) > tolRho) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: rho " << rho
+                                << " vs ref " << rc.rho << " diff=" << (rho - rc.rho));
+        }
+        if (std::abs(divRho - rc.divRho) > tolDivRho) {
+            BOOST_ERROR(typeStr << " K=" << rc.K << " S=" << rc.S << " r=" << rc.r << " q=" << rc.q
+                                << " v=" << rc.v << " T=" << rc.mat << "d: divRho " << divRho
+                                << " vs ref " << rc.divRho << " diff=" << (divRho - rc.divRho));
+        }
+    }
+
+    // --- QdPlus engine comparison (informational, no assertions) ---
+    const auto plusEngine = ext::make_shared<QdPlusAmericanEngine>(bsProcess);
+
+    BOOST_TEST_MESSAGE("\n=== QdPlus vs FD reference ===");
+    for (const auto& rc : refCases) {
+        if (rc.price == 0.0)
+            continue;
+
+        spot->setValue(rc.S);
+        rRate->setValue(rc.r);
+        qRate->setValue(rc.q);
+        vol->setValue(rc.v);
+        const Date matDate = today + Period(rc.mat, Days);
+        VanillaOption opt(ext::make_shared<PlainVanillaPayoff>(rc.type, rc.K),
+                          ext::make_shared<AmericanExercise>(today, matDate));
+        opt.setPricingEngine(plusEngine);
+
+        const Real price = opt.NPV();
+        const Real delta = opt.delta();
+        const Real gamma = opt.gamma();
+        const Real vega = opt.vega();
+        const Real rho = opt.rho();
+        const Real divRho = opt.dividendRho();
+
+        const char* typeStr = (rc.type == Option::Put) ? "Put" : "Call";
+
+        BOOST_TEST_MESSAGE(
+            std::fixed << std::setprecision(6) << typeStr << " K=" << rc.K << " S=" << rc.S
+                       << " r=" << rc.r << " q=" << rc.q << " v=" << rc.v << " T=" << rc.mat << "d"
+                       << "\n             " << std::setw(14) << "QdPlus" << "  " << std::setw(14)
+                       << "FD ref" << "  " << std::setw(12) << "diff"
+                       << "\n  price:   " << std::setw(14) << price << "  " << std::setw(14)
+                       << rc.price << "  " << std::setw(12) << (price - rc.price) << "\n  delta:   "
+                       << std::setw(14) << delta << "  " << std::setw(14) << rc.delta << "  "
+                       << std::setw(12) << (delta - rc.delta) << "\n  gamma:   " << std::setw(14)
+                       << gamma << "  " << std::setw(14) << rc.gamma << "  " << std::setw(12)
+                       << (gamma - rc.gamma) << "\n  vega:    " << std::setw(14) << vega << "  "
+                       << std::setw(14) << rc.vega << "  " << std::setw(12) << (vega - rc.vega)
+                       << "\n  rho:     " << std::setw(14) << rho << "  " << std::setw(14) << rc.rho
+                       << "  " << std::setw(12) << (rho - rc.rho)
+                       << "\n  divRho:  " << std::setw(14) << divRho << "  " << std::setw(14)
+                       << rc.divRho << "  " << std::setw(12) << (divRho - rc.divRho));
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR incorporates the double boundary case for QD+ and QDFP american engines and adds analytical delta, gamma, vega, rho, dividendrho for both engines for all boundary configurations. Prices and greeks are tested against a large grid FD engine.