### PR TITLE
Add term structure to G2 processes

### DIFF
--- a/ql/processes/g2process.cpp
+++ b/ql/processes/g2process.cpp
@@ -22,10 +22,14 @@
 
 namespace QuantLib {
 
-    G2Process::G2Process(Real a, Real sigma, Real b, Real eta, Real rho)
+    G2Process::G2Process(const Handle<YieldTermStructure>& termStructure,
+                         Real a, Real sigma, Real b, Real eta, Real rho)
     : a_(a), sigma_(sigma), b_(b), eta_(eta), rho_(rho),
       xProcess_(new QuantLib::OrnsteinUhlenbeckProcess(a, sigma, 0.0)),
-      yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)) {}
+      yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)),
+      termStructure_(termStructure) {
+        registerWith(termStructure_);
+    }
 
     Size G2Process::size() const {
         return 2;
@@ -123,11 +127,32 @@ namespace QuantLib {
         return rho_;
     }
 
+    const Handle<YieldTermStructure>& G2Process::termStructure() const {
+        return termStructure_;
+    }
 
-    G2ForwardProcess::G2ForwardProcess(Real a, Real sigma, Real b, Real eta, Real rho)
+    Real G2Process::phi(Time t) const {
+        QL_REQUIRE(!termStructure_.empty(),
+                   "no term structure given to G2Process");
+        Rate forward = termStructure_->forwardRate(t, t, Continuous, NoFrequency);
+        Real temp1 = sigma_*(1.0-std::exp(-a_*t))/a_;
+        Real temp2 = eta_ *(1.0-std::exp(-b_*t))/b_;
+        return 0.5*temp1*temp1 + 0.5*temp2*temp2 + rho_*temp1*temp2 + forward;
+    }
+
+    Rate G2Process::shortRate(Time t, Real x, Real y) const {
+        return x + y + phi(t);
+    }
+
+
+    G2ForwardProcess::G2ForwardProcess(const Handle<YieldTermStructure>& termStructure,
+                                       Real a, Real sigma, Real b, Real eta, Real rho)
     : a_(a), sigma_(sigma), b_(b), eta_(eta), rho_(rho),
       xProcess_(new QuantLib::OrnsteinUhlenbeckProcess(a, sigma, 0.0)),
-      yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)) {}
+      yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)),
+      termStructure_(termStructure) {
+        registerWith(termStructure_);
+    }
 
     Size G2ForwardProcess::size() const {
         return 2;
@@ -219,6 +244,23 @@ namespace QuantLib {
         M += -(rho_*sigma_*eta_)/(a_*(a_+b_))
             * (std::exp(-a_*(T-t))-std::exp(-a_*T-b_*t+(a_+b_)*s));
         return M;
+    }
+
+    const Handle<YieldTermStructure>& G2ForwardProcess::termStructure() const {
+        return termStructure_;
+    }
+
+    Real G2ForwardProcess::phi(Time t) const {
+        QL_REQUIRE(!termStructure_.empty(),
+                   "no term structure given to G2ForwardProcess");
+        Rate forward = termStructure_->forwardRate(t, t, Continuous, NoFrequency);
+        Real temp1 = sigma_*(1.0-std::exp(-a_*t))/a_;
+        Real temp2 = eta_ *(1.0-std::exp(-b_*t))/b_;
+        return 0.5*temp1*temp1 + 0.5*temp2*temp2 + rho_*temp1*temp2 + forward;
+    }
+
+    Rate G2ForwardProcess::shortRate(Time t, Real x, Real y) const {
+        return x + y + phi(t);
     }
 
 }

--- a/ql/processes/g2process.cpp
+++ b/ql/processes/g2process.cpp
@@ -22,8 +22,8 @@
 
 namespace QuantLib {
 
-    G2Process::G2Process(const Handle<YieldTermStructure>& termStructure,
-                         Real a, Real sigma, Real b, Real eta, Real rho)
+    G2Process::G2Process(Real a, Real sigma, Real b, Real eta, Real rho,
+                         const Handle<YieldTermStructure>& termStructure)
     : a_(a), sigma_(sigma), b_(b), eta_(eta), rho_(rho),
       xProcess_(new QuantLib::OrnsteinUhlenbeckProcess(a, sigma, 0.0)),
       yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)),
@@ -165,8 +165,8 @@ namespace QuantLib {
     }
 
 
-    G2ForwardProcess::G2ForwardProcess(const Handle<YieldTermStructure>& termStructure,
-                                       Real a, Real sigma, Real b, Real eta, Real rho)
+    G2ForwardProcess::G2ForwardProcess(Real a, Real sigma, Real b, Real eta, Real rho,
+                                       const Handle<YieldTermStructure>& termStructure)
     : a_(a), sigma_(sigma), b_(b), eta_(eta), rho_(rho),
       xProcess_(new QuantLib::OrnsteinUhlenbeckProcess(a, sigma, 0.0)),
       yProcess_(new QuantLib::OrnsteinUhlenbeckProcess(b, eta, 0.0)),

--- a/ql/processes/g2process.cpp
+++ b/ql/processes/g2process.cpp
@@ -36,13 +36,25 @@ namespace QuantLib {
     }
 
     Array G2Process::initialValues() const {
-        return { x0_, y0_ };
+        Real z1_0 = termStructure_.empty() ? x0_ : phi(0.0);
+        return { z1_0, y0_ };
     }
 
-    Array G2Process::drift(Time t, const Array& x) const {
+    Array G2Process::drift(Time t, const Array& z) const {
+        // Drift in shifted coordinates z1 = x + phi(t), z2 = y:
+        //   dz1 = (-a*z1 + a*phi(t) + phi'(t)) dt + sigma dW1
+        //   dz2 = -b*z2 dt + eta dW2
+        Real shiftDrift = 0.0;
+        if (!termStructure_.empty()) {
+            const Real h = 1.0e-4;
+            Real phi_t  = phi(t);
+            Real phi_th = phi(t + h);
+            Real phiPrime = (phi_th - phi_t) / h;
+            shiftDrift = a_ * phi_t + phiPrime;
+        }
         return {
-            xProcess_->drift(t, x[0]),
-            yProcess_->drift(t, x[1])
+            xProcess_->drift(t, z[0]) + shiftDrift,
+            yProcess_->drift(t, z[1])
         };
     }
 
@@ -62,11 +74,18 @@ namespace QuantLib {
         return tmp;
     }
 
-    Array G2Process::expectation(Time t0, const Array& x0,
+    Array G2Process::expectation(Time t0, const Array& z0,
                                  Time dt) const {
+        // E[z1(t0+dt) | z1(t0)] = z1(t0)*exp(-a*dt)
+        //                       + phi(t0+dt) - phi(t0)*exp(-a*dt)
+        // E[z2(t0+dt) | z2(t0)] = z2(t0)*exp(-b*dt)
+        Real shiftExp = 0.0;
+        if (!termStructure_.empty()) {
+            shiftExp = phi(t0 + dt) - phi(t0) * std::exp(-a_ * dt);
+        }
         return {
-            xProcess_->expectation(t0, x0[0], dt),
-            yProcess_->expectation(t0, x0[1], dt)
+            xProcess_->expectation(t0, z0[0], dt) + shiftExp,
+            yProcess_->expectation(t0, z0[1], dt)
         };
     }
 
@@ -100,7 +119,7 @@ namespace QuantLib {
     }
 
     Real G2Process::x0() const {
-        return x0_;
+        return termStructure_.empty() ? x0_ : phi(0.0);
     }
 
     Real G2Process::y0() const {
@@ -140,8 +159,9 @@ namespace QuantLib {
         return 0.5*temp1*temp1 + 0.5*temp2*temp2 + rho_*temp1*temp2 + forward;
     }
 
-    Rate G2Process::shortRate(Time t, Real x, Real y) const {
-        return x + y + phi(t);
+    Rate G2Process::shortRate(Time, Real z1, Real z2) const {
+        // The simulated state already includes phi(t) in z1, so r = z1 + z2.
+        return z1 + z2;
     }
 
 
@@ -159,13 +179,22 @@ namespace QuantLib {
     }
 
     Array G2ForwardProcess::initialValues() const {
-        return { x0_, y0_ };
+        Real z1_0 = termStructure_.empty() ? x0_ : phi(0.0);
+        return { z1_0, y0_ };
     }
 
-    Array G2ForwardProcess::drift(Time t, const Array& x) const {
+    Array G2ForwardProcess::drift(Time t, const Array& z) const {
+        Real shiftDrift = 0.0;
+        if (!termStructure_.empty()) {
+            const Real h = 1.0e-4;
+            Real phi_t  = phi(t);
+            Real phi_th = phi(t + h);
+            Real phiPrime = (phi_th - phi_t) / h;
+            shiftDrift = a_ * phi_t + phiPrime;
+        }
         return {
-            xProcess_->drift(t, x[0]) + xForwardDrift(t, T_),
-            yProcess_->drift(t, x[1]) + yForwardDrift(t, T_)
+            xProcess_->drift(t, z[0]) + xForwardDrift(t, T_) + shiftDrift,
+            yProcess_->drift(t, z[1]) + yForwardDrift(t, T_)
         };
     }
 
@@ -178,11 +207,15 @@ namespace QuantLib {
         return tmp;
     }
 
-    Array G2ForwardProcess::expectation(Time t0, const Array& x0,
+    Array G2ForwardProcess::expectation(Time t0, const Array& z0,
                                         Time dt) const {
+        Real shiftExp = 0.0;
+        if (!termStructure_.empty()) {
+            shiftExp = phi(t0 + dt) - phi(t0) * std::exp(-a_ * dt);
+        }
         return {
-            xProcess_->expectation(t0, x0[0], dt) - Mx_T(t0, t0+dt, T_),
-            yProcess_->expectation(t0, x0[1], dt) - My_T(t0, t0+dt, T_)
+            xProcess_->expectation(t0, z0[0], dt) - Mx_T(t0, t0+dt, T_) + shiftExp,
+            yProcess_->expectation(t0, z0[1], dt) - My_T(t0, t0+dt, T_)
         };
     }
 
@@ -259,8 +292,8 @@ namespace QuantLib {
         return 0.5*temp1*temp1 + 0.5*temp2*temp2 + rho_*temp1*temp2 + forward;
     }
 
-    Rate G2ForwardProcess::shortRate(Time t, Real x, Real y) const {
-        return x + y + phi(t);
+    Rate G2ForwardProcess::shortRate(Time, Real z1, Real z2) const {
+        return z1 + z2;
     }
 
 }

--- a/ql/processes/g2process.hpp
+++ b/ql/processes/g2process.hpp
@@ -26,6 +26,7 @@
 
 #include <ql/processes/forwardmeasureprocess.hpp>
 #include <ql/processes/ornsteinuhlenbeckprocess.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
 
 namespace QuantLib {
 
@@ -33,7 +34,8 @@ namespace QuantLib {
     /*! \ingroup processes */
     class G2Process : public StochasticProcess {
       public:
-        G2Process(Real a, Real sigma, Real b, Real eta, Real rho);
+        G2Process(const Handle<YieldTermStructure>& termStructure,
+                  Real a, Real sigma, Real b, Real eta, Real rho);
         //! \name StochasticProcess interface
         //@{
         Size size() const override;
@@ -51,17 +53,22 @@ namespace QuantLib {
         Real b() const;
         Real eta() const;
         Real rho() const;
+        const Handle<YieldTermStructure>& termStructure() const;
+        Real phi(Time t) const;
+        Rate shortRate(Time t, Real x, Real y) const;
       private:
         Real x0_ = 0.0, y0_ = 0.0, a_, sigma_, b_, eta_, rho_;
         ext::shared_ptr<QuantLib::OrnsteinUhlenbeckProcess> xProcess_;
         ext::shared_ptr<QuantLib::OrnsteinUhlenbeckProcess> yProcess_;
+        Handle<YieldTermStructure> termStructure_;
     };
 
     //! %Forward %G2 stochastic process
     /*! \ingroup processes */
     class G2ForwardProcess : public ForwardMeasureProcess {
       public:
-        G2ForwardProcess(Real a, Real sigma, Real b, Real eta, Real rho);
+        G2ForwardProcess(const Handle<YieldTermStructure>& termStructure,
+                         Real a, Real sigma, Real b, Real eta, Real rho);
         //! \name StochasticProcess interface
         //@{
         Size size() const override;
@@ -72,10 +79,14 @@ namespace QuantLib {
         Matrix stdDeviation(Time t0, const Array& x0, Time dt) const override;
         Matrix covariance(Time t0, const Array& x0, Time dt) const override;
         //@}
+        const Handle<YieldTermStructure>& termStructure() const;
+        Real phi(Time t) const;
+        Rate shortRate(Time t, Real x, Real y) const;
       protected:
         Real x0_ = 0.0, y0_ = 0.0, a_, sigma_, b_, eta_, rho_;
         ext::shared_ptr<QuantLib::OrnsteinUhlenbeckProcess> xProcess_;
         ext::shared_ptr<QuantLib::OrnsteinUhlenbeckProcess> yProcess_;
+        Handle<YieldTermStructure> termStructure_;
         Real xForwardDrift(Time t, Time T) const;
         Real yForwardDrift(Time t, Time T) const;
         Real Mx_T(Real s, Real t, Real T) const;

--- a/ql/processes/g2process.hpp
+++ b/ql/processes/g2process.hpp
@@ -48,8 +48,9 @@ namespace QuantLib {
     */
     class G2Process : public StochasticProcess {
       public:
-        G2Process(const Handle<YieldTermStructure>& termStructure,
-                  Real a, Real sigma, Real b, Real eta, Real rho);
+        G2Process(Real a, Real sigma, Real b, Real eta, Real rho,
+                  const Handle<YieldTermStructure>& termStructure
+                      = Handle<YieldTermStructure>());
         //! \name StochasticProcess interface
         //@{
         Size size() const override;
@@ -87,8 +88,9 @@ namespace QuantLib {
     */
     class G2ForwardProcess : public ForwardMeasureProcess {
       public:
-        G2ForwardProcess(const Handle<YieldTermStructure>& termStructure,
-                         Real a, Real sigma, Real b, Real eta, Real rho);
+        G2ForwardProcess(Real a, Real sigma, Real b, Real eta, Real rho,
+                         const Handle<YieldTermStructure>& termStructure
+                             = Handle<YieldTermStructure>());
         //! \name StochasticProcess interface
         //@{
         Size size() const override;

--- a/ql/processes/g2process.hpp
+++ b/ql/processes/g2process.hpp
@@ -31,7 +31,21 @@
 namespace QuantLib {
 
     //! %G2 stochastic process
-    /*! \ingroup processes */
+    /*! Simulates the two-factor G2++ process with state shifted so that
+        the two simulated components sum to the short rate, i.e. the state
+        is \f$ (z_1, z_2) = (x + \varphi(t),\, y) \f$, where \f$ x \f$ and
+        \f$ y \f$ are the underlying zero-mean OU factors and
+        \f$ \varphi(t) \f$ is the deterministic offset that fits the
+        initial term structure. As a consequence, sample paths produced by
+        a path generator built on this process satisfy
+        \f$ r(t_i) = \mathrm{state}[0]_i + \mathrm{state}[1]_i \f$ and have
+        curve-consistent expectation \f$ \varphi(t_i) \f$.
+
+        If an empty term-structure handle is passed, the process degenerates
+        to a pair of zero-mean OU processes (\f$ \varphi \equiv 0 \f$).
+
+        \ingroup processes
+    */
     class G2Process : public StochasticProcess {
       public:
         G2Process(const Handle<YieldTermStructure>& termStructure,
@@ -64,7 +78,13 @@ namespace QuantLib {
     };
 
     //! %Forward %G2 stochastic process
-    /*! \ingroup processes */
+    /*! Forward-measure counterpart of G2Process. The simulated state is
+        again shifted so that \f$ \mathrm{state}[0] + \mathrm{state}[1] = r(t) \f$,
+        on top of the usual T-forward convexity adjustments to the drift
+        and the conditional expectation.
+
+        \ingroup processes
+    */
     class G2ForwardProcess : public ForwardMeasureProcess {
       public:
         G2ForwardProcess(const Handle<YieldTermStructure>& termStructure,

--- a/ql/processes/g2process.hpp
+++ b/ql/processes/g2process.hpp
@@ -49,7 +49,7 @@ namespace QuantLib {
     class G2Process : public StochasticProcess {
       public:
         G2Process(Real a, Real sigma, Real b, Real eta, Real rho,
-                  const Handle<YieldTermStructure>& termStructure = {}});
+                  const Handle<YieldTermStructure>& termStructure = {});
         //! \name StochasticProcess interface
         //@{
         Size size() const override;

--- a/ql/processes/g2process.hpp
+++ b/ql/processes/g2process.hpp
@@ -49,8 +49,7 @@ namespace QuantLib {
     class G2Process : public StochasticProcess {
       public:
         G2Process(Real a, Real sigma, Real b, Real eta, Real rho,
-                  const Handle<YieldTermStructure>& termStructure
-                      = Handle<YieldTermStructure>());
+                  const Handle<YieldTermStructure>& termStructure = {}});
         //! \name StochasticProcess interface
         //@{
         Size size() const override;
@@ -89,8 +88,7 @@ namespace QuantLib {
     class G2ForwardProcess : public ForwardMeasureProcess {
       public:
         G2ForwardProcess(Real a, Real sigma, Real b, Real eta, Real rho,
-                         const Handle<YieldTermStructure>& termStructure
-                             = Handle<YieldTermStructure>());
+                         const Handle<YieldTermStructure>& termStructure = {});
         //! \name StochasticProcess interface
         //@{
         Size size() const override;

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -73,6 +73,7 @@ set(QL_TEST_SOURCES
     forwardrateagreement.cpp
     functions.cpp
     fxforward.cpp
+    g2process.cpp
     garch.cpp
     gaussianquadratures.cpp
     gjrgarchmodel.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -74,6 +74,7 @@ QL_TEST_SRCS = \
 	forwardrateagreement.cpp \
 	functions.cpp \
 	fxforward.cpp \
+	g2process.cpp \
 	garch.cpp \
 	gaussianquadratures.cpp \
 	gjrgarchmodel.cpp \

--- a/test-suite/g2process.cpp
+++ b/test-suite/g2process.cpp
@@ -1,7 +1,7 @@
 /* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 
 /*
- Copyright (C) 2026 QuantLib contributors
+ Copyright (C) 2026 Junjie Guo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/

--- a/test-suite/g2process.cpp
+++ b/test-suite/g2process.cpp
@@ -1,0 +1,240 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 QuantLib contributors
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include "utilities.hpp"
+#include <ql/processes/g2process.hpp>
+#include <ql/models/shortrate/twofactormodel.hpp>
+#include <ql/models/shortrate/twofactormodels/g2.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/target.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <cmath>
+
+using namespace QuantLib;
+using boost::unit_test_framework::test_suite;
+
+BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(G2ProcessTests)
+
+namespace {
+
+    // Reference implementation of the G2++ deterministic offset phi(t),
+    // copied verbatim from G2::FittingParameter::Impl::value in
+    // ql/models/shortrate/twofactormodels/g2.hpp. The tests check that
+    // G2Process / G2ForwardProcess match this formula.
+    Real referencePhi(const Handle<YieldTermStructure>& h, Time t,
+                      Real a, Real sigma, Real b, Real eta, Real rho) {
+        Rate forward = h->forwardRate(t, t, Continuous, NoFrequency);
+        Real temp1 = sigma*(1.0-std::exp(-a*t))/a;
+        Real temp2 = eta *(1.0-std::exp(-b*t))/b;
+        return 0.5*temp1*temp1 + 0.5*temp2*temp2 + rho*temp1*temp2 + forward;
+    }
+
+    Handle<YieldTermStructure> makeFlatCurve(Rate rate) {
+        return Handle<YieldTermStructure>(
+            ext::make_shared<FlatForward>(0, TARGET(), rate, Actual365Fixed()));
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessDriftUnchangedByTermStructure) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that G2Process drift/diffusion ignore the term structure...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
+
+    G2Process paramOnly(Handle<YieldTermStructure>(), a, sigma, b, eta, rho);
+    G2Process withCurve(makeFlatCurve(0.04), a, sigma, b, eta, rho);
+
+    const Time t = 1.5;
+    Array x(2);
+    x[0] = 0.002;
+    x[1] = -0.003;
+
+    Array d1 = paramOnly.drift(t, x);
+    Array d2 = withCurve.drift(t, x);
+
+    const Real tol = 1e-14;
+    if (std::fabs(d1[0] - d2[0]) > tol || std::fabs(d1[1] - d2[1]) > tol) {
+        BOOST_ERROR("G2Process drift changed when term structure was provided:\n"
+                    << "  without curve: [" << d1[0] << ", " << d1[1] << "]\n"
+                    << "  with curve:    [" << d2[0] << ", " << d2[1] << "]");
+    }
+
+    // x_t and y_t are OU with zero mean-reversion level, so at x = 0 the
+    // drift must be exactly zero regardless of the curve.
+    Array zero(2, 0.0);
+    Array dz = withCurve.drift(t, zero);
+    if (std::fabs(dz[0]) > tol || std::fabs(dz[1]) > tol) {
+        BOOST_ERROR("G2Process drift at x=y=0 is not zero: ["
+                    << dz[0] << ", " << dz[1] << "]");
+    }
+
+    Matrix diff1 = paramOnly.diffusion(t, x);
+    Matrix diff2 = withCurve.diffusion(t, x);
+    for (Size i=0; i<2; ++i)
+        for (Size j=0; j<2; ++j)
+            if (std::fabs(diff1[i][j] - diff2[i][j]) > tol)
+                BOOST_ERROR("G2Process diffusion changed when term structure "
+                            "was provided at (" << i << "," << j << "): "
+                            << diff1[i][j] << " vs " << diff2[i][j]);
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessPhiAndShortRate) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing G2Process phi(t) and shortRate(t, x, y)...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
+    const Rate flatRate = 0.03;
+    Handle<YieldTermStructure> curve = makeFlatCurve(flatRate);
+
+    G2Process process(curve, a, sigma, b, eta, rho);
+
+    const Time times[] = { 0.25, 1.0, 5.0, 10.0 };
+    const Real xs[]    = { -0.01, 0.0, 0.005 };
+    const Real ys[]    = { -0.002, 0.0, 0.004 };
+
+    const Real tol = 1e-12;
+    for (Time t : times) {
+        Real expectedPhi =
+            referencePhi(curve, t, a, sigma, b, eta, rho);
+        Real actualPhi = process.phi(t);
+        if (std::fabs(actualPhi - expectedPhi) > tol) {
+            BOOST_ERROR("G2Process::phi mismatch at t=" << t
+                        << ": expected " << expectedPhi
+                        << ", got " << actualPhi);
+        }
+
+        for (Real x : xs)
+            for (Real y : ys) {
+                Rate expected = x + y + expectedPhi;
+                Rate actual = process.shortRate(t, x, y);
+                if (std::fabs(actual - expected) > tol) {
+                    BOOST_ERROR("G2Process::shortRate mismatch at t="
+                                << t << ", x=" << x << ", y=" << y
+                                << ": expected " << expected
+                                << ", got " << actual);
+                }
+            }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessPhiMatchesG2Model) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that G2Process::phi matches the G2 model fitting parameter...");
+
+    const Real a = 0.12, sigma = 0.011, b = 0.17, eta = 0.009, rho = -0.3;
+    Handle<YieldTermStructure> curve = makeFlatCurve(0.025);
+
+    G2Process process(curve, a, sigma, b, eta, rho);
+    G2 model(curve, a, sigma, b, eta, rho);
+    ext::shared_ptr<TwoFactorModel::ShortRateDynamics> dyn = model.dynamics();
+    BOOST_REQUIRE(dyn);
+
+    const Real tol = 1e-12;
+    for (Time t : {0.1, 0.5, 2.0, 7.5, 20.0}) {
+        Rate fromProcess = process.shortRate(t, 0.0, 0.0);
+        Rate fromModel = dyn->shortRate(t, 0.0, 0.0);
+        if (std::fabs(fromProcess - fromModel) > tol) {
+            BOOST_ERROR("G2Process::shortRate disagrees with G2 model at t="
+                        << t << ": process=" << fromProcess
+                        << ", model=" << fromModel);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessPhiRequiresTermStructure) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that G2Process::phi throws without a term structure...");
+
+    G2Process process(Handle<YieldTermStructure>(), 0.1, 0.01, 0.2, 0.013, -0.5);
+    BOOST_CHECK(process.termStructure().empty());
+    BOOST_CHECK_THROW(process.phi(1.0), Error);
+    BOOST_CHECK_THROW(process.shortRate(1.0, 0.01, 0.01), Error);
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessObservesTermStructure) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that G2Process phi(t) updates when the curve moves...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
+
+    ext::shared_ptr<SimpleQuote> rate = ext::make_shared<SimpleQuote>(0.02);
+    Handle<YieldTermStructure> curve(ext::make_shared<FlatForward>(
+        0, TARGET(), Handle<Quote>(rate), Actual365Fixed()));
+
+    G2Process process(curve, a, sigma, b, eta, rho);
+
+    const Time t = 2.0;
+    Real phiBefore = process.phi(t);
+    rate->setValue(0.05);
+    Real phiAfter = process.phi(t);
+
+    // Under a flat curve, increasing the instantaneous forward by 300bp
+    // must raise phi by approximately the same amount.
+    const Real expectedDelta = 0.03;
+    if (std::fabs((phiAfter - phiBefore) - expectedDelta) > 1e-10) {
+        BOOST_ERROR("G2Process did not respond to term-structure change: "
+                    << "delta=" << (phiAfter - phiBefore)
+                    << " (expected " << expectedDelta << ")");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testG2ForwardProcessPhiAndShortRate) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing G2ForwardProcess phi(t) and shortRate(t, x, y)...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
+    Handle<YieldTermStructure> curve = makeFlatCurve(0.035);
+
+    G2ForwardProcess fwd(curve, a, sigma, b, eta, rho);
+
+    const Real tol = 1e-12;
+    for (Time t : {0.25, 1.0, 5.0}) {
+        Real expected =
+            referencePhi(curve, t, a, sigma, b, eta, rho);
+        Real actual = fwd.phi(t);
+        if (std::fabs(actual - expected) > tol) {
+            BOOST_ERROR("G2ForwardProcess::phi mismatch at t=" << t
+                        << ": expected " << expected << ", got " << actual);
+        }
+
+        Rate sr = fwd.shortRate(t, 0.002, -0.001);
+        if (std::fabs(sr - (0.002 - 0.001 + expected)) > tol) {
+            BOOST_ERROR("G2ForwardProcess::shortRate mismatch at t=" << t);
+        }
+    }
+
+    G2ForwardProcess paramOnly(Handle<YieldTermStructure>(), a, sigma, b, eta, rho);
+    BOOST_CHECK(paramOnly.termStructure().empty());
+    BOOST_CHECK_THROW(paramOnly.phi(1.0), Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/g2process.cpp
+++ b/test-suite/g2process.cpp
@@ -67,8 +67,8 @@ BOOST_AUTO_TEST_CASE(testG2ProcessDriftIncludesTermStructure) {
 
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
 
-    G2Process paramOnly(Handle<YieldTermStructure>(), a, sigma, b, eta, rho);
-    G2Process withCurve(makeFlatCurve(0.04), a, sigma, b, eta, rho);
+    G2Process paramOnly(a, sigma, b, eta, rho);
+    G2Process withCurve(a, sigma, b, eta, rho, makeFlatCurve(0.04));
 
     const Time t = 1.5;
     Array z(2);
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiAndShortRate) {
     const Rate flatRate = 0.03;
     Handle<YieldTermStructure> curve = makeFlatCurve(flatRate);
 
-    G2Process process(curve, a, sigma, b, eta, rho);
+    G2Process process(a, sigma, b, eta, rho, curve);
 
     const Time times[] = { 0.25, 1.0, 5.0, 10.0 };
 
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiMatchesG2Model) {
     const Real a = 0.12, sigma = 0.011, b = 0.17, eta = 0.009, rho = -0.3;
     Handle<YieldTermStructure> curve = makeFlatCurve(0.025);
 
-    G2Process process(curve, a, sigma, b, eta, rho);
+    G2Process process(a, sigma, b, eta, rho, curve);
     G2 model(curve, a, sigma, b, eta, rho);
     ext::shared_ptr<TwoFactorModel::ShortRateDynamics> dyn = model.dynamics();
     BOOST_REQUIRE(dyn);
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessExpectationConsistentWithCurve) {
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.4;
     Handle<YieldTermStructure> curve = makeFlatCurve(0.035);
 
-    G2Process process(curve, a, sigma, b, eta, rho);
+    G2Process process(a, sigma, b, eta, rho, curve);
     Array iv = process.initialValues();
 
     const Real tol = 1e-12;
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiRequiresTermStructure) {
     BOOST_TEST_MESSAGE(
         "Testing that G2Process::phi throws without a term structure...");
 
-    G2Process process(Handle<YieldTermStructure>(), 0.1, 0.01, 0.2, 0.013, -0.5);
+    G2Process process(0.1, 0.01, 0.2, 0.013, -0.5);
     BOOST_CHECK(process.termStructure().empty());
     BOOST_CHECK_THROW(process.phi(1.0), Error);
 
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessObservesTermStructure) {
     Handle<YieldTermStructure> curve(ext::make_shared<FlatForward>(
         0, TARGET(), Handle<Quote>(rate), Actual365Fixed()));
 
-    G2Process process(curve, a, sigma, b, eta, rho);
+    G2Process process(a, sigma, b, eta, rho, curve);
 
     const Time t = 2.0;
     Real phiBefore = process.phi(t);
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPathGeneratorMatchesCurve) {
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.3;
     Handle<YieldTermStructure> curve = makeFlatCurve(0.03);
 
-    auto process = ext::make_shared<G2Process>(curve, a, sigma, b, eta, rho);
+    auto process = ext::make_shared<G2Process>(a, sigma, b, eta, rho, curve);
 
     const Time horizon = 5.0;
     const Size steps = 50;
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(testG2ForwardProcessPhiAndShortRate) {
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
     Handle<YieldTermStructure> curve = makeFlatCurve(0.035);
 
-    G2ForwardProcess fwd(curve, a, sigma, b, eta, rho);
+    G2ForwardProcess fwd(a, sigma, b, eta, rho, curve);
 
     const Real tol = 1e-12;
     for (Time t : {0.25, 1.0, 5.0}) {
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(testG2ForwardProcessPhiAndShortRate) {
     }
 
     // Without a curve, phi() throws but shortRate() still works.
-    G2ForwardProcess paramOnly(Handle<YieldTermStructure>(), a, sigma, b, eta, rho);
+    G2ForwardProcess paramOnly(a, sigma, b, eta, rho);
     BOOST_CHECK(paramOnly.termStructure().empty());
     BOOST_CHECK_THROW(paramOnly.phi(1.0), Error);
     BOOST_CHECK_NO_THROW(paramOnly.shortRate(1.0, 0.01, 0.01));

--- a/test-suite/g2process.cpp
+++ b/test-suite/g2process.cpp
@@ -26,7 +26,11 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/quotes/simplequote.hpp>
+#include <ql/methods/montecarlo/multipathgenerator.hpp>
+#include <ql/methods/montecarlo/mctraits.hpp>
+#include <ql/timegrid.hpp>
 #include <cmath>
+#include <vector>
 
 using namespace QuantLib;
 using boost::unit_test_framework::test_suite;
@@ -56,10 +60,10 @@ namespace {
 
 }
 
-BOOST_AUTO_TEST_CASE(testG2ProcessDriftUnchangedByTermStructure) {
+BOOST_AUTO_TEST_CASE(testG2ProcessDriftIncludesTermStructure) {
 
     BOOST_TEST_MESSAGE(
-        "Testing that G2Process drift/diffusion ignore the term structure...");
+        "Testing that G2Process drift includes the term-structure shift...");
 
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
 
@@ -67,34 +71,38 @@ BOOST_AUTO_TEST_CASE(testG2ProcessDriftUnchangedByTermStructure) {
     G2Process withCurve(makeFlatCurve(0.04), a, sigma, b, eta, rho);
 
     const Time t = 1.5;
-    Array x(2);
-    x[0] = 0.002;
-    x[1] = -0.003;
+    Array z(2);
+    z[0] = 0.002;
+    z[1] = -0.003;
 
-    Array d1 = paramOnly.drift(t, x);
-    Array d2 = withCurve.drift(t, x);
+    Array d1 = paramOnly.drift(t, z);
+    Array d2 = withCurve.drift(t, z);
 
-    const Real tol = 1e-14;
-    if (std::fabs(d1[0] - d2[0]) > tol || std::fabs(d1[1] - d2[1]) > tol) {
-        BOOST_ERROR("G2Process drift changed when term structure was provided:\n"
-                    << "  without curve: [" << d1[0] << ", " << d1[1] << "]\n"
-                    << "  with curve:    [" << d2[0] << ", " << d2[1] << "]");
+    // The y-component must not depend on the term structure.
+    const Real tol = 1e-12;
+    if (std::fabs(d1[1] - d2[1]) > tol) {
+        BOOST_ERROR("y-drift should not depend on the term structure: "
+                    << d1[1] << " vs " << d2[1]);
     }
 
-    // x_t and y_t are OU with zero mean-reversion level, so at x = 0 the
-    // drift must be exactly zero regardless of the curve.
-    Array zero(2, 0.0);
-    Array dz = withCurve.drift(t, zero);
-    if (std::fabs(dz[0]) > tol || std::fabs(dz[1]) > tol) {
-        BOOST_ERROR("G2Process drift at x=y=0 is not zero: ["
-                    << dz[0] << ", " << dz[1] << "]");
+    // The x-component must differ by exactly a*phi(t) + phi'(t)
+    // (computed with the same numerical derivative as the implementation).
+    const Real h = 1.0e-4;
+    Real phi_t  = withCurve.phi(t);
+    Real phi_th = withCurve.phi(t + h);
+    Real expectedDelta = a * phi_t + (phi_th - phi_t) / h;
+    Real actualDelta = d2[0] - d1[0];
+    if (std::fabs(actualDelta - expectedDelta) > 1e-10) {
+        BOOST_ERROR("x-drift shift mismatch: expected " << expectedDelta
+                    << ", got " << actualDelta);
     }
 
-    Matrix diff1 = paramOnly.diffusion(t, x);
-    Matrix diff2 = withCurve.diffusion(t, x);
+    // Diffusion is purely deterministic and curve-independent.
+    Matrix diff1 = paramOnly.diffusion(t, z);
+    Matrix diff2 = withCurve.diffusion(t, z);
     for (Size i=0; i<2; ++i)
         for (Size j=0; j<2; ++j)
-            if (std::fabs(diff1[i][j] - diff2[i][j]) > tol)
+            if (std::fabs(diff1[i][j] - diff2[i][j]) > 1e-14)
                 BOOST_ERROR("G2Process diffusion changed when term structure "
                             "was provided at (" << i << "," << j << "): "
                             << diff1[i][j] << " vs " << diff2[i][j]);
@@ -103,7 +111,7 @@ BOOST_AUTO_TEST_CASE(testG2ProcessDriftUnchangedByTermStructure) {
 BOOST_AUTO_TEST_CASE(testG2ProcessPhiAndShortRate) {
 
     BOOST_TEST_MESSAGE(
-        "Testing G2Process phi(t) and shortRate(t, x, y)...");
+        "Testing G2Process phi(t), shortRate(t, z1, z2), and initialValues...");
 
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
     const Rate flatRate = 0.03;
@@ -112,8 +120,6 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiAndShortRate) {
     G2Process process(curve, a, sigma, b, eta, rho);
 
     const Time times[] = { 0.25, 1.0, 5.0, 10.0 };
-    const Real xs[]    = { -0.01, 0.0, 0.005 };
-    const Real ys[]    = { -0.002, 0.0, 0.004 };
 
     const Real tol = 1e-12;
     for (Time t : times) {
@@ -125,18 +131,35 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiAndShortRate) {
                         << ": expected " << expectedPhi
                         << ", got " << actualPhi);
         }
+    }
 
-        for (Real x : xs)
-            for (Real y : ys) {
-                Rate expected = x + y + expectedPhi;
-                Rate actual = process.shortRate(t, x, y);
-                if (std::fabs(actual - expected) > tol) {
-                    BOOST_ERROR("G2Process::shortRate mismatch at t="
-                                << t << ", x=" << x << ", y=" << y
-                                << ": expected " << expected
-                                << ", got " << actual);
-                }
+    // shortRate is just the sum of the simulated components: the term-structure
+    // offset phi(t) is already baked into the first component.
+    const Real zs1[] = { -0.01, 0.0, 0.005 };
+    const Real zs2[] = { -0.002, 0.0, 0.004 };
+    for (Real z1 : zs1)
+        for (Real z2 : zs2) {
+            Rate expected = z1 + z2;
+            Rate actual = process.shortRate(1.0, z1, z2);
+            if (std::fabs(actual - expected) > tol) {
+                BOOST_ERROR("G2Process::shortRate(t, z1, z2) should equal z1+z2: "
+                            << "got " << actual << ", expected " << expected);
             }
+        }
+
+    // Initial state must satisfy z1(0) + z2(0) = phi(0) = f(0,0).
+    Array iv = process.initialValues();
+    Real expectedR0 = referencePhi(curve, 0.0, a, sigma, b, eta, rho);
+    if (std::fabs((iv[0] + iv[1]) - expectedR0) > 1e-12) {
+        BOOST_ERROR("initialValues do not sum to phi(0): "
+                    << iv[0] + iv[1] << " vs " << expectedR0);
+    }
+    if (std::fabs(process.x0() - expectedR0) > 1e-12) {
+        BOOST_ERROR("x0() should equal phi(0) when a curve is set: "
+                    << process.x0() << " vs " << expectedR0);
+    }
+    if (std::fabs(process.y0()) > 1e-14) {
+        BOOST_ERROR("y0() should be zero, got " << process.y0());
     }
 }
 
@@ -155,12 +178,39 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiMatchesG2Model) {
 
     const Real tol = 1e-12;
     for (Time t : {0.1, 0.5, 2.0, 7.5, 20.0}) {
-        Rate fromProcess = process.shortRate(t, 0.0, 0.0);
+        // dyn->shortRate(t, 0, 0) collapses to fitting_(t) = phi(t).
         Rate fromModel = dyn->shortRate(t, 0.0, 0.0);
+        Rate fromProcess = process.phi(t);
         if (std::fabs(fromProcess - fromModel) > tol) {
-            BOOST_ERROR("G2Process::shortRate disagrees with G2 model at t="
+            BOOST_ERROR("G2Process::phi disagrees with G2 model at t="
                         << t << ": process=" << fromProcess
                         << ", model=" << fromModel);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testG2ProcessExpectationConsistentWithCurve) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that G2Process expectation reproduces phi(t)...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.4;
+    Handle<YieldTermStructure> curve = makeFlatCurve(0.035);
+
+    G2Process process(curve, a, sigma, b, eta, rho);
+    Array iv = process.initialValues();
+
+    const Real tol = 1e-12;
+    for (Time t : {0.1, 0.5, 2.0, 5.0, 10.0}) {
+        // Expectation starting from t=0 in the initial state must satisfy
+        // E[z1(t) + z2(t)] = phi(t), since z2(0) = 0 and y is zero-mean OU.
+        Array exp_t = process.expectation(0.0, iv, t);
+        Real expectedR = process.phi(t);
+        Real actualR = exp_t[0] + exp_t[1];
+        if (std::fabs(actualR - expectedR) > tol) {
+            BOOST_ERROR("E[r(t)] mismatch at t=" << t
+                        << ": expected " << expectedR
+                        << ", got " << actualR);
         }
     }
 }
@@ -173,7 +223,19 @@ BOOST_AUTO_TEST_CASE(testG2ProcessPhiRequiresTermStructure) {
     G2Process process(Handle<YieldTermStructure>(), 0.1, 0.01, 0.2, 0.013, -0.5);
     BOOST_CHECK(process.termStructure().empty());
     BOOST_CHECK_THROW(process.phi(1.0), Error);
-    BOOST_CHECK_THROW(process.shortRate(1.0, 0.01, 0.01), Error);
+
+    // shortRate no longer touches the curve: it just sums the two components.
+    BOOST_CHECK_NO_THROW(process.shortRate(1.0, 0.01, 0.01));
+    if (std::fabs(process.shortRate(1.0, 0.01, 0.02) - 0.03) > 1e-14) {
+        BOOST_ERROR("shortRate(t, z1, z2) should equal z1+z2 with no curve");
+    }
+
+    // Without a curve, the process degenerates to two zero-mean OU factors.
+    Array iv = process.initialValues();
+    if (std::fabs(iv[0]) > 1e-14 || std::fabs(iv[1]) > 1e-14) {
+        BOOST_ERROR("initialValues should be (0,0) without a curve, got ("
+                    << iv[0] << ", " << iv[1] << ")");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testG2ProcessObservesTermStructure) {
@@ -204,10 +266,53 @@ BOOST_AUTO_TEST_CASE(testG2ProcessObservesTermStructure) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testG2ProcessPathGeneratorMatchesCurve) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing that MultiPathGenerator on G2Process reproduces "
+        "the curve-implied short-rate expectation...");
+
+    const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.3;
+    Handle<YieldTermStructure> curve = makeFlatCurve(0.03);
+
+    auto process = ext::make_shared<G2Process>(curve, a, sigma, b, eta, rho);
+
+    const Time horizon = 5.0;
+    const Size steps = 50;
+    TimeGrid grid(horizon, steps);
+
+    typedef PseudoRandom::rsg_type rsg_type;
+    rsg_type rsg = PseudoRandom::make_sequence_generator(
+        process->factors() * steps, 42);
+    MultiPathGenerator<rsg_type> generator(process, grid, rsg, false);
+
+    const Size nPaths = 20000;
+    std::vector<Real> sumR(steps + 1, 0.0);
+    for (Size n = 0; n < nPaths; ++n) {
+        const MultiPath& mp = generator.next().value;
+        for (Size i = 0; i <= steps; ++i)
+            sumR[i] += mp[0][i] + mp[1][i];
+    }
+
+    // Empirical mean of r(t_i) should converge to phi(t_i). With 20k
+    // antithetic-free paths the MC standard error is comfortably below 5e-4
+    // for the parameters above.
+    for (Size i = 0; i <= steps; ++i) {
+        Real meanR = sumR[i] / nPaths;
+        Real expected = process->phi(grid[i]);
+        if (std::fabs(meanR - expected) > 5e-4) {
+            BOOST_ERROR("MC mean of r at t=" << grid[i]
+                        << " is " << meanR
+                        << ", expected " << expected
+                        << " (diff " << (meanR - expected) << ")");
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testG2ForwardProcessPhiAndShortRate) {
 
     BOOST_TEST_MESSAGE(
-        "Testing G2ForwardProcess phi(t) and shortRate(t, x, y)...");
+        "Testing G2ForwardProcess phi(t) and shortRate(t, z1, z2)...");
 
     const Real a = 0.1, sigma = 0.01, b = 0.2, eta = 0.013, rho = -0.5;
     Handle<YieldTermStructure> curve = makeFlatCurve(0.035);
@@ -224,15 +329,19 @@ BOOST_AUTO_TEST_CASE(testG2ForwardProcessPhiAndShortRate) {
                         << ": expected " << expected << ", got " << actual);
         }
 
+        // shortRate sums the simulated components.
         Rate sr = fwd.shortRate(t, 0.002, -0.001);
-        if (std::fabs(sr - (0.002 - 0.001 + expected)) > tol) {
-            BOOST_ERROR("G2ForwardProcess::shortRate mismatch at t=" << t);
+        if (std::fabs(sr - 0.001) > tol) {
+            BOOST_ERROR("G2ForwardProcess::shortRate mismatch at t=" << t
+                        << ": expected 0.001, got " << sr);
         }
     }
 
+    // Without a curve, phi() throws but shortRate() still works.
     G2ForwardProcess paramOnly(Handle<YieldTermStructure>(), a, sigma, b, eta, rho);
     BOOST_CHECK(paramOnly.termStructure().empty());
     BOOST_CHECK_THROW(paramOnly.phi(1.0), Error);
+    BOOST_CHECK_NO_THROW(paramOnly.shortRate(1.0, 0.01, 0.01));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -718,6 +718,7 @@
     <ClCompile Include="forwardoption.cpp" />
     <ClCompile Include="forwardrateagreement.cpp" />
     <ClCompile Include="fxforward.cpp" />
+    <ClCompile Include="g2process.cpp" />
     <ClCompile Include="garch.cpp" />
     <ClCompile Include="gaussianquadratures.cpp" />
     <ClCompile Include="gjrgarchmodel.cpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -182,6 +182,9 @@
     <ClCompile Include="forwardrateagreement.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="g2process.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="garch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Extends G2Process and G2ForwardProcess with a yield term structure handle, deterministic drift phi(t), and a shortRate(t, x, y) helper so the processes can be used for short-rate simulation consistent with an initial curve. Also adds a corresponding g2process test.

The phi(t) is the same analytical expression already used by G2::FittingParameter in ql/models/shortrate/twofactormodels/g2.hpp.

Based on https://github.com/lballabio/QuantLib/pull/1937
Address https://github.com/lballabio/QuantLib/issues/1904
