### PR TITLE
Deprecated obsolete bits of interpolation code in year-on-year inflation indexes

### DIFF
--- a/ql/cashflows/cpicoupon.hpp
+++ b/ql/cashflows/cpicoupon.hpp
@@ -243,7 +243,7 @@ namespace QuantLib {
         DayCounter paymentDayCounter_;
         BusinessDayConvention paymentAdjustment_ = ModifiedFollowing;
         Calendar paymentCalendar_;
-        CPI::InterpolationType observationInterpolation_ = CPI::AsIndex;
+        CPI::InterpolationType observationInterpolation_ = CPI::Flat;
         bool subtractInflationNominal_ = true;
         std::vector<Rate> caps_, floors_;
         Period exCouponPeriod_;

--- a/ql/experimental/inflation/cpicapfloorengines.cpp
+++ b/ql/experimental/inflation/cpicapfloorengines.cpp
@@ -54,7 +54,9 @@ namespace QuantLib {
 
 
         // what interpolation do we use? Index / flat / linear
+        QL_DEPRECATED_DISABLE_WARNING
         if (arguments_.observationInterpolation == CPI::AsIndex) {
+        QL_DEPRECATED_ENABLE_WARNING
             // same as index means we can just use the price surface
             // since this uses the index
             if (arguments_.type == Option::Call) {

--- a/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
+++ b/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
@@ -113,7 +113,7 @@ namespace QuantLib {
         capfloor_ =
             MakeYoYInflationCapFloor(type, anIndex,
                                      (Size)std::floor(0.5+surf->timeFromReference(surf->minMaturity())),
-                                     surf->calendar(), lag, CPI::AsIndex)
+                                     surf->calendar(), lag, CPI::Flat)
             .withNominal(10000.0)
             .withStrike(K);
 

--- a/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
+++ b/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
@@ -105,7 +105,7 @@ namespace QuantLib {
         ext::shared_ptr<YoYInflationCapFloorEngine> p,
         Real priceToMatch)
     : slope_(slope), K_(K), frequency_(anIndex->frequency()),
-      indexIsInterpolated_(anIndex->interpolated()), tvec_(std::vector<Time>(2)),
+      indexIsInterpolated_(false), tvec_(std::vector<Time>(2)),
       dvec_(std::vector<Date>(2)), vvec_(std::vector<Volatility>(2)), priceToMatch_(priceToMatch),
       surf_(surf), p_(std::move(p)) {
 

--- a/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
+++ b/ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp
@@ -112,7 +112,7 @@ namespace QuantLib {
                                     dc,
                                     lag,
                                     capFloorPrices->yoyIndex()->frequency(),
-                                    capFloorPrices->yoyIndex()->interpolated(),
+                                    false,
                                     volType,
                                     displacement),
       capFloorPrices_(capFloorPrices), yoyInflationCouponPricer_(std::move(pricer)),

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -244,12 +244,14 @@ namespace QuantLib {
     }
 
 
+    QL_DEPRECATED_DISABLE_WARNING
+
     YoYInflationIndex::YoYInflationIndex(const ext::shared_ptr<ZeroInflationIndex>& underlyingIndex,
                                          Handle<YoYInflationTermStructure> yoyInflation)
     : InflationIndex("YYR_" + underlyingIndex->familyName(), underlyingIndex->region(),
                      underlyingIndex->revised(), underlyingIndex->frequency(),
                      underlyingIndex->availabilityLag(), underlyingIndex->currency()),
-      interpolated_(false), ratio_(true), underlyingIndex_(underlyingIndex),
+      ratio_(true), underlyingIndex_(underlyingIndex),
       yoyInflation_(std::move(yoyInflation)) {
         registerWith(underlyingIndex_);
         registerWith(yoyInflation_);
@@ -263,10 +265,11 @@ namespace QuantLib {
                                          const Currency& currency,
                                          Handle<YoYInflationTermStructure> yoyInflation)
     : InflationIndex(familyName, region, revised, frequency, availabilityLag, currency),
-      interpolated_(false), ratio_(false), yoyInflation_(std::move(yoyInflation)) {
+      ratio_(false), yoyInflation_(std::move(yoyInflation)) {
         registerWith(yoyInflation_);
     }
 
+    QL_DEPRECATED_ENABLE_WARNING
 
     Rate YoYInflationIndex::fixing(const Date& fixingDate,
                                    bool /*forecastTodaysFixing*/) const {
@@ -293,10 +296,12 @@ namespace QuantLib {
 
         auto fixingPeriod = inflationPeriod(fixingDate, frequency_);
         Date latestNeededDate;
+        QL_DEPRECATED_DISABLE_WARNING
         if (!interpolated() || fixingDate == fixingPeriod.first)
             latestNeededDate = fixingPeriod.first;
         else
             latestNeededDate = fixingPeriod.second + 1;
+        QL_DEPRECATED_ENABLE_WARNING
 
         if (ratio()) {
             return underlyingIndex_->needsForecast(latestNeededDate);
@@ -322,7 +327,9 @@ namespace QuantLib {
     Real YoYInflationIndex::pastFixing(const Date& fixingDate) const {
         if (ratio()) {
 
+            QL_DEPRECATED_DISABLE_WARNING
             auto interpolationType = interpolated() ? CPI::Linear : CPI::Flat;
+            QL_DEPRECATED_ENABLE_WARNING
 
             Rate pastFixing = CPI::laggedFixing(underlyingIndex_, fixingDate, Period(0, Months), interpolationType);
             Rate previousFixing = CPI::laggedFixing(underlyingIndex_, fixingDate - 1*Years, Period(0, Months), interpolationType);
@@ -338,7 +345,10 @@ namespace QuantLib {
             QL_REQUIRE(YY0 != Null<Rate>(),
                        "Missing " << name() << " fixing for " << periodStart);
 
-            if (!interpolated() || /* degenerate case */ fixingDate == periodStart) {
+            QL_DEPRECATED_DISABLE_WARNING
+            bool is_interpolated = interpolated();
+            QL_DEPRECATED_ENABLE_WARNING
+            if (!is_interpolated || /* degenerate case */ fixingDate == periodStart) {
 
                 return YY0;
 
@@ -358,7 +368,10 @@ namespace QuantLib {
     Real YoYInflationIndex::forecastFixing(const Date& fixingDate) const {
 
         Date d;
-        if (interpolated()) {
+        QL_DEPRECATED_DISABLE_WARNING
+        bool is_interpolated = interpolated();
+        QL_DEPRECATED_ENABLE_WARNING
+        if (is_interpolated) {
             d = fixingDate;
         } else {
             // if the value is not interpolated use the starting value
@@ -394,7 +407,9 @@ namespace QuantLib {
     detail::CPI::effectiveInterpolationType(const QuantLib::CPI::InterpolationType& type,
                                             const ext::shared_ptr<YoYInflationIndex>& index) {
         if (type == QuantLib::CPI::AsIndex) {
+            QL_DEPRECATED_DISABLE_WARNING
             return index->interpolated() ? QuantLib::CPI::Linear : QuantLib::CPI::Flat;
+            QL_DEPRECATED_ENABLE_WARNING
         } else {
             return type;
         }

--- a/ql/indexes/inflationindex.cpp
+++ b/ql/indexes/inflationindex.cpp
@@ -31,7 +31,9 @@ namespace QuantLib {
                            CPI::InterpolationType interpolationType) {
 
         switch (interpolationType) {
+          QL_DEPRECATED_DISABLE_WARNING
           case AsIndex:
+          QL_DEPRECATED_ENABLE_WARNING
           case Flat: {
               auto fixingPeriod = inflationPeriod(date - observationLag, index->frequency());
               return index->fixing(fixingPeriod.first);
@@ -68,9 +70,11 @@ namespace QuantLib {
                             CPI::InterpolationType interpolationType) {
 
         switch (interpolationType) {
+          QL_DEPRECATED_DISABLE_WARNING
           case AsIndex: {
               return index->fixing(date - observationLag);
           }
+          QL_DEPRECATED_ENABLE_WARNING
           case Flat: {
               auto fixingPeriod = inflationPeriod(date - observationLag, index->frequency());
               return index->fixing(fixingPeriod.first);
@@ -396,23 +400,25 @@ namespace QuantLib {
 
     CPI::InterpolationType
     detail::CPI::effectiveInterpolationType(const QuantLib::CPI::InterpolationType& type) {
+        QL_DEPRECATED_DISABLE_WARNING
         if (type == QuantLib::CPI::AsIndex) {
             return QuantLib::CPI::Flat;
         } else {
             return type;
         }
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     CPI::InterpolationType
     detail::CPI::effectiveInterpolationType(const QuantLib::CPI::InterpolationType& type,
                                             const ext::shared_ptr<YoYInflationIndex>& index) {
+        QL_DEPRECATED_DISABLE_WARNING
         if (type == QuantLib::CPI::AsIndex) {
-            QL_DEPRECATED_DISABLE_WARNING
             return index->interpolated() ? QuantLib::CPI::Linear : QuantLib::CPI::Flat;
-            QL_DEPRECATED_ENABLE_WARNING
         } else {
             return type;
         }
+        QL_DEPRECATED_ENABLE_WARNING
     }
 
     bool detail::CPI::isInterpolated(const QuantLib::CPI::InterpolationType& type) {

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -213,6 +213,10 @@ namespace QuantLib {
             const Currency& currency,
             Handle<YoYInflationTermStructure> ts = {});
 
+        QL_DEPRECATED_DISABLE_WARNING
+        ~YoYInflationIndex() = default;
+        QL_DEPRECATED_ENABLE_WARNING
+
         //! \name Index interface
         //@{
         /*! \warning the forecastTodaysFixing parameter (required by
@@ -225,6 +229,10 @@ namespace QuantLib {
         //! \name Other methods
         //@{
         Date lastFixingDate() const;
+        /*! \deprecated Indexes no longer interpolate, coupons do.
+                        Deprecated in version 1.43.
+        */
+        [[deprecated("Indexes no longer interpolate, coupons do")]]
         bool interpolated() const;
         bool ratio() const;
         ext::shared_ptr<ZeroInflationIndex> underlyingIndex() const;
@@ -235,7 +243,11 @@ namespace QuantLib {
         //@}
 
       protected:
-        bool interpolated_;
+        /*! \deprecated Indexes no longer interpolate, coupons do.
+                        Deprecated in version 1.43.
+        */
+        [[deprecated("Indexes no longer interpolate, coupons do")]]
+        bool interpolated_ = false;
 
       private:
         Rate forecastFixing(const Date& fixingDate) const;
@@ -301,9 +313,11 @@ namespace QuantLib {
         return zeroInflation_;
     }
 
+    QL_DEPRECATED_DISABLE_WARNING
     inline bool YoYInflationIndex::interpolated() const {
         return interpolated_;
     }
+    QL_DEPRECATED_ENABLE_WARNING
 
     inline bool YoYInflationIndex::ratio() const {
         return ratio_;

--- a/ql/indexes/inflationindex.hpp
+++ b/ql/indexes/inflationindex.hpp
@@ -39,10 +39,13 @@ namespace QuantLib {
     struct CPI {
 
         //! when you observe an index, how do you interpolate between fixings?
+        /*! AsIndex was used to facilitate migration from the index to
+            the coupons using it.  Deprecated in version 1.43.
+        */
         enum InterpolationType {
-            AsIndex, //!< same interpolation as index
-            Flat,    //!< flat from previous fixing
-            Linear   //!< linearly between bracketing fixings
+            AsIndex [[deprecated("Use either Linear or Flat")]] = 0, //!< same interpolation as index
+            Flat = 1,    //!< flat from previous fixing
+            Linear = 2   //!< linearly between bracketing fixings
         };
 
         //! interpolated inflation fixing

--- a/ql/instruments/cpicapfloor.hpp
+++ b/ql/instruments/cpicapfloor.hpp
@@ -76,7 +76,7 @@ namespace QuantLib {
                     Rate strike,
                     ext::shared_ptr<ZeroInflationIndex>  inflationIndex,
                     const Period& observationLag,
-                    CPI::InterpolationType observationInterpolation = CPI::AsIndex);
+                    CPI::InterpolationType observationInterpolation = CPI::Flat);
 
         //! \name Inspectors
         //@{

--- a/ql/instruments/cpiswap.hpp
+++ b/ql/instruments/cpiswap.hpp
@@ -88,7 +88,7 @@ namespace QuantLib {
                 const BusinessDayConvention& fixedRoll,
                 const Period& observationLag,
                 ext::shared_ptr<ZeroInflationIndex> fixedIndex,
-                CPI::InterpolationType observationInterpolation = CPI::AsIndex,
+                CPI::InterpolationType observationInterpolation = CPI::Flat,
                 Real inflationNominal = Null<Real>());
 
         // results

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -371,10 +371,11 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
     Period observationLag = Period(3, Months);
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
+    CPI::InterpolationType interpolation = CPI::Flat;
 
     auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
         return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex);
+            quote, observationLag, maturity, calendar, bdc, dc, ii, interpolation);
     };
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
 
@@ -405,7 +406,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
                                       calendar, bdc, dc,
                                       datum.rate/100.0,
                                       ii, observationLag,
-                                      CPI::AsIndex);
+                                      interpolation);
         nzcis.setPricingEngine(engine);
 
         BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
@@ -421,7 +422,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
                                             calendar, bdc, dc,
                                             datum.rate/100.0 + basisPoint,
                                             ii, observationLag,
-                                            CPI::AsIndex);
+                                            interpolation);
         nzcisBumped.setPricingEngine(engine);
 
         const Real expected = nzcisBumped.legNPV(0) - nzcis.legNPV(0);
@@ -494,7 +495,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructure) {
                                       calendar, bdc, dc,
                                       datum.rate/100.0,
                                       ii, observationLag,
-                                      CPI::AsIndex);
+                                      interpolation);
         nzcis.setPricingEngine(engine);
 
         BOOST_CHECK_MESSAGE(std::fabs(nzcis.NPV()) < eps,
@@ -514,6 +515,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructureLazyBaseDate) {
     Calendar calendar = UnitedKingdom();
     BusinessDayConvention bdc = ModifiedFollowing;
     Period observationLag = Period(3, Months);
+    CPI::InterpolationType interpolation = CPI::Flat;
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
     Date evaluationDate(13, August, 2007);
@@ -547,7 +549,7 @@ BOOST_AUTO_TEST_CASE(testZeroTermStructureLazyBaseDate) {
         quotes.push_back(ext::make_shared<SimpleQuote>());
         helpers.push_back(ext::make_shared<ZeroCouponInflationSwapHelper>(
             Handle<Quote>(quotes.back()), observationLag, datum.date, calendar, bdc, dc,
-            ii, CPI::AsIndex));
+            ii, interpolation));
     }
 
     // Create a curve that will use lastFixingDate as the baseDate. The fixings
@@ -1160,11 +1162,12 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
 
     Period observationLag = Period(2,Months);
     DayCounter dc = Thirty360(Thirty360::BondBasis);
+    CPI::InterpolationType interpolation = CPI::Flat;
 
     // now build the helpers ...
     auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
         return ext::make_shared<YearOnYearInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, iir, CPI::AsIndex,
+            quote, observationLag, maturity, calendar, bdc, dc, iir, interpolation,
             Handle<YieldTermStructure>(nominalTS));
     };
     auto helpers = makeHelpers<YoYInflationTermStructure>(yyData, makeHelper);
@@ -1211,7 +1214,7 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
                                      yoySchedule,
                                      iir,
                                      observationLag,
-                                     CPI::Flat,
+                                     interpolation,
                                      0.0,        //spread on index
                                      dc,
                                      UnitedKingdom());
@@ -1248,7 +1251,7 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
                                      yoySchedule,
                                      iir,
                                      observationLag,
-                                     CPI::Flat,
+                                     interpolation,
                                      0.0,        //spread on index
                                      dc,
                                      UnitedKingdom());
@@ -1404,6 +1407,7 @@ BOOST_AUTO_TEST_CASE(testCpiLinearInterpolation) {
     QL_CHECK_CLOSE(calculated, expected, 1e-8);
 }
 
+QL_DEPRECATED_DISABLE_WARNING
 BOOST_AUTO_TEST_CASE(testCpiAsIndexInterpolation) {
     BOOST_TEST_MESSAGE("Testing CPI as-index interpolation for inflation fixings...");
 
@@ -1438,6 +1442,7 @@ BOOST_AUTO_TEST_CASE(testCpiAsIndexInterpolation) {
 
     QL_CHECK_CLOSE(calculated, expected, 1e-8);
 }
+QL_DEPRECATED_ENABLE_WARNING
 
 BOOST_AUTO_TEST_CASE(testCpiYoYQuotedFlatInterpolation) {
     BOOST_TEST_MESSAGE("Testing CPI flat interpolation for year-on-year quoted rates...");
@@ -1663,10 +1668,11 @@ BOOST_AUTO_TEST_CASE(testExtrapolationRegression) {
     Period observationLag = Period(3, Months);
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     Frequency frequency = Monthly;
+    CPI::InterpolationType interpolation = CPI::Flat;
 
     auto makeHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
         return ext::make_shared<ZeroCouponInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, rpi, CPI::AsIndex);
+            quote, observationLag, maturity, calendar, bdc, dc, rpi, interpolation);
     };
     auto helpers = makeHelpers<ZeroInflationTermStructure>(zcData, makeHelper);
 
@@ -1704,7 +1710,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolationRegression) {
     // now build the helpers ...
     auto makeYoYHelper = [&](const Handle<Quote>& quote, const Date& maturity) {
         return ext::make_shared<YearOnYearInflationSwapHelper>(
-            quote, observationLag, maturity, calendar, bdc, dc, yoy, CPI::AsIndex,
+            quote, observationLag, maturity, calendar, bdc, dc, yoy, interpolation,
             Handle<YieldTermStructure>(nominalTS));
     };
     auto yoyHelpers = makeHelpers<YoYInflationTermStructure>(yyData, makeYoYHelper);

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -932,6 +932,7 @@ BOOST_AUTO_TEST_CASE(testQuotedYYIndex) {
     BOOST_TEST_MESSAGE("Testing quoted year-on-year inflation indices...");
 
     YYUKRPI yyukrpi;
+    QL_DEPRECATED_DISABLE_WARNING
     if (yyukrpi.name() != "UK YY_RPI"
         || yyukrpi.frequency() != Monthly
         || yyukrpi.revised()
@@ -946,6 +947,7 @@ BOOST_AUTO_TEST_CASE(testQuotedYYIndex) {
                     << yyukrpi.ratio() << ", "
                     << yyukrpi.availabilityLag() << ")");
     }
+    QL_DEPRECATED_ENABLE_WARNING
 }
 
 BOOST_AUTO_TEST_CASE(testQuotedYYIndexFutureFixing) {
@@ -990,6 +992,7 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndex) {
     auto ukrpi = ext::make_shared<UKRPI>();
 
     YoYInflationIndex yyukrpir(ukrpi);
+    QL_DEPRECATED_DISABLE_WARNING
     if (yyukrpir.name() != "UK YYR_RPI"
         || yyukrpir.frequency() != Monthly
         || yyukrpir.revised()
@@ -1004,7 +1007,7 @@ BOOST_AUTO_TEST_CASE(testRatioYYIndex) {
                     << yyukrpir.ratio() << ", "
                     << yyukrpir.availabilityLag() << ")");
     }
-
+    QL_DEPRECATED_ENABLE_WARNING
 
     // Retrieval test.
     //----------------

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -215,7 +215,7 @@ struct CommonVars {
                                                        dc,
                                                        observationLag,
                                                        frequency,
-                                                       iir->interpolated()));
+                                                       false));
 
 
         switch (which) {

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -251,7 +251,7 @@ struct CommonVars {
                                 dc,
                                 observationLag,
                                 frequency,
-                                iir->interpolated()));
+                                false));
 
         ext::shared_ptr<YoYInflationCouponPricer> pricer;
         switch (which) {
@@ -313,7 +313,7 @@ struct CommonVars {
                             dc,
                             observationLag,
                             frequency,
-                            iir->interpolated()));
+                            false));
 
 
         switch (which) {

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -66,7 +66,7 @@ std::vector<ext::shared_ptr<Helper> > makeHelpers(
         Handle<Quote> quote(ext::shared_ptr<Quote>(
                                 new SimpleQuote(datum.rate/100.0)));
         auto h = ext::make_shared<ZeroCouponInflationSwapHelper>(
-                quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::AsIndex);
+                quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::Flat);
         instruments.push_back(h);
     }
     return instruments;

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -70,7 +70,7 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
         Handle<Quote> quote(ext::shared_ptr<Quote>(
                                 new SimpleQuote(iiData[i].rate/100.0)));
         auto anInstrument = ext::make_shared<U>(quote, observationLag, maturity,
-                                                calendar, bdc, dc, ii, CPI::AsIndex);
+                                                calendar, bdc, dc, ii, CPI::Flat);
         instruments.push_back(anInstrument);
     }
 
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(cpicapfloorpricer) {
     Calendar fixCalendar = UnitedKingdom(), payCalendar = UnitedKingdom();
     BusinessDayConvention fixConvention(Unadjusted), payConvention(ModifiedFollowing);
     Rate strike(0.03);
-    CPI::InterpolationType observationInterpolation = CPI::AsIndex;
+    CPI::InterpolationType observationInterpolation = CPI::Linear; // because the surface interpolates
     Real baseCPI = CPI::laggedFixing(common.ii, startDate, common.observationLag, observationInterpolation);
     CPICapFloor aCap(Option::Call,
                      nominal,

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -63,11 +63,10 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
     std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
     for (Size i=0; i<N; i++) {
         Date maturity = iiData[i].date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(
-                                new SimpleQuote(iiData[i].rate/100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(iiData[i].rate/100.0));
         auto anInstrument = ext::make_shared<U>(quote, observationLag, maturity,
                                                 calendar, bdc, dc, ii,
-                                                CPI::AsIndex);
+                                                CPI::Flat);
         instruments.push_back(anInstrument);
     }
 
@@ -360,17 +359,18 @@ BOOST_AUTO_TEST_CASE(zciisconsistency) {
     CommonVars common;
 
     Swap::Type ztype = Swap::Payer;
-    Real  nominal = 1000000.0;
+    Real nominal = 1000000.0;
     Date startDate(common.evaluationDate);
     Date endDate(25, November, 2059);
     Calendar cal = UnitedKingdom();
     BusinessDayConvention paymentConvention = ModifiedFollowing;
     DayCounter dummyDC, dc = ActualActual(ActualActual::ISDA);
     Period observationLag(2,Months);
+    CPI::InterpolationType interpolation = CPI::Flat;
 
     Rate quote = 0.03714;
     ZeroCouponInflationSwap zciis(ztype, nominal, startDate, endDate, cal, paymentConvention, dc,
-                                  quote, common.ii, observationLag, CPI::AsIndex);
+                                  quote, common.ii, observationLag, interpolation);
 
     // simple structure so simple pricing engine - most work done by index
     ext::shared_ptr<DiscountingSwapEngine>
@@ -388,14 +388,14 @@ BOOST_AUTO_TEST_CASE(zciisconsistency) {
     bool subtractInflationNominal = true;
     Real dummySpread=0.0, dummyFixedRate=0.0;
     Natural fixingDays = 0;
-    Real baseCPI = CPI::laggedFixing(common.ii, startDate, observationLag, CPI::AsIndex);
+    Real baseCPI = CPI::laggedFixing(common.ii, startDate, observationLag, interpolation);
 
     ext::shared_ptr<IborIndex> dummyFloatIndex;
 
     CPISwap cS(stype, floatNominal, subtractInflationNominal, dummySpread, dummyDC, schOneDate,
                paymentConvention, fixingDays, dummyFloatIndex,
                dummyFixedRate, baseCPI, dummyDC, schOneDate, paymentConvention, observationLag,
-               common.ii, CPI::AsIndex, inflationNominal);
+               common.ii, interpolation, inflationNominal);
 
     cS.setPricingEngine(dse);
     QL_REQUIRE(fabs(cS.NPV())<1e-3,"CPISwap as ZCIIS does not reprice to zero");


### PR DESCRIPTION
Inflation indexes no longer interpolate; inflation coupons do.  Accordingly, the following are no longer relevant:
- The `interpolated()` method in the `YoYInflationIndex` class.
- The corresponding `interpolated_` data member.
- The `AsIndex` case of the `CPI:: InterpolationType` enumeration.
