### PR TITLE
Prevent using non-default `boost::optional` with Boost 1.91 or later

### DIFF
--- a/.ci/userconfig2022.alt.hpp
+++ b/.ci/userconfig2022.alt.hpp
@@ -103,7 +103,7 @@
 
 /* Define this to use std::optional instead of boost::optional. */
 #ifndef QL_USE_STD_OPTIONAL
-//#    define QL_USE_STD_OPTIONAL
+#    define QL_USE_STD_OPTIONAL
 #endif
 
 /* Define this to use standard smart pointers instead of Boost ones.

--- a/.ci/userconfig2026.alt.hpp
+++ b/.ci/userconfig2026.alt.hpp
@@ -103,7 +103,7 @@
 
 /* Define this to use std::optional instead of boost::optional. */
 #ifndef QL_USE_STD_OPTIONAL
-//#    define QL_USE_STD_OPTIONAL
+#    define QL_USE_STD_OPTIONAL
 #endif
 
 /* Define this to use standard smart pointers instead of Boost ones.

--- a/.github/workflows/cmake-latest-runners.yml
+++ b/.github/workflows/cmake-latest-runners.yml
@@ -90,13 +90,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $BoostUri = "https://archives.boost.io/release/1.90.0/binaries/boost_1_90_0-msvc-14.3-64.exe"
+          $BoostUri = "https://archives.boost.io/release/1.91.0/binaries/boost_1_91_0-msvc-14.3-64.exe"
           Start-BitsTransfer -Source $BoostUri -Destination $env:RUNNER_TEMP\boost.exe
           Start-Process -Wait -FilePath "$env:RUNNER_TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=$env:RUNNER_TEMP\boost"
 
           choco install -y ninja
 
-          Write "Boost_DIR=$env:RUNNER_TEMP\boost\lib64-msvc-14.3\cmake\Boost-1.90.0"   >> $env:GITHUB_ENV
+          Write "Boost_DIR=$env:RUNNER_TEMP\boost\lib64-msvc-14.3\cmake\Boost-1.91.0"   >> $env:GITHUB_ENV
 
       - name: Set up Visual Studio shell on Windows
         if: runner.os == 'Windows'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,10 +79,10 @@ jobs:
         variant: sccache
     - name: Setup
       run: |
-        $Url = "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.zip"
+        $Url = "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.zip"
         (New-Object System.Net.WebClient).DownloadFile($Url, "$RUNNER_TEMP\boost.zip")
         Expand-Archive -Path "$RUNNER_TEMP\boost.zip" -DestinationPath C:\local
-        Rename-Item -Path "C:\local\boost_1_90_0" -NewName "boost"
+        Rename-Item -Path "C:\local\boost_1_91_0" -NewName "boost"
         $Url = "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip"
         (New-Object System.Net.WebClient).DownloadFile($Url, "$RUNNER_TEMP\ninja-win.zip")
         Expand-Archive -Path "$RUNNER_TEMP\ninja-win.zip" -DestinationPath C:\local\ninja
@@ -121,10 +121,10 @@ jobs:
         variant: sccache
     - name: Setup
       run: |
-        $Url = "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.zip"
+        $Url = "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.zip"
         (New-Object System.Net.WebClient).DownloadFile($Url, "$RUNNER_TEMP\boost.zip")
         Expand-Archive -Path "$RUNNER_TEMP\boost.zip" -DestinationPath C:\local
-        Rename-Item -Path "C:\local\boost_1_90_0" -NewName "boost"
+        Rename-Item -Path "C:\local\boost_1_91_0" -NewName "boost"
         $Url = "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip"
         (New-Object System.Net.WebClient).DownloadFile($Url, "$RUNNER_TEMP\ninja-win.zip")
         Expand-Archive -Path "$RUNNER_TEMP\ninja-win.zip" -DestinationPath C:\local\ninja

--- a/.github/workflows/linux-nondefault.yml
+++ b/.github/workflows/linux-nondefault.yml
@@ -153,7 +153,7 @@ jobs:
             configureflags: --enable-unity-build
           - name: "Standard Library classes enabled"
             shortname: stdclasses
-            tag: rolling
+            tag: oracular
             cc: gcc
             cxx: g++
             configureflags: --enable-std-pointers --disable-std-any --disable-std-optional

--- a/.github/workflows/macos-nondefault.yml
+++ b/.github/workflows/macos-nondefault.yml
@@ -14,7 +14,7 @@ jobs:
         classes: [boost, std]
         include:
           - classes: std
-            configureflags: --enable-std-pointers --disable-std-any --disable-std-optional
+            configureflags: --enable-std-pointers --disable-std-any
     steps:
     - uses: actions/checkout@v6
     - name: Setup

--- a/.github/workflows/msvc-analysis.yml
+++ b/.github/workflows/msvc-analysis.yml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Setup
         run: |
-          $Url = "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.zip"
+          $Url = "https://archives.boost.io/release/1.91.0/source/boost_1_91_0.zip"
           (New-Object System.Net.WebClient).DownloadFile($Url, "$RUNNER_TEMP\boost.zip")
           Expand-Archive -Path "$RUNNER_TEMP\boost.zip" -DestinationPath C:\local
-          Rename-Item -Path "C:\local\boost_1_90_0" -NewName "boost"
+          Rename-Item -Path "C:\local\boost_1_91_0" -NewName "boost"
 
       - name: Configure CMake
         env:

--- a/.github/workflows/msvc-nondefault.yml
+++ b/.github/workflows/msvc-nondefault.yml
@@ -18,11 +18,11 @@ jobs:
             vsversion: 2019
             image: windows-2022
           - toolset: v143
-            boost_version: 90
+            boost_version: 91
             vsversion: 2022
             image: windows-2022
           - toolset: v145
-            boost_version: 90
+            boost_version: 91
             vsversion: 2026
             image: windows-2025-vs2026
     runs-on: ${{ matrix.image }}

--- a/Docs/pages/config.docs
+++ b/Docs/pages/config.docs
@@ -130,7 +130,9 @@
     \endcode
     If defined (the default), `std::optional` and related classes and
     functions will be used instead of `boost::optional`. If undefined,
-    the Boost facilities will be used.
+    the Boost facilities will be used; however, be aware that Boost
+    1.91 introduced changes in boost::optional that silently changed
+    the behavior of our code and would cause it to work incorrectly.
 
     \code
     #define QL_USE_STD_SHARED_PTR
@@ -138,8 +140,8 @@
     If defined, `std::shared_ptr` and related classes and functions
     will used instead of `boost::shared_ptr`. If undefined (the
     default) the Boost facilities will be used. Note that
-    `std::shared_ptr` does not check access and can cause segmentation
-    faults.
+    `std::shared_ptr` does not check access and will cause a
+    segmentation fault if you access a null pointer.
 
     \code
     #define QL_NULL_AS_FUNCTIONS

--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,11 @@ AC_ARG_ENABLE([std-optional],
                              [If enabled (the default), std::optional and
                               related classes and functions will be used
                               instead of boost::optional. If disabled,
-                              the Boost facilities will be used.]),
+                              the Boost facilities will be used; however,
+                              be aware that Boost 1.91 introduced changes
+                              in boost::optional that silently changed
+                              the behavior of our code and would cause it
+                              to work incorrectly.]),
               [ql_use_std_optional=$enableval],
               [ql_use_std_optional=yes])
 if test "$ql_use_std_optional" = "yes" ; then
@@ -311,7 +315,8 @@ AC_ARG_ENABLE([std-pointers],
                               If disabled (the default) the Boost facilities
                               will be used.
                               Note that std::shared_ptr does not check
-                              access and can cause segmentation faults.]),
+                              access and will cause a segmentation fault
+                              if you access a null pointer.]),
               [ql_use_std_pointers=$enableval],
               [ql_use_std_pointers=no])
 if test "$ql_use_std_pointers" = "yes" ; then

--- a/ql/optional.hpp
+++ b/ql/optional.hpp
@@ -29,6 +29,9 @@
 #if defined(QL_USE_STD_OPTIONAL)
 #include <optional>
 #else
+#if BOOST_VERSION >= 109100
+#error Boost 1.91 introduced changes in boost::optional that silently changed the behavior of our code and would cause it to work incorrectly.  Use std::optional instead.
+#endif
 // Deprecated in version 1.39
 #pragma message("Warning: using boost::optional is deprecated.  Enable std::optional instead.")
 #include <boost/optional.hpp>

--- a/ql/userconfig.hpp
+++ b/ql/userconfig.hpp
@@ -129,7 +129,9 @@
 
 /* If defined, `std::optional` and related classes and functions will
    be used instead of `boost::optional`. If undefined, the Boost
-   facilities will be used.
+   facilities will be used; however, be aware that Boost 1.91
+   introduced changes in boost::optional that silently changed the
+   behavior of our code and would cause it to work incorrectly.
 */
 #ifndef QL_USE_STD_OPTIONAL
 #    define QL_USE_STD_OPTIONAL
@@ -138,7 +140,8 @@
 /* If defined, `std::shared_ptr` and related classes and functions
    will used instead of `boost::shared_ptr`. If undefined, the Boost
    facilities will be used. Note that `std::shared_ptr` does not check
-   access and can cause segmentation faults.
+   access and will cause a segmentation fault if you access a null
+   pointer.
 */
 #ifndef QL_USE_STD_SHARED_PTR
 //#    define QL_USE_STD_SHARED_PTR


### PR DESCRIPTION
Using `std::optional` has been the default for a while now, but the possibility of using `boost::optional` can still be enabled by a compilation switch.

However, Boost 1.91 introduced changes in `boost::optional` that silently changed the behavior of our code, as shown by a few failing tests.  Since the possibility of using `boost::optional` is already deprecated and scheduled to be removed soon, I don't think it's worth diagnosing and fixing the errors.  When the usage of `boost::optional` is explicitly enabled, a compilation check now rejects Boost 1.91 or later.  If you really want to use `boost::optional` until it's removed, stay on Boost 1.90.

For most people, this is a non-issue: using Boost 1.91 works correctly when `std::optional` is used (as per library default).