### PR TITLE
Add missing `<vector>` include in `blackvoltimeextrapolation.hpp`

### DIFF
--- a/ql/termstructures/volatility/equityfx/blackvoltimeextrapolation.hpp
+++ b/ql/termstructures/volatility/equityfx/blackvoltimeextrapolation.hpp
@@ -27,6 +27,7 @@
 
 #include <ql/types.hpp>
 #include <functional>
+#include <vector>
 
 namespace QuantLib {
 


### PR DESCRIPTION
Adds the missing `#include <vector>` to `blackvoltimeextrapolation.hpp`, which caused build failures on some platforms when compiling `blackvoltimeextrapolation.cpp`.

The header uses `std::vector<Time>` but only had a forward declaration via `<iosfwd>`, leading to errors like:

```
error: implicit instantiation of undefined template 'std::vector<double>'
```

Fixes #2557