### PR TITLE
Add `FlatExtrapolator` wrapper for 1-D interpolations

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1040,6 +1040,7 @@
     <ClInclude Include="ql\math\interpolations\convexmonotoneinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\cubicinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\extrapolation.hpp" />
+    <ClInclude Include="ql\math\interpolations\flatextrapolation.hpp" />
     <ClInclude Include="ql\math\interpolations\flatextrapolation2d.hpp" />
     <ClInclude Include="ql\math\interpolations\forwardflatinterpolation.hpp" />
     <ClInclude Include="ql\math\interpolations\interpolation2d.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -1086,6 +1086,9 @@
     <ClInclude Include="ql\math\interpolations\extrapolation.hpp">
       <Filter>math\interpolations</Filter>
     </ClInclude>
+    <ClInclude Include="ql\math\interpolations\flatextrapolation.hpp">
+      <Filter>math\interpolations</Filter>
+    </ClInclude>
     <ClInclude Include="ql\math\interpolations\flatextrapolation2d.hpp">
       <Filter>math\interpolations</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -1469,6 +1469,7 @@ set(QL_HEADERS
     math/interpolations/convexmonotoneinterpolation.hpp
     math/interpolations/cubicinterpolation.hpp
     math/interpolations/extrapolation.hpp
+    math/interpolations/flatextrapolation.hpp
     math/interpolations/flatextrapolation2d.hpp
     math/interpolations/forwardflatinterpolation.hpp
     math/interpolations/interpolation2d.hpp

--- a/ql/math/interpolation.hpp
+++ b/ql/math/interpolation.hpp
@@ -140,6 +140,12 @@ namespace QuantLib {
         Real xMax() const {
             return impl_->xMax();
         }
+        std::vector<Real> xValues() const {
+            return impl_->xValues();
+        }
+        std::vector<Real> yValues() const {
+            return impl_->yValues();
+        }
         bool isInRange(Real x) const {
             return impl_->isInRange(x);
         }

--- a/ql/math/interpolations/Makefile.am
+++ b/ql/math/interpolations/Makefile.am
@@ -12,6 +12,7 @@ this_include_HEADERS = \
 	convexmonotoneinterpolation.hpp \
 	cubicinterpolation.hpp \
 	extrapolation.hpp \
+	flatextrapolation.hpp \
 	flatextrapolation2d.hpp \
 	forwardflatinterpolation.hpp \
 	interpolation2d.hpp \

--- a/ql/math/interpolations/all.hpp
+++ b/ql/math/interpolations/all.hpp
@@ -10,6 +10,7 @@
 #include <ql/math/interpolations/convexmonotoneinterpolation.hpp>
 #include <ql/math/interpolations/cubicinterpolation.hpp>
 #include <ql/math/interpolations/extrapolation.hpp>
+#include <ql/math/interpolations/flatextrapolation.hpp>
 #include <ql/math/interpolations/flatextrapolation2d.hpp>
 #include <ql/math/interpolations/forwardflatinterpolation.hpp>
 #include <ql/math/interpolations/interpolation2d.hpp>

--- a/ql/math/interpolations/flatextrapolation.hpp
+++ b/ql/math/interpolations/flatextrapolation.hpp
@@ -1,0 +1,105 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Junjie Guo
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file flatextrapolation.hpp
+    \brief flat extrapolation decorator for 1-D interpolations
+*/
+
+#ifndef quantlib_flatextrapolation_hpp
+#define quantlib_flatextrapolation_hpp
+
+#include <ql/math/interpolation.hpp>
+#include <utility>
+
+namespace QuantLib {
+
+    /*! \ingroup interpolations
+        Decorator that turns any 1-D interpolation into one that
+        extrapolates flat (i.e. clamping to the boundary values)
+        outside the original data range.
+
+        \warning See the Interpolation class for information about the
+                 required lifetime of the underlying data.
+    */
+    class FlatExtrapolator : public Interpolation {
+      public:
+        explicit FlatExtrapolator(ext::shared_ptr<Interpolation> decoratedInterpolation) {
+            impl_ = ext::make_shared<FlatExtrapolatorImpl>(
+                std::move(decoratedInterpolation));
+        }
+      protected:
+        class FlatExtrapolatorImpl : public Interpolation::Impl {
+          public:
+            explicit FlatExtrapolatorImpl(ext::shared_ptr<Interpolation> decoratedInterpolation)
+            : decoratedInterp_(std::move(decoratedInterpolation)) {
+                FlatExtrapolatorImpl::calculate();
+            }
+            Real xMin() const override { return decoratedInterp_->xMin(); }
+            Real xMax() const override { return decoratedInterp_->xMax(); }
+            std::vector<Real> xValues() const override {
+                return decoratedInterp_->xValues();
+            }
+            std::vector<Real> yValues() const override {
+                return decoratedInterp_->yValues();
+            }
+            bool isInRange(Real x) const override {
+                return decoratedInterp_->isInRange(x);
+            }
+            void update() override { decoratedInterp_->update(); }
+            Real value(Real x) const override {
+                return (*decoratedInterp_)(bind(x), true);
+            }
+            Real primitive(Real x) const override {
+                if (x < xMin())
+                    return decoratedInterp_->primitive(xMin(), true) +
+                           (*decoratedInterp_)(xMin(), true) * (x - xMin());
+                if (x > xMax())
+                    return decoratedInterp_->primitive(xMax(), true) +
+                           (*decoratedInterp_)(xMax(), true) * (x - xMax());
+                return decoratedInterp_->primitive(x, true);
+            }
+            Real derivative(Real x) const override {
+                if (x < xMin() || x > xMax())
+                    return 0.0;
+                return decoratedInterp_->derivative(x, true);
+            }
+            Real secondDerivative(Real x) const override {
+                if (x < xMin() || x > xMax())
+                    return 0.0;
+                return decoratedInterp_->secondDerivative(x, true);
+            }
+
+          private:
+            ext::shared_ptr<Interpolation> decoratedInterp_;
+
+            Real bind(Real x) const {
+                if (x < xMin())
+                    return xMin();
+                if (x > xMax())
+                    return xMax();
+                return x;
+            }
+
+            void calculate() { decoratedInterp_->update(); }
+        };
+    };
+
+}
+
+#endif

--- a/ql/math/interpolations/flatextrapolation.hpp
+++ b/ql/math/interpolations/flatextrapolation.hpp
@@ -25,6 +25,7 @@
 #define quantlib_flatextrapolation_hpp
 
 #include <ql/math/interpolation.hpp>
+#include <algorithm>
 #include <utility>
 
 namespace QuantLib {
@@ -89,11 +90,7 @@ namespace QuantLib {
             ext::shared_ptr<Interpolation> decoratedInterp_;
 
             Real bind(Real x) const {
-                if (x < xMin())
-                    return xMin();
-                if (x > xMax())
-                    return xMax();
-                return x;
+                return std::clamp(x, xMin(), xMax());
             }
 
             void calculate() { decoratedInterp_->update(); }

--- a/ql/math/interpolations/flatextrapolation.hpp
+++ b/ql/math/interpolations/flatextrapolation.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
                 std::move(decoratedInterpolation));
         }
       protected:
-        class FlatExtrapolatorImpl : public Interpolation::Impl {
+        class FlatExtrapolatorImpl final : public Interpolation::Impl {
           public:
             explicit FlatExtrapolatorImpl(ext::shared_ptr<Interpolation> decoratedInterpolation)
             : decoratedInterp_(std::move(decoratedInterpolation)) {

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -19,6 +19,7 @@
 
 #include <ql/math/integrals/gaussianquadratures.hpp>
 #include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/math/interpolations/flatextrapolation.hpp>
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/models/shortrate/onefactormodels/markovfunctional.hpp>
 #include <ql/termstructures/volatility/atmadjustedsmilesection.hpp>
@@ -218,10 +219,12 @@ namespace QuantLib {
         discreteNumeraire_ = ext::make_shared<Matrix>(
             times_.size(), 2 * modelSettings_.yGridPoints_ + 1, 1.0);
         for (Size i = 0; i < times_.size(); i++) {
-            ext::shared_ptr<Interpolation> numInt(new CubicInterpolation(
+            auto cubicInt = ext::make_shared<CubicInterpolation>(
                 y_.begin(), y_.end(), discreteNumeraire_->row_begin(i),
                 CubicInterpolation::Spline, true, CubicInterpolation::Lagrange,
-                0.0, CubicInterpolation::Lagrange, 0.0));
+                0.0, CubicInterpolation::Lagrange, 0.0);
+            cubicInt->enableExtrapolation();
+            auto numInt = ext::make_shared<FlatExtrapolator>(cubicInt);
             numInt->enableExtrapolation();
             numeraire_.push_back(numInt);
         }
@@ -723,18 +726,10 @@ namespace QuantLib {
         Real dt = tb - ta;
 
         for (Size j = 0; j < y.size(); j++) {
-            Real yv = y[j];
-            if (yv < y_.front())
-                yv = y_.front();
-            // FIXME flat extrapolation should be incoperated into interpolation
-            // object, see above
-            if (yv > y_.back())
-                yv = y_.back();
-            Real na = (*numeraire_[i - 1])(yv);
-            Real nb = (*numeraire_[i])(yv);
+            Real na = (*numeraire_[i - 1])(y[j]);
+            Real nb = (*numeraire_[i])(y[j]);
             res[j] =
                 inverseNormalization / ((tz - ta) / nb + (tb - tz) / na) * dt;
-            // linear in reciprocal of normalized numeraire
         }
 
         return res;

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -34,6 +34,7 @@
 #include <ql/math/interpolations/bicubicsplineinterpolation.hpp>
 #include <ql/math/interpolations/chebyshevinterpolation.hpp>
 #include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/math/interpolations/flatextrapolation.hpp>
 #include <ql/math/interpolations/forwardflatinterpolation.hpp>
 #include <ql/math/interpolations/kernelinterpolation.hpp>
 #include <ql/math/interpolations/kernelinterpolation2d.hpp>
@@ -2881,6 +2882,122 @@ BOOST_AUTO_TEST_CASE(testLaplaceInterpolation) {
         QL_CHECK_CLOSE(v, 1.0, 0.1);
     }
 
+}
+
+BOOST_AUTO_TEST_CASE(testFlatExtrapolation) {
+
+    BOOST_TEST_MESSAGE("Testing flat extrapolation of 1-D interpolation...");
+
+    const Real x[] = { 0.0, 1.0, 2.0, 3.0, 4.0 };
+    const Real y[] = { 5.0, 3.0, 4.0, 2.0, 1.0 };
+    const Size N = std::size(x);
+
+    auto cubic = ext::make_shared<CubicInterpolation>(
+        std::begin(x), std::end(x), std::begin(y),
+        CubicInterpolation::Spline, false,
+        CubicInterpolation::SecondDerivative, 0.0,
+        CubicInterpolation::SecondDerivative, 0.0);
+    cubic->enableExtrapolation();
+
+    FlatExtrapolator f(cubic);
+
+    Real tolerance = 1.0e-12;
+
+    // extrapolation not allowed by default
+    try {
+        f(-1.0);
+        BOOST_ERROR("failed to throw when extrapolating without permission");
+    } catch (Error&) {
+        // expected
+    }
+
+    f.enableExtrapolation();
+
+    // in-range: must match underlying cubic at knots
+    for (Size i = 0; i < N; ++i) {
+        Real calculated = f(x[i]);
+        Real expected = y[i];
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("in-range mismatch at x=" << x[i]
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // in-range at midpoints: must match underlying cubic
+    for (Size i = 0; i < N - 1; ++i) {
+        Real mid = (x[i] + x[i + 1]) / 2.0;
+        Real calculated = f(mid);
+        Real expected = (*cubic)(mid);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("in-range mismatch at midpoint x=" << mid
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // below range: flat at y[0]
+    for (Real p : { -2.0, -1.0, -0.01 }) {
+        Real calculated = f(p);
+        Real expected = y[0];
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("flat extrapolation below range failed at " << p
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // above range: flat at y[N-1]
+    for (Real p : { 4.01, 5.0, 10.0 }) {
+        Real calculated = f(p);
+        Real expected = y[N - 1];
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("flat extrapolation above range failed at " << p
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // derivative outside range is zero
+    Real calc = f.derivative(-1.0);
+    if (std::fabs(calc) > tolerance)
+        BOOST_ERROR("derivative should be zero below range"
+                    << "\n    calculated: " << calc);
+    calc = f.derivative(5.0);
+    if (std::fabs(calc) > tolerance)
+        BOOST_ERROR("derivative should be zero above range"
+                    << "\n    calculated: " << calc);
+
+    // second derivative outside range is zero
+    calc = f.secondDerivative(-1.0);
+    if (std::fabs(calc) > tolerance)
+        BOOST_ERROR("second derivative should be zero below range"
+                    << "\n    calculated: " << calc);
+    calc = f.secondDerivative(5.0);
+    if (std::fabs(calc) > tolerance)
+        BOOST_ERROR("second derivative should be zero above range"
+                    << "\n    calculated: " << calc);
+
+    // derivative inside range matches underlying
+    for (Real p : { 0.5, 1.5, 2.5, 3.5 }) {
+        Real calculated = f.derivative(p);
+        Real expected = cubic->derivative(p);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("in-range derivative mismatch at x=" << p
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -2998,6 +2998,100 @@ BOOST_AUTO_TEST_CASE(testFlatExtrapolation) {
                         << std::scientific
                         << "\n    error:      " << std::fabs(calculated - expected));
     }
+
+    // second derivative inside range matches underlying
+    for (Real p : { 0.5, 1.5, 2.5, 3.5 }) {
+        Real calculated = f.secondDerivative(p);
+        Real expected = cubic->secondDerivative(p);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("in-range second derivative mismatch at x=" << p
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // primitive below range
+    {
+        Real calculated = f.primitive(-1.0);
+        Real expected = cubic->primitive(x[0], true) + y[0] * (-1.0 - x[0]);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("primitive below range mismatch at x=-1.0"
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // primitive above range
+    {
+        Real calculated = f.primitive(5.0);
+        Real expected = cubic->primitive(x[N - 1], true) + y[N - 1] * (5.0 - x[N - 1]);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("primitive above range mismatch at x=5.0"
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // primitive inside range matches underlying
+    for (Real p : { 0.5, 1.5, 2.5, 3.5 }) {
+        Real calculated = f.primitive(p);
+        Real expected = cubic->primitive(p);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("in-range primitive mismatch at x=" << p
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
+
+    // xValues and yValues accessors
+    std::vector<Real> xs = f.xValues();
+    std::vector<Real> ys = f.yValues();
+    if (xs.size() != N)
+        BOOST_ERROR("xValues size mismatch"
+                    << "\n    expected: " << N
+                    << "\n    got:      " << xs.size());
+    if (ys.size() != N)
+        BOOST_ERROR("yValues size mismatch"
+                    << "\n    expected: " << N
+                    << "\n    got:      " << ys.size());
+    for (Size i = 0; i < N; ++i) {
+        if (std::fabs(xs[i] - x[i]) > tolerance)
+            BOOST_ERROR("xValues mismatch at index " << i
+                        << "\n    expected: " << x[i]
+                        << "\n    got:      " << xs[i]);
+        if (std::fabs(ys[i] - y[i]) > tolerance)
+            BOOST_ERROR("yValues mismatch at index " << i
+                        << "\n    expected: " << y[i]
+                        << "\n    got:      " << ys[i]);
+    }
+
+    // isInRange
+    if (!f.isInRange(2.0))
+        BOOST_ERROR("isInRange should return true for x=2.0");
+    if (f.isInRange(-1.0))
+        BOOST_ERROR("isInRange should return false for x=-1.0");
+
+    // update smoke test
+    f.update();
+    {
+        Real calculated = f(2.0);
+        Real expected = (*cubic)(2.0);
+        if (std::fabs(calculated - expected) > tolerance)
+            BOOST_ERROR("mismatch after update at x=2.0"
+                        << std::fixed
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << calculated
+                        << std::scientific
+                        << "\n    error:      " << std::fabs(calculated - expected));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Use it in MarkovFunctional to replace manual clamping logic, resolving the existing FIXME about incorporating flat extrapolation into the interpolation object.