### PR TITLE
Pass `allowExtrapolation=true` to mixed-interpolation `derivative()`

### DIFF
--- a/ql/math/interpolations/mixedinterpolation.hpp
+++ b/ql/math/interpolations/mixedinterpolation.hpp
@@ -78,7 +78,7 @@ namespace QuantLib {
                 if (!matchDerivatives) return;
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
                 auto& cubicImpl = static_cast<detail::CubicInterpolationBaseImpl&>(*right.impl_);
-                cubicImpl.leftValue_ = left.derivative(x);
+                cubicImpl.leftValue_ = left.derivative(x, true);
             };
             impl_ = ext::make_shared<detail::MixedInterpolationImpl<I1, I2, decltype(switchFn)>>(
                 xBegin, xEnd, yBegin, n, behavior,


### PR DESCRIPTION
For consistency with other calls.