### PR TITLE
Cache invariants in `ImpliedTermStructure`

### DIFF
--- a/ql/termstructures/yield/impliedtermstructure.hpp
+++ b/ql/termstructures/yield/impliedtermstructure.hpp
@@ -26,6 +26,7 @@
 #define quantlib_implied_term_structure_hpp
 
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/utilities/null.hpp>
 #include <utility>
 
 namespace QuantLib {
@@ -58,8 +59,14 @@ namespace QuantLib {
       protected:
         DiscountFactor discountImpl(Time) const override;
         //@}
+        //! \name Observer interface
+        //@{
+        void update() override;
+        //@}
       private:
         Handle<YieldTermStructure> originalCurve_;
+        mutable DiscountFactor refDf_ = Null<DiscountFactor>();
+        mutable Time refTime_ = Null<Time>();
     };
 
 
@@ -68,6 +75,8 @@ namespace QuantLib {
     inline ImpliedTermStructure::ImpliedTermStructure(Handle<YieldTermStructure> h,
                                                       const Date& referenceDate)
     : YieldTermStructure(referenceDate), originalCurve_(std::move(h)) {
+        if (!originalCurve_.empty())
+            enableExtrapolation(originalCurve_->allowsExtrapolation());
         registerWith(originalCurve_);
     }
 
@@ -87,18 +96,24 @@ namespace QuantLib {
         return originalCurve_->maxDate();
     }
 
+    inline void ImpliedTermStructure::update() {
+        refDf_ = Null<DiscountFactor>();
+        refTime_ = Null<Time>();
+        if (!originalCurve_.empty())
+            enableExtrapolation(originalCurve_->allowsExtrapolation());
+        YieldTermStructure::update();
+    }
+
     inline DiscountFactor ImpliedTermStructure::discountImpl(Time t) const {
         /* t is relative to the current reference date
            and needs to be converted to the time relative
            to the reference date of the original curve */
-        Date ref = referenceDate();
-        Time originalTime = t + dayCounter().yearFraction(
-                                        originalCurve_->referenceDate(), ref);
-        /* discount at evaluation date cannot be cached
-           since the original curve could change between
-           invocations of this method */
-        return originalCurve_->discount(originalTime, true) /
-               originalCurve_->discount(ref, true);
+        if (refDf_ == Null<DiscountFactor>()) {
+            const Date ref = referenceDate();
+            refTime_ = dayCounter().yearFraction(originalCurve_->referenceDate(), ref);
+            refDf_ = originalCurve_->discount(ref, true);
+        }
+        return originalCurve_->discount(t + refTime_, true) / refDf_;
     }
 
 }

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -159,6 +159,9 @@ BOOST_AUTO_TEST_CASE(testImplied) {
 
     CommonVars vars;
 
+    auto flatRate = ext::make_shared<SimpleQuote>();
+    vars.termStructure = ext::make_shared<FlatForward>(
+        vars.settlementDays, NullCalendar(), Handle<Quote>(flatRate), Actual360());
     Real tolerance = 1.0e-10;
     Date today = Settings::instance().evaluationDate();
     Date newToday = today + 3*Years;
@@ -168,15 +171,18 @@ BOOST_AUTO_TEST_CASE(testImplied) {
     ext::shared_ptr<YieldTermStructure> implied(
         new ImpliedTermStructure(Handle<YieldTermStructure>(vars.termStructure),
                                  newSettlement));
-    DiscountFactor baseDiscount = vars.termStructure->discount(newSettlement);
-    DiscountFactor discount = vars.termStructure->discount(testDate);
-    DiscountFactor impliedDiscount = implied->discount(testDate);
-    if (std::fabs(discount - baseDiscount*impliedDiscount) > tolerance)
-        BOOST_ERROR(
-            "unable to reproduce discount from implied curve\n"
-            << std::fixed << std::setprecision(10)
-            << "    calculated: " << baseDiscount*impliedDiscount << "\n"
-            << "    expected:   " << discount);
+    for (int i = 1; i < 4; i++) {
+        flatRate->setValue(i / 100.0);
+        DiscountFactor baseDiscount = vars.termStructure->discount(newSettlement);
+        DiscountFactor discount = vars.termStructure->discount(testDate);
+        DiscountFactor impliedDiscount = implied->discount(testDate);
+        if (std::fabs(discount - baseDiscount*impliedDiscount) > tolerance)
+            BOOST_ERROR(
+                "unable to reproduce discount from implied curve\n"
+                << std::fixed << std::setprecision(10)
+                << "    calculated: " << baseDiscount*impliedDiscount << "\n"
+                << "    expected:   " << discount);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testImpliedObs) {


### PR DESCRIPTION
Also, auto-enable extrapolation based on the original curve for
consistency with other derived curves.