### PR TITLE
Add VNBinomialVanillaEngine: LR tree with discrete-dividend interpola…

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1646,6 +1646,7 @@
     <ClInclude Include="ql\pricingengines\vanilla\mcvanillaengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\qdfpamericanengine.hpp" />
     <ClInclude Include="ql\pricingengines\vanilla\qdplusamericanengine.hpp" />
+    <ClInclude Include="ql\pricingengines\vanilla\vnbinomialengine.hpp" />
     <ClInclude Include="ql\processes\all.hpp" />
     <ClInclude Include="ql\processes\batesprocess.hpp" />
     <ClInclude Include="ql\processes\blackscholesprocess.hpp" />
@@ -2708,6 +2709,7 @@
     <ClCompile Include="ql\pricingengines\vanilla\mchestonhullwhiteengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\qdfpamericanengine.cpp" />
     <ClCompile Include="ql\pricingengines\vanilla\qdplusamericanengine.cpp" />
+    <ClCompile Include="ql\pricingengines\vanilla\vnbinomialengine.cpp" />
     <ClCompile Include="ql\processes\batesprocess.cpp" />
     <ClCompile Include="ql\processes\blackscholesprocess.cpp" />
     <ClCompile Include="ql\processes\coxingersollrossprocess.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4455,6 +4455,9 @@
     <ClInclude Include="ql\pricingengines\vanilla\qdplusamericanengine.hpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\vanilla\vnbinomialengine.hpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClInclude>
     <ClInclude Include="ql\models\equity\hestonslvfdmmodel.hpp">
       <Filter>models\equity</Filter>
     </ClInclude>
@@ -7295,6 +7298,9 @@
       <Filter>pricingengines\vanilla</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\vanilla\qdplusamericanengine.cpp">
+      <Filter>pricingengines\vanilla</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\pricingengines\vanilla\vnbinomialengine.cpp">
       <Filter>pricingengines\vanilla</Filter>
     </ClCompile>
     <ClCompile Include="ql\models\equity\hestonslvfdmmodel.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -758,6 +758,7 @@ set(QL_SOURCES
     pricingengines/vanilla/coshestonengine.cpp
     pricingengines/vanilla/cashdividendeuropeanengine.cpp
     pricingengines/vanilla/discretizedvanillaoption.cpp
+    pricingengines/vanilla/vnbinomialengine.cpp
     pricingengines/vanilla/exponentialfittinghestonengine.cpp
     pricingengines/vanilla/fdbatesvanillaengine.cpp
     pricingengines/vanilla/fdblackscholesvanillaengine.cpp
@@ -2006,6 +2007,7 @@ set(QL_HEADERS
     pricingengines/vanilla/cashdividendeuropeanengine.hpp
     pricingengines/vanilla/coshestonengine.hpp
     pricingengines/vanilla/discretizedvanillaoption.hpp
+    pricingengines/vanilla/vnbinomialengine.hpp
     pricingengines/vanilla/exponentialfittinghestonengine.hpp
     pricingengines/vanilla/fdbatesvanillaengine.hpp
     pricingengines/vanilla/fdblackscholesvanillaengine.hpp

--- a/ql/pricingengines/vanilla/Makefile.am
+++ b/ql/pricingengines/vanilla/Makefile.am
@@ -45,7 +45,8 @@ this_include_HEADERS = \
     mchestonhullwhiteengine.hpp \
     mcvanillaengine.hpp \
     qdfpamericanengine.hpp \
-    qdplusamericanengine.hpp
+    qdplusamericanengine.hpp \
+    vnbinomialengine.hpp
 
 cpp_files = \
     analyticbsmhullwhiteengine.cpp \
@@ -84,7 +85,8 @@ cpp_files = \
     mcdigitalengine.cpp \
     mchestonhullwhiteengine.cpp \
     qdfpamericanengine.cpp \
-    qdplusamericanengine.cpp
+    qdplusamericanengine.cpp \
+    vnbinomialengine.cpp
 
 if UNITY_BUILD
 

--- a/ql/pricingengines/vanilla/all.hpp
+++ b/ql/pricingengines/vanilla/all.hpp
@@ -43,4 +43,5 @@
 #include <ql/pricingengines/vanilla/mcvanillaengine.hpp>
 #include <ql/pricingengines/vanilla/qdfpamericanengine.hpp>
 #include <ql/pricingengines/vanilla/qdplusamericanengine.hpp>
+#include <ql/pricingengines/vanilla/vnbinomialengine.hpp>
 

--- a/ql/pricingengines/vanilla/vnbinomialengine.cpp
+++ b/ql/pricingengines/vanilla/vnbinomialengine.cpp
@@ -1,0 +1,261 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/pricingengines/vanilla/vnbinomialengine.hpp>
+#include <ql/exercise.hpp>
+#include <ql/math/distributions/binomialdistribution.hpp>
+#include <ql/pricingengines/greeks.hpp>
+#include <algorithm>
+#include <cmath>
+
+namespace QuantLib {
+
+    VNBinomialVanillaEngine::VNBinomialVanillaEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+        DividendSchedule dividends,
+        Size timeSteps)
+    : process_(std::move(process)),
+      dividends_(std::move(dividends)),
+      timeSteps_(timeSteps) {
+        QL_REQUIRE(timeSteps >= 2,
+                   "at least 2 time steps required, "
+                   << timeSteps << " provided");
+        registerWith(process_);
+    }
+
+    void VNBinomialVanillaEngine::calculate() const {
+
+        DayCounter rfdc  = process_->riskFreeRate()->dayCounter();
+        DayCounter divdc = process_->dividendYield()->dayCounter();
+
+        Real S0 = process_->stateVariable()->value();
+        QL_REQUIRE(S0 > 0.0, "negative or null underlying given");
+
+        Date referenceDate = process_->riskFreeRate()->referenceDate();
+        Date maturityDate  = arguments_.exercise->lastDate();
+        Time T = rfdc.yearFraction(referenceDate, maturityDate);
+
+        Rate r = process_->riskFreeRate()->zeroRate(
+            maturityDate, rfdc, Continuous, NoFrequency);
+        Rate q = process_->dividendYield()->zeroRate(
+            maturityDate, divdc, Continuous, NoFrequency);
+        Volatility sigma = process_->blackVolatility()->blackVol(
+            maturityDate, S0);
+
+        auto payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
+        QL_REQUIRE(payoff, "non-plain payoff given");
+        Real K = payoff->strike();
+        QL_REQUIRE(K > 0.0, "strike must be positive");
+
+        bool isAmerican =
+            (arguments_.exercise->type() == Exercise::American);
+
+        // Earliest exercise time (for American options with a window)
+        Time earliestExercise = 0.0;
+        if (arguments_.exercise->dates().size() > 1)
+            earliestExercise = rfdc.yearFraction(
+                referenceDate, arguments_.exercise->date(0));
+
+        // -----------------------------------------------------------------
+        // Collect fixed cash dividends within (referenceDate, maturityDate].
+        // Each entry is (time, dollar amount).  The BSM process carries any
+        // continuous dividend yield; discrete dividends here are additive
+        // cash amounts that reduce the stock price at the ex-date.
+        // -----------------------------------------------------------------
+        struct DivInfo { Time t; Real amount; };
+        std::vector<DivInfo> cashDivs;
+
+        for (const auto& div : dividends_) {
+            if (div->date() > referenceDate && div->date() <= maturityDate) {
+                Time td = rfdc.yearFraction(referenceDate, div->date());
+                cashDivs.push_back({td, div->amount()});
+            }
+        }
+        std::sort(cashDivs.begin(), cashDivs.end(),
+                  [](const DivInfo& a, const DivInfo& b) {
+                      return a.t < b.t;
+                  });
+
+        // -----------------------------------------------------------------
+        // Leisen-Reimer tree parameters (odd number of steps required)
+        // -----------------------------------------------------------------
+        Size N = (timeSteps_ % 2 == 0) ? timeSteps_ + 1 : timeSteps_;
+        Time dt = T / N;
+
+        Real variance     = sigma * sigma * T;
+        Real sqrtVar      = std::sqrt(variance);
+        // Log-space drift per step: matches process->drift(0, x0) * dt
+        Real driftPerStep = (r - q - 0.5 * sigma * sigma) * dt;
+        Real ermqdt       = std::exp(driftPerStep + 0.5 * variance / N);
+
+        Real d2 = (std::log(S0 / K) + driftPerStep * N) / sqrtVar;
+        Real pu = PeizerPrattMethod2Inversion(d2, N);
+        Real pd = 1.0 - pu;
+        Real pdash = PeizerPrattMethod2Inversion(d2 + sqrtVar, N);
+        Real up   = ermqdt * pdash / pu;
+        Real down = (ermqdt - pu * up) / pd;
+        Real disc = std::exp(-r * dt);
+
+        QL_ENSURE(up > down,
+                  "LR tree: up (" << up << ") must exceed down (" << down << ")");
+
+        // -----------------------------------------------------------------
+        // Map ex-div dates to nearest tree step (merge if colliding)
+        // -----------------------------------------------------------------
+        std::vector<Size> divStep;
+        std::vector<Real> divAmt;
+        for (const auto& d : cashDivs) {
+            Size s = std::max<Size>(
+                1, std::min<Size>(
+                    static_cast<Size>(std::round(d.t / dt)), N - 1));
+            if (!divStep.empty() && divStep.back() == s)
+                divAmt.back() += d.amount;
+            else {
+                divStep.push_back(s);
+                divAmt.push_back(d.amount);
+            }
+        }
+        Size nDiv = divStep.size();
+
+        // -----------------------------------------------------------------
+        // Helper: stock price at node (step i, index j)
+        //   S_{i,j} = S0 * up^j * down^(i-j)
+        // Precompute power tables to avoid repeated std::pow in hot loops.
+        // -----------------------------------------------------------------
+        std::vector<Real> upPow(N + 1), dnPow(N + 1);
+        upPow[0] = dnPow[0] = 1.0;
+        for (Size k = 1; k <= N; ++k) {
+            upPow[k] = upPow[k-1] * up;
+            dnPow[k] = dnPow[k-1] * down;
+        }
+
+        auto stockPrice = [&](Size i, Size j) -> Real {
+            return S0 * upPow[j] * dnPow[i - j];
+        };
+
+        // -----------------------------------------------------------------
+        // Terminal payoff
+        // -----------------------------------------------------------------
+        Array V(N + 1);
+        for (Size j = 0; j <= N; ++j)
+            V[j] = (*payoff)(stockPrice(N, j));
+
+        // -----------------------------------------------------------------
+        // Backward induction with VN interpolation at ex-div dates
+        // -----------------------------------------------------------------
+        // Dividend pointer walks backwards through the sorted list.
+        Size divIdx = nDiv;
+
+        // Variables to capture values at steps 2, 1 for Greeks
+        Real p2d = 0, p2m = 0, p2u = 0;
+        Real s2d = 0, s2m = 0, s2u = 0;
+        Real p1d = 0, p1u = 0;
+        Real s1d = 0, s1u = 0;
+
+        for (Integer i = N - 1; i >= 0; --i) {
+            Size si = static_cast<Size>(i);
+
+            // --- standard one-step backward induction ---
+            Array newV(si + 1);
+            for (Size j = 0; j <= si; ++j)
+                newV[j] = disc * (pd * V[j] + pu * V[j + 1]);
+
+            // --- VN interpolation if this step is an ex-div date ---
+            if (divIdx > 0 && divStep[divIdx - 1] == si) {
+                --divIdx;
+                Real D = divAmt[divIdx];
+
+                // Stock prices at this step (monotonically increasing in j)
+                std::vector<Real> prices(si + 1);
+                for (Size j = 0; j <= si; ++j)
+                    prices[j] = stockPrice(si, j);
+
+                Array adjV(si + 1);
+                for (Size j = 0; j <= si; ++j) {
+                    Real Spost = prices[j] - D;
+
+                    if (Spost <= 0.0) {
+                        // dividend exceeds stock price
+                        adjV[j] = (*payoff)(std::max(Spost, 0.0));
+                    } else {
+                        // linear interpolation / extrapolation
+                        auto it = std::lower_bound(
+                            prices.begin(), prices.end(), Spost);
+
+                        Size j1, j0;
+                        if (it == prices.begin()) {
+                            j0 = 0; j1 = 1;      // extrapolate below
+                        } else if (it == prices.end()) {
+                            j1 = si; j0 = si - 1; // extrapolate above
+                        } else {
+                            j1 = static_cast<Size>(
+                                std::distance(prices.begin(), it));
+                            j0 = j1 - 1;
+                        }
+                        Real w = (Spost - prices[j0])
+                               / (prices[j1] - prices[j0]);
+                        adjV[j] = newV[j0] + w * (newV[j1] - newV[j0]);
+                    }
+                }
+                newV = adjV;
+            }
+
+            // --- early exercise (American) ---
+            if (isAmerican) {
+                Time stepTime = si * dt;
+                if (stepTime >= earliestExercise) {
+                    for (Size j = 0; j <= si; ++j)
+                        newV[j] = std::max(newV[j],
+                                           (*payoff)(stockPrice(si, j)));
+                }
+            }
+
+            // --- capture nodes for Greeks ---
+            if (si == 2) {
+                p2d = newV[0]; p2m = newV[1]; p2u = newV[2];
+                s2d = stockPrice(2, 0);
+                s2m = stockPrice(2, 1);
+                s2u = stockPrice(2, 2);
+            }
+            if (si == 1) {
+                p1d = newV[0]; p1u = newV[1];
+                s1d = stockPrice(1, 0);
+                s1u = stockPrice(1, 1);
+            }
+
+            V = newV;
+        }
+
+        // -----------------------------------------------------------------
+        // Results
+        // -----------------------------------------------------------------
+        results_.value = V[0];
+
+        Real delta2u = (p2u - p2m) / (s2u - s2m);
+        Real delta2d = (p2m - p2d) / (s2m - s2d);
+        results_.gamma = (delta2u - delta2d) / ((s2u - s2d) / 2.0);
+
+        results_.delta = (p1u - p1d) / (s1u - s1d);
+
+        results_.theta = blackScholesTheta(process_,
+                                           results_.value,
+                                           results_.delta,
+                                           results_.gamma);
+    }
+
+}

--- a/ql/pricingengines/vanilla/vnbinomialengine.hpp
+++ b/ql/pricingengines/vanilla/vnbinomialengine.hpp
@@ -1,0 +1,62 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file vnbinomialengine.hpp
+    \brief Vellekoop-Nieuwenhuis binomial engine for discrete dividends
+*/
+
+#ifndef quantlib_vn_binomial_engine_hpp
+#define quantlib_vn_binomial_engine_hpp
+
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/instruments/dividendschedule.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+
+namespace QuantLib {
+
+    //! Leisen-Reimer tree with Vellekoop-Nieuwenhuis dividend interpolation
+    /*! Prices European and American vanilla options with discrete cash
+        dividends using a recombining Leisen-Reimer binomial tree.
+        At each ex-dividend date, option values are adjusted via linear
+        interpolation in the stock-price grid following the method of
+        Vellekoop & Nieuwenhuis (2006).
+
+        Continuous dividend yield is carried by the BSM process.
+        Discrete dividends are fixed dollar amounts passed via
+        DividendSchedule (each entry's amount() is the cash drop).
+
+        When no dividends are present, this reduces to a standard
+        Leisen-Reimer tree.
+
+        \ingroup vanillaengines
+    */
+    class VNBinomialVanillaEngine : public VanillaOption::engine {
+      public:
+        VNBinomialVanillaEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess> process,
+            DividendSchedule dividends,
+            Size timeSteps);
+        void calculate() const override;
+      private:
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
+        DividendSchedule dividends_;
+        Size timeSteps_;
+    };
+
+}
+
+#endif

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -29,6 +29,8 @@
 #include <ql/pricingengines/vanilla/analyticdividendeuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
 #include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
+#include <ql/pricingengines/vanilla/vnbinomialengine.hpp>
+#include <ql/pricingengines/vanilla/binomialengine.hpp>
 #include <ql/pricingengines/vanilla/cashdividendeuropeanengine.hpp>
 #include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvariancecurve.hpp>
@@ -1463,6 +1465,234 @@ BOOST_AUTO_TEST_CASE(testAmericanOptionsWithEscrowedDividends) {
         }
 }
 
+
+
+BOOST_AUTO_TEST_CASE(testVNBinomialNoDividendsMatchesLR) {
+    BOOST_TEST_MESSAGE(
+        "Testing VN binomial engine matches standard LR tree without dividends...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today(8, April, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(100.0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.05, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, 0.02, dc));
+    const Handle<BlackVolTermStructure> volTS(flatVol(today, 0.25, dc));
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        spot, qTS, rTS, volTS);
+
+    const Date maturityDate = today + Period(6, Months);
+    const DividendSchedule noDivs;
+
+    for (const Option::Type type : {Option::Put, Option::Call}) {
+        VanillaOption option(
+            ext::make_shared<PlainVanillaPayoff>(type, 100.0),
+            ext::make_shared<AmericanExercise>(maturityDate));
+
+        option.setPricingEngine(
+            ext::make_shared<VNBinomialVanillaEngine>(process, noDivs, 201));
+        const Real vnNPV = option.NPV();
+
+        option.setPricingEngine(
+            ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(process, 201));
+        const Real lrNPV = option.NPV();
+
+        const Real tol = 1e-10;
+        if (std::abs(vnNPV - lrNPV) > tol) {
+            BOOST_FAIL("VN without dividends does not match standard LR tree"
+                       << "\n    option type: "
+                       << ((type == Option::Call) ? "Call" : "Put")
+                       << "\n    VN NPV:      " << vnNPV
+                       << "\n    LR NPV:      " << lrNPV
+                       << "\n    difference:   " << std::abs(vnNPV - lrNPV)
+                       << "\n    tolerance:    " << tol);
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(testVNBinomialConvergence) {
+    BOOST_TEST_MESSAGE(
+        "Testing VN binomial convergence vs FD with discrete dividends...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today(8, April, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(100.0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.05, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, 0.02, dc));
+    const Handle<BlackVolTermStructure> volTS(flatVol(today, 0.25, dc));
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        spot, qTS, rTS, volTS);
+
+    const Date maturityDate = today + Period(6, Months);
+
+    DividendSchedule divs;
+    divs.push_back(ext::make_shared<FixedDividend>(2.0, today + Period(2, Months)));
+    divs.push_back(ext::make_shared<FixedDividend>(2.0, today + Period(5, Months)));
+
+    // FD 500x500 baseline
+    const auto fdEngine =
+        MakeFdBlackScholesVanillaEngine(process)
+            .withTGrid(500).withXGrid(500)
+            .withCashDividends(
+                {today + Period(2, Months), today + Period(5, Months)},
+                {2.0, 2.0});
+
+    const Real strikes[] = {90.0, 100.0, 110.0};
+    const Option::Type types[] = {Option::Put, Option::Call};
+    const Real tol = 0.005; // 0.5%
+
+    for (auto type : types) {
+        for (auto K : strikes) {
+            VanillaOption option(
+                ext::make_shared<PlainVanillaPayoff>(type, K),
+                ext::make_shared<AmericanExercise>(maturityDate));
+
+            option.setPricingEngine(fdEngine);
+            const Real fdNPV = option.NPV();
+
+            option.setPricingEngine(
+                ext::make_shared<VNBinomialVanillaEngine>(process, divs, 501));
+            const Real vnNPV = option.NPV();
+
+            const Real relErr = std::abs(vnNPV - fdNPV) / fdNPV;
+            if (relErr > tol) {
+                BOOST_FAIL("VN binomial exceeds tolerance vs FD"
+                           << "\n    option type: "
+                           << ((type == Option::Call) ? "Call" : "Put")
+                           << "\n    strike:      " << K
+                           << "\n    VN NPV:      " << vnNPV
+                           << "\n    FD NPV:      " << fdNPV
+                           << "\n    relative err: " << relErr
+                           << "\n    tolerance:    " << tol);
+            }
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(testVNBinomialFourQuarterlyDividends) {
+    BOOST_TEST_MESSAGE(
+        "Testing VN binomial with four quarterly dividends...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today(8, April, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(100.0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.05, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, 0.02, dc));
+    const Handle<BlackVolTermStructure> volTS(flatVol(today, 0.25, dc));
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        spot, qTS, rTS, volTS);
+
+    const Date maturityDate = today + Period(1, Years);
+
+    std::vector<Date> divDates;
+    std::vector<Real> divAmts;
+    DividendSchedule divs;
+    for (int m : {3, 6, 9, 12}) {
+        Date d = today + Period(m, Months);
+        divs.push_back(ext::make_shared<FixedDividend>(1.50, d));
+        divDates.push_back(d);
+        divAmts.push_back(1.50);
+    }
+
+    const auto fdEngine =
+        MakeFdBlackScholesVanillaEngine(process)
+            .withTGrid(500).withXGrid(500)
+            .withCashDividends(divDates, divAmts);
+
+    const Real tol = 0.005;
+
+    for (auto type : {Option::Put, Option::Call}) {
+        for (Real K : {90.0, 100.0, 110.0}) {
+            VanillaOption option(
+                ext::make_shared<PlainVanillaPayoff>(type, K),
+                ext::make_shared<AmericanExercise>(maturityDate));
+
+            option.setPricingEngine(fdEngine);
+            const Real fdNPV = option.NPV();
+
+            option.setPricingEngine(
+                ext::make_shared<VNBinomialVanillaEngine>(process, divs, 501));
+            const Real vnNPV = option.NPV();
+
+            const Real relErr = std::abs(vnNPV - fdNPV) / fdNPV;
+            if (relErr > tol) {
+                BOOST_FAIL("VN binomial four-div exceeds tolerance vs FD"
+                           << "\n    option type: "
+                           << ((type == Option::Call) ? "Call" : "Put")
+                           << "\n    strike:      " << K
+                           << "\n    VN NPV:      " << vnNPV
+                           << "\n    FD NPV:      " << fdNPV
+                           << "\n    relative err: " << relErr
+                           << "\n    tolerance:    " << tol);
+            }
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(testVNBinomialHighDividend) {
+    BOOST_TEST_MESSAGE(
+        "Testing VN binomial with high dividend / spot ratio...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today(8, April, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(100.0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.05, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, 0.02, dc));
+    const Handle<BlackVolTermStructure> volTS(flatVol(today, 0.25, dc));
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        spot, qTS, rTS, volTS);
+
+    const Date maturityDate = today + Period(6, Months);
+    const Date divDate = today + Period(3, Months);
+
+    // 8% of spot
+    DividendSchedule divs;
+    divs.push_back(ext::make_shared<FixedDividend>(8.0, divDate));
+
+    const auto fdEngine =
+        MakeFdBlackScholesVanillaEngine(process)
+            .withTGrid(500).withXGrid(500)
+            .withCashDividends({divDate}, {8.0});
+
+    const Real tol = 0.005;
+
+    for (Real K : {90.0, 100.0, 110.0}) {
+        VanillaOption option(
+            ext::make_shared<PlainVanillaPayoff>(Option::Put, K),
+            ext::make_shared<AmericanExercise>(maturityDate));
+
+        option.setPricingEngine(fdEngine);
+        const Real fdNPV = option.NPV();
+
+        option.setPricingEngine(
+            ext::make_shared<VNBinomialVanillaEngine>(process, divs, 501));
+        const Real vnNPV = option.NPV();
+
+        const Real relErr = std::abs(vnNPV - fdNPV) / fdNPV;
+        if (relErr > tol) {
+            BOOST_FAIL("VN binomial high-div exceeds tolerance vs FD"
+                       << "\n    strike:      " << K
+                       << "\n    VN NPV:      " << vnNPV
+                       << "\n    FD NPV:      " << fdNPV
+                       << "\n    relative err: " << relErr
+                       << "\n    tolerance:    " << tol);
+        }
+    }
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

Vellekoop-Nieuwenhuis (2006) method applied to a Leisen-Reimer binomial tree.  At each ex-dividend date the option-value array is adjusted via linear interpolation in the stock-price grid, keeping the tree fully recombining while correctly handling discrete cash dividends.