### PR TITLE
Add `PearsonSpreadEngine` for spread option pricing

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1509,6 +1509,7 @@
     <ClInclude Include="ql\pricingengines\basket\mcamericanbasketengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\mceuropeanbasketengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\operatorsplittingspreadengine.hpp" />
+    <ClInclude Include="ql\pricingengines\basket\pearsonspreadengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\singlefactorbsmbasketengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\spreadblackscholesvanillaengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\stulzengine.hpp" />
@@ -2602,6 +2603,7 @@
     <ClCompile Include="ql\pricingengines\basket\mcamericanbasketengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\mceuropeanbasketengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\operatorsplittingspreadengine.cpp" />
+    <ClCompile Include="ql\pricingengines\basket\pearsonspreadengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\singlefactorbsmbasketengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\spreadblackscholesvanillaengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\stulzengine.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4503,6 +4503,9 @@
     <ClInclude Include="ql\pricingengines\basket\operatorsplittingspreadengine.hpp">
       <Filter>pricingengines\basket</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\basket\pearsonspreadengine.hpp">
+      <Filter>pricingengines\basket</Filter>
+    </ClInclude>
     <ClInclude Include="ql\pricingengines\basket\singlefactorbsmbasketengine.hpp">
       <Filter>pricingengines\basket</Filter>
     </ClInclude>
@@ -7331,6 +7334,9 @@
       <Filter>pricingengines\basket</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\basket\operatorsplittingspreadengine.cpp">
+      <Filter>pricingengines\basket</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\pricingengines\basket\pearsonspreadengine.cpp">
       <Filter>pricingengines\basket</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\basket\singlefactorbsmbasketengine.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -682,6 +682,7 @@ set(QL_SOURCES
     pricingengines/basket/mcamericanbasketengine.cpp
     pricingengines/basket/mceuropeanbasketengine.cpp
     pricingengines/basket/operatorsplittingspreadengine.cpp
+    pricingengines/basket/pearsonspreadengine.cpp
     pricingengines/basket/singlefactorbsmbasketengine.cpp
     pricingengines/basket/spreadblackscholesvanillaengine.cpp
     pricingengines/basket/stulzengine.cpp
@@ -1906,6 +1907,7 @@ set(QL_HEADERS
     pricingengines/basket/mcamericanbasketengine.hpp
     pricingengines/basket/mceuropeanbasketengine.hpp
     pricingengines/basket/operatorsplittingspreadengine.hpp
+    pricingengines/basket/pearsonspreadengine.hpp
     pricingengines/basket/singlefactorbsmbasketengine.hpp
     pricingengines/basket/spreadblackscholesvanillaengine.hpp
     pricingengines/basket/stulzengine.hpp

--- a/ql/pricingengines/basket/Makefile.am
+++ b/ql/pricingengines/basket/Makefile.am
@@ -13,6 +13,7 @@ this_include_HEADERS = \
 	mcamericanbasketengine.hpp \
 	mceuropeanbasketengine.hpp \
 	operatorsplittingspreadengine.hpp \
+	pearsonspreadengine.hpp \
 	singlefactorbsmbasketengine.hpp \
 	spreadblackscholesvanillaengine.hpp \
 	stulzengine.hpp \
@@ -28,6 +29,7 @@ cpp_files = \
 	mcamericanbasketengine.cpp \
 	mceuropeanbasketengine.cpp \
 	operatorsplittingspreadengine.cpp \
+	pearsonspreadengine.cpp \
 	singlefactorbsmbasketengine.cpp \
 	spreadblackscholesvanillaengine.cpp \
 	stulzengine.cpp \

--- a/ql/pricingengines/basket/all.hpp
+++ b/ql/pricingengines/basket/all.hpp
@@ -10,6 +10,7 @@
 #include <ql/pricingengines/basket/mcamericanbasketengine.hpp>
 #include <ql/pricingengines/basket/mceuropeanbasketengine.hpp>
 #include <ql/pricingengines/basket/operatorsplittingspreadengine.hpp>
+#include <ql/pricingengines/basket/pearsonspreadengine.hpp>
 #include <ql/pricingengines/basket/singlefactorbsmbasketengine.hpp>
 #include <ql/pricingengines/basket/spreadblackscholesvanillaengine.hpp>
 #include <ql/pricingengines/basket/stulzengine.hpp>

--- a/ql/pricingengines/basket/pearsonspreadengine.cpp
+++ b/ql/pricingengines/basket/pearsonspreadengine.cpp
@@ -1,0 +1,93 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/pricingengines/basket/pearsonspreadengine.hpp>
+#include <ql/pricingengines/blackcalculator.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/math/integrals/gausslobattointegral.hpp>
+#include <utility>
+
+namespace QuantLib {
+
+    PearsonSpreadEngine::PearsonSpreadEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process1,
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process2,
+        Real correlation,
+        Real integrationTolerance,
+        Size maxIntegrationIterations,
+        Real nStd)
+    : SpreadBlackScholesVanillaEngine(
+          std::move(process1), std::move(process2), correlation),
+      integrationTolerance_(integrationTolerance),
+      maxIntegrationIterations_(maxIntegrationIterations),
+      nStd_(nStd) {
+    }
+
+    Real PearsonSpreadEngine::calculate(
+        Real f1, Real f2, Real strike, Option::Type optionType,
+        Real variance1, Real variance2, DiscountFactor df) const {
+
+        const Real sigma1 = std::sqrt(variance1);
+        const Real sigma2 = std::sqrt(variance2);
+
+        // Under the forward measure, the joint dynamics are:
+        //   ln F1 ~ N(mu1, sigma1^2),  ln F2 ~ N(mu2, sigma2^2)
+        //   with correlation rho_
+        //
+        // Condition on z = standard normal driving F2:
+        //   F2(z) = f2 * exp(-0.5*sigma2^2 + sigma2*z)
+        //
+        // Conditional on z, F1 is log-normal with:
+        //   conditional mean of ln F1:  mu1_cond = ln(f1) - 0.5*sigma1^2 + rho_*sigma1*z
+        //   conditional variance:       sigma1_cond^2 = sigma1^2*(1 - rho_^2)
+        //
+        // The conditional spread option value is a Black call/put:
+        //   BS(F1_cond, K + F2(z), sigma1_cond)
+
+        const Real sigma1Cond = sigma1 * std::sqrt(std::max(1.0 - rho_ * rho_, 0.0));
+
+        const NormalDistribution phi;
+
+        // Integrate over the standard normal variable z
+        // that drives F2. Truncate at +/- 8 standard deviations.
+        auto integrand = [&](Real z) -> Real {
+            const Real f2z = f2 * std::exp(-0.5 * variance2 + sigma2 * z);
+            const Real effectiveStrike = f2z + strike;
+
+            if (effectiveStrike <= 0.0)
+                return phi(z) * std::max(0.0, f1 * std::exp(rho_ * sigma1 * z
+                           - 0.5 * rho_ * rho_ * variance1) - effectiveStrike);
+
+            const Real f1Cond = f1 * std::exp(rho_ * sigma1 * z
+                                              - 0.5 * rho_ * rho_ * variance1);
+
+            BlackCalculator black(
+                ext::make_shared<PlainVanillaPayoff>(optionType, effectiveStrike),
+                f1Cond, sigma1Cond, 1.0);
+
+            return phi(z) * black.value();
+        };
+
+        GaussLobattoIntegral integrator(maxIntegrationIterations_,
+                                       integrationTolerance_);
+        const Real undiscounted = integrator(integrand, -nStd_, nStd_);
+
+        return df * undiscounted;
+    }
+}

--- a/ql/pricingengines/basket/pearsonspreadengine.hpp
+++ b/ql/pricingengines/basket/pearsonspreadengine.hpp
@@ -1,0 +1,60 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file pearsonspreadengine.hpp
+    \brief Pearson (1995) spread option pricing via 1-D numerical integration
+*/
+
+#ifndef quantlib_pearson_spread_engine_hpp
+#define quantlib_pearson_spread_engine_hpp
+
+#include <ql/pricingengines/basket/spreadblackscholesvanillaengine.hpp>
+
+namespace QuantLib {
+
+    //! Pricing engine for spread options using Pearson (1995)
+    /*! References: Neil D. Pearson, "An Efficient Approach for
+        Pricing Spread Options", Journal of Derivatives, 3 (1995), 76-91.
+
+        \ingroup basketengines
+
+        \test the correctness of the returned value is tested by
+              benchmarking against 2D PDE spread-option pricing.
+    */
+    class PearsonSpreadEngine : public SpreadBlackScholesVanillaEngine {
+      public:
+        PearsonSpreadEngine(ext::shared_ptr<GeneralizedBlackScholesProcess> process1,
+                            ext::shared_ptr<GeneralizedBlackScholesProcess> process2,
+                            Real correlation,
+                            Real integrationTolerance = 1e-10,
+                            Size maxIntegrationIterations = 10000,
+                            Real nStd = 8.0);
+
+      protected:
+        Real calculate(Real f1, Real f2, Real strike, Option::Type optionType,
+                       Real variance1, Real variance2, DiscountFactor df) const override;
+
+      private:
+        Real integrationTolerance_;
+        Size maxIntegrationIterations_;
+        Real nStd_;
+    };
+}
+
+#endif

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -4,6 +4,7 @@
  Copyright (C) 2003, 2004, 2005, 2008 StatPro Italia srl
  Copyright (C) 2004 Ferdinando Ametrano
  Copyright (C) 2004 Neil Firth
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,6 +29,7 @@
 #include <ql/pricingengines/basket/fd2dblackscholesvanillaengine.hpp>
 #include <ql/pricingengines/basket/fdndimblackscholesvanillaengine.hpp>
 #include <ql/pricingengines/basket/kirkengine.hpp>
+#include <ql/pricingengines/basket/pearsonspreadengine.hpp>
 #include <ql/pricingengines/basket/choibasketengine.hpp>
 #include <ql/pricingengines/basket/mcamericanbasketengine.hpp>
 #include <ql/pricingengines/basket/mceuropeanbasketengine.hpp>
@@ -1381,7 +1383,7 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
 
     const Real strike = 5;
 
-    IncrementalStatistics statKirk, statBS2014, statOs1, statOs2;
+    IncrementalStatistics statKirk, statBS2014, statOs1, statOs2, statPearson;
 
     for (Option::Type type: {Option::Call, Option::Put}) {
         BasketOption option(
@@ -1403,6 +1405,9 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
             const ext::shared_ptr<PricingEngine> osEngine2
                 = ext::make_shared<OperatorSplittingSpreadEngine>(
                     p1, p2, rho, OperatorSplittingSpreadEngine::Second);
+
+            const ext::shared_ptr<PricingEngine> pearsonEngine
+                = ext::make_shared<PearsonSpreadEngine>(p1, p2, rho);
 
             const ext::shared_ptr<PricingEngine> fdEngine
                 = ext::make_shared<Fd2dBlackScholesVanillaEngine>(
@@ -1427,6 +1432,9 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
 
                     option.setPricingEngine(osEngine2);
                     statOs2.add(option.NPV() - fdNPV);
+
+                    option.setPricingEngine(pearsonEngine);
+                    statPearson.add(option.NPV() - fdNPV);
                 }
             }
         }
@@ -1459,6 +1467,14 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
                 " with Operator-Splitting engine (second order)."
                    << std::fixed << std::setprecision(5)
                    << "\n    stdev     : " << statOs2.standardDeviation()
+                   << "\n    tolerance : " << 0.02);
+    }
+
+    if (statPearson.standardDeviation() > 0.02) {
+        BOOST_FAIL("failed to reproduce PDE spread option prices"
+                " with Pearson engine."
+                   << std::fixed << std::setprecision(5)
+                   << "\n    stdev     : " << statPearson.standardDeviation()
                    << "\n    tolerance : " << 0.02);
     }
 }
@@ -2227,6 +2243,11 @@ BOOST_AUTO_TEST_CASE(testSpreadAndBasketBenchmarks) {
         return ext::make_shared<DengLiZhouBasketEngine>(p, rho);
     };
 
+    const auto pearsonEngine = [](const BlackScholesProcesses& p, const Matrix& rho, Time)
+        -> ext::shared_ptr<PricingEngine> {
+        return ext::make_shared<PearsonSpreadEngine>(p[0], p[1], rho[0][1]);
+    };
+
     const auto kirkEngine = [](const BlackScholesProcesses& p, const Matrix& rho, Time)
         -> ext::shared_ptr<PricingEngine> {
         return ext::make_shared<KirkEngine>(p[0], p[1], rho[0][1]);
@@ -2272,6 +2293,7 @@ BOOST_AUTO_TEST_CASE(testSpreadAndBasketBenchmarks) {
         {"Choi", choiEngine, 0.000182177},
         {"Choi Control Variate", choiCvEngine, 0.000228738},
         {"Deng-Li-Zhou", dengLiZhouEngine, 0.0629703},
+        {"Pearson", pearsonEngine, 0.0005},
         {"Kirk", kirkEngine, 0.030673},
         {"Quasi-Monte-Carlo", qmcEngine, 0.28862},
         {"Bjerksund-Stensland", bsEngine, 0.0222423},
@@ -2569,6 +2591,90 @@ BOOST_AUTO_TEST_CASE(testNoDivByZeroOperatorSplitting) {
            << "\n    expected:    " << expected
            << "\n    diff:        " << diff
            << "\n    tolerance:   " << tol);
+}
+
+
+BOOST_AUTO_TEST_CASE(testPearsonSpreadEngine) {
+    BOOST_TEST_MESSAGE("Testing Pearson spread engine...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(1, March, 2025);
+    const Date maturity = today + Period(12, Months);
+
+    const ext::shared_ptr<EuropeanExercise> exercise
+        = ext::make_shared<EuropeanExercise>(maturity);
+
+    const Real rho = 0.75;
+    const Real f1 = 100, f2 = 110;
+    const Handle<YieldTermStructure> r
+        = Handle<YieldTermStructure>(flatRate(today, 0.05, dc));
+    const ext::shared_ptr<BlackProcess> p1 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(f1)), r,
+            Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc))
+    );
+    const ext::shared_ptr<BlackProcess> p2 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(f2)), r,
+            Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc))
+    );
+
+    const ext::shared_ptr<PricingEngine> engine
+        = ext::make_shared<PearsonSpreadEngine>(p1, p2, rho);
+
+    // 1. Put-call parity: (C - P) / df = F1 - F2 - K
+    const Real strike = 5;
+    BasketOption callOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, strike)),
+        exercise);
+    callOption.setPricingEngine(engine);
+    const Real callNPV = callOption.NPV();
+
+    BasketOption putOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(Option::Put, strike)),
+        exercise);
+    putOption.setPricingEngine(engine);
+    const Real putNPV = putOption.NPV();
+
+    const DiscountFactor df = r->discount(maturity);
+    const Real fwd = (callNPV - putNPV)/df;
+    Real diff = std::abs(fwd - (f1 - f2 - strike));
+    constexpr double tol = 1e-10;
+
+    if (diff > tol) {
+        BOOST_FAIL("failed to reproduce call-put parity "
+                "using the Pearson spread engine."
+                   << std::fixed << std::setprecision(8)
+                   << "\n    calculated fwd: " << fwd
+                   << "\n    expected fwd  : " << f1 - f2 - strike
+                   << "\n    diff          : " << diff
+                   << "\n    tolerance     : " << tol);
+    }
+
+    // 2. Exchange option (K=0): should match Bjerksund-Stensland
+    const Real exchangeStrike = 0.0;
+    BasketOption exchangeOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, exchangeStrike)),
+        exercise);
+
+    exchangeOption.setPricingEngine(engine);
+    const Real pearsonExchange = exchangeOption.NPV();
+
+    const ext::shared_ptr<PricingEngine> bsEngine
+        = ext::make_shared<BjerksundStenslandSpreadEngine>(p1, p2, rho);
+    exchangeOption.setPricingEngine(bsEngine);
+    const Real bsExchange = exchangeOption.NPV();
+
+    diff = std::abs(pearsonExchange - bsExchange);
+    if (diff > 1e-6) {
+        BOOST_FAIL("failed to reproduce exchange option price "
+                "using the Pearson spread engine."
+                   << std::fixed << std::setprecision(8)
+                   << "\n    Pearson   : " << pearsonExchange
+                   << "\n    BS2014    : " << bsExchange
+                   << "\n    diff      : " << diff
+                   << "\n    tolerance : " << 1e-6);
+    }
 }
 
 


### PR DESCRIPTION
Adds `PearsonSpreadEngine` for European spread option pricing.

The method conditions on one of the two log-asset prices and integrates the resulting 1D Black-Scholes price numerically.

Tested in `testPDEvsApproximations`, included in `testSpreadAndBasketBenchmarks` and covered by a dedicated `testPearsonSpreadEngine`.