### PR TITLE
Modernize small C++ constructs in selected files

### DIFF
--- a/ql/math/array.hpp
+++ b/ql/math/array.hpp
@@ -265,27 +265,27 @@ namespace QuantLib {
     // inline definitions
 
     inline Array::Array(Size size)
-    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {}
+    : data_(size != 0U ? new Real[size] : nullptr), n_(size) {}
 
     inline Array::Array(Size size, Real value)
-    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {
+    : data_(size != 0U ? new Real[size] : nullptr), n_(size) {
         std::fill(begin(),end(),value);
     }
 
     inline Array::Array(Size size, Real value, Real increment)
-    : data_(size != 0U ? new Real[size] : (Real*)nullptr), n_(size) {
+    : data_(size != 0U ? new Real[size] : nullptr), n_(size) {
         for (iterator i=begin(); i!=end(); ++i, value+=increment)
             *i = value;
     }
 
     inline Array::Array(const Array& from)
-    : data_(from.n_ != 0U ? new Real[from.n_] : (Real*)nullptr), n_(from.n_) {
+    : data_(from.n_ != 0U ? new Real[from.n_] : nullptr), n_(from.n_) {
         if (data_)
             std::copy(from.begin(),from.end(),begin());
     }
 
     inline Array::Array(Array&& from) noexcept
-    : data_((Real*)nullptr), n_(0) {
+    : data_(nullptr), n_(0) {
         swap(from);
     }
 
@@ -303,7 +303,7 @@ namespace QuantLib {
             // Array with a given value, which we do here.
             Size n = begin;
             Real value = end;
-            data_.reset(n ? new Real[n] : (Real*)nullptr);
+            data_.reset(n ? new Real[n] : nullptr);
             n_ = n;
             std::fill(a.begin(),a.end(),value);
         }
@@ -316,7 +316,7 @@ namespace QuantLib {
                                  const std::false_type&) {
             // true iterators
             Size n = std::distance(begin, end);
-            data_.reset(n ? new Real[n] : (Real*)nullptr);
+            data_.reset(n ? new Real[n] : nullptr);
             n_ = n;
             #if defined(QL_PATCH_MSVC) && defined(QL_DEBUG)
             if (n_)

--- a/ql/methods/finitedifferences/utilities/fdmquantohelper.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmquantohelper.cpp
@@ -25,6 +25,7 @@
 #include <ql/methods/finitedifferences/utilities/fdmquantohelper.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
+#include <algorithm>
 #include <utility>
 
 namespace QuantLib {
@@ -56,10 +57,10 @@ namespace QuantLib {
             = fxVolTS_->blackForwardVol(t1, t2, exchRateATMlevel_);
 
         Array retVal(equityVol.size());
-        for (Size i=0; i < retVal.size(); ++i) {
-            retVal[i]
-                = rDomestic - rForeign + equityVol[i]*fxVol*equityFxCorrelation_;
-        }
+        std::transform(equityVol.begin(), equityVol.end(), retVal.begin(),
+                       [&](Volatility vol) {
+                           return rDomestic - rForeign + vol*fxVol*equityFxCorrelation_;
+                       });
         return retVal;
     }
 }

--- a/ql/time/date.hpp
+++ b/ql/time/date.hpp
@@ -436,7 +436,7 @@ namespace QuantLib {
     }
 
     inline Time daysBetween(const Date& d1, const Date& d2) {
-        return Time(d2-d1);
+        return static_cast<Time>(d2-d1);
     }
 
     inline bool operator==(const Date& d1, const Date& d2) {

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(testSettings) {
     std::vector<ext::shared_ptr<CashFlow> > leg;
     leg.reserve(3);
     for (Integer i = 0; i < 3; ++i)
-        leg.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(1.0, today+i)));
+        leg.emplace_back(ext::make_shared<SimpleCashFlow>(1.0, today+i));
 
 
     #define CHECK_INCLUSION(n, days, expected) \

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(testSettings) {
     std::vector<ext::shared_ptr<CashFlow> > leg;
     leg.reserve(3);
     for (Integer i = 0; i < 3; ++i)
-        leg.emplace_back(ext::make_shared<SimpleCashFlow>(1.0, today+i));
+        leg.push_back(ext::make_shared<SimpleCashFlow>(1.0, today+i));
 
 
     #define CHECK_INCLUSION(n, days, expected) \

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -223,9 +223,9 @@ void setup() {
     coefficients[0]= c;
     coefficients[1]= b;
     coefficients[2]= a;
-    costFunctions_.emplace_back(ext::make_shared<OneDimensionalPolynomialDegreeN>(coefficients));
+    costFunctions_.push_back(ext::make_shared<OneDimensionalPolynomialDegreeN>(coefficients));
     // Set constraint for optimizers: unconstrained problem
-    constraints_.emplace_back(ext::make_shared<NoConstraint>());
+    constraints_.push_back(ext::make_shared<NoConstraint>());
     // Set initial guess for optimizer
     Array initialValue(1);
     initialValue[0] = -100;

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -168,11 +168,11 @@ ext::shared_ptr<OptimizationMethod> makeOptimizationMethod(
                                        levenbergMarquardtGtol,
                                        true));
       case conjugateGradient:
-        return ext::shared_ptr<OptimizationMethod>(new ConjugateGradient);
+        return ext::make_shared<ConjugateGradient>();
       case steepestDescent:
-        return ext::shared_ptr<OptimizationMethod>(new SteepestDescent);
+        return ext::make_shared<SteepestDescent>();
       case bfgs:
-        return ext::shared_ptr<OptimizationMethod>(new BFGS);
+        return ext::make_shared<BFGS>();
       case conjugateGradient_goldstein:
         return ext::shared_ptr<OptimizationMethod>(new ConjugateGradient(ext::make_shared<GoldsteinLineSearch>()));
       case steepestDescent_goldstein:
@@ -223,10 +223,9 @@ void setup() {
     coefficients[0]= c;
     coefficients[1]= b;
     coefficients[2]= a;
-    costFunctions_.push_back(ext::shared_ptr<CostFunction>(
-            new OneDimensionalPolynomialDegreeN(coefficients)));
+    costFunctions_.emplace_back(ext::make_shared<OneDimensionalPolynomialDegreeN>(coefficients));
     // Set constraint for optimizers: unconstrained problem
-    constraints_.push_back(ext::shared_ptr<Constraint>(new NoConstraint()));
+    constraints_.emplace_back(ext::make_shared<NoConstraint>());
     // Set initial guess for optimizer
     Array initialValue(1);
     initialValue[0] = -100;

--- a/test-suite/quantlibbenchmark.cpp
+++ b/test-suite/quantlibbenchmark.cpp
@@ -424,7 +424,7 @@ namespace {
         struct AddBenchmark {
             template<class CALLABLE>
                 AddBenchmark(std::vector<Benchmark> &bm, CALLABLE && test_body, const char* name, double cost) {
-                    bm.push_back( Benchmark(name, std::forward<CALLABLE>(test_body), cost) );
+                    bm.emplace_back(name, std::forward<CALLABLE>(test_body), cost);
                 }
         };
     };


### PR DESCRIPTION
This PR applies a very small set of modern C++ cleanups in selected QuantLib files.

The main goal is to address selected clang-tidy warnings while keeping the changes intentionally small.
