### PR TITLE
Avoid dangling references in `FdmCEVOp` and `TrBDF2Scheme` classes

### DIFF
--- a/ql/methods/finitedifferences/operators/fdmcevop.hpp
+++ b/ql/methods/finitedifferences/operators/fdmcevop.hpp
@@ -60,7 +60,7 @@ namespace QuantLib {
         std::vector<SparseMatrix> toMatrixDecomp() const override;
 
       private:
-        const ext::shared_ptr<YieldTermStructure>& rTS_;
+        const ext::shared_ptr<YieldTermStructure> rTS_;
         const Size direction_;
         const TripleBandLinearOp dxxMap_;
         TripleBandLinearOp mapT_;

--- a/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
+++ b/ql/methods/finitedifferences/schemes/trbdf2scheme.hpp
@@ -68,7 +68,7 @@ namespace QuantLib {
 
         const Real alpha_;
         const ext::shared_ptr<FdmLinearOpComposite> map_;
-        const ext::shared_ptr<TrapezoidalScheme>& trapezoidalScheme_;
+        const ext::shared_ptr<TrapezoidalScheme> trapezoidalScheme_;
         const BoundaryConditionSchemeHelper bcSet_;
         const Real relTol_;
         const SolverType solverType_;


### PR DESCRIPTION
Stores `FdmCEVOp::rTS_` and `TrBDF2Scheme::trapezoidalScheme_` by value rather than as const references to a `shared_ptr`, avoiding dangling references.