### PR TITLE
Make `performCalculations` methods protected on some curves

### DIFF
--- a/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp
@@ -89,9 +89,10 @@ namespace QuantLib {
         //@{
         void update() override;
         //@}
+      protected:
+        void performCalculations() const override;
       private:
         // methods
-        void performCalculations() const override;
         Rate yoyRateImpl(Time t) const override;
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;

--- a/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
+++ b/ql/termstructures/inflation/piecewisezeroinflationcurve.hpp
@@ -108,9 +108,10 @@ namespace QuantLib {
         //@{
         void update() override;
         //@}
+      protected:
+        void performCalculations() const override;
       private:
         // methods
-        void performCalculations() const override;
         Rate zeroRateImpl(Time t) const override;
         // data members
         std::vector<ext::shared_ptr<typename Traits::helper> > instruments_;

--- a/ql/termstructures/yield/piecewiseyieldcurve.hpp
+++ b/ql/termstructures/yield/piecewiseyieldcurve.hpp
@@ -163,11 +163,11 @@ namespace QuantLib {
           accuracy_(1.0e-12), bootstrap_(std::move(bootstrap)) {
             bootstrap_.setup(this);
         }
-      private:
         //! \name LazyObject interface
         //@{
         void performCalculations() const override;
         //@}
+      private:
         // methods
         DiscountFactor discountImpl(Time) const override;
         // data members


### PR DESCRIPTION
Having them private does not actually prevent subclasses from overriding them, but it prevents subclasses from calling parent classes' implementations.