### PR TITLE
Use `Real` instead of `double` in `CompoundingOvernightIndexedCouponPricer` lambda

### DIFF
--- a/ql/cashflows/overnightindexedcouponpricer.cpp
+++ b/ql/cashflows/overnightindexedcouponpricer.cpp
@@ -115,12 +115,13 @@ namespace QuantLib {
 
         Size i = 0;
         const Size n = determineNumberOfFixings(interestDates, date);
-        const auto growthFactor = [&, applyObservationShift, compoundSpreadDaily](double fixing, Size idx) {
-            const auto span = (applyObservationShift || date >= interestDates[idx + 1])
+        const auto growthFactor = [&, applyObservationShift, compoundSpreadDaily](Real fixing, Size idx) {
+            const Time span = (applyObservationShift || date >= interestDates[idx + 1])
                               ? dt[idx]
                               : dc.yearFraction(interestDates[idx], date);
-            const auto gf = 1.0 + fixing * span;
-            return std::make_pair(gf, compoundSpreadDaily ? gf + couponSpread * span : gf);
+            const Real gf = 1.0 + fixing * span;
+            const Real gfSpread = compoundSpreadDaily ? Real(gf + couponSpread * span) : gf;
+            return std::make_pair(gf, gfSpread);
         };
 
         Real compoundFactor = 1.0, compoundFactorWithoutSpread = 1.0;


### PR DESCRIPTION
The `growthFactor` lambda in `CompoundingOvernightIndexedCouponPricer::compute` (introduced in 5348d7a) takes `double` as the parameter type for `fixing`. When `Real` is replaced by a non-`double` type (e.g. for automatic differentiation), this breaks compilation:

- `Rate` (aka `Real`) can't implicitly convert to `double` at call sites
- The ternary in the return produces mismatched expression template types

Fixed by using `Real` for the lambda parameter and explicit types instead of `auto` to keep the ternary branches consistent.