### PR TITLE
Add additional harnesses to be consumed by OSS-Fuzz

### DIFF
--- a/fuzz-test-suite/CMakeLists.txt
+++ b/fuzz-test-suite/CMakeLists.txt
@@ -56,3 +56,52 @@ set_target_properties(BlackFormulaFuzzer PROPERTIES
     LINK_FLAGS "${FUZZING_LINK_FLAGS}"
 )
 target_link_libraries(BlackFormulaFuzzer ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(VanillaOptionFuzzer fuzz_vanilla_option.cpp)
+set_target_properties(VanillaOptionFuzzer PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(VanillaOptionFuzzer ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_CashFlows fuzz_cashflows.cpp)
+set_target_properties(Fuzz_CashFlows PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_CashFlows ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_IndexManager fuzz_indexmanager.cpp)
+set_target_properties(Fuzz_IndexManager PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_IndexManager ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_ExchangeRateManager fuzz_exchangeratemanager.cpp)
+set_target_properties(Fuzz_ExchangeRateManager PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_ExchangeRateManager ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_BarrierOption fuzz_barrieroption.cpp)
+set_target_properties(Fuzz_BarrierOption PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_BarrierOption ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_AsianOption fuzz_asianoption.cpp)
+set_target_properties(Fuzz_AsianOption PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_AsianOption ql_library ${QL_THREAD_LIBRARIES})
+
+add_executable(Fuzz_BasketOption fuzz_basketoption.cpp)
+set_target_properties(Fuzz_BasketOption PROPERTIES
+    COMPILE_FLAGS "${FUZZING_COMPILE_FLAGS}"
+    LINK_FLAGS "${FUZZING_LINK_FLAGS}"
+)
+target_link_libraries(Fuzz_BasketOption ql_library ${QL_THREAD_LIBRARIES})

--- a/fuzz-test-suite/fuzz_asianoption.cpp
+++ b/fuzz-test-suite/fuzz_asianoption.cpp
@@ -1,0 +1,99 @@
+/*
+ Copyright (C) 2026 David Korczynski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/exercise.hpp>
+#include <ql/instruments/asianoption.hpp>
+#include <ql/pricingengines/asian/analytic_cont_geom_av_price.hpp>
+#include <ql/pricingengines/asian/analytic_discr_geom_av_price.hpp>
+#include <ql/settings.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        auto type = fdp.PickValueInArray({Option::Put, Option::Call});
+        auto averageType = fdp.PickValueInArray({Average::Arithmetic, Average::Geometric});
+        
+        Real strike = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Real spot = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        
+        Rate r = fdp.ConsumeFloatingPointInRange<Real>(-0.02, 0.15);
+        Rate q = fdp.ConsumeFloatingPointInRange<Real>(0.0, 0.10);
+        Volatility vol = fdp.ConsumeFloatingPointInRange<Volatility>(0.01, 3.0);
+        auto maturityDays = fdp.ConsumeIntegralInRange<int>(7, 3650);
+        
+        bool continuous = fdp.ConsumeBool();
+
+        Date today(15, January, 2025);
+        Settings::instance().evaluationDate() = today;
+        DayCounter dc = Actual360();
+
+        auto spotQuote = ext::make_shared<SimpleQuote>(spot);
+        auto rTS = ext::make_shared<FlatForward>(today, r, dc);
+        auto qTS = ext::make_shared<FlatForward>(today, q, dc);
+        auto volTS = ext::make_shared<BlackConstantVol>(
+            today, NullCalendar(), vol, dc);
+
+        auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
+            Handle<Quote>(spotQuote),
+            Handle<YieldTermStructure>(qTS),
+            Handle<YieldTermStructure>(rTS),
+            Handle<BlackVolTermStructure>(volTS));
+
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+        Date exDate = today + maturityDays;
+        auto exercise = ext::make_shared<EuropeanExercise>(exDate);
+
+        if (continuous) {
+            ContinuousAveragingAsianOption option(averageType, payoff, exercise);
+            // Analytic engine only supports Geometric average
+            if (averageType == Average::Geometric) {
+                auto engine = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianEngine>(bsmProcess);
+                option.setPricingEngine(engine);
+                (void)option.NPV();
+            }
+        } else {
+            auto fixingCount = fdp.ConsumeIntegralInRange<int>(1, 10);
+            std::vector<Date> fixingDates;
+            for (int i = 0; i < fixingCount; ++i) {
+                fixingDates.push_back(today + fdp.ConsumeIntegralInRange<int>(1, maturityDays));
+            }
+            std::sort(fixingDates.begin(), fixingDates.end());
+            // unique
+            fixingDates.erase(std::unique(fixingDates.begin(), fixingDates.end()), fixingDates.end());
+            if (fixingDates.empty()) fixingDates.push_back(today + maturityDays);
+
+            DiscreteAveragingAsianOption option(averageType, fixingDates, payoff, exercise);
+            if (averageType == Average::Geometric) {
+                auto engine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(bsmProcess);
+                option.setPricingEngine(engine);
+                (void)option.NPV();
+            }
+        }
+
+    } catch (const std::exception&) {
+    }
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_barrieroption.cpp
+++ b/fuzz-test-suite/fuzz_barrieroption.cpp
@@ -1,0 +1,93 @@
+/*
+ Copyright (C) 2026 David Korczynski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/exercise.hpp>
+#include <ql/instruments/barrieroption.hpp>
+#include <ql/pricingengines/barrier/analyticbarrierengine.hpp>
+#include <ql/pricingengines/barrier/fdblackscholesbarrierengine.hpp>
+#include <ql/settings.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        auto type = fdp.PickValueInArray({Option::Put, Option::Call});
+        auto barrierType = fdp.PickValueInArray({Barrier::DownIn, Barrier::UpIn, Barrier::DownOut, Barrier::UpOut});
+        
+        Real strike = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Real spot = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Real barrier = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Real rebate = fdp.ConsumeFloatingPointInRange<Real>(0.0, 100.0);
+        
+        Rate r = fdp.ConsumeFloatingPointInRange<Real>(-0.02, 0.15);
+        Rate q = fdp.ConsumeFloatingPointInRange<Real>(0.0, 0.10);
+        Volatility vol = fdp.ConsumeFloatingPointInRange<Volatility>(0.01, 3.0);
+        auto maturityDays = fdp.ConsumeIntegralInRange<int>(7, 3650);
+        auto engineChoice = fdp.ConsumeIntegralInRange<int>(0, 1);
+
+        Date today(15, January, 2025);
+        Settings::instance().evaluationDate() = today;
+        DayCounter dc = Actual360();
+
+        auto spotQuote = ext::make_shared<SimpleQuote>(spot);
+        auto rTS = ext::make_shared<FlatForward>(today, r, dc);
+        auto qTS = ext::make_shared<FlatForward>(today, q, dc);
+        auto volTS = ext::make_shared<BlackConstantVol>(
+            today, NullCalendar(), vol, dc);
+
+        auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
+            Handle<Quote>(spotQuote),
+            Handle<YieldTermStructure>(qTS),
+            Handle<YieldTermStructure>(rTS),
+            Handle<BlackVolTermStructure>(volTS));
+
+        ext::shared_ptr<PricingEngine> engine;
+        switch (engineChoice) {
+        case 0:
+            engine = ext::make_shared<AnalyticBarrierEngine>(bsmProcess);
+            break;
+        case 1:
+            engine = ext::make_shared<FdBlackScholesBarrierEngine>(bsmProcess);
+            break;
+        }
+
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+        Date exDate = today + maturityDays;
+        auto exercise = ext::make_shared<EuropeanExercise>(exDate);
+
+        BarrierOption option(barrierType, barrier, rebate, payoff, exercise);
+        option.setPricingEngine(engine);
+
+        (void)option.NPV();
+        (void)option.delta();
+        (void)option.gamma();
+        (void)option.vega();
+        (void)option.theta();
+        (void)option.rho();
+
+    } catch (const std::exception&) {
+    }
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_basketoption.cpp
+++ b/fuzz-test-suite/fuzz_basketoption.cpp
@@ -1,0 +1,121 @@
+/*
+ Copyright (C) 2026 David Korczynski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/exercise.hpp>
+#include <ql/instruments/basketoption.hpp>
+#include <ql/pricingengines/basket/stulzengine.hpp>
+#include <ql/pricingengines/basket/mceuropeanbasketengine.hpp>
+#include <ql/settings.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        auto type = fdp.PickValueInArray({Option::Put, Option::Call});
+        auto basketTypeChoice = fdp.ConsumeIntegralInRange<int>(0, 2);
+        
+        Real strike = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        
+        auto nAssets = fdp.ConsumeIntegralInRange<int>(2, 4);
+        std::vector<ext::shared_ptr<StochasticProcess1D>> processes;
+        
+        Date today(15, January, 2025);
+        Settings::instance().evaluationDate() = today;
+        DayCounter dc = Actual360();
+
+        Rate r = fdp.ConsumeFloatingPointInRange<Real>(-0.02, 0.15);
+        auto rTS = ext::make_shared<FlatForward>(today, r, dc);
+        Handle<YieldTermStructure> rH(rTS);
+
+        for (int i = 0; i < nAssets; ++i) {
+            Real spot = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+            Volatility vol = fdp.ConsumeFloatingPointInRange<Volatility>(0.01, 3.0);
+            Rate q = fdp.ConsumeFloatingPointInRange<Real>(0.0, 0.10);
+            
+            auto qTS = ext::make_shared<FlatForward>(today, q, dc);
+            auto volTS = ext::make_shared<BlackConstantVol>(today, NullCalendar(), vol, dc);
+            
+            processes.push_back(ext::make_shared<BlackScholesMertonProcess>(
+                Handle<Quote>(ext::make_shared<SimpleQuote>(spot)),
+                Handle<YieldTermStructure>(qTS),
+                rH,
+                Handle<BlackVolTermStructure>(volTS)));
+        }
+
+        Matrix correlation(nAssets, nAssets, 0.0);
+        for (int i = 0; i < nAssets; ++i) {
+            correlation[i][i] = 1.0;
+            for (int j = 0; j < i; ++j) {
+                Real rho = fdp.ConsumeFloatingPointInRange<Real>(-0.99, 0.99);
+                correlation[i][j] = correlation[j][i] = rho;
+            }
+        }
+
+        auto process = ext::make_shared<StochasticProcessArray>(processes, correlation);
+        
+        ext::shared_ptr<BasketPayoff> payoff;
+        auto vanillaPayoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+        switch (basketTypeChoice) {
+        case 0:
+            payoff = ext::make_shared<MaxBasketPayoff>(vanillaPayoff);
+            break;
+        case 1:
+            payoff = ext::make_shared<MinBasketPayoff>(vanillaPayoff);
+            break;
+        case 2:
+            payoff = ext::make_shared<AverageBasketPayoff>(vanillaPayoff, nAssets);
+            break;
+        }
+
+        auto maturityDays = fdp.ConsumeIntegralInRange<int>(7, 3650);
+        Date exDate = today + maturityDays;
+        auto exercise = ext::make_shared<EuropeanExercise>(exDate);
+
+        BasketOption option(payoff, exercise);
+
+        auto engineChoice = fdp.ConsumeIntegralInRange<int>(0, 1);
+        ext::shared_ptr<PricingEngine> engine;
+        if (engineChoice == 0 && nAssets == 2) {
+            auto p1 = ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(processes[0]);
+            auto p2 = ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(processes[1]);
+            if (p1 && p2) {
+                engine = ext::make_shared<StulzEngine>(p1, p2, correlation[0][1]);
+            }
+        } 
+        
+        if (!engine) {
+            engine = MakeMCEuropeanBasketEngine<PseudoRandom>(process)
+                .withSteps(10)
+                .withSamples(100)
+                .withSeed(42);
+        }
+        
+        option.setPricingEngine(engine);
+        (void)option.NPV();
+
+    } catch (const std::exception&) {
+    }
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_cashflows.cpp
+++ b/fuzz-test-suite/fuzz_cashflows.cpp
@@ -1,0 +1,74 @@
+#include <ql/cashflows/cashflows.hpp>
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/cashflows/simplecashflow.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/settings.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/schedule.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        Date today(15, January, 2025);
+        Settings::instance().evaluationDate() = today;
+
+        Leg leg;
+        size_t numCashFlows = fdp.ConsumeIntegralInRange<size_t>(1, 20);
+        for (size_t i = 0; i < numCashFlows; ++i) {
+            Date d = today + fdp.ConsumeIntegralInRange<int>(1, 365 * 10);
+            Real amount = fdp.ConsumeFloatingPointInRange<Real>(0.0, 10000.0);
+            leg.push_back(ext::make_shared<SimpleCashFlow>(amount, d));
+        }
+
+        if (fdp.ConsumeBool()) {
+            Schedule schedule = MakeSchedule()
+                .from(today)
+                .to(today + Period(5, Years))
+                .withFrequency(Semiannual)
+                .withCalendar(NullCalendar());
+            
+            Rate rate = fdp.ConsumeFloatingPointInRange<Rate>(0.0, 0.2);
+            DayCounter dc = Actual360();
+            Leg coupons = FixedRateLeg(schedule)
+                .withNotionals(100.0)
+                .withCouponRates(rate, dc);
+            
+            leg.insert(leg.end(), coupons.begin(), coupons.end());
+        }
+
+        if (leg.empty()) return 0;
+
+        Rate yield = fdp.ConsumeFloatingPointInRange<Rate>(0.0, 0.2);
+        DayCounter dc = Actual360();
+        Compounding comp = fdp.PickValueInArray({Simple, Compounded, Continuous, SimpleThenCompounded});
+        Frequency freq = fdp.PickValueInArray({NoFrequency, Once, Annual, Semiannual, EveryFourthMonth, Quarterly, Bimonthly, Monthly, EveryFourthWeek, Biweekly, Weekly, Daily, OtherFrequency});
+
+        (void)CashFlows::startDate(leg);
+        (void)CashFlows::maturityDate(leg);
+        (void)CashFlows::isExpired(leg);
+        
+        (void)CashFlows::npv(leg, yield, dc, comp, freq);
+        (void)CashFlows::bps(leg, yield, dc, comp, freq);
+        
+        Duration::Type durationType = fdp.PickValueInArray({Duration::Simple, Duration::Modified, Duration::Macaulay});
+        (void)CashFlows::duration(leg, yield, dc, comp, freq, durationType);
+        (void)CashFlows::convexity(leg, yield, dc, comp, freq);
+        (void)CashFlows::basisPointValue(leg, yield, dc, comp, freq);
+        (void)CashFlows::yieldValueBasisPoint(leg, yield, dc, comp, freq);
+
+        if (numCashFlows <= 10 && fdp.ConsumeBool()) {
+            Real npv = fdp.ConsumeFloatingPointInRange<Real>(1.0, 200.0);
+            try {
+                (void)CashFlows::yield(leg, npv, dc, comp, freq);
+            } catch (...) {}
+        }
+
+    } catch (...) {}
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_exchangeratemanager.cpp
+++ b/fuzz-test-suite/fuzz_exchangeratemanager.cpp
@@ -1,0 +1,57 @@
+#include <ql/currencies/exchangeratemanager.hpp>
+#include <ql/currencies/europe.hpp>
+#include <ql/currencies/america.hpp>
+#include <ql/currencies/asia.hpp>
+#include <ql/currencies/oceania.hpp>
+#include <ql/settings.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        ExchangeRateManager& erm = ExchangeRateManager::instance();
+
+        if (fdp.ConsumeBool()) {
+            erm.clear();
+        }
+
+        const Currency currencies[] = {
+            EURCurrency(), USDCurrency(), GBPCurrency(), JPYCurrency(),
+            CHFCurrency(), CADCurrency(), AUDCurrency(), HKDCurrency()
+        };
+
+        size_t numRates = fdp.ConsumeIntegralInRange<size_t>(0, 10);
+        for (size_t i = 0; i < numRates; ++i) {
+            Currency c1 = fdp.PickValueInArray(currencies);
+            Currency c2 = fdp.PickValueInArray(currencies);
+            if (c1 == c2) continue;
+
+            Rate rate = fdp.ConsumeFloatingPointInRange<Rate>(0.01, 2.0);
+            ExchangeRate er(c1, c2, rate);
+
+            Date d1(fdp.ConsumeIntegralInRange<int>(1, 31),
+                    static_cast<Month>(fdp.ConsumeIntegralInRange<int>(1, 12)),
+                    fdp.ConsumeIntegralInRange<int>(1901, 2199));
+            Date d2 = d1 + fdp.ConsumeIntegralInRange<int>(1, 365);
+            
+            erm.add(er, d1, d2);
+        }
+
+        Currency s = fdp.PickValueInArray(currencies);
+        Currency t = fdp.PickValueInArray(currencies);
+        Date d(fdp.ConsumeIntegralInRange<int>(1, 31),
+               static_cast<Month>(fdp.ConsumeIntegralInRange<int>(1, 12)),
+               fdp.ConsumeIntegralInRange<int>(1901, 2199));
+        ExchangeRate::Type type = fdp.PickValueInArray({ExchangeRate::Direct, ExchangeRate::Derived});
+        
+        try {
+            (void)erm.lookup(s, t, d, type);
+        } catch (...) {}
+
+    } catch (...) {}
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_indexmanager.cpp
+++ b/fuzz-test-suite/fuzz_indexmanager.cpp
@@ -1,0 +1,45 @@
+#include <ql/indexes/indexmanager.hpp>
+#include <ql/indexes/ibor/euribor.hpp>
+#include <ql/settings.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        IndexManager& im = IndexManager::instance();
+
+        if (fdp.ConsumeBool()) {
+            im.clearHistories();
+        }
+
+        ext::shared_ptr<IborIndex> euribor = ext::make_shared<Euribor6M>();
+        
+        size_t numFixings = fdp.ConsumeIntegralInRange<size_t>(0, 10);
+        for (size_t i = 0; i < numFixings; ++i) {
+            Date d(fdp.ConsumeIntegralInRange<int>(1, 31),
+                   static_cast<Month>(fdp.ConsumeIntegralInRange<int>(1, 12)),
+                   fdp.ConsumeIntegralInRange<int>(1901, 2199));
+            if (euribor->isValidFixingDate(d)) {
+                Real fixing = fdp.ConsumeFloatingPointInRange<Real>(-1.0, 1.0);
+                try {
+                    euribor->addFixing(d, fixing);
+                } catch (...) {}
+            }
+        }
+
+        Date d2(fdp.ConsumeIntegralInRange<int>(1, 31),
+                static_cast<Month>(fdp.ConsumeIntegralInRange<int>(1, 12)),
+                fdp.ConsumeIntegralInRange<int>(1901, 2199));
+        (void)euribor->hasHistoricalFixing(d2);
+
+        (void)im.histories();
+        
+        euribor->clearFixings();
+
+    } catch (...) {}
+    return 0;
+}

--- a/fuzz-test-suite/fuzz_vanilla_option.cpp
+++ b/fuzz-test-suite/fuzz_vanilla_option.cpp
@@ -1,0 +1,110 @@
+/*
+ Copyright (C) 2026 David Korczynski
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/exercise.hpp>
+#include <ql/instruments/vanillaoption.hpp>
+#include <ql/pricingengines/vanilla/analyticeuropeanengine.hpp>
+#include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
+#include <ql/pricingengines/vanilla/integralengine.hpp>
+#include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
+#include <ql/pricingengines/vanilla/bjerksundstenslandengine.hpp>
+#include <ql/settings.hpp>
+#include <ql/termstructures/volatility/equityfx/blackconstantvol.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/calendars/nullcalendar.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <fuzzer/FuzzedDataProvider.h>
+
+using namespace QuantLib;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider fdp(data, size);
+    SavedSettings saved_settings;
+
+    try {
+        auto type = fdp.PickValueInArray({Option::Put, Option::Call});
+        Real strike = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Real spot = fdp.ConsumeFloatingPointInRange<Real>(1.0, 500.0);
+        Rate r = fdp.ConsumeFloatingPointInRange<Real>(-0.02, 0.15);
+        Rate q = fdp.ConsumeFloatingPointInRange<Real>(0.0, 0.10);
+        Volatility vol = fdp.ConsumeFloatingPointInRange<Volatility>(0.01, 3.0);
+        auto maturityDays = fdp.ConsumeIntegralInRange<int>(7, 3650);
+        
+        bool isAmerican = fdp.ConsumeBool();
+
+        Date today(15, January, 2025);
+        Settings::instance().evaluationDate() = today;
+        DayCounter dc = Actual360();
+
+        auto spotQuote = ext::make_shared<SimpleQuote>(spot);
+        auto rTS = ext::make_shared<FlatForward>(today, r, dc);
+        auto qTS = ext::make_shared<FlatForward>(today, q, dc);
+        auto volTS = ext::make_shared<BlackConstantVol>(
+            today, NullCalendar(), vol, dc);
+
+        auto bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
+            Handle<Quote>(spotQuote),
+            Handle<YieldTermStructure>(qTS),
+            Handle<YieldTermStructure>(rTS),
+            Handle<BlackVolTermStructure>(volTS));
+
+        ext::shared_ptr<PricingEngine> engine;
+        ext::shared_ptr<Exercise> exercise;
+        Date exDate = today + maturityDays;
+
+        if (isAmerican) {
+            exercise = ext::make_shared<AmericanExercise>(today, exDate);
+            auto engineChoice = fdp.ConsumeIntegralInRange<int>(0, 1);
+            if (engineChoice == 0) {
+                engine = ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(bsmProcess);
+            } else {
+                engine = ext::make_shared<BjerksundStenslandApproximationEngine>(bsmProcess);
+            }
+        } else {
+            exercise = ext::make_shared<EuropeanExercise>(exDate);
+            auto engineChoice = fdp.ConsumeIntegralInRange<int>(0, 2);
+            switch (engineChoice) {
+            case 0:
+                engine = ext::make_shared<AnalyticEuropeanEngine>(bsmProcess);
+                break;
+            case 1:
+                engine = ext::make_shared<FdBlackScholesVanillaEngine>(
+                    bsmProcess, 25, 25);
+                break;
+            case 2:
+                engine = ext::make_shared<IntegralEngine>(bsmProcess);
+                break;
+            }
+        }
+
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+        VanillaOption option(payoff, exercise);
+        option.setPricingEngine(engine);
+
+        (void)option.NPV();
+        if (!isAmerican) {
+            (void)option.delta();
+            (void)option.gamma();
+            (void)option.vega();
+            (void)option.theta();
+            (void)option.rho();
+        }
+
+    } catch (const std::exception&) {
+    }
+    return 0;
+}


### PR DESCRIPTION
Adds additional fuzzingh harnesses that will be run on OSS-Fuzz. The main goal is to increase code coverage, for which a recent code coverage report is available at
https://storage.googleapis.com/oss-fuzz-coverage/quantlib/reports/20260504/linux/report.html

The recent added harnesses has shown an increase, although there is still much room to go:
https://introspector.oss-fuzz.com/project-profile?project=quantlib

The harnesses added here roughly doubles the coverage on a short local run.