### PR TITLE
Use make_shared and make_unique for pointer construction

### DIFF
--- a/ql/cashflows/averagebmacoupon.cpp
+++ b/ql/cashflows/averagebmacoupon.cpp
@@ -125,8 +125,7 @@ namespace QuantLib {
 
         fixingSchedule_ = index->fixingSchedule(fixingStart, endDate);
 
-        setPricer(ext::shared_ptr<FloatingRateCouponPricer>(
-                                                 new AverageBMACouponPricer));
+        setPricer(ext::make_shared<AverageBMACouponPricer>());
     }
 
     Date AverageBMACoupon::fixingDate() const {
@@ -236,15 +235,14 @@ namespace QuantLib {
                 refEnd = calendar.adjust(start + schedule_.tenor(),
                                          paymentAdjustment_);
 
-            cashflows.push_back(ext::shared_ptr<CashFlow>(new
-                AverageBMACoupon(paymentDate,
+            cashflows.push_back(ext::make_shared<AverageBMACoupon>(paymentDate,
                                  detail::get(notionals_, i, notionals_.back()),
                                  start, end,
                                  index_,
                                  detail::get(gearings_, i, 1.0),
                                  detail::get(spreads_, i, 0.0),
                                  refStart, refEnd,
-                                 paymentDayCounter_)));
+                                 paymentDayCounter_));
         }
 
         return cashflows;

--- a/ql/cashflows/capflooredcoupon.hpp
+++ b/ql/cashflows/capflooredcoupon.hpp
@@ -119,11 +119,10 @@ namespace QuantLib {
                   bool isInArrears = false,
                   const Date& exCouponDate = Date(),
                   BusinessDayConvention fixingConvention = Preceding)
-        : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
-            IborCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
+        : CappedFlooredCoupon(ext::make_shared<IborCoupon>(paymentDate, nominal, startDate, endDate, fixingDays,
                        index, gearing, spread, refPeriodStart, refPeriodEnd,
                        dayCounter, isInArrears, exCouponDate,
-                       fixingConvention)), cap, floor) {}
+                       fixingConvention), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredIborCoupon>*>(&v);
@@ -153,11 +152,10 @@ namespace QuantLib {
                   bool isInArrears = false,
                   const Date& exCouponDate = Date(),
                   BusinessDayConvention fixingConvention = Preceding)
-        : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
-            CmsCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
+        : CappedFlooredCoupon(ext::make_shared<CmsCoupon>(paymentDate, nominal, startDate, endDate, fixingDays,
                       index, gearing, spread, refPeriodStart, refPeriodEnd,
                       dayCounter, isInArrears, exCouponDate,
-                      fixingConvention)), cap, floor) {}
+                      fixingConvention), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsCoupon>*>(&v);

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -1160,8 +1160,7 @@ namespace QuantLib {
             npvDate = settlementDate;
 
         Handle<YieldTermStructure> discountCurveHandle(discountCurve);
-        Handle<Quote> zSpreadQuoteHandle(ext::shared_ptr<Quote>(new
-            SimpleQuote(zSpread)));
+        Handle<Quote> zSpreadQuoteHandle(ext::make_shared<SimpleQuote>(zSpread));
 
         ZeroSpreadedTermStructure spreadedCurve(discountCurveHandle,
                                                 zSpreadQuoteHandle,

--- a/ql/cashflows/cashflowvectors.hpp
+++ b/ql/cashflows/cashflowvectors.hpp
@@ -132,14 +132,13 @@ namespace QuantLib {
                                                          exCouponAdjustment, exCouponEndOfMonth);
             }
             if (detail::get(gearings, i, 1.0) == 0.0) { // fixed coupon
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    FixedRateCoupon(paymentDate,
+                leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate,
                                     detail::get(nominals, i, 1.0),
                                     detail::effectiveFixedRate(spreads,caps,
                                                                floors,i),
                                     paymentDayCounter,
                                     start, end, refStart, refEnd, 
-						            exCouponDate)));
+						            exCouponDate));
             } else { // floating coupon
                 if (detail::noOption(caps, floors, i)) {
                     if constexpr (std::is_constructible_v<FloatingCouponType,
@@ -148,8 +147,7 @@ namespace QuantLib {
                                       Real, Spread, Date, Date,
                                       DayCounter, bool, Date,
                                       BusinessDayConvention>) {
-                        leg.push_back(ext::shared_ptr<CashFlow>(new
-                            FloatingCouponType(
+                        leg.push_back(ext::make_shared<FloatingCouponType>(
                                 paymentDate,
                                 detail::get(nominals, i, 1.0),
                                 start, end,
@@ -159,10 +157,9 @@ namespace QuantLib {
                                 detail::get(spreads, i, 0.0),
                                 refStart, refEnd,
                                 paymentDayCounter, isInArrears, exCouponDate,
-                                fixingConvention)));
+                                fixingConvention));
                     } else {
-                        leg.push_back(ext::shared_ptr<CashFlow>(new
-                            FloatingCouponType(
+                        leg.push_back(ext::make_shared<FloatingCouponType>(
                                 paymentDate,
                                 detail::get(nominals, i, 1.0),
                                 start, end,
@@ -171,7 +168,7 @@ namespace QuantLib {
                                 detail::get(gearings, i, 1.0),
                                 detail::get(spreads, i, 0.0),
                                 refStart, refEnd,
-                                paymentDayCounter, isInArrears, exCouponDate)));
+                                paymentDayCounter, isInArrears, exCouponDate));
                     }
                 } else {
                     if constexpr (std::is_constructible_v<CappedFlooredCouponType,
@@ -180,8 +177,7 @@ namespace QuantLib {
                                       Real, Spread, Rate, Rate, Date, Date,
                                       DayCounter, bool, Date,
                                       BusinessDayConvention>) {
-                        leg.push_back(ext::shared_ptr<CashFlow>(new
-                            CappedFlooredCouponType(
+                        leg.push_back(ext::make_shared<CappedFlooredCouponType>(
                                    paymentDate,
                                    detail::get(nominals, i, 1.0),
                                    start, end,
@@ -194,10 +190,9 @@ namespace QuantLib {
                                    refStart, refEnd,
                                    paymentDayCounter,
                                    isInArrears, exCouponDate,
-                                   fixingConvention)));
+                                   fixingConvention));
                     } else {
-                        leg.push_back(ext::shared_ptr<CashFlow>(new
-                            CappedFlooredCouponType(
+                        leg.push_back(ext::make_shared<CappedFlooredCouponType>(
                                    paymentDate,
                                    detail::get(nominals, i, 1.0),
                                    start, end,
@@ -209,7 +204,7 @@ namespace QuantLib {
                                    detail::get(floors, i, Null<Rate>()),
                                    refStart, refEnd,
                                    paymentDayCounter,
-                                   isInArrears, exCouponDate)));
+                                   isInArrears, exCouponDate));
                     }
                 }
             }
@@ -280,15 +275,13 @@ namespace QuantLib {
                 refEnd = calendar.adjust(start + schedule.tenor(), bdc);
             }
             if (detail::get(gearings, i, 1.0) == 0.0) { // fixed coupon
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    FixedRateCoupon(paymentDate,
+                leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate,
                                     detail::get(nominals, i, 1.0),
                                     detail::get(spreads, i, 1.0),
                                     paymentDayCounter,
-                                    start, end, refStart, refEnd)));
+                                    start, end, refStart, refEnd));
             } else { // floating digital coupon
-                ext::shared_ptr<FloatingCouponType> underlying(new
-                    FloatingCouponType(paymentDate,
+                ext::shared_ptr<FloatingCouponType> underlying = ext::make_shared<FloatingCouponType>(paymentDate,
                                        detail::get(nominals, i, 1.0),
                                        start, end,
                                        detail::get(fixingDays, i, index->fixingDays()),
@@ -296,9 +289,8 @@ namespace QuantLib {
                                        detail::get(gearings, i, 1.0),
                                        detail::get(spreads, i, 0.0),
                                        refStart, refEnd,
-                                       paymentDayCounter, isInArrears));
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    DigitalCouponType(
+                                       paymentDayCounter, isInArrears);
+                leg.push_back(ext::make_shared<DigitalCouponType>(
                              underlying,
                              detail::get(callStrikes, i, Null<Real>()),
                              callPosition,
@@ -308,7 +300,7 @@ namespace QuantLib {
                              putPosition,
                              isPutATMIncluded,
                              detail::get(putDigitalPayoffs, i, Null<Real>()),
-                             replication, nakedOption)));
+                             replication, nakedOption));
             }
         }
         return leg;

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -133,7 +133,7 @@ namespace QuantLib {
                     gFunction_ = GFunctionFactory::newGFunctionExactYield(*coupon_);
                     break;
                 case GFunctionFactory::ParallelShifts: {
-                    Handle<Quote> nullMeanReversionQuote(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+                    Handle<Quote> nullMeanReversionQuote(ext::make_shared<SimpleQuote>(0.0));
                     gFunction_ = GFunctionFactory::newGFunctionWithShifts(*coupon_, nullMeanReversionQuote);
                     }
                     break;
@@ -143,9 +143,8 @@ namespace QuantLib {
                 default:
                     QL_FAIL("unknown/illegal gFunction type");
             }
-            vanillaOptionPricer_= ext::shared_ptr<VanillaOptionPricer>(new
-                MarketQuotedOptionPricer(swapRateValue_, fixingDate_, swapTenor_,
-                                        *swaptionVolatility()));
+            vanillaOptionPricer_= ext::make_shared<MarketQuotedOptionPricer>(swapRateValue_, fixingDate_, swapTenor_,
+                                        *swaptionVolatility());
          }
     }
 
@@ -346,10 +345,9 @@ namespace QuantLib {
     Real NumericHaganPricer::optionletPrice(
                                 Option::Type optionType, Real strike) const {
 
-        ext::shared_ptr<ConundrumIntegrand> integrand(new
-            ConundrumIntegrand(vanillaOptionPricer_, rateCurve_, gFunction_,
+        ext::shared_ptr<ConundrumIntegrand> integrand = ext::make_shared<ConundrumIntegrand>(vanillaOptionPricer_, rateCurve_, gFunction_,
                                fixingDate_, paymentDate_, annuity_,
-                               swapRateValue_, strike, optionType));
+                               swapRateValue_, strike, optionType);
         stdDeviationsForUpperLimit_= requiredStdDeviations_;
         stdDeviationsForLowerLimit_= requiredStdDeviations_;
         Real a, b, integralValue;
@@ -630,7 +628,7 @@ namespace QuantLib {
 
     ext::shared_ptr<GFunction> GFunctionFactory::newGFunctionStandard(Size q,
                                                             Real delta, Size swapLength) {
-        return ext::shared_ptr<GFunction>(new GFunctionStandard(q, delta, swapLength));
+        return ext::make_shared<GFunctionStandard>(q, delta, swapLength);
     }
 
 //===========================================================================//
@@ -724,7 +722,7 @@ namespace QuantLib {
     }
 
     ext::shared_ptr<GFunction> GFunctionFactory::newGFunctionExactYield(const CmsCoupon& coupon) {
-        return ext::shared_ptr<GFunction>(new GFunctionExactYield(coupon));
+        return ext::make_shared<GFunctionExactYield>(coupon);
     }
 
 
@@ -981,7 +979,7 @@ namespace QuantLib {
 
     ext::shared_ptr<GFunction> GFunctionFactory::newGFunctionWithShifts(const CmsCoupon& coupon,
                                                                           const Handle<Quote>& meanReversion) {
-        return ext::shared_ptr<GFunction>(new GFunctionWithShifts(coupon, meanReversion));
+        return ext::make_shared<GFunctionWithShifts>(coupon, meanReversion);
     }
 
 }

--- a/ql/cashflows/couponpricer.hpp
+++ b/ql/cashflows/couponpricer.hpp
@@ -114,7 +114,7 @@ namespace QuantLib {
         BlackIborCouponPricer(
             const Handle<OptionletVolatilityStructure>& v = Handle<OptionletVolatilityStructure>(),
             const TimingAdjustment timingAdjustment = Black76,
-            Handle<Quote> correlation = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(1.0))),
+            Handle<Quote> correlation = Handle<Quote>(ext::make_shared<SimpleQuote>(1.0)),
             const ext::optional<bool> useIndexedCoupon = ext::nullopt)
         : IborCouponPricer(v, useIndexedCoupon), timingAdjustment_(timingAdjustment),
           correlation_(std::move(correlation)) {

--- a/ql/cashflows/dividend.cpp
+++ b/ql/cashflows/dividend.cpp
@@ -44,8 +44,7 @@ namespace QuantLib {
         items.reserve(dividendDates.size());
         for (dd = dividendDates.begin(), d = dividends.begin();
              dd != dividendDates.end(); ++dd, ++d) {
-            items.push_back(ext::shared_ptr<Dividend>(new
-                FixedDividend(*d, *dd)));
+            items.push_back(ext::make_shared<FixedDividend>(*d, *dd));
         }
         return items;
     }

--- a/ql/cashflows/fixedratecoupon.cpp
+++ b/ql/cashflows/fixedratecoupon.cpp
@@ -206,9 +206,8 @@ namespace QuantLib {
                        firstPeriodDC_.empty() ? rate.dayCounter()
                        : firstPeriodDC_,
                        rate.compounding(), rate.frequency());
-        leg.push_back(ext::shared_ptr<CashFlow>(new
-            FixedRateCoupon(paymentDate, nominal, r,
-                            start, end, ref, end, exCouponDate)));
+        leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate, nominal, r,
+                            start, end, ref, end, exCouponDate));
         // regular periods
         for (Size i=2; i<schedule_.size()-1; ++i) {
             start = end; end = schedule_.date(i);
@@ -228,9 +227,8 @@ namespace QuantLib {
                 nominal = notionals_[i-1];
             else
                 nominal = notionals_.back();
-            leg.push_back(ext::shared_ptr<CashFlow>(new
-                FixedRateCoupon(paymentDate, nominal, rate,
-                                start, end, start, end, exCouponDate)));
+            leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate, nominal, rate,
+                                start, end, start, end, exCouponDate));
         }
         if (schedule_.size() > 2) {
             // last period might be short or long
@@ -257,18 +255,16 @@ namespace QuantLib {
                 lastPeriodDC_ , rate.compounding(), rate.frequency() );
             if ((schedule_.hasIsRegular() && schedule_.isRegular(N - 1)) ||
                 !schedule_.hasTenor()) {
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    FixedRateCoupon(paymentDate, nominal, r,
-                                    start, end, start, end, exCouponDate)));
+                leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate, nominal, r,
+                                    start, end, start, end, exCouponDate));
             } else {
                 Date ref = schedule_.calendar().advance(
                                             start,
                                             schedule_.tenor(),
                                             schedule_.businessDayConvention(),
                                             schedule_.endOfMonth());
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    FixedRateCoupon(paymentDate, nominal, r,
-                                    start, end, start, ref, exCouponDate)));
+                leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate, nominal, r,
+                                    start, end, start, ref, exCouponDate));
             }
         }
         return leg;

--- a/ql/cashflows/rangeaccrual.cpp
+++ b/ql/cashflows/rangeaccrual.cpp
@@ -661,12 +661,11 @@ namespace QuantLib {
                 refEnd = calendar.adjust(start + schedule_.tenor(), bdc);
             }
             if (detail::get(gearings_, i, 1.0) == 0.0) { // fixed coupon
-                leg.push_back(ext::shared_ptr<CashFlow>(new
-                    FixedRateCoupon(paymentDate,
+                leg.push_back(ext::make_shared<FixedRateCoupon>(paymentDate,
                                     detail::get(notionals_, i, Null<Real>()),
                                     detail::get(spreads_, i, 0.0),
                                     paymentDayCounter_,
-                                    start, end, refStart, refEnd)));
+                                    start, end, refStart, refEnd));
             } else { // floating coupon
                 auto observationSchedule =
                     Schedule(start, end,
@@ -675,8 +674,7 @@ namespace QuantLib {
                              observationConvention_,
                              DateGeneration::Forward, false);
 
-                    leg.push_back(ext::shared_ptr<CashFlow>(new
-                       RangeAccrualFloatersCoupon(
+                    leg.push_back(ext::make_shared<RangeAccrualFloatersCoupon>(
                             paymentDate,
                             detail::get(notionals_, i, Null<Real>()),
                             index_,
@@ -688,7 +686,7 @@ namespace QuantLib {
                             refStart, refEnd,
                             observationSchedule,
                             detail::get(lowerTriggers_, i, Null<Rate>()),
-                            detail::get(upperTriggers_, i, Null<Rate>()))));
+                            detail::get(upperTriggers_, i, Null<Rate>())));
             }
         }
         return leg;

--- a/ql/experimental/barrieroption/binomialdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/binomialdoublebarrierengine.hpp
@@ -88,14 +88,11 @@ namespace QuantLib {
 
         // binomial trees with constant coefficient
         Handle<YieldTermStructure> flatRiskFree(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, r, rfdc)));
+            ext::make_shared<FlatForward>(referenceDate, r, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, q, divdc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
         Handle<BlackVolTermStructure> flatVol(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
@@ -103,18 +100,16 @@ namespace QuantLib {
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(
-                         new GeneralizedBlackScholesProcess(
+        ext::shared_ptr<StochasticProcess1D> bs = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
-                                      flatDividends, flatRiskFree, flatVol));
+                                      flatDividends, flatRiskFree, flatVol);
 
         TimeGrid grid(maturity, timeSteps_);
 
-        ext::shared_ptr<T> tree(new T(bs, maturity, timeSteps_,
-                                        payoff->strike()));
+        ext::shared_ptr<T> tree = ext::make_shared<T>(bs, maturity, timeSteps_,
+                                        payoff->strike());
 
-        ext::shared_ptr<BlackScholesLattice<T> > lattice(
-            new BlackScholesLattice<T>(tree, r, maturity, timeSteps_));
+        ext::shared_ptr<BlackScholesLattice<T> > lattice = ext::make_shared<BlackScholesLattice<T>>(tree, r, maturity, timeSteps_);
         
         D option(arguments_, *process_, grid);
         option.initialize(lattice, maturity);

--- a/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
+++ b/ql/experimental/barrieroption/mcdoublebarrierengine.hpp
@@ -70,9 +70,8 @@ namespace QuantLib {
             TimeGrid grid = timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -188,16 +187,14 @@ namespace QuantLib {
         for (Size i=0; i<grid.size(); i++)
             discounts[i] = process_->riskFreeRate()->discount(grid[i]);
 
-        return ext::shared_ptr<
-                    typename MCDoubleBarrierEngine<RNG,S>::path_pricer_type>(
-            new DoubleBarrierPathPricer(
+        return ext::make_shared<DoubleBarrierPathPricer>(
                 arguments_.barrierType,
                 arguments_.barrier_lo,
                 arguments_.barrier_hi,
                 arguments_.rebate,
                 payoff->optionType(),
                 payoff->strike(),
-                discounts));
+                discounts);
         }
 
         template <class RNG, class S>

--- a/ql/experimental/basismodels/swaptioncfs.cpp
+++ b/ql/experimental/basismodels/swaptioncfs.cpp
@@ -45,8 +45,8 @@ namespace QuantLib {
                             ->accrualStartDate()) { // otherwise there is no floating coupon left
             ext::shared_ptr<Coupon> firstFloatCoupon =
                 ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]);
-            floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
-                firstFloatCoupon->nominal(), firstFloatCoupon->accrualStartDate())));
+            floatLeg_.push_back(ext::make_shared<SimpleCashFlow>(
+                firstFloatCoupon->nominal(), firstFloatCoupon->accrualStartDate()));
             // calculate spread payments
             for (Size k = floatIdx; k < iborLeg.size(); ++k) {
                 ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(iborLeg[k]);
@@ -73,14 +73,14 @@ namespace QuantLib {
                     spread = liborForwardRate - discForwardRate;
                     payDate = coupon->date();
                 }
-                floatLeg_.push_back(ext::shared_ptr<CashFlow>(new FixedRateCoupon(
-                    payDate, coupon->nominal(), spread, coupon->dayCounter(), startDate, endDate)));
+                floatLeg_.push_back(ext::make_shared<FixedRateCoupon>(
+                    payDate, coupon->nominal(), spread, coupon->dayCounter(), startDate, endDate));
             } // for ...
               // finally, add the notional at the last date
             ext::shared_ptr<Coupon> lastFloatCoupon =
                 ext::dynamic_pointer_cast<Coupon>(iborLeg.back());
-            floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
-                -1.0 * lastFloatCoupon->nominal(), lastFloatCoupon->accrualEndDate())));
+            floatLeg_.push_back(ext::make_shared<SimpleCashFlow>(
+                -1.0 * lastFloatCoupon->nominal(), lastFloatCoupon->accrualEndDate()));
         } // if ...
         // assemble raw cash flow data...
         Actual365Fixed dc;

--- a/ql/experimental/basismodels/tenoroptionletvts.hpp
+++ b/ql/experimental/basismodels/tenoroptionletvts.hpp
@@ -113,7 +113,7 @@ namespace QuantLib {
 
         //! implements the actual smile calculation in derived classes
         ext::shared_ptr<SmileSection> smileSectionImpl(Time optionTime) const override {
-            return ext::shared_ptr<SmileSection>(new TenorOptionletSmileSection(*this, optionTime));
+            return ext::make_shared<TenorOptionletSmileSection>(*this, optionTime);
         }
         //! implements the actual volatility calculation in derived classes
         Volatility volatilityImpl(Time optionTime, Rate strike) const override {

--- a/ql/experimental/basismodels/tenorswaptionvts.cpp
+++ b/ql/experimental/basismodels/tenorswaptionvts.cpp
@@ -72,22 +72,22 @@ namespace QuantLib {
             volTS.targIndex_, 0.0, volTS.targIndex_->dayCounter());
         // adding engines
         baseSwap->setPricingEngine(
-            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(volTS.discountCurve_)));
+            ext::make_shared<DiscountingSwapEngine>(volTS.discountCurve_));
         targSwap->setPricingEngine(
-            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(volTS.discountCurve_)));
+            ext::make_shared<DiscountingSwapEngine>(volTS.discountCurve_));
         finlSwap->setPricingEngine(
-            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(volTS.discountCurve_)));
+            ext::make_shared<DiscountingSwapEngine>(volTS.discountCurve_));
         // swap rates
         swapRateBase_ = baseSwap->fairRate();
         swapRateTarg_ = targSwap->fairRate();
         swapRateFinl_ = finlSwap->fairRate();
         SwaptionCashFlows cfs(
             ext::make_shared<Swaption>(
-                baseSwap, ext::shared_ptr<Exercise>(new EuropeanExercise(exerciseDate))),
+                baseSwap, ext::make_shared<EuropeanExercise>(exerciseDate)),
             volTS.discountCurve_);
         SwaptionCashFlows cf2(
             ext::make_shared<Swaption>(
-                targSwap, ext::shared_ptr<Exercise>(new EuropeanExercise(exerciseDate))),
+                targSwap, ext::make_shared<EuropeanExercise>(exerciseDate)),
             volTS.discountCurve_);
         // calculate affine TSR model u and v
         // Sum tau_j   (fixed leg)

--- a/ql/experimental/basismodels/tenorswaptionvts.hpp
+++ b/ql/experimental/basismodels/tenorswaptionvts.hpp
@@ -112,8 +112,7 @@ namespace QuantLib {
 
         ext::shared_ptr<SmileSection> smileSectionImpl(Time optionTime,
                                                        Time swapLength) const override {
-            return ext::shared_ptr<SmileSection>(
-                new TenorSwaptionSmileSection(*this, optionTime, swapLength));
+            return ext::make_shared<TenorSwaptionSmileSection>(*this, optionTime, swapLength);
         }
 
         Volatility volatilityImpl(Time optionTime, Time swapLength, Rate strike) const override {

--- a/ql/experimental/callablebonds/blackcallablebondengine.cpp
+++ b/ql/experimental/callablebonds/blackcallablebondengine.cpp
@@ -31,8 +31,7 @@ namespace QuantLib {
 
     BlackCallableFixedRateBondEngine::BlackCallableFixedRateBondEngine(
         const Handle<Quote>& fwdYieldVol, Handle<YieldTermStructure> discountCurve)
-    : volatility_(ext::shared_ptr<CallableBondVolatilityStructure>(
-          new CallableBondConstantVolatility(0, NullCalendar(), fwdYieldVol, Actual365Fixed()))),
+    : volatility_(ext::make_shared<CallableBondConstantVolatility>(0, NullCalendar(), fwdYieldVol, Actual365Fixed())),
       discountCurve_(std::move(discountCurve)) {
         registerWith(volatility_);
         registerWith(discountCurve_);

--- a/ql/experimental/callablebonds/callablebondconstantvol.cpp
+++ b/ql/experimental/callablebonds/callablebondconstantvol.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
                                                                    Volatility volatility,
                                                                    DayCounter dayCounter)
     : CallableBondVolatilityStructure(referenceDate),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)), maxBondTenor_(100 * Years) {}
 
     CallableBondConstantVolatility::CallableBondConstantVolatility(const Date& referenceDate,
@@ -44,7 +44,7 @@ namespace QuantLib {
                                                                    Volatility volatility,
                                                                    DayCounter dayCounter)
     : CallableBondVolatilityStructure(settlementDays, calendar),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)), maxBondTenor_(100 * Years) {}
 
     CallableBondConstantVolatility::CallableBondConstantVolatility(Natural settlementDays,
@@ -72,10 +72,9 @@ namespace QuantLib {
     CallableBondConstantVolatility::smileSectionImpl(Time optionTime,
                                                      Time) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-                                    new FlatSmileSection(optionTime,
+        return ext::make_shared<FlatSmileSection>(optionTime,
                                                          atmVol,
-                                                         dayCounter_));
+                                                         dayCounter_);
     }
 
 }

--- a/ql/experimental/commodities/petroleumunitsofmeasure.hpp
+++ b/ql/experimental/commodities/petroleumunitsofmeasure.hpp
@@ -31,8 +31,7 @@ namespace QuantLib {
     class BarrelUnitOfMeasure : public UnitOfMeasure {
       public:
         BarrelUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                           new Data("Barrels", "BBL", UnitOfMeasure::Volume));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Barrels", "BBL", UnitOfMeasure::Volume);
             data_ = data;
         }
     };
@@ -40,8 +39,7 @@ namespace QuantLib {
     class MTUnitOfMeasure : public UnitOfMeasure {
       public:
         MTUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                        new Data("Metric Tonnes", "MT", UnitOfMeasure::Mass));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Metric Tonnes", "MT", UnitOfMeasure::Mass);
             data_ = data;
         }
     };
@@ -49,9 +47,8 @@ namespace QuantLib {
     class MBUnitOfMeasure : public UnitOfMeasure {
       public:
         MBUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                         new Data("1000 Barrels", "MB", UnitOfMeasure::Volume,
-                                  BarrelUnitOfMeasure()));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("1000 Barrels", "MB", UnitOfMeasure::Volume,
+                                  BarrelUnitOfMeasure());
             data_ = data;
         }
     };
@@ -59,9 +56,8 @@ namespace QuantLib {
     class GallonUnitOfMeasure : public UnitOfMeasure {
       public:
         GallonUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                          new Data("US Gallons", "GAL", UnitOfMeasure::Volume,
-                                   BarrelUnitOfMeasure()));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("US Gallons", "GAL", UnitOfMeasure::Volume,
+                                   BarrelUnitOfMeasure());
             data_ = data;
         }
     };
@@ -69,9 +65,8 @@ namespace QuantLib {
     class LitreUnitOfMeasure : public UnitOfMeasure {
       public:
         LitreUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                                new Data("Litres", "l", UnitOfMeasure::Volume,
-                                         BarrelUnitOfMeasure()));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Litres", "l", UnitOfMeasure::Volume,
+                                         BarrelUnitOfMeasure());
             data_ = data;
         }
     };
@@ -79,9 +74,8 @@ namespace QuantLib {
     class KilolitreUnitOfMeasure : public UnitOfMeasure {
       public:
         KilolitreUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                           new Data("Kilolitres", "kl", UnitOfMeasure::Volume,
-                                    BarrelUnitOfMeasure()));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Kilolitres", "kl", UnitOfMeasure::Volume,
+                                    BarrelUnitOfMeasure());
             data_ = data;
         }
     };
@@ -89,9 +83,8 @@ namespace QuantLib {
     class TokyoKilolitreUnitOfMeasure : public UnitOfMeasure {
       public:
         TokyoKilolitreUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                new Data("Tokyo Kilolitres", "KL_tk", UnitOfMeasure::Volume,
-                         BarrelUnitOfMeasure()));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Tokyo Kilolitres", "KL_tk", UnitOfMeasure::Volume,
+                         BarrelUnitOfMeasure());
             data_ = data;
         }
     };

--- a/ql/experimental/commodities/unitofmeasure.hpp
+++ b/ql/experimental/commodities/unitofmeasure.hpp
@@ -138,8 +138,7 @@ namespace QuantLib {
     class LotUnitOfMeasure : public UnitOfMeasure {
       public:
         LotUnitOfMeasure() {
-            static ext::shared_ptr<Data> data(
-                new Data("Lot", "Lot", UnitOfMeasure::Quantity));
+            static ext::shared_ptr<Data> data = ext::make_shared<Data>("Lot", "Lot", UnitOfMeasure::Quantity);
             data_ = data;
         }
     };

--- a/ql/experimental/coupons/cmsspreadcoupon.hpp
+++ b/ql/experimental/coupons/cmsspreadcoupon.hpp
@@ -87,11 +87,10 @@ namespace QuantLib {
                   bool isInArrears = false,
                   const Date& exCouponDate = Date(),
                   BusinessDayConvention fixingConvention = Preceding)
-        : CappedFlooredCoupon(ext::shared_ptr<FloatingRateCoupon>(new
-            CmsSpreadCoupon(paymentDate, nominal, startDate, endDate, fixingDays,
+        : CappedFlooredCoupon(ext::make_shared<CmsSpreadCoupon>(paymentDate, nominal, startDate, endDate, fixingDays,
                       index, gearing, spread, refPeriodStart, refPeriodEnd,
                       dayCounter, isInArrears, exCouponDate,
-                      fixingConvention)), cap, floor) {}
+                      fixingConvention), cap, floor) {}
 
         void accept(AcyclicVisitor& v) override {
             auto* v1 = dynamic_cast<Visitor<CappedFlooredCmsSpreadCoupon>*>(&v);

--- a/ql/experimental/credit/basket.hpp
+++ b/ql/experimental/credit/basket.hpp
@@ -66,7 +66,7 @@ namespace QuantLib {
                ext::shared_ptr<Pool> pool,
                Real attachmentRatio = 0.0,
                Real detachmentRatio = 1.0,
-               ext::shared_ptr<Claim> claim = ext::shared_ptr<Claim>(new FaceValueClaim()));
+               ext::shared_ptr<Claim> claim = ext::make_shared<FaceValueClaim>());
         void update() override {
             computeBasket();
             LazyObject::update();

--- a/ql/experimental/credit/cdsoption.cpp
+++ b/ql/experimental/credit/cdsoption.cpp
@@ -42,9 +42,8 @@ namespace QuantLib {
             : targetValue_(targetValue), vol_(ext::make_shared<SimpleQuote>(0.0)) {
 
                 Handle<Quote> h(vol_);
-                engine_ = ext::shared_ptr<PricingEngine>(
-                           new BlackCdsOptionEngine(probability, recoveryRate,
-                                                    termStructure, h));
+                engine_ = ext::make_shared<BlackCdsOptionEngine>(probability, recoveryRate,
+                                                    termStructure, h);
                 cdsoption.setupArguments(engine_->getArguments());
 
                 results_ =
@@ -69,7 +68,7 @@ namespace QuantLib {
     CdsOption::CdsOption(const ext::shared_ptr<CreditDefaultSwap>& swap,
                          const ext::shared_ptr<Exercise>& exercise,
                          bool knocksOut)
-    : Option(ext::shared_ptr<Payoff>(new NullPayoff), exercise),
+    : Option(ext::make_shared<NullPayoff>(), exercise),
       swap_(swap), knocksOut_(knocksOut) {
         QL_REQUIRE(swap->side() == Protection::Buyer || knocksOut_,
                    "receiver CDS options must knock out");

--- a/ql/experimental/credit/defaultprobabilitykey.cpp
+++ b/ql/experimental/credit/defaultprobabilitykey.cpp
@@ -78,9 +78,8 @@ namespace QuantLib {
         Restructuring::Type resType)
     : DefaultProbKey(std::vector<ext::shared_ptr<DefaultType> >(),
                      currency, sen) {
-        eventTypes_.push_back( ext::shared_ptr<DefaultType>(
-            new FailureToPay(graceFailureToPay,
-            amountFailure)));
+        eventTypes_.push_back( ext::make_shared<FailureToPay>(graceFailureToPay,
+            amountFailure));
         // no specifics for Bankruptcy
         eventTypes_.push_back( ext::make_shared<DefaultType>(
             AtomicDefault::Bankruptcy,

--- a/ql/experimental/credit/syntheticcdo.cpp
+++ b/ql/experimental/credit/syntheticcdo.cpp
@@ -231,10 +231,9 @@ namespace QuantLib {
         Real targetNPV,
         Real accuracy) const
     {
-        ext::shared_ptr<SimpleQuote> correl(new SimpleQuote(0.0));
+        ext::shared_ptr<SimpleQuote> correl = ext::make_shared<SimpleQuote>(0.0);
 
-        ext::shared_ptr<GaussianLHPLossModel> lhp(new
-            GaussianLHPLossModel(Handle<Quote>(correl), recoveries));
+        ext::shared_ptr<GaussianLHPLossModel> lhp = ext::make_shared<GaussianLHPLossModel>(Handle<Quote>(correl), recoveries);
 
         // lock
         basket_->setLossModel(lhp);

--- a/ql/experimental/exoticoptions/everestoption.cpp
+++ b/ql/experimental/exoticoptions/everestoption.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
     EverestOption::EverestOption(Real notional,
                                  Rate guarantee,
                                  const ext::shared_ptr<Exercise>& exercise)
-    : MultiAssetOption(ext::shared_ptr<Payoff>(new NullPayoff), exercise),
+    : MultiAssetOption(ext::make_shared<NullPayoff>(), exercise),
       notional_(notional), guarantee_(guarantee) {}
 
     Rate EverestOption::yield() const {

--- a/ql/experimental/exoticoptions/himalayaoption.cpp
+++ b/ql/experimental/exoticoptions/himalayaoption.cpp
@@ -25,10 +25,8 @@ namespace QuantLib {
 
     HimalayaOption::HimalayaOption(const std::vector<Date>& fixingDates,
                                    Real strike)
-    : MultiAssetOption(ext::shared_ptr<Payoff>(
-                                new PlainVanillaPayoff(Option::Call, strike)),
-                       ext::shared_ptr<Exercise>(
-                                   new EuropeanExercise(fixingDates.back()))),
+    : MultiAssetOption(ext::make_shared<PlainVanillaPayoff>(Option::Call, strike),
+                       ext::make_shared<EuropeanExercise>(fixingDates.back())),
       fixingDates_(fixingDates) {}
 
     void HimalayaOption::setupArguments(PricingEngine::arguments* args) const {

--- a/ql/experimental/exoticoptions/mceverestengine.hpp
+++ b/ql/experimental/exoticoptions/mceverestengine.hpp
@@ -81,9 +81,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(numAssets*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(processes_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(processes_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
 
@@ -198,11 +197,9 @@ namespace QuantLib {
     inline ext::shared_ptr<typename MCEverestEngine<RNG,S>::path_pricer_type>
     MCEverestEngine<RNG,S>::pathPricer() const {
 
-        return ext::shared_ptr<
-                         typename MCEverestEngine<RNG,S>::path_pricer_type>(
-                              new EverestMultiPathPricer(arguments_.notional,
+        return ext::make_shared<EverestMultiPathPricer>(arguments_.notional,
                                                          arguments_.guarantee,
-                                                         endDiscount()));
+                                                         endDiscount());
     }
 
 

--- a/ql/experimental/exoticoptions/mchimalayaengine.hpp
+++ b/ql/experimental/exoticoptions/mchimalayaengine.hpp
@@ -73,9 +73,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(numAssets*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(processes_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(processes_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
 
@@ -165,11 +164,9 @@ namespace QuantLib {
                                                       processes_->process(0));
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                         typename MCHimalayaEngine<RNG,S>::path_pricer_type>(
-            new HimalayaMultiPathPricer(arguments_.payoff,
+        return ext::make_shared<HimalayaMultiPathPricer>(arguments_.payoff,
                                         process->riskFreeRate()->discount(
-                                           arguments_.exercise->lastDate())));
+                                           arguments_.exercise->lastDate()));
     }
 
 

--- a/ql/experimental/exoticoptions/mcpagodaengine.hpp
+++ b/ql/experimental/exoticoptions/mcpagodaengine.hpp
@@ -73,9 +73,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(numAssets*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(processes_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(processes_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
 
@@ -167,11 +166,9 @@ namespace QuantLib {
                                                       processes_->process(0));
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                         typename MCPagodaEngine<RNG,S>::path_pricer_type>(
-            new PagodaMultiPathPricer(arguments_.roof, arguments_.fraction,
+        return ext::make_shared<PagodaMultiPathPricer>(arguments_.roof, arguments_.fraction,
                                       process->riskFreeRate()->discount(
-                                           arguments_.exercise->lastDate())));
+                                           arguments_.exercise->lastDate()));
     }
 
 

--- a/ql/experimental/exoticoptions/pagodaoption.cpp
+++ b/ql/experimental/exoticoptions/pagodaoption.cpp
@@ -26,9 +26,8 @@ namespace QuantLib {
     PagodaOption::PagodaOption(const std::vector<Date>& fixingDates,
                                Real roof,
                                Real fraction)
-    : MultiAssetOption(ext::shared_ptr<Payoff>(new NullPayoff),
-                       ext::shared_ptr<Exercise>(
-                                   new EuropeanExercise(fixingDates.back()))),
+    : MultiAssetOption(ext::make_shared<NullPayoff>(),
+                       ext::make_shared<EuropeanExercise>(fixingDates.back())),
       fixingDates_(fixingDates), roof_(roof), fraction_(fraction) {}
 
 

--- a/ql/experimental/finitedifferences/dynprogvppintrinsicvalueengine.cpp
+++ b/ql/experimental/finitedifferences/dynprogvppintrinsicvalueengine.cpp
@@ -85,15 +85,12 @@ namespace QuantLib {
       fuelCostAddon_(fuelCostAddon), rTS_(std::move(rTS)) {}
 
     void DynProgVPPIntrinsicValueEngine::calculate() const {
-        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrice(
-            new FuelPrice(fuelPrices_));
-        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpreadPrice(
-            new SparkSpreadPrice(arguments_.heatRate,fuelPrices_,powerPrices_));
+        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrice = ext::make_shared<FuelPrice>(fuelPrices_);
+        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpreadPrice = ext::make_shared<SparkSpreadPrice>(arguments_.heatRate,fuelPrices_,powerPrices_);
 
         const FdmVPPStepConditionFactory stepConditionFactory(arguments_);
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(stepConditionFactory.stateMesher()));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(stepConditionFactory.stateMesher());
 
         const FdmVPPStepConditionMesher mesh = { 0, mesher };
 

--- a/ql/experimental/finitedifferences/fdextoujumpvanillaengine.cpp
+++ b/ql/experimental/finitedifferences/fdextoujumpvanillaengine.cpp
@@ -18,7 +18,7 @@
 */
 
 /*! \file fdoujumpvanillaengine.cpp
-    \brief Finite Differences Ornstein Uhlenbeck plus exponential jumps engine 
+    \brief Finite Differences Ornstein Uhlenbeck plus exponential jumps engine
            for simple swing options
 */
 
@@ -53,47 +53,42 @@ namespace QuantLib {
 
     void FdExtOUJumpVanillaEngine::calculate() const {
         // 1. Mesher
-        const Time maturity 
+        const Time maturity
             = rTS_->dayCounter().yearFraction(rTS_->referenceDate(),
                                               arguments_.exercise->lastDate());
         const ext::shared_ptr<StochasticProcess1D> ouProcess(
             process_->getExtendedOrnsteinUhlenbeckProcess());
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-            new FdmSimpleProcess1dMesher(xGrid_, ouProcess,maturity));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_, ouProcess,maturity);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-            new ExponentialJump1dMesher(yGrid_, 
-                                        process_->beta(), 
+        const ext::shared_ptr<Fdm1dMesher> yMesher = ext::make_shared<ExponentialJump1dMesher>(yGrid_,
+                                        process_->beta(),
                                         process_->jumpIntensity(),
-                                        process_->eta()));
+                                        process_->eta());
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(xMesher, yMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-            new FdmExtOUJumpModelInnerValue(arguments_.payoff, mesher, shape_));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmExtOUJumpModelInnerValue>(arguments_.payoff, mesher, shape_);
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
             FdmStepConditionComposite::vanillaComposite(
-                                DividendSchedule(), arguments_.exercise, 
-                                mesher, calculator, 
+                                DividendSchedule(), arguments_.exercise,
+                                mesher, calculator,
                                 rTS_->referenceDate(), rTS_->dayCounter());
 
         // 4. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
-        
+
         // 5. set-up solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                     calculator, maturity, tGrid_, 0 };
 
-        const ext::shared_ptr<FdmExtOUJumpSolver> solver(
-            new FdmExtOUJumpSolver(Handle<ExtOUWithJumpsProcess>(process_), 
-                                   rTS_, solverDesc, schemeDesc_));
-      
+        const ext::shared_ptr<FdmExtOUJumpSolver> solver = ext::make_shared<FdmExtOUJumpSolver>(Handle<ExtOUWithJumpsProcess>(process_),
+                                   rTS_, solverDesc, schemeDesc_);
+
         const Real x = process_->initialValues()[0];
         const Real y = process_->initialValues()[1];
-        results_.value = solver->valueAt(x, y);      
+        results_.value = solver->valueAt(x, y);
     }
 }

--- a/ql/experimental/finitedifferences/fdklugeextouspreadengine.cpp
+++ b/ql/experimental/finitedifferences/fdklugeextouspreadengine.cpp
@@ -60,40 +60,32 @@ namespace QuantLib {
                                           = klugeOUProcess_->getKlugeProcess();
         const ext::shared_ptr<StochasticProcess1D> ouProcess
                         = klugeProcess->getExtendedOrnsteinUhlenbeckProcess();
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-            new FdmSimpleProcess1dMesher(xGrid_, ouProcess,maturity));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_, ouProcess,maturity);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-            new ExponentialJump1dMesher(yGrid_,
+        const ext::shared_ptr<Fdm1dMesher> yMesher = ext::make_shared<ExponentialJump1dMesher>(yGrid_,
                                         klugeProcess->beta(),
                                         klugeProcess->jumpIntensity(),
-                                        klugeProcess->eta()));
+                                        klugeProcess->eta());
 
-        const ext::shared_ptr<Fdm1dMesher> uMesher(
-            new FdmSimpleProcess1dMesher(uGrid_,
+        const ext::shared_ptr<Fdm1dMesher> uMesher = ext::make_shared<FdmSimpleProcess1dMesher>(uGrid_,
                                          klugeOUProcess_->getExtOUProcess(),
-                                         maturity));
+                                         maturity);
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(xMesher, yMesher, uMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher, uMesher);
 
         // 2. Calculator
         ext::shared_ptr<BasketPayoff> basketPayoff =
             ext::dynamic_pointer_cast<BasketPayoff>(arguments_.payoff);
         QL_REQUIRE(basketPayoff," basket payoff expected");
 
-        const ext::shared_ptr<Payoff> zeroStrikeCall(
-            new PlainVanillaPayoff(Option::Call, 0.0));
+        const ext::shared_ptr<Payoff> zeroStrikeCall = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> gasPrice(
-            new FdmExpExtOUInnerValueCalculator(zeroStrikeCall,
-                                                mesher, gasShape_, 2));
+        const ext::shared_ptr<FdmInnerValueCalculator> gasPrice = ext::make_shared<FdmExpExtOUInnerValueCalculator>(zeroStrikeCall,
+                                                mesher, gasShape_, 2);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> powerPrice(
-            new FdmExtOUJumpModelInnerValue(zeroStrikeCall,mesher,powerShape_));
+        const ext::shared_ptr<FdmInnerValueCalculator> powerPrice = ext::make_shared<FdmExtOUJumpModelInnerValue>(zeroStrikeCall,mesher,powerShape_);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-            new FdmSpreadPayoffInnerValue(basketPayoff, powerPrice, gasPrice));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmSpreadPayoffInnerValue>(basketPayoff, powerPrice, gasPrice);
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -109,10 +101,9 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
 
-        const ext::shared_ptr<FdmKlugeExtOUSolver<3> > solver(
-            new FdmKlugeExtOUSolver<3>(
+        const ext::shared_ptr<FdmKlugeExtOUSolver<3> > solver = ext::make_shared<FdmKlugeExtOUSolver<3>>(
                 Handle<KlugeExtOUProcess>(klugeOUProcess_),
-                rTS_, solverDesc, schemeDesc_));
+                rTS_, solverDesc, schemeDesc_);
 
         std::vector<Real> x(3);
         x[0] = klugeOUProcess_->initialValues()[0];

--- a/ql/experimental/finitedifferences/fdmklugeextouop.cpp
+++ b/ql/experimental/finitedifferences/fdmklugeextouop.cpp
@@ -52,11 +52,9 @@ namespace QuantLib {
                                   integroIntegrationOrder)),
       ouOp_   (new FdmExtendedOrnsteinUhlenbeckOp(
                   mesher, extOU_,
-                  ext::shared_ptr<YieldTermStructure>(
-                      new FlatForward(rTS->referenceDate(),
-                              Handle<Quote>(ext::shared_ptr<Quote>(
-                                      new SimpleQuote(0.0))),
-                                      rTS->dayCounter())),
+                  ext::make_shared<FlatForward>(rTS->referenceDate(),
+                              Handle<Quote>(ext::make_shared<SimpleQuote>(0.0)),
+                                      rTS->dayCounter()),
                   bcSet, 2)),
       corrMap_(SecondOrderMixedDerivativeOp(0, 2, mesher).mult(
           Array(mesher->layout()->size(),

--- a/ql/experimental/finitedifferences/fdmklugeextousolver.hpp
+++ b/ql/experimental/finitedifferences/fdmklugeextousolver.hpp
@@ -62,8 +62,7 @@ namespace QuantLib {
                                     klugeOUProcess_.currentLink(),
                                     rTS_, solverDesc_.bcSet, 16));
 
-            solver_ = ext::shared_ptr<FdmNdimSolver<N> >(
-                          new FdmNdimSolver<N>(solverDesc_, schemeDesc_, op));
+            solver_ = ext::make_shared<FdmNdimSolver<N>>(solverDesc_, schemeDesc_, op);
         }
 
       private:

--- a/ql/experimental/finitedifferences/fdmvppstepconditionfactory.cpp
+++ b/ql/experimental/finitedifferences/fdmvppstepconditionfactory.cpp
@@ -60,8 +60,7 @@ namespace QuantLib {
             QL_FAIL("vpp type is not supported");
         }
 
-        return ext::shared_ptr<Fdm1dMesher>(
-            new Uniform1dMesher(0.0, 1.0, nStates));
+        return ext::make_shared<Uniform1dMesher>(0.0, 1.0, nStates);
     }
 
     ext::shared_ptr<FdmVPPStepCondition> FdmVPPStepConditionFactory::build(
@@ -80,9 +79,8 @@ namespace QuantLib {
         switch (type_) {
           case Vanilla:
           case StartLimit:
-              return ext::shared_ptr<FdmVPPStepCondition>(
-                  new FdmVPPStartLimitStepCondition(params, args_.nStarts,
-                          mesh, fuel, spark));
+              return ext::make_shared<FdmVPPStartLimitStepCondition>(params, args_.nStarts,
+                          mesh, fuel, spark);
           default:
             QL_FAIL("vpp type is not supported");
         }

--- a/ql/experimental/finitedifferences/fdornsteinuhlenbeckvanillaengine.cpp
+++ b/ql/experimental/finitedifferences/fdornsteinuhlenbeckvanillaengine.cpp
@@ -99,16 +99,13 @@ namespace QuantLib {
         const Time maturity = dc.yearFraction(
             referenceDate, arguments_.exercise->lastDate());
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmSimpleProcess1dMesher(
-                xGrid_, process_, maturity, 1, epsilon_));
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmSimpleProcess1dMesher>(
+                xGrid_, process_, maturity, 1, epsilon_);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-            new FdmOUInnerValue(payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmOUInnerValue>(payoff, mesher, 0);
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -124,11 +121,9 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions, calculator,
                                      maturity, tGrid_, dampingSteps_ };
 
-        const ext::shared_ptr<FdmOrnsteinUhlenbeckOp> op(
-            new FdmOrnsteinUhlenbeckOp(mesher, process_, rTS_, 0));
+        const ext::shared_ptr<FdmOrnsteinUhlenbeckOp> op = ext::make_shared<FdmOrnsteinUhlenbeckOp>(mesher, process_, rTS_, 0);
 
-        const ext::shared_ptr<Fdm1DimSolver> solver(
-                new Fdm1DimSolver(solverDesc, schemeDesc_, op));
+        const ext::shared_ptr<Fdm1DimSolver> solver = ext::make_shared<Fdm1DimSolver>(solverDesc, schemeDesc_, op);
 
         const Real spot = process_->x0();
 

--- a/ql/experimental/finitedifferences/fdsimpleextoujumpswingengine.cpp
+++ b/ql/experimental/finitedifferences/fdsimpleextoujumpswingengine.cpp
@@ -68,25 +68,20 @@ namespace QuantLib {
         const Time maturity = exerciseTimes.back();
         const ext::shared_ptr<StochasticProcess1D> ouProcess(
                               process_->getExtendedOrnsteinUhlenbeckProcess());
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-                     new FdmSimpleProcess1dMesher(xGrid_, ouProcess,maturity));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_, ouProcess,maturity);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-                        new ExponentialJump1dMesher(yGrid_,
+        const ext::shared_ptr<Fdm1dMesher> yMesher = ext::make_shared<ExponentialJump1dMesher>(yGrid_,
                                                     process_->beta(),
                                                     process_->jumpIntensity(),
-                                                    process_->eta()));
-        const ext::shared_ptr<Fdm1dMesher> exerciseMesher(
-                       new Uniform1dMesher(
+                                                    process_->eta());
+        const ext::shared_ptr<Fdm1dMesher> exerciseMesher = ext::make_shared<Uniform1dMesher>(
                            0, static_cast<Real>(arguments_.maxExerciseRights),
-                           arguments_.maxExerciseRights+1));
+                           arguments_.maxExerciseRights+1);
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(xMesher, yMesher, exerciseMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher, exerciseMesher);
 
         // 3. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                                    new FdmZeroInnerValue());
+        ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmZeroInnerValue>();
         // 4. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
         std::list<std::vector<Time> > stoppingTimes;
@@ -94,16 +89,13 @@ namespace QuantLib {
         // 4.1 Bermudan step conditions
         stoppingTimes.push_back(exerciseTimes);
 
-        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator(
-            new FdmExtOUJumpModelInnerValue(arguments_.payoff, mesher, shape_));
+        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator = ext::make_shared<FdmExtOUJumpModelInnerValue>(arguments_.payoff, mesher, shape_);
 
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-            new FdmSimpleSwingCondition(
+        stepConditions.push_back(ext::make_shared<FdmSimpleSwingCondition>(
                 exerciseTimes, mesher, exerciseCalculator,
-                2, arguments_.minExerciseRights)));
+                2, arguments_.minExerciseRights));
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
 
         // 5. Boundary conditions
@@ -113,10 +105,9 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
 
-        const ext::shared_ptr<FdmSimple3dExtOUJumpSolver> solver(
-            new FdmSimple3dExtOUJumpSolver(
+        const ext::shared_ptr<FdmSimple3dExtOUJumpSolver> solver = ext::make_shared<FdmSimple3dExtOUJumpSolver>(
                                     Handle<ExtOUWithJumpsProcess>(process_),
-                                    rTS_, solverDesc, schemeDesc_));
+                                    rTS_, solverDesc, schemeDesc_);
 
         const Real x = process_->initialValues()[0];
         const Real y = process_->initialValues()[1];

--- a/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
+++ b/ql/experimental/finitedifferences/fdsimpleextoustorageengine.cpp
@@ -93,8 +93,7 @@ namespace QuantLib {
             = rTS_->dayCounter().yearFraction(rTS_->referenceDate(),
                                               arguments_.exercise->lastDate());
 
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-                     new FdmSimpleProcess1dMesher(xGrid_, process_, maturity));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_, process_, maturity);
 
         ext::shared_ptr<Fdm1dMesher> storageMesher;
 
@@ -114,21 +113,17 @@ namespace QuantLib {
                 storageValues.begin(), storageValues.end());
             storageValues.assign(orderedValues.begin(), orderedValues.end());
 
-            storageMesher =    ext::shared_ptr<Fdm1dMesher>(
-                new Predefined1dMesher(storageValues));
+            storageMesher =    ext::make_shared<Predefined1dMesher>(storageValues);
         }
         else {
             // uniform mesher
-            storageMesher = ext::shared_ptr<Fdm1dMesher>(
-                new Uniform1dMesher(0, arguments_.capacity, yGrid_));
+            storageMesher = ext::make_shared<Uniform1dMesher>(0, arguments_.capacity, yGrid_);
         }
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(xMesher, storageMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, storageMesher);
 
         // 3. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> storageCalculator(
-                                                  new FdmStorageValue(mesher));
+        ext::shared_ptr<FdmInnerValueCalculator> storageCalculator = ext::make_shared<FdmStorageValue>(mesher);
 
         // 4. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -144,19 +139,15 @@ namespace QuantLib {
         }
         stoppingTimes.push_back(exerciseTimes);
 
-        ext::shared_ptr<Payoff> payoff(
-                                    new PlainVanillaPayoff(Option::Call, 0.0));
+        ext::shared_ptr<Payoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
-        ext::shared_ptr<FdmInnerValueCalculator> underlyingCalculator(
-            new FdmExpExtOUInnerValueCalculator(payoff, mesher, shape_));
+        ext::shared_ptr<FdmInnerValueCalculator> underlyingCalculator = ext::make_shared<FdmExpExtOUInnerValueCalculator>(payoff, mesher, shape_);
 
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-            new FdmSimpleStorageCondition(exerciseTimes,
+        stepConditions.push_back(ext::make_shared<FdmSimpleStorageCondition>(exerciseTimes,
                                           mesher, underlyingCalculator,
-                                          arguments_.changeRate)));
+                                          arguments_.changeRate));
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 5. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -165,10 +156,9 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      storageCalculator, maturity, tGrid_, 0 };
 
-        ext::shared_ptr<FdmSimple2dExtOUSolver> solver(
-                new FdmSimple2dExtOUSolver(
+        ext::shared_ptr<FdmSimple2dExtOUSolver> solver = ext::make_shared<FdmSimple2dExtOUSolver>(
                            Handle<ExtendedOrnsteinUhlenbeckProcess>(process_),
-                           rTS_, solverDesc, schemeDesc_));
+                           rTS_, solverDesc, schemeDesc_);
 
         const Real x = process_->x0();
         const Real y = arguments_.load;

--- a/ql/experimental/finitedifferences/fdsimpleklugeextouvppengine.cpp
+++ b/ql/experimental/finitedifferences/fdsimpleklugeextouvppengine.cpp
@@ -111,43 +111,34 @@ namespace QuantLib {
         const ext::shared_ptr<StochasticProcess1D> klugeOUProcess
             = klugeProcess->getExtendedOrnsteinUhlenbeckProcess();
 
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-            new FdmSimpleProcess1dMesher(xGrid_, klugeOUProcess, maturity));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_, klugeOUProcess, maturity);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-            new ExponentialJump1dMesher(yGrid_,
+        const ext::shared_ptr<Fdm1dMesher> yMesher = ext::make_shared<ExponentialJump1dMesher>(yGrid_,
                                         klugeProcess->beta(),
                                         klugeProcess->jumpIntensity(),
-                                        klugeProcess->eta(), 1e-3));
+                                        klugeProcess->eta(), 1e-3);
 
-        const ext::shared_ptr<Fdm1dMesher> gMesher(
-            new FdmSimpleProcess1dMesher(gGrid_,
-                                         process_->getExtOUProcess(),maturity));
+        const ext::shared_ptr<Fdm1dMesher> gMesher = ext::make_shared<FdmSimpleProcess1dMesher>(gGrid_,
+                                         process_->getExtOUProcess(),maturity);
 
         const ext::shared_ptr<Fdm1dMesher> exerciseMesher(
             stepConditionFactory.stateMesher());
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(xMesher, yMesher, gMesher, exerciseMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher, gMesher, exerciseMesher);
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> zeroInnerValue(
-            new FdmZeroInnerValue());
+        const ext::shared_ptr<FdmInnerValueCalculator> zeroInnerValue = ext::make_shared<FdmZeroInnerValue>();
 
-        const ext::shared_ptr<Payoff> zeroStrikeCall(
-            new PlainVanillaPayoff(Option::Call, 0.0));
+        const ext::shared_ptr<Payoff> zeroStrikeCall = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrice(
-            new FdmExpExtOUInnerValueCalculator(zeroStrikeCall,
-                                                mesher, fuelShape_, 2));
+        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrice = ext::make_shared<FdmExpExtOUInnerValueCalculator>(zeroStrikeCall,
+                                                mesher, fuelShape_, 2);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> powerPrice(
-            new FdmExtOUJumpModelInnerValue(zeroStrikeCall,mesher,powerShape_));
+        const ext::shared_ptr<FdmInnerValueCalculator> powerPrice = ext::make_shared<FdmExtOUJumpModelInnerValue>(zeroStrikeCall,mesher,powerShape_);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpread(
-            new FdmSparkSpreadInnerValue(
+        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpread = ext::make_shared<FdmSparkSpreadInnerValue>(
                 ext::dynamic_pointer_cast<BasketPayoff>(arguments_.payoff),
-                fuelPrice, powerPrice));
+                fuelPrice, powerPrice);
 
         // 4. Step conditions
         std::list<std::vector<Time> > stoppingTimes;
@@ -163,8 +154,7 @@ namespace QuantLib {
 
         stepConditions.push_back(stepCondition);
 
-        const ext::shared_ptr<FdmStepConditionComposite> conditions(
-            new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        const ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 5. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -173,9 +163,8 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      zeroInnerValue, maturity, tGrid_, 0 };
 
-        const ext::shared_ptr<FdmKlugeExtOUSolver<4> > solver(
-            new FdmKlugeExtOUSolver<4>(Handle<KlugeExtOUProcess>(process_),
-                                       rTS_, solverDesc, schemeDesc_));
+        const ext::shared_ptr<FdmKlugeExtOUSolver<4> > solver = ext::make_shared<FdmKlugeExtOUSolver<4>>(Handle<KlugeExtOUProcess>(process_),
+                                       rTS_, solverDesc, schemeDesc_);
 
         std::vector<Real> x(4);
         x[0] = process_->initialValues()[0];

--- a/ql/experimental/finitedifferences/vanillavppoption.cpp
+++ b/ql/experimental/finitedifferences/vanillavppoption.cpp
@@ -55,8 +55,8 @@ namespace QuantLib {
         Array weigths(2);
         weigths[0] = 1.0; weigths[1] = -heatRate;
 
-        payoff_ = ext::shared_ptr<Payoff>(new AverageBasketPayoff(
-            ext::shared_ptr<Payoff>(new IdenticalPayoff()), weigths));
+        payoff_ = ext::make_shared<AverageBasketPayoff>(
+            ext::make_shared<IdenticalPayoff>(), weigths);
     }
 
     void VanillaVPPOption::arguments::validate() const {

--- a/ql/experimental/forward/analytichestonforwardeuropeanengine.cpp
+++ b/ql/experimental/forward/analytichestonforwardeuropeanengine.cpp
@@ -152,7 +152,7 @@ namespace QuantLib {
         // calculation, both for accuracy and because tStar==0 causes some numerical issues...
         std::pair<Real, Real> P1HatP2Hat;
         if (resetTime <= 1e-3) {
-            Handle<Quote> tempQuote(ext::shared_ptr<Quote>(new SimpleQuote(s0_->value())));
+            Handle<Quote> tempQuote(ext::make_shared<SimpleQuote>(s0_->value()));
             P1HatP2Hat = calculateP1P2(tenor, tempQuote, moneyness * s0_->value(), expiryRatio, phiRightLimit);
         } else {
             P1HatP2Hat = calculateP1P2Hat(tenor, resetTime, moneyness, expiryRatio/resetRatio, phiRightLimit, nuRightLimit);
@@ -197,7 +197,7 @@ namespace QuantLib {
                                                                                 Real phiRightLimit,
                                                                                 Real nuRightLimit) const {
 
-        Handle<Quote> unitQuote(ext::shared_ptr<Quote>(new SimpleQuote(1.0)));
+        Handle<Quote> unitQuote(ext::make_shared<SimpleQuote>(1.0));
 
         // Re-expressing moneyness in terms of the forward here (strike fixes to spot, but in
         // our pricing calculation we need to compare it to the future at expiry)
@@ -236,14 +236,12 @@ namespace QuantLib {
 
         // Probably a wasteful implementation here, could be improved by importing
         // only the CF-generating parts of the AnalyticHestonEngine (currently private)
-        ext::shared_ptr<HestonProcess> hestonProcess(new
-            HestonProcess(riskFreeRate_, dividendYield_, spotReset,
-                varReset, kappa_, theta_, sigma_, rho_));
+        ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(riskFreeRate_, dividendYield_, spotReset,
+                varReset, kappa_, theta_, sigma_, rho_);
 
-        ext::shared_ptr<HestonModel> hestonModel(new HestonModel(hestonProcess));
+        ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
-        ext::shared_ptr<AnalyticHestonEngine> analyticHestonEngine(
-            new AnalyticHestonEngine(hestonModel, integrationOrder_));
+        ext::shared_ptr<AnalyticHestonEngine> analyticHestonEngine = ext::make_shared<AnalyticHestonEngine>(hestonModel, integrationOrder_);
 
         // Not sure how to pass only the chF, so just pass the whole thing for now!
         return analyticHestonEngine;

--- a/ql/experimental/inflation/genericindexes.hpp
+++ b/ql/experimental/inflation/genericindexes.hpp
@@ -33,8 +33,7 @@ namespace QuantLib {
     class GenericRegion : public Region {
       public:
         GenericRegion() {
-            static ext::shared_ptr<Data> GENERICdata(
-                                               new Data("Generic","GENERIC"));
+            static ext::shared_ptr<Data> GENERICdata = ext::make_shared<Data>("Generic","GENERIC");
             data_ = GENERICdata;
         }
     };

--- a/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
+++ b/ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp
@@ -144,13 +144,12 @@ namespace QuantLib {
         vvec_[0] = guess - slope_ * (tvec_[1] - tvec_[0]) * guess;
         // could have Interpolator1D instead of Linear
         ext::shared_ptr<InterpolatedYoYOptionletVolatilityCurve<Linear> >
-        vCurve(
-            new InterpolatedYoYOptionletVolatilityCurve<Linear>(
+        vCurve = ext::make_shared<InterpolatedYoYOptionletVolatilityCurve<Linear>>(
                                                0, TARGET(), ModifiedFollowing,
                                                Actual365Fixed(), lag_,
                                                frequency_, indexIsInterpolated_,
                                                dvec_, vvec_,
-                                               -1.0, 3.0) ); // strike limits
+                                               -1.0, 3.0); // strike limits
         Handle<YoYOptionletVolatilitySurface> hCurve(vCurve);
         p_->setVolatility(hCurve);
         // hopefully this gets to the pricer ... then
@@ -183,10 +182,9 @@ namespace QuantLib {
         // provided that the lag and frequency are correct
         RelinkableHandle<YoYInflationTermStructure> hYoY(
                                        YoYCapFloorTermPriceSurface_->YoYTS());
-        ext::shared_ptr<YoYInflationIndex> anIndex(
-                                           new YYGenericCPI(frequency_,
+        ext::shared_ptr<YoYInflationIndex> anIndex = ext::make_shared<YYGenericCPI>(frequency_,
                                                             false, lag_,
-                                                            Currency(), hYoY));
+                                                            Currency(), hYoY);
 
         // strip each K separatly
         for (Size i=0; i<YoYCapFloorTermPriceSurface_->strikes().size(); i++) {
@@ -227,26 +225,23 @@ namespace QuantLib {
                      YoYCapFloorTermPriceSurface_->capPrice(Tp, K) :
                      YoYCapFloorTermPriceSurface_->floorPrice(Tp, K));
 
-                Handle<Quote> quote1(ext::shared_ptr<Quote>(
-                                               new SimpleQuote( nextPrice )));
+                Handle<Quote> quote1(ext::make_shared<SimpleQuote>( nextPrice ));
                 // helper should be an integer number of periods away,
                 // this is enforced by rounding
                 Size nT = (Size)floor(s->timeFromReference(s->yoyOptionDateFromTenor(Tp))+0.5);
-                helpers.push_back(ext::shared_ptr<YoYOptionletHelper>(
-                          new YoYOptionletHelper(quote1, notional, useType,
+                helpers.push_back(ext::make_shared<YoYOptionletHelper>(quote1, notional, useType,
                                                  lag_,
                                                  dc, cal,
                                                  fixingDays_,
                                                  anIndex, CPI::Flat,
-                                                 K, nT, p_)));
+                                                 K, nT, p_));
 
-                ext::shared_ptr<ConstantYoYOptionletVolatility> yoyVolBLACK(
-                          new ConstantYoYOptionletVolatility(found, settlementDays,
+                ext::shared_ptr<ConstantYoYOptionletVolatility> yoyVolBLACK = ext::make_shared<ConstantYoYOptionletVolatility>(found, settlementDays,
                                                              cal, bdc, dc,
                                                              lag_, frequency_,
                                                              false,
                                                              // -100% to +300%
-                                                             -1.0,3.0));
+                                                             -1.0,3.0);
 
                 helpers[j]->setTermStructure(
                        // gets underlying pointer & removes const
@@ -262,13 +257,12 @@ namespace QuantLib {
             Rate minStrike = K-eps;
             Rate maxStrike = K+eps;
             ext::shared_ptr<
-                PiecewiseYoYOptionletVolatilityCurve<Interpolator1D> > testPW(
-                new PiecewiseYoYOptionletVolatilityCurve<Interpolator1D>(
+                PiecewiseYoYOptionletVolatilityCurve<Interpolator1D> > testPW = ext::make_shared<PiecewiseYoYOptionletVolatilityCurve<Interpolator1D>>(
                                             settlementDays, cal, bdc, dc, lag_,
                                             frequency_, indexIsInterpolated_,
                                             minStrike, maxStrike,
                                             baseYoYVolatility,
-                                            helperInstruments) );
+                                            helperInstruments);
             testPW->recalculate();
             volCurves_.push_back(testPW);
         }

--- a/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
+++ b/ql/experimental/inflation/yoycapfloortermpricesurface.hpp
@@ -529,8 +529,7 @@ namespace QuantLib {
         std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > YYhelpers;
         for (Size i=1; i<=nYears; i++) {
             Date maturity = nominalTS_->referenceDate() + Period(i,Years);
-            Handle<Quote> quote(ext::shared_ptr<Quote>(
-                               new SimpleQuote( atmYoYSwapRate( maturity ) )));//!
+            Handle<Quote> quote(ext::make_shared<SimpleQuote>( atmYoYSwapRate( maturity ) ));//!
             auto anInstrument =
                 ext::make_shared<YearOnYearInflationSwapHelper>(
                                 quote, observationLag(), maturity,

--- a/ql/experimental/mcbasket/mcamericanpathengine.hpp
+++ b/ql/experimental/mcbasket/mcamericanpathengine.hpp
@@ -254,8 +254,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCAmericanPathEngine<RNG>(process_,
+        return ext::make_shared<MCAmericanPathEngine<RNG>>(process_,
                                         steps_,
                                         stepsPerYear_,
                                         brownianBridge_,
@@ -265,7 +264,7 @@ namespace QuantLib {
                                         tolerance_,
                                         maxSamples_,
                                         seed_,
-                                        calibrationSamples_));
+                                        calibrationSamples_);
     }
 
 }

--- a/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
+++ b/ql/experimental/mcbasket/mclongstaffschwartzpathengine.hpp
@@ -184,9 +184,8 @@ namespace QuantLib {
         TimeGrid grid = this->timeGrid();
         typename RNG::rsg_type generator =
             RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-        return ext::shared_ptr<path_generator_type>(
-                   new path_generator_type(process_,
-                                           grid, generator, brownianBridge_));
+        return ext::make_shared<path_generator_type>(process_,
+                                           grid, generator, brownianBridge_);
     }
 }
 

--- a/ql/experimental/mcbasket/mcpathbasketengine.hpp
+++ b/ql/experimental/mcbasket/mcpathbasketengine.hpp
@@ -153,9 +153,8 @@ namespace QuantLib {
         typename RNG::rsg_type gen =
             RNG::make_sequence_generator(numAssets * (grid.size() - 1), seed_);
 
-        return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+        return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
     }
 
     template <class RNG, class S>
@@ -210,11 +209,9 @@ namespace QuantLib {
                                                          fixings[i]));
         }
 
-        return ext::shared_ptr<
-            typename MCPathBasketEngine<RNG,S>::path_pricer_type>(
-                        new EuropeanPathMultiPathPricer(payoff, timePositions,
+        return ext::make_shared<EuropeanPathMultiPathPricer>(payoff, timePositions,
                                                         forwardTermStructures,
-                                                        discountFactors));
+                                                        discountFactors);
     }
 
 

--- a/ql/experimental/processes/extendedblackscholesprocess.hpp
+++ b/ql/experimental/processes/extendedblackscholesprocess.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& riskFreeTS,
             const Handle<BlackVolTermStructure>& blackVolTS,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization),
+                  ext::make_shared<EulerDiscretization>(),
             Discretization evolDisc = Milstein);
         Real drift(Time t, Real x) const override;
         Real diffusion(Time t, Real x) const override;

--- a/ql/experimental/processes/gemanroncoroniprocess.cpp
+++ b/ql/experimental/processes/gemanroncoroniprocess.cpp
@@ -37,8 +37,7 @@ namespace QuantLib {
                                       Real sig2, Real a, Real b,
                                       Real theta1, Real theta2, Real theta3,
                                       Real psi)
-    : StochasticProcess1D(ext::shared_ptr<discretization>(
-                                                    new EulerDiscretization)),
+    : StochasticProcess1D(ext::make_shared<EulerDiscretization>()),
       x0_(x0),
       alpha_(alpha), beta_(beta),
       gamma_(gamma), delta_(delta),

--- a/ql/experimental/processes/vegastressedblackscholesprocess.hpp
+++ b/ql/experimental/processes/vegastressedblackscholesprocess.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
             Real upperAssetBorderForStressTest = 1000000,
             Real stressLevel = 0,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization));
+                  ext::make_shared<EulerDiscretization>());
         //! \name StochasticProcess1D interface
         //@{
         Real diffusion(Time t, Real x) const override;

--- a/ql/experimental/shortrate/generalizedhullwhite.cpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.cpp
@@ -212,12 +212,9 @@ namespace QuantLib {
                                                   const TimeGrid& grid) const{
 
         TermStructureFittingParameter phi(termStructure());
-        ext::shared_ptr<ShortRateDynamics> numericDynamics(
-            new Dynamics(phi, speed(), vol(), f_, fInverse_));
-        ext::shared_ptr<TrinomialTree> trinomial(
-            new TrinomialTree(numericDynamics->process(), grid));
-        ext::shared_ptr<ShortRateTree> numericTree(
-            new ShortRateTree(trinomial, numericDynamics, grid));
+        ext::shared_ptr<ShortRateDynamics> numericDynamics = ext::make_shared<Dynamics>(phi, speed(), vol(), f_, fInverse_);
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(numericDynamics->process(), grid);
+        ext::shared_ptr<ShortRateTree> numericTree = ext::make_shared<ShortRateTree>(trinomial, numericDynamics, grid);
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
         ext::shared_ptr<NumericalImpl> impl =
             ext::dynamic_pointer_cast<NumericalImpl>(phi.implementation());

--- a/ql/experimental/shortrate/generalizedhullwhite.hpp
+++ b/ql/experimental/shortrate/generalizedhullwhite.hpp
@@ -48,8 +48,7 @@ namespace QuantLib {
             Size count,
             const Constraint& constraint = NoConstraint())
         : Parameter(count,
-            ext::shared_ptr<Parameter::Impl>(
-                new InterpolationParameter::Impl()),
+            ext::make_shared<InterpolationParameter::Impl>(),
                 constraint)
         { }
         void reset(const Interpolation &interp) {
@@ -237,14 +236,13 @@ namespace QuantLib {
                  const std::function<Real(Time)>& sigma,
                  std::function<Real(Real)> f,
                  std::function<Real(Real)> fInverse)
-        : ShortRateDynamics(ext::shared_ptr<StochasticProcess1D>(
-              new GeneralizedOrnsteinUhlenbeckProcess(alpha, sigma))),
+        : ShortRateDynamics(ext::make_shared<GeneralizedOrnsteinUhlenbeckProcess>(alpha, sigma)),
           fitting_(std::move(fitting)), _f_(std::move(f)), _fInverse_(std::move(fInverse)) {}
 
         //classical HW dynamics
         Dynamics(Parameter fitting, Real a, Real sigma)
         : GeneralizedHullWhite::ShortRateDynamics(
-              ext::shared_ptr<StochasticProcess1D>(new OrnsteinUhlenbeckProcess(a, sigma))),
+              ext::make_shared<OrnsteinUhlenbeckProcess>(a, sigma)),
           fitting_(std::move(fitting)), _f_(identity()), _fInverse_(identity()) {}
 
         Real variable(Time t, Rate r) const override { return _f_(r) - fitting_(t); }
@@ -291,15 +289,13 @@ namespace QuantLib {
       public:
         FittingParameter(const Handle<YieldTermStructure>& termStructure,
                          Real a, Real sigma)
-        : TermStructureFittingParameter(ext::shared_ptr<Parameter::Impl>(
-                      new FittingParameter::Impl(termStructure, a, sigma))) {}
+        : TermStructureFittingParameter(ext::make_shared<FittingParameter::Impl>(termStructure, a, sigma)) {}
     };
 
     // Analytic fitting dynamics
     inline ext::shared_ptr<OneFactorModel::ShortRateDynamics>
     GeneralizedHullWhite::HWdynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(
-          new Dynamics(phi_, a(), sigma()));
+        return ext::make_shared<Dynamics>(phi_, a(), sigma());
     }
 
     namespace detail {

--- a/ql/experimental/swaptions/haganirregularswaptionengine.cpp
+++ b/ql/experimental/swaptions/haganirregularswaptionengine.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
     : swap_(std::move(swap)), termStructure_(std::move(termStructure)),
       volatilityStructure_(std::move(volatilityStructure)) {
 
-        engine_ = ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(termStructure_));
+        engine_ = ext::make_shared<DiscountingSwapEngine>(termStructure_);
 
         // store swap npv
         swap_->setPricingEngine(engine_);
@@ -89,7 +89,7 @@ namespace QuantLib {
 
                     if (!newCpn->isInArrears())
                         newCpn->setPricer(
-                            ext::shared_ptr<FloatingRateCouponPricer>(new BlackIborCouponPricer()));
+                            ext::make_shared<BlackIborCouponPricer>());
 
                     floatCFS.push_back(newCpn);
                 }
@@ -266,7 +266,7 @@ namespace QuantLib {
 
             if (!newCpn->isInArrears())
                 newCpn->setPricer(
-                    ext::shared_ptr<FloatingRateCouponPricer>(new BlackIborCouponPricer()));
+                    ext::make_shared<BlackIborCouponPricer>());
 
             floatCFS.push_back(newCpn);
         }
@@ -339,8 +339,7 @@ namespace QuantLib {
                    "swaptionEngine: only normal volatility implemented.");
 
 
-        ext::shared_ptr<PricingEngine> swaptionEngine = ext::shared_ptr<PricingEngine>(
-            new BachelierSwaptionEngine(termStructure_, volatilityStructure_));
+        ext::shared_ptr<PricingEngine> swaptionEngine = ext::make_shared<BachelierSwaptionEngine>(termStructure_, volatilityStructure_);
 
 
         // retrieve weights of underlying swaps

--- a/ql/experimental/swaptions/irregularswaption.cpp
+++ b/ql/experimental/swaptions/irregularswaption.cpp
@@ -56,8 +56,7 @@ namespace QuantLib {
           vol_(ext::make_shared<SimpleQuote>(-1.0)) {
 
             Handle<Quote> h(vol_);
-            engine_ = ext::shared_ptr<PricingEngine>(new
-                                    BlackSwaptionEngine(discountCurve_, h));
+            engine_ = ext::make_shared<BlackSwaptionEngine>(discountCurve_, h);
             swaption.setupArguments(engine_->getArguments());
 
             results_ =

--- a/ql/experimental/variancegamma/fftengine.cpp
+++ b/ql/experimental/variancegamma/fftengine.cpp
@@ -66,7 +66,7 @@ namespace QuantLib {
 
     void FFTEngine::calculateUncached(const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                       const ext::shared_ptr<Exercise>& exercise) const {
-        ext::shared_ptr<VanillaOption> option(new VanillaOption(payoff, exercise));
+        ext::shared_ptr<VanillaOption> option = ext::make_shared<VanillaOption>(payoff, exercise);
         std::vector<ext::shared_ptr<Instrument> > optionList;
         optionList.push_back(option);
 

--- a/ql/experimental/variancegamma/fftvanillaengine.cpp
+++ b/ql/experimental/variancegamma/fftvanillaengine.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     {
         ext::shared_ptr<GeneralizedBlackScholesProcess> process =
             ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(process_);
-        return std::unique_ptr<FFTEngine>(new FFTVanillaEngine(process, lambda_));
+        return std::make_unique<FFTVanillaEngine>(process, lambda_);
     }
 
     void FFTVanillaEngine::precalculateExpiry(Date d)

--- a/ql/experimental/variancegamma/fftvariancegammaengine.cpp
+++ b/ql/experimental/variancegamma/fftvariancegammaengine.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
     {
         ext::shared_ptr<VarianceGammaProcess> process =
             ext::dynamic_pointer_cast<VarianceGammaProcess>(process_);
-        return std::unique_ptr<FFTEngine>(new FFTVarianceGammaEngine(process, lambda_));
+        return std::make_unique<FFTVarianceGammaEngine>(process, lambda_);
     }
 
     void FFTVarianceGammaEngine::precalculateExpiry(Date d)

--- a/ql/experimental/variancegamma/variancegammaprocess.cpp
+++ b/ql/experimental/variancegamma/variancegammaprocess.cpp
@@ -31,7 +31,7 @@ namespace QuantLib {
                                                Real sigma,
                                                Real nu,
                                                Real theta)
-    : StochasticProcess1D(ext::shared_ptr<discretization>(new EulerDiscretization)),
+    : StochasticProcess1D(ext::make_shared<EulerDiscretization>()),
       s0_(std::move(s0)), dividendYield_(std::move(dividendYield)),
       riskFreeRate_(std::move(riskFreeRate)), sigma_(sigma), nu_(nu), theta_(theta) {
         registerWith(riskFreeRate_);

--- a/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -58,14 +58,14 @@ namespace QuantLib {
                       Real v0, Real eprice, Time tau, Real rtax)
     {
         Real ss=0.0;
-        std::unique_ptr<double[]> xiv(new double[2048*2048+1]);
+        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
         double nris=0.0;
         int j=0,mm=0;
         double pi=0,pi2=0;
         double dstep=0;
         Real option=0, impart=0;
 
-        std::unique_ptr<Complex[]> ff(new Complex[2048*2048]);
+        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
         Complex ui,beta,zita,gamma,csum,vero;
         Complex contrib, caux, caux1,caux2,caux3;
@@ -203,8 +203,8 @@ namespace QuantLib {
                     const std::function<Real(Real)>& payoff) {
 
         Real ss=0.0;
-        std::unique_ptr<double[]> xiv(new double[2048*2048+1]);
-        std::unique_ptr<double[]> ivet(new double[2048 * 2048 + 1]);
+        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
+        std::unique_ptr<double[]> ivet = std::make_unique<double[]>(2048 * 2048 + 1);
         double nris=0.0;
         int j=0,mm=0,k=0;
         double pi=0,pi2=0;
@@ -217,7 +217,7 @@ namespace QuantLib {
         Real sumr=0;//,sumi=0;
         Complex dxi,z;
 
-        std::unique_ptr<Complex[]> ff(new Complex[2048*2048]);
+        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
         Complex ui,beta,zita,gamma,csum;
         Complex caux,caux1,caux2,caux3;

--- a/ql/experimental/volatility/noarbsabrinterpolatedsmilesection.cpp
+++ b/ql/experimental/volatility/noarbsabrinterpolatedsmilesection.cpp
@@ -77,8 +77,8 @@ namespace QuantLib {
         ext::shared_ptr<OptimizationMethod> method,
         const DayCounter& dc)
     : SmileSection(optionDate, dc),
-      forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-      atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+      forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+      atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
       volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
       hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), alpha_(alpha), beta_(beta),
       nu_(nu), rho_(rho), isAlphaFixed_(isAlphaFixed), isBetaFixed_(isBetaFixed),
@@ -86,16 +86,16 @@ namespace QuantLib {
       endCriteria_(std::move(endCriteria)), method_(std::move(method)) {
 
         for (Size i = 0; i < volHandles_.size(); ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(volHandles[i]));
     }
 
     void NoArbSabrInterpolatedSmileSection::createInterpolation() const {
-         ext::shared_ptr<NoArbSabrInterpolation> tmp(new NoArbSabrInterpolation(
+         ext::shared_ptr<NoArbSabrInterpolation> tmp = ext::make_shared<NoArbSabrInterpolation>(
                      actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
                      exerciseTime(), forwardValue_,
                      alpha_, beta_, nu_, rho_,
                      isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, vegaWeighted_,
-                     endCriteria_, method_));
+                     endCriteria_, method_);
          swap(tmp, noArbSabrInterpolation_);
     }
 

--- a/ql/experimental/volatility/sabrvolsurface.cpp
+++ b/ql/experimental/volatility/sabrvolsurface.cpp
@@ -125,8 +125,7 @@ namespace QuantLib {
         // calculate sabr fit
         std::array<Real, 4> sabrParameters1 = sabrGuesses(d);
 
-        ext::shared_ptr<SabrInterpolatedSmileSection> tmp(new
-            SabrInterpolatedSmileSection(d,
+        ext::shared_ptr<SabrInterpolatedSmileSection> tmp = ext::make_shared<SabrInterpolatedSmileSection>(d,
                                          index_->fixing(d,true), atmRateSpreads_, true,
                                             atmCurve_->atmVol(d), volSpreads,
                                             sabrParameters1[0], sabrParameters1[1],
@@ -136,7 +135,7 @@ namespace QuantLib {
                                             vegaWeighted_/*,
                                             const ext::shared_ptr<EndCriteria>& endCriteria,
                                             const ext::shared_ptr<OptimizationMethod>& method,
-                                            const DayCounter& dc*/));
+                                            const DayCounter& dc*/);
 
         // update guess
 

--- a/ql/experimental/volatility/sviinterpolatedsmilesection.cpp
+++ b/ql/experimental/volatility/sviinterpolatedsmilesection.cpp
@@ -81,8 +81,8 @@ namespace QuantLib {
         ext::shared_ptr<OptimizationMethod> method,
         const DayCounter& dc)
     : SmileSection(optionDate, dc),
-      forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-      atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+      forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+      atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
       volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
       hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), a_(a), b_(b),
       sigma_(sigma), rho_(rho), m_(m), isAFixed_(isAFixed), isBFixed_(isBFixed),
@@ -91,15 +91,15 @@ namespace QuantLib {
       method_(std::move(method)) {
 
         for (Size i = 0; i < volHandles_.size(); ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(volHandles[i]));
     }
 
 void SviInterpolatedSmileSection::createInterpolation() const {
-    ext::shared_ptr<SviInterpolation> tmp(new SviInterpolation(
+    ext::shared_ptr<SviInterpolation> tmp = ext::make_shared<SviInterpolation>(
         actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
         exerciseTime(), forwardValue_, a_, b_, sigma_, rho_, m_, isAFixed_,
         isBFixed_, isSigmaFixed_, isRhoFixed_, isMFixed_, vegaWeighted_,
-        endCriteria_, method_));
+        endCriteria_, method_);
     swap(tmp, sviInterpolation_);
 }
 

--- a/ql/indexes/ibor/shibor.cpp
+++ b/ql/indexes/ibor/shibor.cpp
@@ -49,6 +49,6 @@ namespace QuantLib {
     
     ext::shared_ptr<IborIndex> Shibor::clone(
                                   const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(new Shibor(tenor(), h));
+        return ext::make_shared<Shibor>(tenor(), h);
     }
 }

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -84,13 +84,12 @@ namespace QuantLib {
 
     ext::shared_ptr<IborIndex> OvernightIndex::clone(
                                const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(
-                                        new OvernightIndex(familyName(),
+        return ext::make_shared<OvernightIndex>(familyName(),
                                                            fixingDays(),
                                                            currency(),
                                                            fixingCalendar(),
                                                            dayCounter(),
-                                                           h));
+                                                           h);
     }
 
 }

--- a/ql/indexes/region.cpp
+++ b/ql/indexes/region.cpp
@@ -29,32 +29,32 @@ namespace QuantLib {
 
 
     AustraliaRegion::AustraliaRegion() {
-        static ext::shared_ptr<Data> AUdata(new Data("Australia","AU"));
+        static ext::shared_ptr<Data> AUdata = ext::make_shared<Data>("Australia","AU");
         data_ = AUdata;
     }
 
     EURegion::EURegion() {
-        static ext::shared_ptr<Data> EUdata(new Data("EU","EU"));
+        static ext::shared_ptr<Data> EUdata = ext::make_shared<Data>("EU","EU");
         data_ = EUdata;
     }
 
     FranceRegion::FranceRegion() {
-        static ext::shared_ptr<Data> FRdata(new Data("France","FR"));
+        static ext::shared_ptr<Data> FRdata = ext::make_shared<Data>("France","FR");
         data_ = FRdata;
     }
 
     UKRegion::UKRegion() {
-        static ext::shared_ptr<Data> UKdata(new Data("UK","UK"));
+        static ext::shared_ptr<Data> UKdata = ext::make_shared<Data>("UK","UK");
         data_ = UKdata;
     }
 
     USRegion::USRegion() {
-        static ext::shared_ptr<Data> USdata(new Data("USA","US"));
+        static ext::shared_ptr<Data> USdata = ext::make_shared<Data>("USA","US");
         data_ = USdata;
     }
 
     ZARegion::ZARegion() {
-        static ext::shared_ptr<Data> ZAdata(new Data("South Africa","ZA"));
+        static ext::shared_ptr<Data> ZAdata = ext::make_shared<Data>("South Africa","ZA");
         data_ = ZAdata;
     }
 

--- a/ql/indexes/swap/chfliborswap.cpp
+++ b/ql/indexes/swap/chfliborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, h))) {}
+                    ext::make_shared<CHFLibor>(6*Months, h) :
+                    ext::make_shared<CHFLibor>(3*Months, h)) {}
 
     ChfLiborSwapIsdaFix::ChfLiborSwapIsdaFix(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, forwarding)),
+                    ext::make_shared<CHFLibor>(6*Months, forwarding) :
+                    ext::make_shared<CHFLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/euriborswap.cpp
+++ b/ql/indexes/swap/euriborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIsdaFixA::EuriborSwapIsdaFixA(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
@@ -70,8 +70,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
                                 const Period& tenor,
@@ -86,8 +86,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
 
@@ -102,8 +102,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIfrFix::EuriborSwapIfrFix(
                                 const Period& tenor,
@@ -118,8 +118,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
 

--- a/ql/indexes/swap/eurliborswap.cpp
+++ b/ql/indexes/swap/eurliborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIsdaFixA::EurLiborSwapIsdaFixA(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
@@ -70,8 +70,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
                                 const Period& tenor,
@@ -86,8 +86,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
@@ -102,8 +102,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
                                 const Period& tenor,
@@ -118,8 +118,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/gbpliborswap.cpp
+++ b/ql/indexes/swap/gbpliborswap.cpp
@@ -39,8 +39,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, h))) {}
+                    ext::make_shared<GBPLibor>(6*Months, h) :
+                    ext::make_shared<GBPLibor>(3*Months, h)) {}
 
     GbpLiborSwapIsdaFix::GbpLiborSwapIsdaFix(
                             const Period& tenor,
@@ -56,8 +56,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, forwarding)),
+                    ext::make_shared<GBPLibor>(6*Months, forwarding) :
+                    ext::make_shared<GBPLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/jpyliborswap.cpp
+++ b/ql/indexes/swap/jpyliborswap.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::make_shared<JPYLibor>(6*Months, h)) {}
 
     JpyLiborSwapIsdaFixAm::JpyLiborSwapIsdaFixAm(
                                 const Period& tenor,
@@ -50,7 +50,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
+                ext::make_shared<JPYLibor>(6*Months, forwarding),
                 discounting) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
@@ -64,7 +64,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::make_shared<JPYLibor>(6*Months, h)) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
                                 const Period& tenor,
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
+                ext::make_shared<JPYLibor>(6*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/usdliborswap.cpp
+++ b/ql/indexes/swap/usdliborswap.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::make_shared<USDLibor>(3*Months, h)) {}
 
     UsdLiborSwapIsdaFixAm::UsdLiborSwapIsdaFixAm(
                                 const Period& tenor,
@@ -50,7 +50,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
+                ext::make_shared<USDLibor>(3*Months, forwarding),
                 discounting) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
@@ -64,7 +64,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::make_shared<USDLibor>(3*Months, h)) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
                                 const Period& tenor,
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
+                ext::make_shared<USDLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/instruments/barrieroption.cpp
+++ b/ql/instruments/barrieroption.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
              Volatility maxVol) const {
         QL_REQUIRE(!isExpired(), "option expired");
 
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         ext::shared_ptr<GeneralizedBlackScholesProcess> newProcess =
             detail::ImpliedVolatilityHelper::clone(process, volQuote);

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -332,8 +332,7 @@ namespace QuantLib {
                                    Real redemption,
                                    const Date& date) {
 
-        ext::shared_ptr<CashFlow> redemptionCashflow(
-                         new Redemption(notional*redemption/100.0, date));
+        ext::shared_ptr<CashFlow> redemptionCashflow = ext::make_shared<Redemption>(notional*redemption/100.0, date);
         setSingleRedemption(notional, redemptionCashflow);
     }
 

--- a/ql/instruments/bondforward.cpp
+++ b/ql/instruments/bondforward.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                     const Handle<YieldTermStructure>& discountCurve,
                     const Handle<YieldTermStructure>& incomeDiscountCurve)
     : Forward(dayCounter, calendar, businessDayConvention, settlementDays,
-              ext::shared_ptr<Payoff>(new ForwardTypePayoff(type,strike)),
+              ext::make_shared<ForwardTypePayoff>(type,strike),
               valueDate, maturityDate, discountCurve), bond_(bond) {
 
         incomeDiscountCurve_ = incomeDiscountCurve;

--- a/ql/instruments/capfloor.cpp
+++ b/ql/instruments/capfloor.cpp
@@ -67,14 +67,12 @@ namespace QuantLib {
 
             switch (type) {
             case ShiftedLognormal:
-                engine_ = ext::shared_ptr<PricingEngine>(new
-                    BlackCapFloorEngine(discountCurve_, h, Actual365Fixed(),
-                                                                displacement));
+                engine_ = ext::make_shared<BlackCapFloorEngine>(discountCurve_, h, Actual365Fixed(),
+                                                                displacement);
                 break;
             case Normal:
-                engine_ = ext::shared_ptr<PricingEngine>(new
-                    BachelierCapFloorEngine(discountCurve_, h, 
-                                                            Actual365Fixed()));
+                engine_ = ext::make_shared<BachelierCapFloorEngine>(discountCurve_, h,
+                                                            Actual365Fixed());
                 break;
             default:
                 QL_FAIL("unknown VolatilityType (" << type << ")");

--- a/ql/instruments/cpiswap.cpp
+++ b/ql/instruments/cpiswap.cpp
@@ -93,7 +93,7 @@ namespace QuantLib {
             }
 
             Real floatAmount = subtractInflationNominal_ ? nominal_ - inflationNominal_ : nominal_;
-            ext::shared_ptr<CashFlow> nf(new SimpleCashFlow(floatAmount, payNotional));
+            ext::shared_ptr<CashFlow> nf = ext::make_shared<SimpleCashFlow>(floatAmount, payNotional);
             floatingLeg.push_back(nf);
         }
 

--- a/ql/instruments/doublebarrieroption.cpp
+++ b/ql/instruments/doublebarrieroption.cpp
@@ -59,7 +59,7 @@ namespace QuantLib {
 
         QL_REQUIRE(!isExpired(), "option expired");
 
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         ext::shared_ptr<GeneralizedBlackScholesProcess> newProcess =
             detail::ImpliedVolatilityHelper::clone(process, volQuote);

--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -335,8 +335,7 @@ namespace QuantLib {
                     auto it1 = legs_[0].begin();
                     std::advance(it1, i + 1);
                     legs_[0].insert(
-                        it1, ext::shared_ptr<CashFlow>(
-                                 new Redemption(cap, legs_[0][i]->date())));
+                        it1, ext::make_shared<Redemption>(cap, legs_[0][i]->date()));
                     auto it2 = nominal1_.begin();
                     std::advance(it2, i + 1);
                     nominal1_.insert(it2, nominal1_[i]);
@@ -349,8 +348,7 @@ namespace QuantLib {
                     auto it1 = legs_[1].begin();
                     std::advance(it1, i + 1);
                     legs_[1].insert(
-                        it1, ext::shared_ptr<CashFlow>(
-                                 new Redemption(cap, legs_[1][i]->date())));
+                        it1, ext::make_shared<Redemption>(cap, legs_[1][i]->date()));
                     auto it2 = nominal2_.begin();
                     std::advance(it2, i + 1);
                     nominal2_.insert(it2, nominal2_[i]);
@@ -360,11 +358,9 @@ namespace QuantLib {
         }
 
         if (finalCapitalExchange_) {
-            legs_[0].push_back(ext::shared_ptr<CashFlow>(
-                new Redemption(nominal1_.back(), legs_[0].back()->date())));
+            legs_[0].push_back(ext::make_shared<Redemption>(nominal1_.back(), legs_[0].back()->date()));
             nominal1_.push_back(nominal1_.back());
-            legs_[1].push_back(ext::shared_ptr<CashFlow>(
-                new Redemption(nominal2_.back(), legs_[1].back()->date())));
+            legs_[1].push_back(ext::make_shared<Redemption>(nominal2_.back(), legs_[1].back()->date()));
             nominal2_.push_back(nominal2_.back());
         }
 

--- a/ql/instruments/impliedvolatility.cpp
+++ b/ql/instruments/impliedvolatility.cpp
@@ -91,11 +91,10 @@ namespace QuantLib {
 
             Handle<BlackVolTermStructure> blackVol = process->blackVolatility();
             Handle<BlackVolTermStructure> volatility(
-                ext::shared_ptr<BlackVolTermStructure>(
-                               new BlackConstantVol(blackVol->referenceDate(),
+                ext::make_shared<BlackConstantVol>(blackVol->referenceDate(),
                                                     blackVol->calendar(),
                                                     Handle<Quote>(volQuote),
-                                                    blackVol->dayCounter())));
+                                                    blackVol->dayCounter()));
 
             return ext::make_shared<GeneralizedBlackScholesProcess>(
                 stateVariable, dividendYield,

--- a/ql/instruments/makecapfloor.cpp
+++ b/ql/instruments/makecapfloor.cpp
@@ -72,8 +72,7 @@ namespace QuantLib {
                                                  discountCurve->referenceDate());
         }
 
-        ext::shared_ptr<CapFloor> capFloor(new
-            CapFloor(capFloorType_, leg, strikeVector));
+        ext::shared_ptr<CapFloor> capFloor = ext::make_shared<CapFloor>(capFloorType_, leg, strikeVector);
         capFloor->setPricingEngine(engine_);
         return capFloor;
     }

--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -149,8 +149,7 @@ namespace QuantLib {
                            "null term structure set to this instance of " <<
                            overnightIndex_->name());
                 bool includeSettlementDateFlows = false;
-                ext::shared_ptr<PricingEngine> engine(new
-                    DiscountingSwapEngine(disc, includeSettlementDateFlows));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(disc, includeSettlementDateFlows);
                 temp.setPricingEngine(engine);
             } else
                 temp.setPricingEngine(engine_);
@@ -158,8 +157,7 @@ namespace QuantLib {
             usedFixedRate = temp.fairRate();
         }
 
-        ext::shared_ptr<OvernightIndexedSwap> ois(new
-            OvernightIndexedSwap(type_, nominal_,
+        ext::shared_ptr<OvernightIndexedSwap> ois = ext::make_shared<OvernightIndexedSwap>(type_, nominal_,
                                  fixedSchedule,
                                  usedFixedRate, fixedDayCount_,
                                  overnightSchedule,
@@ -167,14 +165,13 @@ namespace QuantLib {
                                  paymentLag_, paymentAdjustment_,
                                  paymentCalendar_, telescopicValueDates_, 
                                  averagingMethod_, lookbackDays_,
-                                 lockoutDays_, applyObservationShift_));
+                                 lockoutDays_, applyObservationShift_);
 
         if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
                                 overnightIndex_->forwardingTermStructure();
             bool includeSettlementDateFlows = false;
-            ext::shared_ptr<PricingEngine> engine(new
-                DiscountingSwapEngine(disc, includeSettlementDateFlows));
+            ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(disc, includeSettlementDateFlows);
             ois->setPricingEngine(engine);
         } else
             ois->setPricingEngine(engine_);
@@ -274,8 +271,7 @@ namespace QuantLib {
     MakeOIS& MakeOIS::withDiscountingTermStructure(
                                         const Handle<YieldTermStructure>& d) {
         bool includeSettlementDateFlows = false;
-        engine_ = ext::shared_ptr<PricingEngine>(new
-            DiscountingSwapEngine(d, includeSettlementDateFlows));
+        engine_ = ext::make_shared<DiscountingSwapEngine>(d, includeSettlementDateFlows);
         return *this;
     }
 

--- a/ql/instruments/makeswaption.cpp
+++ b/ql/instruments/makeswaption.cpp
@@ -64,14 +64,12 @@ namespace QuantLib {
             fixingDate_ = calendar.advance(refDate, optionTenor_,
                                            optionConvention_);
         if (exerciseDate_ == Date()) {
-            exercise_ = ext::shared_ptr<Exercise>(new
-                EuropeanExercise(fixingDate_));
+            exercise_ = ext::make_shared<EuropeanExercise>(fixingDate_);
         } else {
             QL_REQUIRE(exerciseDate_ <= fixingDate_,
                        "exercise date (" << exerciseDate_ << ") must be less "
                        "than or equal to fixing date (" << fixingDate_ << ")");
-            exercise_ = ext::shared_ptr<Exercise>(new
-                EuropeanExercise(exerciseDate_));
+            exercise_ = ext::make_shared<EuropeanExercise>(exerciseDate_);
         }
 
         Rate usedStrike;

--- a/ql/instruments/makevanillaswap.cpp
+++ b/ql/instruments/makevanillaswap.cpp
@@ -169,8 +169,7 @@ namespace QuantLib {
                            "null term structure set to this instance of " <<
                            iborIndex_->name());
                 bool includeSettlementDateFlows = false;
-                ext::shared_ptr<PricingEngine> engine(new
-                    DiscountingSwapEngine(disc, includeSettlementDateFlows));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(disc, includeSettlementDateFlows);
                 temp.setPricingEngine(engine);
             } else
                 temp.setPricingEngine(engine_);
@@ -178,16 +177,15 @@ namespace QuantLib {
             usedFixedRate = temp.fairRate();
         }
 
-        ext::shared_ptr<VanillaSwap> swap(new VanillaSwap(
+        ext::shared_ptr<VanillaSwap> swap = ext::make_shared<VanillaSwap>(
             type_, nominal_, fixedSchedule, usedFixedRate, fixedDayCount, floatSchedule, iborIndex_,
-            floatSpread_, floatDayCount_, paymentConvention_, useIndexedCoupons_));
+            floatSpread_, floatDayCount_, paymentConvention_, useIndexedCoupons_);
 
         if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
                                     iborIndex_->forwardingTermStructure();
             bool includeSettlementDateFlows = false;
-            ext::shared_ptr<PricingEngine> engine(new
-                DiscountingSwapEngine(disc, includeSettlementDateFlows));
+            ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(disc, includeSettlementDateFlows);
             swap->setPricingEngine(engine);
         } else
             swap->setPricingEngine(engine_);
@@ -243,8 +241,7 @@ namespace QuantLib {
     MakeVanillaSwap& MakeVanillaSwap::withDiscountingTermStructure(
                                         const Handle<YieldTermStructure>& d) {
         bool includeSettlementDateFlows = false;
-        engine_ = ext::shared_ptr<PricingEngine>(new
-            DiscountingSwapEngine(d, includeSettlementDateFlows));
+        engine_ = ext::make_shared<DiscountingSwapEngine>(d, includeSettlementDateFlows);
         return *this;
     }
 

--- a/ql/instruments/makeyoyinflationcapfloor.cpp
+++ b/ql/instruments/makeyoyinflationcapfloor.cpp
@@ -82,8 +82,7 @@ namespace QuantLib {
                                                  false, nominalTermStructure_->referenceDate());
         }
 
-        ext::shared_ptr<YoYInflationCapFloor> capFloor(new
-                    YoYInflationCapFloor(capFloorType_, leg, strikeVector));
+        ext::shared_ptr<YoYInflationCapFloor> capFloor = ext::make_shared<YoYInflationCapFloor>(capFloorType_, leg, strikeVector);
         capFloor->setPricingEngine(engine_);
         return capFloor;
     }

--- a/ql/instruments/margrabeoption.cpp
+++ b/ql/instruments/margrabeoption.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
     MargrabeOption::MargrabeOption(Integer Q1,
                                    Integer Q2,
                                    const ext::shared_ptr<Exercise>& exercise)
-    : MultiAssetOption(ext::shared_ptr<Payoff>(new NullPayoff), exercise),
+    : MultiAssetOption(ext::make_shared<NullPayoff>(), exercise),
       Q1_(Q1),
       Q2_(Q2) {}
 

--- a/ql/instruments/nonstandardswap.cpp
+++ b/ql/instruments/nonstandardswap.cpp
@@ -173,8 +173,7 @@ namespace QuantLib {
                     auto it1 = legs_[0].begin();
                     std::advance(it1, i + 1);
                     legs_[0].insert(
-                        it1, ext::shared_ptr<CashFlow>(
-                                 new Redemption(cap, legs_[0][i]->date())));
+                        it1, ext::make_shared<Redemption>(cap, legs_[0][i]->date()));
                     auto it2 = fixedNominal_.begin();
                     std::advance(it2, i + 1);
                     fixedNominal_.insert(it2, fixedNominal_[i]);
@@ -190,8 +189,7 @@ namespace QuantLib {
                     auto it1 = legs_[1].begin();
                     std::advance(it1, i + 1);
                     legs_[1].insert(
-                        it1, ext::shared_ptr<CashFlow>(
-                                 new Redemption(cap, legs_[1][i]->date())));
+                        it1, ext::make_shared<Redemption>(cap, legs_[1][i]->date()));
                     auto it2 = floatingNominal_.begin();
                     std::advance(it2, i + 1);
                     floatingNominal_.insert(it2, floatingNominal_[i]);
@@ -201,12 +199,11 @@ namespace QuantLib {
         }
 
         if (finalCapitalExchange_) {
-            legs_[0].push_back(ext::shared_ptr<CashFlow>(
-                new Redemption(fixedNominal_.back(), legs_[0].back()->date())));
+            legs_[0].push_back(ext::make_shared<Redemption>(fixedNominal_.back(), legs_[0].back()->date()));
             fixedNominal_.push_back(fixedNominal_.back());
             fixedRate_.push_back(0.0);
-            legs_[1].push_back(ext::shared_ptr<CashFlow>(new Redemption(
-                floatingNominal_.back(), legs_[1].back()->date())));
+            legs_[1].push_back(ext::make_shared<Redemption>(
+                floatingNominal_.back(), legs_[1].back()->date()));
             floatingNominal_.push_back(floatingNominal_.back());
         }
 

--- a/ql/instruments/softbarrieroption.cpp
+++ b/ql/instruments/softbarrieroption.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
 
         QL_REQUIRE(!isExpired(), "option expired");
 
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         ext::shared_ptr<GeneralizedBlackScholesProcess> newProcess =
             detail::ImpliedVolatilityHelper::clone(process, volQuote);

--- a/ql/instruments/vanillaoption.cpp
+++ b/ql/instruments/vanillaoption.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
 
         QL_REQUIRE(!isExpired(), "option expired");
 
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         ext::shared_ptr<GeneralizedBlackScholesProcess> newProcess =
             detail::ImpliedVolatilityHelper::clone(process, volQuote);

--- a/ql/instruments/vanillastorageoption.hpp
+++ b/ql/instruments/vanillastorageoption.hpp
@@ -37,7 +37,7 @@ namespace QuantLib {
           class arguments;
           VanillaStorageOption(const ext::shared_ptr<BermudanExercise>& ex,
                                Real capacity, Real load, Real changeRate)
-        : OneAssetOption(ext::shared_ptr<Payoff>(new NullPayoff), ex),
+        : OneAssetOption(ext::make_shared<NullPayoff>(), ex),
           capacity_  (capacity),
           load_      (load),
           changeRate_(changeRate) {}

--- a/ql/legacy/libormarketmodels/lfmprocess.cpp
+++ b/ql/legacy/libormarketmodels/lfmprocess.cpp
@@ -31,7 +31,7 @@
 namespace QuantLib {
 
     LiborForwardModelProcess::LiborForwardModelProcess(Size size, ext::shared_ptr<IborIndex> index)
-    : StochasticProcess(ext::shared_ptr<discretization>(new EulerDiscretization)), size_(size),
+    : StochasticProcess(ext::make_shared<EulerDiscretization>()), size_(size),
       index_(std::move(index)), initialValues_(size_), fixingTimes_(size_), fixingDates_(size_),
       accrualStartTimes_(size), accrualEndTimes_(size), accrualPeriod_(size_), m1(size_),
       m2(size_) {

--- a/ql/legacy/libormarketmodels/lfmswaptionengine.cpp
+++ b/ql/legacy/libormarketmodels/lfmswaptionengine.cpp
@@ -40,8 +40,7 @@ namespace QuantLib {
         static const Spread basisPoint = 1.0e-4;
 
         auto swap = arguments_.swap;
-        swap->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                  new DiscountingSwapEngine(discountCurve_, false)));
+        swap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(discountCurve_, false));
 
         Spread correction = swap->spread() *
             std::fabs(swap->floatingLegBPS()/swap->fixedLegBPS());

--- a/ql/math/interpolations/abcdinterpolation.hpp
+++ b/ql/math/interpolations/abcdinterpolation.hpp
@@ -105,14 +105,13 @@ namespace QuantLib {
                     times.push_back(*x);
                     blackVols.push_back(*y);
                 }
-                abcdCalibrator_ = ext::shared_ptr<AbcdCalibration>(
-                    new AbcdCalibration(times, blackVols,
+                abcdCalibrator_ = ext::make_shared<AbcdCalibration>(times, blackVols,
                                         this->a_, this->b_, this->c_, this->d_,
                                         this->aIsFixed_, this->bIsFixed_,
                                         this->cIsFixed_, this->dIsFixed_,
                                         vegaWeighted_,
                                         endCriteria_,
-                                        optMethod_));
+                                        optMethod_);
                 abcdCalibrator_->compute();
                 this->a_ = abcdCalibrator_->a();
                 this->b_ = abcdCalibrator_->b();

--- a/ql/math/interpolations/convexmonotoneinterpolation.hpp
+++ b/ql/math/interpolations/convexmonotoneinterpolation.hpp
@@ -588,10 +588,9 @@ namespace QuantLib {
         void ConvexMonotoneImpl<I1,I2>::update() {
             sectionHelpers_.clear();
             if (length_ == 2) { //single period
-                ext::shared_ptr<SectionHelper> singleHelper(
-                              new EverywhereConstantHelper(this->yBegin_[1],
+                ext::shared_ptr<SectionHelper> singleHelper = ext::make_shared<EverywhereConstantHelper>(this->yBegin_[1],
                                                            0.0,
-                                                           this->xBegin_[0]));
+                                                           this->xBegin_[0]);
                 sectionHelpers_[this->xBegin_[1]] = singleHelper;
                 extrapolationHelper_ = singleHelper;
                 return;
@@ -639,11 +638,10 @@ namespace QuantLib {
                 //first deal with the zero gradient case
                 if ( std::fabs(gPrev) < 1.0E-14
                      && std::fabs(gNext) < 1.0E-14 ) {
-                    ext::shared_ptr<SectionHelper> singleHelper(
-                                     new ConstantGradHelper(f[i-1], primitive,
+                    ext::shared_ptr<SectionHelper> singleHelper = ext::make_shared<ConstantGradHelper>(f[i-1], primitive,
                                                             this->xBegin_[i-1],
                                                             this->xBegin_[i],
-                                                            f[i]));
+                                                            f[i]);
                     sectionHelpers_[this->xBegin_[i]] = singleHelper;
                 } else {
                     Real quadraticity = quadraticity_;
@@ -652,20 +650,18 @@ namespace QuantLib {
                     if (quadraticity_ > 0.0) {
                         if (gPrev >= -2.0*gNext && gPrev > -0.5*gNext && forcePositive_) {
                             quadraticHelper =
-                                ext::shared_ptr<SectionHelper>(
-                                    new QuadraticMinHelper(this->xBegin_[i-1],
+                                ext::make_shared<QuadraticMinHelper>(this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            f[i-1], f[i],
                                                            this->yBegin_[i],
-                                                           primitive) );
+                                                           primitive);
                         } else {
                             quadraticHelper =
-                                ext::shared_ptr<SectionHelper>(
-                                    new QuadraticHelper(this->xBegin_[i-1],
+                                ext::make_shared<QuadraticHelper>(this->xBegin_[i-1],
                                                         this->xBegin_[i],
                                                         f[i-1], f[i],
                                                         this->yBegin_[i],
-                                                        primitive) );
+                                                        primitive);
                         }
                     }
                     if (quadraticity_ < 1.0) {
@@ -676,22 +672,20 @@ namespace QuantLib {
                             if (quadraticity_ == 0) {
                                 if (forcePositive_) {
                                     quadraticHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new QuadraticMinHelper(
+                                        ext::make_shared<QuadraticMinHelper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            f[i-1], f[i],
                                                            this->yBegin_[i],
-                                                           primitive) );
+                                                           primitive);
                                 } else {
                                     quadraticHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new QuadraticHelper(
+                                        ext::make_shared<QuadraticHelper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            f[i-1], f[i],
                                                            this->yBegin_[i],
-                                                           primitive) );
+                                                           primitive);
                                 }
                             }
                         }
@@ -702,32 +696,29 @@ namespace QuantLib {
                             Real b2 = (1.0 + monotonicity_)/2.0;
                             if (eta < b2) {
                                 convMonotoneHelper =
-                                    ext::shared_ptr<SectionHelper>(
-                                        new ConvexMonotone2Helper(
+                                    ext::make_shared<ConvexMonotone2Helper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           eta, primitive));
+                                                           eta, primitive);
                             } else {
                                 if (forcePositive_) {
                                     convMonotoneHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new ConvexMonotone4MinHelper(
+                                        ext::make_shared<ConvexMonotone4MinHelper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           b2, primitive));
+                                                           b2, primitive);
                                 } else {
                                     convMonotoneHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new ConvexMonotone4Helper(
+                                        ext::make_shared<ConvexMonotone4Helper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           b2, primitive));
+                                                           b2, primitive);
                                 }
                             }
                         }
@@ -737,32 +728,29 @@ namespace QuantLib {
                             Real b3 = (1.0 - monotonicity_)/2.0;
                             if (eta > b3) {
                                 convMonotoneHelper =
-                                    ext::shared_ptr<SectionHelper>(
-                                        new ConvexMonotone3Helper(
+                                    ext::make_shared<ConvexMonotone3Helper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           eta, primitive));
+                                                           eta, primitive);
                             } else {
                                 if (forcePositive_) {
                                     convMonotoneHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new ConvexMonotone4MinHelper(
+                                        ext::make_shared<ConvexMonotone4MinHelper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           b3, primitive));
+                                                           b3, primitive);
                                 } else {
                                     convMonotoneHelper =
-                                        ext::shared_ptr<SectionHelper>(
-                                            new ConvexMonotone4Helper(
+                                        ext::make_shared<ConvexMonotone4Helper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           b3, primitive));
+                                                           b3, primitive);
                                 }
                             }
                         } else {
@@ -775,22 +763,20 @@ namespace QuantLib {
                                 eta = b3;
                             if (forcePositive_) {
                                 convMonotoneHelper =
-                                    ext::shared_ptr<SectionHelper>(
-                                        new ConvexMonotone4MinHelper(
+                                    ext::make_shared<ConvexMonotone4MinHelper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           eta, primitive));
+                                                           eta, primitive);
                             } else {
                                 convMonotoneHelper =
-                                    ext::shared_ptr<SectionHelper>(
-                                        new ConvexMonotone4Helper(
+                                    ext::make_shared<ConvexMonotone4Helper>(
                                                            this->xBegin_[i-1],
                                                            this->xBegin_[i],
                                                            gPrev, gNext,
                                                            this->yBegin_[i],
-                                                           eta, primitive));
+                                                           eta, primitive);
                             }
                         }
                     }
@@ -801,10 +787,9 @@ namespace QuantLib {
                         sectionHelpers_[this->xBegin_[i]] = convMonotoneHelper;
                     } else {
                         sectionHelpers_[this->xBegin_[i]] =
-                            ext::shared_ptr<SectionHelper>(
-                                           new ComboHelper(quadraticHelper,
+                            ext::make_shared<ComboHelper>(quadraticHelper,
                                                            convMonotoneHelper,
-                                                           quadraticity));
+                                                           quadraticity);
                     }
 
                 }
@@ -814,18 +799,16 @@ namespace QuantLib {
 
             if (constantLastPeriod_) {
                 sectionHelpers_[this->xBegin_[length_-1]] =
-                    ext::shared_ptr<SectionHelper>(
-                        new EverywhereConstantHelper(this->yBegin_[length_-1],
+                    ext::make_shared<EverywhereConstantHelper>(this->yBegin_[length_-1],
                                                      primitive,
-                                                     this->xBegin_[length_-2]));
+                                                     this->xBegin_[length_-2]);
                 extrapolationHelper_ = sectionHelpers_[this->xBegin_[length_-1]];
             } else {
                 extrapolationHelper_ =
-                    ext::shared_ptr<SectionHelper>(
-                        new EverywhereConstantHelper(
+                    ext::make_shared<EverywhereConstantHelper>(
                                 (sectionHelpers_.rbegin())->second->value(*(this->xEnd_-1)),
                                 primitive,
-                                *(this->xEnd_-1)));
+                                *(this->xEnd_-1));
             }
         }
 

--- a/ql/math/interpolations/flatextrapolation2d.hpp
+++ b/ql/math/interpolations/flatextrapolation2d.hpp
@@ -36,8 +36,7 @@ namespace QuantLib {
     class FlatExtrapolator2D : public Interpolation2D {
       public:
         FlatExtrapolator2D(const ext::shared_ptr<Interpolation2D>& decoratedInterpolation) {
-            impl_ = ext::shared_ptr<Interpolation2D::Impl>(
-                  new FlatExtrapolator2DImpl(decoratedInterpolation));
+            impl_ = ext::make_shared<FlatExtrapolator2DImpl>(decoratedInterpolation);
         }
       protected:
        class FlatExtrapolator2DImpl: public Interpolation2D::Impl{

--- a/ql/math/interpolations/xabrinterpolation.hpp
+++ b/ql/math/interpolations/xabrinterpolation.hpp
@@ -123,8 +123,7 @@ class XABRInterpolationImpl final : public Interpolation::templateImpl<I1, I2>,
       vegaWeighted_(vegaWeighted), volatilityType_(volatilityType) {
         // if no optimization method or endCriteria is provided, we provide one
         if (!optMethod_)
-            optMethod_ = ext::shared_ptr<OptimizationMethod>(
-                new LevenbergMarquardt(1e-8, 1e-8, 1e-8));
+            optMethod_ = ext::make_shared<LevenbergMarquardt>(1e-8, 1e-8, 1e-8);
         // optMethod_ = ext::shared_ptr<OptimizationMethod>(new
         //    Simplex(0.01));
         if (!endCriteria_) {

--- a/ql/math/matrixutilities/qrdecomposition.cpp
+++ b/ql/math/matrixutilities/qrdecomposition.cpp
@@ -35,9 +35,9 @@ namespace QuantLib {
         const Size m = M.rows();
         const Size n = M.columns();
 
-        std::unique_ptr<int[]> lipvt(new int[n]);
-        std::unique_ptr<Real[]> rdiag(new Real[n]);
-        std::unique_ptr<Real[]> wa(new Real[n]);
+        std::unique_ptr<int[]> lipvt = std::make_unique<int[]>(n);
+        std::unique_ptr<Real[]> rdiag = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
 
         MINPACK::qrfac(m, n, mT.begin(), 0, (pivot)?1:0,
                        lipvt.get(), n, rdiag.get(), rdiag.get(), wa.get());
@@ -135,13 +135,13 @@ namespace QuantLib {
 
         std::vector<Size> lipvt = qrDecomposition(a, q, r, pivot);
 
-        std::unique_ptr<int[]> ipvt(new int[n]);
+        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
         std::copy(lipvt.begin(), lipvt.end(), ipvt.get());
 
         Matrix rT = transpose(r);
 
-        std::unique_ptr<Real[]> sdiag(new Real[n]);
-        std::unique_ptr<Real[]> wa(new Real[n]);
+        std::unique_ptr<Real[]> sdiag = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
 
         Array ld(n, 0.0);
         if (!d.empty()) {

--- a/ql/math/optimization/constraint.hpp
+++ b/ql/math/optimization/constraint.hpp
@@ -84,8 +84,7 @@ namespace QuantLib {
         };
       public:
         NoConstraint()
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                                   new NoConstraint::Impl)) {}
+        : Constraint(ext::make_shared<NoConstraint::Impl>()) {}
     };
 
     //! %Constraint imposing positivity to all arguments
@@ -106,8 +105,7 @@ namespace QuantLib {
         };
       public:
         PositiveConstraint()
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                             new PositiveConstraint::Impl)) {}
+        : Constraint(ext::make_shared<PositiveConstraint::Impl>()) {}
     };
 
     //! %Constraint imposing all arguments to be in [low,high]
@@ -132,8 +130,7 @@ namespace QuantLib {
         };
       public:
         BoundaryConstraint(Real low, Real high)
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                  new BoundaryConstraint::Impl(low, high))) {}
+        : Constraint(ext::make_shared<BoundaryConstraint::Impl>(low, high)) {}
     };
 
     //! %Constraint enforcing both given sub-constraints
@@ -169,8 +166,7 @@ namespace QuantLib {
         };
       public:
         CompositeConstraint(const Constraint& c1, const Constraint& c2)
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                     new CompositeConstraint::Impl(c1,c2))) {}
+        : Constraint(ext::make_shared<CompositeConstraint::Impl>(c1,c2)) {}
     };
 
     //! %Constraint imposing i-th argument to be in [low_i,high_i] for all i
@@ -199,8 +195,7 @@ namespace QuantLib {
         };
       public:
         NonhomogeneousBoundaryConstraint(const Array& low, const Array& high)
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-              new NonhomogeneousBoundaryConstraint::Impl(low, high))) {}
+        : Constraint(ext::make_shared<NonhomogeneousBoundaryConstraint::Impl>(low, high)) {}
     };
 
 }

--- a/ql/math/optimization/leastsquare.cpp
+++ b/ql/math/optimization/leastsquare.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
                                                Real accuracy,
                                                Size maxiter)
     : exitFlag_(-1), accuracy_ (accuracy), maxIterations_ (maxiter),
-      om_ (ext::shared_ptr<OptimizationMethod>(new ConjugateGradient())),
+      om_ (ext::make_shared<ConjugateGradient>()),
       c_(c)
     {}
 

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -48,8 +48,8 @@ namespace QuantLib {
             P.costFunction().jacobian(initJacobian_, initX);
         }
         Array xx = initX;
-        std::unique_ptr<Real[]> fvec(new Real[m]);
-        std::unique_ptr<Real[]> diag(new Real[n]);
+        std::unique_ptr<Real[]> fvec = std::make_unique<Real[]>(m);
+        std::unique_ptr<Real[]> diag = std::make_unique<Real[]>(n);
         int mode = 1;
         // magic number recommended by the documentation
         Real factor = 100;
@@ -59,14 +59,14 @@ namespace QuantLib {
         int nprint = 0;
         int info = 0;
         int nfev = 0;
-        std::unique_ptr<Real[]> fjac(new Real[m*n]);
+        std::unique_ptr<Real[]> fjac = std::make_unique<Real[]>(m*n);
         int ldfjac = m;
-        std::unique_ptr<int[]> ipvt(new int[n]);
-        std::unique_ptr<Real[]> qtf(new Real[n]);
-        std::unique_ptr<Real[]> wa1(new Real[n]);
-        std::unique_ptr<Real[]> wa2(new Real[n]);
-        std::unique_ptr<Real[]> wa3(new Real[n]);
-        std::unique_ptr<Real[]> wa4(new Real[m]);
+        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
+        std::unique_ptr<Real[]> qtf = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa1 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa2 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa3 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa4 = std::make_unique<Real[]>(m);
         // requirements; check here to get more detailed error messages.
         QL_REQUIRE(n > 0, "no variables given");
         QL_REQUIRE(m >= n,

--- a/ql/math/optimization/linesearchbasedmethod.cpp
+++ b/ql/math/optimization/linesearchbasedmethod.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
     LineSearchBasedMethod::LineSearchBasedMethod(ext::shared_ptr<LineSearch> lineSearch)
     : lineSearch_(std::move(lineSearch)) {
         if (!lineSearch_)
-           lineSearch_ = ext::shared_ptr<LineSearch>(new ArmijoLineSearch);
+           lineSearch_ = ext::make_shared<ArmijoLineSearch>();
     }
 
     EndCriteria::Type

--- a/ql/math/optimization/projectedconstraint.hpp
+++ b/ql/math/optimization/projectedconstraint.hpp
@@ -62,14 +62,12 @@ namespace QuantLib {
         ProjectedConstraint(const Constraint &constraint,
                             const Array &parameterValues,
                             const std::vector<bool> &fixParameters)
-            : Constraint(ext::shared_ptr<Constraint::Impl>(
-                  new ProjectedConstraint::Impl(constraint, parameterValues,
-                                                fixParameters))) {}
+            : Constraint(ext::make_shared<ProjectedConstraint::Impl>(constraint, parameterValues,
+                                                fixParameters)) {}
 
         ProjectedConstraint(const Constraint &constraint,
                             const Projection &projection)
-            : Constraint(ext::shared_ptr<Constraint::Impl>(
-                  new ProjectedConstraint::Impl(constraint, projection))) {}
+            : Constraint(ext::make_shared<ProjectedConstraint::Impl>(constraint, projection)) {}
     };
 }
 

--- a/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/concentrating1dmesher.cpp
@@ -80,8 +80,7 @@ namespace QuantLib {
                 }
                 u.push_back(1.0);
                 z.push_back(1.0);
-                transform = ext::shared_ptr<Interpolation>(
-                    new LinearInterpolation(u.begin(), u.end(), z.begin()));
+                transform = ext::make_shared<LinearInterpolation>(u.begin(), u.end(), z.begin());
             }
 
             for (Size i = 1; i < size - 1; ++i) {

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmesher.cpp
@@ -94,10 +94,10 @@ namespace QuantLib {
 
         // Set the grid boundaries
         const Real normInvEps = InverseCumulativeNormal()(1-eps);
-        const Real sigmaSqrtT 
+        const Real sigmaSqrtT
             = process->blackVolatility()->blackVol(maturity, strike)
                                                         *std::sqrt(maturity);
-        
+
         Real xMin = std::log(mi) - sigmaSqrtT*normInvEps*scaleFactor;
         Real xMax = std::log(ma) + sigmaSqrtT*normInvEps*scaleFactor;
 
@@ -109,42 +109,39 @@ namespace QuantLib {
         }
 
         ext::shared_ptr<Fdm1dMesher> helper;
-        if (   cPoint.first != Null<Real>() 
+        if (   cPoint.first != Null<Real>()
             && std::log(cPoint.first) >=xMin && std::log(cPoint.first) <=xMax) {
-            
-            helper = ext::shared_ptr<Fdm1dMesher>(
-                new Concentrating1dMesher(xMin, xMax, size, 
+
+            helper = ext::make_shared<Concentrating1dMesher>(xMin, xMax, size,
                     std::pair<Real,Real>(std::log(cPoint.first),
-                                         cPoint.second)));
+                                         cPoint.second));
         }
         else {
-            helper = ext::shared_ptr<Fdm1dMesher>(
-                                        new Uniform1dMesher(xMin, xMax, size));
-            
+            helper = ext::make_shared<Uniform1dMesher>(xMin, xMax, size);
+
         }
-        
+
         locations_ = helper->locations();
         for (Size i=0; i < locations_.size(); ++i) {
             dplus_[i]  = helper->dplus(i);
             dminus_[i] = helper->dminus(i);
         }
     }
-            
-    ext::shared_ptr<GeneralizedBlackScholesProcess> 
+
+    ext::shared_ptr<GeneralizedBlackScholesProcess>
     FdmBlackScholesMesher::processHelper(const Handle<Quote>& s0,
                                          const Handle<YieldTermStructure>& rTS,
                                          const Handle<YieldTermStructure>& qTS,
                                          Volatility vol) {
-        
+
         return ext::make_shared<GeneralizedBlackScholesProcess>(
-            
+
                 s0, qTS, rTS,
                 Handle<BlackVolTermStructure>(
-                    ext::shared_ptr<BlackVolTermStructure>(
-                        new BlackConstantVol(rTS->referenceDate(),
+                    ext::make_shared<BlackConstantVol>(rTS->referenceDate(),
                                              Calendar(),
                                              vol,
-                                             rTS->dayCounter()))));
+                                             rTS->dayCounter())));
     }
 }
 

--- a/ql/methods/finitedifferences/meshers/fdmblackscholesmultistrikemesher.cpp
+++ b/ql/methods/finitedifferences/meshers/fdmblackscholesmultistrikemesher.cpp
@@ -46,21 +46,21 @@ namespace QuantLib {
                                  / process->riskFreeRate()->discount(maturity);
         const Real minStrike= *std::min_element(strikes.begin(), strikes.end());
         const Real maxStrike= *std::max_element(strikes.begin(), strikes.end());
-                
+
         const Real Fmin = spot*spot/maxStrike*d;
         const Real Fmax = spot*spot/minStrike*d;
-        
+
         QL_REQUIRE(Fmin > 0.0, "negative forward given");
 
         // Set the grid boundaries
         const Real normInvEps = InverseCumulativeNormal()(1-eps);
-        const Real sigmaSqrtTmin 
+        const Real sigmaSqrtTmin
             = process->blackVolatility()->blackVol(maturity, minStrike)
                                                         *std::sqrt(maturity);
-        const Real sigmaSqrtTmax 
+        const Real sigmaSqrtTmax
             = process->blackVolatility()->blackVol(maturity, maxStrike)
                                                         *std::sqrt(maturity);
-        
+
         const Real xMin
             = std::min(0.8*std::log(0.8*spot*spot/maxStrike),
                        std::log(Fmin) - sigmaSqrtTmin*normInvEps*scaleFactor
@@ -71,17 +71,15 @@ namespace QuantLib {
                                       - sigmaSqrtTmax*sigmaSqrtTmax/2.0);
 
         ext::shared_ptr<Fdm1dMesher> helper;
-        if (   cPoint.first != Null<Real>() 
+        if (   cPoint.first != Null<Real>()
             && std::log(cPoint.first) >=xMin && std::log(cPoint.first) <=xMax) {
-            
-            helper = ext::shared_ptr<Fdm1dMesher>(
-                new Concentrating1dMesher(xMin, xMax, size, 
-                    std::pair<Real,Real>(std::log(cPoint.first),cPoint.second)));
+
+            helper = ext::make_shared<Concentrating1dMesher>(xMin, xMax, size,
+                    std::pair<Real,Real>(std::log(cPoint.first),cPoint.second));
         }
         else {
-            helper = ext::shared_ptr<Fdm1dMesher>(
-                                        new Uniform1dMesher(xMin, xMax, size));
-            
+            helper = ext::make_shared<Uniform1dMesher>(xMin, xMax, size);
+
         }
 
         locations_ = helper->locations();
@@ -89,5 +87,5 @@ namespace QuantLib {
             dplus_[i]  = helper->dplus(i);
             dminus_[i] = helper->dminus(i);
         }
-    }            
+    }
 }

--- a/ql/methods/finitedifferences/operators/fdmbatesop.cpp
+++ b/ql/methods/finitedifferences/operators/fdmbatesop.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
               batesProcess->riskFreeRate(),
               Handle<YieldTermStructure>(ext::make_shared<ZeroSpreadedTermStructure>(
                   batesProcess->dividendYield(),
-                  Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(lambda_ * m_))),
+                  Handle<Quote>(ext::make_shared<SimpleQuote>(lambda_ * m_)),
                   Continuous)),
               batesProcess->s0(),
               batesProcess->v0(),

--- a/ql/methods/finitedifferences/solvers/fdmbatessolver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmbatessolver.cpp
@@ -41,12 +41,11 @@ namespace QuantLib {
     }
 
     void FdmBatesSolver::performCalculations() const {
-        ext::shared_ptr<FdmLinearOpComposite> op(
-            new FdmBatesOp(solverDesc_.mesher, process_.currentLink(),
+        ext::shared_ptr<FdmLinearOpComposite> op = ext::make_shared<FdmBatesOp>(solverDesc_.mesher, process_.currentLink(),
                            solverDesc_.bcSet, integroIntegrationOrder_,
                            (!quantoHelper_.empty()) 
                                    ? quantoHelper_.currentLink()
-                                   : ext::shared_ptr<FdmQuantoHelper>()));
+                                   : ext::shared_ptr<FdmQuantoHelper>());
 
         solver_ = ext::make_shared<Fdm2DimSolver>(
                                solverDesc_, schemeDesc_, op);

--- a/ql/methods/finitedifferences/solvers/fdmg2solver.cpp
+++ b/ql/methods/finitedifferences/solvers/fdmg2solver.cpp
@@ -38,8 +38,7 @@ namespace QuantLib {
 
 
     void FdmG2Solver::performCalculations() const {
-        const ext::shared_ptr<FdmG2Op> op(
-            new FdmG2Op(solverDesc_.mesher, model_.currentLink(), 0, 1));
+        const ext::shared_ptr<FdmG2Op> op = ext::make_shared<FdmG2Op>(solverDesc_.mesher, model_.currentLink(), 0, 1);
 
         solver_ = ext::make_shared<Fdm2DimSolver>(
             solverDesc_, schemeDesc_, op);

--- a/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
+++ b/ql/methods/finitedifferences/solvers/fdmndimsolver.hpp
@@ -106,7 +106,7 @@ namespace QuantLib {
             }
         }
 
-        f_ = ext::shared_ptr<data_table>(new data_table(x_));
+        f_ = ext::make_shared<data_table>(x_);
     }
 
 
@@ -123,8 +123,7 @@ namespace QuantLib {
             setValue(*f_, iter.coordinates(), rhs[iter.index()]);
         }
 
-        interp_ = ext::shared_ptr<MultiCubicSpline<N> >(
-            new MultiCubicSpline<N>(x_, *f_, extrapolation_));
+        interp_ = ext::make_shared<MultiCubicSpline<N>>(x_, *f_, extrapolation_);
     }
 
 

--- a/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
+++ b/ql/methods/finitedifferences/stepconditions/fdmstepconditioncomposite.cpp
@@ -126,15 +126,13 @@ namespace QuantLib {
         if (exercise->type() == Exercise::American) {
             const Time exerciseStart =
                 dayCounter.yearFraction(refDate, exercise->date(0));
-            stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-                          new FdmAmericanStepCondition(mesher, calculator,
-                                                      exerciseStart)));
+            stepConditions.push_back(ext::make_shared<FdmAmericanStepCondition>(mesher, calculator,
+                                                      exerciseStart));
         }
         else if (exercise->type() == Exercise::Bermudan) {
-            ext::shared_ptr<FdmBermudanStepCondition> bermudanCondition(
-                new FdmBermudanStepCondition(exercise->dates(),
+            ext::shared_ptr<FdmBermudanStepCondition> bermudanCondition = ext::make_shared<FdmBermudanStepCondition>(exercise->dates(),
                                              refDate, dayCounter,
-                                             mesher, calculator));
+                                             mesher, calculator);
             stepConditions.push_back(bermudanCondition);
             stoppingTimes.push_back(bermudanCondition->exerciseTimes());
         }

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -126,19 +126,17 @@ namespace QuantLib {
             const Handle<YieldTermStructure> discount
                 = disModel_->termStructure();
 
-            disTs_.linkTo(ext::shared_ptr<YieldTermStructure>(
-                new FdmAffineModelTermStructure(disRate,
+            disTs_.linkTo(ext::make_shared<FdmAffineModelTermStructure>(disRate,
                     discount->calendar(), discount->dayCounter(),
                     iterExerciseDate, discount->referenceDate(),
-                    disModel_)));
+                    disModel_));
 
             const Handle<YieldTermStructure> fwd = fwdModel_->termStructure();
 
-            fwdTs_.linkTo(ext::shared_ptr<YieldTermStructure>(
-                new FdmAffineModelTermStructure(fwdRate,
+            fwdTs_.linkTo(ext::make_shared<FdmAffineModelTermStructure>(fwdRate,
                     fwd->calendar(), fwd->dayCounter(),
                     iterExerciseDate, fwd->referenceDate(),
-                    fwdModel_)));
+                    fwdModel_));
 
         }
         else {

--- a/ql/methods/finitedifferences/utilities/fdmmesherintegral.cpp
+++ b/ql/methods/finitedifferences/utilities/fdmmesherintegral.cpp
@@ -38,10 +38,9 @@ namespace QuantLib {
             return integrator1d_(x, f);
         }
 
-        const ext::shared_ptr<FdmMesherComposite> subMesher(
-            new FdmMesherComposite(
+        const ext::shared_ptr<FdmMesherComposite> subMesher = ext::make_shared<FdmMesherComposite>(
                 std::vector<ext::shared_ptr<Fdm1dMesher> >(
-                    meshers_.begin(), meshers_.end()-1)));
+                    meshers_.begin(), meshers_.end()-1));
 
         FdmMesherIntegral subMesherIntegral(subMesher, integrator1d_);
         const Size subSize = subMesher->layout()->size();

--- a/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/localvolrndcalculator.cpp
@@ -231,9 +231,8 @@ namespace QuantLib {
         Real sLowerBound = xm - normInvEps * stdDevOfFirstStep;
         Real sUpperBound = xm + normInvEps * stdDevOfFirstStep;
 
-        ext::shared_ptr<Fdm1dMesher> mesher(
-            new Concentrating1dMesher(sLowerBound, sUpperBound, xGrid_,
-                std::make_pair(xm, x0Density_), true));
+        ext::shared_ptr<Fdm1dMesher> mesher = ext::make_shared<Concentrating1dMesher>(sLowerBound, sUpperBound, xGrid_,
+                std::make_pair(xm, x0Density_), true);
 
         Array p(mesher->size());
         Array x(mesher->locations().begin(), mesher->locations().end());
@@ -250,11 +249,10 @@ namespace QuantLib {
 
         const Size b = std::max(Size(1), Size(x.size()*0.04));
 
-        ext::shared_ptr<DouglasScheme> evolver(
-            new DouglasScheme(0.5,
+        ext::shared_ptr<DouglasScheme> evolver = ext::make_shared<DouglasScheme>(0.5,
                 ext::make_shared<FdmLocalVolFwdOp>(
                     ext::make_shared<FdmMesherComposite>(mesher),
-                    spot_, rTS_, qTS_, localVol_)));
+                    spot_, rTS_, qTS_, localVol_));
 
         pFct_.resize(tGrid_);
 
@@ -291,9 +289,8 @@ namespace QuantLib {
                 if (maxRightValue > localVolProbEps_)
                     sUpperBound += scalingFactor*(oldUpperBound-oldLowerBound);
 
-                mesher = ext::shared_ptr<Fdm1dMesher>(
-                    new Concentrating1dMesher(sLowerBound, sUpperBound, xGrid_,
-                        std::make_pair(xm, 0.1), false));
+                mesher = ext::make_shared<Concentrating1dMesher>(sLowerBound, sUpperBound, xGrid_,
+                        std::make_pair(xm, 0.1), false);
 
                 const CubicNaturalSpline pSpline(x.begin(), x.end(), p.begin());
                 const Array xn(mesher->locations().begin(),

--- a/ql/models/equity/gjrgarchmodel.cpp
+++ b/ql/models/equity/gjrgarchmodel.cpp
@@ -36,8 +36,7 @@ namespace QuantLib {
         };
       public:
         VolatilityConstraint()
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                           new VolatilityConstraint::Impl)) {}
+        : Constraint(ext::make_shared<VolatilityConstraint::Impl>()) {}
     };
 
     GJRGARCHModel::GJRGARCHModel(
@@ -55,8 +54,7 @@ namespace QuantLib {
         arguments_[5] = ConstantParameter(process->v0(),
                                           PositiveConstraint());
 
-        constraint_ = ext::shared_ptr<Constraint>(
-            new CompositeConstraint(*constraint_, VolatilityConstraint()));
+        constraint_ = ext::make_shared<CompositeConstraint>(*constraint_, VolatilityConstraint());
 
         GJRGARCHModel::generateArguments();
 

--- a/ql/models/equity/hestonmodel.hpp
+++ b/ql/models/equity/hestonmodel.hpp
@@ -77,8 +77,7 @@ namespace QuantLib {
         };
       public:
         FellerConstraint()
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                           new FellerConstraint::Impl)) {}
+        : Constraint(ext::make_shared<FellerConstraint::Impl>()) {}
     };
 }
 

--- a/ql/models/equity/hestonmodelhelper.cpp
+++ b/ql/models/equity/hestonmodelhelper.cpp
@@ -69,8 +69,7 @@ namespace QuantLib {
                         s0_->value() * dividendYield_->discount(tau_)
                     ? Option::Call
                     : Option::Put;
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(type_, strikePrice_));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type_, strikePrice_);
         ext::shared_ptr<Exercise> exercise =
             ext::make_shared<EuropeanExercise>(exerciseDate_);
         option_ = ext::make_shared<VanillaOption>(payoff, exercise);

--- a/ql/models/equity/hestonslvfdmmodel.cpp
+++ b/ql/models/equity/hestonslvfdmmodel.cpp
@@ -218,30 +218,24 @@ namespace QuantLib {
 
             switch (desc.type) {
               case FdmSchemeDesc::HundsdorferType:
-                  return ext::shared_ptr<FdmScheme>(
-                      new FdmSchemeWrapper<HundsdorferScheme>(
-                          new HundsdorferScheme(desc.theta, desc.mu, op)));
+                  return ext::make_shared<FdmSchemeWrapper<HundsdorferScheme>>(
+                          new HundsdorferScheme(desc.theta, desc.mu, op));
               case FdmSchemeDesc::DouglasType:
-                  return ext::shared_ptr<FdmScheme>(
-                      new FdmSchemeWrapper<DouglasScheme>(
-                          new DouglasScheme(desc.theta, op)));
+                  return ext::make_shared<FdmSchemeWrapper<DouglasScheme>>(
+                          new DouglasScheme(desc.theta, op));
               case FdmSchemeDesc::CraigSneydType:
-                  return ext::shared_ptr<FdmScheme>(
-                      new FdmSchemeWrapper<CraigSneydScheme>(
-                          new CraigSneydScheme(desc.theta, desc.mu, op)));
+                  return ext::make_shared<FdmSchemeWrapper<CraigSneydScheme>>(
+                          new CraigSneydScheme(desc.theta, desc.mu, op));
               case FdmSchemeDesc::ModifiedCraigSneydType:
-                  return ext::shared_ptr<FdmScheme>(
-                     new FdmSchemeWrapper<ModifiedCraigSneydScheme>(
+                  return ext::make_shared<FdmSchemeWrapper<ModifiedCraigSneydScheme>>(
                           new ModifiedCraigSneydScheme(
-                              desc.theta, desc.mu, op)));
+                              desc.theta, desc.mu, op));
               case FdmSchemeDesc::ImplicitEulerType:
-                  return ext::shared_ptr<FdmScheme>(
-                      new FdmSchemeWrapper<ImplicitEulerScheme>(
-                          new ImplicitEulerScheme(op)));
+                  return ext::make_shared<FdmSchemeWrapper<ImplicitEulerScheme>>(
+                          new ImplicitEulerScheme(op));
               case FdmSchemeDesc::ExplicitEulerType:
-                  return ext::shared_ptr<FdmScheme>(
-                      new FdmSchemeWrapper<ExplicitEulerScheme>(
-                          new ExplicitEulerScheme(op)));
+                  return ext::make_shared<FdmSchemeWrapper<ExplicitEulerScheme>>(
+                          new ExplicitEulerScheme(op));
               default:
                   QL_FAIL("Unknown scheme type");
             }
@@ -329,8 +323,7 @@ namespace QuantLib {
             times.push_back(dc.yearFraction(referenceDate, mandatoryDate));
         }
 
-        const ext::shared_ptr<TimeGrid> timeGrid(
-            new TimeGrid(times.begin(), times.end()));
+        const ext::shared_ptr<TimeGrid> timeGrid = ext::make_shared<TimeGrid>(times.begin(), times.end());
 
         // build 1d meshers
         const LocalVolRNDCalculator localVolRND(
@@ -383,7 +376,7 @@ namespace QuantLib {
         const Volatility lv0
             = localVol_->localVol(0.0, spot->value())/std::sqrt(v0);
 
-        ext::shared_ptr<Matrix> L(new Matrix(xGrid, timeGrid->size()));
+        ext::shared_ptr<Matrix> L = ext::make_shared<Matrix>(xGrid, timeGrid->size());
 
         const Real l0 = lv0;
         std::fill(L->column_begin(0),L->column_end(0), l0);
@@ -408,11 +401,9 @@ namespace QuantLib {
             }
         }
 
-        const ext::shared_ptr<FixedLocalVolSurface> leverageFct(
-            new FixedLocalVolSurface(referenceDate, times, vStrikes, L, dc));
+        const ext::shared_ptr<FixedLocalVolSurface> leverageFct = ext::make_shared<FixedLocalVolSurface>(referenceDate, times, vStrikes, L, dc);
 
-        ext::shared_ptr<FdmLinearOpComposite> hestonFwdOp(
-            new FdmHestonFwdOp(mesher, hestonProcess, trafoType, leverageFct, mixingFactor_));
+        ext::shared_ptr<FdmLinearOpComposite> hestonFwdOp = ext::make_shared<FdmHestonFwdOp>(mesher, hestonProcess, trafoType, leverageFct, mixingFactor_);
 
         Array p = FdmHestonGreensFct(mesher, hestonProcess, trafoType, lv0)
             .get(timeGrid->at(1), params_.greensAlgorithm);
@@ -429,17 +420,15 @@ namespace QuantLib {
 
             if (   mesher->getFdm1dMeshers()[0] != xMesher[i]
                 || mesher->getFdm1dMeshers()[1] != vMesher[i]) {
-                const ext::shared_ptr<FdmMesherComposite> newMesher(
-                    new FdmMesherComposite(xMesher[i], vMesher[i]));
+                const ext::shared_ptr<FdmMesherComposite> newMesher = ext::make_shared<FdmMesherComposite>(xMesher[i], vMesher[i]);
 
                 p = reshapePDF<Bilinear>(p, mesher, newMesher);
                 mesher = newMesher;
 
                 p = rescalePDF(p, mesher, trafoType, alpha);
 
-                hestonFwdOp = ext::shared_ptr<FdmLinearOpComposite>(
-                                new FdmHestonFwdOp(mesher, hestonProcess,
-                                               trafoType, leverageFct, mixingFactor_));
+                hestonFwdOp = ext::make_shared<FdmHestonFwdOp>(mesher, hestonProcess,
+                                               trafoType, leverageFct, mixingFactor_);
             }
 
             Array pn = p;

--- a/ql/models/equity/hestonslvmcmodel.cpp
+++ b/ql/models/equity/hestonslvmcmodel.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
         const Volatility lv0
             = localVol_->localVol(0.0, spot->value())/std::sqrt(v0);
 
-        const ext::shared_ptr<Matrix> L(new Matrix(nBins_, timeGrid_->size()));
+        const ext::shared_ptr<Matrix> L = ext::make_shared<Matrix>(nBins_, timeGrid_->size());
 
         std::vector<ext::shared_ptr<std::vector<Real> > >
             vStrikes(timeGrid_->size());

--- a/ql/models/marketmodels/browniangenerators/mtbrowniangenerator.cpp
+++ b/ql/models/marketmodels/browniangenerators/mtbrowniangenerator.cpp
@@ -61,8 +61,7 @@ namespace QuantLib {
 
     ext::shared_ptr<BrownianGenerator>
     MTBrownianGeneratorFactory::create(Size factors, Size steps) const {
-        return ext::shared_ptr<BrownianGenerator>(
-                              new MTBrownianGenerator(factors, steps, seed_));
+        return ext::make_shared<MTBrownianGenerator>(factors, steps, seed_);
     }
 
 }

--- a/ql/models/marketmodels/browniangenerators/sobolbrowniangenerator.cpp
+++ b/ql/models/marketmodels/browniangenerators/sobolbrowniangenerator.cpp
@@ -218,9 +218,8 @@ namespace QuantLib {
 
     ext::shared_ptr<BrownianGenerator>
     SobolBrownianGeneratorFactory::create(Size factors, Size steps) const {
-        return ext::shared_ptr<BrownianGenerator>(
-                         new SobolBrownianGenerator(factors, steps, ordering_,
-                                                    seed_, integers_));
+        return ext::make_shared<SobolBrownianGenerator>(factors, steps, ordering_,
+                                                    seed_, integers_);
     }
 
     Burley2020SobolBrownianGenerator::Burley2020SobolBrownianGenerator(
@@ -247,8 +246,8 @@ namespace QuantLib {
 
     ext::shared_ptr<BrownianGenerator>
     Burley2020SobolBrownianGeneratorFactory::create(Size factors, Size steps) const {
-        return ext::shared_ptr<BrownianGenerator>(new Burley2020SobolBrownianGenerator(
-            factors, steps, ordering_, seed_, integers_, scrambleSeed_));
+        return ext::make_shared<Burley2020SobolBrownianGenerator>(
+            factors, steps, ordering_, seed_, integers_, scrambleSeed_);
     }
 }
 

--- a/ql/models/marketmodels/callability/bermudanswaptionexercisevalue.cpp
+++ b/ql/models/marketmodels/callability/bermudanswaptionexercisevalue.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelExerciseValue>
     BermudanSwaptionExerciseValue::clone() const {
-        return std::unique_ptr<MarketModelExerciseValue>(new BermudanSwaptionExerciseValue(*this));
+        return std::make_unique<BermudanSwaptionExerciseValue>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/lsstrategy.cpp
+++ b/ql/models/marketmodels/callability/lsstrategy.cpp
@@ -156,7 +156,7 @@ namespace QuantLib {
 
     std::unique_ptr<ExerciseStrategy<CurveState>>
     LongstaffSchwartzExerciseStrategy::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new LongstaffSchwartzExerciseStrategy(*this));
+        return std::make_unique<LongstaffSchwartzExerciseStrategy>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/nothingexercisevalue.cpp
+++ b/ql/models/marketmodels/callability/nothingexercisevalue.cpp
@@ -86,7 +86,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelExerciseValue>
     NothingExerciseValue::clone() const {
-        return std::unique_ptr<MarketModelExerciseValue>(new NothingExerciseValue(*this));
+        return std::make_unique<NothingExerciseValue>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/parametricexerciseadapter.cpp
+++ b/ql/models/marketmodels/callability/parametricexerciseadapter.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<ExerciseStrategy<CurveState>> ParametricExerciseAdapter::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new ParametricExerciseAdapter(*this));
+        return std::make_unique<ParametricExerciseAdapter>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapbasissystem.cpp
+++ b/ql/models/marketmodels/callability/swapbasissystem.cpp
@@ -77,7 +77,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelBasisSystem>
     SwapBasisSystem::clone() const {
-        return std::unique_ptr<MarketModelBasisSystem>(new SwapBasisSystem(*this));
+        return std::make_unique<SwapBasisSystem>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapforwardbasissystem.cpp
+++ b/ql/models/marketmodels/callability/swapforwardbasissystem.cpp
@@ -129,7 +129,7 @@ namespace QuantLib
 
     std::unique_ptr<MarketModelBasisSystem>
     SwapForwardBasisSystem::clone() const {
-        return std::unique_ptr<MarketModelBasisSystem>(new SwapForwardBasisSystem(*this));
+        return std::make_unique<SwapForwardBasisSystem>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapratetrigger.cpp
+++ b/ql/models/marketmodels/callability/swapratetrigger.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
 
     std::unique_ptr<ExerciseStrategy<CurveState>>
     SwapRateTrigger::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new SwapRateTrigger(*this));
+        return std::make_unique<SwapRateTrigger>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/triggeredswapexercise.cpp
+++ b/ql/models/marketmodels/callability/triggeredswapexercise.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelParametricExercise>
     TriggeredSwapExercise::clone() const {
-        return std::unique_ptr<MarketModelParametricExercise>(new TriggeredSwapExercise(*this));
+        return std::make_unique<TriggeredSwapExercise>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/upperboundengine.cpp
+++ b/ql/models/marketmodels/callability/upperboundengine.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
             }
 
             std::unique_ptr<MarketModelMultiProduct> clone() const override {
-                return std::unique_ptr<MarketModelMultiProduct>(new DecoratedHedge(*this));
+                return std::make_unique<DecoratedHedge>(*this);
             }
 
             void save() {

--- a/ql/models/marketmodels/curvestates/cmswapcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/cmswapcurvestate.cpp
@@ -179,7 +179,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<CurveState> CMSwapCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new CMSwapCurveState(*this));
+        return std::make_unique<CMSwapCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/curvestates/coterminalswapcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/coterminalswapcurvestate.cpp
@@ -142,7 +142,7 @@ namespace QuantLib {
 
     std::unique_ptr<CurveState>
     CoterminalSwapCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new CoterminalSwapCurveState(*this));
+        return std::make_unique<CoterminalSwapCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/curvestates/lmmcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/lmmcurvestate.cpp
@@ -196,7 +196,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<CurveState> LMMCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new LMMCurveState(*this));
+        return std::make_unique<LMMCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/historicalforwardratesanalysis.hpp
+++ b/ql/models/marketmodels/historicalforwardratesanalysis.hpp
@@ -77,34 +77,32 @@ namespace QuantLib {
         std::vector<ext::shared_ptr<SimpleQuote> > iborQuotes;
         std::vector<ext::shared_ptr<IborIndex> >::const_iterator ibor;
         for (ibor=iborIndexes.begin(); ibor!=iborIndexes.end(); ++ibor) {
-            ext::shared_ptr<SimpleQuote> quote(new SimpleQuote);
+            ext::shared_ptr<SimpleQuote> quote = ext::make_shared<SimpleQuote>();
             iborQuotes.push_back(quote);
             Handle<Quote> quoteHandle(quote);
-            rateHelpers.push_back(ext::shared_ptr<RateHelper> (new
-                DepositRateHelper(quoteHandle,
+            rateHelpers.push_back(ext::make_shared<DepositRateHelper>(quoteHandle,
                                   (*ibor)->tenor(),
                                   (*ibor)->fixingDays(),
                                   (*ibor)->fixingCalendar(),
                                   (*ibor)->businessDayConvention(),
                                   (*ibor)->endOfMonth(),
-                                  (*ibor)->dayCounter())));
+                                  (*ibor)->dayCounter()));
         }
 
         // Create SwapRateHelper
         std::vector<ext::shared_ptr<SimpleQuote> > swapQuotes;
         std::vector<ext::shared_ptr<SwapIndex> >::const_iterator swap;
         for (swap=swapIndexes.begin(); swap!=swapIndexes.end(); ++swap) {
-            ext::shared_ptr<SimpleQuote> quote(new SimpleQuote);
+            ext::shared_ptr<SimpleQuote> quote = ext::make_shared<SimpleQuote>();
             swapQuotes.push_back(quote);
             Handle<Quote> quoteHandle(quote);
-            rateHelpers.push_back(ext::shared_ptr<RateHelper> (new
-                SwapRateHelper(quoteHandle,
+            rateHelpers.push_back(ext::make_shared<SwapRateHelper>(quoteHandle,
                                (*swap)->tenor(),
                                (*swap)->fixingCalendar(),
                                (*swap)->fixedLegTenor().frequency(),
                                (*swap)->fixedLegConvention(),
                                (*swap)->dayCounter(),
-                               (*swap)->iborIndex())));
+                               (*swap)->iborIndex()));
         }
 
         // Set up the forward rates time grid

--- a/ql/models/marketmodels/models/capletcoterminalalphacalibration.cpp
+++ b/ql/models/marketmodels/models/capletcoterminalalphacalibration.cpp
@@ -47,7 +47,7 @@ namespace QuantLib {
       alpha_(numberOfRates_), a_(numberOfRates_), b_(numberOfRates_) {
         if (!parametricForm_)
             parametricForm_ =
-                ext::shared_ptr<AlphaForm>(new AlphaFormLinearHyperbolic(evolution.rateTimes()));
+                ext::make_shared<AlphaFormLinearHyperbolic>(evolution.rateTimes());
 
         QL_REQUIRE(numberOfRates_==alphaInitial.size(),
             "mismatch between number of rates (" << numberOfRates_ <<

--- a/ql/models/marketmodels/models/capletcoterminalperiodic.cpp
+++ b/ql/models/marketmodels/models/capletcoterminalperiodic.cpp
@@ -128,21 +128,20 @@ namespace QuantLib
 
             swapCovariancePseudoRoots = unperiodicCalibrator.swapPseudoRoots();
 
-            ext::shared_ptr<MarketModel> smm(new
-                PseudoRootFacade(swapCovariancePseudoRoots,
+            ext::shared_ptr<MarketModel> smm = ext::make_shared<PseudoRootFacade>(swapCovariancePseudoRoots,
                 evolution.rateTimes(),
                 cs->coterminalSwapRates(),
-                std::vector<Spread>(evolution.numberOfRates(), displacement)));
+                std::vector<Spread>(evolution.numberOfRates(), displacement));
 
-            ext::shared_ptr<MarketModel> flmm(new CotSwapToFwdAdapter(smm));
+            ext::shared_ptr<MarketModel> flmm = ext::make_shared<CotSwapToFwdAdapter>(smm);
 
             Matrix capletTotCovariance = flmm->totalCovariance(numberSmallRates-1);
 
-            ext::shared_ptr<MarketModel> periodflmm( new FwdPeriodAdapter(flmm, period,
+            ext::shared_ptr<MarketModel> periodflmm = ext::make_shared<FwdPeriodAdapter>(flmm, period,
                 offset,
-                newDisplacements));
+                newDisplacements);
 
-            ext::shared_ptr<MarketModel> periodsmm(new FwdToCotSwapAdapter(periodflmm));
+            ext::shared_ptr<MarketModel> periodsmm = ext::make_shared<FwdToCotSwapAdapter>(periodflmm);
 
 
             Matrix swaptionTotCovariance(periodsmm->totalCovariance(periodsmm->numberOfSteps()-1));

--- a/ql/models/marketmodels/models/cotswaptofwdadapter.cpp
+++ b/ql/models/marketmodels/models/cotswaptofwdadapter.cpp
@@ -91,8 +91,7 @@ namespace QuantLib {
                                         Size numberOfFactors) const {
         ext::shared_ptr<MarketModel> coterminalModel =
             coterminalFactory_->create(evolution,numberOfFactors);
-        return ext::shared_ptr<MarketModel>(
-                             new CotSwapToFwdAdapter(coterminalModel));
+        return ext::make_shared<CotSwapToFwdAdapter>(coterminalModel);
     }
 
     void CotSwapToFwdAdapterFactory::update() {

--- a/ql/models/marketmodels/models/ctsmmcapletcalibration.cpp
+++ b/ql/models/marketmodels/models/ctsmmcapletcalibration.cpp
@@ -149,11 +149,10 @@ namespace QuantLib {
                                          innerSolvingMaxIterations,
                                          innerSolvingTolerance);
 
-            ext::shared_ptr<MarketModel> ctsmm(new
-                PseudoRootFacade(swapCovariancePseudoRoots_,
+            ext::shared_ptr<MarketModel> ctsmm = ext::make_shared<PseudoRootFacade>(swapCovariancePseudoRoots_,
                                  rateTimes,
                                  cs_->coterminalSwapRates(),
-                                 displacements));
+                                 displacements);
             const Matrix& swaptionTotCovariance =
                 ctsmm->totalCovariance(numberOfRates_-1);
 
@@ -185,11 +184,10 @@ namespace QuantLib {
         } while (iterations<maxIterations &&
                  capletRmsError_>capletVolTolerance);
 
-         ext::shared_ptr<MarketModel> ctsmm(new
-                PseudoRootFacade(swapCovariancePseudoRoots_,
+         ext::shared_ptr<MarketModel> ctsmm = ext::make_shared<PseudoRootFacade>(swapCovariancePseudoRoots_,
                                  rateTimes,
                                  cs_->coterminalSwapRates(),
-                                 displacements));
+                                 displacements);
 
          timeDependentCalibratedSwaptionVols_.clear();
          for (Size i=0; i<numberOfRates_; ++i)

--- a/ql/models/marketmodels/models/flatvol.cpp
+++ b/ql/models/marketmodels/models/flatvol.cpp
@@ -186,16 +186,14 @@ namespace QuantLib {
         Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                       longTermCorrelation_,
                                                       beta_);
-        ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-            TimeHomogeneousForwardCorrelation(correlations,
-                                              rateTimes));
-        return ext::shared_ptr<MarketModel>(new
-            FlatVol(displacedVolatilities,
+        ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(correlations,
+                                              rateTimes);
+        return ext::make_shared<FlatVol>(displacedVolatilities,
                            corr,
                            evolution,
                            numberOfFactors,
                            initialRates,
-                           displacements));
+                           displacements);
     }
 
     void FlatVolFactory::update() {

--- a/ql/models/marketmodels/models/fwdtocotswapadapter.cpp
+++ b/ql/models/marketmodels/models/fwdtocotswapadapter.cpp
@@ -91,8 +91,7 @@ namespace QuantLib {
                                         Size numberOfFactors) const {
         ext::shared_ptr<MarketModel> forwardModel =
             forwardFactory_->create(evolution,numberOfFactors);
-        return ext::shared_ptr<MarketModel>(
-                                new FwdToCotSwapAdapter(forwardModel));
+        return ext::make_shared<FwdToCotSwapAdapter>(forwardModel);
     }
 
     void FwdToCotSwapAdapterFactory::update() {

--- a/ql/models/marketmodels/models/volatilityinterpolationspecifierabcd.cpp
+++ b/ql/models/marketmodels/models/volatilityinterpolationspecifierabcd.cpp
@@ -64,7 +64,7 @@ namespace QuantLib
 
         // change type of array to PiecewiseConstantVariance for client, from PiecewiseConstantAbcdVariance
         for (Size i=0; i < noBigRates_; ++i)
-            originalVariances_[i] = ext::shared_ptr<PiecewiseConstantVariance>(new PiecewiseConstantAbcdVariance(originalVariances[i]));
+            originalVariances_[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(originalVariances[i]);
 
         recompute();
 
@@ -146,8 +146,7 @@ namespace QuantLib
             originalABCDVariancesScaled_[0].getABCD(a,b,c,d);
 
             for (Size i=0; i < offset_; ++i)
-                interpolatedVariances_[i] = ext::shared_ptr<PiecewiseConstantVariance>(
-                new PiecewiseConstantAbcdVariance(a,b,c,d,i,timesForSmallRates_));
+                interpolatedVariances_[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(a,b,c,d,i,timesForSmallRates_);
         }
 
 
@@ -166,8 +165,7 @@ namespace QuantLib
             d= 0.5*(d0+d1);
 
             for (Size i=0; i < period_; ++i)
-                interpolatedVariances_[i+j*period_+offset_] =  ext::shared_ptr<PiecewiseConstantVariance>(
-                new PiecewiseConstantAbcdVariance(a,b,c,d,i+j*period_,timesForSmallRates_));
+                interpolatedVariances_[i+j*period_+offset_] =  ext::make_shared<PiecewiseConstantAbcdVariance>(a,b,c,d,i+j*period_,timesForSmallRates_);
 
         }
 
@@ -177,8 +175,7 @@ namespace QuantLib
             originalABCDVariancesScaled_[noBigRates_-1].getABCD(a,b,c,d);
 
             for (Size i=offset_+(noBigRates_-1)*period_; i < noSmallRates_; ++i)
-                interpolatedVariances_[i] = ext::shared_ptr<PiecewiseConstantVariance>(
-                                                                         new PiecewiseConstantAbcdVariance(a,b,c,d,i,timesForSmallRates_));
+                interpolatedVariances_[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(a,b,c,d,i,timesForSmallRates_);
 
             // very last rate is special as we must match the caplet vol
              Real vol = interpolatedVariances_[noSmallRates_-1]->totalVolatility(noSmallRates_-1);
@@ -187,8 +184,7 @@ namespace QuantLib
              a*=scale;
              b*=scale;
              d*=scale;
-             interpolatedVariances_[noSmallRates_-1] = ext::shared_ptr<PiecewiseConstantVariance>(
-                                                                         new PiecewiseConstantAbcdVariance(a,b,c,d,noSmallRates_-1,timesForSmallRates_));
+             interpolatedVariances_[noSmallRates_-1] = ext::make_shared<PiecewiseConstantAbcdVariance>(a,b,c,d,noSmallRates_-1,timesForSmallRates_);
 
        }
     }

--- a/ql/models/marketmodels/products/multiproductcomposite.cpp
+++ b/ql/models/marketmodels/products/multiproductcomposite.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiProductComposite::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiProductComposite(*this));
+        return std::make_unique<MultiProductComposite>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
+++ b/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
@@ -170,7 +170,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     CallSpecifiedMultiProduct::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new CallSpecifiedMultiProduct(*this));
+        return std::make_unique<CallSpecifiedMultiProduct>(*this);
     }
 
     const MarketModelMultiProduct&

--- a/ql/models/marketmodels/products/multistep/cashrebate.cpp
+++ b/ql/models/marketmodels/products/multistep/cashrebate.cpp
@@ -96,7 +96,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     MarketModelCashRebate::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new MarketModelCashRebate(*this));
+        return std::make_unique<MarketModelCashRebate>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/exerciseadapter.cpp
+++ b/ql/models/marketmodels/products/multistep/exerciseadapter.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     ExerciseAdapter::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new ExerciseAdapter(*this));
+        return std::make_unique<ExerciseAdapter>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoinitialSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoinitialSwaps(*this));
+        return std::make_unique<MultiStepCoinitialSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoterminalSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoterminalSwaps(*this));
+        return std::make_unique<MultiStepCoterminalSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoterminalswaptions.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoterminalswaptions.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoterminalSwaptions::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoterminalSwaptions(*this));
+        return std::make_unique<MultiStepCoterminalSwaptions>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepforwards.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepforwards.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepForwards::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepForwards(*this));
+        return std::make_unique<MultiStepForwards>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepinversefloater.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepinversefloater.cpp
@@ -68,7 +68,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepInverseFloater::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepInverseFloater(*this));
+        return std::make_unique<MultiStepInverseFloater>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepnothing.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepnothing.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepNothing::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepNothing(*this));
+        return std::make_unique<MultiStepNothing>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepoptionlets.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepoptionlets.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepOptionlets::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepOptionlets(*this));
+        return std::make_unique<MultiStepOptionlets>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
+++ b/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
@@ -86,7 +86,7 @@ namespace QuantLib
         std::unique_ptr<MarketModelMultiProduct>
         MultiProductPathwiseWrapper::clone() const
         {
-            return std::unique_ptr<MarketModelMultiProduct>(new MultiProductPathwiseWrapper(*this));
+            return std::make_unique<MultiProductPathwiseWrapper>(*this);
         }
 
       

--- a/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -132,7 +132,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepPeriodCapletSwaptions::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepPeriodCapletSwaptions(*this));
+        return std::make_unique<MultiStepPeriodCapletSwaptions>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepratchet.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepratchet.cpp
@@ -67,7 +67,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepRatchet::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepRatchet(*this));
+        return std::make_unique<MultiStepRatchet>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepswap.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepswap.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepSwap::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepSwap(*this));
+        return std::make_unique<MultiStepSwap>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepswaption.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepswaption.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepSwaption::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepSwaption(*this));
+        return std::make_unique<MultiStepSwaption>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multisteptarn.cpp
+++ b/ql/models/marketmodels/products/multistep/multisteptarn.cpp
@@ -85,7 +85,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepTarn::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepTarn(*this));
+        return std::make_unique<MultiStepTarn>(*this);
     }
 
 

--- a/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepCoinitialSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepCoinitialSwaps(*this));
+        return std::make_unique<OneStepCoinitialSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepCoterminalSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepCoterminalSwaps(*this));
+        return std::make_unique<OneStepCoterminalSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepforwards.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepforwards.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepForwards::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepForwards(*this));
+        return std::make_unique<OneStepForwards>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepoptionlets.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepoptionlets.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepOptionlets::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepOptionlets(*this));
+        return std::make_unique<OneStepOptionlets>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
@@ -155,7 +155,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     CallSpecifiedPathwiseMultiProduct::clone() const {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new CallSpecifiedPathwiseMultiProduct(*this));
+        return std::make_unique<CallSpecifiedPathwiseMultiProduct>(*this);
     }
 
     const MarketModelPathwiseMultiProduct& CallSpecifiedPathwiseMultiProduct::underlying() const {

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcaplet.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcaplet.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiCaplet::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiCaplet(*this));
+        return std::make_unique<MarketModelPathwiseMultiCaplet>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseMultiCaplet::suggestedNumeraires() const
@@ -241,7 +241,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiDeflatedCaplet::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiDeflatedCaplet(*this));
+        return std::make_unique<MarketModelPathwiseMultiDeflatedCaplet>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseMultiDeflatedCaplet::suggestedNumeraires() const
@@ -375,7 +375,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiDeflatedCap::clone() const
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiDeflatedCap(*this));
+        return std::make_unique<MarketModelPathwiseMultiDeflatedCap>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcashrebate.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcashrebate.cpp
@@ -108,7 +108,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCashRebate::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseCashRebate(*this));
+        return std::make_unique<MarketModelPathwiseCashRebate>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductinversefloater.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductinversefloater.cpp
@@ -101,7 +101,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseInverseFloater::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseInverseFloater(*this));
+        return std::make_unique<MarketModelPathwiseInverseFloater>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseInverseFloater::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductswap.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductswap.cpp
@@ -88,7 +88,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseSwap::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseSwap(*this));
+        return std::make_unique<MarketModelPathwiseSwap>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseSwap::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductswaption.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductswaption.cpp
@@ -89,7 +89,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCoterminalSwaptionsDeflated::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseCoterminalSwaptionsDeflated(*this));
+        return std::make_unique<MarketModelPathwiseCoterminalSwaptionsDeflated>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseCoterminalSwaptionsDeflated::suggestedNumeraires() const
@@ -210,8 +210,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCoterminalSwaptionsNumericalDeflated::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(
-          new MarketModelPathwiseCoterminalSwaptionsNumericalDeflated(*this));
+        return std::make_unique<MarketModelPathwiseCoterminalSwaptionsNumericalDeflated>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseCoterminalSwaptionsNumericalDeflated::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/singleproductcomposite.cpp
+++ b/ql/models/marketmodels/products/singleproductcomposite.cpp
@@ -72,7 +72,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     SingleProductComposite::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new SingleProductComposite(*this));
+        return std::make_unique<SingleProductComposite>(*this);
     }
 
 }

--- a/ql/models/model.hpp
+++ b/ql/models/model.hpp
@@ -224,8 +224,7 @@ namespace QuantLib {
         };
       public:
         explicit PrivateConstraint(const std::vector<Parameter>& arguments)
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                   new PrivateConstraint::Impl(arguments))) {}
+        : Constraint(ext::make_shared<PrivateConstraint::Impl>(arguments)) {}
     };
 
 }

--- a/ql/models/parameter.hpp
+++ b/ql/models/parameter.hpp
@@ -78,7 +78,7 @@ namespace QuantLib {
         ConstantParameter(const Constraint& constraint)
         : Parameter(
               1,
-              ext::shared_ptr<Parameter::Impl>(new ConstantParameter::Impl),
+              ext::make_shared<ConstantParameter::Impl>(),
               constraint)
         {}
 
@@ -86,7 +86,7 @@ namespace QuantLib {
                           const Constraint& constraint)
         : Parameter(
               1,
-              ext::shared_ptr<Parameter::Impl>(new ConstantParameter::Impl),
+              ext::make_shared<ConstantParameter::Impl>(),
               constraint) {
             params_[0] = value;
             QL_REQUIRE(testParams(params_),
@@ -106,7 +106,7 @@ namespace QuantLib {
         NullParameter()
         : Parameter(
                   0,
-                  ext::shared_ptr<Parameter::Impl>(new NullParameter::Impl),
+                  ext::make_shared<NullParameter::Impl>(),
                   NoConstraint())
         {}
     };
@@ -135,8 +135,7 @@ namespace QuantLib {
                                    const Constraint& constraint =
                                                              NoConstraint())
         : Parameter(times.size()+1,
-                    ext::shared_ptr<Parameter::Impl>(
-                                 new PiecewiseConstantParameter::Impl(times)),
+                    ext::make_shared<PiecewiseConstantParameter::Impl>(times),
                     constraint)
         {}
     };
@@ -182,7 +181,7 @@ namespace QuantLib {
         TermStructureFittingParameter(const Handle<YieldTermStructure>& term)
         : Parameter(
                   0,
-                  ext::shared_ptr<Parameter::Impl>(new NumericalImpl(term)),
+                  ext::make_shared<NumericalImpl>(term),
                   NoConstraint())
         {}
     };

--- a/ql/models/shortrate/calibrationhelpers/caphelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/caphelper.cpp
@@ -68,7 +68,7 @@ namespace QuantLib {
 
     Real CapHelper::blackPrice(Volatility sigma) const {
         calculate();
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(sigma)));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(sigma));
         ext::shared_ptr<PricingEngine> engine;
         switch(volatilityType_) {
           case ShiftedLognormal:
@@ -100,8 +100,7 @@ namespace QuantLib {
             startDate = termStructure_->referenceDate() + indexTenor;
             maturity = termStructure_->referenceDate() + length_;
         }
-        ext::shared_ptr<IborIndex> dummyIndex(new
-            IborIndex("dummy",
+        ext::shared_ptr<IborIndex> dummyIndex = ext::make_shared<IborIndex>("dummy",
                       indexTenor,
                       index_->fixingDays(),
                       index_->currency(),
@@ -109,7 +108,7 @@ namespace QuantLib {
                       index_->businessDayConvention(),
                       index_->endOfMonth(),
                       termStructure_->dayCounter(),
-                      termStructure_));
+                      termStructure_);
 
         std::vector<Real> nominals(1,1.0);
 
@@ -133,8 +132,7 @@ namespace QuantLib {
             .withPaymentAdjustment(index_->businessDayConvention());
 
         Swap swap(floatingLeg, fixedLeg);
-        swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                            new DiscountingSwapEngine(termStructure_, false)));
+        swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(termStructure_, false));
         Rate fairRate = fixedRate - swap.NPV()/(swap.legBPS(1)/1.0e-4);
         cap_ = ext::make_shared<Cap>(floatingLeg,
                                               std::vector<Rate>(1, fairRate));

--- a/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
+++ b/ql/models/shortrate/calibrationhelpers/swaptionhelper.cpp
@@ -128,7 +128,7 @@ namespace QuantLib {
 
     Real SwaptionHelper::blackPrice(Volatility sigma) const {
         calculate();
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(sigma)));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(sigma));
         ext::shared_ptr<PricingEngine> engine;
         switch(volatilityType_) {
         case ShiftedLognormal:
@@ -182,7 +182,7 @@ namespace QuantLib {
         auto swapEngine = ext::make_shared<DiscountingSwapEngine>(termStructure_, false);
 
         Swap::Type type = Swap::Receiver;
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
         auto temp = makeSwap(fixedSchedule, floatSchedule, 0.0, type);
         temp->setPricingEngine(swapEngine);
         Real forward = temp->fairRate();

--- a/ql/models/shortrate/onefactormodel.cpp
+++ b/ql/models/shortrate/onefactormodel.cpp
@@ -88,10 +88,8 @@ namespace QuantLib {
 
     ext::shared_ptr<Lattice>
     OneFactorModel::tree(const TimeGrid& grid) const {
-        ext::shared_ptr<TrinomialTree> trinomial(
-                              new TrinomialTree(dynamics()->process(), grid));
-        return ext::shared_ptr<Lattice>(
-                              new ShortRateTree(trinomial, dynamics(), grid));
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(dynamics()->process(), grid);
+        return ext::make_shared<ShortRateTree>(trinomial, dynamics(), grid);
     }
 
     DiscountFactor OneFactorAffineModel::discount(Time t) const {

--- a/ql/models/shortrate/onefactormodels/blackkarasinski.cpp
+++ b/ql/models/shortrate/onefactormodels/blackkarasinski.cpp
@@ -69,12 +69,9 @@ namespace QuantLib {
     ext::shared_ptr<Lattice>
     BlackKarasinski::tree(const TimeGrid& grid) const {
 
-        ext::shared_ptr<ShortRateDynamics> numericDynamics(
-                         new Dynamics(phi_, a(), sigma()));
-        ext::shared_ptr<TrinomialTree> trinomial(
-                         new TrinomialTree(numericDynamics->process(), grid));
-        ext::shared_ptr<ShortRateTree> numericTree(
-                         new ShortRateTree(trinomial, numericDynamics, grid));
+        ext::shared_ptr<ShortRateDynamics> numericDynamics = ext::make_shared<Dynamics>(phi_, a(), sigma());
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(numericDynamics->process(), grid);
+        ext::shared_ptr<ShortRateTree> numericTree = ext::make_shared<ShortRateTree>(trinomial, numericDynamics, grid);
 
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
         ext::shared_ptr<NumericalImpl> impl =
@@ -102,8 +99,7 @@ namespace QuantLib {
         Size steps = 50;
         ext::shared_ptr<Lattice> lattice = this->tree(
             TimeGrid(termStructure()->maxTime(), steps));
-        ext::shared_ptr<ShortRateDynamics> numericDynamics(
-            new Dynamics(phi_, a(), sigma()));
+        ext::shared_ptr<ShortRateDynamics> numericDynamics = ext::make_shared<Dynamics>(phi_, a(), sigma());
         return numericDynamics;
     }
 

--- a/ql/models/shortrate/onefactormodels/blackkarasinski.hpp
+++ b/ql/models/shortrate/onefactormodels/blackkarasinski.hpp
@@ -76,7 +76,7 @@ namespace QuantLib {
       public:
         Dynamics(Parameter fitting, Real alpha, Real sigma)
         : ShortRateDynamics(
-              ext::shared_ptr<StochasticProcess1D>(new OrnsteinUhlenbeckProcess(alpha, sigma))),
+              ext::make_shared<OrnsteinUhlenbeckProcess>(alpha, sigma)),
           fitting_(std::move(fitting)) {}
 
         Real variable(Time t, Rate r) const override { return std::log(r) - fitting_(t); }

--- a/ql/models/shortrate/onefactormodels/coxingersollross.cpp
+++ b/ql/models/shortrate/onefactormodels/coxingersollross.cpp
@@ -36,8 +36,7 @@ namespace QuantLib {
         };
       public:
         VolatilityConstraint(Real k, Real theta)
-        : Constraint(ext::shared_ptr<Constraint::Impl>(
-                                 new VolatilityConstraint::Impl(k, theta))) {}
+        : Constraint(ext::make_shared<VolatilityConstraint::Impl>(k, theta)) {}
     };
 
     CoxIngersollRoss::CoxIngersollRoss(Rate r0, Real theta,
@@ -57,8 +56,7 @@ namespace QuantLib {
 
     ext::shared_ptr<OneFactorModel::ShortRateDynamics>
     CoxIngersollRoss::dynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(
-                                  new Dynamics(theta(), k() , sigma(), x0()));
+        return ext::make_shared<Dynamics>(theta(), k() , sigma(), x0());
     }
 
     Real CoxIngersollRoss::A(Time t, Time T) const {
@@ -124,10 +122,8 @@ namespace QuantLib {
 
     ext::shared_ptr<Lattice>
     CoxIngersollRoss::tree(const TimeGrid& grid) const {
-        ext::shared_ptr<TrinomialTree> trinomial(
-                        new TrinomialTree(dynamics()->process(), grid, true));
-        return ext::shared_ptr<Lattice>(
-                              new ShortRateTree(trinomial, dynamics(), grid));
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(dynamics()->process(), grid, true);
+        return ext::make_shared<ShortRateTree>(trinomial, dynamics(), grid);
     }
 
 }

--- a/ql/models/shortrate/onefactormodels/coxingersollross.hpp
+++ b/ql/models/shortrate/onefactormodels/coxingersollross.hpp
@@ -90,8 +90,7 @@ namespace QuantLib {
                  Real k,
                  Real sigma,
                  Real x0)
-        : ShortRateDynamics(ext::shared_ptr<StochasticProcess1D>(
-                        new CoxIngersollRossProcess(k, sigma, x0, theta))) {}
+        : ShortRateDynamics(ext::make_shared<CoxIngersollRossProcess>(k, sigma, x0, theta)) {}
 
         Real variable(Time, Rate r) const override { return r; }
         Real shortRate(Time, Real y) const override { return y; }

--- a/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
+++ b/ql/models/shortrate/onefactormodels/extendedcoxingersollross.cpp
@@ -36,18 +36,15 @@ namespace QuantLib {
     ext::shared_ptr<Lattice> ExtendedCoxIngersollRoss::tree(
                                                  const TimeGrid& grid) const {
         TermStructureFittingParameter phi(termStructure());
-        ext::shared_ptr<Dynamics> numericDynamics(
-                              new Dynamics(phi, theta(), k(), sigma(), x0()));
+        ext::shared_ptr<Dynamics> numericDynamics = ext::make_shared<Dynamics>(phi, theta(), k(), sigma(), x0());
 
-        ext::shared_ptr<TrinomialTree> trinomial(
-                   new TrinomialTree(numericDynamics->process(), grid, true));
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(numericDynamics->process(), grid, true);
 
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
         ext::shared_ptr<NumericalImpl> impl =
             ext::dynamic_pointer_cast<NumericalImpl>(phi.implementation());
 
-        return ext::shared_ptr<Lattice>(
-                   new ShortRateTree(trinomial, numericDynamics, impl, grid));
+        return ext::make_shared<ShortRateTree>(trinomial, numericDynamics, impl, grid);
     }
 
     Real ExtendedCoxIngersollRoss::A(Time t, Time s) const {

--- a/ql/models/shortrate/onefactormodels/extendedcoxingersollross.hpp
+++ b/ql/models/shortrate/onefactormodels/extendedcoxingersollross.hpp
@@ -138,17 +138,15 @@ namespace QuantLib {
       public:
         FittingParameter(const Handle<YieldTermStructure>& termStructure,
                          Real theta, Real k, Real sigma, Real x0)
-        : TermStructureFittingParameter(ext::shared_ptr<Parameter::Impl>(
-                 new FittingParameter::Impl(
-                                     termStructure, theta, k, sigma, x0))) {}
+        : TermStructureFittingParameter(ext::make_shared<FittingParameter::Impl>(
+                                     termStructure, theta, k, sigma, x0)) {}
     };
 
     // inline definitions
 
     inline ext::shared_ptr<OneFactorModel::ShortRateDynamics>
     ExtendedCoxIngersollRoss::dynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(
-                            new Dynamics(phi_, theta(), k() , sigma(), x0()));
+        return ext::make_shared<Dynamics>(phi_, theta(), k() , sigma(), x0());
     }
 
     inline void ExtendedCoxIngersollRoss::generateArguments() {

--- a/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -43,12 +43,9 @@ namespace QuantLib {
     ext::shared_ptr<Lattice> HullWhite::tree(const TimeGrid& grid) const {
 
         TermStructureFittingParameter phi(termStructure());
-        ext::shared_ptr<ShortRateDynamics> numericDynamics(
-                                             new Dynamics(phi, a(), sigma()));
-        ext::shared_ptr<TrinomialTree> trinomial(
-                         new TrinomialTree(numericDynamics->process(), grid));
-        ext::shared_ptr<ShortRateTree> numericTree(
-                         new ShortRateTree(trinomial, numericDynamics, grid));
+        ext::shared_ptr<ShortRateDynamics> numericDynamics = ext::make_shared<Dynamics>(phi, a(), sigma());
+        ext::shared_ptr<TrinomialTree> trinomial = ext::make_shared<TrinomialTree>(numericDynamics->process(), grid);
+        ext::shared_ptr<ShortRateTree> numericTree = ext::make_shared<ShortRateTree>(trinomial, numericDynamics, grid);
 
         typedef TermStructureFittingParameter::NumericalImpl NumericalImpl;
         ext::shared_ptr<NumericalImpl> impl =

--- a/ql/models/shortrate/onefactormodels/hullwhite.hpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.hpp
@@ -111,7 +111,7 @@ namespace QuantLib {
       public:
         Dynamics(Parameter fitting, Real a, Real sigma)
         : ShortRateDynamics(
-              ext::shared_ptr<StochasticProcess1D>(new OrnsteinUhlenbeckProcess(a, sigma))),
+              ext::make_shared<OrnsteinUhlenbeckProcess>(a, sigma)),
           fitting_(std::move(fitting)) {}
 
         Real variable(Time t, Rate r) const override { return r - fitting_(t); }
@@ -152,8 +152,7 @@ namespace QuantLib {
       public:
         FittingParameter(const Handle<YieldTermStructure>& termStructure,
                          Real a, Real sigma)
-        : TermStructureFittingParameter(ext::shared_ptr<Parameter::Impl>(
-                      new FittingParameter::Impl(termStructure, a, sigma))) {}
+        : TermStructureFittingParameter(ext::make_shared<FittingParameter::Impl>(termStructure, a, sigma)) {}
     };
 
 
@@ -161,8 +160,7 @@ namespace QuantLib {
 
     inline ext::shared_ptr<OneFactorModel::ShortRateDynamics>
     HullWhite::dynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(
-                                            new Dynamics(phi_, a(), sigma()));
+        return ext::make_shared<Dynamics>(phi_, a(), sigma());
     }
 
 }

--- a/ql/models/shortrate/onefactormodels/markovfunctional.cpp
+++ b/ql/models/shortrate/onefactormodels/markovfunctional.cpp
@@ -324,8 +324,7 @@ namespace QuantLib {
                     i->first, i->second.tenor_, true);
             }
 
-            i->second.rawSmileSection_ = ext::shared_ptr<SmileSection>(
-                new AtmSmileSection(smileSection, i->second.atm_));
+            i->second.rawSmileSection_ = ext::make_shared<AtmSmileSection>(smileSection, i->second.atm_);
 
             int forcedLeftIndex = -1;
             int forcedRightIndex = QL_MAX_INTEGER;
@@ -379,8 +378,7 @@ namespace QuantLib {
 
                     // TODO should we fix beta to avoid numerical instabilities
                     // during calibration ?
-                    ext::shared_ptr<SabrInterpolatedSmileSection> sabrSection(
-                        new SabrInterpolatedSmileSection(
+                    ext::shared_ptr<SabrInterpolatedSmileSection> sabrSection = ext::make_shared<SabrInterpolatedSmileSection>(
                             i->first, i->second.atm_, k, false,
                             i->second.rawSmileSection_->volatility(
                                 i->second.atm_),
@@ -388,7 +386,7 @@ namespace QuantLib {
                             false, true, ext::shared_ptr<EndCriteria>(),
                             ext::shared_ptr<OptimizationMethod>(),
                             Actual365Fixed(),
-                                i->second.rawSmileSection_->shift()));
+                                i->second.rawSmileSection_->shift());
 
                     // we make the sabr section arbitrage free by superimposing
                     // a kahalesection

--- a/ql/models/shortrate/onefactormodels/vasicek.hpp
+++ b/ql/models/shortrate/onefactormodels/vasicek.hpp
@@ -81,8 +81,7 @@ namespace QuantLib {
                  Real b,
                  Real sigma,
                  Real r0)
-        : ShortRateDynamics(ext::shared_ptr<StochasticProcess1D>(
-                             new OrnsteinUhlenbeckProcess(a, sigma, r0 - b))),
+        : ShortRateDynamics(ext::make_shared<OrnsteinUhlenbeckProcess>(a, sigma, r0 - b)),
           b_(b) {}
 
         Real variable(Time, Rate r) const override { return r - b_; }
@@ -97,8 +96,7 @@ namespace QuantLib {
 
     inline ext::shared_ptr<OneFactorModel::ShortRateDynamics>
     Vasicek::dynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(
-                                     new Dynamics(a(), b() , sigma(), r0_));
+        return ext::make_shared<Dynamics>(a(), b() , sigma(), r0_);
     }
 
 }

--- a/ql/models/shortrate/twofactormodel.cpp
+++ b/ql/models/shortrate/twofactormodel.cpp
@@ -30,13 +30,10 @@ namespace QuantLib {
     TwoFactorModel::tree(const TimeGrid& grid) const {
         ext::shared_ptr<ShortRateDynamics> dyn = dynamics();
 
-        ext::shared_ptr<TrinomialTree> tree1(
-                                    new TrinomialTree(dyn->xProcess(), grid));
-        ext::shared_ptr<TrinomialTree> tree2(
-                                    new TrinomialTree(dyn->yProcess(), grid));
+        ext::shared_ptr<TrinomialTree> tree1 = ext::make_shared<TrinomialTree>(dyn->xProcess(), grid);
+        ext::shared_ptr<TrinomialTree> tree2 = ext::make_shared<TrinomialTree>(dyn->yProcess(), grid);
 
-        return ext::shared_ptr<Lattice>(
-                        new TwoFactorModel::ShortRateTree(tree1, tree2, dyn));
+        return ext::make_shared<TwoFactorModel::ShortRateTree>(tree1, tree2, dyn);
     }
 
     TwoFactorModel::ShortRateTree::ShortRateTree(
@@ -55,8 +52,7 @@ namespace QuantLib {
         std::vector<ext::shared_ptr<StochasticProcess1D> > processes(2);
         processes[0] = xProcess_;
         processes[1] = yProcess_;
-        return ext::shared_ptr<StochasticProcess>(
-                           new StochasticProcessArray(processes,correlation));
+        return ext::make_shared<StochasticProcessArray>(processes,correlation);
     }
 
 }

--- a/ql/models/shortrate/twofactormodels/g2.cpp
+++ b/ql/models/shortrate/twofactormodels/g2.cpp
@@ -46,8 +46,7 @@ namespace QuantLib {
     }
 
     ext::shared_ptr<TwoFactorModel::ShortRateDynamics> G2::dynamics() const {
-        return ext::shared_ptr<ShortRateDynamics>(new
-            Dynamics(phi_, a(), sigma(), b(), eta(), rho()));
+        return ext::make_shared<Dynamics>(phi_, a(), sigma(), b(), eta(), rho());
     }
 
     void G2::generateArguments() {

--- a/ql/models/shortrate/twofactormodels/g2.hpp
+++ b/ql/models/shortrate/twofactormodels/g2.hpp
@@ -119,8 +119,8 @@ namespace QuantLib {
       public:
         Dynamics(Parameter fitting, Real a, Real sigma, Real b, Real eta, Real rho)
         : ShortRateDynamics(
-              ext::shared_ptr<StochasticProcess1D>(new OrnsteinUhlenbeckProcess(a, sigma)),
-              ext::shared_ptr<StochasticProcess1D>(new OrnsteinUhlenbeckProcess(b, eta)),
+              ext::make_shared<OrnsteinUhlenbeckProcess>(a, sigma),
+              ext::make_shared<OrnsteinUhlenbeckProcess>(b, eta),
               rho),
           fitting_(std::move(fitting)) {}
         Rate shortRate(Time t, Real x, Real y) const override { return fitting_(t) + x + y; }
@@ -174,9 +174,8 @@ namespace QuantLib {
                          Real b,
                          Real eta,
                          Real rho)
-        : TermStructureFittingParameter(ext::shared_ptr<Parameter::Impl>(
-                          new FittingParameter::Impl(termStructure, a, sigma,
-                                                     b, eta, rho))) {}
+        : TermStructureFittingParameter(ext::make_shared<FittingParameter::Impl>(termStructure, a, sigma,
+                                                     b, eta, rho)) {}
     };
 
 }

--- a/ql/models/volatility/garch.cpp
+++ b/ql/models/volatility/garch.cpp
@@ -46,8 +46,7 @@ namespace QuantLib {
             };
           public:
             Garch11Constraint(Real gammaLower, Real gammaUpper)
-            : Constraint(ext::shared_ptr<Constraint::Impl>(
-                      new Garch11Constraint::Impl(gammaLower, gammaUpper))) {}
+            : Constraint(ext::make_shared<Garch11Constraint::Impl>(gammaLower, gammaUpper)) {}
         };
 
 
@@ -219,8 +218,7 @@ namespace QuantLib {
             };
           public:
             FitAcfConstraint(Real gammaLower, Real gammaUpper)
-            : Constraint(ext::shared_ptr<Constraint::Impl>(
-                       new FitAcfConstraint::Impl(gammaLower, gammaUpper))) {}
+            : Constraint(ext::make_shared<FitAcfConstraint::Impl>(gammaLower, gammaUpper)) {}
         };
 
 
@@ -529,8 +527,7 @@ namespace QuantLib {
                const EndCriteria &endCriteria,
                const Array &initGuess, Real &alpha, Real &beta, Real &omega) {
         Garch11CostFunction cost(r2);
-        ext::shared_ptr<Problem> problem(
-                               new Problem(cost, constraints, initGuess));
+        ext::shared_ptr<Problem> problem = ext::make_shared<Problem>(cost, constraints, initGuess);
         // TODO: check return value from minimize()
         /* EndCriteria::Type ret = */
         method.minimize(*problem, endCriteria);

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -503,7 +503,7 @@ namespace QuantLib {
     }
 
     inline Observer::Observer(const Observer& o) {
-        proxy_.reset(new Proxy(this));
+        proxy_ = ext::make_shared<Proxy>(this);
 
         {
              std::lock_guard<std::recursive_mutex> lock(o.mutex_);
@@ -517,7 +517,7 @@ namespace QuantLib {
     inline Observer& Observer::operator=(const Observer& o) {
         std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
-            proxy_.reset(new Proxy(this));
+            proxy_ = ext::make_shared<Proxy>(this);
         }
 
         for (const auto& observable : observables_)
@@ -546,7 +546,7 @@ namespace QuantLib {
     Observer::registerWith(const ext::shared_ptr<Observable>& h) {
         std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
-            proxy_.reset(new Proxy(this));
+            proxy_ = ext::make_shared<Proxy>(this);
         }
 
         if (h) {

--- a/ql/pricingengines/asian/fdblackscholesasianengine.cpp
+++ b/ql/pricingengines/asian/fdblackscholesasianengine.cpp
@@ -57,9 +57,8 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(xGrid_, process_, maturity,
-                                      payoff->strike()));
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_, maturity,
+                                      payoff->strike());
 
         const Real spot = process_->x0();
         QL_REQUIRE(spot > 0.0, "negative or null underlying given");
@@ -76,16 +75,13 @@ namespace QuantLib {
         Real xMin = std::min(std::log(avg)  - 0.25*r, std::log(spot) - 1.5*r);
         Real xMax = std::max(std::log(avg)  + 0.25*r, std::log(spot) + 1.5*r);
 
-        const ext::shared_ptr<Fdm1dMesher> averageMesher(
-            new FdmBlackScholesMesher(aGrid_, process_, maturity,
-                                      payoff->strike(), xMin, xMax));
+        const ext::shared_ptr<Fdm1dMesher> averageMesher = ext::make_shared<FdmBlackScholesMesher>(aGrid_, process_, maturity,
+                                      payoff->strike(), xMin, xMax);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, averageMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, averageMesher);
 
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 1));
+        ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 1);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -99,13 +95,11 @@ namespace QuantLib {
             averageTimes.push_back(t);
         }
         stoppingTimes.emplace_back(averageTimes);
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-                new FdmArithmeticAverageCondition(
+        stepConditions.push_back(ext::make_shared<FdmArithmeticAverageCondition>(
                         averageTimes, arguments_.runningAccumulator,
-                        arguments_.pastFixings, mesher, 0)));
+                        arguments_.pastFixings, mesher, 0));
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -113,10 +107,9 @@ namespace QuantLib {
         // 5. Solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
-        ext::shared_ptr<FdmSimple2dBSSolver> solver(
-              new FdmSimple2dBSSolver(
+        ext::shared_ptr<FdmSimple2dBSSolver> solver = ext::make_shared<FdmSimple2dBSSolver>(
                               Handle<GeneralizedBlackScholesProcess>(process_),
-                              payoff->strike(), solverDesc, schemeDesc_));
+                              payoff->strike(), solverDesc, schemeDesc_);
 
         results_.value = solver->valueAt(spot, avg);
         results_.delta = solver->deltaAt(spot, avg, spot*0.01);

--- a/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
@@ -75,8 +75,7 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
                     this->process_);
             QL_REQUIRE(process, "Black-Scholes process required");
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticDiscreteGeometricAveragePriceAsianEngine(process));
+            return ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(process);
         }
     };
 
@@ -141,14 +140,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPEngine<RNG,S>::path_pricer_type>(
-                new ArithmeticAPOPathPricer(
+        return ext::make_shared<ArithmeticAPOPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S>
@@ -175,12 +172,10 @@ namespace QuantLib {
         // for seasoned option the geometric strike might be rescaled
         // to obtain an equivalent arithmetic strike.
         // Any change applied here MUST be applied to the analytic engine too
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPEngine<RNG,S>::path_pricer_type>(
-            new GeometricAPOPathPricer(
+        return ext::make_shared<GeometricAPOPathPricer>(
               payoff->optionType(),
               payoff->strike(),
-              process->riskFreeRate()->discount(this->timeGrid().back())));
+              process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
     template <class RNG = PseudoRandom, class S = Statistics>

--- a/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
@@ -74,8 +74,7 @@ namespace QuantLib {
             ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
             QL_REQUIRE(process, "Heston-like process required");
 
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(process));
+            return ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine>(process);
         }
     };
 
@@ -180,15 +179,13 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ArithmeticAPOHestonPathPricer(
+        return ext::make_shared<ArithmeticAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     fixingIndexes,
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S, class P>
@@ -224,13 +221,11 @@ namespace QuantLib {
         // pass seasoning details to the path pricer (NB. NEED to pass them to
         // the analytic pricer as well in that case).
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new GeometricAPOHestonPathPricer(
+        return ext::make_shared<GeometricAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
-                    fixingIndexes));
+                    fixingIndexes);
     }
 
     template <class RNG, class S, class P>

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -143,14 +143,12 @@ namespace QuantLib {
             }
         }
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticASEngine<RNG,S>::path_pricer_type>(
-                new ArithmeticASOPathPricer(
+        return ext::make_shared<ArithmeticASOPathPricer>(
                     payoff->optionType(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings,
-                    fixingCount));
+                    fixingCount);
     }
 
 

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -128,14 +128,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteGeometricAPEngine<RNG,S>::path_pricer_type>(
-                new GeometricAPOPathPricer(
+        return ext::make_shared<GeometricAPOPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
 

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
@@ -162,15 +162,13 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteGeometricAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new GeometricAPOHestonPathPricer(
+        return ext::make_shared<GeometricAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     fixingIndexes,
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S, class P>

--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -113,9 +113,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         Real controlVariateValue() const override;
         // data members

--- a/ql/pricingengines/bacheliercalculator.cpp
+++ b/ql/pricingengines/bacheliercalculator.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         Option::Type optionType, Real strike, Real forward, Real stdDev, Real discount)
     : strike_(strike), forward_(forward), stdDev_(stdDev),
       discount_(discount), variance_(stdDev*stdDev) {
-        initialize(ext::shared_ptr<StrikedTypePayoff>(new PlainVanillaPayoff(optionType, strike)));
+        initialize(ext::make_shared<PlainVanillaPayoff>(optionType, strike));
     }
 
     void BachelierCalculator::initialize(const ext::shared_ptr<StrikedTypePayoff>& p) {

--- a/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
+++ b/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
@@ -102,11 +102,10 @@ namespace QuantLib {
         if ((barrierType == Barrier::DownIn && spot <= barrier) ||
            (barrierType == Barrier::UpIn && spot >= barrier)) {
             // knocked in - is a digital european
-            ext::shared_ptr<Exercise> exercise(new EuropeanExercise(
-                                             arguments_.exercise->lastDate()));
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(
+                                             arguments_.exercise->lastDate());
 
-            ext::shared_ptr<PricingEngine> engine(
-                                       new AnalyticEuropeanEngine(process_));
+            ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(process_);
 
             VanillaOption opt(payoff, exercise);
             opt.setPricingEngine(engine);

--- a/ql/pricingengines/barrier/binomialbarrierengine.hpp
+++ b/ql/pricingengines/barrier/binomialbarrierengine.hpp
@@ -112,21 +112,17 @@ namespace QuantLib {
 
         // binomial trees with constant coefficient
         Handle<YieldTermStructure> flatRiskFree(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, r, rfdc)));
+            ext::make_shared<FlatForward>(referenceDate, r, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, q, divdc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
         Handle<BlackVolTermStructure> flatVol(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(
-                         new GeneralizedBlackScholesProcess(
+        ext::shared_ptr<StochasticProcess1D> bs = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
-                                      flatDividends, flatRiskFree, flatVol));
+                                      flatDividends, flatRiskFree, flatVol);
 
         // correct timesteps to ensure a (local) minimum, using Boyle and Lau
         // approach. See Journal of Derivatives, 1/1994,
@@ -157,11 +153,10 @@ namespace QuantLib {
 
         TimeGrid grid(maturity, optimum_steps);
 
-        ext::shared_ptr<T> tree(new T(bs, maturity, optimum_steps,
-                                        payoff->strike()));
+        ext::shared_ptr<T> tree = ext::make_shared<T>(bs, maturity, optimum_steps,
+                                        payoff->strike());
 
-        ext::shared_ptr<BlackScholesLattice<T> > lattice(
-            new BlackScholesLattice<T>(tree, r, maturity, optimum_steps));
+        ext::shared_ptr<BlackScholesLattice<T> > lattice = ext::make_shared<BlackScholesLattice<T>>(tree, r, maturity, optimum_steps);
 
         D option(arguments_, *process_, grid);
         option.initialize(lattice, maturity);

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -99,12 +99,11 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
         
         const ext::shared_ptr<FdmMesher> mesher (
             ext::make_shared<FdmMesherComposite>(equityMesher));

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -83,21 +83,17 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
         
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher);
         
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(
-                new CashOrNothingPayoff(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(rebatePayoff, mesher, 0));
+        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff = ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate);
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0);
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
@@ -130,11 +126,10 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions, calculator,
                                      maturity, tGrid_, dampingSteps_ };
 
-        const ext::shared_ptr<FdmBlackScholesSolver> solver(
-                new FdmBlackScholesSolver(
+        const ext::shared_ptr<FdmBlackScholesSolver> solver = ext::make_shared<FdmBlackScholesSolver>(
                                 Handle<GeneralizedBlackScholesProcess>(process_),
                                 payoff->strike(), solverDesc, schemeDesc_,
-                                localVol_, illegalLocalVolOverwrite_));
+                                localVol_, illegalLocalVolOverwrite_);
 
         const Real spot = process_->x0();
         results_.value = solver->valueAt(spot);

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -94,8 +94,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
@@ -103,7 +102,7 @@ namespace QuantLib {
                 maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
 
         const ext::shared_ptr<FdmMesher> mesher (
 			ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));

--- a/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
@@ -70,20 +70,17 @@ namespace QuantLib {
         Real xMin = std::log(arguments_.barrier_lo);
         Real xMax = std::log(arguments_.barrier_hi);
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
                     process->riskFreeRate(), vMesher->volaEstimate()),
-                maturity, payoff->strike(), xMin, xMax));
+                maturity, payoff->strike(), xMin, xMax);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -92,8 +89,7 @@ namespace QuantLib {
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "only european style option are supported");
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
@@ -110,9 +106,9 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        ext::shared_ptr<FdmHestonSolver> solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_);
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -95,8 +95,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
@@ -104,16 +103,13 @@ namespace QuantLib {
                 maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(
-                new CashOrNothingPayoff(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(rebatePayoff, mesher, 0));
+        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff = ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate);
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0);
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
@@ -147,9 +143,9 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        ext::shared_ptr<FdmHestonSolver> solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_);
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/mcbarrierengine.hpp
+++ b/ql/pricingengines/barrier/mcbarrierengine.hpp
@@ -95,9 +95,8 @@ namespace QuantLib {
             TimeGrid grid = timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -243,21 +242,17 @@ namespace QuantLib {
 
         // do this with template parameters?
         if (isBiased_) {
-            return ext::shared_ptr<
-                        typename MCBarrierEngine<RNG,S>::path_pricer_type>(
-                new BiasedBarrierPathPricer(
+            return ext::make_shared<BiasedBarrierPathPricer>(
                        arguments_.barrierType,
                        arguments_.barrier,
                        arguments_.rebate,
                        payoff->optionType(),
                        payoff->strike(),
-                       discounts));
+                       discounts);
         } else {
             PseudoRandom::ursg_type sequenceGen(grid.size()-1,
                                                 PseudoRandom::urng_type(5));
-            return ext::shared_ptr<
-                        typename MCBarrierEngine<RNG,S>::path_pricer_type>(
-                new BarrierPathPricer(
+            return ext::make_shared<BarrierPathPricer>(
                     arguments_.barrierType,
                     arguments_.barrier,
                     arguments_.rebate,
@@ -265,7 +260,7 @@ namespace QuantLib {
                     payoff->strike(),
                     discounts,
                     process_,
-                    sequenceGen));
+                    sequenceGen);
         }
     }
 

--- a/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
+++ b/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
@@ -56,24 +56,20 @@ namespace QuantLib {
 
         // 2. Mesher
         const Time maturity = p1_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> em1(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> em1 = ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_, p1_, maturity, p1_->x0(), 
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
-                    std::pair<Real, Real>(p1_->x0(), 0.1)));
+                    std::pair<Real, Real>(p1_->x0(), 0.1));
 
-        const ext::shared_ptr<Fdm1dMesher> em2(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> em2 = ext::make_shared<FdmBlackScholesMesher>(
                     yGrid_, p2_, maturity, p2_->x0(),
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
-                    std::pair<Real, Real>(p2_->x0(), 0.1)));
+                    std::pair<Real, Real>(p2_->x0(), 0.1));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(em1, em2));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(em1, em2);
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogBasketInnerValue(payoff, mesher));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogBasketInnerValue>(payoff, mesher);
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -91,12 +87,11 @@ namespace QuantLib {
                                            conditions, calculator,
                                            maturity, tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<Fdm2dBlackScholesSolver> solver(
-                new Fdm2dBlackScholesSolver(
+        ext::shared_ptr<Fdm2dBlackScholesSolver> solver = ext::make_shared<Fdm2dBlackScholesSolver>(
                              Handle<GeneralizedBlackScholesProcess>(p1_),
                              Handle<GeneralizedBlackScholesProcess>(p2_),
                              correlation_, solverDesc, schemeDesc_,
-                             localVol_, illegalLocalVolOverwrite_));
+                             localVol_, illegalLocalVolOverwrite_);
 
         const Real x = p1_->x0();
         const Real y = p2_->x0();

--- a/ql/pricingengines/basket/mcamericanbasketengine.hpp
+++ b/ql/pricingengines/basket/mcamericanbasketengine.hpp
@@ -174,11 +174,10 @@ namespace QuantLib {
         QL_REQUIRE(!exercise->payoffAtExpiry(),
                    "payoff at expiry not handled");
 
-        ext::shared_ptr<AmericanBasketPathPricer> earlyExercisePathPricer(
-            new AmericanBasketPathPricer(processArray->size(),
+        ext::shared_ptr<AmericanBasketPathPricer> earlyExercisePathPricer = ext::make_shared<AmericanBasketPathPricer>(processArray->size(),
                                          this->arguments_.payoff,
                                          polynomialOrder_,
-                                         polynomialType_));
+                                         polynomialType_);
 
         return ext::make_shared<LongstaffSchwartzPathPricer<MultiPath> > (
              
@@ -287,8 +286,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCAmericanBasketEngine<RNG>(process_,
+        return ext::make_shared<MCAmericanBasketEngine<RNG>>(process_,
                                         steps_,
                                         stepsPerYear_,
                                         brownianBridge_,
@@ -299,7 +297,7 @@ namespace QuantLib {
                                         seed_,
                                         calibrationSamples_,
                                         polynomialOrder_,
-                                        polynomialType_));
+                                        polynomialType_);
     }
 
 }

--- a/ql/pricingengines/basket/mceuropeanbasketengine.hpp
+++ b/ql/pricingengines/basket/mceuropeanbasketengine.hpp
@@ -80,9 +80,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(numAssets*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(processes_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(processes_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -193,11 +192,9 @@ namespace QuantLib {
                                                       processes_->process(0));
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                    typename MCEuropeanBasketEngine<RNG,S>::path_pricer_type>(
-            new EuropeanMultiPathPricer(payoff,
+        return ext::make_shared<EuropeanMultiPathPricer>(payoff,
                                         process->riskFreeRate()->discount(
-                                           arguments_.exercise->lastDate())));
+                                           arguments_.exercise->lastDate()));
     }
 
 

--- a/ql/pricingengines/basket/stulzengine.cpp
+++ b/ql/pricingengines/basket/stulzengine.cpp
@@ -84,8 +84,7 @@ namespace QuantLib {
                                        Real variance1, Real variance2,
                                        Real rho) {
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new
-                PlainVanillaPayoff(Option::Call, strike));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strike);
 
             Real black1 = blackFormula(payoff->optionType(), payoff->strike(),
                 forward1, std::sqrt(variance1)) * riskFreeDiscount;

--- a/ql/pricingengines/blackcalculator.cpp
+++ b/ql/pricingengines/blackcalculator.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
                                      Real discount)
     : strike_(strike), forward_(forward), stdDev_(stdDev),
       discount_(discount), variance_(stdDev*stdDev) {
-        initialize(ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(optionType, strike)));
+        initialize(ext::make_shared<PlainVanillaPayoff>(optionType, strike));
     }
 
     void BlackCalculator::initialize(const ext::shared_ptr<StrikedTypePayoff>& p) {

--- a/ql/pricingengines/bond/binomialconvertibleengine.hpp
+++ b/ql/pricingengines/bond/binomialconvertibleengine.hpp
@@ -101,25 +101,22 @@ namespace QuantLib {
             "negative value after subtracting dividends");
 
         // binomial trees with constant coefficient
-        Handle<Quote> underlying(ext::shared_ptr<Quote>(new SimpleQuote(s0)));
-        Handle<YieldTermStructure> flatRiskFree(ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(referenceDate, riskFreeRate, rfdc)));
+        Handle<Quote> underlying(ext::make_shared<SimpleQuote>(s0));
+        Handle<YieldTermStructure> flatRiskFree(ext::make_shared<FlatForward>(referenceDate, riskFreeRate, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(new FlatForward(referenceDate, q, divdc)));
-        Handle<BlackVolTermStructure> flatVol(ext::shared_ptr<BlackVolTermStructure>(
-            new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
+        Handle<BlackVolTermStructure> flatVol(ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         Time maturity = rfdc.yearFraction(arguments_.settlementDate, maturityDate);
         Real strike = arguments_.redemption / arguments_.conversionRatio ;
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bs(
-            new GeneralizedBlackScholesProcess(underlying, flatDividends, flatRiskFree, flatVol));
-        ext::shared_ptr<T> tree(new T(bs, maturity, timeSteps_, strike));
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bs = ext::make_shared<GeneralizedBlackScholesProcess>(underlying, flatDividends, flatRiskFree, flatVol);
+        ext::shared_ptr<T> tree = ext::make_shared<T>(bs, maturity, timeSteps_, strike);
 
         Real creditSpread = creditSpread_->value();
 
-        ext::shared_ptr<Lattice> lattice(new TsiveriotisFernandesLattice<T>(
-            tree, riskFreeRate, maturity, timeSteps_, creditSpread, v, q));
+        ext::shared_ptr<Lattice> lattice = ext::make_shared<TsiveriotisFernandesLattice<T>>(
+            tree, riskFreeRate, maturity, timeSteps_, creditSpread, v, q);
 
         DiscretizedConvertible convertible(arguments_, bs, dividends_, creditSpread_, TimeGrid(maturity, timeSteps_));
 

--- a/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
@@ -32,8 +32,7 @@ namespace QuantLib {
                                                      Volatility v,
                                                      const DayCounter& dc)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))) {
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)) {
         registerWith(discountCurve_);
     }
 
@@ -41,8 +40,7 @@ namespace QuantLib {
                                                      const Handle<Quote>& v,
                                                      const DayCounter& dc)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))) {
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)) {
         registerWith(discountCurve_);
         registerWith(vol_);
     }

--- a/ql/pricingengines/capfloor/blackcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/blackcapfloorengine.cpp
@@ -35,8 +35,7 @@ namespace QuantLib {
                                              const DayCounter& dc,
                                              Real displacement)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))),
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)),
       displacement_(displacement) {
         registerWith(discountCurve_);
     }
@@ -46,8 +45,7 @@ namespace QuantLib {
                                              const DayCounter& dc,
                                              Real displacement)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))),
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)),
       displacement_(displacement) {
         registerWith(discountCurve_);
         registerWith(vol_);

--- a/ql/pricingengines/capfloor/mchullwhiteengine.hpp
+++ b/ql/pricingengines/capfloor/mchullwhiteengine.hpp
@@ -101,9 +101,8 @@ namespace QuantLib {
             Time forwardMeasureTime =
                 dayCounter.yearFraction(referenceDate,
                                         arguments_.endDates.back());
-            return ext::shared_ptr<path_pricer_type>(
-                     new detail::HullWhiteCapFloorPricer(arguments_, model_,
-                                                         forwardMeasureTime));
+            return ext::make_shared<detail::HullWhiteCapFloorPricer>(arguments_, model_,
+                                                         forwardMeasureTime);
         }
 
         TimeGrid timeGrid() const {
@@ -137,16 +136,14 @@ namespace QuantLib {
                                         arguments_.endDates.back());
             Array parameters = model_->params();
             Real a = parameters[0], sigma = parameters[1];
-            ext::shared_ptr<HullWhiteForwardProcess> process(
-                                new HullWhiteForwardProcess(curve, a, sigma));
+            ext::shared_ptr<HullWhiteForwardProcess> process = ext::make_shared<HullWhiteForwardProcess>(curve, a, sigma);
             process->setForwardMeasureTime(forwardMeasureTime);
 
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type generator =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                             new path_generator_type(process, grid, generator,
-                                                     brownianBridge_));
+            return ext::make_shared<path_generator_type>(process, grid, generator,
+                                                     brownianBridge_);
         }
     };
 

--- a/ql/pricingengines/cliquet/analyticcliquetengine.cpp
+++ b/ql/pricingengines/cliquet/analyticcliquetengine.cpp
@@ -55,8 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
         Real strike = underlying * moneyness->strike();
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                      new PlainVanillaPayoff(moneyness->optionType(),strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(),strike);
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;

--- a/ql/pricingengines/cliquet/analyticperformanceengine.cpp
+++ b/ql/pricingengines/cliquet/analyticperformanceengine.cpp
@@ -55,8 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(moneyness->optionType(), 1.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(), 1.0);
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;

--- a/ql/pricingengines/cliquet/mcperformanceengine.hpp
+++ b/ql/pricingengines/cliquet/mcperformanceengine.hpp
@@ -66,9 +66,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -174,11 +173,9 @@ namespace QuantLib {
         discounts.push_back(this->process_->riskFreeRate()->discount(
                                             arguments_.exercise->lastDate()));
 
-        return ext::shared_ptr<
-            typename MCPerformanceEngine<RNG,S>::path_pricer_type>(
-                         new PerformanceOptionPathPricer(payoff->optionType(),
+        return ext::make_shared<PerformanceOptionPathPricer>(payoff->optionType(),
                                                          payoff->strike(),
-                                                         discounts));
+                                                         discounts);
     }
 
 

--- a/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
+++ b/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
@@ -62,10 +62,9 @@ namespace QuantLib {
         Real s1 = process1_->stateVariable()->value();
         Real s2 = process2_->stateVariable()->value();
 
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(arguments_.Q1*s1));
+        ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(arguments_.Q1*s1);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                      new PlainVanillaPayoff(Option::Call, arguments_.Q2*s2));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, arguments_.Q2*s2);
 
         DiscountFactor dividendDiscount1 =
             process1_->dividendYield()->discount(exercise->lastDate());
@@ -75,11 +74,9 @@ namespace QuantLib {
             process2_->dividendYield()->discount(exercise->lastDate());
         Rate q2 = -std::log(dividendDiscount2)/t;
 
-        ext::shared_ptr<YieldTermStructure> qTS(
-                                            new FlatForward(today, q1, rfdc));
+        ext::shared_ptr<YieldTermStructure> qTS = ext::make_shared<FlatForward>(today, q1, rfdc);
 
-        ext::shared_ptr<YieldTermStructure> rTS(
-                                            new FlatForward(today, q2, rfdc));
+        ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<FlatForward>(today, q2, rfdc);
 
         Real variance1 = process1_->blackVolatility()->blackVariance(
                                                 exercise->lastDate(), s1);
@@ -89,17 +86,14 @@ namespace QuantLib {
                       - 2*rho_*std::sqrt(variance1)*std::sqrt(variance2);
         Volatility volatility = std::sqrt(variance/t);
 
-        ext::shared_ptr<BlackVolTermStructure> volTS(
-               new BlackConstantVol(today, NullCalendar(), volatility, rfdc));
+        ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackConstantVol>(today, NullCalendar(), volatility, rfdc);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                     new BjerksundStenslandApproximationEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);

--- a/ql/pricingengines/exotic/analyticcompoundoptionengine.cpp
+++ b/ql/pricingengines/exotic/analyticcompoundoptionengine.cpp
@@ -85,9 +85,8 @@ namespace QuantLib {
             process_->riskFreeRate()->discount(helpMaturity);
 
 
-        ext::shared_ptr<ImpliedSpotHelper> f(
-                new ImpliedSpotHelper(dividendDiscount, riskFreeDiscount,
-                                      vol, payoffDaughter(), strikeMother()));
+        ext::shared_ptr<ImpliedSpotHelper> f = ext::make_shared<ImpliedSpotHelper>(dividendDiscount, riskFreeDiscount,
+                                      vol, payoffDaughter(), strikeMother());
 
         Brent solver;
         solver.setMaxEvaluations(1000);

--- a/ql/pricingengines/forward/forwardengine.hpp
+++ b/ql/pricingengines/forward/forwardengine.hpp
@@ -81,10 +81,9 @@ namespace QuantLib {
                 this->arguments_.payoff);
         QL_REQUIRE(argumentsPayoff, "wrong payoff given");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                   new PlainVanillaPayoff(argumentsPayoff->optionType(),
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(argumentsPayoff->optionType(),
                                           this->arguments_.moneyness *
-                                          process_->x0()));
+                                          process_->x0());
 
         // maybe the forward value is "better", in some fashion
         // the right level is needed in order to interpolate
@@ -92,29 +91,25 @@ namespace QuantLib {
         Handle<Quote> spot = process_->stateVariable();
         QL_REQUIRE(spot->value() > 0.0, "negative or null underlying given");
         Handle<YieldTermStructure> dividendYield(
-            ext::shared_ptr<YieldTermStructure>(
-               new ImpliedTermStructure(process_->dividendYield(),
-                                        this->arguments_.resetDate)));
+            ext::make_shared<ImpliedTermStructure>(process_->dividendYield(),
+                                        this->arguments_.resetDate));
         Handle<YieldTermStructure> riskFreeRate(
-            ext::shared_ptr<YieldTermStructure>(
-               new ImpliedTermStructure(process_->riskFreeRate(),
-                                        this->arguments_.resetDate)));
+            ext::make_shared<ImpliedTermStructure>(process_->riskFreeRate(),
+                                        this->arguments_.resetDate));
         // The following approach is ok if the vol is at most
         // time-dependent. It is plain wrong if it is asset-dependent.
         // In the latter case the right solution would be stochastic
         // volatility or at least local volatility (which unfortunately
         // implies an unrealistic time-decreasing smile)
         Handle<BlackVolTermStructure> blackVolatility(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new ImpliedVolTermStructure(process_->blackVolatility(),
-                                            this->arguments_.resetDate)));
+            ext::make_shared<ImpliedVolTermStructure>(process_->blackVolatility(),
+                                            this->arguments_.resetDate));
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> fwdProcess(
-                       new GeneralizedBlackScholesProcess(spot, dividendYield,
+        ext::shared_ptr<GeneralizedBlackScholesProcess> fwdProcess = ext::make_shared<GeneralizedBlackScholesProcess>(spot, dividendYield,
                                                           riskFreeRate,
-                                                          blackVolatility));
+                                                          blackVolatility);
 
-        originalEngine_ = ext::shared_ptr<Engine>(new Engine(fwdProcess));
+        originalEngine_ = ext::make_shared<Engine>(fwdProcess);
         originalEngine_->reset();
 
         originalArguments_ =

--- a/ql/pricingengines/forward/mcforwardeuropeanbsengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanbsengine.hpp
@@ -152,14 +152,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanBSEngine<RNG,S>::path_pricer_type>(
-                new ForwardEuropeanBSPathPricer(
+        return ext::make_shared<ForwardEuropeanBSPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
 

--- a/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
@@ -77,9 +77,8 @@ namespace QuantLib {
             ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
             QL_REQUIRE(process, "Heston-like process required");
 
-            ext::shared_ptr<HestonModel> hestonModel(new HestonModel(process));
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticHestonEngine(hestonModel));
+            ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(process);
+            return ext::make_shared<AnalyticHestonEngine>(hestonModel);
         }
     };
 
@@ -173,14 +172,12 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ForwardEuropeanHestonPathPricer(
+        return ext::make_shared<ForwardEuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
     template <class RNG, class S, class P>
@@ -206,14 +203,12 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ForwardEuropeanHestonPathPricer(
+        return ext::make_shared<ForwardEuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
     template <class RNG, class S, class P>

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -74,9 +74,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         // data members
         ext::shared_ptr<StochasticProcess> process_;
@@ -159,8 +158,7 @@ namespace QuantLib {
         Real moneyness = this->arguments_.moneyness;
         Real strike = moneyness * spot;
 
-        ext::shared_ptr<StrikedTypePayoff> newPayoff(new
-            PlainVanillaPayoff(payoff->optionType(), strike));
+        ext::shared_ptr<StrikedTypePayoff> newPayoff = ext::make_shared<PlainVanillaPayoff>(payoff->optionType(), strike);
 
         auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
 

--- a/ql/pricingengines/forward/mcvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/mcvarianceswapengine.hpp
@@ -112,9 +112,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid, gen,
-                                                 brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid, gen,
+                                                 brownianBridge_);
         }
         // data members
         ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
@@ -215,9 +214,7 @@ namespace QuantLib {
         typename MCVarianceSwapEngine<RNG,S>::path_pricer_type>
     MCVarianceSwapEngine<RNG,S>::pathPricer() const {
 
-        return ext::shared_ptr<
-            typename MCVarianceSwapEngine<RNG,S>::path_pricer_type>(
-                                            new VariancePathPricer(process_));
+        return ext::make_shared<VariancePathPricer>(process_);
     }
 
 

--- a/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
@@ -132,8 +132,7 @@ namespace QuantLib {
             slope = std::fabs((computeLogPayoff(*(k+1), f) -
                                computeLogPayoff(*k, f))/
                               (*(k+1) - *k));
-            ext::shared_ptr<StrikedTypePayoff> payoff(
-                                            new PlainVanillaPayoff(type, *k));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, *k);
             if ( k == strikes.begin() )
                 optionWeights.emplace_back(payoff,slope);
             else
@@ -155,10 +154,8 @@ namespace QuantLib {
     Real ReplicatingVarianceSwapEngine::computeReplicatingPortfolio(
                                     const weights_type& optionWeights) const {
 
-        ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(arguments_.maturityDate));
-        ext::shared_ptr<PricingEngine> optionEngine(
-                                        new AnalyticEuropeanEngine(process_));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(arguments_.maturityDate);
+        ext::shared_ptr<PricingEngine> optionEngine = ext::make_shared<AnalyticEuropeanEngine>(process_);
         Real optionsValue = 0.0;
 
         for (auto i = optionWeights.begin(); i < optionWeights.end(); ++i) {

--- a/ql/pricingengines/lookback/mclookbackengine.cpp
+++ b/ql/pricingengines/lookback/mclookbackengine.cpp
@@ -83,10 +83,9 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<PlainVanillaPayoff>(args.payoff);
             QL_REQUIRE(payoff, "non-plain payoff given");
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackFixedPathPricer(payoff->optionType(),
+            return ext::make_shared<LookbackFixedPathPricer>(payoff->optionType(),
                                             payoff->strike(),
-                                            discount));
+                                            discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -100,11 +99,10 @@ namespace QuantLib {
 
             Time lookbackStart = process.time(args.lookbackPeriodStart);
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackPartialFixedPathPricer(lookbackStart,
+            return ext::make_shared<LookbackPartialFixedPathPricer>(lookbackStart,
                                                    payoff->optionType(),
                                                    payoff->strike(),
-                                                   discount));
+                                                   discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -116,9 +114,8 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<FloatingTypePayoff>(args.payoff);
             QL_REQUIRE(payoff, "non-floating payoff given");
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackFloatingPathPricer(payoff->optionType(),
-                                               discount));
+            return ext::make_shared<LookbackFloatingPathPricer>(payoff->optionType(),
+                                               discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -132,10 +129,9 @@ namespace QuantLib {
 
             Time lookbackEnd = process.time(args.lookbackPeriodEnd);
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackPartialFloatingPathPricer(lookbackEnd,
+            return ext::make_shared<LookbackPartialFloatingPathPricer>(lookbackEnd,
                                                       payoff->optionType(),
-                                                      discount));
+                                                      discount);
         }
 
     }

--- a/ql/pricingengines/lookback/mclookbackengine.hpp
+++ b/ql/pricingengines/lookback/mclookbackengine.hpp
@@ -70,9 +70,8 @@ namespace QuantLib {
             TimeGrid grid = timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members

--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -250,9 +250,8 @@ namespace QuantLib {
         TimeGrid grid = this->timeGrid();
         typename RNG::rsg_type generator =
             RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-        return ext::shared_ptr<path_generator_type>(
-                   new path_generator_type(process_,
-                                           grid, generator, brownianBridge_));
+        return ext::make_shared<path_generator_type>(process_,
+                                           grid, generator, brownianBridge_);
     }
 
 }

--- a/ql/pricingengines/quanto/quantoengine.hpp
+++ b/ql/pricingengines/quanto/quantoengine.hpp
@@ -99,22 +99,20 @@ namespace QuantLib {
         Handle<YieldTermStructure> riskFreeRate = process_->riskFreeRate();
         // dividendTS needs modification
         Handle<YieldTermStructure> dividendYield(
-            ext::shared_ptr<YieldTermStructure>(
-                new QuantoTermStructure(process_->dividendYield(),
+            ext::make_shared<QuantoTermStructure>(process_->dividendYield(),
                                         process_->riskFreeRate(),
                                         foreignRiskFreeRate_,
                                         process_->blackVolatility(),
                                         strike,
                                         exchangeRateVolatility_,
                                         exchangeRateATMlevel,
-                                        correlation_->value())));
+                                        correlation_->value()));
         Handle<BlackVolTermStructure> blackVol = process_->blackVolatility();
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> quantoProcess(
-                  new GeneralizedBlackScholesProcess(spot, dividendYield,
-                                                     riskFreeRate, blackVol));
+        ext::shared_ptr<GeneralizedBlackScholesProcess> quantoProcess = ext::make_shared<GeneralizedBlackScholesProcess>(spot, dividendYield,
+                                                     riskFreeRate, blackVol);
 
-        ext::shared_ptr<Engine> originalEngine(new Engine(quantoProcess));
+        ext::shared_ptr<Engine> originalEngine = ext::make_shared<Engine>(quantoProcess);
         originalEngine->reset();
         auto* originalArguments =
             dynamic_cast<typename Instr::arguments*>(originalEngine->getArguments());

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -186,8 +186,8 @@ namespace QuantLib {
             Real displacement,
             CashAnnuityModel model)
         : discountCurve_(std::move(discountCurve)),
-          vol_(ext::shared_ptr<SwaptionVolatilityStructure>(new ConstantSwaptionVolatility(
-              0, NullCalendar(), Following, vol, dc, Spec().type, displacement))),
+          vol_(ext::make_shared<ConstantSwaptionVolatility>(
+              0, NullCalendar(), Following, vol, dc, Spec().type, displacement)),
           model_(model) {
             registerWith(discountCurve_);
         }
@@ -200,8 +200,8 @@ namespace QuantLib {
             Real displacement,
             CashAnnuityModel model)
         : discountCurve_(std::move(discountCurve)),
-          vol_(ext::shared_ptr<SwaptionVolatilityStructure>(new ConstantSwaptionVolatility(
-              0, NullCalendar(), Following, vol, dc, Spec().type, displacement))),
+          vol_(ext::make_shared<ConstantSwaptionVolatility>(
+              0, NullCalendar(), Following, vol, dc, Spec().type, displacement)),
           model_(model) {
             registerWith(discountCurve_);
             registerWith(vol_);

--- a/ql/pricingengines/swaption/fdg2swaptionengine.cpp
+++ b/ql/pricingengines/swaption/fdg2swaptionengine.cpp
@@ -57,20 +57,15 @@ namespace QuantLib {
         const Time maturity = dc.yearFraction(referenceDate,
                                               arguments_.exercise->lastDate());
 
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process1(
-            new OrnsteinUhlenbeckProcess(model_->a(), model_->sigma()));
+        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process1 = ext::make_shared<OrnsteinUhlenbeckProcess>(model_->a(), model_->sigma());
 
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process2(
-            new OrnsteinUhlenbeckProcess(model_->b(), model_->eta()));
+        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process2 = ext::make_shared<OrnsteinUhlenbeckProcess>(model_->b(), model_->eta());
 
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-            new FdmSimpleProcess1dMesher(xGrid_,process1,maturity,1,invEps_));
+        const ext::shared_ptr<Fdm1dMesher> xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_,process1,maturity,1,invEps_);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-            new FdmSimpleProcess1dMesher(yGrid_,process2,maturity,1,invEps_));
+        const ext::shared_ptr<Fdm1dMesher> yMesher = ext::make_shared<FdmSimpleProcess1dMesher>(yGrid_,process2,maturity,1,invEps_);
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(xMesher, yMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher);
 
         // 3. Inner Value Calculator
         const std::vector<Date>& exerciseDates = arguments_.exercise->dates();
@@ -92,14 +87,12 @@ namespace QuantLib {
         QL_REQUIRE(fwdTs->referenceDate() == disTs->referenceDate(),
                 "reference date of forward and discount curve must match");
 
-        const ext::shared_ptr<G2> fwdModel(
-            new G2(fwdTs, model_->a(), model_->sigma(),
-                   model_->b(), model_->eta(), model_->rho()));
+        const ext::shared_ptr<G2> fwdModel = ext::make_shared<G2>(fwdTs, model_->a(), model_->sigma(),
+                   model_->b(), model_->eta(), model_->rho());
 
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-             new FdmAffineModelSwapInnerValue<G2>(
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmAffineModelSwapInnerValue<G2>>(
                  model_.currentLink(), fwdModel,
-                 arguments_.swap, t2d, mesher, 0));
+                 arguments_.swap, t2d, mesher, 0);
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =

--- a/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
+++ b/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
@@ -110,18 +110,15 @@ namespace QuantLib {
         }
 
         Handle<BlackVolTermStructure> volTS(
-             ext::shared_ptr<BlackVolTermStructure>(
-              new ShiftedBlackVolTermStructure(varianceOffset,
-                                               process_->blackVolatility())));
+             ext::make_shared<ShiftedBlackVolTermStructure>(varianceOffset,
+                                               process_->blackVolatility()));
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> adjProcess(
-                new GeneralizedBlackScholesProcess(process_->stateVariable(),
+        ext::shared_ptr<GeneralizedBlackScholesProcess> adjProcess = ext::make_shared<GeneralizedBlackScholesProcess>(process_->stateVariable(),
                                                    process_->dividendYield(),
                                                    process_->riskFreeRate(),
-                                                   volTS));
+                                                   volTS);
 
-        ext::shared_ptr<AnalyticEuropeanEngine> bsmEngine(
-                                      new AnalyticEuropeanEngine(adjProcess));
+        ext::shared_ptr<AnalyticEuropeanEngine> bsmEngine = ext::make_shared<AnalyticEuropeanEngine>(adjProcess);
 
         VanillaOption(payoff, exercise).setupArguments(
                                                    bsmEngine->getArguments());

--- a/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
+++ b/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
@@ -137,9 +137,9 @@ namespace QuantLib {
             m1 = m1_; m2 = m2_; m3 = m3_; 
             v1 = v1_; v2 = v2_; /*v3 = v3_;*/ z1 = z1_; /*z2 = z2_;*/ x1 = x1_;
 
-            std::unique_ptr<Real[]> m1ai(new Real[T]);
-            std::unique_ptr<Real[]> m2ai(new Real[T]);
-            std::unique_ptr<Real[]> m3ai(new Real[T]);
+            std::unique_ptr<Real[]> m1ai = std::make_unique<Real[]>(T);
+            std::unique_ptr<Real[]> m2ai = std::make_unique<Real[]>(T);
+            std::unique_ptr<Real[]> m3ai = std::make_unique<Real[]>(T);
             m1ai[0] = m2ai[0] = m3ai[0] = 1.0;
             for (i=1; i < T; ++i) {
                 m1ai[i] = m1ai[i-1]*m1;

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -887,88 +887,77 @@ namespace QuantLib {
     AnalyticHestonEngine::Integration::gaussLobatto(
        Real relTolerance, Real absTolerance, Size maxEvaluations, bool useConvergenceEstimate) {
        return Integration(GaussLobatto,
-                           ext::shared_ptr<Integrator>(
-                               new GaussLobattoIntegral(maxEvaluations,
+                           ext::make_shared<GaussLobattoIntegral>(maxEvaluations,
                                                         absTolerance,
                                                         relTolerance,
-                                                        useConvergenceEstimate)));
+                                                        useConvergenceEstimate));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussKronrod(Real absTolerance,
                                                    Size maxEvaluations) {
         return Integration(GaussKronrod,
-                           ext::shared_ptr<Integrator>(
-                               new GaussKronrodAdaptive(absTolerance,
-                                                        maxEvaluations)));
+                           ext::make_shared<GaussKronrodAdaptive>(absTolerance,
+                                                        maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::simpson(Real absTolerance,
                                                Size maxEvaluations) {
         return Integration(Simpson,
-                           ext::shared_ptr<Integrator>(
-                               new SimpsonIntegral(absTolerance,
-                                                   maxEvaluations)));
+                           ext::make_shared<SimpsonIntegral>(absTolerance,
+                                                   maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::trapezoid(Real absTolerance,
                                         Size maxEvaluations) {
         return Integration(Trapezoid,
-                           ext::shared_ptr<Integrator>(
-                              new TrapezoidIntegral<Default>(absTolerance,
-                                                             maxEvaluations)));
+                           ext::make_shared<TrapezoidIntegral<Default>>(absTolerance,
+                                                             maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussLaguerre(Size intOrder) {
         QL_REQUIRE(intOrder <= 192, "maximum integraton order (192) exceeded");
         return Integration(GaussLaguerre,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussLaguerreIntegration(intOrder)));
+                           ext::make_shared<GaussLaguerreIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussLegendre(Size intOrder) {
         return Integration(GaussLegendre,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussLegendreIntegration(intOrder)));
+                           ext::make_shared<GaussLegendreIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussChebyshev(Size intOrder) {
         return Integration(GaussChebyshev,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussChebyshevIntegration(intOrder)));
+                           ext::make_shared<GaussChebyshevIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussChebyshev2nd(Size intOrder) {
         return Integration(GaussChebyshev2nd,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussChebyshev2ndIntegration(intOrder)));
+                           ext::make_shared<GaussChebyshev2ndIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::discreteSimpson(Size evaluations) {
         return Integration(
-            DiscreteSimpson, ext::shared_ptr<Integrator>(
-                new DiscreteSimpsonIntegrator(evaluations)));
+            DiscreteSimpson, ext::make_shared<DiscreteSimpsonIntegrator>(evaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::discreteTrapezoid(Size evaluations) {
         return Integration(
-            DiscreteTrapezoid, ext::shared_ptr<Integrator>(
-                new DiscreteTrapezoidIntegrator(evaluations)));
+            DiscreteTrapezoid, ext::make_shared<DiscreteTrapezoidIntegrator>(evaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::expSinh(Real relTolerance) {
         return Integration(
-            ExpSinh, ext::shared_ptr<Integrator>(
-                new ExpSinhIntegral(relTolerance)));
+            ExpSinh, ext::make_shared<ExpSinhIntegral>(relTolerance));
     }
 
     Size AnalyticHestonEngine::Integration::numberOfEvaluations() const {

--- a/ql/pricingengines/vanilla/binomialengine.hpp
+++ b/ql/pricingengines/vanilla/binomialengine.hpp
@@ -92,14 +92,11 @@ namespace QuantLib {
 
         // binomial trees with constant coefficient
         Handle<YieldTermStructure> flatRiskFree(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, r, rfdc)));
+            ext::make_shared<FlatForward>(referenceDate, r, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, q, divdc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
         Handle<BlackVolTermStructure> flatVol(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         ext::shared_ptr<PlainVanillaPayoff> payoff =
             ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
@@ -107,18 +104,16 @@ namespace QuantLib {
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(
-                         new GeneralizedBlackScholesProcess(
+        ext::shared_ptr<StochasticProcess1D> bs = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
-                                      flatDividends, flatRiskFree, flatVol));
+                                      flatDividends, flatRiskFree, flatVol);
 
         TimeGrid grid(maturity, timeSteps_);
 
-        ext::shared_ptr<T> tree(new T(bs, maturity, timeSteps_,
-                                        payoff->strike()));
+        ext::shared_ptr<T> tree = ext::make_shared<T>(bs, maturity, timeSteps_,
+                                        payoff->strike());
 
-        ext::shared_ptr<BlackScholesLattice<T> > lattice(
-            new BlackScholesLattice<T>(tree, r, maturity, timeSteps_));
+        ext::shared_ptr<BlackScholesLattice<T> > lattice = ext::make_shared<BlackScholesLattice<T>>(tree, r, maturity, timeSteps_);
 
         DiscretizedVanillaOption option(arguments_, *process_, grid);
 

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
@@ -69,9 +69,8 @@ namespace QuantLib {
         const ext::shared_ptr<BatesProcess> process =
                 ext::dynamic_pointer_cast<BatesProcess>(model_->process());
 
-        ext::shared_ptr<FdmBatesSolver> solver(
-            new FdmBatesSolver(Handle<BatesProcess>(process),
-                               solverDesc, schemeDesc_));
+        ext::shared_ptr<FdmBatesSolver> solver = ext::make_shared<FdmBatesSolver>(Handle<BatesProcess>(process),
+                               solverDesc, schemeDesc_);
 
         const Real v0   = process->v0();
         const Real spot = process->s0()->value();

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -70,24 +70,20 @@ namespace QuantLib {
         const Time maturity = bsProcess_->time(arguments_.exercise->lastDate());
 
         // The short rate mesher
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
-            new FdmSimpleProcess1dMesher(rGrid_, cirProcess_, maturity, tGrid_));
+        const ext::shared_ptr<Fdm1dMesher> shortRateMesher = ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, cirProcess_, maturity, tGrid_);
 
         // The equity mesher
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, bsProcess_, maturity, payoff->strike(),
                 Null<Real>(), Null<Real>(), 0.0001, 1.5,
                 std::pair<Real, Real>(payoff->strike(), 0.1),
                 dividends_, quantoHelper_,
-                0.0));
+                0.0);
         
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, shortRateMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, shortRateMesher);
 
         // Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                          new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -112,11 +108,11 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
 
-        ext::shared_ptr<FdmCIRSolver> solver(new FdmCIRSolver(
+        ext::shared_ptr<FdmCIRSolver> solver = ext::make_shared<FdmCIRSolver>(
                     Handle<CoxIngersollRossProcess>(cirProcess_),
                     Handle<GeneralizedBlackScholesProcess>(bsProcess_),
                     getSolverDesc(1.5), schemeDesc_,
-                    rho_, payoff->strike()));
+                    rho_, payoff->strike());
 
         const Real r0   = cirProcess_->x0();
         const Real spot = bsProcess_->x0();

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
@@ -73,7 +73,7 @@ namespace QuantLib {
       schemeDesc_(schemeDesc), controlVariate_(controlVariate) {}
 
     void FdHestonHullWhiteVanillaEngine::calculate() const {
-  
+
         // 1. cache lookup for precalculated results
         for (auto& cachedArgs2result : cachedArgs2results_) {
             if (cachedArgs2result.first.exercise->type() == arguments_.exercise->type() &&
@@ -100,9 +100,8 @@ namespace QuantLib {
 
         // 2.1 The variance mesher
         const Size tGridMin = 5;
-        const ext::shared_ptr<FdmHestonVarianceMesher> varianceMesher(
-            new FdmHestonVarianceMesher(vGrid_, hestonProcess,
-                                        maturity,std::max(tGridMin,tGrid_/50)));
+        const ext::shared_ptr<FdmHestonVarianceMesher> varianceMesher = ext::make_shared<FdmHestonVarianceMesher>(vGrid_, hestonProcess,
+                                        maturity,std::max(tGridMin,tGrid_/50));
 
         // 2.2 The equity mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -111,51 +110,45 @@ namespace QuantLib {
 
         ext::shared_ptr<Fdm1dMesher> equityMesher;
         if (strikes_.empty()) {
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMesher(
-                    xGrid_, 
+            equityMesher = ext::make_shared<FdmBlackScholesMesher>(
+                    xGrid_,
                     FdmBlackScholesMesher::processHelper(
-                      hestonProcess->s0(), hestonProcess->dividendYield(), 
-                      hestonProcess->riskFreeRate(), 
+                      hestonProcess->s0(), hestonProcess->dividendYield(),
+                      hestonProcess->riskFreeRate(),
                       varianceMesher->volaEstimate()),
                       maturity, payoff->strike(),
-                      Null<Real>(), Null<Real>(), 0.0001, 1.5, 
+                      Null<Real>(), Null<Real>(), 0.0001, 1.5,
                       std::pair<Real, Real>(payoff->strike(), 0.1),
-                      dividends_));
+                      dividends_);
         }
         else {
             QL_REQUIRE(dividends_.empty(),
                        "multiple strikes engine does not work with discrete dividends");
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMultiStrikeMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMultiStrikeMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
-                      hestonProcess->s0(), hestonProcess->dividendYield(), 
-                      hestonProcess->riskFreeRate(), 
+                      hestonProcess->s0(), hestonProcess->dividendYield(),
+                      hestonProcess->riskFreeRate(),
                       varianceMesher->volaEstimate()),
                     maturity, strikes_, 0.0001, 1.5,
-                    std::pair<Real, Real>(payoff->strike(), 0.075)));            
+                    std::pair<Real, Real>(payoff->strike(), 0.075));
         }
-       
-        //2.3 The short rate mesher        
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> ouProcess(
-            new OrnsteinUhlenbeckProcess(hwProcess_->a(),hwProcess_->sigma()));
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
-                   new FdmSimpleProcess1dMesher(rGrid_, ouProcess, maturity));
-        
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, varianceMesher,
-                                   shortRateMesher));
+
+        //2.3 The short rate mesher
+        const ext::shared_ptr<OrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<OrnsteinUhlenbeckProcess>(hwProcess_->a(),hwProcess_->sigma());
+        const ext::shared_ptr<Fdm1dMesher> shortRateMesher = ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, ouProcess, maturity);
+
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, varianceMesher,
+                                   shortRateMesher);
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                            new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // 4. Step conditions
-        const ext::shared_ptr<FdmStepConditionComposite> conditions = 
+        const ext::shared_ptr<FdmStepConditionComposite> conditions =
             FdmStepConditionComposite::vanillaComposite(
-                                dividends_, arguments_.exercise, 
-                                mesher, calculator, 
+                                dividends_, arguments_.exercise,
+                                mesher, calculator,
                                 hestonProcess->riskFreeRate()->referenceDate(),
                                 hestonProcess->riskFreeRate()->dayCounter());
 
@@ -167,11 +160,10 @@ namespace QuantLib {
                                            calculator, maturity,
                                            tGrid_, dampingSteps_ };
 
-        const ext::shared_ptr<FdmHestonHullWhiteSolver> solver(
-            new FdmHestonHullWhiteSolver(Handle<HestonProcess>(hestonProcess),
+        const ext::shared_ptr<FdmHestonHullWhiteSolver> solver = ext::make_shared<FdmHestonHullWhiteSolver>(Handle<HestonProcess>(hestonProcess),
                                          Handle<HullWhiteProcess>(hwProcess_),
                                          corrEquityShortRate_,
-                                         solverDesc, schemeDesc_));
+                                         solverDesc, schemeDesc_);
 
         const Real spot = hestonProcess->s0()->value();
         const Real v0   = hestonProcess->v0();
@@ -180,10 +172,10 @@ namespace QuantLib {
         results_.gamma = solver->gammaAt(spot, v0, 0, spot*0.01);
         results_.theta = solver->thetaAt(spot, v0, 0);
 
-        cachedArgs2results_.resize(strikes_.size());        
+        cachedArgs2results_.resize(strikes_.size());
         for (Size i=0; i < strikes_.size(); ++i) {
             cachedArgs2results_[i].first.exercise = arguments_.exercise;
-            cachedArgs2results_[i].first.payoff = 
+            cachedArgs2results_[i].first.payoff =
                 ext::make_shared<PlainVanillaPayoff>(
                     payoff->optionType(), strikes_[i]);
             const Real d = payoff->strike()/strikes_[i];
@@ -194,41 +186,37 @@ namespace QuantLib {
             results.gamma = solver->gammaAt(spot*d, v0, 0, spot*d*0.01)*d;
             results.theta = solver->thetaAt(spot*d, v0, 0)/d;
         }
-     
+
         if (controlVariate_) {
-            ext::shared_ptr<PricingEngine> analyticEngine(
-                                       new AnalyticHestonEngine(*model_, 164));
-            ext::shared_ptr<Exercise> exercise(
-                        new EuropeanExercise(arguments_.exercise->lastDate()));
-            
+            ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<AnalyticHestonEngine>(*model_, 164);
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(arguments_.exercise->lastDate());
+
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(analyticEngine);
             Real analyticNPV = option.NPV();
 
-            ext::shared_ptr<FdHestonVanillaEngine> fdEngine(
-                    new FdHestonVanillaEngine(*model_, tGrid_, xGrid_,
-                                              vGrid_, dampingSteps_, 
-                                              schemeDesc_));
+            ext::shared_ptr<FdHestonVanillaEngine> fdEngine = ext::make_shared<FdHestonVanillaEngine>(*model_, tGrid_, xGrid_,
+                                              vGrid_, dampingSteps_,
+                                              schemeDesc_);
             fdEngine->enableMultipleStrikesCaching(strikes_);
             option.setPricingEngine(fdEngine);
-            
+
             Real fdNPV = option.NPV();
             results_.value += analyticNPV - fdNPV;
             for (Size i=0; i < strikes_.size(); ++i) {
                 VanillaOption controlVariateOption(
-                    ext::shared_ptr<StrikedTypePayoff>(
-                        new PlainVanillaPayoff(payoff->optionType(), 
-                                               strikes_[i])), exercise);
+                    ext::make_shared<PlainVanillaPayoff>(payoff->optionType(),
+                                               strikes_[i]), exercise);
                 controlVariateOption.setPricingEngine(analyticEngine);
                 analyticNPV = controlVariateOption.NPV();
-                
+
                 controlVariateOption.setPricingEngine(fdEngine);
                 fdNPV = controlVariateOption.NPV();
                 cachedArgs2results_[i].second.value += analyticNPV - fdNPV;
             }
         }
     }
-    
+
     void FdHestonHullWhiteVanillaEngine::update() {
         cachedArgs2results_.clear();
         GenericModelEngine<HestonModel,

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -121,8 +121,7 @@ namespace QuantLib {
 
         ext::shared_ptr<Fdm1dMesher> equityMesher;
         if (strikes_.empty()) {
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
                         process->s0(), process->dividendYield(),
@@ -131,27 +130,24 @@ namespace QuantLib {
                     Null<Real>(), Null<Real>(), 0.0001, 2.0,
                     std::pair<Real, Real>(payoff->strike(), 0.1),
                     dividends_,
-                    quantoHelper_));
+                    quantoHelper_);
         }
         else {
             QL_REQUIRE(dividends_.empty(),
                        "multiple strikes engine does not work with discrete dividends");
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMultiStrikeMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMultiStrikeMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
                       process->s0(), process->dividendYield(),
                       process->riskFreeRate(), avgVolaEstimate),
                     maturity, strikes_, 0.0001, 1.5,
-                    std::pair<Real, Real>(payoff->strike(), 0.075)));
+                    std::pair<Real, Real>(payoff->strike(), 0.075));
         }
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                          new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -196,11 +192,11 @@ namespace QuantLib {
 
         const ext::shared_ptr<HestonProcess> process = model_->process();
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        ext::shared_ptr<FdmHestonSolver> solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process),
                     getSolverDesc(1.5), schemeDesc_,
                     Handle<FdmQuantoHelper>(quantoHelper_), leverageFct_,
-                    mixingFactor_));
+                    mixingFactor_);
 
         const Real v0   = process->v0();
         const Real spot = process->s0()->value();

--- a/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
+++ b/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
@@ -52,21 +52,17 @@ namespace QuantLib {
         QL_REQUIRE(payoff, "Strike type payoff expected");
             
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(xGrid_, process_,
-                                      maturity, payoff->strike()));
+        const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_,
+                                      maturity, payoff->strike());
         
-        const ext::shared_ptr<Fdm1dMesher> exerciseMesher(
-                 new Uniform1dMesher(
+        const ext::shared_ptr<Fdm1dMesher> exerciseMesher = ext::make_shared<Uniform1dMesher>(
                            0, static_cast<Real>(arguments_.maxExerciseRights),
-                           arguments_.maxExerciseRights+1));
+                           arguments_.maxExerciseRights+1);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, exerciseMesher));
+        const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher, exerciseMesher);
         
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                                    new FdmZeroInnerValue());
+        ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmZeroInnerValue>();
         
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -81,16 +77,13 @@ namespace QuantLib {
         }
         stoppingTimes.push_back(exerciseTimes);
         
-        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator(
-                                    new FdmLogInnerValue(payoff, mesher, 0));
+        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-            new FdmSimpleSwingCondition(
+        stepConditions.push_back(ext::make_shared<FdmSimpleSwingCondition>(
                 exerciseTimes, mesher, exerciseCalculator,
-                1, arguments_.minExerciseRights)));
+                1, arguments_.minExerciseRights));
         
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
         
         // 4. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -98,10 +91,9 @@ namespace QuantLib {
         // 5. Solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
-        ext::shared_ptr<FdmSimple2dBSSolver> solver(
-                new FdmSimple2dBSSolver(
+        ext::shared_ptr<FdmSimple2dBSSolver> solver = ext::make_shared<FdmSimple2dBSSolver>(
                                Handle<GeneralizedBlackScholesProcess>(process_),
-                               payoff->strike(), solverDesc, schemeDesc_));
+                               payoff->strike(), solverDesc, schemeDesc_);
     
         const Real spot = process_->x0();
 

--- a/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
+++ b/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
@@ -75,9 +75,8 @@ namespace QuantLib {
         RelinkableHandle<BlackVolTermStructure> volTS(
                                                 *process_->blackVolatility());
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-                 new GeneralizedBlackScholesProcess(stateVariable, dividendTS,
-                                                    riskFreeTS, volTS));
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess = ext::make_shared<GeneralizedBlackScholesProcess>(stateVariable, dividendTS,
+                                                    riskFreeTS, volTS);
 
         AnalyticEuropeanEngine baseEngine(bsProcess);
 
@@ -111,10 +110,8 @@ namespace QuantLib {
             v = std::sqrt((variance + i*jumpSquareVol)/t);
             r = riskFreeRate - process_->jumpIntensity()->value()*k
                 + i*muPlusHalfSquareVol/t;
-            riskFreeTS.linkTo(ext::shared_ptr<YieldTermStructure>(new
-                FlatForward(rateRefDate, r, voldc)));
-            volTS.linkTo(ext::shared_ptr<BlackVolTermStructure>(new
-                BlackConstantVol(rateRefDate, volcal, v, voldc)));
+            riskFreeTS.linkTo(ext::make_shared<FlatForward>(rateRefDate, r, voldc));
+            volTS.linkTo(ext::make_shared<BlackConstantVol>(rateRefDate, volcal, v, voldc));
 
             baseArguments->validate();
             baseEngine.calculate();

--- a/ql/pricingengines/vanilla/mcamericanengine.hpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.hpp
@@ -197,9 +197,8 @@ namespace QuantLib {
         QL_REQUIRE(!exercise->payoffAtExpiry(),
                    "payoff at expiry not handled");
 
-        ext::shared_ptr<AmericanPathPricer> earlyExercisePathPricer(
-            new AmericanPathPricer(this->arguments_.payoff,
-                                   polynomialOrder_, polynomialType_));
+        ext::shared_ptr<AmericanPathPricer> earlyExercisePathPricer = ext::make_shared<AmericanPathPricer>(this->arguments_.payoff,
+                                   polynomialOrder_, polynomialType_);
 
         return ext::make_shared<LongstaffSchwartzPathPricer<Path> > (
              
@@ -221,12 +220,10 @@ namespace QuantLib {
                                                               this->process_);
         QL_REQUIRE(process, "generalized Black-Scholes process required");
 
-        return ext::shared_ptr<PathPricer<Path> >(
-            new EuropeanPathPricer(
+        return ext::make_shared<EuropeanPathPricer>(
                 payoff->optionType(),
                 payoff->strike(),
-                process->riskFreeRate()->discount(this->timeGrid().back()))
-            );
+                process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
     template <class RNG, class S, class RNG_Calibration>
@@ -237,8 +234,7 @@ namespace QuantLib {
                                                               this->process_);
         QL_REQUIRE(process, "generalized Black-Scholes process required");
 
-        return ext::shared_ptr<PricingEngine>(
-                                         new AnalyticEuropeanEngine(process));
+        return ext::make_shared<AnalyticEuropeanEngine>(process);
     }
 
     template <class RNG, class S, class RNG_Calibration>
@@ -253,8 +249,7 @@ namespace QuantLib {
 
         auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
         *controlArguments = this->arguments_;
-        controlArguments->exercise = ext::shared_ptr<Exercise>(
-             new EuropeanExercise(this->arguments_.exercise->lastDate()));
+        controlArguments->exercise = ext::make_shared<EuropeanExercise>(this->arguments_.exercise->lastDate());
 
         controlPE->calculate();
 

--- a/ql/pricingengines/vanilla/mcdigitalengine.hpp
+++ b/ql/pricingengines/vanilla/mcdigitalengine.hpp
@@ -176,13 +176,11 @@ namespace QuantLib {
         PseudoRandom::ursg_type sequenceGen(grid.size()-1,
                                             PseudoRandom::urng_type(76));
 
-        return ext::shared_ptr<
-                        typename MCDigitalEngine<RNG,S>::path_pricer_type>(
-          new DigitalPathPricer(payoff,
+        return ext::make_shared<DigitalPathPricer>(payoff,
                                 exercise,
                                 process->riskFreeRate(),
                                 process,
-                                sequenceGen));
+                                sequenceGen);
     }
 
 

--- a/ql/pricingengines/vanilla/mceuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeanengine.hpp
@@ -144,12 +144,10 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                       typename MCEuropeanEngine<RNG,S>::path_pricer_type>(
-          new EuropeanPathPricer(
+        return ext::make_shared<EuropeanPathPricer>(
               payoff->optionType(),
               payoff->strike(),
-              process->riskFreeRate()->discount(this->timeGrid().back())));
+              process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
 

--- a/ql/pricingengines/vanilla/mceuropeangjrgarchengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeangjrgarchengine.hpp
@@ -119,13 +119,11 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<GJRGARCHProcess>(this->process_);
         QL_REQUIRE(process, "GJRGARCH process required");
 
-        return ext::shared_ptr<
-            typename MCEuropeanGJRGARCHEngine<RNG,S>::path_pricer_type>(
-                   new EuropeanGJRGARCHPathPricer(
+        return ext::make_shared<EuropeanGJRGARCHPathPricer>(
                                         payoff->optionType(),
                                         payoff->strike(),
                                         process->riskFreeRate()->discount(
-                                                   this->timeGrid().back())));
+                                                   this->timeGrid().back()));
     }
 
 

--- a/ql/pricingengines/vanilla/mceuropeanhestonengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeanhestonengine.hpp
@@ -122,13 +122,11 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<
-            typename MCEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                   new EuropeanHestonPathPricer(
+        return ext::make_shared<EuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         payoff->strike(),
                                         process->riskFreeRate()->discount(
-                                                   this->timeGrid().back())));
+                                                   this->timeGrid().back()));
     }
 
 

--- a/ql/pricingengines/vanilla/mchestonhullwhiteengine.hpp
+++ b/ql/pricingengines/vanilla/mchestonhullwhiteengine.hpp
@@ -146,10 +146,9 @@ namespace QuantLib {
 
         const Time exerciseTime = process_->time(exercise->lastDate());
 
-        return ext::shared_ptr<path_pricer_type>(
-             new HestonHullWhitePathPricer(exerciseTime,
+        return ext::make_shared<HestonHullWhitePathPricer>(exerciseTime,
                                            this->arguments_.payoff,
-                                           process_));
+                                           process_);
     }
 
     template <class RNG, class S> inline
@@ -170,11 +169,10 @@ namespace QuantLib {
 
         const Time exerciseTime = process_->time(exercise->lastDate());
 
-        return ext::shared_ptr<path_pricer_type>(
-             new HestonHullWhitePathPricer(
+        return ext::make_shared<HestonHullWhitePathPricer>(
                   exerciseTime,
                   this->arguments_.payoff,
-                  process_) );
+                  process_);
     }
 
     template <class RNG, class S> inline
@@ -187,15 +185,12 @@ namespace QuantLib {
         ext::shared_ptr<HullWhiteForwardProcess> hullWhiteProcess =
             process_->hullWhiteProcess();
 
-        ext::shared_ptr<HestonModel> hestonModel(
-                                              new HestonModel(hestonProcess));
-        ext::shared_ptr<HullWhite> hwModel(
-                              new HullWhite(hestonProcess->riskFreeRate(),
+        ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
+        ext::shared_ptr<HullWhite> hwModel = ext::make_shared<HullWhite>(hestonProcess->riskFreeRate(),
                                             hullWhiteProcess->a(),
-                                            hullWhiteProcess->sigma()));
+                                            hullWhiteProcess->sigma());
 
-        return ext::shared_ptr<PricingEngine>(
-                new AnalyticHestonHullWhiteEngine(hestonModel, hwModel, 144));
+        return ext::make_shared<AnalyticHestonHullWhiteEngine>(hestonModel, hwModel, 144);
     }
 
     template <class RNG, class S> inline
@@ -209,14 +204,12 @@ namespace QuantLib {
             RNG::make_sequence_generator(dimensions*(grid.size()-1),
                                          this->seed_);
 
-        ext::shared_ptr<HybridHestonHullWhiteProcess> cvProcess(
-            new HybridHestonHullWhiteProcess(process_->hestonProcess(),
+        ext::shared_ptr<HybridHestonHullWhiteProcess> cvProcess = ext::make_shared<HybridHestonHullWhiteProcess>(process_->hestonProcess(),
                                              process_->hullWhiteProcess(),
                                              0.0,
-                                             process_->discretization()));
+                                             process_->discretization());
 
-        return ext::shared_ptr<path_generator_type>(
-                  new path_generator_type(cvProcess, grid, generator, false));
+        return ext::make_shared<path_generator_type>(cvProcess, grid, generator, false);
     }
 
 

--- a/ql/pricingengines/vanilla/mcvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/mcvanillaengine.hpp
@@ -75,9 +75,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type generator =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                   new path_generator_type(process_, grid,
-                                           generator, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                           generator, brownianBridge_);
         }
         result_type controlVariateValue() const override;
         // data members

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -455,12 +455,14 @@ namespace QuantLib {
         const ext::shared_ptr<DqFpEquation> eqn
             = (fpEquation_ == FP_A
                || (fpEquation_ == Auto && std::abs(r-q) < 0.001))?
-              ext::shared_ptr<DqFpEquation>(new DqFpEquation_A(
-                  K, r, q, vol, B,
-                  iterationScheme_->getFixedPointIntegrator()))
-            : ext::shared_ptr<DqFpEquation>(new DqFpEquation_B(
-                    K, r, q, vol, B,
-                    iterationScheme_->getFixedPointIntegrator()));
+              ext::shared_ptr<DqFpEquation>(
+                  ext::make_shared<DqFpEquation_A>(
+                      K, r, q, vol, B,
+                      iterationScheme_->getFixedPointIntegrator()))
+            : ext::shared_ptr<DqFpEquation>(
+                  ext::make_shared<DqFpEquation_B>(
+                      K, r, q, vol, B,
+                      iterationScheme_->getFixedPointIntegrator()));
 
         Array y(x.size());
         y[0] = 0.0;
@@ -516,7 +518,6 @@ namespace QuantLib {
     }
 
 }
-
 
 
 

--- a/ql/processes/blackscholesprocess.cpp
+++ b/ql/processes/blackscholesprocess.cpp
@@ -235,8 +235,7 @@ namespace QuantLib {
     : GeneralizedBlackScholesProcess(
              x0,
              // no dividend yield
-             Handle<YieldTermStructure>(ext::shared_ptr<YieldTermStructure>(
-                  new FlatForward(0, NullCalendar(), 0.0, Actual365Fixed()))),
+             Handle<YieldTermStructure>(ext::make_shared<FlatForward>(0, NullCalendar(), 0.0, Actual365Fixed())),
              riskFreeTS,
              blackVolTS,
              d,forceDiscretization) {}

--- a/ql/processes/blackscholesprocess.hpp
+++ b/ql/processes/blackscholesprocess.hpp
@@ -58,7 +58,7 @@ namespace QuantLib {
                                        Handle<YieldTermStructure> riskFreeTS,
                                        Handle<BlackVolTermStructure> blackVolTS,
                                        const ext::shared_ptr<discretization>& d =
-                                           ext::shared_ptr<discretization>(new EulerDiscretization),
+                                           ext::make_shared<EulerDiscretization>(),
                                        bool forceDiscretization = false);
 
         GeneralizedBlackScholesProcess(Handle<Quote> x0,
@@ -127,7 +127,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& riskFreeTS,
             const Handle<BlackVolTermStructure>& blackVolTS,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization),
+                ext::make_shared<EulerDiscretization>(),
             bool forceDiscretization = false);
     };
 
@@ -149,7 +149,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& riskFreeTS,
             const Handle<BlackVolTermStructure>& blackVolTS,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization),
+                ext::make_shared<EulerDiscretization>(),
             bool forceDiscretization = false);
     };
 
@@ -172,7 +172,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& riskFreeTS,
             const Handle<BlackVolTermStructure>& blackVolTS,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization),
+                ext::make_shared<EulerDiscretization>(),
             bool forceDiscretization = false);
     };
 
@@ -197,7 +197,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& domesticRiskFreeTS,
             const Handle<BlackVolTermStructure>& blackVolTS,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization),
+                ext::make_shared<EulerDiscretization>(),
             bool forceDiscretization = false);
     };
 

--- a/ql/processes/geometricbrownianprocess.cpp
+++ b/ql/processes/geometricbrownianprocess.cpp
@@ -28,8 +28,7 @@ namespace QuantLib {
                                                           Real initialValue,
                                                           Real mue,
                                                           Real sigma)
-    : StochasticProcess1D(ext::shared_ptr<discretization>(
-                                                    new EulerDiscretization)),
+    : StochasticProcess1D(ext::make_shared<EulerDiscretization>()),
       initialValue_(initialValue), mue_(mue), sigma_(sigma) {}
 
     Real GeometricBrownianMotionProcess::x0() const {

--- a/ql/processes/gjrgarchprocess.cpp
+++ b/ql/processes/gjrgarchprocess.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
                                      Real lambda,
                                      Real daysPerYear,
                                      Discretization d)
-    : StochasticProcess(ext::shared_ptr<discretization>(new EulerDiscretization)),
+    : StochasticProcess(ext::make_shared<EulerDiscretization>()),
       riskFreeRate_(std::move(riskFreeRate)), dividendYield_(std::move(dividendYield)),
       s0_(std::move(s0)), v0_(v0), omega_(omega), alpha_(alpha), beta_(beta), gamma_(gamma),
       lambda_(lambda), daysPerYear_(daysPerYear), discretization_(d) {

--- a/ql/processes/hestonprocess.cpp
+++ b/ql/processes/hestonprocess.cpp
@@ -43,7 +43,7 @@ namespace QuantLib {
                                  Real sigma,
                                  Real rho,
                                  Discretization d)
-    : StochasticProcess(ext::shared_ptr<discretization>(new EulerDiscretization)),
+    : StochasticProcess(ext::make_shared<EulerDiscretization>()),
       riskFreeRate_(std::move(riskFreeRate)), dividendYield_(std::move(dividendYield)),
       s0_(std::move(s0)), v0_(v0), kappa_(kappa), theta_(theta), sigma_(sigma), rho_(rho),
       discretization_(d) {

--- a/ql/processes/merton76process.hpp
+++ b/ql/processes/merton76process.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
                         Handle<Quote> logJMean,
                         Handle<Quote> logJVol,
                         const ext::shared_ptr<discretization>& d =
-                            ext::shared_ptr<discretization>(new EulerDiscretization));
+                            ext::make_shared<EulerDiscretization>());
         //! \name StochasticProcess1D interface
         //@{
         Real x0() const override;

--- a/ql/processes/squarerootprocess.hpp
+++ b/ql/processes/squarerootprocess.hpp
@@ -44,7 +44,7 @@ namespace QuantLib {
         SquareRootProcess(
             Real b, Real a, Volatility sigma, Real x0 = 0.0,
             const ext::shared_ptr<discretization>& d =
-                  ext::shared_ptr<discretization>(new EulerDiscretization));
+                  ext::make_shared<EulerDiscretization>());
         //! \name StochasticProcess interface
         //@{
         Real x0() const override;

--- a/ql/termstructures/credit/flathazardrate.cpp
+++ b/ql/termstructures/credit/flathazardrate.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                                    Rate hazardRate,
                                    const DayCounter& dayCounter)
     : HazardRateStructure(referenceDate, Calendar(), dayCounter),
-      hazardRate_(ext::shared_ptr<Quote>(new SimpleQuote(hazardRate))) {}
+      hazardRate_(ext::make_shared<SimpleQuote>(hazardRate)) {}
 
     FlatHazardRate::FlatHazardRate(Natural settlementDays,
                                    const Calendar& calendar,
@@ -52,6 +52,6 @@ namespace QuantLib {
                                    Rate hazardRate,
                                    const DayCounter& dayCounter)
     : HazardRateStructure(settlementDays, calendar, dayCounter),
-      hazardRate_(ext::shared_ptr<Quote>(new SimpleQuote(hazardRate))) {}
+      hazardRate_(ext::make_shared<SimpleQuote>(hazardRate)) {}
 
 }

--- a/ql/termstructures/volatility/abcdcalibration.cpp
+++ b/ql/termstructures/volatility/abcdcalibration.cpp
@@ -84,8 +84,7 @@ namespace QuantLib {
             Real xtol = 1.0e-8;
             Real gtol = 1.0e-8;
             bool useCostFunctionsJacobian = false;
-            optMethod_ = ext::shared_ptr<OptimizationMethod>(new
-                LevenbergMarquardt(epsfcn, xtol, gtol, useCostFunctionsJacobian));
+            optMethod_ = ext::make_shared<LevenbergMarquardt>(epsfcn, xtol, gtol, useCostFunctionsJacobian);
         }
         if (!endCriteria_) {
             Size maxIterations = 10000;
@@ -122,8 +121,7 @@ namespace QuantLib {
         } else {
 
             AbcdError costFunction(this);
-            transformation_ = ext::shared_ptr<ParametersTransformation>(new
-                AbcdParametersTransformation);
+            transformation_ = ext::make_shared<AbcdParametersTransformation>();
 
             Array guess(4);
             guess[0] = a_;

--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
@@ -91,8 +91,7 @@ namespace QuantLib {
         initializeOptionDatesAndTimes();
         // fill dummy handles to allow generic handle-based computations later
         for (Size i=0; i<nOptionTenors_; ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(vols_[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i]));
         interpolate();
     }
 
@@ -116,8 +115,7 @@ namespace QuantLib {
         initializeOptionDatesAndTimes();
         // fill dummy handles to allow generic handle-based computations later
         for (Size i=0; i<nOptionTenors_; ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(vols_[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i]));
         interpolate();
     }
 

--- a/ql/termstructures/volatility/capfloor/capfloortermvolsurface.cpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolsurface.cpp
@@ -114,8 +114,7 @@ namespace QuantLib {
         for (Size i=0; i<nOptionTenors_; ++i) {
             volHandles_[i].resize(nStrikes_);
             for (Size j=0; j<nStrikes_; ++j)
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols_[i][j])));
+                volHandles_[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i][j]));
         }
         interpolate();
     }
@@ -145,8 +144,7 @@ namespace QuantLib {
         for (Size i=0; i<nOptionTenors_; ++i) {
             volHandles_[i].resize(nStrikes_);
             for (Size j=0; j<nStrikes_; ++j)
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols_[i][j])));
+                volHandles_[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i][j]));
         }
         interpolate();
     }

--- a/ql/termstructures/volatility/capfloor/constantcapfloortermvol.cpp
+++ b/ql/termstructures/volatility/capfloor/constantcapfloortermvol.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
                                                     Volatility vol,
                                                     const DayCounter& dc)
     : CapFloorTermVolatilityStructure(settlementDays, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))) {}
+      volatility_(ext::make_shared<SimpleQuote>(vol)) {}
 
     // fixed reference date, fixed market data
     ConstantCapFloorTermVolatility::ConstantCapFloorTermVolatility(
@@ -61,7 +61,7 @@ namespace QuantLib {
                                                     Volatility vol,
                                                     const DayCounter& dc)
     : CapFloorTermVolatilityStructure(referenceDate, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))) {}
+      volatility_(ext::make_shared<SimpleQuote>(vol)) {}
 
     Volatility ConstantCapFloorTermVolatility::volatilityImpl(Time,
                                                               Rate) const {

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
@@ -72,7 +72,7 @@ namespace QuantLib {
             Real minStrike = Null<Real>(),
             Real maxStrike = Null<Real>(),
             ext::shared_ptr<OptimizationMethod> optimizationMethod =
-                ext::shared_ptr<OptimizationMethod>(new LevenbergMarquardt),
+                ext::make_shared<LevenbergMarquardt>(),
             const EndCriteria& endCriteria = EndCriteria(500, 100, 1e-12, 1e-10, 1e-10));
 
         Date maxDate() const;

--- a/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
@@ -83,7 +83,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               const DayCounter& dc)
     : BlackVolatilityTermStructure(referenceDate, cal, Following, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))) {}
+      volatility_(ext::make_shared<SimpleQuote>(volatility)) {}
 
     inline BlackConstantVol::BlackConstantVol(const Date& referenceDate,
                                               const Calendar& cal,
@@ -99,7 +99,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               const DayCounter& dc)
     : BlackVolatilityTermStructure(settlementDays, cal, Following, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))) {}
+      volatility_(ext::make_shared<SimpleQuote>(volatility)) {}
 
     inline BlackConstantVol::BlackConstantVol(Natural settlementDays,
                                               const Calendar& cal,

--- a/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/gridmodellocalvolsurface.cpp
@@ -83,8 +83,7 @@ namespace QuantLib {
     }
 
     void GridModelLocalVolSurface::generateArguments() {
-        const ext::shared_ptr<Matrix> localVolMatrix(
-            new Matrix(strikes_.front()->size(), times_.size()));
+        const ext::shared_ptr<Matrix> localVolMatrix = ext::make_shared<Matrix>(strikes_.front()->size(), times_.size());
 
         std::transform(arguments_.begin(), arguments_.end(),
                        localVolMatrix->begin(),

--- a/ql/termstructures/volatility/equityfx/localconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/localconstantvol.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               DayCounter dayCounter)
     : LocalVolTermStructure(referenceDate),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)) {}
 
     inline LocalConstantVol::LocalConstantVol(const Date& referenceDate,
@@ -93,7 +93,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               DayCounter dayCounter)
     : LocalVolTermStructure(settlementDays, calendar),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)) {}
 
     inline LocalConstantVol::LocalConstantVol(Natural settlementDays,

--- a/ql/termstructures/volatility/equityfx/localvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
                                      Real underlying)
     : LocalVolTermStructure(blackTS->businessDayConvention(), blackTS->dayCounter()),
       blackTS_(blackTS), riskFreeTS_(std::move(riskFreeTS)), dividendTS_(std::move(dividendTS)),
-      underlying_(ext::shared_ptr<Quote>(new SimpleQuote(underlying))) {
+      underlying_(ext::make_shared<SimpleQuote>(underlying)) {
         registerWith(blackTS_);
         registerWith(riskFreeTS_);
         registerWith(dividendTS_);

--- a/ql/termstructures/volatility/interpolatedsmilesection.hpp
+++ b/ql/termstructures/volatility/interpolatedsmilesection.hpp
@@ -145,10 +145,9 @@ namespace QuantLib {
         // fill dummy handles to allow generic handle-based
         // computations later on
         for (Size i=0; i<stdDevs.size(); ++i)
-            stdDevHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(stdDevs[i])));
+            stdDevHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(stdDevs[i]));
         atmLevel_ = Handle<Quote>
-           (ext::shared_ptr<Quote>(new SimpleQuote(atmLevel)));
+           (ext::make_shared<SimpleQuote>(atmLevel));
         
         checkStrikes();
         interpolation_ = interpolator.interpolate(strikes_.begin(),
@@ -203,10 +202,9 @@ namespace QuantLib {
         //fill dummy handles to allow generic handle-based
         // computations later on
         for (Size i=0; i<stdDevs.size(); ++i)
-            stdDevHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(stdDevs[i])));
+            stdDevHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(stdDevs[i]));
         atmLevel_ = Handle<Quote>
-           (ext::shared_ptr<Quote>(new SimpleQuote(atmLevel)));
+           (ext::make_shared<SimpleQuote>(atmLevel));
         
         checkStrikes();
         interpolation_ = interpolator.interpolate(strikes_.begin(),

--- a/ql/termstructures/volatility/kahalesmilesection.cpp
+++ b/ql/termstructures/volatility/kahalesmilesection.cpp
@@ -99,8 +99,7 @@ namespace QuantLib {
                                      QL_KAHALE_SMAX); // numerical parameters
                                                       // hardcoded here
                 sh1(s);
-                ext::shared_ptr<cFunction> cFct1(
-                    new cFunction(sh1.f_, s, 0.0, sh1.b_));
+                ext::shared_ptr<cFunction> cFct1 = ext::make_shared<cFunction>(sh1.f_, s, 0.0, sh1.b_);
                 cFunctions_[0] = cFct1;
                 // sanity check - in rare cases we can get digitials
                 // which are not monotonic or greater than 1.0
@@ -166,8 +165,7 @@ namespace QuantLib {
                 }
                 if (valid) {
                     ah(a);
-                    ext::shared_ptr<cFunction> cFct(
-                        new cFunction(ah.f_, ah.s_, a, ah.b_));
+                    ext::shared_ptr<cFunction> cFct = ext::make_shared<cFunction>(ah.f_, ah.s_, a, ah.b_);
                     cFunctions_[leftIndex_ > 0 ? i - leftIndex_ + 1 : 0] = cFct;
                     cp0 = cp1;
                 }

--- a/ql/termstructures/volatility/optionlet/constantoptionletvol.cpp
+++ b/ql/termstructures/volatility/optionlet/constantoptionletvol.cpp
@@ -58,7 +58,7 @@ namespace QuantLib {
         Volatility vol, const DayCounter &dc, VolatilityType type,
         Real displacement)
         : OptionletVolatilityStructure(settlementDays, cal, bdc, dc),
-          volatility_(ext::shared_ptr< Quote >(new SimpleQuote(vol))),
+          volatility_(ext::make_shared<SimpleQuote>(vol)),
           type_(type), displacement_(displacement) {}
 
     // fixed reference date, fixed market data
@@ -67,21 +67,19 @@ namespace QuantLib {
         BusinessDayConvention bdc, Volatility vol, const DayCounter &dc,
         VolatilityType type, Real displacement)
         : OptionletVolatilityStructure(referenceDate, cal, bdc, dc),
-          volatility_(ext::shared_ptr< Quote >(new SimpleQuote(vol))),
+          volatility_(ext::make_shared<SimpleQuote>(vol)),
           type_(type), displacement_(displacement) {}
 
     ext::shared_ptr<SmileSection>
     ConstantOptionletVolatility::smileSectionImpl(const Date& d) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(new
-            FlatSmileSection(d, atmVol, dayCounter(), referenceDate()));
+        return ext::make_shared<FlatSmileSection>(d, atmVol, dayCounter(), referenceDate());
     }
 
     ext::shared_ptr<SmileSection>
     ConstantOptionletVolatility::smileSectionImpl(Time optionTime) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(new
-            FlatSmileSection(optionTime, atmVol, dayCounter()));
+        return ext::make_shared<FlatSmileSection>(optionTime, atmVol, dayCounter());
     }
 
     Volatility ConstantOptionletVolatility::volatilityImpl(Time,

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -63,10 +63,9 @@ namespace QuantLib {
         // update dates
         const Date& referenceDate = termVolSurface_->referenceDate();
         const DayCounter& dc = termVolSurface_->dayCounter();
-        ext::shared_ptr<BlackCapFloorEngine> dummy(new
-                    BlackCapFloorEngine(// discounting does not matter here
+        ext::shared_ptr<BlackCapFloorEngine> dummy = ext::make_shared<BlackCapFloorEngine>(// discounting does not matter here
                                         iborIndex_->forwardingTermStructure(),
-                                        0.20, dc));
+                                        0.20, dc);
         for (Size i=0; i<nOptionletTenors_; ++i) {
             CapFloor temp = MakeCapFloor(CapFloor::Cap,
                                          capFloorLengths_[i],
@@ -100,7 +99,7 @@ namespace QuantLib {
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
 
         ext::shared_ptr<PricingEngine> capFloorEngine;
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         if (volatilityType_ == ShiftedLognormal) {
             capFloorEngine = ext::make_shared<BlackCapFloorEngine>(

--- a/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
@@ -76,9 +76,8 @@ namespace QuantLib {
         for (Size j=0; j<nOptionExpiries_; ++j) {
             Volatility atmOptionVol = atmCapFloorTermVolCurve_->volatility(
                 optionExpiriesTimes[j], 33.3333); // dummy strike
-            ext::shared_ptr<BlackCapFloorEngine> engine(new
-                    BlackCapFloorEngine(iborIndex_->forwardingTermStructure(),
-                                        atmOptionVol, dc_));
+            ext::shared_ptr<BlackCapFloorEngine> engine = ext::make_shared<BlackCapFloorEngine>(iborIndex_->forwardingTermStructure(),
+                                        atmOptionVol, dc_);
             caps_[j] = MakeCapFloor(CapFloor::Cap,
                                     optionExpiriesTenors[j],
                                     iborIndex_,
@@ -159,22 +158,19 @@ namespace QuantLib {
         ext::shared_ptr<CapFloor> cap,
         Real targetValue)
     : cap_(std::move(cap)), targetValue_(targetValue) {
-        ext::shared_ptr<OptionletVolatilityStructure> adapter(new
-            StrippedOptionletAdapter(optionletStripper1));
+        ext::shared_ptr<OptionletVolatilityStructure> adapter = ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
         adapter->enableExtrapolation();
 
         // set an implausible value, so that calculation is forced
         // at first operator()(Volatility x) call
         spreadQuote_ = ext::make_shared<SimpleQuote>(-1.0);
 
-        ext::shared_ptr<OptionletVolatilityStructure> spreadedAdapter(new
-            SpreadedOptionletVolatility(Handle<OptionletVolatilityStructure>(
-                adapter), Handle<Quote>(spreadQuote_)));
+        ext::shared_ptr<OptionletVolatilityStructure> spreadedAdapter = ext::make_shared<SpreadedOptionletVolatility>(Handle<OptionletVolatilityStructure>(
+                adapter), Handle<Quote>(spreadQuote_));
 
-        ext::shared_ptr<BlackCapFloorEngine> engine(new
-            BlackCapFloorEngine(
+        ext::shared_ptr<BlackCapFloorEngine> engine = ext::make_shared<BlackCapFloorEngine>(
                 optionletStripper1->iborIndex()->forwardingTermStructure(),
-                Handle<OptionletVolatilityStructure>(spreadedAdapter)));
+                Handle<OptionletVolatilityStructure>(spreadedAdapter));
 
         cap_->setPricingEngine(engine);
     }

--- a/ql/termstructures/volatility/optionlet/spreadedoptionletvol.cpp
+++ b/ql/termstructures/volatility/optionlet/spreadedoptionletvol.cpp
@@ -37,16 +37,14 @@ namespace QuantLib {
     SpreadedOptionletVolatility::smileSectionImpl(const Date& d) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(d, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     ext::shared_ptr<SmileSection>
     SpreadedOptionletVolatility::smileSectionImpl(Time optionTime) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(optionTime, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     Volatility SpreadedOptionletVolatility::volatilityImpl(Time t,

--- a/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
+++ b/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
@@ -73,9 +73,8 @@ namespace QuantLib {
 
         const std::vector<Time>& optionletTimes =
                                     optionletStripper_->optionletFixingTimes();
-        ext::shared_ptr<LinearInterpolation> timeInterpolator(new
-            LinearInterpolation(optionletTimes.begin(), optionletTimes.end(),
-                                vol.begin()));
+        ext::shared_ptr<LinearInterpolation> timeInterpolator = ext::make_shared<LinearInterpolation>(optionletTimes.begin(), optionletTimes.end(),
+                                vol.begin());
         return (*timeInterpolator)(length, true);
     }
 

--- a/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
+++ b/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
@@ -81,8 +81,8 @@ namespace QuantLib {
         const DayCounter& dc,
         const Real shift)
     : SmileSection(optionDate, dc, Date(), ShiftedLognormal, shift),
-      forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-      atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+      forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+      atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
       volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
       hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), alpha_(alpha), beta_(beta),
       nu_(nu), rho_(rho), isAlphaFixed_(isAlphaFixed), isBetaFixed_(isBetaFixed),
@@ -91,16 +91,16 @@ namespace QuantLib {
       evaluationDate_(Settings::instance().evaluationDate()) {
 
         for (Size i = 0; i < volHandles_.size(); ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(volHandles[i]));
     }
 
     void SabrInterpolatedSmileSection::createInterpolation() const {
-         ext::shared_ptr<SABRInterpolation> tmp(new SABRInterpolation(
+         ext::shared_ptr<SABRInterpolation> tmp = ext::make_shared<SABRInterpolation>(
                      actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
                      exerciseTime(), forwardValue_,
                      alpha_, beta_, nu_, rho_,
                      isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, vegaWeighted_,
-                     endCriteria_, method_, 0.0020, false, 50, shift()));
+                     endCriteria_, method_, 0.0020, false, 50, shift());
          swap(tmp, sabrInterpolation_);
     }
 

--- a/ql/termstructures/volatility/swaption/interpolatedswaptionvolatilitycube.cpp
+++ b/ql/termstructures/volatility/swaption/interpolatedswaptionvolatilitycube.cpp
@@ -102,14 +102,13 @@ namespace QuantLib {
                 atmVol + volSpreadsInterpolator_[i](length, optionTime)));
         }
         Real shift = atmVol_->shift(optionTime,length);
-        return ext::shared_ptr<SmileSection>(new
-            InterpolatedSmileSection<Linear>(optionTime,
+        return ext::make_shared<InterpolatedSmileSection<Linear>>(optionTime,
                                              strikes,
                                              stdDevs,
                                              atmForward,
                                              Linear(),
                                              Actual365Fixed(),
                                              volatilityType(),
-                                             shift));
+                                             shift);
     }
 }

--- a/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
+++ b/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
@@ -1027,8 +1027,7 @@ namespace QuantLib {
                         optionTimes_.begin(), optionTimes_.end(),
                         swapLengths_.begin(), swapLengths_.end(),
                         transposedPoints_[k]);
-            interpolators_.push_back(ext::shared_ptr<Interpolation2D>(
-                new FlatExtrapolator2D(interpolation)));
+            interpolators_.push_back(ext::make_shared<FlatExtrapolator2D>(interpolation));
             interpolators_[k]->enableExtrapolation();
         }
         setPoints(points);
@@ -1053,8 +1052,7 @@ namespace QuantLib {
                         optionTimes_.begin(), optionTimes_.end(),
                         swapLengths_.begin(), swapLengths_.end(),
                         transposedPoints_[k]);
-            interpolators_.push_back(ext::shared_ptr<Interpolation2D>(
-                new FlatExtrapolator2D(interpolation)));
+            interpolators_.push_back(ext::make_shared<FlatExtrapolator2D>(interpolation));
             interpolators_[k]->enableExtrapolation();
         }
         setPoints(o.points_);
@@ -1084,8 +1082,7 @@ namespace QuantLib {
                         optionTimes_.begin(), optionTimes_.end(),
                         swapLengths_.begin(), swapLengths_.end(),
                         transposedPoints_[k]);
-            interpolators_.push_back(ext::shared_ptr<Interpolation2D>(
-                new FlatExtrapolator2D(interpolation)));
+            interpolators_.push_back(ext::make_shared<FlatExtrapolator2D>(interpolation));
             interpolators_[k]->enableExtrapolation();
         }
         setPoints(o.points_);
@@ -1236,8 +1233,7 @@ namespace QuantLib {
                         optionTimes_.begin(), optionTimes_.end(),
                         swapLengths_.begin(), swapLengths_.end(),
                         transposedPoints_[k]);
-            interpolators_[k] = ext::shared_ptr<Interpolation2D>(
-                new FlatExtrapolator2D(interpolation));
+            interpolators_[k] = ext::make_shared<FlatExtrapolator2D>(interpolation);
             interpolators_[k]->enableExtrapolation();
         }
     }

--- a/ql/termstructures/volatility/swaption/spreadedswaptionvol.cpp
+++ b/ql/termstructures/volatility/swaption/spreadedswaptionvol.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
                                                  const Period& swapT) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(d, swapT, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     ext::shared_ptr<SmileSection>
@@ -48,8 +47,7 @@ namespace QuantLib {
                                                  Time swapLength) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(optionTime, swapLength, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     Volatility SpreadedSwaptionVolatility::volatilityImpl(const Date& d,

--- a/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
                                                     const VolatilityType type,
                                                     const Real shift)
     : SwaptionVolatilityStructure(settlementDays, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))),
+      volatility_(ext::make_shared<SimpleQuote>(vol)),
       maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     // fixed reference date, fixed market data
@@ -75,25 +75,23 @@ namespace QuantLib {
                                                     const VolatilityType type,
                                                     const Real shift)
     : SwaptionVolatilityStructure(referenceDate, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))),
+      volatility_(ext::make_shared<SimpleQuote>(vol)),
       maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     ext::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(const Date& d,
                                                  const Period&) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-            new FlatSmileSection(d, atmVol, dayCounter(), referenceDate(),
-                                 Null<Rate>(), volatilityType_, shift_));
+        return ext::make_shared<FlatSmileSection>(d, atmVol, dayCounter(), referenceDate(),
+                                 Null<Rate>(), volatilityType_, shift_);
     }
 
     ext::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                  Time) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-            new FlatSmileSection(optionTime, atmVol, dayCounter(), Null<Rate>(),
-                                 volatilityType_, shift_));
+        return ext::make_shared<FlatSmileSection>(optionTime, atmVol, dayCounter(), Null<Rate>(),
+                                 volatilityType_, shift_);
     }
 
     Volatility ConstantSwaptionVolatility::volatilityImpl(const Date&,

--- a/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
@@ -131,8 +131,7 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -180,8 +179,7 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -229,8 +227,7 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -321,9 +318,9 @@ namespace QuantLib {
                                                Time swapLength) const {
         // dummy strike
         Volatility atmVol = volatilityImpl(optionTime, swapLength, 0.05);
-        return ext::shared_ptr<SmileSection>(new FlatSmileSection(
+        return ext::make_shared<FlatSmileSection>(
             optionTime, atmVol, dayCounter(), Null<Real>(), volatilityType(),
-            shift(optionTime, swapLength, true)));
+            shift(optionTime, swapLength, true));
     }
 
 }

--- a/ql/termstructures/volatility/zabr.cpp
+++ b/ql/termstructures/volatility/zabr.cpp
@@ -138,26 +138,24 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
 
     // Layout
     std::vector<Size> dim(1, size);
-    const ext::shared_ptr<FdmLinearOpLayout> layout(
-        new FdmLinearOpLayout(dim));
+    const ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
 
 #if defined(__GNUC__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic pop
 #endif
 
     // Mesher
-    const ext::shared_ptr<Fdm1dMesher> m1(new Concentrating1dMesher(
-        start, end, size, std::pair<Real, Real>(forward_, density), true));
+    const ext::shared_ptr<Fdm1dMesher> m1 = ext::make_shared<Concentrating1dMesher>(
+        start, end, size, std::pair<Real, Real>(forward_, density), true);
     // const ext::shared_ptr<Fdm1dMesher> m1(new
     // Uniform1dMesher(start,end,size));
     // const ext::shared_ptr<Fdm1dMesher> m1a(new
     // Uniform1dMesher(start,0.03,101));
     // const ext::shared_ptr<Fdm1dMesher> m1b(new
     // Uniform1dMesher(0.03,end,100));
-    // const ext::shared_ptr<Fdm1dMesher> m1(new Glued1dMesher(*m1a,*m1b));
+    // const ext::shared_ptr<Fdm1dMesher> m1 = ext::make_shared<Glued1dMesher>(*m1a,*m1b);
     const std::vector<ext::shared_ptr<Fdm1dMesher> > meshers(1, m1);
-    const ext::shared_ptr<FdmMesher> mesher(
-        new FdmMesherComposite(layout, meshers));
+    const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(layout, meshers);
 
     // Boundary conditions
     FdmBoundaryConditionSet boundaries;
@@ -178,17 +176,17 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
     std::copy(locVolv.begin(), locVolv.end(), locVol.begin());
 
     // solver
-    ext::shared_ptr<FdmDupire1dOp> map(new FdmDupire1dOp(mesher, locVol));
+    ext::shared_ptr<FdmDupire1dOp> map = ext::make_shared<FdmDupire1dOp>(mesher, locVol);
     FdmBackwardSolver solver(map, boundaries,
                              ext::shared_ptr<FdmStepConditionComposite>(),
                              FdmSchemeDesc::Douglas());
     solver.rollback(rhs, expiryTime_, 0.0, steps, dampingSteps);
 
     // interpolate solution
-    ext::shared_ptr<Interpolation> solution(new CubicInterpolation(
+    ext::shared_ptr<Interpolation> solution = ext::make_shared<CubicInterpolation>(
         k.begin(), k.end(), rhs.begin(), CubicInterpolation::Spline, true,
         CubicInterpolation::SecondDerivative, 0.0,
-        CubicInterpolation::SecondDerivative, 0.0));
+        CubicInterpolation::SecondDerivative, 0.0);
     // ext::shared_ptr<Interpolation> solution(new
     // LinearInterpolation(k.begin(),k.end(),rhs.begin()));
     solution->disableExtrapolation();
@@ -232,8 +230,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     std::vector<Size> dim;
     dim.push_back(sizef);
     dim.push_back(sizev);
-    const ext::shared_ptr<FdmLinearOpLayout> layout(
-        new FdmLinearOpLayout(dim));
+    const ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
 
     // Mesher
     // two concentrating mesher around f and k to get the mesher for f
@@ -243,21 +240,19 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
         4, (Size)std::ceil(((x0 + x1) / 2.0 - f0) / (f1 - f0) * (Real)sizef));
     const Size sizefb = sizef - sizefa + 1; // common point, so we can spend
     // one more here
-    const ext::shared_ptr<Fdm1dMesher> mfa(
-        new Concentrating1dMesher(f0, (x0 + x1) / 2.0, sizefa,
-                                  std::pair<Real, Real>(x0, densityf), true));
-    const ext::shared_ptr<Fdm1dMesher> mfb(
-        new Concentrating1dMesher((x0 + x1) / 2.0, f1, sizefb,
-                                  std::pair<Real, Real>(x1, densityf), true));
-    const ext::shared_ptr<Fdm1dMesher> mf(new Glued1dMesher(*mfa, *mfb));
+    const ext::shared_ptr<Fdm1dMesher> mfa = ext::make_shared<Concentrating1dMesher>(f0, (x0 + x1) / 2.0, sizefa,
+                                  std::pair<Real, Real>(x0, densityf), true);
+    const ext::shared_ptr<Fdm1dMesher> mfb = ext::make_shared<Concentrating1dMesher>((x0 + x1) / 2.0, f1, sizefb,
+                                  std::pair<Real, Real>(x1, densityf), true);
+    const ext::shared_ptr<Fdm1dMesher> mf = ext::make_shared<Glued1dMesher>(*mfa, *mfb);
 
     // concentraing mesher around f to get the forward mesher
-    // const ext::shared_ptr<Fdm1dMesher> mf(new Concentrating1dMesher(
-    //     f0, f1, sizef, std::pair<Real, Real>(forward_, densityf), true));
+    // const ext::shared_ptr<Fdm1dMesher> mf = ext::make_shared<Concentrating1dMesher>(
+    //     f0, f1, sizef, std::pair<Real, Real>(forward_, densityf), true);
 
     // Volatility mesher
-    const ext::shared_ptr<Fdm1dMesher> mv(new Concentrating1dMesher(
-        v0, v1, sizev, std::pair<Real, Real>(alpha_, densityv), true));
+    const ext::shared_ptr<Fdm1dMesher> mv = ext::make_shared<Concentrating1dMesher>(
+        v0, v1, sizev, std::pair<Real, Real>(alpha_, densityv), true);
 
     // uniform meshers
     // const ext::shared_ptr<Fdm1dMesher> mf(new
@@ -268,8 +263,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     std::vector<ext::shared_ptr<Fdm1dMesher> > meshers;
     meshers.push_back(mf);
     meshers.push_back(mv);
-    const ext::shared_ptr<FdmMesher> mesher(
-        new FdmMesherComposite(layout, meshers));
+    const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(layout, meshers);
 
     // initial values
     Array rhs(mesher->layout()->size());
@@ -288,8 +282,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     // Boundary conditions
     FdmBoundaryConditionSet boundaries;
 
-    ext::shared_ptr<FdmZabrOp> map(
-        new FdmZabrOp(mesher, beta_, nu_, rho_, gamma_));
+    ext::shared_ptr<FdmZabrOp> map = ext::make_shared<FdmZabrOp>(mesher, beta_, nu_, rho_, gamma_);
     FdmBackwardSolver solver(map, boundaries,
                              ext::shared_ptr<FdmStepConditionComposite>(),
                              FdmSchemeDesc::/*CraigSneyd()*/ Hundsdorfer());

--- a/ql/termstructures/volatility/zabr.cpp
+++ b/ql/termstructures/volatility/zabr.cpp
@@ -153,7 +153,7 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
     // Uniform1dMesher(start,0.03,101));
     // const ext::shared_ptr<Fdm1dMesher> m1b(new
     // Uniform1dMesher(0.03,end,100));
-    // const ext::shared_ptr<Fdm1dMesher> m1 = ext::make_shared<Glued1dMesher>(*m1a,*m1b);
+    // const ext::shared_ptr<Fdm1dMesher> m1(new Glued1dMesher(*m1a,*m1b));
     const std::vector<ext::shared_ptr<Fdm1dMesher> > meshers(1, m1);
     const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(layout, meshers);
 
@@ -247,7 +247,7 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
     const ext::shared_ptr<Fdm1dMesher> mf = ext::make_shared<Glued1dMesher>(*mfa, *mfb);
 
     // concentraing mesher around f to get the forward mesher
-    // const ext::shared_ptr<Fdm1dMesher> mf = ext::make_shared<Concentrating1dMesher>(
+    // const ext::shared_ptr<Fdm1dMesher> mf(new Concentrating1dMesher(
     //     f0, f1, sizef, std::pair<Real, Real>(forward_, densityf), true);
 
     // Volatility mesher

--- a/ql/termstructures/volatility/zabrinterpolatedsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrinterpolatedsmilesection.hpp
@@ -274,8 +274,8 @@ ZabrInterpolatedSmileSection<Evaluation>::ZabrInterpolatedSmileSection(
     ext::shared_ptr<OptimizationMethod> method,
     const DayCounter& dc)
 : SmileSection(optionDate, dc),
-  forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-  atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+  forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+  atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
   volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
   hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), alpha_(alpha), beta_(beta),
   nu_(nu), rho_(rho), gamma_(gamma), isAlphaFixed_(isAlphaFixed), isBetaFixed_(isBetaFixed),
@@ -284,17 +284,16 @@ ZabrInterpolatedSmileSection<Evaluation>::ZabrInterpolatedSmileSection(
 
     for (Size i = 0; i < volHandles_.size(); ++i)
         volHandles_[i] = Handle<Quote>(
-            ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+            ext::make_shared<SimpleQuote>(volHandles[i]));
 }
 
 template <typename Evaluation>
 void ZabrInterpolatedSmileSection<Evaluation>::createInterpolation() const {
-    ext::shared_ptr<ZabrInterpolation<Evaluation> > tmp(
-        new ZabrInterpolation<Evaluation>(
+    ext::shared_ptr<ZabrInterpolation<Evaluation> > tmp = ext::make_shared<ZabrInterpolation<Evaluation>>(
             actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
             exerciseTime(), forwardValue_, alpha_, beta_, nu_, rho_, gamma_,
             isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, isGammaFixed_,
-            vegaWeighted_, endCriteria_, method_));
+            vegaWeighted_, endCriteria_, method_);
     swap(tmp, zabrInterpolation_);
 }
 

--- a/ql/termstructures/volatility/zabrsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrsmilesection.hpp
@@ -236,7 +236,7 @@ void ZabrSmileSection<Evaluation>::init3(ZabrLocalVolatility) {
         CubicInterpolation::Spline, true, CubicInterpolation::SecondDerivative,
         0.0, CubicInterpolation::SecondDerivative, 0.0);
     // callPriceFct_ =
-    //     ext::make_shared<LinearInterpolation>(
+    //     ext::shared_ptr<Interpolation>(new LinearInterpolation(
     //         strikes_.begin(), strikes_.end(), callPrices_.begin());
 
     callPriceFct_->enableExtrapolation();

--- a/ql/termstructures/volatility/zabrsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrsmilesection.hpp
@@ -231,13 +231,13 @@ void ZabrSmileSection<Evaluation>::init3(ZabrLocalVolatility) {
     strikes_.insert(strikes_.begin(), 0.0);
     callPrices_.insert(callPrices_.begin(), forward_);
 
-    callPriceFct_ = ext::shared_ptr<Interpolation>(new CubicInterpolation(
+    callPriceFct_ = ext::make_shared<CubicInterpolation>(
         strikes_.begin(), strikes_.end(), callPrices_.begin(),
         CubicInterpolation::Spline, true, CubicInterpolation::SecondDerivative,
-        0.0, CubicInterpolation::SecondDerivative, 0.0));
+        0.0, CubicInterpolation::SecondDerivative, 0.0);
     // callPriceFct_ =
-    //     ext::shared_ptr<Interpolation>(new LinearInterpolation(
-    //         strikes_.begin(), strikes_.end(), callPrices_.begin()));
+    //     ext::make_shared<LinearInterpolation>(
+    //         strikes_.begin(), strikes_.end(), callPrices_.begin());
 
     callPriceFct_->enableExtrapolation();
 

--- a/ql/termstructures/yield/bondhelpers.cpp
+++ b/ql/termstructures/yield/bondhelpers.cpp
@@ -160,11 +160,11 @@ namespace QuantLib {
                             const Bond::Price::Type priceType)
     : BondHelper(price,
                  // make_shared and deprecation interfere; restore later
-                 ext::shared_ptr<Bond>(new CPIBond(settlementDays, faceAmount, growthOnly, baseCPI,
+                 ext::make_shared<CPIBond>(settlementDays, faceAmount, growthOnly, baseCPI,
                                            observationLag, cpiIndex, observationInterpolation,
                                            std::move(schedule), fixedRate, accrualDayCounter, paymentConvention,
                                            issueDate, paymentCalendar, exCouponPeriod, exCouponCalendar,
-                                           exCouponConvention, exCouponEndOfMonth)),
+                                           exCouponConvention, exCouponEndOfMonth),
                  priceType) {}
 
     QL_DEPRECATED_ENABLE_WARNING

--- a/ql/termstructures/yield/flatforward.cpp
+++ b/ql/termstructures/yield/flatforward.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
                              Compounding compounding,
                              Frequency frequency)
     : YieldTermStructure(referenceDate, Calendar(), dayCounter),
-      forward_(ext::shared_ptr<Quote>(new SimpleQuote(forward))),
+      forward_(ext::make_shared<SimpleQuote>(forward)),
       compounding_(compounding), frequency_(frequency) {}
 
     FlatForward::FlatForward(Natural settlementDays,
@@ -61,7 +61,7 @@ namespace QuantLib {
                              Compounding compounding,
                              Frequency frequency)
     : YieldTermStructure(settlementDays, calendar, dayCounter),
-      forward_(ext::shared_ptr<Quote>(new SimpleQuote(forward))),
+      forward_(ext::make_shared<SimpleQuote>(forward)),
       compounding_(compounding), frequency_(frequency) {}
 
 }

--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -675,7 +675,7 @@ namespace QuantLib {
         Date maturity = earliestDate_ + tenor_;
 
         // dummy BMA index with curve/swap arguments
-        ext::shared_ptr<BMAIndex> clonedIndex(new BMAIndex(termStructureHandle_));
+        ext::shared_ptr<BMAIndex> clonedIndex = ext::make_shared<BMAIndex>(termStructureHandle_);
 
         Schedule bmaSchedule =
             MakeSchedule().from(earliestDate_).to(maturity)
@@ -701,8 +701,7 @@ namespace QuantLib {
                                           bmaSchedule,
                                           clonedIndex,
                                           bmaDayCount_);
-        swap_->setPricingEngine(ext::shared_ptr<PricingEngine>(new
-            DiscountingSwapEngine(iborIndex_->forwardingTermStructure())));
+        swap_->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(iborIndex_->forwardingTermStructure()));
 
         Date d = calendar_.adjust(swap_->maturityDate(), Following);
         Weekday w = d.weekday();

--- a/ql/time/calendars/argentina.cpp
+++ b/ql/time/calendars/argentina.cpp
@@ -23,8 +23,7 @@ namespace QuantLib {
 
     Argentina::Argentina(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(
-                                                   new Argentina::MervalImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Argentina::MervalImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/australia.cpp
+++ b/ql/time/calendars/australia.cpp
@@ -23,10 +23,8 @@ namespace QuantLib {
 
     Australia::Australia(Australia::Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                            new Australia::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> asxImpl(
-                                            new Australia::AsxImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Australia::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> asxImpl = ext::make_shared<Australia::AsxImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/austria.cpp
+++ b/ql/time/calendars/austria.cpp
@@ -25,10 +25,8 @@ namespace QuantLib {
     Austria::Austria(Austria::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                   new Austria::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                                   new Austria::ExchangeImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Austria::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<Austria::ExchangeImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/botswana.cpp
+++ b/ql/time/calendars/botswana.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     Botswana::Botswana() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Botswana::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Botswana::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/brazil.cpp
+++ b/ql/time/calendars/brazil.cpp
@@ -26,10 +26,8 @@ namespace QuantLib {
     Brazil::Brazil(Brazil::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                  new Brazil::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                                    new Brazil::ExchangeImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Brazil::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<Brazil::ExchangeImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/canada.cpp
+++ b/ql/time/calendars/canada.cpp
@@ -25,9 +25,8 @@ namespace QuantLib {
 
     Canada::Canada(Canada::Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                  new Canada::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> tsxImpl(new Canada::TsxImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Canada::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> tsxImpl = ext::make_shared<Canada::TsxImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/chile.cpp
+++ b/ql/time/calendars/chile.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
     Chile::Chile(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Chile::SseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Chile::SseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/china.cpp
+++ b/ql/time/calendars/china.cpp
@@ -26,8 +26,8 @@ namespace QuantLib {
 
     China::China(Market m) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> sseImpl(new China::SseImpl);
-        static ext::shared_ptr<Calendar::Impl> IBImpl(new China::IbImpl);
+        static ext::shared_ptr<Calendar::Impl> sseImpl = ext::make_shared<China::SseImpl>();
+        static ext::shared_ptr<Calendar::Impl> IBImpl = ext::make_shared<China::IbImpl>();
         switch (m) {
           case SSE:
             impl_ = sseImpl;

--- a/ql/time/calendars/croatia.cpp
+++ b/ql/time/calendars/croatia.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Croatia::Croatia(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Croatia::ZseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Croatia::ZseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/czechrepublic.cpp
+++ b/ql/time/calendars/czechrepublic.cpp
@@ -23,8 +23,7 @@ namespace QuantLib {
 
     CzechRepublic::CzechRepublic(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(
-                                                  new CzechRepublic::PseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<CzechRepublic::PseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/denmark.cpp
+++ b/ql/time/calendars/denmark.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     Denmark::Denmark() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Denmark::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Denmark::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/finland.cpp
+++ b/ql/time/calendars/finland.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Finland::Finland() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Finland::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Finland::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/france.cpp
+++ b/ql/time/calendars/france.cpp
@@ -25,10 +25,8 @@ namespace QuantLib {
     France::France(France::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                   new France::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                                   new France::ExchangeImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<France::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<France::ExchangeImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/germany.cpp
+++ b/ql/time/calendars/germany.cpp
@@ -25,16 +25,11 @@ namespace QuantLib {
     Germany::Germany(Germany::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-            new Germany::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> frankfurtStockExchangeImpl(
-            new Germany::FrankfurtStockExchangeImpl);
-        static ext::shared_ptr<Calendar::Impl> xetraImpl(
-            new Germany::XetraImpl);
-        static ext::shared_ptr<Calendar::Impl> eurexImpl(
-            new Germany::EurexImpl);
-        static ext::shared_ptr<Calendar::Impl> euwaxImpl(
-            new Germany::EuwaxImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Germany::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> frankfurtStockExchangeImpl = ext::make_shared<Germany::FrankfurtStockExchangeImpl>();
+        static ext::shared_ptr<Calendar::Impl> xetraImpl = ext::make_shared<Germany::XetraImpl>();
+        static ext::shared_ptr<Calendar::Impl> eurexImpl = ext::make_shared<Germany::EurexImpl>();
+        static ext::shared_ptr<Calendar::Impl> euwaxImpl = ext::make_shared<Germany::EuwaxImpl>();
 
         switch (market) {
           case Settlement:

--- a/ql/time/calendars/hongkong.cpp
+++ b/ql/time/calendars/hongkong.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     HongKong::HongKong(Market m) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new HongKong::HkexImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<HongKong::HkexImpl>();
         switch (m) {
           case HKEx:
             impl_ = impl;

--- a/ql/time/calendars/hungary.cpp
+++ b/ql/time/calendars/hungary.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Hungary::Hungary() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Hungary::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Hungary::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/iceland.cpp
+++ b/ql/time/calendars/iceland.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Iceland::Iceland(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Iceland::IcexImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Iceland::IcexImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/india.cpp
+++ b/ql/time/calendars/india.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     India::India(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new India::NseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<India::NseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/indonesia.cpp
+++ b/ql/time/calendars/indonesia.cpp
@@ -24,8 +24,7 @@ namespace QuantLib {
 
     Indonesia::Indonesia(Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> bejImpl(
-                                                      new Indonesia::BejImpl);
+        static ext::shared_ptr<Calendar::Impl> bejImpl = ext::make_shared<Indonesia::BejImpl>();
         switch (market) {
           case BEJ:
           case JSX:

--- a/ql/time/calendars/italy.cpp
+++ b/ql/time/calendars/italy.cpp
@@ -25,10 +25,8 @@ namespace QuantLib {
     Italy::Italy(Italy::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                   new Italy::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                                   new Italy::ExchangeImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Italy::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<Italy::ExchangeImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/japan.cpp
+++ b/ql/time/calendars/japan.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     Japan::Japan() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Japan::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Japan::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/jointcalendar.cpp
+++ b/ql/time/calendars/jointcalendar.cpp
@@ -124,16 +124,14 @@ namespace QuantLib {
     JointCalendar::JointCalendar(const Calendar& c1,
                                  const Calendar& c2,
                                  JointCalendarRule r) {
-        impl_ = ext::shared_ptr<Calendar::Impl>(
-                                            new JointCalendar::Impl(c1,c2,r));
+        impl_ = ext::make_shared<JointCalendar::Impl>(c1,c2,r);
     }
 
     JointCalendar::JointCalendar(const Calendar& c1,
                                  const Calendar& c2,
                                  const Calendar& c3,
                                  JointCalendarRule r) {
-        impl_ = ext::shared_ptr<Calendar::Impl>(
-                                         new JointCalendar::Impl(c1,c2,c3,r));
+        impl_ = ext::make_shared<JointCalendar::Impl>(c1,c2,c3,r);
     }
 
     JointCalendar::JointCalendar(const Calendar& c1,
@@ -141,14 +139,12 @@ namespace QuantLib {
                                  const Calendar& c3,
                                  const Calendar& c4,
                                  JointCalendarRule r) {
-        impl_ = ext::shared_ptr<Calendar::Impl>(
-                                      new JointCalendar::Impl(c1,c2,c3,c4,r));
+        impl_ = ext::make_shared<JointCalendar::Impl>(c1,c2,c3,c4,r);
     }
 
     JointCalendar::JointCalendar(const std::vector<Calendar> &cv,
                                  JointCalendarRule r) {
-        impl_ = ext::shared_ptr<Calendar::Impl>(
-                                      new JointCalendar::Impl(cv,r));
+        impl_ = ext::make_shared<JointCalendar::Impl>(cv,r);
     }
 
 }

--- a/ql/time/calendars/malta.cpp
+++ b/ql/time/calendars/malta.cpp
@@ -23,7 +23,7 @@
 namespace QuantLib {
 
     Malta::Malta(Market) {
-        static ext::shared_ptr<Calendar::Impl> impl(new Malta::MseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Malta::MseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/mexico.cpp
+++ b/ql/time/calendars/mexico.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     Mexico::Mexico(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Mexico::BmvImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Mexico::BmvImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/montenegro.cpp
+++ b/ql/time/calendars/montenegro.cpp
@@ -22,7 +22,7 @@
 namespace QuantLib {
 
     Montenegro::Montenegro(Market) {
-        static ext::shared_ptr<Calendar::Impl> impl(new Montenegro::MnseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Montenegro::MnseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/northmacedonia.cpp
+++ b/ql/time/calendars/northmacedonia.cpp
@@ -23,7 +23,7 @@
 namespace QuantLib {
 
     NorthMacedonia::NorthMacedonia(Market) {
-        static ext::shared_ptr<Calendar::Impl> impl(new NorthMacedonia::MseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<NorthMacedonia::MseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/norway.cpp
+++ b/ql/time/calendars/norway.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Norway::Norway() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Norway::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Norway::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/nullcalendar.hpp
+++ b/ql/time/calendars/nullcalendar.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         };
       public:
         NullCalendar() {
-            impl_ = ext::shared_ptr<Calendar::Impl>(new NullCalendar::Impl);
+            impl_ = ext::make_shared<NullCalendar::Impl>();
         }
     };
 

--- a/ql/time/calendars/russia.cpp
+++ b/ql/time/calendars/russia.cpp
@@ -25,10 +25,8 @@ namespace QuantLib {
 
     Russia::Russia(Russia::Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                                  new Russia::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                                    new Russia::ExchangeImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<Russia::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<Russia::ExchangeImpl>();
 
         switch (market) {
           case Settlement:

--- a/ql/time/calendars/saudiarabia.cpp
+++ b/ql/time/calendars/saudiarabia.cpp
@@ -128,8 +128,7 @@ namespace QuantLib {
 
     SaudiArabia::SaudiArabia(Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> tadawulImpl(
-                                                new SaudiArabia::TadawulImpl);
+        static ext::shared_ptr<Calendar::Impl> tadawulImpl = ext::make_shared<SaudiArabia::TadawulImpl>();
         switch (market) {
           case Tadawul:
             impl_ = tadawulImpl;

--- a/ql/time/calendars/serbia.cpp
+++ b/ql/time/calendars/serbia.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Serbia::Serbia(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Serbia::BseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Serbia::BseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/singapore.cpp
+++ b/ql/time/calendars/singapore.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     Singapore::Singapore(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Singapore::SgxImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Singapore::SgxImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/slovakia.cpp
+++ b/ql/time/calendars/slovakia.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Slovakia::Slovakia(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Slovakia::BsseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Slovakia::BsseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/slovenia.cpp
+++ b/ql/time/calendars/slovenia.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Slovenia::Slovenia(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Slovenia::LseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Slovenia::LseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/southafrica.cpp
+++ b/ql/time/calendars/southafrica.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     SouthAfrica::SouthAfrica() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new SouthAfrica::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<SouthAfrica::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/southkorea.cpp
+++ b/ql/time/calendars/southkorea.cpp
@@ -30,10 +30,8 @@ namespace QuantLib {
 
     SouthKorea::SouthKorea(Market market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                              new SouthKorea::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> krxImpl(
-                                                     new SouthKorea::KrxImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<SouthKorea::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> krxImpl = ext::make_shared<SouthKorea::KrxImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/sweden.cpp
+++ b/ql/time/calendars/sweden.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Sweden::Sweden() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Sweden::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Sweden::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/switzerland.cpp
+++ b/ql/time/calendars/switzerland.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Switzerland::Switzerland() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Switzerland::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Switzerland::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/taiwan.cpp
+++ b/ql/time/calendars/taiwan.cpp
@@ -25,7 +25,7 @@ namespace QuantLib {
 
     Taiwan::Taiwan(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Taiwan::TsecImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Taiwan::TsecImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/target.cpp
+++ b/ql/time/calendars/target.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     TARGET::TARGET() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new TARGET::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<TARGET::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -24,7 +24,7 @@ namespace QuantLib {
 
     Thailand::Thailand() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Thailand::SetImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Thailand::SetImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/turkey.cpp
+++ b/ql/time/calendars/turkey.cpp
@@ -26,7 +26,7 @@ namespace QuantLib {
 
     Turkey::Turkey() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Turkey::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Turkey::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/ukraine.cpp
+++ b/ql/time/calendars/ukraine.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     Ukraine::Ukraine(Market) {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new Ukraine::UseImpl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Ukraine::UseImpl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/unitedkingdom.cpp
+++ b/ql/time/calendars/unitedkingdom.cpp
@@ -56,12 +56,9 @@ namespace QuantLib {
     UnitedKingdom::UnitedKingdom(UnitedKingdom::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
-        static ext::shared_ptr<Calendar::Impl> settlementImpl(
-                                           new UnitedKingdom::SettlementImpl);
-        static ext::shared_ptr<Calendar::Impl> exchangeImpl(
-                                           new UnitedKingdom::ExchangeImpl);
-        static ext::shared_ptr<Calendar::Impl> metalsImpl(
-                                           new UnitedKingdom::MetalsImpl);
+        static ext::shared_ptr<Calendar::Impl> settlementImpl = ext::make_shared<UnitedKingdom::SettlementImpl>();
+        static ext::shared_ptr<Calendar::Impl> exchangeImpl = ext::make_shared<UnitedKingdom::ExchangeImpl>();
+        static ext::shared_ptr<Calendar::Impl> metalsImpl = ext::make_shared<UnitedKingdom::MetalsImpl>();
         switch (market) {
           case Settlement:
             impl_ = settlementImpl;

--- a/ql/time/calendars/uzbekistan.cpp
+++ b/ql/time/calendars/uzbekistan.cpp
@@ -24,7 +24,7 @@
 namespace QuantLib {
 
     Uzbekistan::Uzbekistan(Market) {
-        static ext::shared_ptr<Calendar::Impl> impl(new Uzbekistan::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<Uzbekistan::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/calendars/weekendsonly.cpp
+++ b/ql/time/calendars/weekendsonly.cpp
@@ -23,7 +23,7 @@ namespace QuantLib {
 
     WeekendsOnly::WeekendsOnly() {
         // all calendar instances share the same implementation instance
-        static ext::shared_ptr<Calendar::Impl> impl(new WeekendsOnly::Impl);
+        static ext::shared_ptr<Calendar::Impl> impl = ext::make_shared<WeekendsOnly::Impl>();
         impl_ = impl;
     }
 

--- a/ql/time/daycounters/actual360.hpp
+++ b/ql/time/daycounters/actual360.hpp
@@ -58,8 +58,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual360(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual360::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual360::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actual364.hpp
+++ b/ql/time/daycounters/actual364.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         };
       public:
         Actual364()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Actual364::Impl)) {}
+        : DayCounter(ext::make_shared<Actual364::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/actual36525.hpp
+++ b/ql/time/daycounters/actual36525.hpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual36525(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual36525::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual36525::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actual365fixed.cpp
+++ b/ql/time/daycounters/actual365fixed.cpp
@@ -27,11 +27,11 @@ namespace QuantLib {
     Actual365Fixed::implementation(Actual365Fixed::Convention c) {
         switch (c) {
           case Standard:
-            return ext::shared_ptr<DayCounter::Impl>(new Impl);
+            return ext::make_shared<Impl>();
           case Canadian:
-            return ext::shared_ptr<DayCounter::Impl>(new CA_Impl);
+            return ext::make_shared<CA_Impl>();
           case NoLeap:
-            return ext::shared_ptr<DayCounter::Impl>(new NL_Impl);
+            return ext::make_shared<NL_Impl>();
           default:
             QL_FAIL("unknown Actual/365 (Fixed) convention");
         }

--- a/ql/time/daycounters/actual366.hpp
+++ b/ql/time/daycounters/actual366.hpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual366(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual366::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual366::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -118,16 +118,16 @@ namespace QuantLib {
           case ISMA:
           case Bond:
             if (!schedule.empty())
-                return ext::shared_ptr<DayCounter::Impl>(new ISMA_Impl(std::move(schedule)));
+                return ext::make_shared<ISMA_Impl>(std::move(schedule));
             else
-                return ext::shared_ptr<DayCounter::Impl>(new Old_ISMA_Impl);
+                return ext::make_shared<Old_ISMA_Impl>();
           case ISDA:
           case Historical:
           case Actual365:
-            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl);
+            return ext::make_shared<ISDA_Impl>();
           case AFB:
           case Euro:
-            return ext::shared_ptr<DayCounter::Impl>(new AFB_Impl);
+            return ext::make_shared<AFB_Impl>();
           default:
             QL_FAIL("unknown act/act convention");
         }

--- a/ql/time/daycounters/business252.hpp
+++ b/ql/time/daycounters/business252.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         };
       public:
         Business252(const Calendar& c = Brazil())
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Business252::Impl(c))) {}
+        : DayCounter(ext::make_shared<Business252::Impl>(c)) {}
     };
 
 }

--- a/ql/time/daycounters/one.hpp
+++ b/ql/time/daycounters/one.hpp
@@ -46,8 +46,7 @@ namespace QuantLib {
         };
       public:
         OneDayCounter()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-                                        new OneDayCounter::Impl)) {}
+        : DayCounter(ext::make_shared<OneDayCounter::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/simpledaycounter.hpp
+++ b/ql/time/daycounters/simpledaycounter.hpp
@@ -54,8 +54,7 @@ namespace QuantLib {
         };
       public:
         SimpleDayCounter()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-                                             new SimpleDayCounter::Impl())) {}
+        : DayCounter(ext::make_shared<SimpleDayCounter::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -35,20 +35,20 @@ namespace QuantLib {
     Thirty360::implementation(Thirty360::Convention c, const Date& terminationDate) {
         switch (c) {
           case USA:
-            return ext::shared_ptr<DayCounter::Impl>(new US_Impl);
+            return ext::make_shared<US_Impl>();
           case European:
           case EurobondBasis:
-            return ext::shared_ptr<DayCounter::Impl>(new EU_Impl);
+            return ext::make_shared<EU_Impl>();
           case Italian:
-            return ext::shared_ptr<DayCounter::Impl>(new IT_Impl);
+            return ext::make_shared<IT_Impl>();
           case ISMA:
           case BondBasis:
-            return ext::shared_ptr<DayCounter::Impl>(new ISMA_Impl);
+            return ext::make_shared<ISMA_Impl>();
           case ISDA:
           case German:
-            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl(terminationDate));
+            return ext::make_shared<ISDA_Impl>(terminationDate);
           case NASD:
-            return ext::shared_ptr<DayCounter::Impl>(new NASD_Impl);
+            return ext::make_shared<NASD_Impl>();
           default:
             QL_FAIL("unknown 30/360 convention");
         }

--- a/ql/time/daycounters/thirty365.cpp
+++ b/ql/time/daycounters/thirty365.cpp
@@ -36,6 +36,6 @@ namespace QuantLib {
     }
 
     Thirty365::Thirty365()
-    : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Thirty365::Impl)) {}
+    : DayCounter(ext::make_shared<Thirty365::Impl>()) {}
 
 }

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -138,36 +138,33 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyValues) {
 
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Real tolerance = 3.0e-3;
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(
-                                         new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                      new BaroneAdesiWhaleyApproximationEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -206,35 +203,33 @@ BOOST_AUTO_TEST_CASE(testBjerksundStenslandValues) {
 
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Real tolerance = 5.0e-5;
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                     new BjerksundStenslandApproximationEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -328,37 +323,33 @@ BOOST_AUTO_TEST_CASE(testJuValues) {
 
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Real tolerance = 1.0e-3;
 
     for (auto& juValue : juValues) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(juValue.type, juValue.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(juValue.type, juValue.strike);
         Date exDate = today + timeToDays(juValue.t);
-        ext::shared_ptr<Exercise> exercise(
-                                         new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(juValue.s);
         qRate->setValue(juValue.q);
         rRate->setValue(juValue.r);
         vol->setValue(juValue.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                            new JuQuadraticApproximationEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<JuQuadraticApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -378,12 +369,12 @@ BOOST_AUTO_TEST_CASE(testFdValues) {
 
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Real tolerance = 8.0e-2;
@@ -403,12 +394,10 @@ BOOST_AUTO_TEST_CASE(testFdValues) {
 
     for (auto& juValue : juValues) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(juValue.type, juValue.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(juValue.type, juValue.strike);
 
         Date exDate = today + timeToDays(juValue.t);
-        ext::shared_ptr<Exercise> exercise(
-                                         new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(juValue.s);
         qRate->setValue(juValue.q);
@@ -465,12 +454,12 @@ void testFdGreeks() {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     ext::shared_ptr<StrikedTypePayoff> payoff;
@@ -479,12 +468,11 @@ void testFdGreeks() {
         for (Real strike : strikes) {
             for (int year : years) {
                 Date exDate = today + year * Years;
-                ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-                ext::shared_ptr<PricingEngine> engine(new Engine(stochProcess, 50));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<Engine>(stochProcess, 50);
 
                 VanillaOption option(payoff, exercise);
                 option.setPricingEngine(engine);
@@ -735,7 +723,7 @@ BOOST_AUTO_TEST_CASE(testEscrowedVsSpotAmericanOption) {
     const auto today = Date(27, February, 2021);
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.3));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.3);
 
     const auto process = ext::make_shared<BlackScholesMertonProcess>(
         Handle<Quote>(ext::make_shared<SimpleQuote>(100)),
@@ -806,7 +794,7 @@ BOOST_AUTO_TEST_CASE(testTodayIsDividendDate) {
     const auto today = Date(27, February, 2021);
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.3));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.3);
 
     const auto process = ext::make_shared<BlackScholesMertonProcess>(
         Handle<Quote>(ext::make_shared<SimpleQuote>(100)),

--- a/test-suite/asianoptions.cpp
+++ b/test-suite/asianoptions.cpp
@@ -159,22 +159,20 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePrice) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(80.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(-0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(80.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(-0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
+                                  Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engine(new
-            AnalyticContinuousGeometricAveragePriceAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianEngine>(stochProcess);
 
     Average::Type averageType = Average::Geometric;
     Option::Type type = Option::Put;
@@ -184,10 +182,9 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePrice) {
     Size pastFixings = Null<Size>();
     Real runningAccumulator = Null<Real>();
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     ContinuousAveragingAsianOption option(averageType, payoff, exercise);
     option.setPricingEngine(engine);
@@ -209,8 +206,7 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePrice) {
     for (Size i=0; i<fixingDates.size(); i++) {
         fixingDates[i] = today + i;
     }
-    ext::shared_ptr<PricingEngine> engine2(new
-              AnalyticDiscreteGeometricAveragePriceAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine2 = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(stochProcess);
     DiscreteAveragingAsianOption option2(averageType,
                                          runningAccumulator, pastFixings,
                                          fixingDates,
@@ -254,28 +250,25 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceGreeks) {
     Date today = Settings::instance().evaluationDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-         new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
 
-                ext::shared_ptr<EuropeanExercise> maturity(
-                    new EuropeanExercise(today + length * Years));
+                ext::shared_ptr<EuropeanExercise> maturity = ext::make_shared<EuropeanExercise>(today + length * Years);
 
-                ext::shared_ptr<PlainVanillaPayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-                ext::shared_ptr<PricingEngine> engine(
-                    new AnalyticContinuousGeometricAveragePriceAsianEngine(process));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianEngine>(process);
 
                 ContinuousAveragingAsianOption option(Average::Geometric, payoff, maturity);
                 option.setPricingEngine(engine);
@@ -383,22 +376,20 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePrice) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
+                                  Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engine(
-          new AnalyticDiscreteGeometricAveragePriceAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(stochProcess);
 
     Average::Type averageType = Average::Geometric;
     Real runningAccumulator = 1.0;
@@ -406,11 +397,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePrice) {
     Size futureFixings = 10;
     Option::Type type = Option::Call;
     Real strike = 100.0;
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
     Date exerciseDate = today + 360;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     std::vector<Date> fixingDates(futureFixings);
     auto dt = (Integer)std::lround(360.0 / futureFixings);
@@ -442,22 +432,20 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAverageStrike) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
+                                  Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engine(
-          new AnalyticDiscreteGeometricAverageStrikeAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDiscreteGeometricAverageStrikeAsianEngine>(stochProcess);
 
     Average::Type averageType = Average::Geometric;
     Real runningAccumulator = 1.0;
@@ -465,11 +453,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAverageStrike) {
     Size futureFixings = 10;
     Option::Type type = Option::Call;
     Real strike = 100.0;
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
     Date exerciseDate = today + 360;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     std::vector<Date> fixingDates(futureFixings);
     auto dt = (Integer)std::lround(360.0 / futureFixings);
@@ -504,19 +491,18 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteGeometricAveragePrice) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
+                                  Handle<BlackVolTermStructure>(volTS));
 
     Real tolerance = 4.0e-3;
 
@@ -530,11 +516,10 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteGeometricAveragePrice) {
     Size futureFixings = 10;
     Option::Type type = Option::Call;
     Real strike = 100.0;
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
     Date exerciseDate = today + 360;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     std::vector<Date> fixingDates(futureFixings);
     auto dt = (Integer)std::lround(360.0 / futureFixings);
@@ -549,8 +534,7 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteGeometricAveragePrice) {
 
     Real calculated = option.NPV();
 
-    ext::shared_ptr<PricingEngine> engine2(
-          new AnalyticDiscreteGeometricAveragePriceAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine2 = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(stochProcess);
     option.setPricingEngine(engine2);
     Real expected = option.NPV();
 
@@ -588,9 +572,9 @@ void testDiscreteGeometricAveragePriceHeston(const ext::shared_ptr<PricingEngine
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
 
     Real v0 = 0.09;
 
@@ -616,8 +600,8 @@ void testDiscreteGeometricAveragePriceHeston(const ext::shared_ptr<PricingEngine
             fixingDates[i] = expiryDate - i * 7;
         }
 
-        ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(expiryDate));
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(expiryDate);
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
         DiscreteAveragingAsianOption option(averageType, runningAccumulator, pastFixings,
                                             fixingDates, payoff, europeanExercise);
@@ -649,10 +633,10 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteGeometricAveragePriceHeston) {
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
@@ -661,9 +645,8 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteGeometricAveragePriceHeston) {
     Real sigma = 0.39;
     Real rho = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new
-        HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-            spot, v0, kappa, theta, sigma, rho));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+            spot, v0, kappa, theta, sigma, rho);
 
     ext::shared_ptr<PricingEngine> engine =
         MakeMCDiscreteGeometricAPHestonEngine<LowDiscrepancy>(hestonProcess)
@@ -747,12 +730,12 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePrice) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     const ext::shared_ptr<BlackScholesMertonProcess> stochProcess
@@ -777,7 +760,7 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePrice) {
     Real runningSum = 0.0;
     Size pastFixings = 0;
     for (auto& l : cases4) {
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(l.type, l.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(l.type, l.strike);
 
         Time dt = l.length / (l.fixings - 1);
         std::vector<Time> timeIncrements(l.fixings);
@@ -788,7 +771,7 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePrice) {
             timeIncrements[i] = i * dt + l.first;
             fixingDates[i] = today + timeToDays(timeIncrements[i]);
         }
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[l.fixings - 1]));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(fixingDates[l.fixings - 1]);
 
         spot->setValue(l.underlying);
         qRate->setValue(l.dividendYield);
@@ -880,10 +863,10 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePriceHeston) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Average::Type averageType = Average::Arithmetic;
@@ -892,7 +875,7 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePriceHeston) {
 
     for (auto& l : cases) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(l.type, l.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(l.type, l.strike);
 
         Time dt = l.length / (l.fixings - 1);
         std::vector<Time> timeIncrements(l.fixings);
@@ -903,17 +886,16 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePriceHeston) {
             timeIncrements[i] = i * dt + l.first;
             fixingDates[i] = today + Integer(timeIncrements[i]*365.25);
         }
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[l.fixings - 1]));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(fixingDates[l.fixings - 1]);
 
         spot->setValue(l.underlying);
         qRate->setValue(l.dividendYield);
         rRate->setValue(l.riskFreeRate);
 
-        ext::shared_ptr<HestonProcess> hestonProcess(new
-            HestonProcess(Handle<YieldTermStructure>(rTS),
+        ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS),
             Handle<YieldTermStructure>(qTS),
             Handle<Quote>(spot),
-            v0, kappa, theta, sigma, rho));
+            v0, kappa, theta, sigma, rho);
 
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess)
@@ -977,17 +959,16 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePriceHeston) {
 
     DayCounter dc2 = Actual365Fixed();
 
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, qRate2, dc2);
-    ext::shared_ptr<SimpleQuote> rRate2(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> rRate2 = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> rTS2 = flatRate(today, rRate2, dc2);
 
-    ext::shared_ptr<HestonProcess> hestonProcess2(new
-        HestonProcess(Handle<YieldTermStructure>(rTS2),
+    ext::shared_ptr<HestonProcess> hestonProcess2 = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS2),
         Handle<YieldTermStructure>(qTS2),
         Handle<Quote>(spot2),
-        v02, kappa2, theta2, sigma2, rho2));
+        v02, kappa2, theta2, sigma2, rho2);
 
     ext::shared_ptr<PricingEngine> engine3 =
         MakeMCDiscreteArithmeticAPHestonEngine<LowDiscrepancy>(hestonProcess2)
@@ -1007,15 +988,13 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAveragePriceHeston) {
         fixingDates[i-1] = today + Period(i, Months);
     }
 
-    ext::shared_ptr<Exercise> exercise(new
-        EuropeanExercise(fixingDates[119]));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(fixingDates[119]);
 
     for (Size i=0; i<std::size(prices); i++) {
         Real strike = strikes[i];
         Real expected = prices[i];
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new
-            PlainVanillaPayoff(Option::Call, strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strike);
 
         DiscreteAveragingAsianOption option(averageType, runningSum,
                                             pastFixings, fixingDates,
@@ -1120,12 +1099,12 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAverageStrike) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Average::Type averageType = Average::Arithmetic;
@@ -1133,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAverageStrike) {
     Size pastFixings = 0;
     for (auto& l : cases5) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(l.type, l.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(l.type, l.strike);
 
         Time dt = l.length / (l.fixings - 1);
         std::vector<Time> timeIncrements(l.fixings);
@@ -1144,18 +1123,17 @@ BOOST_AUTO_TEST_CASE(testMCDiscreteArithmeticAverageStrike) {
             timeIncrements[i] = i * dt + l.first;
             fixingDates[i] = today + timeToDays(timeIncrements[i]);
         }
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(fixingDates[l.fixings - 1]));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(fixingDates[l.fixings - 1]);
 
         spot->setValue(l.underlying);
         qRate->setValue(l.dividendYield);
         rRate->setValue(l.riskFreeRate);
         vol->setValue(l.volatility);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
         ext::shared_ptr<PricingEngine> engine =
             MakeMCDiscreteArithmeticASEngine<LowDiscrepancy>(stochProcess)
@@ -1267,25 +1245,23 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePriceGreeks) {
     Date today = Settings::instance().evaluationDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-         new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
 
-                ext::shared_ptr<EuropeanExercise> maturity(
-                    new EuropeanExercise(today + length * Years));
+                ext::shared_ptr<EuropeanExercise> maturity = ext::make_shared<EuropeanExercise>(today + length * Years);
 
-                ext::shared_ptr<PlainVanillaPayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
                 Real runningAverage = 120;
                 Size pastFixings = 1;
@@ -1295,8 +1271,7 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePriceGreeks) {
                     fixingDates.push_back(d);
 
 
-                ext::shared_ptr<PricingEngine> engine(
-                    new AnalyticDiscreteGeometricAveragePriceAsianEngine(process));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(process);
 
                 DiscreteAveragingAsianOption option(Average::Geometric, runningAverage, pastFixings,
                                                     fixingDates, payoff, maturity);
@@ -1398,25 +1373,23 @@ BOOST_AUTO_TEST_CASE(testPastFixings) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Put, 100.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100.0);
 
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(today + 1*Years));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(today + 1*Years);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-        new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
     // MC arithmetic average-price
 
@@ -1522,8 +1495,7 @@ BOOST_AUTO_TEST_CASE(testPastFixings) {
                                          pastFixings, fixingDates2,
                                          payoff, exercise);
 
-    engine = ext::shared_ptr<PricingEngine>(
-          new AnalyticDiscreteGeometricAveragePriceAsianEngine(stochProcess));
+    engine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(stochProcess);
 
     option3.setPricingEngine(engine);
     option4.setPricingEngine(engine);
@@ -1567,31 +1539,30 @@ BOOST_AUTO_TEST_CASE(testPastFixingsModelDependency) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.03);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.06));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.06);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<StrikedTypePayoff> call_payoff(new PlainVanillaPayoff(Option::Call, 20.0));
-    ext::shared_ptr<StrikedTypePayoff> put_payoff(new PlainVanillaPayoff(Option::Put, 20.0));
+    ext::shared_ptr<StrikedTypePayoff> call_payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 20.0);
+    ext::shared_ptr<StrikedTypePayoff> put_payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 20.0);
 
     std::vector<Date> fixingDates = {today - 6 * Weeks, today - 2 * Weeks, today + 2 * Weeks,
                                      today + 6 * Weeks};
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(today + 6 * Weeks));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(today + 6 * Weeks);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
         Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-        Handle<BlackVolTermStructure>(volTS)));
+        Handle<BlackVolTermStructure>(volTS));
 
     // Test guaranteed exercise (calls) and permanent OTMness (puts), with the average price TW
     // engine
 
-    ext::shared_ptr<PricingEngine> engine = ext::shared_ptr<PricingEngine>(
-        new TurnbullWakemanAsianEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcess);
 
     std::vector<Real> allPastFixings = {spot->value(), spot->value()};
 
@@ -1624,22 +1595,20 @@ BOOST_AUTO_TEST_CASE(testPastFixingsModelDependency) {
     Real putDelta = put_option.delta();
     Real putGamma = put_option.gamma();
 
-    ext::shared_ptr<SimpleQuote> spotUp(new SimpleQuote(100.0+dS));
-    ext::shared_ptr<SimpleQuote> spotDown(new SimpleQuote(100.0-dS));
+    ext::shared_ptr<SimpleQuote> spotUp = ext::make_shared<SimpleQuote>(100.0+dS);
+    ext::shared_ptr<SimpleQuote> spotDown = ext::make_shared<SimpleQuote>(100.0-dS);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcessUp(new BlackScholesMertonProcess(
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcessUp = ext::make_shared<BlackScholesMertonProcess>(
         Handle<Quote>(spotUp), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-        Handle<BlackVolTermStructure>(volTS)));
+        Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcessDown(new BlackScholesMertonProcess(
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcessDown = ext::make_shared<BlackScholesMertonProcess>(
         Handle<Quote>(spotDown), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-        Handle<BlackVolTermStructure>(volTS)));
+        Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engineUp(
-        new TurnbullWakemanAsianEngine(stochProcessUp));
+    ext::shared_ptr<PricingEngine> engineUp = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcessUp);
 
-    ext::shared_ptr<PricingEngine> engineDown(
-        new TurnbullWakemanAsianEngine(stochProcessDown));
+    ext::shared_ptr<PricingEngine> engineDown = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcessDown);
 
     call_option.setPricingEngine(engineUp);
     Real callCalculatedUp = call_option.NPV();
@@ -1692,19 +1661,18 @@ BOOST_AUTO_TEST_CASE(testAllFixingsInThePast) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.005));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.005);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-        new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
     Date exerciseDate = today + 2*Weeks;
     Date startDate = exerciseDate - 1*Years;
@@ -1714,9 +1682,8 @@ BOOST_AUTO_TEST_CASE(testAllFixingsInThePast) {
         fixingDates.push_back(startDate + i*Months);
     Size pastFixings = 12;
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Put, 100.0));
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100.0);
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     // MC arithmetic average-price
 
@@ -1898,7 +1865,7 @@ BOOST_AUTO_TEST_CASE(testTurnbullWakemanAsianEngine) {
         }
 
         // Set up market data
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(l.underlying));
+        ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(l.underlying);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, l.b + l.riskFreeRate, dc);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, l.riskFreeRate, dc);
         ext::shared_ptr<BlackVolTermStructure> volTS;
@@ -1927,19 +1894,18 @@ BOOST_AUTO_TEST_CASE(testTurnbullWakemanAsianEngine) {
 
         Average::Type averageType = Average::Arithmetic;
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(l.type, l.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(l.type, l.strike);
 
         Date maturity = today + timeToDays(l.expiry, 360);
 
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
         // Construct engine
-        ext::shared_ptr<PricingEngine> engine(
-            new TurnbullWakemanAsianEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcess);
 
         DiscreteAveragingAsianOption option(averageType, 0, 0, fixingDates, payoff, exercise);
         option.setPricingEngine(engine);
@@ -1965,22 +1931,20 @@ BOOST_AUTO_TEST_CASE(testTurnbullWakemanAsianEngine) {
         Real delta = option.delta();
         Real gamma = option.gamma();
 
-        ext::shared_ptr<SimpleQuote> spotUp(new SimpleQuote(l.underlying+dS));
-        ext::shared_ptr<SimpleQuote> spotDown(new SimpleQuote(l.underlying-dS));
+        ext::shared_ptr<SimpleQuote> spotUp = ext::make_shared<SimpleQuote>(l.underlying+dS);
+        ext::shared_ptr<SimpleQuote> spotDown = ext::make_shared<SimpleQuote>(l.underlying-dS);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcessUp(new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcessUp = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spotUp), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcessDown(new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcessDown = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spotDown), Handle<YieldTermStructure>(qTS), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engineUp(
-            new TurnbullWakemanAsianEngine(stochProcessUp));
+        ext::shared_ptr<PricingEngine> engineUp = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcessUp);
 
-        ext::shared_ptr<PricingEngine> engineDown(
-            new TurnbullWakemanAsianEngine(stochProcessDown));
+        ext::shared_ptr<PricingEngine> engineDown = ext::make_shared<TurnbullWakemanAsianEngine>(stochProcessDown);
 
         option.setPricingEngine(engineUp);
         Real calculatedUp = option.NPV();
@@ -2053,26 +2017,25 @@ BOOST_AUTO_TEST_CASE(testLevyEngine) {
 
     for (auto& l : cases) {
 
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(l.spot));
+        ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(l.spot);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, l.dividendYield, dc);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, l.riskFreeRate, dc);
         ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, l.volatility, dc);
 
         Average::Type averageType = Average::Arithmetic;
-        ext::shared_ptr<Quote> average(new SimpleQuote(l.currentAverage));
+        ext::shared_ptr<Quote> average = ext::make_shared<SimpleQuote>(l.currentAverage);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(l.type, l.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(l.type, l.strike);
 
         Date startDate = today - l.elapsed;
         Date maturity = startDate + l.length;
 
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-                                                                BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                                                                           Handle<YieldTermStructure>(qTS),
                                                                                           Handle<YieldTermStructure>(rTS),
-                                                                                          Handle<BlackVolTermStructure>(volTS)));
+                                                                                          Handle<BlackVolTermStructure>(volTS));
 
         auto engine = ext::make_shared<ContinuousArithmeticAsianLevyEngine>(
                 stochProcess, Handle<Quote>(average));
@@ -2180,10 +2143,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
     Option::Type type(Option::Call);
     Average::Type averageType = Average::Geometric;
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
@@ -2192,12 +2155,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
     Real sigma = 0.39;
     Real rho = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new
-                                                 HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-                                                               spot, v0, kappa, theta, sigma, rho));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                                                               spot, v0, kappa, theta, sigma, rho);
 
-    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine(new
-                                                                                     AnalyticContinuousGeometricAveragePriceAsianHestonEngine(hestonProcess));
+    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianHestonEngine>(hestonProcess);
 
     for (Size i=0; i<std::size(strikes); i++) {
         Real strike = strikes[i];
@@ -2206,8 +2167,8 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
 
         Date expiryDate = today + day*Days;
 
-        ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(expiryDate));
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(expiryDate);
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
         ContinuousAveragingAsianOption option(averageType, payoff, europeanExercise);
         option.setPricingEngine(engine);
@@ -2228,12 +2189,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
     Real sigma_2 = 1.0;
     Real rho_2 = -0.3;
 
-    ext::shared_ptr<HestonProcess> hestonProcess_2(new
-                                                   HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-                                                                 spot, v0_2, kappa_2, theta_2, sigma_2, rho_2));
+    ext::shared_ptr<HestonProcess> hestonProcess_2 = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                                                                 spot, v0_2, kappa_2, theta_2, sigma_2, rho_2);
 
-    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine_2(new
-                                                                                       AnalyticContinuousGeometricAveragePriceAsianHestonEngine(hestonProcess_2));
+    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine_2 = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianHestonEngine>(hestonProcess_2);
 
     for (Size i=0; i<std::size(strikes); i++) {
         Real strike = strikes[i];
@@ -2242,8 +2201,8 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
 
         Date expiryDate = today + day*Days;
 
-        ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(expiryDate));
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(expiryDate);
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
         ContinuousAveragingAsianOption option(averageType, payoff, europeanExercise);
         option.setPricingEngine(engine_2);
@@ -2287,12 +2246,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
     Real sigma_3 = 0.39;
     Real rho_3 = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess_3(new
-                                                   HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-                                                                 spot, v0_3, kappa_3, theta_3, sigma_3, rho_3));
+    ext::shared_ptr<HestonProcess> hestonProcess_3 = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                                                                 spot, v0_3, kappa_3, theta_3, sigma_3, rho_3);
 
-    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine_3(new
-                                                                                       AnalyticContinuousGeometricAveragePriceAsianHestonEngine(hestonProcess_3));
+    ext::shared_ptr<AnalyticContinuousGeometricAveragePriceAsianHestonEngine> engine_3 = ext::make_shared<AnalyticContinuousGeometricAveragePriceAsianHestonEngine>(hestonProcess_3);
 
     for (Size i=0; i<std::size(strikes_3); i++) {
         Real strike = strikes_3[i];
@@ -2302,8 +2259,8 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousGeometricAveragePriceHeston) {
 
         Date expiryDate = today + day*Days;
 
-        ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(expiryDate));
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(expiryDate);
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
         ContinuousAveragingAsianOption option(averageType, payoff, europeanExercise);
         option.setPricingEngine(engine_3);
@@ -2333,10 +2290,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePriceHeston) {
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
@@ -2345,12 +2302,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticDiscreteGeometricAveragePriceHeston) {
     Real sigma = 0.39;
     Real rho = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new
-                                                 HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-                                                               spot, v0, kappa, theta, sigma, rho));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                                                               spot, v0, kappa, theta, sigma, rho);
 
-    ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> engine(new
-                                                                                   AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(hestonProcess));
+    ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> engine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine>(hestonProcess);
 
     AsianOptionTests::testDiscreteGeometricAveragePriceHeston(engine, tol);
 }
@@ -2431,10 +2386,10 @@ BOOST_AUTO_TEST_CASE(testDiscreteGeometricAveragePriceHestonPastFixings) {
     DayCounter dc = Actual365Fixed();
     Date today = Settings::instance().evaluationDate();
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     Real v0 = 0.09;
@@ -2443,12 +2398,10 @@ BOOST_AUTO_TEST_CASE(testDiscreteGeometricAveragePriceHestonPastFixings) {
     Real sigma = 0.39;
     Real rho = -0.64;
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new
-                                                 HestonProcess(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
-                                                               spot, v0, kappa, theta, sigma, rho));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(Handle<YieldTermStructure>(rTS), Handle<YieldTermStructure>(qTS),
+                                                               spot, v0, kappa, theta, sigma, rho);
 
-    ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> analyticEngine(new
-                                                                                           AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(hestonProcess));
+    ext::shared_ptr<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine> analyticEngine = ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine>(hestonProcess);
 
     ext::shared_ptr<PricingEngine> mcEngine =
         MakeMCDiscreteGeometricAPHestonEngine<LowDiscrepancy>(hestonProcess)
@@ -2472,8 +2425,8 @@ BOOST_AUTO_TEST_CASE(testDiscreteGeometricAveragePriceHestonPastFixings) {
                     fixingDates[i] = expiryDate - i * 30;
                 }
 
-                ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(expiryDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strikes[strike_index]));
+                ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(expiryDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strikes[strike_index]);
 
                 Real runningAccumulator = 1.0;
                 Size pastFixingsCount = 0;

--- a/test-suite/assetswap.cpp
+++ b/test-suite/assetswap.cpp
@@ -82,8 +82,7 @@ struct CommonVars {
         compounding = Continuous;
         Frequency fixedFrequency = Annual;
         Frequency floatingFrequency = Semiannual;
-        iborIndex = ext::shared_ptr<IborIndex>(
-                     new Euribor(Period(floatingFrequency), termStructure));
+        iborIndex = ext::make_shared<Euribor>(Period(floatingFrequency), termStructure);
         Calendar calendar = iborIndex->fixingCalendar();
         swapIndex = ext::make_shared<SwapIndex>(
                 "EuriborSwapIsdaFixA", 10*Years, swapSettlementDays,
@@ -96,17 +95,14 @@ struct CommonVars {
         Settings::instance().evaluationDate() = today;
 
         termStructure.linkTo(flatRate(today, 0.05, Actual365Fixed()));
-        pricer = ext::shared_ptr<IborCouponPricer>(new BlackIborCouponPricer);
+        pricer = ext::make_shared<BlackIborCouponPricer>();
         Handle<SwaptionVolatilityStructure> swaptionVolatilityStructure(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    ConstantSwaptionVolatility(today, NullCalendar(),Following,
-                                               0.2, Actual365Fixed())));
-        Handle<Quote> meanReversionQuote(ext::shared_ptr<Quote>(new
-                SimpleQuote(0.01)));
-        cmspricer = ext::shared_ptr<CmsCouponPricer>(new
-                AnalyticHaganPricer(swaptionVolatilityStructure,
+                ext::make_shared<ConstantSwaptionVolatility>(today, NullCalendar(),Following,
+                                               0.2, Actual365Fixed()));
+        Handle<Quote> meanReversionQuote(ext::make_shared<SimpleQuote>(0.01));
+        cmspricer = ext::make_shared<AnalyticHaganPricer>(swaptionVolatilityStructure,
                                     GFunctionFactory::Standard,
-                                    meanReversionQuote));
+                                    meanReversionQuote);
     }
 };
 
@@ -128,13 +124,12 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
                           Period(Annual), bondCalendar,
                           Unadjusted, Unadjusted,
                           DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> bond(new
-        FixedRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> bond = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount,
                       bondSchedule,
                       std::vector<Rate>(1, 0.04),
                       ActualActual(ActualActual::ISDA),
                       Following,
-                      100.0, Date(4,January,2005)));
+                      100.0, Date(4,January,2005));
 
     bool payFixedRate = true;
     Real bondPrice = 95.0;
@@ -147,11 +142,10 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
                          vars.iborIndex->dayCounter(),
                          isPar);
 
-    ext::shared_ptr<PricingEngine> swapEngine(new
-        DiscountingSwapEngine(vars.termStructure,
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure,
                               true,
                               bond->settlementDate(),
-                              Settings::instance().evaluationDate()));
+                              Settings::instance().evaluationDate());
 
     parAssetSwap.setPricingEngine(swapEngine);
     Real fairCleanPrice = parAssetSwap.fairCleanPrice();
@@ -226,11 +220,10 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
     }
 
     // let's change the npv date
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
+    swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure,
                               true,
                               bond->settlementDate(),
-                              bond->settlementDate()));
+                              bond->settlementDate());
 
     parAssetSwap.setPricingEngine(swapEngine);
     // fair clean price and fair spread should not change
@@ -421,11 +414,10 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
                            vars.iborIndex->dayCounter(),
                            isPar);
 
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
+    swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure,
                               true,
                               bond->settlementDate(),
-                              Settings::instance().evaluationDate()));
+                              Settings::instance().evaluationDate());
 
     mktAssetSwap.setPricingEngine(swapEngine);
     fairCleanPrice = mktAssetSwap.fairCleanPrice();
@@ -498,11 +490,10 @@ BOOST_AUTO_TEST_CASE(testConsistency) {
     }
 
     // let's change the npv date
-    swapEngine = ext::shared_ptr<PricingEngine>(new
-        DiscountingSwapEngine(vars.termStructure,
+    swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure,
                               true,
                               bond->settlementDate(),
-                              bond->settlementDate()));
+                              bond->settlementDate());
 
     mktAssetSwap.setPricingEngine(swapEngine);
     // fair clean price and fair spread should not change
@@ -697,18 +688,15 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(
-                         new FixedRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount,
                                            fixedBondSchedule1,
                                            std::vector<Rate>(1, 0.04),
                                            ActualActual(ActualActual::ISDA),
                                            Following,
-                                           100.0, Date(4,January,2005)));
+                                           100.0, Date(4,January,2005));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                            new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
@@ -749,13 +737,12 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(
-                         new FixedRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount,
                                            fixedBondSchedule2,
                                            std::vector<Rate>(1, 0.05),
                                            Thirty360(Thirty360::BondBasis),
                                            Following,
-                                           100.0, Date(5,February,2005)));
+                                           100.0, Date(5,February,2005));
 
     fixedBond2->setPricingEngine(bondEngine);
 
@@ -789,8 +776,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                    Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(
-                      new FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                                            floatingBondSchedule1,
                                            vars.iborIndex, Actual360(),
                                            Following, fixingDays,
@@ -799,7 +785,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                            std::vector<Rate>(),
                                            std::vector<Rate>(),
                                            inArrears,
-                                           100.0, Date(29,September,2003)));
+                                           100.0, Date(29,September,2003));
 
     floatingBond1->setPricingEngine(bondEngine);
 
@@ -834,8 +820,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                    Period(Semiannual), bondCalendar,
                                    ModifiedFollowing, ModifiedFollowing,
                                    DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(
-                      new FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                                            floatingBondSchedule2,
                                            vars.iborIndex, Actual360(),
                                            ModifiedFollowing, fixingDays,
@@ -844,7 +829,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                            std::vector<Rate>(),
                                            std::vector<Rate>(),
                                            inArrears,
-                                           100.0, Date(24,September,2004)));
+                                           100.0, Date(24,September,2004));
 
     floatingBond2->setPricingEngine(bondEngine);
 
@@ -894,8 +879,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(
-                          new CmsRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount,
                                           cmsBondSchedule1,
                                           vars.swapIndex, Thirty360(Thirty360::BondBasis),
                                           Following, fixingDays,
@@ -904,7 +888,7 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                                           std::vector<Rate>(1,0.055),
                                           std::vector<Rate>(1,0.025),
                                           inArrears,
-                                          100.0, Date(22,August,2005)));
+                                          100.0, Date(22,August,2005));
 
     cmsBond1->setPricingEngine(bondEngine);
 
@@ -939,14 +923,13 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule2,
                     vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
                     inArrears,
-                    100.0, Date(06,May,2005)));
+                    100.0, Date(06,May,2005));
 
     cmsBond2->setPricingEngine(bondEngine);
 
@@ -976,11 +959,10 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(20,December,2015),
                        Following,
-                       100.0, Date(19,December,1985)));
+                       100.0, Date(19,December,1985));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
@@ -1008,11 +990,10 @@ BOOST_AUTO_TEST_CASE(testImpliedValue) {
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(17,February,2028),
                        Following,
-                       100.0, Date(17,February,1998)));
+                       100.0, Date(17,February,1998));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
@@ -1064,16 +1045,13 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule1,
                       std::vector<Rate>(1, 0.04),
                       ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005)));
+                      100.0, Date(4,January,2005));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                            new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondMktPrice1 = 89.22 ; // market price observed on 7th June 2007
@@ -1120,11 +1098,10 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule2,
                       std::vector<Rate>(1, 0.05),
                       Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+                      100.0, Date(5,February,2005));
 
     fixedBond2->setPricingEngine(bondEngine);
 
@@ -1169,15 +1146,14 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                                    Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule1,
                          vars.iborIndex, Actual360(),
                          Following, fixingDays,
                          std::vector<Real>(1,1), std::vector<Spread>(1,0.0056),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(29,September,2003)));
+                         100.0, Date(29,September,2003));
 
     floatingBond1->setPricingEngine(bondEngine);
 
@@ -1227,15 +1203,14 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                                    Period(Semiannual), bondCalendar,
                                    ModifiedFollowing, ModifiedFollowing,
                                    DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule2,
                          vars.iborIndex, Actual360(),
                          ModifiedFollowing, fixingDays,
                          std::vector<Real>(1,1), std::vector<Spread>(1,0.0025),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(24,September,2004)));
+                         100.0, Date(24,September,2004));
 
     floatingBond2->setPricingEngine(bondEngine);
 
@@ -1285,14 +1260,13 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule1,
                     vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
                     inArrears,
-                    100.0, Date(22,August,2005)));
+                    100.0, Date(22,August,2005));
 
     cmsBond1->setPricingEngine(bondEngine);
 
@@ -1338,14 +1312,13 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule2,
                     vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
                     inArrears,
-                    100.0, Date(06,May,2005)));
+                    100.0, Date(06,May,2005));
 
     cmsBond2->setPricingEngine(bondEngine);
 
@@ -1386,11 +1359,10 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
     // Zero Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(20,December,2015),
                        Following,
-                       100.0, Date(19,December,1985)));
+                       100.0, Date(19,December,1985));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
@@ -1431,11 +1403,10 @@ BOOST_AUTO_TEST_CASE(testMarketASWSpread) {
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity occurs on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(17,February,2028),
                        Following,
-                       100.0, Date(17,February,1998)));
+                       100.0, Date(17,February,1998));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
@@ -1497,14 +1468,12 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule1,
                       std::vector<Rate>(1, 0.04),
                       ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005)));
+                      100.0, Date(4,January,2005));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                            new DiscountingBondEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue1 = fixedBond1->cleanPrice();
@@ -1536,11 +1505,10 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                                 Period(Annual), bondCalendar,
                                 Unadjusted, Unadjusted,
                                 DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> fixedBond2(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule2,
                       std::vector<Rate>(1, 0.05),
                       Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+                      100.0, Date(5,February,2005));
 
     fixedBond2->setPricingEngine(bondEngine);
 
@@ -1573,15 +1541,14 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                                    Unadjusted, Unadjusted,
                                    DateGeneration::Backward, false);
 
-    ext::shared_ptr<Bond> floatingBond1(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule1,
                          vars.iborIndex, Actual360(),
                          Following, fixingDays,
                          std::vector<Real>(1,1), std::vector<Spread>(1,0.0056),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(29,September,2003)));
+                         100.0, Date(29,September,2003));
 
     floatingBond1->setPricingEngine(bondEngine);
 
@@ -1614,15 +1581,14 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                                    Period(Semiannual), bondCalendar,
                                    ModifiedFollowing, ModifiedFollowing,
                                    DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> floatingBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule2,
                          vars.iborIndex, Actual360(),
                          ModifiedFollowing, fixingDays,
                          std::vector<Real>(1,1), std::vector<Spread>(1,0.0025),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(24,September,2004)));
+                         100.0, Date(24,September,2004));
 
     floatingBond2->setPricingEngine(bondEngine);
 
@@ -1655,14 +1621,13 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule1,
                     vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
                     inArrears,
-                    100.0, Date(22,August,2005)));
+                    100.0, Date(22,August,2005));
 
     cmsBond1->setPricingEngine(bondEngine);
 
@@ -1695,14 +1660,13 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
                               Period(Annual), bondCalendar,
                               Unadjusted, Unadjusted,
                               DateGeneration::Backward, false);
-    ext::shared_ptr<Bond> cmsBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule2,
                     vars.swapIndex, Thirty360(Thirty360::BondBasis),
                     Following, fixingDays,
                     std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                     std::vector<Rate>(), std::vector<Rate>(),
                     inArrears,
-                    100.0, Date(06,May,2005)));
+                    100.0, Date(06,May,2005));
 
     cmsBond2->setPricingEngine(bondEngine);
 
@@ -1730,11 +1694,10 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // Zero-Coupon bond (Isin: DE0004771662 IBRD 0 12/20/15)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(20,December,2015),
                        Following,
-                       100.0, Date(19,December,1985)));
+                       100.0, Date(19,December,1985));
 
     zeroCpnBond1->setPricingEngine(bondEngine);
 
@@ -1763,11 +1726,10 @@ BOOST_AUTO_TEST_CASE(testZSpread) {
     // Zero Coupon bond (Isin: IT0001200390 ISPIM 0 02/17/28)
     // maturity doesn't occur on a business day
 
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                        Date(17,February,2028),
                        Following,
-                       100.0, Date(17,February,1998)));
+                       100.0, Date(17,February,1998));
 
     zeroCpnBond2->setPricingEngine(bondEngine);
 
@@ -1825,16 +1787,12 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
     Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
                                                     Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    fixedBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption1));
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+             fixedBondLeg1);
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
@@ -1877,11 +1835,9 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
     Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
                                                     Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    fixedBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption2));
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2);
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondPrice2 = fixedBond2->cleanPrice();
@@ -1922,12 +1878,10 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .inArrears(inArrears);
     Date floatingbondRedemption1 =
         bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption1));
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+             floatingBondLeg1);
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
@@ -1972,12 +1926,10 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption2));
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+             floatingBondLeg2);
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
@@ -2037,11 +1989,9 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .inArrears(inArrears);
     Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
                                                   Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    cmsBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption1));
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1);
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
@@ -2084,11 +2034,9 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
         .inArrears(inArrears);
     Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
                                                   Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    cmsBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption2));
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2);
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
@@ -2120,11 +2068,9 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
     Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
     Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
                                                       Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Leg zeroCpnBondLeg1 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zeroCpnBondRedemption1));
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1);
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice1 = zeroCpnBond1->cleanPrice();
@@ -2154,11 +2100,9 @@ BOOST_AUTO_TEST_CASE(testGenericBondImplied) {
     Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
     Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
                                                       Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Leg zeroCpnBondLeg2 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zerocpbondRedemption2));
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2);
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
@@ -2215,16 +2159,12 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
     Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
                                                     Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    fixedBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption1));
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+             fixedBondLeg1);
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondMktPrice1 = 89.22 ; // market price observed on 7th June 2007
@@ -2277,11 +2217,9 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
     Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
                                                     Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    fixedBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption2));
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2);
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondMktPrice2 = 99.98 ; // market price observed on 7th June 2007
@@ -2333,12 +2271,10 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption1 =
         bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption1));
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+             floatingBondLeg1);
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
@@ -2397,12 +2333,10 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption2));
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+             floatingBondLeg2);
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
@@ -2461,11 +2395,9 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
                                                   Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    cmsBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption1));
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1);
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
@@ -2519,11 +2451,9 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
                                                   Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    cmsBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption2));
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2);
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
@@ -2566,11 +2496,9 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
     Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
     Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
                                                       Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Leg zeroCpnBondLeg1 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zeroCpnBondRedemption1));
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1);
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // market price observed on 12th June 2007
@@ -2613,11 +2541,9 @@ BOOST_AUTO_TEST_CASE(testMASWWithGenericBond) {
     Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
     Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
                                                       Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Leg zeroCpnBondLeg2 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zerocpbondRedemption2));
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2);
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();
@@ -2683,14 +2609,11 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
     Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
                                                     Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    fixedBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption1));
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(new
-        DiscountingBondEngine(vars.termStructure));
+             fixedBondLeg1);
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue1 = fixedBond1->cleanPrice();
@@ -2729,11 +2652,9 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
     Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
                                                     Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    fixedBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption2));
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2);
     fixedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondImpliedValue2 = fixedBond2->cleanPrice();
@@ -2775,12 +2696,10 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption1 =
         bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption1));
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+             floatingBondLeg1);
     floatingBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
@@ -2823,12 +2742,10 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    floatingBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption2));
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+             floatingBondLeg2);
     floatingBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
@@ -2871,11 +2788,9 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
                                                   Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    cmsBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption1));
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1);
     cmsBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
@@ -2917,11 +2832,9 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
                                                   Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    cmsBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption2));
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2);
     cmsBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
@@ -2952,11 +2865,9 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
     Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
                                                       Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    Leg zeroCpnBondLeg1 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zeroCpnBondRedemption1));
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1);
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue1 = zeroCpnBond1->cleanPrice();
@@ -2988,11 +2899,9 @@ BOOST_AUTO_TEST_CASE(testZSpreadWithGenericBond) {
     Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
     Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
                                                       Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    Leg zeroCpnBondLeg2 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zerocpbondRedemption2));
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2);
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondImpliedValue2 = zeroCpnBond2->cleanPrice();
@@ -3044,23 +2953,19 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
     Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
                                                     Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
+    fixedBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(new
-        DiscountingBondEngine(vars.termStructure));
+             fixedBondLeg1);
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
+    ext::shared_ptr<Bond> fixedSpecializedBond1 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule1,
                       std::vector<Rate>(1, 0.04),
                       ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005) ));
+                      100.0, Date(4,January,2005) );
     fixedSpecializedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondTheoValue1 = fixedBond1->cleanPrice();
@@ -3108,21 +3013,18 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
     Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
                                                     Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
+    fixedBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption2));
 
     // generic bond
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2);
     fixedBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond2(new
-         FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
+    ext::shared_ptr<Bond> fixedSpecializedBond2 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule2,
                       std::vector<Rate>(1, 0.05),
                       Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+                      100.0, Date(5,February,2005));
     fixedSpecializedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondTheoValue2 = fixedBond2->cleanPrice();
@@ -3174,18 +3076,15 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption1 =
         bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
+    floatingBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+             floatingBondLeg1);
     floatingBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond1(new
-           FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingSpecializedBond1 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                             floatingBondSchedule1,
                             vars.iborIndex, Actual360(),
                             Following, fixingDays,
@@ -3193,7 +3092,7 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
                             std::vector<Spread>(1,0.0056),
                             std::vector<Rate>(), std::vector<Rate>(),
                             inArrears,
-                            100.0, Date(29,September,2003)));
+                            100.0, Date(29,September,2003));
     floatingSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
@@ -3253,18 +3152,15 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .inArrears(inArrears);
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2, ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
+    floatingBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+             floatingBondLeg2);
     floatingBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingSpecializedBond2 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule2,
                          vars.iborIndex, Actual360(),
                          ModifiedFollowing, fixingDays,
@@ -3272,7 +3168,7 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
                          std::vector<Spread>(1,0.0025),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(24,September,2004)));
+                         100.0, Date(24,September,2004));
     floatingSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
@@ -3335,23 +3231,20 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
                                                   Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
+    cmsBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption1));
     // generic cms bond
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1);
     cmsBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
+    ext::shared_ptr<Bond> cmsSpecializedBond1 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule1,
                 vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
                 inArrears,
-                100.0, Date(22,August,2005)));
+                100.0, Date(22,August,2005));
     cmsSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond1->cashflows(), vars.cmspricer);
@@ -3404,23 +3297,20 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
         .inArrears(inArrears);
     Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
                                                   Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
+    cmsBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2);
     cmsBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
+    ext::shared_ptr<Bond> cmsSpecializedBond2 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule2,
                 vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(), std::vector<Rate>(),
                 inArrears,
-                100.0, Date(06,May,2005)));
+                100.0, Date(06,May,2005));
     cmsSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
@@ -3463,20 +3353,17 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
     Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
     Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
                                                       Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    Leg zeroCpnBondLeg1 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zeroCpnBondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1);
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond1 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                   Date(20,December,2015),
                   Following,
-                  100.0, Date(19,December,1985)));
+                  100.0, Date(19,December,1985));
     zeroCpnSpecializedBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondTheoValue1 = zeroCpnBond1->cleanPrice();
@@ -3521,20 +3408,17 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBond) {
     Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
     Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
                                                       Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    Leg zeroCpnBondLeg2 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zerocpbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2);
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond2 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                    Date(17,February,2028),
                    Following,
-                   100.0, Date(17,February,1998)));
+                   100.0, Date(17,February,1998));
     zeroCpnSpecializedBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondTheoValue2 = zeroCpnBond2->cleanPrice();
@@ -3605,25 +3489,20 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
         .withCouponRates(0.04, ActualActual(ActualActual::ISDA));
     Date fixedbondRedemption1 = bondCalendar.adjust(fixedBondMaturityDate1,
                                                     Following);
-    fixedBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption1)));
+    fixedBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> fixedBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> fixedBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              fixedBondMaturityDate1, fixedBondStartDate1,
-             fixedBondLeg1));
-    ext::shared_ptr<PricingEngine> bondEngine(
-                               new DiscountingBondEngine(vars.termStructure));
-    ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+             fixedBondLeg1);
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(vars.termStructure);
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     fixedBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond1(new
-        FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule1,
+    ext::shared_ptr<Bond> fixedSpecializedBond1 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule1,
                       std::vector<Rate>(1, 0.04),
                       ActualActual(ActualActual::ISDA), Following,
-                      100.0, Date(4,January,2005) ));
+                      100.0, Date(4,January,2005) );
     fixedSpecializedBond1->setPricingEngine(bondEngine);
 
     Real fixedBondPrice1 = fixedBond1->cleanPrice();
@@ -3708,21 +3587,18 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
         .withCouponRates(0.05, Thirty360(Thirty360::BondBasis));
     Date fixedbondRedemption2 = bondCalendar.adjust(fixedBondMaturityDate2,
                                                     Following);
-    fixedBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, fixedbondRedemption2)));
+    fixedBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, fixedbondRedemption2));
 
     // generic bond
-    ext::shared_ptr<Bond> fixedBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2));
+    ext::shared_ptr<Bond> fixedBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             fixedBondMaturityDate2, fixedBondStartDate2, fixedBondLeg2);
     fixedBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized fixed rate bond
-    ext::shared_ptr<Bond> fixedSpecializedBond2(new
-         FixedRateBond(settlementDays, vars.faceAmount, fixedBondSchedule2,
+    ext::shared_ptr<Bond> fixedSpecializedBond2 = ext::make_shared<FixedRateBond>(settlementDays, vars.faceAmount, fixedBondSchedule2,
                       std::vector<Rate>(1, 0.05),
                       Thirty360(Thirty360::BondBasis), Following,
-                      100.0, Date(5,February,2005)));
+                      100.0, Date(5,February,2005));
     fixedSpecializedBond2->setPricingEngine(bondEngine);
 
     Real fixedBondPrice2 = fixedBond2->cleanPrice();
@@ -3810,18 +3686,15 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
         .inArrears(inArrears);
     Date floatingbondRedemption1 =
         bondCalendar.adjust(floatingBondMaturityDate1, Following);
-    floatingBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption1)));
+    floatingBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate1, floatingBondStartDate1,
-             floatingBondLeg1));
+             floatingBondLeg1);
     floatingBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond1(new
-           FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingSpecializedBond1 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                             floatingBondSchedule1,
                             vars.iborIndex, Actual360(),
                             Following, fixingDays,
@@ -3829,7 +3702,7 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
                             std::vector<Spread>(1,0.0056),
                             std::vector<Rate>(), std::vector<Rate>(),
                             inArrears,
-                            100.0, Date(29,September,2003)));
+                            100.0, Date(29,September,2003));
     floatingSpecializedBond1->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond1->cashflows(), vars.pricer);
@@ -3922,18 +3795,15 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
     Date floatingbondRedemption2 =
         bondCalendar.adjust(floatingBondMaturityDate2,
                             ModifiedFollowing);
-    floatingBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, floatingbondRedemption2)));
+    floatingBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, floatingbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> floatingBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
              floatingBondMaturityDate2, floatingBondStartDate2,
-             floatingBondLeg2));
+             floatingBondLeg2);
     floatingBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized floater
-    ext::shared_ptr<Bond> floatingSpecializedBond2(new
-        FloatingRateBond(settlementDays, vars.faceAmount,
+    ext::shared_ptr<Bond> floatingSpecializedBond2 = ext::make_shared<FloatingRateBond>(settlementDays, vars.faceAmount,
                          floatingBondSchedule2,
                          vars.iborIndex, Actual360(),
                          ModifiedFollowing, fixingDays,
@@ -3941,7 +3811,7 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
                          std::vector<Spread>(1,0.0025),
                          std::vector<Rate>(), std::vector<Rate>(),
                          inArrears,
-                         100.0, Date(24,September,2004)));
+                         100.0, Date(24,September,2004));
     floatingSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(floatingBond2->cashflows(), vars.pricer);
@@ -4035,23 +3905,20 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
         .inArrears(inArrears);
     Date cmsbondRedemption1 = bondCalendar.adjust(cmsBondMaturityDate1,
                                                   Following);
-    cmsBondLeg1.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption1)));
+    cmsBondLeg1.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption1));
     // generic cms bond
-    ext::shared_ptr<Bond> cmsBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1));
+    ext::shared_ptr<Bond> cmsBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate1, cmsBondStartDate1, cmsBondLeg1);
     cmsBond1->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond1(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule1,
+    ext::shared_ptr<Bond> cmsSpecializedBond1 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule1,
                 vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,1.0), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(1,0.055), std::vector<Rate>(1,0.025),
                 inArrears,
-                100.0, Date(22,August,2005)));
+                100.0, Date(22,August,2005));
     cmsSpecializedBond1->setPricingEngine(bondEngine);
 
 
@@ -4137,23 +4004,20 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
         .inArrears(inArrears);
     Date cmsbondRedemption2 = bondCalendar.adjust(cmsBondMaturityDate2,
                                                   Following);
-    cmsBondLeg2.push_back(ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, cmsbondRedemption2)));
+    cmsBondLeg2.push_back(ext::make_shared<SimpleCashFlow>(100.0, cmsbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> cmsBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2));
+    ext::shared_ptr<Bond> cmsBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             cmsBondMaturityDate2, cmsBondStartDate2, cmsBondLeg2);
     cmsBond2->setPricingEngine(bondEngine);
 
     // equivalent specialized cms bond
-    ext::shared_ptr<Bond> cmsSpecializedBond2(new
-        CmsRateBond(settlementDays, vars.faceAmount, cmsBondSchedule2,
+    ext::shared_ptr<Bond> cmsSpecializedBond2 = ext::make_shared<CmsRateBond>(settlementDays, vars.faceAmount, cmsBondSchedule2,
                 vars.swapIndex, Thirty360(Thirty360::BondBasis),
                 Following, fixingDays,
                 std::vector<Real>(1,0.84), std::vector<Spread>(1,0.0),
                 std::vector<Rate>(), std::vector<Rate>(),
                 inArrears,
-                100.0, Date(06,May,2005)));
+                100.0, Date(06,May,2005));
     cmsSpecializedBond2->setPricingEngine(bondEngine);
 
     setCouponPricer(cmsBond2->cashflows(), vars.cmspricer);
@@ -4229,20 +4093,17 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
     Date zeroCpnBondMaturityDate1 = Date(20,December,2015);
     Date zeroCpnBondRedemption1 = bondCalendar.adjust(zeroCpnBondMaturityDate1,
                                                       Following);
-    Leg zeroCpnBondLeg1 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zeroCpnBondRedemption1)));
+    Leg zeroCpnBondLeg1 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zeroCpnBondRedemption1));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond1(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1));
+    ext::shared_ptr<Bond> zeroCpnBond1 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate1, zeroCpnBondStartDate1, zeroCpnBondLeg1);
     zeroCpnBond1->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond1(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond1 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                   Date(20,December,2015),
                   Following,
-                  100.0, Date(19,December,1985)));
+                  100.0, Date(19,December,1985));
     zeroCpnSpecializedBond1->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice1 = zeroCpnBond1->cleanPrice();
@@ -4319,20 +4180,17 @@ BOOST_AUTO_TEST_CASE(testSpecializedBondVsGenericBondUsingAsw) {
     Date zeroCpnBondMaturityDate2 = Date(17,February,2028);
     Date zerocpbondRedemption2 = bondCalendar.adjust(zeroCpnBondMaturityDate2,
                                                       Following);
-    Leg zeroCpnBondLeg2 = Leg(1, ext::shared_ptr<CashFlow>(new
-        SimpleCashFlow(100.0, zerocpbondRedemption2)));
+    Leg zeroCpnBondLeg2 = Leg(1, ext::make_shared<SimpleCashFlow>(100.0, zerocpbondRedemption2));
     // generic bond
-    ext::shared_ptr<Bond> zeroCpnBond2(new
-        Bond(settlementDays, bondCalendar, vars.faceAmount,
-             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2));
+    ext::shared_ptr<Bond> zeroCpnBond2 = ext::make_shared<Bond>(settlementDays, bondCalendar, vars.faceAmount,
+             zeroCpnBondMaturityDate2, zeroCpnBondStartDate2, zeroCpnBondLeg2);
     zeroCpnBond2->setPricingEngine(bondEngine);
 
     // specialized zerocpn bond
-    ext::shared_ptr<Bond> zeroCpnSpecializedBond2(new
-        ZeroCouponBond(settlementDays, bondCalendar, vars.faceAmount,
+    ext::shared_ptr<Bond> zeroCpnSpecializedBond2 = ext::make_shared<ZeroCouponBond>(settlementDays, bondCalendar, vars.faceAmount,
                    Date(17,February,2028),
                    Following,
-                   100.0, Date(17,February,1998)));
+                   100.0, Date(17,February,1998));
     zeroCpnSpecializedBond2->setPricingEngine(bondEngine);
 
     Real zeroCpnBondPrice2 = zeroCpnBond2->cleanPrice();

--- a/test-suite/bacheliercalculator.cpp
+++ b/test-suite/bacheliercalculator.cpp
@@ -64,8 +64,7 @@ BOOST_AUTO_TEST_CASE(testBachelierCalculatorBasicValues) {
         Real value1 = calc1.value();
         
         // Test constructor with Payoff
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(data.type, data.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(data.type, data.strike);
         BachelierCalculator calc2(payoff, data.forward, data.stdDev, data.discount);
         Real value2 = calc2.value();
 

--- a/test-suite/basismodels.cpp
+++ b/test-suite/basismodels.cpp
@@ -76,8 +76,8 @@ Handle<YieldTermStructure> getYTS(const std::vector<Period>& terms,
     for (Real& k : ratesPlusSpread)
         k += spread;
     ext::shared_ptr<YieldTermStructure> ts =
-        ext::shared_ptr<YieldTermStructure>(new InterpolatedZeroCurve<Cubic>(
-                dates, ratesPlusSpread, Actual365Fixed(), NullCalendar()));
+        ext::make_shared<InterpolatedZeroCurve<Cubic>>(
+                dates, ratesPlusSpread, Actual365Fixed(), NullCalendar());
     return RelinkableHandle<YieldTermStructure>(ts);
 }
 
@@ -117,15 +117,14 @@ Handle<OptionletVolatilityStructure> getOptionletTS() {
         std::vector<Handle<Quote> > row;
         row.reserve(capletVol.size());
         for (Real j : capletVol)
-            row.push_back(RelinkableHandle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(j))));
+            row.push_back(RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(j)));
         capletVolQuotes.push_back(row);
     }
     Handle<YieldTermStructure> curve3m = getYTS(terms, proj3mRates);
-    ext::shared_ptr<IborIndex> index(new Euribor3M(curve3m));
-    ext::shared_ptr<StrippedOptionletBase> tmp1(
-            new StrippedOptionlet(2, TARGET(), Following, index, dates, capletStrikes,
-                                  capletVolQuotes, Actual365Fixed(), Normal, 0.0));
-    ext::shared_ptr<StrippedOptionletAdapter> tmp2(new StrippedOptionletAdapter(tmp1));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor3M>(curve3m);
+    ext::shared_ptr<StrippedOptionletBase> tmp1 = ext::make_shared<StrippedOptionlet>(2, TARGET(), Following, index, dates, capletStrikes,
+                                  capletVolQuotes, Actual365Fixed(), Normal, 0.0);
+    ext::shared_ptr<StrippedOptionletAdapter> tmp2 = ext::make_shared<StrippedOptionletAdapter>(tmp1);
     return RelinkableHandle<OptionletVolatilityStructure>(tmp2);
 }
 
@@ -148,12 +147,11 @@ Handle<SwaptionVolatilityStructure> getSwaptionVTS() {
         std::vector<Handle<Quote> > row;
         row.reserve(swaptionVol.size());
         for (Real j : swaptionVol)
-            row.push_back(RelinkableHandle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(j))));
+            row.push_back(RelinkableHandle<Quote>(ext::make_shared<SimpleQuote>(j)));
         swaptionVolQuotes.push_back(row);
     }
-    ext::shared_ptr<SwaptionVolatilityStructure> tmp(
-            new SwaptionVolatilityMatrix(TARGET(), Following, swaptionVTSTerms, swaptionVTSTerms,
-                                         swaptionVolQuotes, Actual365Fixed(), true, Normal));
+    ext::shared_ptr<SwaptionVolatilityStructure> tmp = ext::make_shared<SwaptionVolatilityMatrix>(TARGET(), Following, swaptionVTSTerms, swaptionVTSTerms,
+                                         swaptionVolQuotes, Actual365Fixed(), true, Normal);
     return RelinkableHandle<SwaptionVolatilityStructure>(tmp);
 }
 
@@ -162,7 +160,7 @@ void testSwaptioncfs(bool contTenorSpread) {
     // market data and floating rate index
     Handle<YieldTermStructure> discYTS = getYTS(terms, discRates);
     Handle<YieldTermStructure> proj6mYTS = getYTS(terms, proj6mRates);
-    ext::shared_ptr<IborIndex> euribor6m(new Euribor6M(proj6mYTS));
+    ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<Euribor6M>(proj6mYTS);
     // Vanilla swap details
     Date today = Settings::instance().evaluationDate();
     Date swapStart = TARGET().advance(today, Period(5, Years), Following);
@@ -172,14 +170,12 @@ void testSwaptioncfs(bool contTenorSpread) {
                            ModifiedFollowing, DateGeneration::Backward, false);
     Schedule floatSchedule(swapStart, swapEnd, Period(6, Months), TARGET(), ModifiedFollowing,
                            ModifiedFollowing, DateGeneration::Backward, false);
-    ext::shared_ptr<VanillaSwap> swap(
-            new VanillaSwap(Swap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(Thirty360::BondBasis),
-                            floatSchedule, euribor6m, 0.0, euribor6m->dayCounter()));
-    swap->setPricingEngine(ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(discYTS)));
+    ext::shared_ptr<VanillaSwap> swap = ext::make_shared<VanillaSwap>(Swap::Payer, 10000.0, fixedSchedule, 0.03, Thirty360(Thirty360::BondBasis),
+                            floatSchedule, euribor6m, 0.0, euribor6m->dayCounter());
+    swap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(discYTS));
     // European exercise and swaption
-    ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(exerciseDate));
-    ext::shared_ptr<Swaption> swaption(
-                                       new Swaption(swap, europeanExercise, Settlement::Physical));
+    ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(exerciseDate);
+    ext::shared_ptr<Swaption> swaption = ext::make_shared<Swaption>(swap, europeanExercise, Settlement::Physical);
     // calculate basis model swaption cash flows, discount and conmpare with swap
     SwaptionCashFlows cashFlows(swaption, discYTS, contTenorSpread);
     // model time is always Act365Fixed
@@ -243,8 +239,8 @@ BOOST_AUTO_TEST_CASE(testTenoroptionletvts) {
     Handle<YieldTermStructure> discYTS = getYTS(terms, discRates);
     Handle<YieldTermStructure> proj3mYTS = getYTS(terms, proj3mRates);
     Handle<YieldTermStructure> proj6mYTS = getYTS(terms, proj3mRates, spread);
-    ext::shared_ptr<IborIndex> euribor3m(new Euribor6M(proj3mYTS));
-    ext::shared_ptr<IborIndex> euribor6m(new Euribor6M(proj6mYTS));
+    ext::shared_ptr<IborIndex> euribor3m = ext::make_shared<Euribor6M>(proj3mYTS);
+    ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<Euribor6M>(proj6mYTS);
     // 3m optionlet VTS
     Handle<OptionletVolatilityStructure> optionletVTS3m = getOptionletTS();
     {
@@ -255,15 +251,11 @@ BOOST_AUTO_TEST_CASE(testTenoroptionletvts) {
         std::vector<Real> corrTimes(corrTimesRaw, corrTimesRaw + 2);
         std::vector<Real> rhoInfData(rhoInfDataRaw, rhoInfDataRaw + 2);
         std::vector<Real> betaData(betaDataRaw, betaDataRaw + 2);
-        ext::shared_ptr<Interpolation> rho(
-            new LinearInterpolation(corrTimes.begin(), corrTimes.end(), rhoInfData.begin()));
-        ext::shared_ptr<Interpolation> beta(
-            new LinearInterpolation(corrTimes.begin(), corrTimes.end(), betaData.begin()));
-        ext::shared_ptr<TenorOptionletVTS::CorrelationStructure> corr(
-            new TenorOptionletVTS::TwoParameterCorrelation(rho, beta));
+        ext::shared_ptr<Interpolation> rho = ext::make_shared<LinearInterpolation>(corrTimes.begin(), corrTimes.end(), rhoInfData.begin());
+        ext::shared_ptr<Interpolation> beta = ext::make_shared<LinearInterpolation>(corrTimes.begin(), corrTimes.end(), betaData.begin());
+        ext::shared_ptr<TenorOptionletVTS::CorrelationStructure> corr = ext::make_shared<TenorOptionletVTS::TwoParameterCorrelation>(rho, beta);
         // now we can set up the new volTS and calculate volatilities
-        ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m(
-            new TenorOptionletVTS(optionletVTS3m, euribor3m, euribor6m, corr));
+        ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m = ext::make_shared<TenorOptionletVTS>(optionletVTS3m, euribor3m, euribor6m, corr);
         for (auto& capletTerm : capletTerms) {
             for (Real& capletStrike : capletStrikes) {
                 Real vol3m = optionletVTS3m->volatility(capletTerm, capletStrike, true);
@@ -290,15 +282,11 @@ BOOST_AUTO_TEST_CASE(testTenoroptionletvts) {
         std::vector<Real> corrTimes(corrTimesRaw, corrTimesRaw + 2);
         std::vector<Real> rhoInfData(rhoInfDataRaw, rhoInfDataRaw + 2);
         std::vector<Real> betaData(betaDataRaw, betaDataRaw + 2);
-        ext::shared_ptr<Interpolation> rho(
-            new LinearInterpolation(corrTimes.begin(), corrTimes.end(), rhoInfData.begin()));
-        ext::shared_ptr<Interpolation> beta(
-            new LinearInterpolation(corrTimes.begin(), corrTimes.end(), betaData.begin()));
-        ext::shared_ptr<TenorOptionletVTS::CorrelationStructure> corr(
-            new TenorOptionletVTS::TwoParameterCorrelation(rho, beta));
+        ext::shared_ptr<Interpolation> rho = ext::make_shared<LinearInterpolation>(corrTimes.begin(), corrTimes.end(), rhoInfData.begin());
+        ext::shared_ptr<Interpolation> beta = ext::make_shared<LinearInterpolation>(corrTimes.begin(), corrTimes.end(), betaData.begin());
+        ext::shared_ptr<TenorOptionletVTS::CorrelationStructure> corr = ext::make_shared<TenorOptionletVTS::TwoParameterCorrelation>(rho, beta);
         // now we can set up the new volTS and calculate volatilities
-        ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m(
-            new TenorOptionletVTS(optionletVTS3m, euribor3m, euribor6m, corr));
+        ext::shared_ptr<OptionletVolatilityStructure> optionletVTS6m = ext::make_shared<TenorOptionletVTS>(optionletVTS3m, euribor3m, euribor6m, corr);
         for (Size i = 0; i < capletTerms.size(); ++i) {
             for (Real& capletStrike : capletStrikes) {
                 Real vol3m = optionletVTS3m->volatility(capletTerms[i], capletStrike, true);
@@ -327,14 +315,13 @@ BOOST_AUTO_TEST_CASE(testTenorswaptionvts) {
     Handle<YieldTermStructure> discYTS = getYTS(terms, discRates);
     Handle<YieldTermStructure> proj3mYTS = getYTS(terms, proj3mRates);
     Handle<YieldTermStructure> proj6mYTS = getYTS(terms, proj3mRates, spread);
-    ext::shared_ptr<IborIndex> euribor3m(new Euribor6M(proj3mYTS));
-    ext::shared_ptr<IborIndex> euribor6m(new Euribor6M(proj6mYTS));
+    ext::shared_ptr<IborIndex> euribor3m = ext::make_shared<Euribor6M>(proj3mYTS);
+    ext::shared_ptr<IborIndex> euribor6m = ext::make_shared<Euribor6M>(proj6mYTS);
     // Euribor6m ATM vols
     Handle<SwaptionVolatilityStructure> euribor6mSwVTS = getSwaptionVTS();
     {
-        ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS(
-            new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
-                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
+        ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS = ext::make_shared<TenorSwaptionVTS>(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis));
         // 6m vols should be slightly larger then 3m vols due to basis
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {
@@ -351,9 +338,8 @@ BOOST_AUTO_TEST_CASE(testTenorswaptionvts) {
         }
     }
     {
-        ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2(
-            new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor6m, Period(1, Years),
-                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
+        ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2 = ext::make_shared<TenorSwaptionVTS>(euribor6mSwVTS, discYTS, euribor6m, euribor6m, Period(1, Years),
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis));
         // 6m vols to 6m vols should yield initiial vols
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {
@@ -372,12 +358,11 @@ BOOST_AUTO_TEST_CASE(testTenorswaptionvts) {
         }
     }
     {
-        ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS(
-            new TenorSwaptionVTS(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
-                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
-        ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2(new TenorSwaptionVTS(
+        ext::shared_ptr<TenorSwaptionVTS> euribor3mSwVTS = ext::make_shared<TenorSwaptionVTS>(euribor6mSwVTS, discYTS, euribor6m, euribor3m, Period(1, Years),
+                                 Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis));
+        ext::shared_ptr<TenorSwaptionVTS> euribor6mSwVTS2 = ext::make_shared<TenorSwaptionVTS>(
             RelinkableHandle<SwaptionVolatilityStructure>(euribor3mSwVTS), discYTS, euribor3m,
-            euribor6m, Period(1, Years), Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis)));
+            euribor6m, Period(1, Years), Period(1, Years), Thirty360(Thirty360::BondBasis), Thirty360(Thirty360::BondBasis));
         // 6m vols to 6m vols should yield initiial vols
         for (Size i = 0; i < swaptionVTSTerms.size(); ++i) {
             for (Size j = 0; j < swaptionVTSTerms.size(); ++j) {

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -128,11 +128,11 @@ ext::shared_ptr<BasketPayoff> basketTypeToPayoff(BasketType basketType,
                                                  const ext::shared_ptr<Payoff> &p) {
     switch (basketType) {
       case MinBasket:
-        return ext::shared_ptr<BasketPayoff>(new MinBasketPayoff(p));
+        return ext::make_shared<MinBasketPayoff>(p);
       case MaxBasket:
-        return ext::shared_ptr<BasketPayoff>(new MaxBasketPayoff(p));
+        return ext::make_shared<MaxBasketPayoff>(p);
       case SpreadBasket:
-        return ext::shared_ptr<BasketPayoff>(new SpreadBasketPayoff(p));
+        return ext::make_shared<SpreadBasketPayoff>(p);
     }
     QL_FAIL("unknown basket option type");
 }
@@ -313,20 +313,20 @@ BOOST_AUTO_TEST_CASE(testEuroTwoValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS1 = flatRate(today, qRate1, dc);
-    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, qRate2, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
 
     const Real mcRelativeErrorTolerance = 0.01;
@@ -334,11 +334,10 @@ BOOST_AUTO_TEST_CASE(testEuroTwoValues) {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<PlainVanillaPayoff> payoff(
-            new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot1->setValue(value.s1);
         spot2->setValue(value.s2);
@@ -354,25 +353,22 @@ BOOST_AUTO_TEST_CASE(testEuroTwoValues) {
         switch (value.basketType) {
             case MaxBasket:
             case MinBasket:
-                p1 = ext::shared_ptr<GeneralizedBlackScholesProcess>(new BlackScholesMertonProcess(
+                p1 = ext::make_shared<BlackScholesMertonProcess>(
                     Handle<Quote>(spot1), Handle<YieldTermStructure>(qTS1),
-                    Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS1)));
-                p2 = ext::shared_ptr<GeneralizedBlackScholesProcess>(new BlackScholesMertonProcess(
+                    Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS1));
+                p2 = ext::make_shared<BlackScholesMertonProcess>(
                     Handle<Quote>(spot2), Handle<YieldTermStructure>(qTS2),
-                    Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS2)));
-                analyticEngine = ext::shared_ptr<PricingEngine>(new StulzEngine(p1, p2, value.rho));
+                    Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS2));
+                analyticEngine = ext::make_shared<StulzEngine>(p1, p2, value.rho);
                 break;
             case SpreadBasket:
-                p1 = ext::shared_ptr<GeneralizedBlackScholesProcess>(
-                    new BlackProcess(Handle<Quote>(spot1), Handle<YieldTermStructure>(rTS),
-                                     Handle<BlackVolTermStructure>(volTS1)));
-                p2 = ext::shared_ptr<GeneralizedBlackScholesProcess>(
-                    new BlackProcess(Handle<Quote>(spot2), Handle<YieldTermStructure>(rTS),
-                                     Handle<BlackVolTermStructure>(volTS2)));
+                p1 = ext::make_shared<BlackProcess>(Handle<Quote>(spot1), Handle<YieldTermStructure>(rTS),
+                                     Handle<BlackVolTermStructure>(volTS1));
+                p2 = ext::make_shared<BlackProcess>(Handle<Quote>(spot2), Handle<YieldTermStructure>(rTS),
+                                     Handle<BlackVolTermStructure>(volTS2));
 
-                analyticEngine = ext::shared_ptr<PricingEngine>(
-                    new KirkEngine(ext::dynamic_pointer_cast<BlackProcess>(p1),
-                                   ext::dynamic_pointer_cast<BlackProcess>(p2), value.rho));
+                analyticEngine = ext::make_shared<KirkEngine>(ext::dynamic_pointer_cast<BlackProcess>(p1),
+                                   ext::dynamic_pointer_cast<BlackProcess>(p2), value.rho);
                 break;
             default:
                 QL_FAIL("unknown basket type");
@@ -385,8 +381,7 @@ BOOST_AUTO_TEST_CASE(testEuroTwoValues) {
             correlationMatrix[j][j] = 1.0;
         }
 
-        ext::shared_ptr<StochasticProcessArray> process(
-                         new StochasticProcessArray(procs,correlationMatrix));
+        ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(procs,correlationMatrix);
 
         ext::shared_ptr<PricingEngine> mcEngine =
             MakeMCEuropeanBasketEngine<PseudoRandom, Statistics>(process)
@@ -394,8 +389,7 @@ BOOST_AUTO_TEST_CASE(testEuroTwoValues) {
             .withSamples(10000)
             .withSeed(42);
 
-        ext::shared_ptr<PricingEngine> fdEngine(
-            new Fd2dBlackScholesVanillaEngine(p1, p2, value.rho, 50, 50, 15));
+        ext::shared_ptr<PricingEngine> fdEngine = ext::make_shared<Fd2dBlackScholesVanillaEngine>(p1, p2, value.rho, 50, 50, 15);
 
         BasketOption basketOption(basketTypeToPayoff(value.basketType, payoff), exercise);
 
@@ -521,32 +515,31 @@ BOOST_AUTO_TEST_CASE(testBarraquandThreeValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot3(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot3 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
-    ext::shared_ptr<SimpleQuote> vol3(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol3 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS3 = flatVol(today, vol3, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<PlainVanillaPayoff> payoff(
-            new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + Integer(value.t) * 30;
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
-                                                                    exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
+                                                                    exDate);
 
         spot1->setValue(value.s1);
         spot2->setValue(value.s2);
@@ -556,23 +549,20 @@ BOOST_AUTO_TEST_CASE(testBarraquandThreeValues) {
         vol2->setValue(value.v2);
         vol3->setValue(value.v3);
 
-        ext::shared_ptr<StochasticProcess1D> stochProcess1(new
-            BlackScholesMertonProcess(Handle<Quote>(spot1),
+        ext::shared_ptr<StochasticProcess1D> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS1)));
+                                      Handle<BlackVolTermStructure>(volTS1));
 
-        ext::shared_ptr<StochasticProcess1D> stochProcess2(new
-            BlackScholesMertonProcess(Handle<Quote>(spot2),
+        ext::shared_ptr<StochasticProcess1D> stochProcess2 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot2),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS2)));
+                                      Handle<BlackVolTermStructure>(volTS2));
 
-        ext::shared_ptr<StochasticProcess1D> stochProcess3(new
-            BlackScholesMertonProcess(Handle<Quote>(spot3),
+        ext::shared_ptr<StochasticProcess1D> stochProcess3 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot3),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS3)));
+                                      Handle<BlackVolTermStructure>(volTS3));
 
         std::vector<ext::shared_ptr<StochasticProcess1D> > procs
             = {stochProcess1, stochProcess2, stochProcess3 };
@@ -582,8 +572,7 @@ BOOST_AUTO_TEST_CASE(testBarraquandThreeValues) {
             correlation[j][j] = 1.0;
         }
 
-        ext::shared_ptr<StochasticProcessArray> process(
-                               new StochasticProcessArray(procs,correlation));
+        ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(procs,correlation);
 
         // use a 3D sobol sequence...
         // Think long and hard before moving to more than 1 timestep....
@@ -654,21 +643,21 @@ BOOST_AUTO_TEST_CASE(testTavellaValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot3(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot3 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.1));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.1);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
-    ext::shared_ptr<SimpleQuote> vol3(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol3 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS3 = flatVol(today, vol3, dc);
 
     Real mcRelativeErrorTolerance = 0.01;
@@ -677,11 +666,10 @@ BOOST_AUTO_TEST_CASE(testTavellaValues) {
     BigNatural seed = 0;
 
 
-    ext::shared_ptr<PlainVanillaPayoff> payoff(new
-        PlainVanillaPayoff(values[0].type, values[0].strike));
+    ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(values[0].type, values[0].strike);
 
     Date exDate = today + timeToDays(values[0].t);
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
     spot1 ->setValue(values[0].s1);
     spot2 ->setValue(values[0].s2);
@@ -690,23 +678,20 @@ BOOST_AUTO_TEST_CASE(testTavellaValues) {
     vol2  ->setValue(values[0].v2);
     vol3  ->setValue(values[0].v3);
 
-    ext::shared_ptr<StochasticProcess1D> stochProcess1(new
-        BlackScholesMertonProcess(Handle<Quote>(spot1),
+    ext::shared_ptr<StochasticProcess1D> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS1)));
+                                  Handle<BlackVolTermStructure>(volTS1));
 
-    ext::shared_ptr<StochasticProcess1D> stochProcess2(new
-        BlackScholesMertonProcess(Handle<Quote>(spot2),
+    ext::shared_ptr<StochasticProcess1D> stochProcess2 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot2),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS2)));
+                                  Handle<BlackVolTermStructure>(volTS2));
 
-    ext::shared_ptr<StochasticProcess1D> stochProcess3(new
-        BlackScholesMertonProcess(Handle<Quote>(spot3),
+    ext::shared_ptr<StochasticProcess1D> stochProcess3 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot3),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS3)));
+                                  Handle<BlackVolTermStructure>(volTS3));
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > procs = {stochProcess1,
                                                                 stochProcess2,
@@ -723,8 +708,7 @@ BOOST_AUTO_TEST_CASE(testTavellaValues) {
     correlation[2][1] = 0.3;
     correlation[1][2] = 0.3;
 
-    ext::shared_ptr<StochasticProcessArray> process(
-                               new StochasticProcessArray(procs,correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(procs,correlation);
     ext::shared_ptr<PricingEngine> mcLSMCEngine =
         MakeMCAmericanBasketEngine<>(process)
         .withSteps(timeSteps)
@@ -772,33 +756,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testOneDAmericanValues, T, slices) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
 
     Size requiredSamples = 10000;
     Size timeSteps = 52;
     BigNatural seed = 0;
 
-    ext::shared_ptr<StochasticProcess1D> stochProcess1(new
-        BlackScholesMertonProcess(Handle<Quote>(spot1),
+    ext::shared_ptr<StochasticProcess1D> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS1)));
+                                  Handle<BlackVolTermStructure>(volTS1));
 
     std::vector<ext::shared_ptr<StochasticProcess1D>> procs = {stochProcess1};
 
     Matrix correlation(1, 1, 1.0);
 
-    ext::shared_ptr<StochasticProcessArray> process(
-        new StochasticProcessArray(procs, correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(procs, correlation);
 
     ext::shared_ptr<PricingEngine> mcLSMCEngine =
         MakeMCAmericanBasketEngine<>(process)
@@ -809,11 +791,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testOneDAmericanValues, T, slices) {
             .withSeed(seed);
 
     for (Size i = from; i < to; i++) {
-        ext::shared_ptr<PlainVanillaPayoff> payoff(
-            new PlainVanillaPayoff(oneDataValues[i].type, oneDataValues[i].strike));
+        ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(oneDataValues[i].type, oneDataValues[i].strike);
 
         Date exDate = today + timeToDays(oneDataValues[i].t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot1 ->setValue(oneDataValues[i].s);
         vol1  ->setValue(oneDataValues[i].v);
@@ -859,33 +840,31 @@ BOOST_AUTO_TEST_CASE(testOddSamples) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.05);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
 
 
 
     BigNatural seed = 0;
 
-    ext::shared_ptr<StochasticProcess1D> stochProcess1(new
-        BlackScholesMertonProcess(Handle<Quote>(spot1),
+    ext::shared_ptr<StochasticProcess1D> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS1)));
+                                  Handle<BlackVolTermStructure>(volTS1));
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > procs = {stochProcess1};
 
     Matrix correlation(1, 1, 1.0);
 
-    ext::shared_ptr<StochasticProcessArray> process(
-                               new StochasticProcessArray(procs,correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(procs,correlation);
 
     ext::shared_ptr<PricingEngine> mcLSMCEngine =
         MakeMCAmericanBasketEngine<>(process)
@@ -896,12 +875,11 @@ BOOST_AUTO_TEST_CASE(testOddSamples) {
         .withSeed(seed);
 
     for (auto& value : values) {
-        ext::shared_ptr<PlainVanillaPayoff> payoff(
-            new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,
-                                                                  exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today,
+                                                                  exDate);
 
         spot1->setValue(value.s);
         vol1->setValue(value.v);

--- a/test-suite/batesmodel.cpp
+++ b/test-suite/batesmodel.cpp
@@ -91,13 +91,12 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsBlack) {
     DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate = settlementDate + 6*Months;
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                     new PlainVanillaPayoff(Option::Put, 30));
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 30);
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.1, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.04, dayCounter));
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(32.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(32.0));
 
     Real yearFraction = dayCounter.yearFraction(settlementDate, exerciseDate);
     Real forwardPrice = s0->value()*std::exp((0.1-0.04)*yearFraction);
@@ -110,17 +109,16 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsBlack) {
     const Real sigma = 1.0e-4;
     const Real rho = 0.0;
     const Real lambda = 0.0001;
-    const Real nu = 0.0; 
+    const Real nu = 0.0;
     const Real delta = 0.0001;
 
     VanillaOption option(payoff, exercise);
 
-    ext::shared_ptr<BatesProcess> process(
-        new BatesProcess(riskFreeTS, dividendTS, s0, v0, 
-                         kappa, theta, sigma, rho, lambda, nu, delta));
+    ext::shared_ptr<BatesProcess> process = ext::make_shared<BatesProcess>(riskFreeTS, dividendTS, s0, v0,
+                         kappa, theta, sigma, rho, lambda, nu, delta);
 
-    ext::shared_ptr<PricingEngine> engine(new BatesEngine(
-        ext::make_shared<BatesModel>(process), 64));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<BatesEngine>(
+        ext::make_shared<BatesModel>(process), 64);
 
     option.setPricingEngine(engine);
     Real calculated = option.NPV();
@@ -136,9 +134,9 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsBlack) {
                     << "\n    error:      " << error);
     }
 
-    engine = ext::shared_ptr<PricingEngine>(new BatesDetJumpEngine(
+    engine = ext::make_shared<BatesDetJumpEngine>(
         ext::make_shared<BatesDetJumpModel>(
-            process, 1.0, 0.0001), 64));
+            process, 1.0, 0.0001), 64);
 
     option.setPricingEngine(engine);
     calculated = option.NPV();
@@ -154,9 +152,9 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsBlack) {
                     << "\n    error:      " << error);
     }
 
-    engine = ext::shared_ptr<PricingEngine>(new BatesDoubleExpEngine(
+    engine = ext::make_shared<BatesDoubleExpEngine>(
         ext::make_shared<BatesDoubleExpModel>(
-            process, 0.0001, 0.0001, 0.0001), 64));
+            process, 0.0001, 0.0001, 0.0001), 64);
 
     option.setPricingEngine(engine);
     calculated = option.NPV();
@@ -171,10 +169,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsBlack) {
                     << "\n    error:      " << error);
     }
 
-    engine = ext::shared_ptr<PricingEngine>(new BatesDoubleExpDetJumpEngine(
+    engine = ext::make_shared<BatesDoubleExpDetJumpEngine>(
         ext::make_shared<BatesDoubleExpDetJumpModel>(
-            
-                process, 0.0001, 0.0001, 0.0001, 0.5, 1.0, 0.0001), 64));
+
+                process, 0.0001, 0.0001, 0.0001, 0.5, 1.0, 0.0001), 64);
 
     option.setPricingEngine(engine);
     calculated = option.NPV();
@@ -200,15 +198,14 @@ BOOST_AUTO_TEST_CASE(testAnalyticAndMcVsJumpDiffusion) {
 
     DayCounter dayCounter = ActualActual(ActualActual::ISDA);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                     new PlainVanillaPayoff(Option::Put, 95));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 95);
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.1, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.04, dayCounter));
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
 
     Real v0 = 0.0433;
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(std::sqrt(v0)));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(std::sqrt(v0));
     ext::shared_ptr<BlackVolTermStructure> volTS =
         flatVol(settlementDate, vol, dayCounter);
 
@@ -217,23 +214,22 @@ BOOST_AUTO_TEST_CASE(testAnalyticAndMcVsJumpDiffusion) {
     const Real sigma = 1.0e-4;
     const Real rho = 0.0;
 
-    ext::shared_ptr<SimpleQuote> jumpIntensity(new SimpleQuote(2));
-    ext::shared_ptr<SimpleQuote> meanLogJump(new SimpleQuote(-0.2));
-    ext::shared_ptr<SimpleQuote> jumpVol(new SimpleQuote(0.2));
+    ext::shared_ptr<SimpleQuote> jumpIntensity = ext::make_shared<SimpleQuote>(2);
+    ext::shared_ptr<SimpleQuote> meanLogJump = ext::make_shared<SimpleQuote>(-0.2);
+    ext::shared_ptr<SimpleQuote> jumpVol = ext::make_shared<SimpleQuote>(0.2);
 
-    ext::shared_ptr<BatesProcess> batesProcess(new BatesProcess(
+    ext::shared_ptr<BatesProcess> batesProcess = ext::make_shared<BatesProcess>(
         riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho,
-        jumpIntensity->value(), meanLogJump->value(), jumpVol->value()));
+        jumpIntensity->value(), meanLogJump->value(), jumpVol->value());
 
-    ext::shared_ptr<Merton76Process> mertonProcess(
-        new Merton76Process(s0, dividendTS, riskFreeTS,
+    ext::shared_ptr<Merton76Process> mertonProcess = ext::make_shared<Merton76Process>(s0, dividendTS, riskFreeTS,
                             Handle<BlackVolTermStructure>(volTS),
                             Handle<Quote>(jumpIntensity),
                             Handle<Quote>(meanLogJump),
-                            Handle<Quote>(jumpVol)));
+                            Handle<Quote>(jumpVol));
 
-    ext::shared_ptr<PricingEngine> batesEngine(new BatesEngine(
-        ext::make_shared<BatesModel>(batesProcess), 160));
+    ext::shared_ptr<PricingEngine> batesEngine = ext::make_shared<BatesEngine>(
+        ext::make_shared<BatesModel>(batesProcess), 160);
 
     const Real mcTol = 0.1;
     ext::shared_ptr<PricingEngine> mcBatesEngine =
@@ -243,13 +239,11 @@ BOOST_AUTO_TEST_CASE(testAnalyticAndMcVsJumpDiffusion) {
             .withAbsoluteTolerance(mcTol)
             .withSeed(1234);
 
-    ext::shared_ptr<PricingEngine> mertonEngine(
-        new JumpDiffusionEngine(mertonProcess, 1e-10, 1000));
+    ext::shared_ptr<PricingEngine> mertonEngine = ext::make_shared<JumpDiffusionEngine>(mertonProcess, 1e-10, 1000);
 
     for (Integer i=1; i<=5; i+=2) {
         Date exerciseDate = settlementDate + i*Years;
-        ext::shared_ptr<Exercise> exercise(
-            new EuropeanExercise(exerciseDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
         VanillaOption batesOption(payoff, exercise);
 
@@ -298,19 +292,18 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsMCPricing) {
     DayCounter dayCounter = ActualActual(ActualActual::ISDA);
     Date exerciseDate(30, March, 2012);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                   new PlainVanillaPayoff(Option::Put, 100));
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100);
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
 
     for (auto& hestonModel : hestonModels) {
         Handle<YieldTermStructure> riskFreeTS(flatRate(hestonModel.r, dayCounter));
         Handle<YieldTermStructure> dividendTS(flatRate(hestonModel.q, dayCounter));
-        Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+        Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
 
-        ext::shared_ptr<BatesProcess> batesProcess(new BatesProcess(
+        ext::shared_ptr<BatesProcess> batesProcess = ext::make_shared<BatesProcess>(
             riskFreeTS, dividendTS, s0, hestonModel.v0, hestonModel.kappa, hestonModel.theta,
-            hestonModel.sigma, hestonModel.rho, 2.0, -0.2, 0.1));
+            hestonModel.sigma, hestonModel.rho, 2.0, -0.2, 0.1);
 
         const Real mcTolerance = 0.5;
         ext::shared_ptr<PricingEngine> mcEngine =
@@ -319,26 +312,24 @@ BOOST_AUTO_TEST_CASE(testAnalyticVsMCPricing) {
                 .withAntitheticVariate()
                 .withAbsoluteTolerance(mcTolerance)
                 .withSeed(1234);
-    
-        ext::shared_ptr<BatesModel> batesModel(new BatesModel(batesProcess));    
-        
-        ext::shared_ptr<PricingEngine> fdEngine(
-                            new FdBatesVanillaEngine(batesModel, 50, 100, 30));
-    
-        ext::shared_ptr<PricingEngine> analyticEngine(
-                                             new BatesEngine(batesModel, 160));
-    
+
+        ext::shared_ptr<BatesModel> batesModel = ext::make_shared<BatesModel>(batesProcess);
+
+        ext::shared_ptr<PricingEngine> fdEngine = ext::make_shared<FdBatesVanillaEngine>(batesModel, 50, 100, 30);
+
+        ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<BatesEngine>(batesModel, 160);
+
         VanillaOption option(payoff, exercise);
-    
+
         option.setPricingEngine(mcEngine);
         const Real calculated = option.NPV();
-    
+
         option.setPricingEngine(analyticEngine);
         const Real expected = option.NPV();
-    
+
         option.setPricingEngine(fdEngine);
         const Real fdCalculated = option.NPV();
-        
+
         const Real mcError = std::fabs(calculated - expected);
         if (mcError > 3*mcTolerance) {
             BOOST_FAIL("failed to reproduce Monte-Carlo price for BatesEngine"
@@ -387,8 +378,7 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
         rates.push_back(r[i]);
     }
     Handle<YieldTermStructure> riskFreeTS(
-                       ext::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, rates, dayCounter)));
+                       ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
 
     Handle<YieldTermStructure> dividendTS(
                                    flatRate(settlementDate, 0.0, dayCounter));
@@ -408,13 +398,13 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
         0.3857,0.2860,0.2578,0.2399,0.2357,0.2327,0.2312,0.2351,
         0.3976,0.2860,0.2607,0.2356,0.2297,0.2268,0.2241,0.2320 };
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(4468.17)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(4468.17));
     Real strike[] = { 3400,3600,3800,4000,4200,4400,
                       4500,4600,4800,5000,5200,5400,5600 };
 
 
     Real v0 = 0.0433;
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(std::sqrt(v0)));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(std::sqrt(v0));
 
     const Real kappa = 1.0;
     const Real theta = v0;
@@ -424,30 +414,26 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
     const Real nu = -0.1285;
     const Real delta = 0.1702;
 
-    ext::shared_ptr<BatesProcess> process(
-        new BatesProcess(riskFreeTS, dividendTS, s0, v0, 
-                         kappa, theta, sigma, rho, lambda, nu, delta));
+    ext::shared_ptr<BatesProcess> process = ext::make_shared<BatesProcess>(riskFreeTS, dividendTS, s0, v0,
+                         kappa, theta, sigma, rho, lambda, nu, delta);
 
-    ext::shared_ptr<BatesModel> batesModel(new BatesModel(process));
+    ext::shared_ptr<BatesModel> batesModel = ext::make_shared<BatesModel>(process);
 
-    ext::shared_ptr<PricingEngine> batesEngine(
-                                            new BatesEngine(batesModel, 64));
+    ext::shared_ptr<PricingEngine> batesEngine = ext::make_shared<BatesEngine>(batesModel, 64);
 
     std::vector<ext::shared_ptr<BlackCalibrationHelper> > options;
 
     for (Size s = 0; s < 13; ++s) {
         for (Size m = 0; m < 8; ++m) {
-            Handle<Quote> vol(ext::shared_ptr<Quote>(
-                                                  new SimpleQuote(v[s*8+m])));
+            Handle<Quote> vol(ext::make_shared<SimpleQuote>(v[s*8+m]));
 
             Period maturity((int)((t[m]+3)/7.), Weeks); // round to weeks
 
             // this is the calibration helper for the bates models
-            options.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-                    new HestonModelHelper(maturity, calendar,
+            options.push_back(ext::make_shared<HestonModelHelper>(maturity, calendar,
                                           s0->value(), strike[s], vol,
-                                          riskFreeTS, dividendTS, 
-                                          BlackCalibrationHelper::ImpliedVolError)));
+                                          riskFreeTS, dividendTS,
+                                          BlackCalibrationHelper::ImpliedVolError));
             options.back()->setPricingEngine(batesEngine);
         }
     }
@@ -467,28 +453,25 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
 
     //check pricing of derived engines
     std::vector<ext::shared_ptr<PricingEngine> > pricingEngines;
-    
+
     process = ext::make_shared<BatesProcess>(
-        riskFreeTS, dividendTS, s0, v0, 
+        riskFreeTS, dividendTS, s0, v0,
                          kappa, theta, sigma, rho, 1.0, -0.1, 0.1);
 
-    pricingEngines.push_back(ext::shared_ptr<PricingEngine>(
-        new BatesDetJumpEngine(
+    pricingEngines.push_back(ext::make_shared<BatesDetJumpEngine>(
             ext::make_shared<BatesDetJumpModel>(
-                             process), 64)) );
+                             process), 64) );
 
-    ext::shared_ptr<HestonProcess> hestonProcess(new HestonProcess(
-                    riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(
+                    riskFreeTS, dividendTS, s0, v0, kappa, theta, sigma, rho);
 
-    pricingEngines.push_back(ext::shared_ptr<PricingEngine>(
-        new BatesDoubleExpEngine(
+    pricingEngines.push_back(ext::make_shared<BatesDoubleExpEngine>(
             ext::make_shared<BatesDoubleExpModel>(
-                         hestonProcess, 1.0), 64)) );
+                         hestonProcess, 1.0), 64) );
 
-    pricingEngines.push_back(ext::shared_ptr<PricingEngine>(
-        new BatesDoubleExpDetJumpEngine(
+    pricingEngines.push_back(ext::make_shared<BatesDoubleExpDetJumpEngine>(
             ext::make_shared<BatesDoubleExpDetJumpModel>(
-                    hestonProcess, 1.0), 64)) );
+                    hestonProcess, 1.0), 64) );
 
     Real expectedValues[] = { 5896.37,
                               5499.29,

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -75,7 +75,7 @@ struct CommonVars {
         fixedFrequency = Annual;
         floatingFrequency = Semiannual;
         fixedDayCount = Thirty360(Thirty360::BondBasis);
-        index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+        index = ext::make_shared<Euribor6M>(termStructure);
         calendar = index->fixingCalendar();
         today = calendar.adjust(Date::todaysDate());
         settlement = calendar.advance(today,settlementDays,Days);
@@ -97,13 +97,11 @@ struct CommonVars {
                                floatingConvention,
                                floatingConvention,
                                DateGeneration::Forward, false);
-        ext::shared_ptr<VanillaSwap> swap(
-                      new VanillaSwap(type, nominal,
+        ext::shared_ptr<VanillaSwap> swap = ext::make_shared<VanillaSwap>(type, nominal,
                                       fixedSchedule, fixedRate, fixedDayCount,
                                       floatSchedule, index, 0.0,
-                                      index->dayCounter()));
-        swap->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                   new DiscountingSwapEngine(termStructure)));
+                                      index->dayCounter());
+        swap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(termStructure));
         return swap;
     }
 };
@@ -135,20 +133,18 @@ BOOST_AUTO_TEST_CASE(testCachedValues) {
     ext::shared_ptr<VanillaSwap> otmSwap = vars.makeSwap(1.2*atmRate);
 
     Real a = 0.048696, sigma = 0.0058904;
-    ext::shared_ptr<HullWhite> model(new HullWhite(vars.termStructure,
-                                                     a, sigma));
+    ext::shared_ptr<HullWhite> model = ext::make_shared<HullWhite>(vars.termStructure,
+                                                     a, sigma);
     std::vector<Date> exerciseDates;
     const Leg& leg = atmSwap->fixedLeg();
     for (const auto& i : leg) {
         ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
         exerciseDates.push_back(coupon->accrualStartDate());
     }
-    ext::shared_ptr<Exercise> exercise(new BermudanExercise(exerciseDates));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<BermudanExercise>(exerciseDates);
 
-    ext::shared_ptr<PricingEngine> treeEngine(
-                                            new TreeSwaptionEngine(model, 50));
-    ext::shared_ptr<PricingEngine> fdmEngine(
-                                         new FdHullWhiteSwaptionEngine(model));
+    ext::shared_ptr<PricingEngine> treeEngine = ext::make_shared<TreeSwaptionEngine>(model, 50);
+    ext::shared_ptr<PricingEngine> fdmEngine = ext::make_shared<FdHullWhiteSwaptionEngine>(model);
 
     Real itmValue,    atmValue,    otmValue;
     Real itmValueFdm, atmValueFdm, otmValueFdm;
@@ -206,7 +202,7 @@ BOOST_AUTO_TEST_CASE(testCachedValues) {
     for (auto& exerciseDate : exerciseDates)
         exerciseDate = vars.calendar.adjust(exerciseDate - 10);
     exercise =
-        ext::shared_ptr<Exercise>(new BermudanExercise(exerciseDates));
+        ext::make_shared<BermudanExercise>(exerciseDates);
 
     if (!usingAtParCoupons) {
         itmValue = 42.1791; atmValue = 12.7699; otmValue = 2.4368;

--- a/test-suite/binaryoption.cpp
+++ b/test-suite/binaryoption.cpp
@@ -127,36 +127,33 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingHaugValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(value.type, value.strike, value.cash));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(value.type, value.strike, value.cash);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
                                                                     exDate,
-                                                                    true));
+                                                                    true);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                             new AnalyticBinaryBarrierEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticBinaryBarrierEngine>(stochProcess);
 
         BarrierOption opt(value.barrierType, value.barrier, 0, payoff, amExercise);
 
@@ -208,34 +205,31 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingHaugValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new AssetOrNothingPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<AssetOrNothingPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today, exDate, true));
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today, exDate, true);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                             new AnalyticBinaryBarrierEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticBinaryBarrierEngine>(stochProcess);
 
         BarrierOption opt(value.barrierType, value.barrier, 0, payoff, amExercise);
 

--- a/test-suite/blackcalculator.cpp
+++ b/test-suite/blackcalculator.cpp
@@ -61,8 +61,7 @@ BOOST_AUTO_TEST_CASE(testBlackCalculatorBasicValues) {
         Real value1 = calc1.value();
         
         // Test constructor with Payoff
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(data.type, data.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(data.type, data.strike);
         BlackCalculator calc2(payoff, data.forward, data.stdDev, data.discount);
         Real value2 = calc2.value();
 

--- a/test-suite/blackdeltacalculator.cpp
+++ b/test-suite/blackdeltacalculator.cpp
@@ -195,23 +195,20 @@ BOOST_AUTO_TEST_CASE(testDeltaPriceConsistency) {
     Real calculatedVal  =0.0;
     Real error          =0.0;
 
-    ext::shared_ptr<SimpleQuote> spotQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spotQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> spotHandle(spotQuote);
 
-    ext::shared_ptr<SimpleQuote> qQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> qHandle(qQuote);
-    ext::shared_ptr<YieldTermStructure> qTS(
-                                         new FlatForward(today, qHandle, dc));
+    ext::shared_ptr<YieldTermStructure> qTS = ext::make_shared<FlatForward>(today, qHandle, dc);
 
-    ext::shared_ptr<SimpleQuote> rQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> rHandle(qQuote);
-    ext::shared_ptr<YieldTermStructure> rTS(
-                                         new FlatForward(today, rHandle, dc));
+    ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<FlatForward>(today, rHandle, dc);
 
-    ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> volHandle(volQuote);
-    ext::shared_ptr<BlackVolTermStructure> volTS(
-                        new BlackConstantVol(today, calendar, volHandle, dc));
+    ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackConstantVol>(today, calendar, volHandle, dc);
 
     ext::shared_ptr<BlackScholesMertonProcess>    stochProcess;
     ext::shared_ptr<PricingEngine>                engine;
@@ -225,9 +222,9 @@ BOOST_AUTO_TEST_CASE(testDeltaPriceConsistency) {
     for (auto& value : values) {
 
         payoff =
-            ext::shared_ptr<StrikedTypePayoff>(new PlainVanillaPayoff(value.type, value.strike));
+            ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         exDate = today + timeToDays(value.t);
-        exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+        exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spotQuote->setValue(value.s);
         volQuote->setValue(value.v);
@@ -246,8 +243,7 @@ BOOST_AUTO_TEST_CASE(testDeltaPriceConsistency) {
                                       Handle<YieldTermStructure>(rTS),
                                       Handle<BlackVolTermStructure>(volTS));
 
-        engine = ext::shared_ptr<PricingEngine>(
-                                    new AnalyticEuropeanEngine(stochProcess));
+        engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         EuropeanOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -383,22 +379,19 @@ BOOST_AUTO_TEST_CASE(testPutCallParity){
     Real error          =0.0;
     Real forward        =0.0;
 
-    ext::shared_ptr<SimpleQuote> spotQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spotQuote = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> qHandle(qQuote);
-    ext::shared_ptr<YieldTermStructure> qTS(
-                                         new FlatForward(today, qHandle, dc));
+    ext::shared_ptr<YieldTermStructure> qTS = ext::make_shared<FlatForward>(today, qHandle, dc);
 
-    ext::shared_ptr<SimpleQuote> rQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> rHandle(qQuote);
-    ext::shared_ptr<YieldTermStructure> rTS(
-                                         new FlatForward(today, rHandle, dc));
+    ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<FlatForward>(today, rHandle, dc);
 
-    ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> volHandle(volQuote);
-    ext::shared_ptr<BlackVolTermStructure> volTS(
-                        new BlackConstantVol(today, calendar, volHandle, dc));
+    ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackConstantVol>(today, calendar, volHandle, dc);
 
     ext::shared_ptr<StrikedTypePayoff> payoff;
     Date exDate;
@@ -409,9 +402,9 @@ BOOST_AUTO_TEST_CASE(testPutCallParity){
     for (auto& value : values) {
 
         payoff =
-            ext::shared_ptr<StrikedTypePayoff>(new PlainVanillaPayoff(Option::Call, value.strike));
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, value.strike);
         exDate = today + timeToDays(value.t);
-        exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+        exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spotQuote->setValue(value.s);
         volQuote->setValue(value.v);

--- a/test-suite/bonds.cpp
+++ b/test-suite/bonds.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(testAtmRate) {
     BusinessDayConvention paymentConvention = ModifiedFollowing;
     Real redemption = 100.0;
     Handle<YieldTermStructure> disc(flatRate(vars.today,0.03,Actual360()));
-    ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(disc));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(disc);
 
     for (int issueMonth : issueMonths) {
         for (int length : lengths) {
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                 Date issue = dated;
                 Date maturity = vars.calendar.advance(issue, length, Years);
 
-                ext::shared_ptr<SimpleQuote> rate(new SimpleQuote(0.0));
+                ext::shared_ptr<SimpleQuote> rate = ext::make_shared<SimpleQuote>(0.0);
                 Handle<YieldTermStructure> discountCurve(flatRate(vars.today, rate, bondDayCount));
 
                 Schedule sch(dated, maturity, Period(frequency), vars.calendar, accrualConvention,
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(testTheoretical) {
                                    std::vector<Rate>(1, coupon), bondDayCount, paymentConvention,
                                    redemption, issue);
 
-                ext::shared_ptr<PricingEngine> bondEngine(new DiscountingBondEngine(discountCurve));
+                ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(discountCurve);
                 bond.setPricingEngine(bondEngine);
 
                 for (Real m : yields) {
@@ -545,8 +545,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
         100.0, Date(1, November, 2004)
     );
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(discountCurve);
     bond1.setPricingEngine(bondEngine);
     bond1NoSchedule.setPricingEngine(bondEngine);
 
@@ -773,8 +772,7 @@ BOOST_AUTO_TEST_CASE(testCachedZero) {
                          ModifiedFollowing,
                          100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(discountCurve);
     bond1.setPricingEngine(bondEngine);
 
     Real cachedPrice1 = 88.551726;
@@ -857,8 +855,7 @@ BOOST_AUTO_TEST_CASE(testCachedFixed) {
                         ModifiedFollowing,
                         100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(discountCurve);
     bond1.setPricingEngine(bondEngine);
 
     Real cachedPrice1 = 99.298100;
@@ -942,13 +939,12 @@ BOOST_AUTO_TEST_CASE(testCachedFloating) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     // plain
 
@@ -967,8 +963,7 @@ BOOST_AUTO_TEST_CASE(testCachedFloating) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                     new DiscountingBondEngine(riskFreeRate));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(riskFreeRate);
     bond1.setPricingEngine(bondEngine);
 
     setCouponPricer(bond1.cashflows(),pricer);
@@ -994,8 +989,7 @@ BOOST_AUTO_TEST_CASE(testCachedFloating) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine2(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine2 = ext::make_shared<DiscountingBondEngine>(discountCurve);
     bond2.setPricingEngine(bondEngine2);
 
     setCouponPricer(bond2.cashflows(),pricer);
@@ -1505,8 +1499,7 @@ BOOST_AUTO_TEST_CASE(testFixedBondWithGivenDates) {
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(discountCurve);
     // plain
 
     Schedule sch1(Date(30,November,2004),
@@ -1620,14 +1613,13 @@ BOOST_AUTO_TEST_CASE(testRiskyBondWithGivenDates) {
     Settings::instance().evaluationDate() = today;
 
     // Probability Structure
-    Handle<Quote> hazardRate(ext::shared_ptr<Quote>(new SimpleQuote(0.1)));
+    Handle<Quote> hazardRate(ext::make_shared<SimpleQuote>(0.1));
     Handle<DefaultProbabilityTermStructure> defaultProbability(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-            new FlatHazardRate(0, TARGET(), hazardRate, Actual360())));
+        ext::make_shared<FlatHazardRate>(0, TARGET(), hazardRate, Actual360()));
 
     // Yield term structure
     RelinkableHandle<YieldTermStructure> riskFree;
-    riskFree.linkTo(ext::shared_ptr<YieldTermStructure>(new FlatForward(today, 0.02, Actual360())));
+    riskFree.linkTo(ext::make_shared<FlatForward>(today, 0.02, Actual360()));
     Schedule sch1(Date(30, November, 2004), Date(30, November, 2008), Period(Semiannual),
                   UnitedStates(UnitedStates::GovernmentBond), Unadjusted, Unadjusted,
                   DateGeneration::Backward, false);
@@ -1648,7 +1640,7 @@ BOOST_AUTO_TEST_CASE(testRiskyBondWithGivenDates) {
                        Date(20, November, 2004));
 
     // Create Engine
-    ext::shared_ptr<PricingEngine> bondEngine(new RiskyBondEngine(defaultProbability, recoveryRate, riskFree));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<RiskyBondEngine>(defaultProbability, recoveryRate, riskFree);
     bond.setPricingEngine(bondEngine);
 
     // Calculate and validate NPV and price
@@ -1707,7 +1699,7 @@ BOOST_AUTO_TEST_CASE(testFixedRateBondWithArbitrarySchedule) {
     }
 
     Handle<YieldTermStructure> discountCurve(flatRate(today, 0.03, Actual360()));
-    bond.setPricingEngine(ext::shared_ptr<PricingEngine>(new DiscountingBondEngine(discountCurve)));
+    bond.setPricingEngine(ext::make_shared<DiscountingBondEngine>(discountCurve));
 
     BOOST_CHECK_NO_THROW(bond.cleanPrice());
 }

--- a/test-suite/brownianbridge.cpp
+++ b/test-suite/brownianbridge.cpp
@@ -178,17 +178,13 @@ BOOST_AUTO_TEST_CASE(testPathGeneration) {
     InverseCumulativeRsg<SobolRsg,InverseCumulativeNormal> gsg(sobol);
 
     Date today = Settings::instance().evaluationDate();
-    Handle<Quote> x0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
-    Handle<YieldTermStructure> r(ext::shared_ptr<YieldTermStructure>(
-                               new FlatForward(today,0.06,Actual365Fixed())));
-    Handle<YieldTermStructure> q(ext::shared_ptr<YieldTermStructure>(
-                               new FlatForward(today,0.03,Actual365Fixed())));
+    Handle<Quote> x0(ext::make_shared<SimpleQuote>(100.0));
+    Handle<YieldTermStructure> r(ext::make_shared<FlatForward>(today,0.06,Actual365Fixed()));
+    Handle<YieldTermStructure> q(ext::make_shared<FlatForward>(today,0.03,Actual365Fixed()));
     Handle<BlackVolTermStructure> sigma(
-                   ext::shared_ptr<BlackVolTermStructure>(
-                          new BlackConstantVol(today, NullCalendar(), 0.20,Actual365Fixed())));
+                   ext::make_shared<BlackConstantVol>(today, NullCalendar(), 0.20,Actual365Fixed()));
 
-    ext::shared_ptr<StochasticProcess1D> process(
-                              new BlackScholesMertonProcess(x0, q, r, sigma));
+    ext::shared_ptr<StochasticProcess1D> process = ext::make_shared<BlackScholesMertonProcess>(x0, q, r, sigma);
 
 
     PathGenerator<InverseCumulativeRsg<SobolRsg,InverseCumulativeNormal> >

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -80,8 +80,7 @@ struct Globals {
 
     template <class R>
     ext::shared_ptr<YieldTermStructure> makeFlatCurve(const R& r) const {
-        return ext::shared_ptr<YieldTermStructure>(
-                                  new FlatForward(settlement, r, dayCounter));
+        return ext::make_shared<FlatForward>(settlement, r, dayCounter);
     }
 
     Globals() {
@@ -303,7 +302,7 @@ BOOST_AUTO_TEST_CASE(testObservability) {
 
     Globals vars;
 
-    ext::shared_ptr<SimpleQuote> observable(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> observable = ext::make_shared<SimpleQuote>(0.03);
     Handle<Quote> h(observable);
     vars.termStructure.linkTo(vars.makeFlatCurve(h));
     vars.model.linkTo(ext::make_shared<HullWhite>(vars.termStructure));

--- a/test-suite/capfloor.cpp
+++ b/test-suite/capfloor.cpp
@@ -63,7 +63,7 @@ struct CommonVars {
     CommonVars()
     : nominals(1,100) {
         frequency = Semiannual;
-        index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+        index = ext::make_shared<Euribor6M>(termStructure);
         calendar = index->fixingCalendar();
         convention = ModifiedFollowing;
         Date today = Settings::instance().evaluationDate();
@@ -88,15 +88,13 @@ struct CommonVars {
     }
 
     ext::shared_ptr<PricingEngine> makeEngine(Volatility volatility) const {
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(volatility)));
-        return ext::shared_ptr<PricingEngine>(
-                                new BlackCapFloorEngine(termStructure, vol));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(volatility));
+        return ext::make_shared<BlackCapFloorEngine>(termStructure, vol);
     }
 
     ext::shared_ptr<PricingEngine> makeBachelierEngine(Volatility volatility) const {
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(volatility)));
-        return ext::shared_ptr<PricingEngine>(
-                                new BachelierCapFloorEngine(termStructure, vol));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(volatility));
+        return ext::make_shared<BachelierCapFloorEngine>(termStructure, vol);
     }
 
     ext::shared_ptr<CapFloor> makeCapFloor(CapFloor::Type type,
@@ -107,12 +105,10 @@ struct CommonVars {
         ext::shared_ptr<CapFloor> result;
         switch (type) {
           case CapFloor::Cap:
-            result = ext::shared_ptr<CapFloor>(
-                                  new Cap(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<Cap>(leg, std::vector<Rate>(1, strike));
             break;
           case CapFloor::Floor:
-            result = ext::shared_ptr<CapFloor>(
-                                new Floor(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<Floor>(leg, std::vector<Rate>(1, strike));
             break;
           default:
             QL_FAIL("unknown cap/floor type");
@@ -379,7 +375,7 @@ BOOST_AUTO_TEST_CASE(testParity) {
                                  vars.index->dayCounter(), schedule, vars.index, 0.0,
                                  vars.index->dayCounter());
                 swap.setPricingEngine(
-                    ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(vars.termStructure)));
+                    ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
                 if (std::fabs((cap->NPV() - floor->NPV()) - swap.NPV()) > 1.0e-10) {
                     BOOST_FAIL("put/call parity violated:\n"
                                << "    length:      " << length << " years\n"
@@ -435,8 +431,7 @@ BOOST_AUTO_TEST_CASE(testATMRate) {
                                  vars.index->dayCounter(),
                                  schedule, vars.index, 0.0,
                                  vars.index->dayCounter());
-                swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                              new DiscountingSwapEngine(vars.termStructure)));
+                swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
                 Real swapNPV = swap.NPV();
                 if (!checkAbsError(swapNPV, 0, 1.0e-10))
                     BOOST_FAIL("the NPV of a Swap struck at ATM rate "
@@ -659,11 +654,11 @@ BOOST_AUTO_TEST_CASE(testOptionLetsDelta) {
 
     // Define spreaded curve with eps as spread used for FD sensitivities
     Real eps = 1.0e-6;
-    ext::shared_ptr<SimpleQuote> spread(new SimpleQuote(0.0));
-    ext::shared_ptr<YieldTermStructure> spreadCurve(new ZeroSpreadedTermStructure(
+    ext::shared_ptr<SimpleQuote> spread = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<YieldTermStructure> spreadCurve = ext::make_shared<ZeroSpreadedTermStructure>(
                                                             baseCurveHandle,
                                                             Handle<Quote>(spread),
-                                                            Continuous));
+                                                            Continuous);
     vars.termStructure.linkTo(spreadCurve);
     Date startDate = vars.termStructure->referenceDate();
     Leg leg = vars.makeLeg(startDate,20);  
@@ -778,11 +773,11 @@ BOOST_AUTO_TEST_CASE(testBachelierOptionLetsDelta) {
 
     // Define spreaded curve with eps as spread used for FD sensitivities
     Real eps = 1.0e-6;
-    ext::shared_ptr<SimpleQuote> spread(new SimpleQuote(0.0));
-    ext::shared_ptr<YieldTermStructure> spreadCurve(new ZeroSpreadedTermStructure(
+    ext::shared_ptr<SimpleQuote> spread = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<YieldTermStructure> spreadCurve = ext::make_shared<ZeroSpreadedTermStructure>(
                                                             baseCurveHandle,
                                                             Handle<Quote>(spread),
-                                                            Continuous));
+                                                            Continuous);
     vars.termStructure.linkTo(spreadCurve);
     Date startDate = vars.termStructure->referenceDate();
     Leg leg = vars.makeLeg(startDate,20);  

--- a/test-suite/capflooredcoupon.cpp
+++ b/test-suite/capflooredcoupon.cpp
@@ -67,7 +67,7 @@ struct CommonVars {
         nominal = 100.;
         nominals = std::vector<Real>(length,nominal);
         frequency = Annual;
-        index = ext::shared_ptr<IborIndex>(new Euribor1Y(termStructure));
+        index = ext::make_shared<Euribor1Y>(termStructure);
         calendar = index->fixingCalendar();
         convention = ModifiedFollowing;
         today = calendar.adjust(Date::todaysDate());
@@ -127,12 +127,10 @@ struct CommonVars {
                           convention,convention,
                           DateGeneration::Forward,false);
         Handle<OptionletVolatilityStructure> vol(
-                ext::shared_ptr<OptionletVolatilityStructure>(new
-                    ConstantOptionletVolatility(0, calendar, Following,
-                                                volatility,Actual365Fixed())));
+                ext::make_shared<ConstantOptionletVolatility>(0, calendar, Following,
+                                                volatility,Actual365Fixed()));
 
-        ext::shared_ptr<IborCouponPricer> pricer(new
-                BlackIborCouponPricer(vol));
+        ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(vol);
         std::vector<Rate> gearingVector(length, gearing);
         std::vector<Spread> spreadVector(length, spread);
 
@@ -150,9 +148,8 @@ struct CommonVars {
     }
 
     ext::shared_ptr<PricingEngine> makeEngine(Volatility volatility) const {
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(volatility)));
-        return ext::shared_ptr<PricingEngine>(
-                                 new BlackCapFloorEngine(termStructure, vol));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(volatility));
+        return ext::make_shared<BlackCapFloorEngine>(termStructure, vol);
     }
 
     ext::shared_ptr<CapFloor> makeCapFloor(CapFloor::Type type,
@@ -163,18 +160,15 @@ struct CommonVars {
         ext::shared_ptr<CapFloor> result;
         switch (type) {
           case CapFloor::Cap:
-            result = ext::shared_ptr<CapFloor>(
-                               new Cap(leg, std::vector<Rate>(1, capStrike)));
+            result = ext::make_shared<Cap>(leg, std::vector<Rate>(1, capStrike));
             break;
           case CapFloor::Floor:
-            result = ext::shared_ptr<CapFloor>(
-                           new Floor(leg, std::vector<Rate>(1, floorStrike)));
+            result = ext::make_shared<Floor>(leg, std::vector<Rate>(1, floorStrike));
             break;
           case CapFloor::Collar:
-            result = ext::shared_ptr<CapFloor>(
-                               new Collar(leg,
+            result = ext::make_shared<Collar>(leg,
                                           std::vector<Rate>(1, capStrike),
-                                          std::vector<Rate>(1, floorStrike)));
+                                          std::vector<Rate>(1, floorStrike));
             break;
           default:
             QL_FAIL("unknown cap/floor type");
@@ -209,8 +203,7 @@ BOOST_AUTO_TEST_CASE(testLargeRates) {
         vars.makeCapFlooredLeg(vars.startDate,vars.length,
                                caps,floors,vars.volatility);
 
-    ext::shared_ptr<PricingEngine> engine(
-                               new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     Swap vanillaLeg(fixedLeg,floatLeg);
     Swap collarLeg(fixedLeg,collaredLeg);
     vanillaLeg.setPricingEngine(engine);
@@ -267,8 +260,7 @@ BOOST_AUTO_TEST_CASE(testDecomposition) {
     // Swap with null fixed leg and floating leg with negative gearing and spread<>0
     Swap vanillaLeg_n(fixedLeg,floatLeg_n);
 
-    ext::shared_ptr<PricingEngine> engine(
-                               new DiscountingSwapEngine(vars.termStructure));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
     vanillaLeg.setPricingEngine(engine);
     vanillaLeg_p.setPricingEngine(engine);
     vanillaLeg_n.setPricingEngine(engine);

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -192,25 +192,23 @@ BOOST_AUTO_TEST_CASE(testAccessViolation) {
     Volatility volatility = 0.10;
     Handle<OptionletVolatilityStructure> vol;
     vol = Handle<OptionletVolatilityStructure>(
-             ext::shared_ptr<OptionletVolatilityStructure>(
-                 new ConstantOptionletVolatility(
+             ext::make_shared<ConstantOptionletVolatility>(
                              2,
                              calendar,
                              ModifiedFollowing,
                              volatility,
-                             Actual365Fixed())));
+                             Actual365Fixed()));
 
-    ext::shared_ptr<IborIndex> index3m (new USDLibor(3*Months,
-                                                       rhTermStructure));
+    ext::shared_ptr<IborIndex> index3m = ext::make_shared<USDLibor>(3*Months,
+                                                       rhTermStructure);
 
     Date payDate(20, December, 2013);
     Date startDate(20, September, 2013);
     Date endDate(20, December, 2013);
     Rate spread = 0.0115;
-    ext::shared_ptr<IborCouponPricer> pricer(new BlackIborCouponPricer(vol));
-    ext::shared_ptr<FloatingRateCoupon> coupon(
-        new FloatingRateCoupon(payDate,100, startDate, endDate, 2,
-                               index3m, 1.0 , spread / 100));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(vol);
+    ext::shared_ptr<FloatingRateCoupon> coupon = ext::make_shared<FloatingRateCoupon>(payDate,100, startDate, endDate, 2,
+                               index3m, 1.0 , spread / 100);
     coupon->setPricer(pricer);
 
     try {
@@ -262,7 +260,7 @@ BOOST_AUTO_TEST_CASE(testNullFixingDays, *precondition(usingAtParCoupons())) {
         .withConvention(Following)
         .backwards();
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months);
     Leg leg = IborLeg(schedule, index)
         .withNotionals(100.0)
         // this can happen with default values, and caused an
@@ -291,7 +289,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
     }
 
     // same for floating legs
-    ext::shared_ptr<IborIndex> index(new Euribor3M);
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor3M>();
     Leg l2 = IborLeg(schedule, index).withNotionals(100.0);
     for (auto& i : l2) {
         ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);

--- a/test-suite/catbonds.cpp
+++ b/test-suite/catbonds.cpp
@@ -53,7 +53,8 @@ BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
 BOOST_AUTO_TEST_SUITE(CatBondTests)
 
 std::pair<Date, Real> data[] = {std::pair<Date, Real>(Date(1, February, 2012), 100), std::pair<Date, Real>(Date(1, July, 2013), 150), std::pair<Date, Real>(Date(5, January, 2014), 50)};
-ext::shared_ptr<std::vector<std::pair<Date, Real> > > sampleEvents(new std::vector<std::pair<Date, Real> >(data, data+3));
+ext::shared_ptr<std::vector<std::pair<Date, Real> > > sampleEvents =
+    ext::make_shared<std::vector<std::pair<Date, Real> > >(data, data + 3);
 
 Date eventsStart(1, January, 2011);
 Date eventsEnd(31, December, 2014);
@@ -131,7 +132,8 @@ BOOST_AUTO_TEST_CASE(testEventSetForIrregularPeriods) {
 BOOST_AUTO_TEST_CASE(testEventSetForNoEvents) {
     BOOST_TEST_MESSAGE("Testing that catastrophe events are split correctly when there are no simulated events...");
 
-    ext::shared_ptr<std::vector<std::pair<Date, Real> > > emptyEvents(new std::vector<std::pair<Date, Real> >());
+    ext::shared_ptr<std::vector<std::pair<Date, Real> > > emptyEvents =
+        ext::make_shared<std::vector<std::pair<Date, Real> > >();
     EventSet catRisk(emptyEvents, eventsStart, eventsEnd);
     ext::shared_ptr<CatSimulation> simulation = catRisk.newSimulation(Date(2, January, 2015), Date(5, January, 2016));
 
@@ -212,13 +214,12 @@ BOOST_AUTO_TEST_CASE(testRiskFreeAgainstFloatingRateBond) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     // plain
 
@@ -229,12 +230,12 @@ BOOST_AUTO_TEST_CASE(testRiskFreeAgainstFloatingRateBond) {
                  ModifiedFollowing, ModifiedFollowing,
                  DateGeneration::Backward, false);
 
-    ext::shared_ptr<CatRisk> noCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> noCatRisk = ext::make_shared<EventSet>(
         ext::make_shared<std::vector<std::pair<Date, Real> > >(), 
-        Date(1, Jan, 2000), Date(31, Dec, 2010)));
+        Date(1, Jan, 2000), Date(31, Dec, 2010));
 
-    ext::shared_ptr<EventPaymentOffset> paymentOffset(new NoOffset());
-    ext::shared_ptr<NotionalRisk> notionalRisk(new DigitalNotionalRisk(paymentOffset, 100));
+    ext::shared_ptr<EventPaymentOffset> paymentOffset = ext::make_shared<NoOffset>();
+    ext::shared_ptr<NotionalRisk> notionalRisk = ext::make_shared<DigitalNotionalRisk>(paymentOffset, 100);
 
     FloatingRateBond bond1(settlementDays, vars.faceAmount, sch,
                            index, ActualActual(ActualActual::ISMA),
@@ -253,12 +254,11 @@ BOOST_AUTO_TEST_CASE(testRiskFreeAgainstFloatingRateBond) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine(
-                                     new DiscountingBondEngine(riskFreeRate));
+    ext::shared_ptr<PricingEngine> bondEngine = ext::make_shared<DiscountingBondEngine>(riskFreeRate);
     bond1.setPricingEngine(bondEngine);
     setCouponPricer(bond1.cashflows(),pricer);
 
-    ext::shared_ptr<PricingEngine> catBondEngine(new MonteCarloCatBondEngine(noCatRisk, riskFreeRate));
+    ext::shared_ptr<PricingEngine> catBondEngine = ext::make_shared<MonteCarloCatBondEngine>(noCatRisk, riskFreeRate);
     catBond1.setPricingEngine(catBondEngine);
     setCouponPricer(catBond1.cashflows(),pricer);
 
@@ -296,12 +296,11 @@ BOOST_AUTO_TEST_CASE(testRiskFreeAgainstFloatingRateBond) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> bondEngine2(
-                                    new DiscountingBondEngine(discountCurve));
+    ext::shared_ptr<PricingEngine> bondEngine2 = ext::make_shared<DiscountingBondEngine>(discountCurve);
     bond2.setPricingEngine(bondEngine2);
     setCouponPricer(bond2.cashflows(),pricer);
 
-    ext::shared_ptr<PricingEngine> catBondEngine2(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngine2 = ext::make_shared<MonteCarloCatBondEngine>(noCatRisk, discountCurve);
     catBond2.setPricingEngine(catBondEngine2);
     setCouponPricer(catBond2.cashflows(),pricer);
 
@@ -376,13 +375,12 @@ BOOST_AUTO_TEST_CASE(testCatBondInDoomScenario) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     Schedule sch(Date(30,November,2004),
                  Date(30,November,2008),
@@ -391,14 +389,15 @@ BOOST_AUTO_TEST_CASE(testCatBondInDoomScenario) {
                  ModifiedFollowing, ModifiedFollowing,
                  DateGeneration::Backward, false);
 
-    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
+    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events =
+        ext::make_shared<std::vector<std::pair<Date, Real> > >();
     events->emplace_back(Date(30,November,2004), 1000);
-    ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> doomCatRisk = ext::make_shared<EventSet>(
         events, 
-        Date(30,November,2004), Date(30,November,2008)));
+        Date(30,November,2004), Date(30,November,2008));
 
-    ext::shared_ptr<EventPaymentOffset> paymentOffset(new NoOffset());
-    ext::shared_ptr<NotionalRisk> notionalRisk(new DigitalNotionalRisk(paymentOffset, 100));
+    ext::shared_ptr<EventPaymentOffset> paymentOffset = ext::make_shared<NoOffset>();
+    ext::shared_ptr<NotionalRisk> notionalRisk = ext::make_shared<DigitalNotionalRisk>(paymentOffset, 100);
 
     FloatingCatBond catBond(settlementDays, vars.faceAmount, sch,
                            index, ActualActual(ActualActual::ISMA),
@@ -409,7 +408,7 @@ BOOST_AUTO_TEST_CASE(testCatBondInDoomScenario) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> catBondEngine(new MonteCarloCatBondEngine(doomCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngine = ext::make_shared<MonteCarloCatBondEngine>(doomCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngine);
     setCouponPricer(catBond.cashflows(),pricer);
 
@@ -438,13 +437,12 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYears) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     Schedule sch(Date(30,November,2004),
                  Date(30,November,2008),
@@ -453,18 +451,19 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYears) {
                  ModifiedFollowing, ModifiedFollowing,
                  DateGeneration::Backward, false);
 
-    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
+    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events =
+        ext::make_shared<std::vector<std::pair<Date, Real> > >();
     events->emplace_back(Date(30,November,2008), 1000);
-    ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> doomCatRisk = ext::make_shared<EventSet>(
         events, 
-        Date(30,November,2004), Date(30,November,2044)));
+        Date(30,November,2004), Date(30,November,2044));
 
-    ext::shared_ptr<CatRisk> noCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> noCatRisk = ext::make_shared<EventSet>(
         ext::make_shared<std::vector<std::pair<Date, Real> > >(), 
-        Date(1, Jan, 2000), Date(31, Dec, 2010)));
+        Date(1, Jan, 2000), Date(31, Dec, 2010));
 
-    ext::shared_ptr<EventPaymentOffset> paymentOffset(new NoOffset());
-    ext::shared_ptr<NotionalRisk> notionalRisk(new DigitalNotionalRisk(paymentOffset, 100));
+    ext::shared_ptr<EventPaymentOffset> paymentOffset = ext::make_shared<NoOffset>();
+    ext::shared_ptr<NotionalRisk> notionalRisk = ext::make_shared<DigitalNotionalRisk>(paymentOffset, 100);
 
     FloatingCatBond catBond(settlementDays, vars.faceAmount, sch,
                            index, ActualActual(ActualActual::ISMA),
@@ -475,7 +474,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYears) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> catBondEngine(new MonteCarloCatBondEngine(doomCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngine = ext::make_shared<MonteCarloCatBondEngine>(doomCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngine);
     setCouponPricer(catBond.cashflows(),pricer);
 
@@ -489,7 +488,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYears) {
     QL_CHECK_CLOSE(Real(0.1), exhaustionProbability, tolerance);
     QL_CHECK_CLOSE(Real(0.1), expectedLoss, tolerance);
 
-    ext::shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngineRF = ext::make_shared<MonteCarloCatBondEngine>(noCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngineRF);
 
     Real riskFreePrice = catBond.cleanPrice();
@@ -519,13 +518,12 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYearsProportional) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     Schedule sch(Date(30,November,2004),
                  Date(30,November,2008),
@@ -534,18 +532,19 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYearsProportional) {
                  ModifiedFollowing, ModifiedFollowing,
                  DateGeneration::Backward, false);
 
-    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events(new std::vector<std::pair<Date, Real> >());
+    ext::shared_ptr<std::vector<std::pair<Date, Real> > > events =
+        ext::make_shared<std::vector<std::pair<Date, Real> > >();
     events->emplace_back(Date(30,November,2008), 1000);
-    ext::shared_ptr<CatRisk> doomCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> doomCatRisk = ext::make_shared<EventSet>(
         events, 
-        Date(30,November,2004), Date(30,November,2044)));
+        Date(30,November,2004), Date(30,November,2044));
 
-    ext::shared_ptr<CatRisk> noCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> noCatRisk = ext::make_shared<EventSet>(
         ext::make_shared<std::vector<std::pair<Date, Real> > >(), 
-        Date(1, Jan, 2000), Date(31, Dec, 2010)));
+        Date(1, Jan, 2000), Date(31, Dec, 2010));
 
-    ext::shared_ptr<EventPaymentOffset> paymentOffset(new NoOffset());
-    ext::shared_ptr<NotionalRisk> notionalRisk(new ProportionalNotionalRisk(paymentOffset, 500, 1500));
+    ext::shared_ptr<EventPaymentOffset> paymentOffset = ext::make_shared<NoOffset>();
+    ext::shared_ptr<NotionalRisk> notionalRisk = ext::make_shared<ProportionalNotionalRisk>(paymentOffset, 500, 1500);
 
     FloatingCatBond catBond(settlementDays, vars.faceAmount, sch,
                            index, ActualActual(ActualActual::ISMA),
@@ -556,7 +555,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYearsProportional) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> catBondEngine(new MonteCarloCatBondEngine(doomCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngine = ext::make_shared<MonteCarloCatBondEngine>(doomCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngine);
     setCouponPricer(catBond.cashflows(),pricer);
 
@@ -570,7 +569,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithDoomOnceInTenYearsProportional) {
     QL_CHECK_CLOSE(Real(0.0), exhaustionProbability, tolerance);
     QL_CHECK_CLOSE(Real(0.05), expectedLoss, tolerance);
 
-    ext::shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngineRF = ext::make_shared<MonteCarloCatBondEngine>(noCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngineRF);
 
     Real riskFreePrice = catBond.cleanPrice();
@@ -598,13 +597,12 @@ BOOST_AUTO_TEST_CASE(testCatBondWithGeneratedEventsProportional) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today,0.025,Actual360()));
     Handle<YieldTermStructure> discountCurve(flatRate(today,0.03,Actual360()));
 
-    ext::shared_ptr<IborIndex> index(new USDLibor(6*Months, riskFreeRate));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<USDLibor>(6*Months, riskFreeRate);
     Natural fixingDays = 1;
 
     Real tolerance = 1.0e-6;
 
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(Handle<OptionletVolatilityStructure>()));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(Handle<OptionletVolatilityStructure>());
 
     Schedule sch(Date(30,November,2004),
                  Date(30,November,2008),
@@ -613,14 +611,14 @@ BOOST_AUTO_TEST_CASE(testCatBondWithGeneratedEventsProportional) {
                  ModifiedFollowing, ModifiedFollowing,
                  DateGeneration::Backward, false);
 
-    ext::shared_ptr<CatRisk> betaCatRisk(new BetaRisk(5000, 50, 500, 500));
+    ext::shared_ptr<CatRisk> betaCatRisk = ext::make_shared<BetaRisk>(5000, 50, 500, 500);
 
-    ext::shared_ptr<CatRisk> noCatRisk(new EventSet(
+    ext::shared_ptr<CatRisk> noCatRisk = ext::make_shared<EventSet>(
         ext::make_shared<std::vector<std::pair<Date, Real> > >(), 
-        Date(1, Jan, 2000), Date(31, Dec, 2010)));
+        Date(1, Jan, 2000), Date(31, Dec, 2010));
 
-    ext::shared_ptr<EventPaymentOffset> paymentOffset(new NoOffset());
-    ext::shared_ptr<NotionalRisk> notionalRisk(new ProportionalNotionalRisk(paymentOffset, 500, 1500));
+    ext::shared_ptr<EventPaymentOffset> paymentOffset = ext::make_shared<NoOffset>();
+    ext::shared_ptr<NotionalRisk> notionalRisk = ext::make_shared<ProportionalNotionalRisk>(paymentOffset, 500, 1500);
 
     FloatingCatBond catBond(settlementDays, vars.faceAmount, sch,
                            index, ActualActual(ActualActual::ISMA),
@@ -631,7 +629,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithGeneratedEventsProportional) {
                            false,
                            100.0, Date(30,November,2004));
 
-    ext::shared_ptr<PricingEngine> catBondEngine(new MonteCarloCatBondEngine(betaCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngine = ext::make_shared<MonteCarloCatBondEngine>(betaCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngine);
     setCouponPricer(catBond.cashflows(),pricer);
 
@@ -645,7 +643,7 @@ BOOST_AUTO_TEST_CASE(testCatBondWithGeneratedEventsProportional) {
     BOOST_CHECK(exhaustionProbability<1.0 && exhaustionProbability>0.0);
     BOOST_CHECK(expectedLoss>0.0);
 
-    ext::shared_ptr<PricingEngine> catBondEngineRF(new MonteCarloCatBondEngine(noCatRisk, discountCurve));
+    ext::shared_ptr<PricingEngine> catBondEngineRF = ext::make_shared<MonteCarloCatBondEngine>(noCatRisk, discountCurve);
     catBond.setPricingEngine(catBondEngineRF);
 
     Real riskFreePrice = catBond.cleanPrice();

--- a/test-suite/cdo.cpp
+++ b/test-suite/cdo.cpp
@@ -133,15 +133,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
 
     Settings::instance().evaluationDate() = asofDate;
 
-    ext::shared_ptr<YieldTermStructure> yieldPtr(
-        new FlatForward(asofDate, rate, daycount, cmp));
+    ext::shared_ptr<YieldTermStructure> yieldPtr = ext::make_shared<FlatForward>(asofDate, rate, daycount, cmp);
     Handle<YieldTermStructure> yieldHandle(yieldPtr);
 
-    Handle<Quote> hazardRate(ext::shared_ptr<Quote>(new SimpleQuote(lambda)));
+    Handle<Quote> hazardRate(ext::make_shared<SimpleQuote>(lambda));
     std::vector<Handle<DefaultProbabilityTermStructure>> basket;
-    ext::shared_ptr<DefaultProbabilityTermStructure> ptr(
-        new FlatHazardRate(asofDate, hazardRate, ActualActual(ActualActual::ISDA)));
-    ext::shared_ptr<Pool> pool(new Pool());
+    ext::shared_ptr<DefaultProbabilityTermStructure> ptr = ext::make_shared<FlatHazardRate>(asofDate, hazardRate, ActualActual(ActualActual::ISDA));
+    ext::shared_ptr<Pool> pool = ext::make_shared<Pool>();
     std::vector<std::string> names;
     // probability key items
     std::vector<Issuer> issuers;
@@ -161,12 +159,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
                   NorthAmericaCorpDefaultKey(EURCurrency(), QuantLib::SeniorSec, Period(), 1.));
     }
 
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> hCorrelation(correlation);
     QL_REQUIRE(std::size(hwAttachment) == std::size(hwDetachment), "data length does not match");
 
-    ext::shared_ptr<PricingEngine> midPCDOEngine(new MidPointCDOEngine(yieldHandle));
-    ext::shared_ptr<PricingEngine> integralCDOEngine(new IntegralCDOEngine(yieldHandle));
+    ext::shared_ptr<PricingEngine> midPCDOEngine = ext::make_shared<MidPointCDOEngine>(yieldHandle);
+    ext::shared_ptr<PricingEngine> integralCDOEngine = ext::make_shared<IntegralCDOEngine>(yieldHandle);
 
     const Size i = dataSet;
     correlation->setValue(hwData7[i].correlation);
@@ -177,37 +175,32 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
     std::vector<Real> relativeToleranceMidp, relativeTolerancePeriod, absoluteTolerance;
 
     if (hwData7[i].nm == -1 && hwData7[i].nz == -1) {
-        ext::shared_ptr<GaussianConstantLossLM> gaussKtLossLM(
-            new GaussianConstantLossLM(hCorrelation, std::vector<Real>(poolSize, recovery),
+        ext::shared_ptr<GaussianConstantLossLM> gaussKtLossLM = ext::make_shared<GaussianConstantLossLM>(hCorrelation, std::vector<Real>(poolSize, recovery),
                                        LatentModelIntegrationType::GaussianQuadrature, poolSize,
-                                       GaussianCopulaPolicy::initTraits()));
+                                       GaussianCopulaPolicy::initTraits());
 
         // 1.-Inhomogeneous gaussian
         modelNames.emplace_back("Inhomogeneous gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new IHGaussPoolLossModel(gaussKtLossLM, nBuckets, 5., -5, 15)));
+        basketModels.push_back(ext::make_shared<IHGaussPoolLossModel>(gaussKtLossLM, nBuckets, 5., -5, 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 2.-homogeneous gaussian
         modelNames.emplace_back("Homogeneous gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new HomogGaussPoolLossModel(gaussKtLossLM, nBuckets, 5., -5, 15)));
+        basketModels.push_back(ext::make_shared<HomogGaussPoolLossModel>(gaussKtLossLM, nBuckets, 5., -5, 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 3.-random default gaussian
         modelNames.emplace_back("Random default gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new RandomDefaultLM<GaussianCopulaPolicy>(gaussKtLossLM, numSims)));
+        basketModels.push_back(ext::make_shared<RandomDefaultLM<GaussianCopulaPolicy>>(gaussKtLossLM, numSims));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.07);
         relativeTolerancePeriod.push_back(0.07);
         // SECOND MC
         // gaussian LHP
         modelNames.emplace_back("Gaussian LHP");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new GaussianLHPLossModel(hCorrelation, std::vector<Real>(poolSize, recovery))));
+        basketModels.push_back(ext::make_shared<GaussianLHPLossModel>(hCorrelation, std::vector<Real>(poolSize, recovery)));
         absoluteTolerance.push_back(10.);
         relativeToleranceMidp.push_back(0.5);
         relativeTolerancePeriod.push_back(0.5);
@@ -218,27 +211,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
         TCopulaPolicy::initTraits initTG;
         initTG.tOrders.push_back(hwData7[i].nm);
         initTG.tOrders.push_back(hwData7[i].nz);
-        ext::shared_ptr<TConstantLossLM> TKtLossLM(new TConstantLossLM(
+        ext::shared_ptr<TConstantLossLM> TKtLossLM = ext::make_shared<TConstantLossLM>(
             hCorrelation, std::vector<Real>(poolSize, recovery),
-            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG));
+            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG);
         // 1.-inhomogeneous studentT
         modelNames.emplace_back("Inhomogeneous student");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new IHStudentPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<IHStudentPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 2.-homogeneous student T
         modelNames.emplace_back("Homogeneous student");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new HomogTPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<HomogTPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 3.-random default student T
         modelNames.emplace_back("Random default studentT");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new RandomDefaultLM<TCopulaPolicy>(TKtLossLM, numSims)));
+        basketModels.push_back(ext::make_shared<RandomDefaultLM<TCopulaPolicy>>(TKtLossLM, numSims));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.07);
         relativeTolerancePeriod.push_back(0.07);
@@ -254,27 +244,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
         be this conservative as the polynomial convolution gets shorter and
         faster as the order decreases.
         */
-        ext::shared_ptr<TConstantLossLM> TKtLossLM(new TConstantLossLM(
+        ext::shared_ptr<TConstantLossLM> TKtLossLM = ext::make_shared<TConstantLossLM>(
             hCorrelation, std::vector<Real>(poolSize, recovery),
-            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG));
+            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG);
         // 1.-inhomogeneous
         modelNames.emplace_back("Inhomogeneous student-gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new IHStudentPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<IHStudentPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 2.-homogeneous
         modelNames.emplace_back("Homogeneous student-gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new HomogTPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<HomogTPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 3.-random default
         modelNames.emplace_back("Random default student-gaussian");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new RandomDefaultLM<TCopulaPolicy>(TKtLossLM, numSims)));
+        basketModels.push_back(ext::make_shared<RandomDefaultLM<TCopulaPolicy>>(TKtLossLM, numSims));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.07);
         relativeTolerancePeriod.push_back(0.07);
@@ -286,27 +273,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
         TCopulaPolicy::initTraits initTG;
         initTG.tOrders.push_back(45); // pretty close to gaussian
         initTG.tOrders.push_back(hwData7[i].nz);
-        ext::shared_ptr<TConstantLossLM> TKtLossLM(new TConstantLossLM(
+        ext::shared_ptr<TConstantLossLM> TKtLossLM = ext::make_shared<TConstantLossLM>(
             hCorrelation, std::vector<Real>(poolSize, recovery),
-            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG));
+            LatentModelIntegrationType::GaussianQuadrature, poolSize, initTG);
         // 1.-inhomogeneous gaussian
         modelNames.emplace_back("Inhomogeneous gaussian-student");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new IHStudentPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<IHStudentPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 2.-homogeneous gaussian
         modelNames.emplace_back("Homogeneous gaussian-student");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new HomogTPoolLossModel(TKtLossLM, nBuckets, 5., -5., 15)));
+        basketModels.push_back(ext::make_shared<HomogTPoolLossModel>(TKtLossLM, nBuckets, 5., -5., 15));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.04);
         relativeTolerancePeriod.push_back(0.04);
         // 3.-random default gaussian
         modelNames.emplace_back("Random default gaussian-student");
-        basketModels.push_back(ext::shared_ptr<DefaultLossModel>(
-            new RandomDefaultLM<TCopulaPolicy>(TKtLossLM, numSims)));
+        basketModels.push_back(ext::make_shared<RandomDefaultLM<TCopulaPolicy>>(TKtLossLM, numSims));
         absoluteTolerance.push_back(1.);
         relativeToleranceMidp.push_back(0.07);
         relativeTolerancePeriod.push_back(0.07);
@@ -319,8 +303,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(testHW, T, dataSets) {
     }
 
     for (Size j = 0; j < std::size(hwAttachment); j++) {
-        ext::shared_ptr<Basket> basketPtr(
-            new Basket(asofDate, names, nominals, pool, hwAttachment[j], hwDetachment[j]));
+        ext::shared_ptr<Basket> basketPtr = ext::make_shared<Basket>(asofDate, names, nominals, pool, hwAttachment[j], hwDetachment[j]);
         std::ostringstream trancheId;
         trancheId << "[" << hwAttachment[j] << " , " << hwDetachment[j] << "]";
         SyntheticCDO cdoe(basketPtr, Protection::Seller, schedule, 0.0, premium, daycount,

--- a/test-suite/cdsoption.cpp
+++ b/test-suite/cdsoption.cpp
@@ -48,8 +48,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
     Calendar calendar = TARGET();
 
     RelinkableHandle<YieldTermStructure> riskFree;
-    riskFree.linkTo(ext::shared_ptr<YieldTermStructure>(
-                              new FlatForward(cachedToday,0.02,Actual360())));
+    riskFree.linkTo(ext::make_shared<FlatForward>(cachedToday,0.02,Actual360()));
 
     Date expiry = calendar.advance(cachedToday,9,Months);
     Date startDate = calendar.advance(expiry,1,Months);
@@ -59,7 +58,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
     BusinessDayConvention convention = ModifiedFollowing;
     Real notional = 1000000.0;
 
-    Handle<Quote> hazardRate(ext::shared_ptr<Quote>(new SimpleQuote(0.001)));
+    Handle<Quote> hazardRate(ext::make_shared<SimpleQuote>(0.001));
 
     Schedule schedule(startDate,maturity, Period(Quarterly),
                       calendar, convention, convention,
@@ -67,29 +66,25 @@ BOOST_AUTO_TEST_CASE(testCached) {
 
     Real recoveryRate = 0.4;
     Handle<DefaultProbabilityTermStructure> defaultProbability(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-                    new FlatHazardRate(0, calendar, hazardRate, dayCounter)));
+        ext::make_shared<FlatHazardRate>(0, calendar, hazardRate, dayCounter));
 
-    ext::shared_ptr<PricingEngine> swapEngine(
-           new MidPointCdsEngine(defaultProbability, recoveryRate, riskFree));
+    ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<MidPointCdsEngine>(defaultProbability, recoveryRate, riskFree);
 
     CreditDefaultSwap swap(Protection::Seller, notional, 0.001, schedule,
                            convention, dayCounter);
     swap.setPricingEngine(swapEngine);
     Rate strike = swap.fairSpread();
 
-    Handle<Quote> cdsVol(ext::shared_ptr<Quote>(new SimpleQuote(0.20)));
+    Handle<Quote> cdsVol(ext::make_shared<SimpleQuote>(0.20));
 
-    ext::shared_ptr<CreditDefaultSwap> underlying(
-         new CreditDefaultSwap(Protection::Seller, notional, strike, schedule,
-                               convention, dayCounter));
+    ext::shared_ptr<CreditDefaultSwap> underlying = ext::make_shared<CreditDefaultSwap>(Protection::Seller, notional, strike, schedule,
+                               convention, dayCounter);
     underlying->setPricingEngine(swapEngine);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(expiry));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(expiry);
     CdsOption option1(underlying, exercise);
-    option1.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new BlackCdsOptionEngine(defaultProbability, recoveryRate,
-                                             riskFree, cdsVol)));
+    option1.setPricingEngine(ext::make_shared<BlackCdsOptionEngine>(defaultProbability, recoveryRate,
+                                             riskFree, cdsVol));
 
     Real cachedValue = 270.976348;
     if (std::fabs(option1.NPV() - cachedValue) > 1.0e-5)
@@ -104,9 +99,8 @@ BOOST_AUTO_TEST_CASE(testCached) {
     underlying->setPricingEngine(swapEngine);
 
     CdsOption option2(underlying, exercise);
-    option2.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                    new BlackCdsOptionEngine(defaultProbability, recoveryRate,
-                                             riskFree, cdsVol)));
+    option2.setPricingEngine(ext::make_shared<BlackCdsOptionEngine>(defaultProbability, recoveryRate,
+                                             riskFree, cdsVol));
 
     cachedValue = 270.976348;
     if (std::fabs(option2.NPV() - cachedValue) > 1.0e-5)

--- a/test-suite/cliquetoption.cpp
+++ b/test-suite/cliquetoption.cpp
@@ -61,20 +61,19 @@ BOOST_AUTO_TEST_CASE(testValues) {
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(60.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(60.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.08));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.08);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.30));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.30);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
-    ext::shared_ptr<PricingEngine> engine(new AnalyticCliquetEngine(process));
+                                       Handle<BlackVolTermStructure>(volTS));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticCliquetEngine>(process);
 
     std::vector<Date> reset;
     reset.push_back(today + 90);
@@ -82,10 +81,8 @@ BOOST_AUTO_TEST_CASE(testValues) {
     Option::Type type = Option::Call;
     Real moneyness = 1.1;
 
-    ext::shared_ptr<PercentageStrikePayoff> payoff(
-                                 new PercentageStrikePayoff(type, moneyness));
-    ext::shared_ptr<EuropeanExercise> exercise(
-                                              new EuropeanExercise(maturity));
+    ext::shared_ptr<PercentageStrikePayoff> payoff = ext::make_shared<PercentageStrikePayoff>(type, moneyness);
+    ext::shared_ptr<EuropeanExercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
     CliquetOption option(payoff, exercise, reset);
     option.setPricingEngine(engine);
@@ -127,35 +124,32 @@ void testOptionGreeks() {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
     for (auto& type : types) {
         for (Real moneynes : moneyness) {
             for (int length : lengths) {
                 for (auto& frequencie : frequencies) {
 
-                    ext::shared_ptr<EuropeanExercise> maturity(
-                            new EuropeanExercise(today + length * Years));
+                    ext::shared_ptr<EuropeanExercise> maturity = ext::make_shared<EuropeanExercise>(today + length * Years);
 
-                    ext::shared_ptr<PercentageStrikePayoff> payoff(
-                            new PercentageStrikePayoff(type, moneynes));
+                    ext::shared_ptr<PercentageStrikePayoff> payoff = ext::make_shared<PercentageStrikePayoff>(type, moneynes);
 
                     std::vector<Date> reset;
                     for (Date d = today + Period(frequencie); d < maturity->lastDate();
                          d += Period(frequencie))
                         reset.push_back(d);
 
-                    ext::shared_ptr<PricingEngine> engine(new T(process));
+                    ext::shared_ptr<PricingEngine> engine = ext::make_shared<T>(process);
 
                     CliquetOption option(payoff, maturity, reset);
                     option.setPricingEngine(engine);
@@ -279,17 +273,16 @@ BOOST_AUTO_TEST_CASE(testMcPerformance) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
     for (auto& type : types) {
         for (Real moneynes : moneyness) {
@@ -297,11 +290,9 @@ BOOST_AUTO_TEST_CASE(testMcPerformance) {
                 for (auto& frequencie : frequencies) {
 
                     auto tenor = Period(frequencie);
-                    ext::shared_ptr<EuropeanExercise> maturity(
-                        new EuropeanExercise(today + length * tenor));
+                    ext::shared_ptr<EuropeanExercise> maturity = ext::make_shared<EuropeanExercise>(today + length * tenor);
 
-                    ext::shared_ptr<PercentageStrikePayoff> payoff(
-                        new PercentageStrikePayoff(type, moneynes));
+                    ext::shared_ptr<PercentageStrikePayoff> payoff = ext::make_shared<PercentageStrikePayoff>(type, moneynes);
 
                     std::vector<Date> reset;
                     for (Date d = today + tenor; d < maturity->lastDate(); d += tenor)
@@ -309,8 +300,7 @@ BOOST_AUTO_TEST_CASE(testMcPerformance) {
 
                     CliquetOption option(payoff, maturity, reset);
 
-                    ext::shared_ptr<PricingEngine> refEngine(
-                        new AnalyticPerformanceEngine(process));
+                    ext::shared_ptr<PricingEngine> refEngine = ext::make_shared<AnalyticPerformanceEngine>(process);
 
                     ext::shared_ptr<PricingEngine> mcEngine =
                         MakeMCPerformanceEngine<PseudoRandom>(process)

--- a/test-suite/cms.cpp
+++ b/test-suite/cms.cpp
@@ -87,13 +87,12 @@ struct CommonVars {
         m[5][0]=0.1130; m[5][1]=0.1090; m[5][2]=0.1070; m[5][3]=0.0930;
 
         atmVol = Handle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    SwaptionVolatilityMatrix(calendar,
+                ext::make_shared<SwaptionVolatilityMatrix>(calendar,
                                              Following,
                                              atmOptionTenors,
                                              atmSwapTenors,
                                              m,
-                                             Actual365Fixed())));
+                                             Actual365Fixed()));
 
         // Vol cubes
         std::vector<Period> optionTenors = {{1, Years}, {10, Years}, {30, Years}};
@@ -161,16 +160,13 @@ struct CommonVars {
         for (Size i=0; i<nRows; ++i){
             volSpreads[i] = std::vector<Handle<Quote> >(nCols);
             for (Size j=0; j<nCols; ++j) {
-                volSpreads[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(
-                                    new SimpleQuote(volSpreadsMatrix[i][j])));
+                volSpreads[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(volSpreadsMatrix[i][j]));
             }
         }
 
-        iborIndex = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
-        ext::shared_ptr<SwapIndex> swapIndexBase(new
-                EuriborSwapIsdaFixA(10*Years, termStructure));
-        ext::shared_ptr<SwapIndex> shortSwapIndexBase(new
-                EuriborSwapIsdaFixA(2*Years, termStructure));
+        iborIndex = ext::make_shared<Euribor6M>(termStructure);
+        ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(10*Years, termStructure);
+        ext::shared_ptr<SwapIndex> shortSwapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(2*Years, termStructure);
 
         bool vegaWeightedSmileFit = false;
 
@@ -189,13 +185,13 @@ struct CommonVars {
         for (Size i=0; i<nRows; ++i) {
             guess[i] = std::vector<Handle<Quote> >(4);
             guess[i][0] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
             guess[i][1] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
             guess[i][2] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
             guess[i][3] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
         }
         std::vector<bool> isParameterFixed(4, false);
         isParameterFixed[1] = true;
@@ -230,15 +226,13 @@ struct CommonVars {
         for (Size j = 0; j < yieldCurveModels.size(); ++j) {
             if (j < yieldCurveModels.size() - 1)
                 numericalPricers.push_back(
-                        ext::shared_ptr<CmsCouponPricer>(new NumericHaganPricer(
-                            atmVol, yieldCurveModels[j], zeroMeanRev)));
+                        ext::make_shared<NumericHaganPricer>(
+                            atmVol, yieldCurveModels[j], zeroMeanRev));
             else
-                numericalPricers.push_back(ext::shared_ptr<CmsCouponPricer>(
-                        new LinearTsrPricer(atmVol, zeroMeanRev)));
+                numericalPricers.push_back(ext::make_shared<LinearTsrPricer>(atmVol, zeroMeanRev));
 
-            analyticPricers.push_back(ext::shared_ptr<CmsCouponPricer>(new
-                    AnalyticHaganPricer(atmVol, yieldCurveModels[j],
-                                        zeroMeanRev)));
+            analyticPricers.push_back(ext::make_shared<AnalyticHaganPricer>(atmVol, yieldCurveModels[j],
+                                        zeroMeanRev));
         }
     }
 };
@@ -250,7 +244,7 @@ BOOST_AUTO_TEST_CASE(testFairRate)  {
 
     CommonVars vars;
 
-    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("EuriborSwapIsdaFixA",
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<SwapIndex>("EuriborSwapIsdaFixA",
                                                        10*Years,
                                                        vars.iborIndex->fixingDays(),
                                                        vars.iborIndex->currency(),
@@ -258,7 +252,7 @@ BOOST_AUTO_TEST_CASE(testFairRate)  {
                                                        1*Years,
                                                        Unadjusted,
                                                        vars.iborIndex->dayCounter(),//??
-                                                       vars.iborIndex));
+                                                       vars.iborIndex);
     // FIXME
     //ext::shared_ptr<SwapIndex> swapIndex(new
     //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
@@ -314,7 +308,7 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("EuriborSwapIsdaFixA",
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<SwapIndex>("EuriborSwapIsdaFixA",
                                                        10*Years,
                                                        vars.iborIndex->fixingDays(),
                                                        vars.iborIndex->currency(),
@@ -322,7 +316,7 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
                                                        1*Years,
                                                        Unadjusted,
                                                        vars.iborIndex->dayCounter(),//??
-                                                       vars.iborIndex));
+                                                       vars.iborIndex);
     // FIXME
     //ext::shared_ptr<SwapIndex> swapIndex(new
     //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
@@ -378,9 +372,8 @@ BOOST_AUTO_TEST_CASE(testParity) {
     std::vector<Handle<SwaptionVolatilityStructure> > swaptionVols = {
                            vars.atmVol, vars.SabrVolCube1, vars.SabrVolCube2};
 
-    ext::shared_ptr<SwapIndex> swapIndex(new
-        EuriborSwapIsdaFixA(10*Years,
-                            vars.iborIndex->forwardingTermStructure()));
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<EuriborSwapIsdaFixA>(10*Years,
+                            vars.iborIndex->forwardingTermStructure());
     Date startDate = vars.termStructure->referenceDate() + 20*Years;
     Date paymentDate = startDate + 1*Years;
     Date endDate = paymentDate;

--- a/test-suite/cms_normal.cpp
+++ b/test-suite/cms_normal.cpp
@@ -90,15 +90,14 @@ struct CommonVars {
 
 
         atmVol = Handle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    SwaptionVolatilityMatrix(calendar,
+                ext::make_shared<SwaptionVolatilityMatrix>(calendar,
                                              Following,
                                              atmOptionTenors,
                                              atmSwapTenors,
                                              m,
                                              Actual365Fixed(),
                                              false,
-                                             QuantLib::VolatilityType::Normal)));
+                                             QuantLib::VolatilityType::Normal));
             
 
         // Vol cubes
@@ -170,20 +169,17 @@ struct CommonVars {
         for (Size i=0; i<nRows; ++i){
             volSpreads[i] = std::vector<Handle<Quote> >(nCols);
             for (Size j=0; j<nCols; ++j) {
-                volSpreads[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(
-                                    new SimpleQuote(volSpreadsMatrix[i][j])));
+                volSpreads[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(volSpreadsMatrix[i][j]));
             }
         }
 
-        iborIndex = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+        iborIndex = ext::make_shared<Euribor6M>(termStructure);
         /*
-          ext::shared_ptr<SwapIndex> swapIndexBase(new
-                EuriborSwapIsdaFixA(10*Years, termStructure,termStructure));
-          ext::shared_ptr<SwapIndex> shortSwapIndexBase(new
-                EuriborSwapIsdaFixA(2*Years, termStructure,termStructure));
+          ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(10*Years, termStructure,termStructure);
+          ext::shared_ptr<SwapIndex> shortSwapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(2*Years, termStructure,termStructure);
         */
 
-        ext::shared_ptr<SwapIndex> swapIndexBase(new SwapIndex("swapIndexBase",
+        ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<SwapIndex>("swapIndexBase",
                                                        2*Years,
                                                        iborIndex->fixingDays(),
                                                        iborIndex->currency(),
@@ -192,8 +188,8 @@ struct CommonVars {
                                                        ModifiedFollowing,
                                                        Thirty360(Thirty360::EurobondBasis),//EUR
                                                        iborIndex,
-                                                       termStructure));
-        ext::shared_ptr<SwapIndex> shortSwapIndexBase(new SwapIndex("shortSwapIndexBase",
+                                                       termStructure);
+        ext::shared_ptr<SwapIndex> shortSwapIndexBase = ext::make_shared<SwapIndex>("shortSwapIndexBase",
                                                        1*Years,
                                                        iborIndex->fixingDays(),
                                                        iborIndex->currency(),
@@ -202,7 +198,7 @@ struct CommonVars {
                                                        ModifiedFollowing,
                                                        Thirty360(Thirty360::EurobondBasis),//EUR
                                                        iborIndex,
-                                                       termStructure));
+                                                       termStructure);
 
         bool vegaWeightedSmileFit = false;
 
@@ -221,13 +217,13 @@ struct CommonVars {
         for (Size i=0; i<nRows; ++i) {
             guess[i] = std::vector<Handle<Quote> >(4);
             guess[i][0] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.01)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.01));
             guess[i][1] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
             guess[i][2] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.3)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.3));
             guess[i][3] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
         }
         std::vector<bool> isParameterFixed(4, false);
         isParameterFixed[1] = true;
@@ -260,12 +256,10 @@ struct CommonVars {
         numericalPricers.clear();
         analyticPricers.clear();
         for (auto& yieldCurveModel : yieldCurveModels) {
-            numericalPricers.push_back(ext::shared_ptr<CmsCouponPricer>(
-                    new NumericHaganPricer(atmVol, yieldCurveModel, zeroMeanRev)));
+            numericalPricers.push_back(ext::make_shared<NumericHaganPricer>(atmVol, yieldCurveModel, zeroMeanRev));
 
 
-            analyticPricers.push_back(ext::shared_ptr<CmsCouponPricer>(
-                    new AnalyticHaganPricer(atmVol, yieldCurveModel, zeroMeanRev)));
+            analyticPricers.push_back(ext::make_shared<AnalyticHaganPricer>(atmVol, yieldCurveModel, zeroMeanRev));
         }
     }
 };
@@ -277,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testFairRate)  {
 
     CommonVars vars;
 
-    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<SwapIndex>("CMS10Y",
                                                        10*Years,
                                                        vars.iborIndex->fixingDays(),
                                                        vars.iborIndex->currency(),
@@ -286,7 +280,7 @@ BOOST_AUTO_TEST_CASE(testFairRate)  {
                                                        ModifiedFollowing,
                                                        Thirty360(Thirty360::EurobondBasis),//EUR
                                                        vars.iborIndex,
-                                                       vars.termStructure));
+                                                       vars.termStructure);
     // FIXME
     //ext::shared_ptr<SwapIndex> swapIndex(new
     //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
@@ -340,7 +334,7 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<SwapIndex>("CMS10Y",
                                                        10*Years,
                                                        vars.iborIndex->fixingDays(),
                                                        vars.iborIndex->currency(),
@@ -349,7 +343,7 @@ BOOST_AUTO_TEST_CASE(testCmsSwap) {
                                                        ModifiedFollowing,
                                                        Thirty360(Thirty360::EurobondBasis),//EUR
                                                        vars.iborIndex,
-                                                       vars.termStructure));
+                                                       vars.termStructure);
     // FIXME
     //ext::shared_ptr<SwapIndex> swapIndex(new
     //    EuriborSwapIsdaFixA(10*Years, vars.iborIndex->termStructure()));
@@ -405,7 +399,7 @@ BOOST_AUTO_TEST_CASE(testParity) {
                            
   
 
-    ext::shared_ptr<SwapIndex> swapIndex(new SwapIndex("CMS10Y",
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<SwapIndex>("CMS10Y",
                                                        10*Years,
                                                        vars.iborIndex->fixingDays(),
                                                        vars.iborIndex->currency(),
@@ -414,7 +408,7 @@ BOOST_AUTO_TEST_CASE(testParity) {
                                                        ModifiedFollowing,
                                                        Thirty360(Thirty360::EurobondBasis),//EUR
                                                        vars.iborIndex,
-                                                       vars.termStructure));
+                                                       vars.termStructure);
 
 
 

--- a/test-suite/compoundoption.cpp
+++ b/test-suite/compoundoption.cpp
@@ -108,39 +108,31 @@ BOOST_AUTO_TEST_CASE(testPutCallParity){
     DayCounter dc = Actual360();
     Date todaysDate = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<YieldTermStructure> rTS(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(rRate), dc));
+    ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<FlatForward>(0, NullCalendar(), Handle<Quote>(rRate), dc);
 
-    ext::shared_ptr<YieldTermStructure> qTS(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(qRate), dc));
+    ext::shared_ptr<YieldTermStructure> qTS = ext::make_shared<FlatForward>(0, NullCalendar(), Handle<Quote>(qRate), dc);
 
-    ext::shared_ptr<BlackVolTermStructure> volTS(
-                              new BlackConstantVol(todaysDate, NullCalendar(),
-                                                   Handle<Quote>(vol), dc));
+    ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackConstantVol>(todaysDate, NullCalendar(),
+                                                   Handle<Quote>(vol), dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoffMotherCall(
-            new PlainVanillaPayoff(Option::Call, value.strikeMother));
+        ext::shared_ptr<StrikedTypePayoff> payoffMotherCall = ext::make_shared<PlainVanillaPayoff>(Option::Call, value.strikeMother);
 
-        ext::shared_ptr<StrikedTypePayoff> payoffMotherPut(
-            new PlainVanillaPayoff(Option::Put, value.strikeMother));
+        ext::shared_ptr<StrikedTypePayoff> payoffMotherPut = ext::make_shared<PlainVanillaPayoff>(Option::Put, value.strikeMother);
 
-        ext::shared_ptr<StrikedTypePayoff> payoffDaughter(
-            new PlainVanillaPayoff(value.typeDaughter, value.strikeDaughter));
+        ext::shared_ptr<StrikedTypePayoff> payoffDaughter = ext::make_shared<PlainVanillaPayoff>(value.typeDaughter, value.strikeDaughter);
 
         Date matDateMom = todaysDate + timeToDays(value.tMother);
         Date matDateDaughter = todaysDate + timeToDays(value.tDaughter);
 
-        ext::shared_ptr<Exercise> exerciseCompound(
-                                            new EuropeanExercise(matDateMom));
-        ext::shared_ptr<Exercise> exerciseDaughter(
-                                       new EuropeanExercise(matDateDaughter));
+        ext::shared_ptr<Exercise> exerciseCompound = ext::make_shared<EuropeanExercise>(matDateMom);
+        ext::shared_ptr<Exercise> exerciseDaughter = ext::make_shared<EuropeanExercise>(matDateDaughter);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
@@ -156,19 +148,16 @@ BOOST_AUTO_TEST_CASE(testPutCallParity){
         VanillaOption vanillaOption(EuropeanOption(payoffDaughter,
                                                    exerciseDaughter));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                       Handle<Quote>(spot),
                       Handle<YieldTermStructure>(qTS),
                       Handle<YieldTermStructure>(rTS),
-                      Handle<BlackVolTermStructure>(volTS)));
+                      Handle<BlackVolTermStructure>(volTS));
 
 
-        ext::shared_ptr<PricingEngine> engineCompound(
-                              new AnalyticCompoundOptionEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engineCompound = ext::make_shared<AnalyticCompoundOptionEngine>(stochProcess);
 
-        ext::shared_ptr<PricingEngine> engineEuropean(
-                                     new AnalyticEuropeanEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engineEuropean = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         compoundOptionCall.setPricingEngine(engineCompound);
         compoundOptionPut.setPricingEngine(engineCompound);
@@ -238,36 +227,29 @@ BOOST_AUTO_TEST_CASE(testValues){
     DayCounter dc = Actual360();
     Date todaysDate = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<YieldTermStructure> rTS(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(rRate), dc));
+    ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<FlatForward>(0, NullCalendar(), Handle<Quote>(rRate), dc);
 
-    ext::shared_ptr<YieldTermStructure> qTS(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(qRate), dc));
+    ext::shared_ptr<YieldTermStructure> qTS = ext::make_shared<FlatForward>(0, NullCalendar(), Handle<Quote>(qRate), dc);
 
-    ext::shared_ptr<BlackVolTermStructure> volTS(
-                              new BlackConstantVol(todaysDate, NullCalendar(),
-                                                   Handle<Quote>(vol), dc));
+    ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackConstantVol>(todaysDate, NullCalendar(),
+                                                   Handle<Quote>(vol), dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoffMother(
-            new PlainVanillaPayoff(value.typeMother, value.strikeMother));
+        ext::shared_ptr<StrikedTypePayoff> payoffMother = ext::make_shared<PlainVanillaPayoff>(value.typeMother, value.strikeMother);
 
-        ext::shared_ptr<StrikedTypePayoff> payoffDaughter(
-            new PlainVanillaPayoff(value.typeDaughter, value.strikeDaughter));
+        ext::shared_ptr<StrikedTypePayoff> payoffDaughter = ext::make_shared<PlainVanillaPayoff>(value.typeDaughter, value.strikeDaughter);
 
         Date matDateMom = todaysDate + timeToDays(value.tMother);
         Date matDateDaughter = todaysDate + timeToDays(value.tDaughter);
 
-        ext::shared_ptr<Exercise> exerciseMother(
-                                            new EuropeanExercise(matDateMom));
-        ext::shared_ptr<Exercise> exerciseDaughter(
-                                       new EuropeanExercise(matDateDaughter));
+        ext::shared_ptr<Exercise> exerciseMother = ext::make_shared<EuropeanExercise>(matDateMom);
+        ext::shared_ptr<Exercise> exerciseDaughter = ext::make_shared<EuropeanExercise>(matDateDaughter);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
@@ -277,15 +259,13 @@ BOOST_AUTO_TEST_CASE(testValues){
         CompoundOption compoundOption(payoffMother,exerciseMother,
                                       payoffDaughter, exerciseDaughter);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                       Handle<Quote>(spot),
                       Handle<YieldTermStructure>(qTS),
                       Handle<YieldTermStructure>(rTS),
-                      Handle<BlackVolTermStructure>(volTS)));
+                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engineCompound(
-                              new AnalyticCompoundOptionEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engineCompound = ext::make_shared<AnalyticCompoundOptionEngine>(stochProcess);
 
         compoundOption.setPricingEngine(engineCompound);
 

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -64,16 +64,14 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
     Calendar calendar = TARGET();
 
     Handle<Quote> hazardRate = Handle<Quote>(
-                ext::shared_ptr<Quote>(new SimpleQuote(0.01234)));
+                ext::make_shared<SimpleQuote>(0.01234));
     RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
     probabilityCurve.linkTo(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-                   new FlatHazardRate(0, calendar, hazardRate, Actual360())));
+        ext::make_shared<FlatHazardRate>(0, calendar, hazardRate, Actual360()));
 
     RelinkableHandle<YieldTermStructure> discountCurve;
 
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                            new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     // Build the schedule
     Date issueDate = calendar.advance(today, -1, Years);
@@ -92,8 +90,7 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
 
     CreditDefaultSwap cds(Protection::Seller, notional, fixedRate,
                           schedule, convention, dayCount, true, true);
-    cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-         new MidPointCdsEngine(probabilityCurve,recoveryRate,discountCurve)));
+    cds.setPricingEngine(ext::make_shared<MidPointCdsEngine>(probabilityCurve,recoveryRate,discountCurve));
 
     Real npv = 295.0153398;
     Rate fairRate = 0.007517539081;
@@ -116,9 +113,8 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
             << "    calculated fair rate: " << calculatedFairRate << "\n"
             << "    expected fair rate:   " << fairRate);
 
-    cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                          new IntegralCdsEngine(1*Days,probabilityCurve,
-                                                recoveryRate,discountCurve)));
+    cds.setPricingEngine(ext::make_shared<IntegralCdsEngine>(1*Days,probabilityCurve,
+                                                recoveryRate,discountCurve));
 
     calculatedNpv = cds.NPV();
     calculatedFairRate = cds.fairSpread();
@@ -140,9 +136,8 @@ BOOST_AUTO_TEST_CASE(testCachedValue) {
             << "    calculated fair rate: " << calculatedFairRate << "\n"
             << "    expected fair rate:   " << fairRate);
 
-    cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                          new IntegralCdsEngine(1*Weeks,probabilityCurve,
-                                                recoveryRate,discountCurve)));
+    cds.setPricingEngine(ext::make_shared<IntegralCdsEngine>(1*Weeks,probabilityCurve,
+                                                recoveryRate,discountCurve));
 
     calculatedNpv = cds.NPV();
     calculatedFairRate = cds.fairSpread();
@@ -218,8 +213,7 @@ BOOST_AUTO_TEST_CASE(testCachedMarketValue) {
 
     RelinkableHandle<YieldTermStructure> discountCurve;
     discountCurve.linkTo(
-        ext::shared_ptr<YieldTermStructure>(
-            new DiscountCurve(discountDates, dfs, curveDayCounter)));
+        ext::make_shared<DiscountCurve>(discountDates, dfs, curveDayCounter));
 
     DayCounter dayCounter = Thirty360(Thirty360::BondBasis);
     std::vector<Date> dates = {
@@ -258,10 +252,9 @@ BOOST_AUTO_TEST_CASE(testCachedMarketValue) {
 
     RelinkableHandle<DefaultProbabilityTermStructure> piecewiseFlatHazardRate;
     piecewiseFlatHazardRate.linkTo(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-               new InterpolatedHazardRateCurve<BackwardFlat>(dates,
+        ext::make_shared<InterpolatedHazardRateCurve<BackwardFlat>>(dates,
                                                              hazardRates,
-                                                             Thirty360(Thirty360::BondBasis))));
+                                                             Thirty360(Thirty360::BondBasis)));
 
     // Testing credit default swap
 
@@ -283,9 +276,8 @@ BOOST_AUTO_TEST_CASE(testCachedMarketValue) {
 
     CreditDefaultSwap cds(Protection::Seller, cdsNotional, fixedRate,
                           schedule, cdsConvention, dayCount, true, true);
-    cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                          new MidPointCdsEngine(piecewiseFlatHazardRate,
-                                                recoveryRate,discountCurve)));
+    cds.setPricingEngine(ext::make_shared<MidPointCdsEngine>(piecewiseFlatHazardRate,
+                                                recoveryRate,discountCurve));
 
     Real calculatedNpv = cds.NPV();
     Real calculatedFairRate = cds.fairSpread();
@@ -334,14 +326,12 @@ BOOST_AUTO_TEST_CASE(testImpliedHazardRate) {
     hazardRates[2] = h2;
 
     RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
-    probabilityCurve.linkTo(ext::shared_ptr<DefaultProbabilityTermStructure>(
-                    new InterpolatedHazardRateCurve<BackwardFlat>(dates,
+    probabilityCurve.linkTo(ext::make_shared<InterpolatedHazardRateCurve<BackwardFlat>>(dates,
                                                                   hazardRates,
-                                                                  dayCounter)));
+                                                                  dayCounter));
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                            new FlatForward(today,0.03,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.03,Actual360()));
 
 
     Frequency frequency = Semiannual;
@@ -364,9 +354,8 @@ BOOST_AUTO_TEST_CASE(testImpliedHazardRate) {
         CreditDefaultSwap cds(Protection::Seller, notional, fixedRate,
                               schedule, convention, cdsDayCount,
                               true, true);
-        cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                         new MidPointCdsEngine(probabilityCurve,
-                                               recoveryRate, discountCurve)));
+        cds.setPricingEngine(ext::make_shared<MidPointCdsEngine>(probabilityCurve,
+                                               recoveryRate, discountCurve));
 
         Real NPV = cds.NPV();
         Rate flatRate = cds.impliedHazardRate(NPV, discountCurve,
@@ -391,18 +380,16 @@ BOOST_AUTO_TEST_CASE(testImpliedHazardRate) {
         latestRate = flatRate;
 
         RelinkableHandle<DefaultProbabilityTermStructure> probability;
-        probability.linkTo(ext::shared_ptr<DefaultProbabilityTermStructure>(
-         new FlatHazardRate(
+        probability.linkTo(ext::make_shared<FlatHazardRate>(
            today,
-           Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(flatRate))),
-           dayCounter)));
+           Handle<Quote>(ext::make_shared<SimpleQuote>(flatRate)),
+           dayCounter));
 
         CreditDefaultSwap cds2(Protection::Seller, notional, fixedRate,
                                schedule, convention, cdsDayCount,
                                true, true);
-        cds2.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                               new MidPointCdsEngine(probability,recoveryRate,
-                                                     discountCurve)));
+        cds2.setPricingEngine(ext::make_shared<MidPointCdsEngine>(probability,recoveryRate,
+                                                     discountCurve));
 
         Real NPV2 = cds2.NPV();
         Real tolerance = 1.0;
@@ -425,15 +412,13 @@ BOOST_AUTO_TEST_CASE(testFairSpread) {
     Settings::instance().evaluationDate() = today;
 
     Handle<Quote> hazardRate = Handle<Quote>(
-                ext::shared_ptr<Quote>(new SimpleQuote(0.01234)));
+                ext::make_shared<SimpleQuote>(0.01234));
     RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
     probabilityCurve.linkTo(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-                   new FlatHazardRate(0, calendar, hazardRate, Actual360())));
+        ext::make_shared<FlatHazardRate>(0, calendar, hazardRate, Actual360()));
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                            new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     // Build the schedule
     Date issueDate = calendar.advance(today, -1, Years);
@@ -454,8 +439,7 @@ BOOST_AUTO_TEST_CASE(testFairSpread) {
     Real notional = 10000.0;
     Real recoveryRate = 0.4;
 
-    ext::shared_ptr<PricingEngine> engine(
-          new MidPointCdsEngine(probabilityCurve,recoveryRate,discountCurve));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<MidPointCdsEngine>(probabilityCurve,recoveryRate,discountCurve);
 
     CreditDefaultSwap cds(Protection::Seller, notional, fixedRate,
                           schedule, convention, dayCount, true, true);
@@ -488,15 +472,13 @@ BOOST_AUTO_TEST_CASE(testFairUpfront) {
     Settings::instance().evaluationDate() = today;
 
     Handle<Quote> hazardRate = Handle<Quote>(
-                ext::shared_ptr<Quote>(new SimpleQuote(0.01234)));
+                ext::make_shared<SimpleQuote>(0.01234));
     RelinkableHandle<DefaultProbabilityTermStructure> probabilityCurve;
     probabilityCurve.linkTo(
-        ext::shared_ptr<DefaultProbabilityTermStructure>(
-                   new FlatHazardRate(0, calendar, hazardRate, Actual360())));
+        ext::make_shared<FlatHazardRate>(0, calendar, hazardRate, Actual360()));
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                            new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     // Build the schedule
     Date issueDate = today;
@@ -518,9 +500,8 @@ BOOST_AUTO_TEST_CASE(testFairUpfront) {
     Real notional = 10000.0;
     Real recoveryRate = 0.4;
 
-    ext::shared_ptr<PricingEngine> engine(
-          new MidPointCdsEngine(probabilityCurve, recoveryRate,
-                                discountCurve, true));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<MidPointCdsEngine>(probabilityCurve, recoveryRate,
+                                discountCurve, true);
 
     CreditDefaultSwap cds(Protection::Seller, notional, upfront, fixedRate,
                           schedule, convention, dayCount, true, true);

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -85,10 +85,10 @@ struct CommonVars {
                                    bool isBasisOnFxBaseCurrencyLeg) const {
         Handle<Quote> quoteHandle(ext::make_shared<SimpleQuote>(q.basis * basisPoint));
         Period tenor(q.n, q.units);
-        return ext::shared_ptr<RateHelper>(new ConstNotionalCrossCurrencyBasisSwapRateHelper(
+        return ext::make_shared<ConstNotionalCrossCurrencyBasisSwapRateHelper>(
                 quoteHandle, tenor, instrumentSettlementDays, calendar, businessConvention, endOfMonth,
             baseCcyIdx, quoteCcyIdx, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-                isBasisOnFxBaseCurrencyLeg));
+                isBasisOnFxBaseCurrencyLeg);
     }
 
     std::vector<ext::shared_ptr<RateHelper> >
@@ -127,10 +127,10 @@ struct CommonVars {
             quoteIndex = quoteCcyIdx;
         }
 
-        return ext::shared_ptr<RateHelper>(new MtMCrossCurrencyBasisSwapRateHelper(
+        return ext::make_shared<MtMCrossCurrencyBasisSwapRateHelper>(
                 quoteHandle, tenor, instrumentSettlementDays, calendar, businessConvention, endOfMonth,
             baseIndex, quoteIndex, collateralHandle, isFxBaseCurrencyCollateralCurrency,
-                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag));
+                isBasisOnFxBaseCurrencyLeg, isFxBaseCurrencyLegResettable, paymentFrequency, paymentLag);
     }
 
     std::vector<ext::shared_ptr<RateHelper> >
@@ -217,10 +217,10 @@ struct CommonVars {
         basisPoint = 1.0e-4;
         fxSpot = 1.25;
 
-        baseCcyIdx = ext::shared_ptr<IborIndex>(new Euribor3M(baseCcyIdxHandle));
-        quoteCcyIdx = ext::shared_ptr<IborIndex>(new USDLibor(3 * Months, quoteCcyIdxHandle));
-        baseOvernightIndex = ext::shared_ptr<IborIndex>(new Eonia(baseCcyIdxHandle));
-        quoteOvernightIndex = ext::shared_ptr<IborIndex>(new Sofr(quoteCcyIdxHandle));
+        baseCcyIdx = ext::make_shared<Euribor3M>(baseCcyIdxHandle);
+        quoteCcyIdx = ext::make_shared<USDLibor>(3 * Months, quoteCcyIdxHandle);
+        baseOvernightIndex = ext::make_shared<Eonia>(baseCcyIdxHandle);
+        quoteOvernightIndex = ext::make_shared<Sofr>(quoteCcyIdxHandle);
 
         /* Data source:
            N. Moreni, A. Pallavicini (2015)
@@ -261,8 +261,7 @@ void testConstantNotionalCrossCurrencySwapsNPV(bool isFxBaseCurrencyCollateralCu
     Handle<YieldTermStructure> collateralHandle =
         isFxBaseCurrencyCollateralCurrency ? vars.baseCcyIdxHandle : vars.quoteCcyIdxHandle;
 
-    ext::shared_ptr<DiscountingSwapEngine> collateralCcyLegEngine(
-        new DiscountingSwapEngine(collateralHandle));
+    ext::shared_ptr<DiscountingSwapEngine> collateralCcyLegEngine = ext::make_shared<DiscountingSwapEngine>(collateralHandle);
 
     std::vector<ext::shared_ptr<RateHelper> > instruments =
         vars.buildConstantNotionalXccyRateHelpers(vars.basisData, collateralHandle,
@@ -272,8 +271,7 @@ void testConstantNotionalCrossCurrencySwapsNPV(bool isFxBaseCurrencyCollateralCu
         new PiecewiseYieldCurve<Discount, LogLinear>(vars.curveSettlementDt, instruments, vars.dayCount));
     foreignCcyCurve->enableExtrapolation();
     Handle<YieldTermStructure> foreignCcyHandle(foreignCcyCurve);
-    ext::shared_ptr<DiscountingSwapEngine> foreignCcyLegEngine(
-        new DiscountingSwapEngine(foreignCcyHandle));
+    ext::shared_ptr<DiscountingSwapEngine> foreignCcyLegEngine = ext::make_shared<DiscountingSwapEngine>(foreignCcyHandle);
 
     Real tolerance = 1.0e-12;
 
@@ -594,8 +592,7 @@ for (auto [tenor, q]: quotes) {
     }
 
     typedef PiecewiseYieldCurve<Discount, LogLinear> Curve;
-    ext::shared_ptr<YieldTermStructure> curve(
-        new Curve(today, helpers, Actual365Fixed()));
+    ext::shared_ptr<YieldTermStructure> curve = ext::make_shared<Curve>(today, helpers, Actual365Fixed());
     curve->enableExtrapolation();
     Handle<YieldTermStructure> curveHandle(curve);
 
@@ -692,8 +689,7 @@ for (auto [tenor, q]: quotes) {
     }
 
     typedef PiecewiseYieldCurve<Discount, LogLinear> Curve;
-    ext::shared_ptr<YieldTermStructure> curve(
-        new Curve(today, helpers, Actual365Fixed()));
+    ext::shared_ptr<YieldTermStructure> curve = ext::make_shared<Curve>(today, helpers, Actual365Fixed());
     curve->enableExtrapolation();
     Handle<YieldTermStructure> curveHandle(curve);
 

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(testDefaultProbability) {
 
     Real hazardRate = 0.0100;
     Handle<Quote> hazardRateQuote = Handle<Quote>(
-                ext::shared_ptr<Quote>(new SimpleQuote(hazardRate)));
+                ext::make_shared<SimpleQuote>(hazardRate));
     DayCounter dayCounter = Actual360();
     Calendar calendar = TARGET();
     Size n = 20;
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(testFlatHazardRate) {
 
     Real hazardRate = 0.0100;
     Handle<Quote> hazardRateQuote = Handle<Quote>(
-                ext::shared_ptr<Quote>(new SimpleQuote(hazardRate)));
+                ext::make_shared<SimpleQuote>(hazardRate));
     DayCounter dayCounter = Actual360();
     Calendar calendar = TARGET();
     Size n = 20;
@@ -168,20 +168,18 @@ void testBootstrapFromSpread() {
     Real recoveryRate = 0.4;
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                    new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     std::vector<ext::shared_ptr<DefaultProbabilityHelper> > helpers;
 
     helpers.reserve(n.size());
     for(Size i=0; i<n.size(); i++)
         helpers.push_back(
-                ext::shared_ptr<DefaultProbabilityHelper>(
-                    new SpreadCdsHelper(quote[i], Period(n[i], Years),
+                ext::make_shared<SpreadCdsHelper>(quote[i], Period(n[i], Years),
                                         settlementDays, calendar,
                                         frequency, convention, rule,
                                         dayCounter, recoveryRate,
-                                        discountCurve)));
+                                        discountCurve));
 
     RelinkableHandle<DefaultProbabilityTermStructure> piecewiseCurve;
     piecewiseCurve.linkTo(
@@ -208,9 +206,8 @@ void testBootstrapFromSpread() {
             CreditDefaultSwap cds(Protection::Buyer, notional, quote[i],
                                   schedule, convention, dayCounter,
                                   true, true, protectionStart);
-            cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                           new MidPointCdsEngine(piecewiseCurve, recoveryRate,
-                                                 discountCurve)));
+            cds.setPricingEngine(ext::make_shared<MidPointCdsEngine>(piecewiseCurve, recoveryRate,
+                                                 discountCurve));
 
             // test
             Rate inputRate = quote[i];
@@ -247,23 +244,21 @@ void testBootstrapFromUpfront() {
     Integer upfrontSettlementDays = 3;
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                    new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     std::vector<ext::shared_ptr<DefaultProbabilityHelper> > helpers;
 
     helpers.reserve(n.size());
     for(Size i=0; i<n.size(); i++)
         helpers.push_back(
-                ext::shared_ptr<DefaultProbabilityHelper>(
-                    new UpfrontCdsHelper(quote[i], fixedRate,
+                ext::make_shared<UpfrontCdsHelper>(quote[i], fixedRate,
                                          Period(n[i], Years),
                                          settlementDays, calendar,
                                          frequency, convention, rule,
                                          dayCounter, recoveryRate,
                                          discountCurve,
                                          upfrontSettlementDays, 
-                                         true, true, Date(), Actual360(true))));
+                                         true, true, Date(), Actual360(true)));
 
     RelinkableHandle<DefaultProbabilityTermStructure> piecewiseCurve;
     piecewiseCurve.linkTo(
@@ -299,9 +294,8 @@ void testBootstrapFromUpfront() {
                                   ext::shared_ptr<Claim>(),
                                   Actual360(true),
                                   true, today);
-            cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                           new MidPointCdsEngine(piecewiseCurve, recoveryRate,
-                                                 discountCurve, true)));
+            cds.setPricingEngine(ext::make_shared<MidPointCdsEngine>(piecewiseCurve, recoveryRate,
+                                                 discountCurve, true));
 
             // test
             Rate inputUpfront = quote[i];
@@ -360,17 +354,15 @@ BOOST_AUTO_TEST_CASE(testSingleInstrumentBootstrap) {
     Real recoveryRate = 0.4;
 
     RelinkableHandle<YieldTermStructure> discountCurve;
-    discountCurve.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                    new FlatForward(today,0.06,Actual360())));
+    discountCurve.linkTo(ext::make_shared<FlatForward>(today,0.06,Actual360()));
 
     std::vector<ext::shared_ptr<DefaultProbabilityHelper> > helpers(1);
 
-    helpers[0] = ext::shared_ptr<DefaultProbabilityHelper>(
-                        new SpreadCdsHelper(quote, tenor,
+    helpers[0] = ext::make_shared<SpreadCdsHelper>(quote, tenor,
                                             settlementDays, calendar,
                                             frequency, convention, rule,
                                             dayCounter, recoveryRate,
-                                            discountCurve));
+                                            discountCurve);
 
     PiecewiseDefaultCurve<HazardRate,BackwardFlat> defaultCurve(today, helpers,
                                                                 dayCounter);

--- a/test-suite/digitalcoupon.cpp
+++ b/test-suite/digitalcoupon.cpp
@@ -55,7 +55,7 @@ struct CommonVars {
     CommonVars() {
         fixingDays = 2;
         nominal = 1000000.0;
-        index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+        index = ext::make_shared<Euribor6M>(termStructure);
         calendar = index->fixingCalendar();
         today = calendar.adjust(Settings::instance().evaluationDate());
         Settings::instance().evaluationDate() = today;
@@ -89,11 +89,11 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothing) {
     Real gap = 1e-7; /* low, in order to compare digital option value
                         with black formula result */
     ext::shared_ptr<DigitalReplication>
-        replication(new DigitalReplication(Replication::Central, gap));
+        replication = ext::make_shared<DigitalReplication>(Replication::Central, gap);
     for (Real capletVol : vols) {
         RelinkableHandle<OptionletVolatilityStructure> vol;
-        vol.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
-            vars.today, vars.calendar, Following, capletVol, Actual360())));
+        vol.linkTo(ext::make_shared<ConstantOptionletVolatility>(
+            vars.today, vars.calendar, Following, capletVol, Actual360()));
         for (Real strike : strikes) {
             for (Size k = 9; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -105,18 +105,16 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothing) {
                     Real gearing = gearings[h];
                     Rate spread = spreads[h];
 
-                    ext::shared_ptr<FloatingRateCoupon> underlying(new
-                        IborCoupon(paymentDate, vars.nominal,
+                    ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                                    startDate, endDate,
                                    vars.fixingDays, vars.index,
-                                   gearing, spread));
+                                   gearing, spread);
                     // Floating Rate Coupon - Call Digital option
                     DigitalCoupon digitalCappedCoupon(underlying,
                                         strike, Position::Short, false, nullstrike,
                                         nullstrike, Position::Short, false, nullstrike,
                                         replication);
-                    ext::shared_ptr<IborCouponPricer> pricer(new
-                                                            BlackIborCouponPricer(vol));
+                    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(vol);
                     digitalCappedCoupon.setPricer(pricer);
 
                     // Check digital option price vs N(d1) price
@@ -149,25 +147,24 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothing) {
                     // Check digital option price vs N(d1) price using Vanilla Option class
                     if (spread==0.0) {
                         ext::shared_ptr<Exercise>
-                            exercise(new EuropeanExercise(exerciseDate));
+                            exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
                         Real discountAtFixing = vars.termStructure->discount(exerciseDate);
                         ext::shared_ptr<SimpleQuote>
-                            fwd(new SimpleQuote(effFwd*discountAtFixing));
-                        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+                            fwd = ext::make_shared<SimpleQuote>(effFwd*discountAtFixing);
+                        ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
                         ext::shared_ptr<YieldTermStructure>
                             qTS = flatRate(vars.today, qRate, Actual360());
-                        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+                        ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
                         ext::shared_ptr<BlackVolTermStructure>
                             volTS = flatVol(vars.today, capletVol, Actual360());
                         ext::shared_ptr<StrikedTypePayoff>
-                            callPayoff(new AssetOrNothingPayoff(Option::Call,effStrike));
-                        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-                            BlackScholesMertonProcess(Handle<Quote>(fwd),
+                            callPayoff = ext::make_shared<AssetOrNothingPayoff>(Option::Call,effStrike);
+                        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(fwd),
                                               Handle<YieldTermStructure>(qTS),
                                               Handle<YieldTermStructure>(vars.termStructure),
-                                              Handle<BlackVolTermStructure>(volTS)));
+                                              Handle<BlackVolTermStructure>(volTS));
                         ext::shared_ptr<PricingEngine>
-                            engine(new AnalyticEuropeanEngine(stochProcess));
+                            engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
                         VanillaOption callOpt(callPayoff, exercise);
                         callOpt.setPricingEngine(engine);
                         Real callVO = vars.nominal * gearing
@@ -212,24 +209,23 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothing) {
                     // Check digital option price vs N(d1) price using Vanilla Option class
                     if (spread==0.0) {
                         ext::shared_ptr<Exercise>
-                            exercise(new EuropeanExercise(exerciseDate));
+                            exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
                         Real discountAtFixing = vars.termStructure->discount(exerciseDate);
                         ext::shared_ptr<SimpleQuote>
-                            fwd(new SimpleQuote(effFwd*discountAtFixing));
-                        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+                            fwd = ext::make_shared<SimpleQuote>(effFwd*discountAtFixing);
+                        ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
                         ext::shared_ptr<YieldTermStructure>
                             qTS = flatRate(vars.today, qRate, Actual360());
-                        ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+                        ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
                         ext::shared_ptr<BlackVolTermStructure>
                             volTS = flatVol(vars.today, capletVol, Actual360());
-                        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-                            BlackScholesMertonProcess(Handle<Quote>(fwd),
+                        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(fwd),
                                               Handle<YieldTermStructure>(qTS),
                                               Handle<YieldTermStructure>(vars.termStructure),
-                                              Handle<BlackVolTermStructure>(volTS)));
+                                              Handle<BlackVolTermStructure>(volTS));
                         ext::shared_ptr<StrikedTypePayoff>
-                            putPayoff(new AssetOrNothingPayoff(Option::Put, effStrike));
-                        ext::shared_ptr<PricingEngine> engine(new AnalyticEuropeanEngine(stochProcess));
+                            putPayoff = ext::make_shared<AssetOrNothingPayoff>(Option::Put, effStrike);
+                        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
                         VanillaOption putOpt(putPayoff, exercise);
                         putOpt.setPricingEngine(engine);
                         Real putVO  = vars.nominal * gearing
@@ -264,9 +260,8 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingDeepInTheMoney) {
 
     Volatility capletVolatility = 0.0001;
     RelinkableHandle<OptionletVolatilityStructure> volatility;
-    volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
-        ConstantOptionletVolatility(vars.today, vars.calendar, Following,
-                                    capletVolatility, Actual360())));
+    volatility.linkTo(ext::make_shared<ConstantOptionletVolatility>(vars.today, vars.calendar, Following,
+                                    capletVolatility, Actual360()));
 
     for (Size k = 0; k<10; k++) {   // Loop on start and end dates
         Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -274,19 +269,17 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingDeepInTheMoney) {
         Rate nullstrike = Null<Rate>();
         Date paymentDate = endDate;
 
-        ext::shared_ptr<FloatingRateCoupon> underlying(new
-            IborCoupon(paymentDate, vars.nominal,
+        ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                        startDate, endDate,
                        vars.fixingDays, vars.index,
-                       gearing, spread));
+                       gearing, spread);
 
         // Floating Rate Coupon - Deep-in-the-money Call Digital option
         Rate strike = 0.001;
         DigitalCoupon digitalCappedCoupon(underlying,
                                           strike, Position::Short, false, nullstrike,
                                           nullstrike, Position::Short, false, nullstrike);
-        ext::shared_ptr<IborCouponPricer> pricer(new
-            BlackIborCouponPricer(volatility));
+        ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
         digitalCappedCoupon.setPricer(pricer);
 
         // Check price vs its target price
@@ -371,9 +364,8 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingDeepOutTheMoney) {
 
     Volatility capletVolatility = 0.0001;
     RelinkableHandle<OptionletVolatilityStructure> volatility;
-    volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
-        ConstantOptionletVolatility(vars.today, vars.calendar, Following,
-                                    capletVolatility, Actual360())));
+    volatility.linkTo(ext::make_shared<ConstantOptionletVolatility>(vars.today, vars.calendar, Following,
+                                    capletVolatility, Actual360()));
 
     for (Size k = 0; k<10; k++) { // loop on start and end dates
         Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -381,18 +373,17 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingDeepOutTheMoney) {
         Rate nullstrike = Null<Rate>();
         Date paymentDate = endDate;
 
-        ext::shared_ptr<FloatingRateCoupon> underlying(new
-            IborCoupon(paymentDate, vars.nominal,
+        ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                        startDate, endDate,
                        vars.fixingDays, vars.index,
-                       gearing, spread));
+                       gearing, spread);
 
         // Floating Rate Coupon - Deep-out-of-the-money Call Digital option
         Rate strike = 0.99;
         DigitalCoupon digitalCappedCoupon(underlying,
                                           strike, Position::Short, false, nullstrike,
                                           nullstrike, Position::Long, false, nullstrike);
-        ext::shared_ptr<IborCouponPricer> pricer(new BlackIborCouponPricer(volatility));
+        ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
         digitalCappedCoupon.setPricer(pricer);
 
         // Check price vs its target
@@ -486,13 +477,12 @@ BOOST_AUTO_TEST_CASE(testCashOrNothing) {
 
     Real gap = 1e-08; /* very low, in order to compare digital option value
                                      with black formula result */
-    ext::shared_ptr<DigitalReplication> replication(new
-        DigitalReplication(Replication::Central, gap));
+    ext::shared_ptr<DigitalReplication> replication = ext::make_shared<DigitalReplication>(Replication::Central, gap);
 
     for (Real capletVol : vols) {
         RelinkableHandle<OptionletVolatilityStructure> vol;
-        vol.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
-            vars.today, vars.calendar, Following, capletVol, Actual360())));
+        vol.linkTo(ext::make_shared<ConstantOptionletVolatility>(
+            vars.today, vars.calendar, Following, capletVol, Actual360()));
         for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -501,17 +491,16 @@ BOOST_AUTO_TEST_CASE(testCashOrNothing) {
                 Rate cashRate = 0.01;
 
                 Date paymentDate = endDate;
-                ext::shared_ptr<FloatingRateCoupon> underlying(new
-                    IborCoupon(paymentDate, vars.nominal,
+                ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                                startDate, endDate,
                                vars.fixingDays, vars.index,
-                               gearing, spread));
+                               gearing, spread);
                 // Floating Rate Coupon - Call Digital option
                 DigitalCoupon digitalCappedCoupon(underlying,
                                           strike, Position::Short, false, cashRate,
                                           nullstrike, Position::Short, false, nullstrike,
                                           replication);
-                ext::shared_ptr<IborCouponPricer> pricer(new BlackIborCouponPricer(vol));
+                ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(vol);
                 digitalCappedCoupon.setPricer(pricer);
 
                 // Check digital option price vs N(d2) price
@@ -538,22 +527,21 @@ BOOST_AUTO_TEST_CASE(testCashOrNothing) {
                                 "\nError = " << error );
 
                 // Check digital option price vs N(d2) price using Vanilla Option class
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
                 Real discountAtFixing = vars.termStructure->discount(exerciseDate);
-                ext::shared_ptr<SimpleQuote> fwd(new SimpleQuote(effFwd*discountAtFixing));
-                ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+                ext::shared_ptr<SimpleQuote> fwd = ext::make_shared<SimpleQuote>(effFwd*discountAtFixing);
+                ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
                 ext::shared_ptr<YieldTermStructure> qTS = flatRate(vars.today, qRate, Actual360());
-                ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+                ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
                 ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(vars.today, capletVol,
                                                                          Actual360());
-                ext::shared_ptr<StrikedTypePayoff> callPayoff(new CashOrNothingPayoff(
-                                                        Option::Call, effStrike, cashRate));
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-                BlackScholesMertonProcess(Handle<Quote>(fwd),
+                ext::shared_ptr<StrikedTypePayoff> callPayoff = ext::make_shared<CashOrNothingPayoff>(
+                                                        Option::Call, effStrike, cashRate);
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(fwd),
                                           Handle<YieldTermStructure>(qTS),
                                           Handle<YieldTermStructure>(vars.termStructure),
-                                          Handle<BlackVolTermStructure>(volTS)));
-                ext::shared_ptr<PricingEngine> engine(new AnalyticEuropeanEngine(stochProcess));
+                                          Handle<BlackVolTermStructure>(volTS));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
                 VanillaOption callOpt(callPayoff, exercise);
                 callOpt.setPricingEngine(engine);
                 Real callVO = vars.nominal * accrualPeriod * callOpt.NPV()
@@ -595,8 +583,7 @@ BOOST_AUTO_TEST_CASE(testCashOrNothing) {
                                 "\nError = " << error );
 
                 // Check digital option price vs N(d2) price using Vanilla Option class
-                ext::shared_ptr<StrikedTypePayoff> putPayoff(new
-                    CashOrNothingPayoff(Option::Put, effStrike, cashRate));
+                ext::shared_ptr<StrikedTypePayoff> putPayoff = ext::make_shared<CashOrNothingPayoff>(Option::Put, effStrike, cashRate);
                 VanillaOption putOpt(putPayoff, exercise);
                 putOpt.setPricingEngine(engine);
                 Real putVO  = vars.nominal * accrualPeriod * putOpt.NPV()
@@ -627,9 +614,8 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingDeepInTheMoney) {
 
     Volatility capletVolatility = 0.0001;
     RelinkableHandle<OptionletVolatilityStructure> volatility;
-    volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
-        ConstantOptionletVolatility(vars.today, vars.calendar, Following,
-                                    capletVolatility, Actual360())));
+    volatility.linkTo(ext::make_shared<ConstantOptionletVolatility>(vars.today, vars.calendar, Following,
+                                    capletVolatility, Actual360()));
 
     for (Size k = 0; k<10; k++) {   // Loop on start and end dates
         Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -638,18 +624,16 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingDeepInTheMoney) {
         Rate cashRate = 0.01;
         Date paymentDate = endDate;
 
-        ext::shared_ptr<FloatingRateCoupon> underlying(new
-            IborCoupon(paymentDate, vars.nominal,
+        ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                        startDate, endDate,
                        vars.fixingDays, vars.index,
-                       gearing, spread));
+                       gearing, spread);
         // Floating Rate Coupon - Deep-in-the-money Call Digital option
         Rate strike = 0.001;
         DigitalCoupon digitalCappedCoupon(underlying,
                                           strike, Position::Short, false, cashRate,
                                           nullstrike, Position::Short, false, nullstrike);
-        ext::shared_ptr<IborCouponPricer> pricer(new
-            BlackIborCouponPricer(volatility));
+        ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
         digitalCappedCoupon.setPricer(pricer);
 
         // Check price vs its target
@@ -732,9 +716,8 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingDeepOutTheMoney) {
 
     Volatility capletVolatility = 0.0001;
     RelinkableHandle<OptionletVolatilityStructure> volatility;
-    volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
-        ConstantOptionletVolatility(vars.today, vars.calendar, Following,
-                                    capletVolatility, Actual360())));
+    volatility.linkTo(ext::make_shared<ConstantOptionletVolatility>(vars.today, vars.calendar, Following,
+                                    capletVolatility, Actual360()));
 
     for (Size k = 0; k<10; k++) { // loop on start and end dates
         Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -743,18 +726,17 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingDeepOutTheMoney) {
         Rate cashRate = 0.01;
         Date paymentDate = endDate;
 
-        ext::shared_ptr<FloatingRateCoupon> underlying(new
-            IborCoupon(paymentDate, vars.nominal,
+        ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                        startDate, endDate,
                        vars.fixingDays, vars.index,
-                       gearing, spread));
+                       gearing, spread);
         // Deep out-of-the-money Capped Digital Coupon
         Rate strike = 0.99;
         DigitalCoupon digitalCappedCoupon(underlying,
                                           strike, Position::Short, false, cashRate,
                                           nullstrike, Position::Short, false, nullstrike);
 
-        ext::shared_ptr<IborCouponPricer> pricer(new BlackIborCouponPricer(volatility));
+        ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
         digitalCappedCoupon.setPricer(pricer);
 
         // Check price vs its target
@@ -841,8 +823,8 @@ BOOST_AUTO_TEST_CASE(testCallPutParity) {
     for (Real capletVolatility : vols) {
         RelinkableHandle<OptionletVolatilityStructure> volatility;
         volatility.linkTo(
-            ext::shared_ptr<OptionletVolatilityStructure>(new ConstantOptionletVolatility(
-                vars.today, vars.calendar, Following, capletVolatility, Actual360())));
+            ext::make_shared<ConstantOptionletVolatility>(
+                vars.today, vars.calendar, Following, capletVolatility, Actual360()));
         for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -851,19 +833,17 @@ BOOST_AUTO_TEST_CASE(testCallPutParity) {
 
                 Date paymentDate = endDate;
 
-                ext::shared_ptr<FloatingRateCoupon> underlying(new
-                    IborCoupon(paymentDate, vars.nominal,
+                ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                                startDate, endDate,
                                vars.fixingDays, vars.index,
-                               gearing, spread));
+                               gearing, spread);
                 // Cash-or-Nothing
                 Rate cashRate = 0.01;
                 // Floating Rate Coupon + Call Digital option
                 DigitalCoupon cash_digitalCallCoupon(underlying,
                                           strike, Position::Long, false, cashRate,
                                           nullstrike, Position::Long, false, nullstrike);
-                ext::shared_ptr<IborCouponPricer> pricer(new
-                    BlackIborCouponPricer(volatility));
+                ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
                 cash_digitalCallCoupon.setPricer(pricer);
                 // Floating Rate Coupon - Put Digital option
                 DigitalCoupon cash_digitalPutCoupon(underlying,
@@ -932,18 +912,14 @@ BOOST_AUTO_TEST_CASE(testReplicationType) {
     Real spread = 0.0;
 
     Real gap = 1e-04;
-    ext::shared_ptr<DigitalReplication> subReplication(new
-        DigitalReplication(Replication::Sub, gap));
-    ext::shared_ptr<DigitalReplication> centralReplication(new
-        DigitalReplication(Replication::Central, gap));
-    ext::shared_ptr<DigitalReplication> superReplication(new
-        DigitalReplication(Replication::Super, gap));
+    ext::shared_ptr<DigitalReplication> subReplication = ext::make_shared<DigitalReplication>(Replication::Sub, gap);
+    ext::shared_ptr<DigitalReplication> centralReplication = ext::make_shared<DigitalReplication>(Replication::Central, gap);
+    ext::shared_ptr<DigitalReplication> superReplication = ext::make_shared<DigitalReplication>(Replication::Super, gap);
 
     for (Real capletVolatility : vols) {
         RelinkableHandle<OptionletVolatilityStructure> volatility;
-        volatility.linkTo(ext::shared_ptr<OptionletVolatilityStructure>(new
-        ConstantOptionletVolatility(vars.today, vars.calendar, Following,
-                                    capletVolatility, Actual360())));
+        volatility.linkTo(ext::make_shared<ConstantOptionletVolatility>(vars.today, vars.calendar, Following,
+                                    capletVolatility, Actual360()));
         for (Real strike : strikes) {
             for (Size k = 0; k < 10; k++) {
                 Date startDate = vars.calendar.advance(vars.settlement,(k+1)*Years);
@@ -952,11 +928,10 @@ BOOST_AUTO_TEST_CASE(testReplicationType) {
 
                 Date paymentDate = endDate;
 
-                ext::shared_ptr<FloatingRateCoupon> underlying(new
-                    IborCoupon(paymentDate, vars.nominal,
+                ext::shared_ptr<FloatingRateCoupon> underlying = ext::make_shared<IborCoupon>(paymentDate, vars.nominal,
                                startDate, endDate,
                                vars.fixingDays, vars.index,
-                               gearing, spread));
+                               gearing, spread);
                 // Cash-or-Nothing
                 Rate cashRate = 0.005;
                 // Floating Rate Coupon + Call Digital option
@@ -972,8 +947,7 @@ BOOST_AUTO_TEST_CASE(testReplicationType) {
                                           strike, Position::Long, false, cashRate,
                                           nullstrike, Position::Long, false, nullstrike,
                                           superReplication);
-                ext::shared_ptr<IborCouponPricer> pricer(new
-                    BlackIborCouponPricer(volatility));
+                ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(volatility);
                 sub_cash_longDigitalCallCoupon.setPricer(pricer);
                 central_cash_longDigitalCallCoupon.setPricer(pricer);
                 over_cash_longDigitalCallCoupon.setPricer(pricer);

--- a/test-suite/digitaloption.cpp
+++ b/test-suite/digitaloption.cpp
@@ -87,34 +87,31 @@ BOOST_AUTO_TEST_CASE(testCashOrNothingEuropeanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(value.type, value.strike, 10.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(value.type, value.strike, 10.0);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         VanillaOption opt(payoff, exercise);
         opt.setPricingEngine(engine);
@@ -141,34 +138,31 @@ BOOST_AUTO_TEST_CASE(testAssetOrNothingEuropeanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new AssetOrNothingPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<AssetOrNothingPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         VanillaOption opt(payoff, exercise);
         opt.setPricingEngine(engine);
@@ -195,33 +189,31 @@ BOOST_AUTO_TEST_CASE(testGapEuropeanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new GapPayoff(value.type, value.strike, 57.00));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<GapPayoff>(value.type, value.strike, 57.00);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         VanillaOption opt(payoff, exercise);
         opt.setPricingEngine(engine);
@@ -260,35 +252,32 @@ BOOST_AUTO_TEST_CASE(testCashAtHitOrNothingAmericanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(value.type, value.strike, 15.00));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(value.type, value.strike, 15.00);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
-                                                                    exDate));
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
+                                                                    exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                             new AnalyticDigitalAmericanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDigitalAmericanEngine>(stochProcess);
 
         VanillaOption opt(payoff, amExercise);
         opt.setPricingEngine(engine);
@@ -325,35 +314,32 @@ BOOST_AUTO_TEST_CASE(testAssetAtHitOrNothingAmericanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new AssetOrNothingPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<AssetOrNothingPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
-                                                                    exDate));
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
+                                                                    exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                             new AnalyticDigitalAmericanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDigitalAmericanEngine>(stochProcess);
 
         VanillaOption opt(payoff, amExercise);
         opt.setPricingEngine(engine);
@@ -389,34 +375,32 @@ BOOST_AUTO_TEST_CASE(testCashAtExpiryOrNothingAmericanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(value.type, value.strike, 15.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(value.type, value.strike, 15.0);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
                                                                     exDate,
-                                                                    true));
+                                                                    true);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
         ext::shared_ptr<PricingEngine> engine;
         if (value.knockin)
             engine = ext::make_shared<AnalyticDigitalAmericanEngine>(stochProcess);
@@ -461,34 +445,32 @@ BOOST_AUTO_TEST_CASE(testAssetAtExpiryOrNothingAmericanValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new AssetOrNothingPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<AssetOrNothingPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
                                                                     exDate,
-                                                                    true));
+                                                                    true);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
         ext::shared_ptr<PricingEngine> engine;
         if (value.knockin)
             engine = ext::make_shared<AnalyticDigitalAmericanEngine>(stochProcess);
@@ -532,31 +514,28 @@ BOOST_AUTO_TEST_CASE(testCashAtHitOrNothingAmericanGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     // there is no cycling on different residual times
     Date exDate = today + 360;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-    ext::shared_ptr<Exercise> amExercise(new AmericanExercise(today,
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+    ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today,
                                                                 exDate,
-                                                                false));
+                                                                false);
     ext::shared_ptr<Exercise> exercises[] = { exercise, amExercise };
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
-    ext::shared_ptr<PricingEngine> euroEngine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> euroEngine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
-    ext::shared_ptr<PricingEngine> amEngine(
-                             new AnalyticDigitalAmericanEngine(stochProcess));
+    ext::shared_ptr<PricingEngine> amEngine = ext::make_shared<AnalyticDigitalAmericanEngine>(stochProcess);
 
     ext::shared_ptr<PricingEngine> engines[] = { euroEngine, amEngine };
 
@@ -564,8 +543,7 @@ BOOST_AUTO_TEST_CASE(testCashAtHitOrNothingAmericanGreeks) {
     for (Size j=0; j<std::size(engines); j++) {
         for (auto& type : types) {
             for (Real strike : strikes) {
-                ext::shared_ptr<StrikedTypePayoff> payoff(
-                    new CashOrNothingPayoff(type, strike, cashPayoff));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(type, strike, cashPayoff);
 
                 VanillaOption opt(payoff, exercises[j]);
                 opt.setPricingEngine(engines[j]);
@@ -676,12 +654,12 @@ BOOST_AUTO_TEST_CASE(testMCCashAtHit) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     Size timeStepsPerYear = 90;
@@ -690,22 +668,19 @@ BOOST_AUTO_TEST_CASE(testMCCashAtHit) {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(value.type, value.strike, 15.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(value.type, value.strike, 15.0);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> amExercise(
-                                         new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> amExercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
         Size requiredSamples = Size(std::pow(2.0, 14)-1);
         ext::shared_ptr<PricingEngine> mcldEngine =

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -83,19 +83,19 @@ BOOST_AUTO_TEST_CASE(testEuropeanValues) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                 std::vector<Date> dividendDates;
                 std::vector<Real> dividends;
@@ -104,12 +104,11 @@ BOOST_AUTO_TEST_CASE(testEuropeanValues) {
                     dividends.push_back(0.0);
                 }
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-                ext::shared_ptr<PricingEngine> ref_engine(new AnalyticEuropeanEngine(stochProcess));
+                ext::shared_ptr<PricingEngine> ref_engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
                 VanillaOption ref_option(payoff, exercise);
                 ref_option.setPricingEngine(ref_engine);
@@ -174,26 +173,24 @@ BOOST_AUTO_TEST_CASE(testEuropeanKnownValue) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     Date exDate = today + 180 * Days;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
     std::vector<Date> dividendDates = {today + 2 * 30 * Days, today + 5 * 30 * Days};
     std::vector<Real> dividends = {0.50, 0.50};
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(Option::Call, 40.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 40.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
     auto engine = ext::make_shared<AnalyticDividendEuropeanEngine>(
         stochProcess, DividendVector(dividendDates, dividends));
@@ -240,29 +237,28 @@ BOOST_AUTO_TEST_CASE(testEuropeanStartLimit) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                 std::vector<Date> dividendDates = {today};
                 std::vector<Real> dividends = {dividendValue};
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-                ext::shared_ptr<PricingEngine> ref_engine(new AnalyticEuropeanEngine(stochProcess));
+                ext::shared_ptr<PricingEngine> ref_engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
                 VanillaOption ref_option(payoff, exercise);
                 ref_option.setPricingEngine(ref_engine);
@@ -321,19 +317,19 @@ BOOST_AUTO_TEST_CASE(testEuropeanStartLimit) {
 //    Date today = Date::todaysDate();
 //    Settings::instance().evaluationDate() = today;
 //
-//    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-//    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+//    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+//    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
 //    Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-//    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+//    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
 //    Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-//    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+//    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
 //    Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 //
 //    for (auto& type : types) {
 //        for (Real strike : strikes) {
 //            for (int length : lengths) {
 //                Date exDate = today + length * Years;
-//                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+//                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 //
 //                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
 //                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
@@ -341,12 +337,12 @@ BOOST_AUTO_TEST_CASE(testEuropeanStartLimit) {
 //                std::vector<Date> dividendDates = {exercise->lastDate()};
 //                std::vector<Real> dividends = {dividendValue};
 //
-//                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+//                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 //
 //                ext::shared_ptr<StrikedTypePayoff> refPayoff(
 //                    new PlainVanillaPayoff(type, strike + dividendValue));
 //
-//                ext::shared_ptr<PricingEngine> ref_engine(new AnalyticEuropeanEngine(stochProcess));
+//                ext::shared_ptr<PricingEngine> ref_engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 //
 //                VanillaOption ref_option(refPayoff, exercise);
 //                ref_option.setPricingEngine(ref_engine);
@@ -420,19 +416,19 @@ BOOST_AUTO_TEST_CASE(testEuropeanGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                 std::vector<Date> dividendDates;
                 std::vector<Real> dividends;
@@ -441,10 +437,9 @@ BOOST_AUTO_TEST_CASE(testEuropeanGreeks) {
                     dividends.push_back(5.0);
                 }
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
                 auto engine = ext::make_shared<AnalyticDividendEuropeanEngine>(
                     stochProcess, DividendVector(dividendDates, dividends));
@@ -550,19 +545,19 @@ BOOST_AUTO_TEST_CASE(testFdEuropeanValues) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * Years;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                 std::vector<Date> dividendDates;
                 std::vector<Real> dividends;
@@ -571,10 +566,9 @@ BOOST_AUTO_TEST_CASE(testFdEuropeanValues) {
                     dividends.push_back(5.0);
                 }
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+                ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
                 auto ref_engine = ext::make_shared<AnalyticDividendEuropeanEngine>(
                     stochProcess, DividendVector(dividendDates, dividends));
@@ -637,12 +631,12 @@ void testFdGreeks(const Date& today,
 
     DayCounter dc = Actual365Fixed();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     for (auto& type : types) {
@@ -657,11 +651,10 @@ void testFdGreeks(const Date& today,
                 dividends.push_back(5.0);
             }
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
-            ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+            ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
             ext::shared_ptr<PricingEngine> engine =
                 MakeFdBlackScholesVanillaEngine(stochProcess)
@@ -727,7 +720,7 @@ BOOST_AUTO_TEST_CASE(testFdEuropeanGreeks) {
 
     for (int length : lengths) {
         Date exDate = today + length * Years;
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Spot);
         testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
     }
@@ -743,7 +736,7 @@ BOOST_AUTO_TEST_CASE(testFdAmericanGreeks) {
 
     for (int length : lengths) {
         Date exDate = today + length * Years;
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today,exDate);
         testFdGreeks(today,exercise,FdBlackScholesVanillaEngine::Spot);
     }
 }
@@ -754,20 +747,18 @@ void testFdDegenerate(const Date& today,
                       FdBlackScholesVanillaEngine::CashDividendModel model) {
 
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(54.625));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(54.625);
     Handle<YieldTermStructure> rTS(flatRate(0.052706, dc));
     Handle<YieldTermStructure> qTS(flatRate(0.0, dc));
     Handle<BlackVolTermStructure> volTS(flatVol(0.282922, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          qTS, rTS, volTS);
 
     Size timeSteps = 100;
     Size gridPoints = 300;
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Call, 55.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 55.0);
 
     Real tolerance = 1.0e-6;
 
@@ -831,7 +822,7 @@ BOOST_AUTO_TEST_CASE(testFdEuropeanDegenerate) {
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
     testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Spot);
     testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
@@ -846,7 +837,7 @@ BOOST_AUTO_TEST_CASE(testFdAmericanDegenerate) {
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
 
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today,exDate);
 
     testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Spot);
     testFdDegenerate(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
@@ -858,19 +849,17 @@ void testFdDividendAtTZero(const Date& today,
                            FdBlackScholesVanillaEngine::CashDividendModel model) {
 
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(54.625));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(54.625);
     Handle<YieldTermStructure> rTS(flatRate(0.0, dc));
     Handle<BlackVolTermStructure> volTS(flatVol(0.282922, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-                            new BlackScholesMertonProcess(Handle<Quote>(spot),
-                                                          rTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
+                                                          rTS, rTS, volTS);
 
     Size timeSteps = 50;
     Size gridPoints = 400;
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                  new PlainVanillaPayoff(Option::Call, 55.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 55.0);
 
     // today's dividend must by taken into account
     std::vector<Rate> dividends(1, 1.0);
@@ -927,7 +916,7 @@ BOOST_AUTO_TEST_CASE(testFdEuropeanWithDividendToday) {
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
     testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Spot);
     testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Escrowed);
@@ -942,7 +931,7 @@ BOOST_AUTO_TEST_CASE(testFdAmericanWithDividendToday) {
     Settings::instance().evaluationDate() = today;
     Date exDate(13,April,2005);
 
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(today,exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today,exDate);
 
     testFdDividendAtTZero(today,exercise,FdBlackScholesVanillaEngine::Spot);
 }

--- a/test-suite/dividendoption.cpp
+++ b/test-suite/dividendoption.cpp
@@ -317,19 +317,19 @@ BOOST_AUTO_TEST_CASE(testEuropeanStartLimit) {
 //    Date today = Date::todaysDate();
 //    Settings::instance().evaluationDate() = today;
 //
-//    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
-//    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
+//    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
+//    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
 //    Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-//    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
+//    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
 //    Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-//    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
+//    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
 //    Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 //
 //    for (auto& type : types) {
 //        for (Real strike : strikes) {
 //            for (int length : lengths) {
 //                Date exDate = today + length * Years;
-//                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+//                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
 //
 //                ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
 //                    new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
@@ -337,12 +337,12 @@ BOOST_AUTO_TEST_CASE(testEuropeanStartLimit) {
 //                std::vector<Date> dividendDates = {exercise->lastDate()};
 //                std::vector<Real> dividends = {dividendValue};
 //
-//                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+//                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
 //
 //                ext::shared_ptr<StrikedTypePayoff> refPayoff(
 //                    new PlainVanillaPayoff(type, strike + dividendValue));
 //
-//                ext::shared_ptr<PricingEngine> ref_engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
+//                ext::shared_ptr<PricingEngine> ref_engine(new AnalyticEuropeanEngine(stochProcess));
 //
 //                VanillaOption ref_option(refPayoff, exercise);
 //                ref_option.setPricingEngine(ref_engine);

--- a/test-suite/doublebarrieroption.cpp
+++ b/test-suite/doublebarrieroption.cpp
@@ -269,38 +269,36 @@ BOOST_AUTO_TEST_CASE(testEuropeanHaugValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
         DoubleBarrierOption opt(value.barrierType, value.barrierlo, value.barrierhi,
                                 0, // no rebate
                                 payoff, exercise);
 
         // Ikeda/Kunitomo engine
-        ext::shared_ptr<PricingEngine> engine(
-                                     new AnalyticDoubleBarrierEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDoubleBarrierEngine>(stochProcess);
         opt.setPricingEngine(engine);
 
         Real calculated = opt.NPV();
@@ -313,8 +311,7 @@ BOOST_AUTO_TEST_CASE(testEuropeanHaugValues) {
         }
 
         // Wulin Suo/Yong Wang engine
-        engine = ext::shared_ptr<PricingEngine>(
-                                     new SuoWangDoubleBarrierEngine(stochProcess));
+        engine = ext::make_shared<SuoWangDoubleBarrierEngine>(stochProcess);
         opt.setPricingEngine(engine);
 
         calculated = opt.NPV();
@@ -546,28 +543,22 @@ BOOST_AUTO_TEST_CASE(testMonteCarloDoubleBarrierWithAnalytical) {
     for (Integer i=1; i<=4; i++)
         exerciseDates.push_back(settlementDate + 3*i*Months);
 
-    ext::shared_ptr<Exercise> europeanExercise(
-        new EuropeanExercise(maturity));
+    ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
 
     Handle<Quote> underlyingH(
-        ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+        ext::make_shared<SimpleQuote>(underlying));
 
     // bootstrap the yield/dividend/vol curves
     Handle<YieldTermStructure> flatTermStructure(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+        ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
     Handle<YieldTermStructure> flatDividendTS(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(settlementDate, dividendYield, dayCounter)));
+        ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
     Handle<BlackVolTermStructure> flatVolTS(
-        ext::shared_ptr<BlackVolTermStructure>(
-            new BlackConstantVol(settlementDate, calendar, volatility,
-                                 dayCounter)));
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(type, strike));
-    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(underlyingH, flatDividendTS,
-                                      flatTermStructure, flatVolTS));
+        ext::make_shared<BlackConstantVol>(settlementDate, calendar, volatility,
+                                 dayCounter));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(underlyingH, flatDividendTS,
+                                      flatTermStructure, flatVolTS);
 
     Real barrierLow = underlying * 0.9;
     Real barrierHigh = underlying * 1.1;
@@ -579,7 +570,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloDoubleBarrierWithAnalytical) {
                                                    payoff,
                                                    europeanExercise);
 
-    ext::shared_ptr<PricingEngine> analyticdoublebarrierengine(new AnalyticDoubleBarrierEngine(bsmProcess));
+    ext::shared_ptr<PricingEngine> analyticdoublebarrierengine = ext::make_shared<AnalyticDoubleBarrierEngine>(bsmProcess);
     knockIndoubleBarrierOption.setPricingEngine(analyticdoublebarrierengine);
     Real analytical = knockIndoubleBarrierOption.NPV();
 

--- a/test-suite/doublebinaryoption.cpp
+++ b/test-suite/doublebinaryoption.cpp
@@ -179,18 +179,17 @@ BOOST_AUTO_TEST_CASE(testHaugValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-            new CashOrNothingPayoff(Option::Call, 0, value.cash));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(Option::Call, 0, value.cash);
 
         Date exDate = today + timeToDays(value.t);
         ext::shared_ptr<Exercise> exercise;
@@ -204,15 +203,13 @@ BOOST_AUTO_TEST_CASE(testHaugValues) {
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
         // checking with analytic engine
-        ext::shared_ptr<PricingEngine> engine(
-                             new AnalyticDoubleBarrierBinaryEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticDoubleBarrierBinaryEngine>(stochProcess);
         DoubleBarrierOption opt(value.barrierType, value.barrier_lo, value.barrier_hi, 0, payoff,
                                 exercise);
         opt.setPricingEngine(engine);

--- a/test-suite/equitytotalreturnswap.cpp
+++ b/test-suite/equitytotalreturnswap.cpp
@@ -90,7 +90,7 @@ struct CommonVars {
         dividendHandle.linkTo(flatRate(0.005, dayCount));
 
         discountEngine =
-            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(interestHandle));
+            ext::make_shared<DiscountingSwapEngine>(interestHandle);
 
         spot = ext::make_shared<SimpleQuote>(8700.0);
         spotHandle.linkTo(spot);

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -117,52 +117,42 @@ makeOption(const ext::shared_ptr<StrikedTypePayoff>& payoff,
     ext::shared_ptr<PricingEngine> engine;
     switch (engineType) {
       case Analytic:
-        engine = ext::shared_ptr<PricingEngine>(
-                                    new AnalyticEuropeanEngine(stochProcess));
+        engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
         break;
       case JR:
-        engine = ext::shared_ptr<PricingEngine>(
-                        new BinomialVanillaEngine<JarrowRudd>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<JarrowRudd>>(stochProcess,
+                                                              binomialSteps);
         break;
       case CRR:
-        engine = ext::shared_ptr<PricingEngine>(
-                 new BinomialVanillaEngine<CoxRossRubinstein>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<CoxRossRubinstein>>(stochProcess,
+                                                              binomialSteps);
         break;
       case EQP:
-        engine = ext::shared_ptr<PricingEngine>(
-                 new BinomialVanillaEngine<AdditiveEQPBinomialTree>(
+        engine = ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree>>(
                                                               stochProcess,
-                                                              binomialSteps));
+                                                              binomialSteps);
         break;
       case TGEO:
-        engine = ext::shared_ptr<PricingEngine>(
-                        new BinomialVanillaEngine<Trigeorgis>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<Trigeorgis>>(stochProcess,
+                                                              binomialSteps);
         break;
       case TIAN:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<Tian>(stochProcess, binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<Tian>>(stochProcess, binomialSteps);
         break;
       case LR:
-        engine = ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<LeisenReimer>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<LeisenReimer>>(stochProcess,
+                                                              binomialSteps);
         break;
       case JOSHI:
-        engine = ext::shared_ptr<PricingEngine>(
-              new BinomialVanillaEngine<Joshi4>(stochProcess, binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<Joshi4>>(stochProcess, binomialSteps);
         break;
       case FiniteDifferences:
-        engine = ext::shared_ptr<PricingEngine>(
-                            new FdBlackScholesVanillaEngine(stochProcess,
+        engine = ext::make_shared<FdBlackScholesVanillaEngine>(stochProcess,
                                                             binomialSteps,
-                                                            samples));
+                                                            samples);
         break;
       case Integral:
-        engine = ext::shared_ptr<PricingEngine>(
-                                            new IntegralEngine(stochProcess));
+        engine = ext::make_shared<IntegralEngine>(stochProcess);
         break;
       case PseudoMonteCarlo:
         engine = MakeMCEuropeanEngine<PseudoRandom>(stochProcess)
@@ -176,15 +166,13 @@ makeOption(const ext::shared_ptr<StrikedTypePayoff>& payoff,
             .withSamples(samples);
         break;
       case FFT:
-        engine = ext::shared_ptr<PricingEngine>(
-                                          new FFTVanillaEngine(stochProcess));
+        engine = ext::make_shared<FFTVanillaEngine>(stochProcess);
         break;
       default:
         QL_FAIL("unknown engine type");
     }
 
-    ext::shared_ptr<VanillaOption> option(
-            new EuropeanOption(payoff, exercise));
+    ext::shared_ptr<VanillaOption> option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     return option;
 }
@@ -211,20 +199,20 @@ void testEngineConsistency(EngineType engine,
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today,vol,dc);
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today,qRate,dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today,rRate,dc);
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * 360;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                 // reference option
                 ext::shared_ptr<VanillaOption> refOption =
                     makeOption(payoff, exercise, spot, qTS, rTS, volTS, Analytic, Null<Size>(),
@@ -338,32 +326,30 @@ BOOST_AUTO_TEST_CASE(testValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-        ext::shared_ptr<PricingEngine> engine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+                                      Handle<BlackVolTermStructure>(volTS));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
         EuropeanOption option(payoff, exercise);
         option.setPricingEngine(engine);
@@ -376,8 +362,7 @@ BOOST_AUTO_TEST_CASE(testValues) {
                            value.result, calculated, error, tolerance);
         }
 
-        engine = ext::shared_ptr<PricingEngine>(
-                    new FdBlackScholesVanillaEngine(stochProcess,200,400));
+        engine = ext::make_shared<FdBlackScholesVanillaEngine>(stochProcess,200,400);
         option.setPricingEngine(engine);
 
         calculated = option.NPV();
@@ -424,20 +409,18 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
-    ext::shared_ptr<PricingEngine> engine(
-                                    new AnalyticEuropeanEngine(stochProcess));
+                                  Handle<BlackVolTermStructure>(volTS));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
 
     ext::shared_ptr<StrikedTypePayoff> payoff;
     Date exDate;
@@ -448,16 +431,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
     Integer i = -1;
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->delta();
     Real error = std::fabs(calculated-values[i].result);
@@ -469,16 +450,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
                        error, tolerance);
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->delta();
     error = std::fabs(calculated-values[i].result);
@@ -489,16 +468,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
                        error, tolerance);
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->elasticity();
     error = std::fabs(calculated-values[i].result);
@@ -510,16 +487,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->gamma();
     error = std::fabs(calculated-values[i].result);
@@ -530,16 +505,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
                        error, tolerance);
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->gamma();
     error = std::fabs(calculated-values[i].result);
@@ -551,16 +524,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->vega();
     error = std::fabs(calculated-values[i].result);
@@ -572,16 +543,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->vega();
     error = std::fabs(calculated-values[i].result);
@@ -593,16 +562,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->theta();
     error = std::fabs(calculated-values[i].result);
@@ -614,16 +581,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->thetaPerDay();
     error = std::fabs(calculated-values[i].result);
@@ -635,16 +600,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->rho();
     error = std::fabs(calculated-values[i].result);
@@ -656,16 +619,14 @@ BOOST_AUTO_TEST_CASE(testGreekValues) {
 
 
     i++;
-    payoff = ext::shared_ptr<StrikedTypePayoff>(new
-        PlainVanillaPayoff(values[i].type, values[i].strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(values[i].type, values[i].strike);
     exDate = today + timeToDays(values[i].t);
-    exercise = ext::shared_ptr<Exercise>(new EuropeanExercise(exDate));
+    exercise = ext::make_shared<EuropeanExercise>(exDate);
     spot ->setValue(values[i].s);
     qRate->setValue(values[i].q);
     rRate->setValue(values[i].r);
     vol  ->setValue(values[i].v);
-    option = ext::shared_ptr<VanillaOption>(
-                                        new EuropeanOption(payoff, exercise));
+    option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     calculated = option->dividendRho();
     error = std::fabs(calculated-values[i].result);
@@ -701,12 +662,12 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     ext::shared_ptr<StrikedTypePayoff> payoff;
@@ -715,26 +676,22 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
         for (Real strike : strikes) {
             for (Real residualTime : residualTimes) {
                 Date exDate = today + timeToDays(residualTime);
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
                 for (Size kk = 0; kk < 4; kk++) {
                     // option to check
                     if (kk == 0) {
-                        payoff = ext::shared_ptr<StrikedTypePayoff>(
-                            new PlainVanillaPayoff(type, strike));
+                        payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                     } else if (kk == 1) {
-                        payoff = ext::shared_ptr<StrikedTypePayoff>(
-                            new CashOrNothingPayoff(type, strike, 100.0));
+                        payoff = ext::make_shared<CashOrNothingPayoff>(type, strike, 100.0);
                     } else if (kk == 2) {
-                        payoff = ext::shared_ptr<StrikedTypePayoff>(
-                            new AssetOrNothingPayoff(type, strike));
+                        payoff = ext::make_shared<AssetOrNothingPayoff>(type, strike);
                     } else if (kk == 3) {
                         payoff =
-                            ext::shared_ptr<StrikedTypePayoff>(new GapPayoff(type, strike, 100.0));
+                            ext::make_shared<GapPayoff>(type, strike, 100.0);
                     }
 
-                    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                        new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
-                    ext::shared_ptr<PricingEngine> engine(new AnalyticEuropeanEngine(stochProcess));
+                    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
+                    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
                     EuropeanOption option(payoff, exercise);
                     option.setPricingEngine(engine);
 
@@ -847,12 +804,12 @@ BOOST_AUTO_TEST_CASE(testImpliedVol) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     for (auto& type : types) {
@@ -860,8 +817,8 @@ BOOST_AUTO_TEST_CASE(testImpliedVol) {
             for (int length : lengths) {
                 // option to check
                 Date exDate = today + length;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                 ext::shared_ptr<VanillaOption> option = makeOption(
                     payoff, exercise, spot, qTS, rTS, volTS, Analytic, Null<Size>(), Null<Size>());
 
@@ -960,12 +917,12 @@ BOOST_AUTO_TEST_CASE(testImpliedVolWithDividends) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     for (auto& type : types) {
@@ -973,8 +930,8 @@ BOOST_AUTO_TEST_CASE(testImpliedVolWithDividends) {
             for (int length : lengths) {
                 // option to check
                 Date exDate = today + length;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                 auto process = makeProcess(spot, qTS, rTS, volTS);
                 auto dividends = DividendVector({ today + length/2 }, { 1.0 });
                 auto option = makeOption(
@@ -1066,32 +1023,27 @@ BOOST_AUTO_TEST_CASE(testImpliedVolContainment) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
     Handle<Quote> underlying(spot);
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.05));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.05);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.03));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.03);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.20));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.20);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
     Date exerciseDate = today + 1*Years;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                 new PlainVanillaPayoff(Option::Call, 100.0));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 100.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-                  new BlackScholesMertonProcess(underlying, qTS, rTS, volTS));
-    ext::shared_ptr<PricingEngine> engine(
-                                        new AnalyticEuropeanEngine(process));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(underlying, qTS, rTS, volTS);
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(process);
     // link to the same stochastic process, which shouldn't be changed
     // by calling methods of either option
 
-    ext::shared_ptr<VanillaOption> option1(
-                                        new EuropeanOption(payoff, exercise));
+    ext::shared_ptr<VanillaOption> option1 = ext::make_shared<EuropeanOption>(payoff, exercise);
     option1->setPricingEngine(engine);
-    ext::shared_ptr<VanillaOption> option2(
-                                        new EuropeanOption(payoff, exercise));
+    ext::shared_ptr<VanillaOption> option2 = ext::make_shared<EuropeanOption>(payoff, exercise);
     option2->setPricingEngine(engine);
 
     // test
@@ -1310,12 +1262,11 @@ BOOST_AUTO_TEST_CASE(testLocalVolatility) {
         dates.push_back(settlementDate + t[i]);
         rates.push_back(r[i]);
     }
-    const ext::shared_ptr<YieldTermStructure> rTS(
-                                   new ZeroCurve(dates, rates, dayCounter));
+    const ext::shared_ptr<YieldTermStructure> rTS = ext::make_shared<ZeroCurve>(dates, rates, dayCounter);
     const ext::shared_ptr<YieldTermStructure> qTS(
                                    flatRate(settlementDate, 0.0, dayCounter));
 
-    const ext::shared_ptr<Quote> s0(new SimpleQuote(4500.00));
+    const ext::shared_ptr<Quote> s0 = ext::make_shared<SimpleQuote>(4500.00);
     
     const std::vector<Real> strikes = { 100 ,500 ,2000,3400,3600,3800,4000,4200,4400,4500,
                                         4600,4800,5000,5200,5400,5600,7500,10000,20000,30000 };
@@ -1348,11 +1299,10 @@ BOOST_AUTO_TEST_CASE(testLocalVolatility) {
             blackVolMatrix[i][j-1] = v[i*(dates.size()-1)+j-1];
         }
     
-    const ext::shared_ptr<BlackVarianceSurface> volTS(
-        new BlackVarianceSurface(settlementDate, calendar,
+    const ext::shared_ptr<BlackVarianceSurface> volTS = ext::make_shared<BlackVarianceSurface>(settlementDate, calendar,
                                  std::vector<Date>(dates.begin()+1, dates.end()),
                                  strikes, blackVolMatrix,
-                                 dayCounter));
+                                 dayCounter);
     volTS->setInterpolation<Bicubic>();
     const ext::shared_ptr<GeneralizedBlackScholesProcess> process =
                                               makeProcess(s0, qTS, rTS,volTS);
@@ -1366,23 +1316,19 @@ BOOST_AUTO_TEST_CASE(testLocalVolatility) {
     for (Size i=2; i < dates.size(); i+=2) {
         for (Size j=3; j < strikes.size()-5; j+=5) {
             const Date& exDate = dates[i];
-            const ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                 PlainVanillaPayoff(Option::Call, strikes[j]));
+            const ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strikes[j]);
     
-            const ext::shared_ptr<Exercise> exercise(
-                                                 new EuropeanExercise(exDate));
+            const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
     
             EuropeanOption option(payoff, exercise);
-            option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                         new AnalyticEuropeanEngine(process)));
+            option.setPricingEngine(ext::make_shared<AnalyticEuropeanEngine>(process));
              
             const Real tol = 0.001;
             const Real expectedNPV   = option.NPV();
             const Real expectedDelta = option.delta();
             const Real expectedGamma = option.gamma();
             
-            option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                         new FdBlackScholesVanillaEngine(process, 200, 400)));
+            option.setPricingEngine(ext::make_shared<FdBlackScholesVanillaEngine>(process, 200, 400));
     
             Real calculatedNPV = option.NPV();
             const Real calculatedDelta = option.delta();
@@ -1437,31 +1383,27 @@ BOOST_AUTO_TEST_CASE(testAnalyticEngineDiscountCurve) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(1000.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(1000.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.01);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.015));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.015);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.02));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.02);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
-    ext::shared_ptr<SimpleQuote> discRate(new SimpleQuote(0.015));
+    ext::shared_ptr<SimpleQuote> discRate = ext::make_shared<SimpleQuote>(0.015);
     ext::shared_ptr<YieldTermStructure> discTS = flatRate(today, discRate, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
             Handle<YieldTermStructure>(qTS),
             Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
-    ext::shared_ptr<PricingEngine> engineSingleCurve(
-        new AnalyticEuropeanEngine(stochProcess));
-    ext::shared_ptr<PricingEngine> engineMultiCurve(
-        new AnalyticEuropeanEngine(stochProcess,
-            Handle<YieldTermStructure>(discTS)));
+            Handle<BlackVolTermStructure>(volTS));
+    ext::shared_ptr<PricingEngine> engineSingleCurve = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
+    ext::shared_ptr<PricingEngine> engineMultiCurve = ext::make_shared<AnalyticEuropeanEngine>(stochProcess,
+            Handle<YieldTermStructure>(discTS));
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-        PlainVanillaPayoff(Option::Call, 1025.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 1025.0);
     Date exDate = today + Period(1, Years);
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
     EuropeanOption option(payoff, exercise);
     Real npvSingleCurve, npvMultiCurve;
     option.setPricingEngine(engineSingleCurve);
@@ -1585,7 +1527,7 @@ BOOST_AUTO_TEST_CASE(testFdEngineWithNonConstantParameters) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(u));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(u);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today,v,dc);
 
     std::vector<Date> dates(5);

--- a/test-suite/everestoption.cpp
+++ b/test-suite/everestoption.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
 
     DayCounter dc = Actual360();
     Date exerciseDate = today+360;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
     Real notional = 1.0;
     Rate guarantee = 0.0;
@@ -49,32 +49,27 @@ BOOST_AUTO_TEST_CASE(testCached) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today, 0.05, dc));
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > processes(4);
-    Handle<Quote> dummyUnderlying(ext::shared_ptr<Quote>(
-                                                       new SimpleQuote(1.0)));
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
+    Handle<Quote> dummyUnderlying(ext::make_shared<SimpleQuote>(1.0));
+    processes[0] = ext::make_shared<BlackScholesMertonProcess>(
                     dummyUnderlying,
                     Handle<YieldTermStructure>(flatRate(today, 0.01, dc)),
                     riskFreeRate,
-                    Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc))));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
+                    Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc)));
+    processes[1] = ext::make_shared<BlackScholesMertonProcess>(
                     dummyUnderlying,
                     Handle<YieldTermStructure>(flatRate(today, 0.05, dc)),
                     riskFreeRate,
-                    Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc))));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
+                    Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc)));
+    processes[2] = ext::make_shared<BlackScholesMertonProcess>(
                     dummyUnderlying,
                     Handle<YieldTermStructure>(flatRate(today, 0.04, dc)),
                     riskFreeRate,
-                    Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc))));
-    processes[3] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
+                    Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc)));
+    processes[3] = ext::make_shared<BlackScholesMertonProcess>(
                     dummyUnderlying,
                     Handle<YieldTermStructure>(flatRate(today, 0.03, dc)),
                     riskFreeRate,
-                    Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc))));
+                    Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc)));
 
     Matrix correlation(4,4);
     correlation[0][0] = 1.00;
@@ -100,8 +95,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
     Size fixedSamples = 1023;
     Real minimumTol = 1.0e-2;
 
-    ext::shared_ptr<StochasticProcessArray> process(
-                          new StochasticProcessArray(processes, correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(processes, correlation);
 
     option.setPricingEngine(MakeMCEverestEngine<PseudoRandom>(process)
                             .withStepsPerYear(1)

--- a/test-suite/extendedtrees.cpp
+++ b/test-suite/extendedtrees.cpp
@@ -88,52 +88,44 @@ makeOption(const ext::shared_ptr<StrikedTypePayoff>& payoff,
     ext::shared_ptr<PricingEngine> engine;
     switch (engineType) {
       case Analytic:
-        engine = ext::shared_ptr<PricingEngine>(
-                                    new AnalyticEuropeanEngine(stochProcess));
+        engine = ext::make_shared<AnalyticEuropeanEngine>(stochProcess);
         break;
       case JR:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedJarrowRudd>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedJarrowRudd>>(stochProcess,
+                                                              binomialSteps);
         break;
       case CRR:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedCoxRossRubinstein>(
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedCoxRossRubinstein>>(
                                                               stochProcess,
-                                                              binomialSteps));
+                                                              binomialSteps);
         break;
       case EQP:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedAdditiveEQPBinomialTree>(
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedAdditiveEQPBinomialTree>>(
                                                               stochProcess,
-                                                              binomialSteps));
+                                                              binomialSteps);
         break;
       case TGEO:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedTrigeorgis>(stochProcess,
-                                                              binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedTrigeorgis>>(stochProcess,
+                                                              binomialSteps);
         break;
       case TIAN:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedTian>(stochProcess,
-                                                        binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedTian>>(stochProcess,
+                                                        binomialSteps);
         break;
       case LR:
-        engine = ext::shared_ptr<PricingEngine>(
-                      new BinomialVanillaEngine<ExtendedLeisenReimer>(
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedLeisenReimer>>(
                                                               stochProcess,
-                                                              binomialSteps));
+                                                              binomialSteps);
         break;
       case JOSHI:
-        engine = ext::shared_ptr<PricingEngine>(
-                new BinomialVanillaEngine<ExtendedJoshi4>(stochProcess,
-                                                          binomialSteps));
+        engine = ext::make_shared<BinomialVanillaEngine<ExtendedJoshi4>>(stochProcess,
+                                                          binomialSteps);
         break;
       default:
         QL_FAIL("unknown engine type");
     }
 
-    ext::shared_ptr<VanillaOption> option(new EuropeanOption(payoff, exercise));
+    ext::shared_ptr<VanillaOption> option = ext::make_shared<EuropeanOption>(payoff, exercise);
     option->setPricingEngine(engine);
     return option;
 }
@@ -158,20 +150,20 @@ void testEngineConsistency(EngineType engine,
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today,vol,dc);
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today,qRate,dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today,rRate,dc);
 
     for (auto& type : types) {
         for (Real strike : strikes) {
             for (int length : lengths) {
                 Date exDate = today + length * 360;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                 // reference option
                 ext::shared_ptr<VanillaOption> refOption =
                     makeOption(payoff, exercise, spot, qTS, rTS, volTS, Analytic, Null<Size>());

--- a/test-suite/fdcir.cpp
+++ b/test-suite/fdcir.cpp
@@ -63,11 +63,10 @@ BOOST_AUTO_TEST_CASE(testFdmCIRConvergence) {
     Date maturity = today + 365;
     DayCounter dayCounter = Actual365Fixed();
 
-    ext::shared_ptr<Exercise> europeanExercise(
-        new EuropeanExercise(maturity));
+    ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
 
     Handle<Quote> underlyingH(
-        ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+        ext::make_shared<SimpleQuote>(underlying));
 
     Handle<YieldTermStructure> flatTermStructure(
         ext::shared_ptr<YieldTermStructure>(flatRate(today, riskFreeRate, dayCounter)));
@@ -75,11 +74,9 @@ BOOST_AUTO_TEST_CASE(testFdmCIRConvergence) {
         ext::shared_ptr<YieldTermStructure>(flatRate(today, dividendYield, dayCounter)));
     Handle<BlackVolTermStructure> flatVolTS(
         ext::shared_ptr<BlackVolTermStructure>(flatVol(today, volatility, dayCounter)));
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(type, strike));
-    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(underlyingH, flatDividendTS,
-                                      flatTermStructure, flatVolTS));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
+    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(underlyingH, flatDividendTS,
+                                      flatTermStructure, flatVolTS);
 
     VanillaOption europeanOption(payoff, europeanExercise);
 
@@ -92,7 +89,7 @@ BOOST_AUTO_TEST_CASE(testFdmCIRConvergence) {
     Real newSpeed = speed + (cirSigma*lambda); //1.0792
     Real newLevel = (level * speed)/(speed + (cirSigma*lambda));//// 0.0240
 
-    ext::shared_ptr<CoxIngersollRossProcess> cirProcess(new CoxIngersollRossProcess(newSpeed, cirSigma, initialRate, newLevel));
+    ext::shared_ptr<CoxIngersollRossProcess> cirProcess = ext::make_shared<CoxIngersollRossProcess>(newSpeed, cirSigma, initialRate, newLevel);
 
     Real expected = 4.275;
     Real tolerance = 0.0003;

--- a/test-suite/fdheston.cpp
+++ b/test-suite/fdheston.cpp
@@ -291,41 +291,37 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBarrierVsBlackScholes) {
     Settings::instance().evaluationDate() = todaysDate;
 
     Handle<Quote> spot(
-            ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+            ext::make_shared<SimpleQuote>(0.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> bsProcess(
-                      new BlackScholesMertonProcess(spot, qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> bsProcess = ext::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS, volTS);
 
-    ext::shared_ptr<PricingEngine> analyticEngine(
-                                        new AnalyticBarrierEngine(bsProcess));
+    ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<AnalyticBarrierEngine>(bsProcess);
 
     for (auto& value : values) {
         Date exDate = todaysDate + timeToDays(value.t, 365);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         ext::dynamic_pointer_cast<SimpleQuote>(spot.currentLink())->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         BarrierOption barrierOption(value.barrierType, value.barrier, value.rebate, payoff,
                                     exercise);
 
         const Real v0 = vol->value()*vol->value();
-        ext::shared_ptr<HestonProcess> hestonProcess(
-             new HestonProcess(rTS, qTS, spot, v0, 1.0, v0, 0.005, 0.0));
+        ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, spot, v0, 1.0, v0, 0.005, 0.0);
 
-        barrierOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-            new FdHestonBarrierEngine(ext::make_shared<HestonModel>(
-                              hestonProcess), 200, 101, 3)));
+        barrierOption.setPricingEngine(ext::make_shared<FdHestonBarrierEngine>(ext::make_shared<HestonModel>(
+                              hestonProcess), 200, 101, 3));
 
         const Real calculatedHE = barrierOption.NPV();
     
@@ -347,27 +343,24 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBarrier) {
     BOOST_TEST_MESSAGE("Testing FDM with barrier option for Heston model vs "
                        "Black-Scholes model...");
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8);
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(28, March, 2005);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Call, 100));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 100);
 
     BarrierOption barrierOption(Barrier::UpOut, 135, 0.0, payoff, exercise);
 
-    barrierOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-            new FdHestonBarrierEngine(ext::make_shared<HestonModel>(
-                              hestonProcess), 50, 400, 100)));
+    barrierOption.setPricingEngine(ext::make_shared<FdHestonBarrierEngine>(ext::make_shared<HestonModel>(
+                              hestonProcess), 50, 400, 100));
 
     const Real tol = 0.01;
     const Real npvExpected   =  9.1530;
@@ -398,26 +391,23 @@ BOOST_AUTO_TEST_CASE(testFdmHestonAmerican) {
 
     BOOST_TEST_MESSAGE("Testing FDM with American option in Heston model...");
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8);
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(28, March, 2005);
 
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(exerciseDate);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Put, 100));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100);
 
     VanillaOption option(payoff, exercise);
-    ext::shared_ptr<PricingEngine> engine(
-         new FdHestonVanillaEngine(ext::make_shared<HestonModel>(
-                             hestonProcess), 200, 100, 50));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdHestonVanillaEngine>(ext::make_shared<HestonModel>(
+                             hestonProcess), 200, 100, 50);
     option.setPricingEngine(engine);
     
     const Real tol = 0.01;
@@ -460,10 +450,9 @@ BOOST_AUTO_TEST_CASE(testFdmHestonIkonenToivanen) {
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(26, June, 2004);
 
-    ext::shared_ptr<Exercise> exercise(new AmericanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(exerciseDate);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Put, 10));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 10);
 
     VanillaOption option(payoff, exercise);
 
@@ -472,13 +461,11 @@ BOOST_AUTO_TEST_CASE(testFdmHestonIkonenToivanen) {
     const Real tol = 0.001;
     
     for (Size i=0; i < std::size(strikes); ++i) {
-        Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(strikes[i])));
-        ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, s0, 0.0625, 5, 0.16, 0.9, 0.1));
+        Handle<Quote> s0(ext::make_shared<SimpleQuote>(strikes[i]));
+        ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.0625, 5, 0.16, 0.9, 0.1);
     
-        ext::shared_ptr<PricingEngine> engine(
-             new FdHestonVanillaEngine(ext::make_shared<HestonModel>(
-                                 hestonProcess), 100, 400));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdHestonVanillaEngine>(ext::make_shared<HestonModel>(
+                                 hestonProcess), 100, 400);
         option.setPricingEngine(engine);
         
         Real calculated = option.NPV();
@@ -504,10 +491,9 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBlackScholes) {
     Handle<BlackVolTermStructure> volTS(
                     flatVol(rTS->referenceDate(), 0.25, rTS->dayCounter()));
     
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Put, 10));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 10);
 
     VanillaOption option(payoff, exercise);
 
@@ -515,24 +501,20 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBlackScholes) {
     const Real tol = 0.0001;
 
     for (Real& strike : strikes) {
-        Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(strike)));
+        Handle<Quote> s0(ext::make_shared<SimpleQuote>(strike));
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-                       new GeneralizedBlackScholesProcess(s0, qTS, rTS, volTS));
+        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess = ext::make_shared<GeneralizedBlackScholesProcess>(s0, qTS, rTS, volTS);
 
-        option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                        new AnalyticEuropeanEngine(bsProcess)));
+        option.setPricingEngine(ext::make_shared<AnalyticEuropeanEngine>(bsProcess));
         
         const Real expected = option.NPV();
         
-        ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, s0, 0.0625, 1, 0.0625, 0.0001, 0.0));
+        ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.0625, 1, 0.0625, 0.0001, 0.0);
 
         // Hundsdorfer scheme
-        option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-             new FdHestonVanillaEngine(ext::make_shared<HestonModel>(
+        option.setPricingEngine(ext::make_shared<FdHestonVanillaEngine>(ext::make_shared<HestonModel>(
                                            hestonProcess), 
-                                       100, 400, 3)));
+                                       100, 400, 3));
         
         Real calculated = option.NPV();
         if (std::fabs(calculated - expected) > tol) {
@@ -542,11 +524,10 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBlackScholes) {
         }
         
         // Explicit scheme
-        option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-             new FdHestonVanillaEngine(ext::make_shared<HestonModel>(
+        option.setPricingEngine(ext::make_shared<FdHestonVanillaEngine>(ext::make_shared<HestonModel>(
                                            hestonProcess),
                                        4000, 400, 3, 0,
-                                       FdmSchemeDesc::ExplicitEuler())));
+                                       FdmSchemeDesc::ExplicitEuler()));
 
         calculated = option.NPV();
         if (std::fabs(calculated - expected) > tol) {
@@ -561,7 +542,7 @@ BOOST_AUTO_TEST_CASE(testFdmHestonEuropeanWithDividends) {
 
     BOOST_TEST_MESSAGE("Testing FDM with European option with dividends in Heston model...");
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
@@ -641,7 +622,7 @@ BOOST_AUTO_TEST_CASE(testFdmHestonConvergence) {
     const Date todaysDate(28, March, 2004); 
     Settings::instance().evaluationDate() = todaysDate;
     
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(75.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(75.0));
 
     for (const auto& scheme : schemes) {
         for (auto& value : values) {
@@ -650,28 +631,25 @@ BOOST_AUTO_TEST_CASE(testFdmHestonConvergence) {
                     Handle<YieldTermStructure> rTS(flatRate(value.r, Actual365Fixed()));
                     Handle<YieldTermStructure> qTS(flatRate(value.q, Actual365Fixed()));
 
-                    ext::shared_ptr<HestonProcess> hestonProcess(new HestonProcess(
-                        rTS, qTS, s0, k, value.kappa, value.theta, value.sigma, value.rho));
+                    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(
+                        rTS, qTS, s0, k, value.kappa, value.theta, value.sigma, value.rho);
 
                     Date exerciseDate =
                         todaysDate + Period(static_cast<Integer>(value.T * 365), Days);
-                    ext::shared_ptr<Exercise> exercise(
-                                          new EuropeanExercise(exerciseDate));
+                    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
-                    ext::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(Option::Call, value.K));
+                    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, value.K);
 
                     VanillaOption option(payoff, exercise);
-                    ext::shared_ptr<PricingEngine> engine(new FdHestonVanillaEngine(
-                        ext::make_shared<HestonModel>(hestonProcess), j, 101, 51, 0, scheme));
+                    ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdHestonVanillaEngine>(
+                        ext::make_shared<HestonModel>(hestonProcess), j, 101, 51, 0, scheme);
                     option.setPricingEngine(engine);
                     
                     const Real calculated = option.NPV();
                     
-                    ext::shared_ptr<PricingEngine> analyticEngine(
-                        new AnalyticHestonEngine(
+                    ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<AnalyticHestonEngine>(
                             ext::make_shared<HestonModel>(
-                                hestonProcess), 144));
+                                hestonProcess), 144);
                     
                     option.setPricingEngine(analyticEngine);
                     const Real expected = option.NPV();
@@ -707,22 +685,18 @@ BOOST_AUTO_TEST_CASE(testFdmHestonIntradayPricing) {
 
     const Date maturity(17, May, 2014, 17, 30, 0);
 
-    const ext::shared_ptr<Exercise> europeanExercise(
-        new EuropeanExercise(maturity));
-    const ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(type, strike));
+    const ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
+    const ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
     VanillaOption option(payoff, europeanExercise);
 
     const Handle<Quote> s0(
-         ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+         ext::make_shared<SimpleQuote>(underlying));
     RelinkableHandle<BlackVolTermStructure> flatVolTS;
     RelinkableHandle<YieldTermStructure> flatTermStructure, flatDividendTS;
-    const ext::shared_ptr<HestonProcess> process(
-        new HestonProcess(flatTermStructure, flatDividendTS, s0,
-              v0, kappa, theta, sigma, rho));
-    const ext::shared_ptr<HestonModel> model(new HestonModel(process));
-    const ext::shared_ptr<PricingEngine> fdm(
-        new FdHestonVanillaEngine(model, 20, 100, 26, 0));
+    const ext::shared_ptr<HestonProcess> process = ext::make_shared<HestonProcess>(flatTermStructure, flatDividendTS, s0,
+              v0, kappa, theta, sigma, rho);
+    const ext::shared_ptr<HestonModel> model = ext::make_shared<HestonModel>(process);
+    const ext::shared_ptr<PricingEngine> fdm = ext::make_shared<FdHestonVanillaEngine>(model, 20, 100, 26, 0);
     option.setPricingEngine(fdm);
 
     const Real gammaExpected[] = {
@@ -733,10 +707,8 @@ BOOST_AUTO_TEST_CASE(testFdmHestonIntradayPricing) {
         const Date now(17, May, 2014, 15, i*15, 0);
         Settings::instance().evaluationDate() = now;
 
-        flatTermStructure.linkTo(ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(now, riskFreeRate, dayCounter)));
-        flatDividendTS.linkTo(ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(now, dividendYield, dayCounter)));
+        flatTermStructure.linkTo(ext::make_shared<FlatForward>(now, riskFreeRate, dayCounter));
+        flatDividendTS.linkTo(ext::make_shared<FlatForward>(now, dividendYield, dayCounter));
 
         const Real gammaCalculated = option.gamma();
         if (std::fabs(gammaCalculated - gammaExpected[i]) > 1e-4) {

--- a/test-suite/fdmlinearop.cpp
+++ b/test-suite/fdmlinearop.cpp
@@ -134,7 +134,7 @@ ext::shared_ptr<HybridHestonHullWhiteProcess> createHestonHullWhite(Time maturit
 
     DayCounter dc = Actual365Fixed();
     const Date today = Settings::instance().evaluationDate();
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     std::vector<Date> dates;
     std::vector<Rate> rates, divRates;
@@ -146,17 +146,14 @@ ext::shared_ptr<HybridHestonHullWhiteProcess> createHestonHullWhite(Time maturit
     }
 
     const Handle<YieldTermStructure> rTS(
-            ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+            ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-            ext::shared_ptr<YieldTermStructure>(
-                new ZeroCurve(dates, divRates, dc)));
+            ext::make_shared<ZeroCurve>(dates, divRates, dc));
 
     const Real v0 = 0.04;
-    ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, s0, v0, 1.0, v0*0.75, 0.4, -0.7));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, v0, 1.0, v0*0.75, 0.4, -0.7);
 
-    ext::shared_ptr<HullWhiteForwardProcess> hwFwdProcess(
-            new HullWhiteForwardProcess(rTS, 0.00883, 0.01));
+    ext::shared_ptr<HullWhiteForwardProcess> hwFwdProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.00883, 0.01);
     hwFwdProcess->setForwardMeasureTime(maturity);
 
     const Real equityShortRateCorr = -0.7;
@@ -173,36 +170,29 @@ FdmSolverDesc createSolverDesc(
     const Time maturity
         = process->hullWhiteProcess()->getForwardMeasureTime();
 
-    ext::shared_ptr<FdmLinearOpLayout> layout(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<ext::shared_ptr<Fdm1dMesher> > mesher1d = {
-        ext::shared_ptr<Fdm1dMesher>(
-                new Uniform1dMesher(std::log(22.0), std::log(440.0), dim[0])),
-        ext::shared_ptr<Fdm1dMesher>(
-                new FdmHestonVarianceMesher(dim[1], process->hestonProcess(),
-                                            maturity)),
-        ext::shared_ptr<Fdm1dMesher>(
-                new Uniform1dMesher(-0.15, 0.15, dim[2]))
+        ext::make_shared<Uniform1dMesher>(std::log(22.0), std::log(440.0), dim[0]),
+        ext::make_shared<FdmHestonVarianceMesher>(dim[1], process->hestonProcess(),
+                                            maturity),
+        ext::make_shared<Uniform1dMesher>(-0.15, 0.15, dim[2])
     };
 
-    const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(mesher1d));
+    const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(mesher1d);
 
     const FdmBoundaryConditionSet boundaries;
 
     std::list<std::vector<Time> > stoppingTimes;
     std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
 
-    ext::shared_ptr<FdmStepConditionComposite> conditions(
-            new FdmStepConditionComposite(
+    ext::shared_ptr<FdmStepConditionComposite> conditions = ext::make_shared<FdmStepConditionComposite>(
                 std::list<std::vector<Time> >(),
-                FdmStepConditionComposite::Conditions()));
+                FdmStepConditionComposite::Conditions());
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-            new PlainVanillaPayoff(Option::Call, 160.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 160.0);
 
-    ext::shared_ptr<FdmInnerValueCalculator> calculator(
-            new FdmLogInnerValue(payoff, mesher, 0));
+    ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
     const Size tGrid = 100;
     const Size dampingSteps = 0;
@@ -337,7 +327,7 @@ BOOST_AUTO_TEST_CASE(testUniformGridMesher) {
 
     const std::vector<Size> dim = {5,7,8};
 
-    ext::shared_ptr<FdmLinearOpLayout> layout(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
     std::vector<std::pair<Real, Real> > boundaries = {{-5, 10}, {5, 100}, {10, 20}};
 
     UniformGridMesher mesher(layout, boundaries);
@@ -363,12 +353,11 @@ BOOST_AUTO_TEST_CASE(testFirstDerivativesMapApply) {
 
     const std::vector<Size> dim = {400, 100, 50};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{-5, 5}, {0, 10}, { 5, 15}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-                                 new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
 
     FirstDerivativeOp map(2, mesher);
 
@@ -416,12 +405,11 @@ BOOST_AUTO_TEST_CASE(testSecondDerivativesMapApply) {
 
     const std::vector<Size> dim = {50, 50, 50};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{0, 0.5}, {0, 0.5}, {0, 0.5}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-                            new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
     Array r(mesher->layout()->size());
     for (const auto& iter : *index) {
         const Real x = mesher->location(iter, 0);
@@ -491,15 +479,11 @@ BOOST_AUTO_TEST_CASE(testSecondDerivativesMapApply) {
 BOOST_AUTO_TEST_CASE(testDerivativeWeightsOnNonUniformGrids) {
     BOOST_TEST_MESSAGE("Testing finite differences coefficients...");
 
-    const ext::shared_ptr<Fdm1dMesher> mesherX(
-        new Concentrating1dMesher(-2.0, 3.0, 50, std::make_pair(0.5, 0.01)));
-    const ext::shared_ptr<Fdm1dMesher> mesherY(
-        new Concentrating1dMesher(0.5, 5.0, 25, std::make_pair(0.5, 0.1)));
-    const ext::shared_ptr<Fdm1dMesher> mesherZ(
-        new Concentrating1dMesher(-1.0, 2.0, 31, std::make_pair(1.5, 0.01)));
+    const ext::shared_ptr<Fdm1dMesher> mesherX = ext::make_shared<Concentrating1dMesher>(-2.0, 3.0, 50, std::make_pair(0.5, 0.01));
+    const ext::shared_ptr<Fdm1dMesher> mesherY = ext::make_shared<Concentrating1dMesher>(0.5, 5.0, 25, std::make_pair(0.5, 0.1));
+    const ext::shared_ptr<Fdm1dMesher> mesherZ = ext::make_shared<Concentrating1dMesher>(-1.0, 2.0, 31, std::make_pair(1.5, 0.01));
 
-    const ext::shared_ptr<FdmMesher> meshers(
-        new FdmMesherComposite(mesherX, mesherY, mesherZ));
+    const ext::shared_ptr<FdmMesher> meshers = ext::make_shared<FdmMesherComposite>(mesherX, mesherY, mesherZ);
 
     const Real tol = 1e-13;
     for (Size direction=0; direction < 3; ++direction) {
@@ -667,12 +651,11 @@ BOOST_AUTO_TEST_CASE(testSecondOrderMixedDerivativesMapApply) {
 
     const std::vector<Size> dim = {50, 50, 50};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{0, 0.5}, {0, 0.5}, {0, 0.5}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-        new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
 
     Array r(mesher->layout()->size());
 
@@ -759,12 +742,11 @@ BOOST_AUTO_TEST_CASE(testTripleBandMapSolve) {
 
     const std::vector<Size> dim = {100, 400};
 
-    ext::shared_ptr<FdmLinearOpLayout> layout(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{0, 1.0}, {0, 1.0}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-        new UniformGridMesher(layout, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(layout, boundaries);
 
     FirstDerivativeOp dy(1, mesher);
     dy.axpyb(Array(1, 2.0), dy, dy, Array(1, 1.0));
@@ -838,26 +820,23 @@ BOOST_AUTO_TEST_CASE(testFdmHestonBarrier) {
 
     const std::vector<Size> dim = {200, 100};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{3.8, 4.905274778}, {0.0, 1.0}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-        new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8);
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(28, March, 2005);
 
-    ext::shared_ptr<FdmLinearOpComposite> hestonOp(
-                                   new FdmHestonOp(mesher, hestonProcess));
+    ext::shared_ptr<FdmLinearOpComposite> hestonOp = ext::make_shared<FdmHestonOp>(mesher, hestonProcess);
 
     Array rhs(mesher->layout()->size());
     for (const auto& iter : *mesher->layout()) {
@@ -924,28 +903,25 @@ BOOST_AUTO_TEST_CASE(testFdmHestonAmerican) {
 
     const std::vector<Size> dim = {200, 100};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{3.8, std::log(220.0)}, {0.0, 1.0}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-        new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.04, 2.5, 0.04, 0.66, -0.8);
 
     Settings::instance().evaluationDate() = Date(28, March, 2004);
     Date exerciseDate(28, March, 2005);
 
-    ext::shared_ptr<FdmLinearOpComposite> LinearOp(
-        new FdmHestonOp(mesher, hestonProcess));
+    ext::shared_ptr<FdmLinearOpComposite> LinearOp = ext::make_shared<FdmHestonOp>(mesher, hestonProcess);
 
-    ext::shared_ptr<Payoff> payoff(new PlainVanillaPayoff(Option::Put, 100.0));
+    ext::shared_ptr<Payoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 100.0);
     Array rhs(mesher->layout()->size());
     for (const auto& iter : *mesher->layout()) {
             rhs[iter.index()]
@@ -953,8 +929,7 @@ BOOST_AUTO_TEST_CASE(testFdmHestonAmerican) {
     }
 
     FdmAmericanStepCondition condition(mesher,
-        ext::shared_ptr<FdmInnerValueCalculator>(
-                                     new FdmLogInnerValue(payoff, mesher, 0)));
+        ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
     const Real theta=0.5+std::sqrt(3.0)/6.;
     HundsdorferScheme hsEvolver(theta, 0.5, LinearOp);
     FiniteDifferenceModel<HundsdorferScheme> hsModel(hsEvolver);
@@ -995,14 +970,13 @@ BOOST_AUTO_TEST_CASE(testFdmHestonExpress) {
 
     const std::vector<Size> dim = {200, 100};
 
-    ext::shared_ptr<FdmLinearOpLayout> index(new FdmLinearOpLayout(dim));
+    ext::shared_ptr<FdmLinearOpLayout> index = ext::make_shared<FdmLinearOpLayout>(dim);
 
     std::vector<std::pair<Real, Real> > boundaries = {{3.8, std::log(220.0)}, {0.0, 1.0}};
 
-    ext::shared_ptr<FdmMesher> mesher(
-                            new UniformGridMesher(index, boundaries));
+    ext::shared_ptr<FdmMesher> mesher = ext::make_shared<UniformGridMesher>(index, boundaries);
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     Handle<YieldTermStructure> rTS(flatRate(0.05, Actual365Fixed()));
     Handle<YieldTermStructure> qTS(flatRate(0.0 , Actual365Fixed()));
@@ -1021,16 +995,13 @@ BOOST_AUTO_TEST_CASE(testFdmHestonExpress) {
     std::vector<Time> exerciseTimes(2);
     exerciseTimes[0] = 0.333; exerciseTimes[1] = 0.666;
 
-    DividendSchedule dividendSchedule(1, ext::shared_ptr<Dividend>(
-        new FixedDividend(2.5, evaluationDate + Period(6, Months))));
-    ext::shared_ptr<FdmDividendHandler> dividendCondition(
-        new FdmDividendHandler(dividendSchedule, mesher,
+    DividendSchedule dividendSchedule(1, ext::make_shared<FixedDividend>(2.5, evaluationDate + Period(6, Months)));
+    ext::shared_ptr<FdmDividendHandler> dividendCondition = ext::make_shared<FdmDividendHandler>(dividendSchedule, mesher,
                                rTS->referenceDate(),
-                               rTS->dayCounter(), 0));
+                               rTS->dayCounter(), 0);
 
-    ext::shared_ptr<StepCondition<Array> > expressCondition(
-        new FdmHestonExpressCondition(redemptions, triggerLevels,
-                                      exerciseTimes, mesher));
+    ext::shared_ptr<StepCondition<Array> > expressCondition = ext::make_shared<FdmHestonExpressCondition>(redemptions, triggerLevels,
+                                      exerciseTimes, mesher);
 
     std::list<std::vector<Time>> stoppingTimes = {
         exerciseTimes, dividendCondition->dividendTimes()
@@ -1040,13 +1011,11 @@ BOOST_AUTO_TEST_CASE(testFdmHestonExpress) {
         expressCondition, dividendCondition
     };
 
-    ext::shared_ptr<FdmStepConditionComposite> condition(
-        new FdmStepConditionComposite(stoppingTimes, conditions));
+    ext::shared_ptr<FdmStepConditionComposite> condition = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, conditions);
 
-    ext::shared_ptr<Payoff> payoff(new ExpressPayoff());
+    ext::shared_ptr<Payoff> payoff = ext::make_shared<ExpressPayoff>();
 
-    ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                    new FdmLogInnerValue(payoff, mesher, 0));
+    ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
     const FdmBoundaryConditionSet bcSet;
     const FdmSolverDesc solverDesc = { mesher, bcSet,
@@ -1098,15 +1067,13 @@ BOOST_AUTO_TEST_CASE(testFdmHestonHullWhiteOp) {
     ext::shared_ptr<HullWhiteForwardProcess> hwFwdProcess
                                             = jointProcess->hullWhiteProcess();
 
-    ext::shared_ptr<HullWhiteProcess> hwProcess(
-        new HullWhiteProcess(jointProcess->hestonProcess()->riskFreeRate(),
-                             hwFwdProcess->a(), hwFwdProcess->sigma()));
+    ext::shared_ptr<HullWhiteProcess> hwProcess = ext::make_shared<HullWhiteProcess>(jointProcess->hestonProcess()->riskFreeRate(),
+                             hwFwdProcess->a(), hwFwdProcess->sigma());
 
-    ext::shared_ptr<FdmLinearOpComposite> linearOp(
-        new FdmHestonHullWhiteOp(mesher,
+    ext::shared_ptr<FdmLinearOpComposite> linearOp = ext::make_shared<FdmHestonHullWhiteOp>(mesher,
                                  jointProcess->hestonProcess(),
                                  hwProcess,
-                                 jointProcess->eta()));
+                                 jointProcess->eta());
 
     Array rhs(mesher->layout()->size());
     for (const auto& iter : *mesher->layout()) {
@@ -1172,9 +1139,8 @@ BOOST_AUTO_TEST_CASE(testFdmHestonHullWhiteOp) {
     }
 
     VanillaOption option(
-            ext::shared_ptr<StrikedTypePayoff>(
-                                new PlainVanillaPayoff(Option::Call, 160.0)),
-            ext::shared_ptr<Exercise>(new EuropeanExercise(exerciseDate)));
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, 160.0),
+            ext::make_shared<EuropeanExercise>(exerciseDate));
 
     const Real tol = 0.025;
     option.setPricingEngine(
@@ -1296,25 +1262,22 @@ BOOST_AUTO_TEST_CASE(testCrankNicolsonWithDamping) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, 0.06, dc);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, 0.06, dc);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, 0.35, dc);
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                             new CashOrNothingPayoff(Option::Put, 100, 10.0));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<CashOrNothingPayoff>(Option::Put, 100, 10.0);
 
     Time maturity = 0.75;
     Date exDate = today + timeToDays(maturity);
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(new
-        BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                   Handle<YieldTermStructure>(qTS),
                                   Handle<YieldTermStructure>(rTS),
-                                  Handle<BlackVolTermStructure>(volTS)));
-    ext::shared_ptr<PricingEngine> engine(
-                                new AnalyticEuropeanEngine(process));
+                                  Handle<BlackVolTermStructure>(volTS));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(process);
 
     VanillaOption opt(payoff, exercise);
     opt.setPricingEngine(engine);
@@ -1325,21 +1288,17 @@ BOOST_AUTO_TEST_CASE(testCrankNicolsonWithDamping) {
     const Size csSteps = 25, dampingSteps = 3, xGrid = 400;
     const std::vector<Size> dim(1, xGrid);
 
-    ext::shared_ptr<FdmLinearOpLayout> layout(new FdmLinearOpLayout(dim));
-    const ext::shared_ptr<Fdm1dMesher> equityMesher(
-        new FdmBlackScholesMesher(
+    ext::shared_ptr<FdmLinearOpLayout> layout = ext::make_shared<FdmLinearOpLayout>(dim);
+    const ext::shared_ptr<Fdm1dMesher> equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 dim[0], process, maturity, payoff->strike(),
                 Null<Real>(), Null<Real>(), 0.0001, 1.5,
-                std::pair<Real, Real>(payoff->strike(), 0.01)));
+                std::pair<Real, Real>(payoff->strike(), 0.01));
 
-    const ext::shared_ptr<FdmMesher> mesher (
-        new FdmMesherComposite(equityMesher));
+    const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(equityMesher);
 
-    ext::shared_ptr<FdmBlackScholesOp> map(
-                     new FdmBlackScholesOp(mesher, process, payoff->strike()));
+    ext::shared_ptr<FdmBlackScholesOp> map = ext::make_shared<FdmBlackScholesOp>(mesher, process, payoff->strike());
 
-    ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                  new FdmLogInnerValue(payoff, mesher, 0));
+    ext::shared_ptr<FdmInnerValueCalculator> calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
     Array rhs(layout->size()), x(layout->size());
 
@@ -1443,14 +1402,13 @@ BOOST_AUTO_TEST_CASE(testSparseMatrixZeroAssignment) {
 BOOST_AUTO_TEST_CASE(testFdmMesherIntegral) {
     BOOST_TEST_MESSAGE("Testing integrals over meshers functions...");
 
-    const ext::shared_ptr<FdmMesherComposite> mesher(
-        new FdmMesherComposite(
-            ext::shared_ptr<Fdm1dMesher>(new Concentrating1dMesher(
-                -1, 1.6, 21, std::pair<Real, Real>(0, 0.1))),
-            ext::shared_ptr<Fdm1dMesher>(new Concentrating1dMesher(
-                -3, 4, 11, std::pair<Real, Real>(1, 0.01))),
-            ext::shared_ptr<Fdm1dMesher>(new Concentrating1dMesher(
-                -2, 1, 5, std::pair<Real, Real>(0.5, 0.1)))));
+    const ext::shared_ptr<FdmMesherComposite> mesher = ext::make_shared<FdmMesherComposite>(
+            ext::make_shared<Concentrating1dMesher>(
+                -1, 1.6, 21, std::pair<Real, Real>(0, 0.1)),
+            ext::make_shared<Concentrating1dMesher>(
+                -3, 4, 11, std::pair<Real, Real>(1, 0.01)),
+            ext::make_shared<Concentrating1dMesher>(
+                -2, 1, 5, std::pair<Real, Real>(0.5, 0.1)));
 
     Array f(mesher->layout()->size());
     for (const auto& iter : *mesher->layout()) {

--- a/test-suite/forwardoption.cpp
+++ b/test-suite/forwardoption.cpp
@@ -100,19 +100,17 @@ void testForwardGreeks() {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-            new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-    ext::shared_ptr<PricingEngine> engine(
-            new Engine<AnalyticEuropeanEngine>(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<Engine<AnalyticEuropeanEngine>>(stochProcess);
 
     for (auto& type : types) {
         for (Real& moneynes : moneyness) {
@@ -120,12 +118,11 @@ void testForwardGreeks() {
                 for (int startMonth : startMonths) {
 
                     Date exDate = today + length * Years;
-                    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                     Date reset = today + startMonth * Months;
 
-                    ext::shared_ptr<StrikedTypePayoff> payoff(
-                            new PlainVanillaPayoff(type, 0.0));
+                    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, 0.0);
 
                     ForwardVanillaOption option(moneynes, reset, payoff, exercise);
                     option.setPricingEngine(engine);
@@ -239,28 +236,26 @@ BOOST_AUTO_TEST_CASE(testValues) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engine(
-              new ForwardVanillaEngine<AnalyticEuropeanEngine>(stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<ForwardVanillaEngine<AnalyticEuropeanEngine>>(stochProcess);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, 0.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, 0.0);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         Date reset = today + timeToDays(value.start);
 
         spot->setValue(value.s);
@@ -298,29 +293,27 @@ BOOST_AUTO_TEST_CASE(testPerformanceValues) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-    ext::shared_ptr<PricingEngine> engine(
-        new ForwardPerformanceVanillaEngine<AnalyticEuropeanEngine>(
-                                                               stochProcess));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<ForwardPerformanceVanillaEngine<AnalyticEuropeanEngine>>(
+                                                               stochProcess);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, 0.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, 0.0);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         Date reset = today + timeToDays(value.start);
 
         spot->setValue(value.s);
@@ -372,31 +365,26 @@ BOOST_AUTO_TEST_CASE(testGreeksInitialization) {
    DayCounter dc = Actual360();
    Date today = Settings::instance().evaluationDate();
 
-   ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
-   ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+   ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
+   ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
    Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-   ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.01));
+   ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.01);
    Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-   ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.11));
+   ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.11);
    Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-   ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-      new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+   ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-   ext::shared_ptr<PricingEngine> engine(
-                        new ForwardVanillaEngine<TestBinomialEngine>(stochProcess));
+   ext::shared_ptr<PricingEngine> engine = ext::make_shared<ForwardVanillaEngine<TestBinomialEngine>>(stochProcess);
    Date exDate = today + 1*Years;
-   ext::shared_ptr<Exercise> exercise(
-                                 new EuropeanExercise(exDate));
+   ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
    Date reset = today + 6*Months;
-   ext::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(Option::Call, 0.0));
+   ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
    ForwardVanillaOption option(0.9, reset, payoff, exercise);
    option.setPricingEngine(engine);
 
-   ext::shared_ptr<PricingEngine> ctrlengine(
-                        new TestBinomialEngine(stochProcess));
+   ext::shared_ptr<PricingEngine> ctrlengine = ext::make_shared<TestBinomialEngine>(stochProcess);
    VanillaOption ctrloption(payoff, exercise);
    ctrloption.setPricingEngine(ctrlengine);
 
@@ -490,19 +478,17 @@ BOOST_AUTO_TEST_CASE(testMCPrices) {
    DayCounter dc = Actual360();
    Date today = Settings::instance().evaluationDate();
 
-   ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(s));
-   ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(q));
+   ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(s);
+   ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(q);
    Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-   ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(r));
+   ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(r);
    Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-   ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(sigma));
+   ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(sigma);
    Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-   ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-      new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+   ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-   ext::shared_ptr<PricingEngine> analyticEngine(
-                        new ForwardVanillaEngine<AnalyticEuropeanEngine>(stochProcess));
+   ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<ForwardVanillaEngine<AnalyticEuropeanEngine>>(stochProcess);
 
    ext::shared_ptr<PricingEngine> mcEngine 
       = MakeMCForwardEuropeanBSEngine<PseudoRandom>(stochProcess)
@@ -511,11 +497,9 @@ BOOST_AUTO_TEST_CASE(testMCPrices) {
             .withSeed(mcSeed);
 
    Date exDate = today + 1*Years;
-   ext::shared_ptr<Exercise> exercise(
-                                 new EuropeanExercise(exDate));
+   ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
    Date reset = today + 6*Months;
-   ext::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(Option::Call, 0.0));
+   ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
    Real moneyness[] = { 0.8, 0.9, 1.0, 1.1, 1.2 };
 
@@ -587,26 +571,23 @@ BOOST_AUTO_TEST_CASE(testHestonMCPrices) {
        Date today = Settings::instance().evaluationDate();
 
        Date exDate = today + 1 * Years;
-       ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+       ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
        Date reset = today + 6 * Months;
-       ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(optionTypes[type_index], 0.0));
+       ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(optionTypes[type_index], 0.0);
 
-       ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(s));
-       ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(q));
+       ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(s);
+       ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(q);
        Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-       ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(r));
+       ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(r);
        Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-       ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(sigma_bs));
+       ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(sigma_bs);
        Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-       ext::shared_ptr<BlackScholesMertonProcess> bsProcess(
-           new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+       ext::shared_ptr<BlackScholesMertonProcess> bsProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
-       ext::shared_ptr<PricingEngine> analyticEngine(
-           new ForwardVanillaEngine<AnalyticEuropeanEngine>(bsProcess));
+       ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<ForwardVanillaEngine<AnalyticEuropeanEngine>>(bsProcess);
 
-       ext::shared_ptr<HestonProcess> hestonProcess(
-           new HestonProcess(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho));
+       ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho);
 
        ext::shared_ptr<PricingEngine> mcEngine =
            MakeMCForwardEuropeanHestonEngine<LowDiscrepancy>(hestonProcess)
@@ -644,8 +625,7 @@ BOOST_AUTO_TEST_CASE(testHestonMCPrices) {
 
        reset = today;
 
-       ext::shared_ptr<HestonProcess> hestonProcessSmile(
-           new HestonProcess(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho));
+       ext::shared_ptr<HestonProcess> hestonProcessSmile = ext::make_shared<HestonProcess>(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho);
 
        ext::shared_ptr<HestonModel> hestonModel(ext::make_shared<HestonModel>(hestonProcessSmile));
 
@@ -658,13 +638,12 @@ BOOST_AUTO_TEST_CASE(testHestonMCPrices) {
                .withSamples(numberOfSamples)
                .withSeed(mcSeed);
 
-       ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticForwardHestonEngine(
-           new AnalyticHestonForwardEuropeanEngine(hestonProcessSmile));
+       ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticForwardHestonEngine = ext::make_shared<AnalyticHestonForwardEuropeanEngine>(hestonProcessSmile);
 
        for (Size moneyness_index = 0; moneyness_index < std::size(moneyness); ++moneyness_index) {
 
            Real strike = s * moneyness[moneyness_index];
-           ext::shared_ptr<StrikedTypePayoff> vanillaPayoff(new PlainVanillaPayoff(optionTypes[type_index], strike));
+           ext::shared_ptr<StrikedTypePayoff> vanillaPayoff = ext::make_shared<PlainVanillaPayoff>(optionTypes[type_index], strike);
 
            VanillaOption vanillaOption(vanillaPayoff, exercise);
            ForwardVanillaOption forwardOption(moneyness[moneyness_index], reset, payoff, exercise);
@@ -736,18 +715,17 @@ BOOST_AUTO_TEST_CASE(testHestonAnalyticalVsMCPrices) {
        Date today = Settings::instance().evaluationDate();
 
        Date exDate = today + 1 * Years;
-       ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+       ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
        Date reset = today + 6 * Months;
-       ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(optionTypes[option_type_index], 0.0));
+       ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(optionTypes[option_type_index], 0.0);
 
-       ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(s));
-       ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(q));
+       ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(s);
+       ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(q);
        Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-       ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(r));
+       ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(r);
        Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
 
-       ext::shared_ptr<HestonProcess> hestonProcess(
-           new HestonProcess(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho));
+       ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, Handle<Quote>(spot), v0, kappa, theta, sigma, rho);
 
        ext::shared_ptr<PricingEngine> mcEngine =
            MakeMCForwardEuropeanHestonEngine<PseudoRandom>(hestonProcess)
@@ -762,8 +740,7 @@ BOOST_AUTO_TEST_CASE(testHestonAnalyticalVsMCPrices) {
                .withSeed(mcSeed)
                .withControlVariate(true);
 
-       ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticEngine(
-           new AnalyticHestonForwardEuropeanEngine(hestonProcess));
+       ext::shared_ptr<AnalyticHestonForwardEuropeanEngine> analyticEngine = ext::make_shared<AnalyticHestonForwardEuropeanEngine>(hestonProcess);
 
       Real moneyness[] = { 0.8, 1.0, 1.2 };
 

--- a/test-suite/gjrgarchmodel.cpp
+++ b/test-suite/gjrgarchmodel.cpp
@@ -145,27 +145,24 @@ BOOST_AUTO_TEST_CASE(testEngines) {
             *(1.0+lambda*lambda)+gamma*lambda*std::exp(-lambda*lambda/2.0)
             /std::sqrt(2.0*M_PI);
         Real v0 = omega/(1.0-m1);
-        Handle<Quote> q(ext::shared_ptr<Quote>(new SimpleQuote(s0)));
-        ext::shared_ptr<GJRGARCHProcess> process(new GJRGARCHProcess(
-            riskFreeTS, dividendTS, q, v0, omega, alpha, beta, gamma, lambda, daysPerYear));
+        Handle<Quote> q(ext::make_shared<SimpleQuote>(s0));
+        ext::shared_ptr<GJRGARCHProcess> process = ext::make_shared<GJRGARCHProcess>(
+            riskFreeTS, dividendTS, q, v0, omega, alpha, beta, gamma, lambda, daysPerYear);
         ext::shared_ptr<PricingEngine> engine1 =
             MakeMCEuropeanGJRGARCHEngine<PseudoRandom>(process)
             .withStepsPerYear(20)
             .withAbsoluteTolerance(0.02)
             .withSeed(1234);
 
-        ext::shared_ptr<PricingEngine> engine2(
-            new AnalyticGJRGARCHEngine(ext::make_shared<GJRGARCHModel>(
-                                               process)));
+        ext::shared_ptr<PricingEngine> engine2 = ext::make_shared<AnalyticGJRGARCHEngine>(ext::make_shared<GJRGARCHModel>(
+                                               process));
         for (Size i = 0; i < 2; ++i) {
             for (Size j = 0; j < 6; ++j) {
                 Real x = strike[j];
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(
-                                     new PlainVanillaPayoff(Option::Call, x));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, x);
                 Date exDate = today + maturity[i];
-                ext::shared_ptr<Exercise> exercise(
-                                                new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                 VanillaOption option(payoff, exercise);
 
@@ -225,8 +222,7 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
         rates.push_back(r[i]);
     }
     Handle<YieldTermStructure> riskFreeTS(
-                       ext::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, rates, dayCounter)));
+                       ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
 
     Handle<YieldTermStructure> dividendTS(
                                    flatRate(settlementDate, 0.0, dayCounter));
@@ -246,7 +242,7 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
         0.3857,0.2860,0.2578,0.2399,0.2357,0.2327,0.2312,0.2351,
         0.3976,0.2860,0.2607,0.2356,0.2297,0.2268,0.2241,0.2320 };
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(4468.17)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(4468.17));
     Real strike[] = { 3400,3600,3800,4000,4200,4400,
                       4500,4600,4800,5000,5200,5400,5600 };
 
@@ -263,25 +259,22 @@ BOOST_AUTO_TEST_CASE(testDAXCalibration) {
             /std::sqrt(2.0*M_PI);
     const Real v0 = omega/(1.0-m1);
 
-    ext::shared_ptr<GJRGARCHProcess> process(new GJRGARCHProcess(
+    ext::shared_ptr<GJRGARCHProcess> process = ext::make_shared<GJRGARCHProcess>(
                              riskFreeTS, dividendTS, s0, v0,
-                             omega, alpha, beta, gamma, lambda, daysPerYear));
-    ext::shared_ptr<GJRGARCHModel> model(new GJRGARCHModel(process));
+                             omega, alpha, beta, gamma, lambda, daysPerYear);
+    ext::shared_ptr<GJRGARCHModel> model = ext::make_shared<GJRGARCHModel>(process);
 
-    ext::shared_ptr<PricingEngine> engine(
-        new AnalyticGJRGARCHEngine(ext::shared_ptr<GJRGARCHModel>(model)));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticGJRGARCHEngine>(ext::shared_ptr<GJRGARCHModel>(model));
 
     for (Size s = 3; s < 10; ++s) {
         for (Size m = 0; m < 3; ++m) {
-            Handle<Quote> vol(ext::shared_ptr<Quote>(
-                                                  new SimpleQuote(v[s*8+m])));
+            Handle<Quote> vol(ext::make_shared<SimpleQuote>(v[s*8+m]));
 
             Period maturity((int)((t[m]+3)/7.), Weeks); // round to weeks
-            ext::shared_ptr<BlackCalibrationHelper> option(
-                    new HestonModelHelper(maturity, calendar,
+            ext::shared_ptr<BlackCalibrationHelper> option = ext::make_shared<HestonModelHelper>(maturity, calendar,
                                           s0->value(), strike[s], vol,
                                           riskFreeTS, dividendTS,
-                                          BlackCalibrationHelper::ImpliedVolError));
+                                          BlackCalibrationHelper::ImpliedVolError);
             option->setPricingEngine(engine);
             options.push_back(option);
         }

--- a/test-suite/gsr.cpp
+++ b/test-suite/gsr.cpp
@@ -70,8 +70,7 @@ BOOST_AUTO_TEST_CASE(testGsrProcess) {
     Real reversion = 0.01;
     Real modelvol = 0.01;
 
-    Handle<YieldTermStructure> yts0(ext::shared_ptr<YieldTermStructure>(
-        new FlatForward(0, TARGET(), 0.00, Actual365Fixed())));
+    Handle<YieldTermStructure> yts0(ext::make_shared<FlatForward>(0, TARGET(), 0.00, Actual365Fixed()));
 
     std::vector<Date> stepDates0;
     std::vector<Real> vols0(1, modelvol);
@@ -86,17 +85,14 @@ BOOST_AUTO_TEST_CASE(testGsrProcess) {
     Real T = 10.0;
     do {
 
-        ext::shared_ptr<Gsr> model(
-            new Gsr(yts0, stepDates0, vols0, reversions0, T));
+        ext::shared_ptr<Gsr> model = ext::make_shared<Gsr>(yts0, stepDates0, vols0, reversions0, T);
         ext::shared_ptr<StochasticProcess1D> gsrProcess =
             model->stateProcess();
-        ext::shared_ptr<Gsr> model2(
-            new Gsr(yts0, stepDates1, vols1, reversions1, T));
+        ext::shared_ptr<Gsr> model2 = ext::make_shared<Gsr>(yts0, stepDates1, vols1, reversions1, T);
         ext::shared_ptr<StochasticProcess1D> gsrProcess2 =
             model2->stateProcess();
 
-        ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-            new HullWhiteForwardProcess(yts0, reversion, modelvol));
+        ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(yts0, reversion, modelvol);
         hwProcess->setForwardMeasureTime(T);
 
         Real w, t, xw, hwVal, gsrVal, gsr2Val;
@@ -188,13 +184,10 @@ BOOST_AUTO_TEST_CASE(testGsrModel) {
     std::vector<Real> vols1(stepDates1.size() + 1, modelvol);
     std::vector<Real> reversions1(stepDates1.size() + 1, reversion);
 
-    Handle<YieldTermStructure> yts(ext::shared_ptr<YieldTermStructure>(
-        new FlatForward(0, TARGET(), 0.03, Actual365Fixed())));
-    ext::shared_ptr<Gsr> model(
-        new Gsr(yts, stepDates, vols, reversions, 50.0));
-    ext::shared_ptr<Gsr> model2(
-        new Gsr(yts, stepDates1, vols1, reversions1, 50.0));
-    ext::shared_ptr<HullWhite> hw(new HullWhite(yts, reversion, modelvol));
+    Handle<YieldTermStructure> yts(ext::make_shared<FlatForward>(0, TARGET(), 0.03, Actual365Fixed()));
+    ext::shared_ptr<Gsr> model = ext::make_shared<Gsr>(yts, stepDates, vols, reversions, 50.0);
+    ext::shared_ptr<Gsr> model2 = ext::make_shared<Gsr>(yts, stepDates1, vols1, reversions1, 50.0);
+    ext::shared_ptr<HullWhite> hw = ext::make_shared<HullWhite>(yts, reversion, modelvol);
 
     // test zerobond prices against existing HullWhite model
     // technically we test two representations of the same constant reversion
@@ -240,7 +233,7 @@ BOOST_AUTO_TEST_CASE(testGsrModel) {
 
     Date expiry = TARGET().advance(refDate, 5 * Years);
     Period tenor = 10 * Years;
-    ext::shared_ptr<SwapIndex> swpIdx(new EuriborSwapIsdaFixA(tenor, yts));
+    ext::shared_ptr<SwapIndex> swpIdx = ext::make_shared<EuriborSwapIsdaFixA>(tenor, yts);
     Real forward = swpIdx->fixing(expiry);
 
     ext::shared_ptr<VanillaSwap> underlying = swpIdx->underlyingSwap(expiry);
@@ -253,24 +246,18 @@ BOOST_AUTO_TEST_CASE(testGsrModel) {
             .withFixedLegConvention(swpIdx->fixedLegConvention())
             .withFixedLegTerminationDateConvention(
                  swpIdx->fixedLegConvention());
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(expiry));
-    ext::shared_ptr<Swaption> stdswaption(
-        new Swaption(underlyingFixed, exercise));
-    ext::shared_ptr<NonstandardSwaption> nonstdswaption(
-        new NonstandardSwaption(*stdswaption));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(expiry);
+    ext::shared_ptr<Swaption> stdswaption = ext::make_shared<Swaption>(underlyingFixed, exercise);
+    ext::shared_ptr<NonstandardSwaption> nonstdswaption = ext::make_shared<NonstandardSwaption>(*stdswaption);
 
-    stdswaption->setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new JamshidianSwaptionEngine(hw, yts)));
+    stdswaption->setPricingEngine(ext::make_shared<JamshidianSwaptionEngine>(hw, yts));
     Real HwJamNpv = stdswaption->NPV();
 
-    nonstdswaption->setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new Gaussian1dNonstandardSwaptionEngine(model, 64, 7.0, true, false)));
-    stdswaption->setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new Gaussian1dSwaptionEngine(model, 64, 7.0, true, false)));
+    nonstdswaption->setPricingEngine(ext::make_shared<Gaussian1dNonstandardSwaptionEngine>(model, 64, 7.0, true, false));
+    stdswaption->setPricingEngine(ext::make_shared<Gaussian1dSwaptionEngine>(model, 64, 7.0, true, false));
     Real GsrNonStdNpv = nonstdswaption->NPV();
     Real GsrStdNpv = stdswaption->NPV();
-    stdswaption->setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new Gaussian1dJamshidianSwaptionEngine(model)));
+    stdswaption->setPricingEngine(ext::make_shared<Gaussian1dJamshidianSwaptionEngine>(model));
     Real GsrJamNpv = stdswaption->NPV();
 
     if (fabs(HwJamNpv - GsrNonStdNpv) > 0.00005)
@@ -305,10 +292,9 @@ BOOST_AUTO_TEST_CASE(testGsrProcessWithPathGenerator) {
 
     // Create GsrProcess with temporary Array objects
     // This simulates what happens in SWIG bindings when Python lists are converted
-    ext::shared_ptr<GsrProcess> process(
-        new GsrProcess(Array(1, 1.0),           // times (temporary)
+    ext::shared_ptr<GsrProcess> process = ext::make_shared<GsrProcess>(Array(1, 1.0),           // times (temporary)
                        Array(2, 0.005),          // vols (temporary)
-                       Array(1, 0.03)));         // reversions (temporary)
+                       Array(1, 0.03));         // reversions (temporary)
 
     // Create path generator
     typedef PseudoRandom::rsg_type rsg_type;

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -1189,8 +1189,7 @@ BOOST_AUTO_TEST_CASE(testAnalyticPiecewiseTimeDependent) {
     
     const Real expected = option.NPV();
 
-    option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-         new AnalyticPTDHestonEngine(model, 192)));
+    option.setPricingEngine(ext::make_shared<AnalyticPTDHestonEngine>(model, 192));
 
     const Real calculatedGatheral = option.NPV();
     if (std::fabs(calculatedGatheral-expected) > 1e-7) {
@@ -1199,11 +1198,10 @@ BOOST_AUTO_TEST_CASE(testAnalyticPiecewiseTimeDependent) {
                    << "\n    expected:   " << expected);
     }
 
-    option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-         new AnalyticPTDHestonEngine(
+    option.setPricingEngine(ext::make_shared<AnalyticPTDHestonEngine>(
              model,
              AnalyticPTDHestonEngine::AndersenPiterbarg,
-             AnalyticPTDHestonEngine::Integration::gaussLobatto(1e-12,  Null<Real>(), 100000))));
+             AnalyticPTDHestonEngine::Integration::gaussLobatto(1e-12,  Null<Real>(), 100000)));
     const Real calculatedAndersenPiterbarg = option.NPV();
 
     if (std::fabs(calculatedAndersenPiterbarg-expected) > 1e-9) {
@@ -1329,32 +1327,26 @@ BOOST_AUTO_TEST_CASE(testAlanLewisReferencePrices) {
     const ext::shared_ptr<PricingEngine> exponentialFittingEngine(
         ext::make_shared<ExponentialFittingHestonEngine>(model));
 
-    const ext::shared_ptr<PricingEngine> andersenPiterbargEngine(
-        new AnalyticHestonEngine(
+    const ext::shared_ptr<PricingEngine> andersenPiterbargEngine = ext::make_shared<AnalyticHestonEngine>(
             model,
             AnalyticHestonEngine::AndersenPiterbarg,
             AnalyticHestonEngine::Integration::gaussLobatto(
                 Null<Real>(), 1e-14, 1000000),
-            QL_EPSILON)
-    );
+            QL_EPSILON);
 
-    const ext::shared_ptr<PricingEngine> angledContourEngine(
-        new AnalyticHestonEngine(
+    const ext::shared_ptr<PricingEngine> angledContourEngine = ext::make_shared<AnalyticHestonEngine>(
             model,
             AnalyticHestonEngine::AngledContour,
             AnalyticHestonEngine::Integration::gaussLobatto(
                 Null<Real>(), 1e-14, 1000000),
-            QL_EPSILON)
-    );
+            QL_EPSILON);
 
-    const ext::shared_ptr<PricingEngine> optimalCvEngine(
-        new AnalyticHestonEngine(
+    const ext::shared_ptr<PricingEngine> optimalCvEngine = ext::make_shared<AnalyticHestonEngine>(
             model,
             AnalyticHestonEngine::OptimalCV,
             AnalyticHestonEngine::Integration::gaussLobatto(
                 Null<Real>(), 1e-14, 1000000),
-            QL_EPSILON)
-    );
+            QL_EPSILON);
 
     const Real strikes[] = { 80, 90, 100, 110, 120 };
     const Option::Type types[] = { Option::Put, Option::Call };
@@ -1953,25 +1945,20 @@ BOOST_AUTO_TEST_CASE(testCosHestonEngineTruncation) {
     Rate riskFreeRate = 0;
     DayCounter dayCounter = Actual365Fixed();
 
-    ext::shared_ptr<Exercise> europeanExercise(new EuropeanExercise(maturity));
-    Handle<Quote> underlyingH(ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+    ext::shared_ptr<Exercise> europeanExercise = ext::make_shared<EuropeanExercise>(maturity);
+    Handle<Quote> underlyingH(ext::make_shared<SimpleQuote>(underlying));
     Handle<YieldTermStructure> riskFreeTS(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(todaysDate, riskFreeRate, dayCounter)));
+        ext::make_shared<FlatForward>(todaysDate, riskFreeRate, dayCounter));
     Handle<YieldTermStructure> dividendTS(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(todaysDate, dividendYield, dayCounter)));
+        ext::make_shared<FlatForward>(todaysDate, dividendYield, dayCounter));
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
     VanillaOption europeanOption(payoff, europeanExercise);
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(riskFreeTS, dividendTS, underlyingH, .007, .8, .007, .1, -.2));
-    ext::shared_ptr<HestonModel> hestonModel(
-            new HestonModel(hestonProcess));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(riskFreeTS, dividendTS, underlyingH, .007, .8, .007, .1, -.2);
+    ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
     
-    europeanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new COSHestonEngine(hestonModel)));
+    europeanOption.setPricingEngine(ext::make_shared<COSHestonEngine>(hestonModel));
                 
     const Real tol = 1e-7;
     const Real error = std::fabs(europeanOption.NPV() - 0.0);
@@ -1995,7 +1982,7 @@ BOOST_AUTO_TEST_CASE(testCharacteristicFct) {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.35, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.17, dayCounter));
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   = -0.85;
@@ -2043,7 +2030,7 @@ BOOST_AUTO_TEST_CASE(testAndersenPiterbargPricing) {
     const Handle<YieldTermStructure> riskFreeTS(flatRate(0.10, dayCounter));
     const Handle<YieldTermStructure> dividendTS(flatRate(0.06, dayCounter));
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.1;
     const Real rho   =  0.80;
@@ -2179,7 +2166,7 @@ BOOST_AUTO_TEST_CASE(testAndersenPiterbargControlVariateIntegrand) {
     const Time maturity = dayCounter.yearFraction(settlementDate, maturityDate);
     const DiscountFactor df = rTS->discount(maturity);
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
     const Real fwd = s0->value()*qTS->discount(maturity)/df;
 
     const Real strike = 150;
@@ -2302,7 +2289,7 @@ BOOST_AUTO_TEST_CASE(testAndersenPiterbargConvergence) {
     const Handle<YieldTermStructure> rTS(flatRate(0.01, dayCounter));
     const Handle<YieldTermStructure> qTS(flatRate(0.02, dayCounter));
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.04;
     const Real rho   = -0.5;
@@ -2354,7 +2341,7 @@ BOOST_AUTO_TEST_CASE(testPiecewiseTimeDependentChFvsHestonChF) {
     const Handle<YieldTermStructure> rTS(flatRate(0.01, dayCounter));
     const Handle<YieldTermStructure> qTS(flatRate(0.02, dayCounter));
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Real v0    =  0.04;
     const Real rho   = -0.5;

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -2127,7 +2127,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloCalibration) {
 //    const ext::shared_ptr<LocalVolTermStructure> leverageFctMC =
 //        HestonSLVMCModel(
 //            localVol, hestonModel,
-//            ext::make_shared<MTBrownianGeneratorFactory>(1234UL),
+//            ext::shared_ptr<BrownianGeneratorFactory>(new MTBrownianGeneratorFactory(1234UL)),
 //            maturityDate, 182, xGrid, nSim)
 //            .leverageFunction();
 //

--- a/test-suite/hestonslvmodel.cpp
+++ b/test-suite/hestonslvmodel.cpp
@@ -2004,10 +2004,13 @@ BOOST_AUTO_TEST_CASE(testMonteCarloCalibration) {
         const ext::shared_ptr<LocalVolTermStructure> leverageFct =
             HestonSLVMCModel(
                 Handle<LocalVolTermStructure>(localVol), Handle<HestonModel>(hestonModel),
-                sobol ? ext::shared_ptr<BrownianGeneratorFactory>(new SobolBrownianGeneratorFactory(
-                            SobolBrownianGenerator::Diagonal, 1234UL, SobolRsg::JoeKuoD7)) :
-                        ext::shared_ptr<BrownianGeneratorFactory>(
-                            new MTBrownianGeneratorFactory(1234UL)),
+                sobol
+                    ? ext::shared_ptr<BrownianGeneratorFactory>(
+                          ext::make_shared<SobolBrownianGeneratorFactory>(
+                              SobolBrownianGenerator::Diagonal, 1234UL,
+                              SobolRsg::JoeKuoD7))
+                    : ext::shared_ptr<BrownianGeneratorFactory>(
+                          ext::make_shared<MTBrownianGeneratorFactory>(1234UL)),
                 maturityDate, 91, xGrid, nSim)
                 .leverageFunction();
 
@@ -2124,7 +2127,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloCalibration) {
 //    const ext::shared_ptr<LocalVolTermStructure> leverageFctMC =
 //        HestonSLVMCModel(
 //            localVol, hestonModel,
-//            ext::shared_ptr<BrownianGeneratorFactory>(new MTBrownianGeneratorFactory(1234UL)),
+//            ext::make_shared<MTBrownianGeneratorFactory>(1234UL),
 //            maturityDate, 182, xGrid, nSim)
 //            .leverageFunction();
 //

--- a/test-suite/himalayaoption.cpp
+++ b/test-suite/himalayaoption.cpp
@@ -50,30 +50,26 @@ BOOST_AUTO_TEST_CASE(testCached) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today, 0.05, dc));
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > processes(4);
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(100.0))),
+    processes[0] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(100.0)),
               Handle<YieldTermStructure>(flatRate(today, 0.01, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc))));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(110.0))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc)));
+    processes[1] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(110.0)),
               Handle<YieldTermStructure>(flatRate(today, 0.05, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc))));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(90.0))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc)));
+    processes[2] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(90.0)),
               Handle<YieldTermStructure>(flatRate(today, 0.04, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc))));
-    processes[3] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(105.0))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc)));
+    processes[3] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(105.0)),
               Handle<YieldTermStructure>(flatRate(today, 0.03, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc))));
+              Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc)));
 
     Matrix correlation(4,4);
     correlation[0][0] = 1.00;
@@ -98,8 +94,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
     BigNatural seed = 86421;
     Size fixedSamples = 1023;
 
-    ext::shared_ptr<StochasticProcessArray> process(
-                          new StochasticProcessArray(processes, correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(processes, correlation);
 
     option.setPricingEngine(MakeMCHimalayaEngine<PseudoRandom>(process)
                             .withSamples(fixedSamples)

--- a/test-suite/hybridhestonhullwhiteprocess.cpp
+++ b/test-suite/hybridhestonhullwhiteprocess.cpp
@@ -71,25 +71,22 @@ BOOST_AUTO_TEST_CASE(testBsmHullWhiteEngine) {
     Settings::instance().evaluationDate() = today;
 
     const Handle<Quote> spot(
-                         ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+                         ext::make_shared<SimpleQuote>(100.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     const Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0525));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0525);
     const Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     const Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<HullWhite> hullWhiteModel(
-        new HullWhite(Handle<YieldTermStructure>(rTS), 0.00883, 0.00526));
+    ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(Handle<YieldTermStructure>(rTS), 0.00883, 0.00526);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                      new BlackScholesMertonProcess(spot, qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS, volTS);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
     Real fwd = spot->value()*qTS->discount(maturity)/rTS->discount(maturity);
-    ext::shared_ptr<StrikedTypePayoff> payoff(new
-                                      PlainVanillaPayoff(Option::Call, fwd));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, fwd);
 
     EuropeanOption option(payoff, exercise);
 
@@ -99,9 +96,8 @@ BOOST_AUTO_TEST_CASE(testBsmHullWhiteEngine) {
                                        0.256402830, 0.268236596, 0.290461343 };
 
     for (Size i=0; i < std::size(corr); ++i) {
-        ext::shared_ptr<PricingEngine> bsmhwEngine(
-                         new AnalyticBSMHullWhiteEngine(corr[i], stochProcess,
-                                                        hullWhiteModel));
+        ext::shared_ptr<PricingEngine> bsmhwEngine = ext::make_shared<AnalyticBSMHullWhiteEngine>(corr[i], stochProcess,
+                                                        hullWhiteModel);
 
         option.setPricingEngine(bsmhwEngine);
         const Real npv = option.NPV();
@@ -109,10 +105,8 @@ BOOST_AUTO_TEST_CASE(testBsmHullWhiteEngine) {
         const Handle<BlackVolTermStructure> compVolTS(
                                         flatVol(today, expectedVol[i], dc));
 
-        ext::shared_ptr<BlackScholesMertonProcess> bsProcess(
-                    new BlackScholesMertonProcess(spot, qTS, rTS, compVolTS));
-        ext::shared_ptr<PricingEngine> bsEngine(
-                                       new AnalyticEuropeanEngine(bsProcess));
+        ext::shared_ptr<BlackScholesMertonProcess> bsProcess = ext::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS, compVolTS);
+        ext::shared_ptr<PricingEngine> bsEngine = ext::make_shared<AnalyticEuropeanEngine>(bsProcess);
 
         EuropeanOption comp(payoff, exercise);
         comp.setPricingEngine(bsEngine);
@@ -164,7 +158,7 @@ BOOST_AUTO_TEST_CASE(testCompareBsmHWandHestonHW) {
     Settings::instance().evaluationDate() = today;
 
     const Handle<Quote> spot(
-                         ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+                         ext::make_shared<SimpleQuote>(100.0));
     std::vector<Date> dates;
     std::vector<Rate> rates, divRates;
 
@@ -174,34 +168,28 @@ BOOST_AUTO_TEST_CASE(testCompareBsmHWandHestonHW) {
         divRates.push_back(0.02 + 0.0001*std::exp(std::sin(i/5.0)));
     }
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
     const Handle<YieldTermStructure> rTS(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-       ext::shared_ptr<YieldTermStructure>(
-                                          new ZeroCurve(dates, divRates, dc)));
+       ext::make_shared<ZeroCurve>(dates, divRates, dc));
 
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     const Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-                      new BlackScholesMertonProcess(spot, qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(spot, qTS, rTS, volTS);
 
-    ext::shared_ptr<HestonProcess> hestonProcess(
-                   new HestonProcess(rTS, qTS, spot,
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, spot,
                                      vol->value()*vol->value(), 1.0,
-                                     vol->value()*vol->value(), 1e-4, 0.0));
+                                     vol->value()*vol->value(), 1e-4, 0.0);
 
-    ext::shared_ptr<HestonModel> hestonModel(new HestonModel(hestonProcess));
+    ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
-    ext::shared_ptr<HullWhite> hullWhiteModel(
-        new HullWhite(Handle<YieldTermStructure>(rTS), 0.01, 0.01));
+    ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(Handle<YieldTermStructure>(rTS), 0.01, 0.01);
 
-    ext::shared_ptr<PricingEngine> bsmhwEngine(
-             new AnalyticBSMHullWhiteEngine(0.0, bsmProcess, hullWhiteModel));
+    ext::shared_ptr<PricingEngine> bsmhwEngine = ext::make_shared<AnalyticBSMHullWhiteEngine>(0.0, bsmProcess, hullWhiteModel);
 
-    ext::shared_ptr<PricingEngine> hestonHwEngine(
-          new AnalyticHestonHullWhiteEngine(hestonModel, hullWhiteModel, 128));
+    ext::shared_ptr<PricingEngine> hestonHwEngine = ext::make_shared<AnalyticHestonHullWhiteEngine>(hestonModel, hullWhiteModel, 128);
 
 
     const Real tol = 1e-5;
@@ -215,13 +203,12 @@ BOOST_AUTO_TEST_CASE(testCompareBsmHWandHestonHW) {
             for (unsigned long l : maturity) {
                 const Date maturityDate = today + Period(l, Years);
 
-                ext::shared_ptr<Exercise> exercise(
-                                         new EuropeanExercise(maturityDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
 
                 Real fwd =
                     j * spot->value() * qTS->discount(maturityDate) / rTS->discount(maturityDate);
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, fwd));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, fwd);
 
                 EuropeanOption option(payoff, exercise);
 
@@ -273,21 +260,18 @@ BOOST_AUTO_TEST_CASE(testZeroBondPricing) {
     rates.push_back(0.04);
     times.push_back(dc.yearFraction(today, dates.back()));
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
 
     const Handle<YieldTermStructure> ts(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> ds(flatRate(today, 0.0, dc));
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(ts, ds, s0, 0.02, 1.0, 0.2, 0.5, -0.8));
-    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-                   new HullWhiteForwardProcess(ts, 0.05, 0.05));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(ts, ds, s0, 0.02, 1.0, 0.2, 0.5, -0.8);
+    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(ts, 0.05, 0.05);
     hwProcess->setForwardMeasureTime(dc.yearFraction(today, maturity));
-    const ext::shared_ptr<HullWhite> hwModel(new HullWhite(ts, 0.05, 0.05));
+    const ext::shared_ptr<HullWhite> hwModel = ext::make_shared<HullWhite>(ts, 0.05, 0.05);
 
-    const ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-        new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, -0.4));
+    const ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(hestonProcess, hwProcess, -0.4);
 
     TimeGrid grid(times.begin(), times.end()-1);
 
@@ -381,21 +365,17 @@ BOOST_AUTO_TEST_CASE(testMcVanillaPricing) {
 
     const Date maturity = today + Period(20, Years);
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
     const Handle<YieldTermStructure> rTS(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-       ext::shared_ptr<YieldTermStructure>(
-                                          new ZeroCurve(dates, divRates, dc)));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.25));
+       ext::make_shared<ZeroCurve>(dates, divRates, dc));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.25);
     const Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-              new BlackScholesMertonProcess(s0, qTS, rTS, volTS));
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-              new HestonProcess(rTS, qTS, s0, 0.0625, 0.5, 0.0625, 1e-5, 0.3));
-    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-              new HullWhiteForwardProcess(rTS, 0.01, 0.01));
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(s0, qTS, rTS, volTS);
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.0625, 0.5, 0.0625, 1e-5, 0.3);
+    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.01, 0.01);
     hwProcess->setForwardMeasureTime(dc.yearFraction(today, maturity));
 
     const Real tol = 0.05;
@@ -404,12 +384,10 @@ BOOST_AUTO_TEST_CASE(testMcVanillaPricing) {
 
     for (Real i : corr) {
         for (Real j : strike) {
-            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-                new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, i));
+            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(hestonProcess, hwProcess, i);
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Put, j));
-            ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(maturity));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, j);
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
             VanillaOption optionHestonHW(payoff, exercise);
             ext::shared_ptr<PricingEngine> engine =
@@ -422,13 +400,11 @@ BOOST_AUTO_TEST_CASE(testMcVanillaPricing) {
 
             optionHestonHW.setPricingEngine(engine);
 
-            const ext::shared_ptr<HullWhite> hwModel(
-                        new HullWhite(Handle<YieldTermStructure>(rTS),
-                                      hwProcess->a(), hwProcess->sigma()));
+            const ext::shared_ptr<HullWhite> hwModel = ext::make_shared<HullWhite>(Handle<YieldTermStructure>(rTS),
+                                      hwProcess->a(), hwProcess->sigma());
 
             VanillaOption optionBsmHW(payoff, exercise);
-            optionBsmHW.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new AnalyticBSMHullWhiteEngine(i, bsmProcess, hwModel)));
+            optionBsmHW.setPricingEngine(ext::make_shared<AnalyticBSMHullWhiteEngine>(i, bsmProcess, hwModel));
 
             const Real calculated = optionHestonHW.NPV();
             const Real error      = optionHestonHW.errorEstimate();
@@ -467,17 +443,14 @@ BOOST_AUTO_TEST_CASE(testMcPureHestonPricing) {
 
     const Date maturity = today + Period(2, Years);
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
     const Handle<YieldTermStructure> rTS(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-       ext::shared_ptr<YieldTermStructure>(
-                                          new ZeroCurve(dates, divRates, dc)));
+       ext::make_shared<ZeroCurve>(dates, divRates, dc));
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-              new HestonProcess(rTS, qTS, s0, 0.08, 1.5, 0.0625, 0.5, -0.8));
-    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-              new HullWhiteForwardProcess(rTS, 0.1, 1e-8));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.08, 1.5, 0.0625, 0.5, -0.8);
+    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.1, 1e-8);
     hwProcess->setForwardMeasureTime(dc.yearFraction(
                                         today, maturity+Period(1, Years)));
 
@@ -487,21 +460,18 @@ BOOST_AUTO_TEST_CASE(testMcPureHestonPricing) {
 
     for (Real i : corr) {
         for (Real j : strike) {
-            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-                new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, i,
-                                                 HybridHestonHullWhiteProcess::Euler));
+            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(hestonProcess, hwProcess, i,
+                                                 HybridHestonHullWhiteProcess::Euler);
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Put, j));
-            ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(maturity));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, j);
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
             VanillaOption optionHestonHW(payoff, exercise);
             VanillaOption optionPureHeston(payoff, exercise);
             optionPureHeston.setPricingEngine(
-                ext::shared_ptr<PricingEngine>(
-                    new AnalyticHestonEngine(
+                ext::make_shared<AnalyticHestonEngine>(
                           ext::make_shared<HestonModel>(
-                                           hestonProcess))));
+                                           hestonProcess)));
 
             Real expected   = optionPureHeston.NPV();
 
@@ -548,23 +518,19 @@ BOOST_AUTO_TEST_CASE(testAnalyticHestonHullWhitePricing) {
     }
 
     const Date maturity = today + Period(5, Years);
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
     const Handle<YieldTermStructure> rTS(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-       ext::shared_ptr<YieldTermStructure>(
-                                          new ZeroCurve(dates, divRates, dc)));
+       ext::make_shared<ZeroCurve>(dates, divRates, dc));
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, s0, 0.08, 1.5, 0.0625, 0.5, -0.8));
-    const ext::shared_ptr<HestonModel> hestonModel(
-                                            new HestonModel(hestonProcess));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, 0.08, 1.5, 0.0625, 0.5, -0.8);
+    const ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
-    const ext::shared_ptr<HullWhiteForwardProcess> hwFwdProcess(
-              new HullWhiteForwardProcess(rTS, 0.01, 0.01));
+    const ext::shared_ptr<HullWhiteForwardProcess> hwFwdProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.01, 0.01);
     hwFwdProcess->setForwardMeasureTime(dc.yearFraction(today, maturity));
-    const ext::shared_ptr<HullWhite> hullWhiteModel(new HullWhite(
-                               rTS, hwFwdProcess->a(), hwFwdProcess->sigma()));
+    const ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(
+                               rTS, hwFwdProcess->a(), hwFwdProcess->sigma());
 
     const Real tol = 0.002;
     const Real strike[] = { 80, 120 };
@@ -572,14 +538,12 @@ BOOST_AUTO_TEST_CASE(testAnalyticHestonHullWhitePricing) {
 
     for (auto type : types) {
         for (Real j : strike) {
-            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-                new HybridHestonHullWhiteProcess(
+            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(
                         hestonProcess, hwFwdProcess, 0.0,
-                        HybridHestonHullWhiteProcess::Euler));
+                        HybridHestonHullWhiteProcess::Euler);
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, j));
-            ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(maturity));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, j);
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
             VanillaOption optionHestonHW(payoff, exercise);
             optionHestonHW.setPricingEngine(
@@ -592,9 +556,8 @@ BOOST_AUTO_TEST_CASE(testAnalyticHestonHullWhitePricing) {
 
             VanillaOption optionPureHeston(payoff, exercise);
             optionPureHeston.setPricingEngine(
-                ext::shared_ptr<PricingEngine>(
-                    new AnalyticHestonHullWhiteEngine(hestonModel,
-                                                      hullWhiteModel, 128)));
+                ext::make_shared<AnalyticHestonHullWhiteEngine>(hestonModel,
+                                                      hullWhiteModel, 128));
 
             Real calculated = optionHestonHW.NPV();
             Real error      = optionHestonHW.errorEstimate();
@@ -627,22 +590,19 @@ BOOST_AUTO_TEST_CASE(testCallableEquityPricing) {
 
     Settings::instance().evaluationDate() = today;
 
-    Handle<Quote> spot(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.04));
+    Handle<Quote> spot(ext::make_shared<SimpleQuote>(100.0));
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.04);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.04));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.04);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, spot, 0.0625, 1.0,
-                              0.24*0.24, 1e-4, 0.0));
-    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-            new HullWhiteForwardProcess(rTS, 0.00883, 0.00526));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, spot, 0.0625, 1.0,
+                              0.24*0.24, 1e-4, 0.0);
+    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.00883, 0.00526);
     hwProcess->setForwardMeasureTime(
                       dc.yearFraction(today, today+Period(maturity+1, Years)));
 
-    const ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-        new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, -0.4));
+    const ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(hestonProcess, hwProcess, -0.4);
 
     Schedule schedule(today, today + Period(maturity, Years),
                       Period(1, Years), TARGET(),
@@ -745,23 +705,19 @@ BOOST_AUTO_TEST_CASE(testDiscretizationError) {
     const Date maturity = today + Period(10, Years);
     const Volatility v = 0.25;
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100)));
-    const ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(v));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100));
+    const ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(v);
     const Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
     const Handle<YieldTermStructure> rTS(
-       ext::shared_ptr<YieldTermStructure>(new ZeroCurve(dates, rates, dc)));
+       ext::make_shared<ZeroCurve>(dates, rates, dc));
     const Handle<YieldTermStructure> qTS(
-       ext::shared_ptr<YieldTermStructure>(
-                                          new ZeroCurve(dates, divRates, dc)));
+       ext::make_shared<ZeroCurve>(dates, divRates, dc));
 
-    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-                          new BlackScholesMertonProcess(s0, qTS, rTS, volTS));
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(s0, qTS, rTS, volTS);
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-           new HestonProcess(rTS, qTS, s0, v*v, 1, v*v, 1e-6, -0.4));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, v*v, 1, v*v, 1e-6, -0.4);
 
-    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess(
-              new HullWhiteForwardProcess(rTS, 0.01, 0.01));
+    const ext::shared_ptr<HullWhiteForwardProcess> hwProcess = ext::make_shared<HullWhiteForwardProcess>(rTS, 0.01, 0.01);
     hwProcess->setForwardMeasureTime(20.1472222222222222);
 
     const Real tol = 0.05;
@@ -770,21 +726,18 @@ BOOST_AUTO_TEST_CASE(testDiscretizationError) {
 
     for (Real i : corr) {
         for (Real j : strike) {
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Put, j));
-            ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(maturity));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, j);
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
             VanillaOption optionBsmHW(payoff, exercise);
-            const ext::shared_ptr<HullWhite> hwModel(new HullWhite(
-                               rTS, hwProcess->a(), hwProcess->sigma()));
-            optionBsmHW.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new AnalyticBSMHullWhiteEngine(i, bsmProcess, hwModel)));
+            const ext::shared_ptr<HullWhite> hwModel = ext::make_shared<HullWhite>(
+                               rTS, hwProcess->a(), hwProcess->sigma());
+            optionBsmHW.setPricingEngine(ext::make_shared<AnalyticBSMHullWhiteEngine>(i, bsmProcess, hwModel));
 
             Real expected = optionBsmHW.NPV();
 
             VanillaOption optionHestonHW(payoff, exercise);
-            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess(
-                new HybridHestonHullWhiteProcess(hestonProcess, hwProcess, i));
+            ext::shared_ptr<HybridHestonHullWhiteProcess> jointProcess = ext::make_shared<HybridHestonHullWhiteProcess>(hestonProcess, hwProcess, i);
             optionHestonHW.setPricingEngine(
                     MakeMCHestonHullWhiteEngine<PseudoRandom>(jointProcess)
                     .withSteps(1)
@@ -814,7 +767,7 @@ BOOST_AUTO_TEST_CASE(testFdmHestonHullWhiteEngine) {
     const Date exerciseDate = Date(28, March, 2012);
     DayCounter dc = Actual365Fixed();
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Handle<YieldTermStructure> rTS(flatRate(0.05, dc));
     const Handle<YieldTermStructure> qTS(flatRate(0.02, dc));
@@ -823,35 +776,30 @@ BOOST_AUTO_TEST_CASE(testFdmHestonHullWhiteEngine) {
     const Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
     const Real v0 = vol*vol;
-    ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, v0, 1.0, v0, 0.000001, 0.0));
+    ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, v0, 1.0, v0, 0.000001, 0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                      new BlackScholesMertonProcess(s0, qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(s0, qTS, rTS, volTS);
 
-    ext::shared_ptr<HullWhiteProcess> hwProcess(
-                              new HullWhiteProcess(rTS, 0.00883, 0.01));
-    ext::shared_ptr<HullWhite> hwModel(
-                    new HullWhite(rTS, hwProcess->a(), hwProcess->sigma()));
+    ext::shared_ptr<HullWhiteProcess> hwProcess = ext::make_shared<HullWhiteProcess>(rTS, 0.00883, 0.01);
+    ext::shared_ptr<HullWhite> hwModel = ext::make_shared<HullWhite>(rTS, hwProcess->a(), hwProcess->sigma());
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exerciseDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
     const Real corr[] = {-0.85, 0.5 };
     const Real strike[] = { 75, 120, 160 };
 
     for (Real i : corr) {
         for (Real j : strike) {
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(Option::Call, j));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, j);
             VanillaOption option(payoff, exercise);
 
             option.setPricingEngine(
-                ext::shared_ptr<PricingEngine>(new FdHestonHullWhiteVanillaEngine(
-                    ext::make_shared<HestonModel>(hestonProcess), hwProcess, i, 50, 200, 10, 15)));
+                ext::make_shared<FdHestonHullWhiteVanillaEngine>(
+                    ext::make_shared<HestonModel>(hestonProcess), hwProcess, i, 50, 200, 10, 15));
             const Real calculated = option.NPV();
             const Real calculatedDelta = option.delta();
             const Real calculatedGamma = option.gamma();
 
-            option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new AnalyticBSMHullWhiteEngine(i, stochProcess, hwModel)));
+            option.setPricingEngine(ext::make_shared<AnalyticBSMHullWhiteEngine>(i, stochProcess, hwModel));
             const Real expected = option.NPV();
             const Real expectedDelta = option.delta();
             const Real expectedGamma = option.gamma();
@@ -960,9 +908,8 @@ ext::shared_ptr<VanillaOption> makeVanillaOption(const VanillaOptionData& params
 
     Date maturity = Date(Settings::instance().evaluationDate())
         + Period(Size(params.maturity*365), Days);
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                    new PlainVanillaPayoff(params.optionType, params.strike));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(params.optionType, params.strike);
 
     return ext::make_shared<VanillaOption>(
                                           payoff, exercise);
@@ -987,26 +934,22 @@ BOOST_AUTO_TEST_CASE(testBsmHullWhitePricing) {
     bool controlVariate[] = { true, false };
 
     ext::shared_ptr<HestonProcess> hp(makeHestonProcess(hestonModelData));
-    ext::shared_ptr<HestonModel> hestonModel(new HestonModel(hp));
+    ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hp);
 
-    ext::shared_ptr<HullWhiteProcess> hwProcess(
-        new HullWhiteProcess(hp->riskFreeRate(),
-                             hwModelData.a, hwModelData.sigma));
-    ext::shared_ptr<HullWhite> hullWhiteModel(
-        new HullWhite(hp->riskFreeRate(),
-                      hwProcess->a(), hwProcess->sigma()));
+    ext::shared_ptr<HullWhiteProcess> hwProcess = ext::make_shared<HullWhiteProcess>(hp->riskFreeRate(),
+                             hwModelData.a, hwModelData.sigma);
+    ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(hp->riskFreeRate(),
+                      hwProcess->a(), hwProcess->sigma());
 
 
-    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(
+    ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
             hp->s0(), hp->dividendYield(), hp->riskFreeRate(),
             Handle<BlackVolTermStructure>(
                 flatVol(today, std::sqrt(hestonModelData.theta),
-                        hp->riskFreeRate()->dayCounter()))));
+                        hp->riskFreeRate()->dayCounter())));
 
-    ext::shared_ptr<PricingEngine> bsmhwEngine(
-                     new AnalyticBSMHullWhiteEngine(equityIrCorr, bsmProcess,
-                                                    hullWhiteModel));
+    ext::shared_ptr<PricingEngine> bsmhwEngine = ext::make_shared<AnalyticBSMHullWhiteEngine>(equityIrCorr, bsmProcess,
+                                                    hullWhiteModel);
 
     Real tolWithCV[]    = { 2e-4, 2e-4, 2e-4, 2e-4, 0.01 };
     Real tolWithOutCV[] = { 5e-3, 5e-3, 5e-3, 5e-3, 0.02 };
@@ -1016,9 +959,8 @@ BOOST_AUTO_TEST_CASE(testBsmHullWhitePricing) {
             for (unsigned long u : listOfTimeStepsPerYear) {
                 Size tSteps = Size(maturity * u);
 
-                ext::shared_ptr<FdHestonHullWhiteVanillaEngine> fdEngine(
-                    new FdHestonHullWhiteVanillaEngine(hestonModel, hwProcess, equityIrCorr, tSteps,
-                                                       400, 2, 10, 0, i, scheme.schemeDesc));
+                ext::shared_ptr<FdHestonHullWhiteVanillaEngine> fdEngine = ext::make_shared<FdHestonHullWhiteVanillaEngine>(hestonModel, hwProcess, equityIrCorr, tSteps,
+                                                       400, 2, 10, 0, i, scheme.schemeDesc);
                 fdEngine->enableMultipleStrikesCaching(strikes);
 
                 Real avgPriceDiff = 0.0;
@@ -1069,18 +1011,15 @@ BOOST_AUTO_TEST_CASE(testSpatialDiscretizatinError) {
             for (auto& j : hestonModels) {
                 Real avgPriceDiff = 0;
                 ext::shared_ptr<HestonProcess> hestonProcess(makeHestonProcess(j));
-                ext::shared_ptr<HestonModel> hestonModel(
-                                        new HestonModel(hestonProcess));
+                ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
-                ext::shared_ptr<PricingEngine> analyticEngine(
-                               new AnalyticHestonEngine(hestonModel, 172));
+                ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<AnalyticHestonEngine>(hestonModel, 172);
 
                 Size tSteps = Size(maturity * u);
 
-                ext::shared_ptr<FdHestonVanillaEngine> fdEngine(
-                    new FdHestonVanillaEngine(
+                ext::shared_ptr<FdHestonVanillaEngine> fdEngine = ext::make_shared<FdHestonVanillaEngine>(
                         hestonModel, tSteps, 200, 40, 0,
-                        schemes[i].schemeDesc));
+                        schemes[i].schemeDesc);
                 fdEngine->enableMultipleStrikesCaching(strikes);
 
                 for (Real& strike : strikes) {
@@ -1128,9 +1067,8 @@ class HestonHullWhiteCorrelationConstraint : public Constraint {
   public:
     explicit HestonHullWhiteCorrelationConstraint(
             Real equityShortRateCorr)
-    : Constraint(ext::shared_ptr<Constraint::Impl>(
-             new HestonHullWhiteCorrelationConstraint::Impl(
-                                                     equityShortRateCorr))) {}
+    : Constraint(ext::make_shared<HestonHullWhiteCorrelationConstraint::Impl>(
+                                                     equityShortRateCorr)) {}
 };
 
 
@@ -1155,13 +1093,11 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
 
     // assuming, that the Hull-White process is already calibrated
     // on a given set of pure interest rate calibration instruments.
-    ext::shared_ptr<HullWhiteProcess> hwProcess(
-                              new HullWhiteProcess(rTS, 0.00883, 0.00631));
-    ext::shared_ptr<HullWhite> hullWhiteModel(
-                    new HullWhite(rTS, hwProcess->a(), hwProcess->sigma()));
+    ext::shared_ptr<HullWhiteProcess> hwProcess = ext::make_shared<HullWhiteProcess>(rTS, 0.00883, 0.00631);
+    ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(rTS, hwProcess->a(), hwProcess->sigma());
 
     const Handle<YieldTermStructure> qTS(flatRate(0.02, dc));
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     // starting point of the pure Heston calibration
     const Real start_v0    = 0.2*0.2;
@@ -1170,15 +1106,11 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
     const Real start_sigma = 0.25;
     const Real start_rho   = -0.5;
 
-    const ext::shared_ptr<HestonProcess> hestonProcess(
-        new HestonProcess(rTS, qTS, s0, start_v0, start_kappa,
-                          start_theta, start_sigma, start_rho));
-    const ext::shared_ptr<HestonModel> analyticHestonModel
-                                            (new HestonModel(hestonProcess));
-    const ext::shared_ptr<PricingEngine> analyticHestonEngine(
-                         new AnalyticHestonEngine(analyticHestonModel, 164));
-    const ext::shared_ptr<HestonModel> fdmHestonModel
-                                            (new HestonModel(hestonProcess));
+    const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, start_v0, start_kappa,
+                          start_theta, start_sigma, start_rho);
+    const ext::shared_ptr<HestonModel> analyticHestonModel = ext::make_shared<HestonModel>(hestonProcess);
+    const ext::shared_ptr<PricingEngine> analyticHestonEngine = ext::make_shared<AnalyticHestonEngine>(analyticHestonModel, 164);
+    const ext::shared_ptr<HestonModel> fdmHestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
 
     const Real equityShortRateCorr = -0.5;
@@ -1202,28 +1134,26 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
 
     for (Size i=0; i < maturities.size(); ++i) {
         const Period maturity((int)std::lround(maturities[i]*12.0), Months);
-        ext::shared_ptr<Exercise> exercise(
-                                        new EuropeanExercise(today + maturity));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(today + maturity);
 
         for (Size j=0; j < strikes.size(); ++j) {
-            ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(
                 strikes[j] * rTS->discount(maturities[i]) >=
                         s0->value() * qTS->discount(maturities[i])
                     ? Option::Call
                     : Option::Put,
-                strikes[j]));
-            RelinkableHandle<Quote> v(ext::shared_ptr<Quote>(new SimpleQuote(vol[i*strikes.size()+j])));
+                strikes[j]);
+            RelinkableHandle<Quote> v(ext::make_shared<SimpleQuote>(vol[i*strikes.size()+j]));
 
-            ext::shared_ptr<BlackCalibrationHelper> helper(
-                new HestonModelHelper(maturity, calendar, s0,
+            ext::shared_ptr<BlackCalibrationHelper> helper = ext::make_shared<HestonModelHelper>(maturity, calendar, s0,
                                       strikes[j], v, rTS, qTS,
-                                      BlackCalibrationHelper::PriceError));
+                                      BlackCalibrationHelper::PriceError);
             options.push_back(helper);
             const Real marketValue = helper->marketValue();
 
             // Improve the quality of the starting point
             // for the full Heston-Hull-White calibration
-            ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+            ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
             ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess =
                 QuantLib::detail::ImpliedVolatilityHelper::clone(
                     ext::make_shared<GeneralizedBlackScholesProcess>(
@@ -1233,15 +1163,14 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
 
             VanillaOption dummyOption(payoff, exercise);
 
-            ext::shared_ptr<PricingEngine> bshwEngine(
-                new AnalyticBSMHullWhiteEngine(equityShortRateCorr,
-                                               bsProcess, hullWhiteModel));
+            ext::shared_ptr<PricingEngine> bshwEngine = ext::make_shared<AnalyticBSMHullWhiteEngine>(equityShortRateCorr,
+                                               bsProcess, hullWhiteModel);
 
             Volatility vt = QuantLib::detail::ImpliedVolatilityHelper::calculate(
                 dummyOption, *bshwEngine, *volQuote,
                 marketValue, 1e-8, 100, 0.0001, 10);
 
-            v.linkTo(ext::shared_ptr<Quote>(new SimpleQuote(vt)));
+            v.linkTo(ext::make_shared<SimpleQuote>(vt));
 
             helper->setPricingEngine(
                 ext::shared_ptr<PricingEngine>(analyticHestonEngine));
@@ -1259,10 +1188,9 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
 
     for (Size i=0; i < maturities.size(); ++i) {
         const Size tGrid = static_cast<Size>(std::max(5.0, maturities[i]*5.0));
-        ext::shared_ptr<FdHestonHullWhiteVanillaEngine> engine(
-            new FdHestonHullWhiteVanillaEngine(fdmHestonModel, hwProcess,
+        ext::shared_ptr<FdHestonHullWhiteVanillaEngine> engine = ext::make_shared<FdHestonHullWhiteVanillaEngine>(fdmHestonModel, hwProcess,
                                                equityShortRateCorr,
-                                               tGrid, 45, 11, 5, 0, true));
+                                               tGrid, 45, 11, 5, 0, true);
 
         engine->enableMultipleStrikesCaching(strikes);
 
@@ -1275,13 +1203,11 @@ BOOST_AUTO_TEST_CASE(testHestonHullWhiteCalibration) {
             // is used to calculate the prices for all strikes
             const Size js = (j + (strikes.size()-1)/2) % strikes.size();
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(
-                             new PlainVanillaPayoff(Option::Call, strikes[js]));
-            Handle<Quote> v(ext::shared_ptr<Quote>(new SimpleQuote(vol[i*strikes.size()+js])));
-            ext::shared_ptr<BlackCalibrationHelper> helper(
-                new HestonModelHelper(maturity, calendar, s0,
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strikes[js]);
+            Handle<Quote> v(ext::make_shared<SimpleQuote>(vol[i*strikes.size()+js]));
+            ext::shared_ptr<BlackCalibrationHelper> helper = ext::make_shared<HestonModelHelper>(maturity, calendar, s0,
                                       strikes[js], v, rTS, qTS,
-                                      BlackCalibrationHelper::PriceError));
+                                      BlackCalibrationHelper::PriceError);
             options.push_back(helper);
 
             helper->setPricingEngine(engine);
@@ -1347,10 +1273,9 @@ BOOST_AUTO_TEST_CASE(testH1HWPricingEngine) {
     const Date exerciseDate = Date(13, July, 2022);
     const DayCounter dc = Actual365Fixed();
 
-    const ext::shared_ptr<Exercise> exercise(
-        new EuropeanExercise(exerciseDate));
+    const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exerciseDate);
 
-    const Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
 
     const Real r       = 0.02;
     const Real q       = 0.00;
@@ -1367,13 +1292,10 @@ BOOST_AUTO_TEST_CASE(testH1HWPricingEngine) {
     const Handle<YieldTermStructure> qTS(flatRate(today, q, dc));
 
     const Handle<BlackVolTermStructure> flatVolTS(flatVol(today, 0.20, dc));
-    const ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-        new GeneralizedBlackScholesProcess(s0, qTS, rTS, flatVolTS));
+    const ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess = ext::make_shared<GeneralizedBlackScholesProcess>(s0, qTS, rTS, flatVolTS);
 
-    const ext::shared_ptr<HullWhiteProcess> hwProcess(
-        new HullWhiteProcess(rTS, kappa_r, sigma_r));
-    const ext::shared_ptr<HullWhite> hullWhiteModel(
-        new HullWhite(Handle<YieldTermStructure>(rTS), kappa_r, sigma_r));
+    const ext::shared_ptr<HullWhiteProcess> hwProcess = ext::make_shared<HullWhiteProcess>(rTS, kappa_r, sigma_r);
+    const ext::shared_ptr<HullWhite> hullWhiteModel = ext::make_shared<HullWhite>(Handle<YieldTermStructure>(rTS), kappa_r, sigma_r);
 
     const Real tol = 0.0001;
     const Real strikes[] = {40, 80, 100, 120, 180 };
@@ -1382,21 +1304,17 @@ BOOST_AUTO_TEST_CASE(testH1HWPricingEngine) {
             { 0.263626, 0.211625, 0.199907, 0.193502, 0.190025 } };
 
     for (Size j=0; j < std::size(sigma_v); ++j) {
-        const ext::shared_ptr<HestonProcess> hestonProcess(
-            new HestonProcess(rTS, qTS, s0, v0, kappa_v, theta,
-                              sigma_v[j], rho_sv));
-        const ext::shared_ptr<HestonModel> hestonModel(
-            new HestonModel(hestonProcess));
+        const ext::shared_ptr<HestonProcess> hestonProcess = ext::make_shared<HestonProcess>(rTS, qTS, s0, v0, kappa_v, theta,
+                              sigma_v[j], rho_sv);
+        const ext::shared_ptr<HestonModel> hestonModel = ext::make_shared<HestonModel>(hestonProcess);
 
         for (Size i=0; i < std::size(strikes); ++i) {
-            const ext::shared_ptr<StrikedTypePayoff> payoff(
-                new PlainVanillaPayoff(Option::Call, strikes[i]));
+            const ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strikes[i]);
 
             VanillaOption option(payoff, exercise);
 
-            const ext::shared_ptr<PricingEngine> analyticH1HWEngine(
-                new AnalyticH1HWEngine(hestonModel, hullWhiteModel,
-                                       rho_sr, 144));
+            const ext::shared_ptr<PricingEngine> analyticH1HWEngine = ext::make_shared<AnalyticH1HWEngine>(hestonModel, hullWhiteModel,
+                                       rho_sr, 144);
             option.setPricingEngine(analyticH1HWEngine);
             const Real impliedH1HW
                 = option.impliedVolatility(option.NPV(), bsProcess);

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -72,8 +72,7 @@ struct Datum {
 
 ext::shared_ptr<YieldTermStructure> nominalTermStructure() {
     Date evaluationDate(13, August, 2007);
-    return ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(evaluationDate, 0.05, Actual360()));
+    return ext::make_shared<FlatForward>(evaluationDate, 0.05, Actual360());
 }
 
 template <class T>
@@ -85,7 +84,7 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
     std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
     for (Datum datum : iiData) {
         Date maturity = datum.date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(new SimpleQuote(datum.rate / 100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(datum.rate / 100.0));
         auto anInstrument = makeHelper(quote, maturity);
         instruments.push_back(anInstrument);
     }
@@ -1190,7 +1189,7 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
     Real eps = 0.000001;
     // usual swap engine
     Handle<YieldTermStructure> hTS(nominalTS);
-    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+    ext::shared_ptr<PricingEngine> sppe = ext::make_shared<DiscountingSwapEngine>(hTS);
 
     // make sure that the index has the latest yoy term structure
     hy.linkTo(pYYTS);

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -74,8 +74,7 @@ std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > makeH
     std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > instruments;
     for (Datum datum : iiData) {
         Date maturity = datum.date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(
-                    new SimpleQuote(datum.rate/100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(datum.rate/100.0));
         auto anInstrument = ext::make_shared<YearOnYearInflationSwapHelper>(
                     quote, observationLag, maturity,
                     calendar, bdc, dc, ii, interpolation, discountCurve);
@@ -142,8 +141,7 @@ struct CommonVars {
         // link from yoy index to yoy TS
         iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
-        ext::shared_ptr<YieldTermStructure> nominalFF(
-                new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
+        ext::shared_ptr<YieldTermStructure> nominalFF = ext::make_shared<FlatForward>(evaluationDate, 0.05, ActualActual(ActualActual::ISDA));
         nominalTS.linkTo(nominalFF);
 
         // now build the YoY inflation curve
@@ -220,16 +218,13 @@ struct CommonVars {
 
         switch (which) {
           case 0:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBlackCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationBlackCapFloorEngine>(iir, vol, nominalTS);
             break;
           case 1:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationUnitDisplacedBlackCapFloorEngine>(iir, vol, nominalTS);
             break;
           case 2:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBachelierCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationBachelierCapFloorEngine>(iir, vol, nominalTS);
             break;
           default:
             BOOST_FAIL("unknown engine request: which = "<<which
@@ -249,12 +244,10 @@ struct CommonVars {
         ext::shared_ptr<YoYInflationCapFloor> result;
         switch (type) {
           case YoYInflationCapFloor::Cap:
-            result = ext::shared_ptr<YoYInflationCapFloor>(
-                        new YoYInflationCap(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<YoYInflationCap>(leg, std::vector<Rate>(1, strike));
             break;
           case YoYInflationCapFloor::Floor:
-            result = ext::shared_ptr<YoYInflationCapFloor>(
-                        new YoYInflationFloor(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<YoYInflationFloor>(leg, std::vector<Rate>(1, strike));
             break;
           default:
             QL_FAIL("unknown YoYInflation cap/floor type");
@@ -428,7 +421,7 @@ BOOST_AUTO_TEST_CASE(testParity) {
                                                  vars.dc, UnitedKingdom());
 
                     Handle<YieldTermStructure> hTS(vars.nominalTS);
-                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+                    ext::shared_ptr<PricingEngine> sppe = ext::make_shared<DiscountingSwapEngine>(hTS);
                     swap.setPricingEngine(sppe);
 
                     // N.B. nominals are 10e6

--- a/test-suite/inflationcapflooredcoupon.cpp
+++ b/test-suite/inflationcapflooredcoupon.cpp
@@ -75,8 +75,7 @@ makeHelpers(const std::vector<Datum>& iiData,
     std::vector<ext::shared_ptr<BootstrapHelper<YoYInflationTermStructure> > > instruments;
     for (Datum datum : iiData) {
         Date maturity = datum.date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(
-                            new SimpleQuote(datum.rate/100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(datum.rate/100.0));
         auto anInstrument = ext::make_shared<YearOnYearInflationSwapHelper>(
                             quote, observationLag, maturity,
                             calendar, bdc, dc, ii, interpolation, discountCurve);
@@ -150,8 +149,7 @@ struct CommonVars {
         // link from yoy index to yoy TS
         iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
 
-        ext::shared_ptr<YieldTermStructure> nominalFF(
-                        new FlatForward(evaluationDate, 0.05, ActualActual(ActualActual::ISDA)));
+        ext::shared_ptr<YieldTermStructure> nominalFF = ext::make_shared<FlatForward>(evaluationDate, 0.05, ActualActual(ActualActual::ISDA));
         nominalTS.linkTo(nominalFF);
 
         // now build the YoY inflation curve
@@ -256,16 +254,13 @@ struct CommonVars {
         ext::shared_ptr<YoYInflationCouponPricer> pricer;
         switch (which) {
           case 0:
-            pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new BlackYoYInflationCouponPricer(vol, nominalTS));
+            pricer = ext::make_shared<BlackYoYInflationCouponPricer>(vol, nominalTS);
             break;
           case 1:
-            pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new UnitDisplacedBlackYoYInflationCouponPricer(vol, nominalTS));
+            pricer = ext::make_shared<UnitDisplacedBlackYoYInflationCouponPricer>(vol, nominalTS);
             break;
           case 2:
-            pricer = ext::shared_ptr<YoYInflationCouponPricer>(
-                            new BachelierYoYInflationCouponPricer(vol, nominalTS));
+            pricer = ext::make_shared<BachelierYoYInflationCouponPricer>(vol, nominalTS);
             break;
           default:
             BOOST_FAIL("unknown coupon pricer request: which = "<<which
@@ -318,16 +313,13 @@ struct CommonVars {
 
         switch (which) {
           case 0:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBlackCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationBlackCapFloorEngine>(iir, vol, nominalTS);
             break;
           case 1:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationUnitDisplacedBlackCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationUnitDisplacedBlackCapFloorEngine>(iir, vol, nominalTS);
             break;
           case 2:
-            return ext::shared_ptr<PricingEngine>(
-                            new YoYInflationBachelierCapFloorEngine(iir, vol, nominalTS));
+            return ext::make_shared<YoYInflationBachelierCapFloorEngine>(iir, vol, nominalTS);
             break;
           default:
             BOOST_FAIL("unknown engine request: which = "<<which
@@ -347,12 +339,10 @@ struct CommonVars {
         ext::shared_ptr<YoYInflationCapFloor> result;
         switch (type) {
           case YoYInflationCapFloor::Cap:
-            result = ext::shared_ptr<YoYInflationCapFloor>(
-                                new YoYInflationCap(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<YoYInflationCap>(leg, std::vector<Rate>(1, strike));
             break;
           case YoYInflationCapFloor::Floor:
-            result = ext::shared_ptr<YoYInflationCapFloor>(
-                                new YoYInflationFloor(leg, std::vector<Rate>(1, strike)));
+            result = ext::make_shared<YoYInflationFloor>(leg, std::vector<Rate>(1, strike));
             break;
           default:
             QL_FAIL("unknown YoYInflation cap/floor type");
@@ -401,8 +391,7 @@ BOOST_AUTO_TEST_CASE(testDecomposition) {
     // Swap with null fixed leg and floating leg with negative gearing and spread<>0
     Swap vanillaLeg_n(fixedLeg,floatLeg_n);
 
-    ext::shared_ptr<PricingEngine> engine(
-            new DiscountingSwapEngine(vars.nominalTS));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingSwapEngine>(vars.nominalTS);
 
     vanillaLeg.setPricingEngine(engine);    // here use the autoset feature
     vanillaLeg_p.setPricingEngine(engine);
@@ -730,7 +719,7 @@ BOOST_AUTO_TEST_CASE(testInstrumentEquality) {
                                                  UnitedKingdom());
 
                     Handle<YieldTermStructure> hTS(vars.nominalTS);
-                    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+                    ext::shared_ptr<PricingEngine> sppe = ext::make_shared<DiscountingSwapEngine>(hTS);
                     swap.setPricingEngine(sppe);
 
                     Leg leg2 = vars.makeYoYCapFlooredLeg(whichPricer, from, length,

--- a/test-suite/inflationcpibond.cpp
+++ b/test-suite/inflationcpibond.cpp
@@ -63,8 +63,7 @@ std::vector<ext::shared_ptr<Helper> > makeHelpers(
     std::vector<ext::shared_ptr<Helper> > instruments;
     for (Datum datum : iiData) {
         Date maturity = datum.date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(
-                                new SimpleQuote(datum.rate/100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(datum.rate/100.0));
         auto h = ext::make_shared<ZeroCouponInflationSwapHelper>(
                 quote, observationLag, maturity, calendar, bdc, dc, ii, CPI::Flat);
         instruments.push_back(h);
@@ -115,8 +114,7 @@ struct CommonVars { // NOLINT(cppcoreguidelines-special-member-functions)
             ii->addFixing(rpiSchedule[i], fixData[i]);
         }
 
-        yTS.linkTo(ext::shared_ptr<YieldTermStructure>(
-                          new FlatForward(evaluationDate, 0.05, dayCounter)));
+        yTS.linkTo(ext::make_shared<FlatForward>(evaluationDate, 0.05, dayCounter));
 
         // now build the zero inflation curve
         observationLag = Period(2,Months);

--- a/test-suite/inflationcpicapfloor.cpp
+++ b/test-suite/inflationcpicapfloor.cpp
@@ -67,8 +67,7 @@ std::vector<ext::shared_ptr<BootstrapHelper<T> > > makeHelpers(
     std::vector<ext::shared_ptr<BootstrapHelper<T> > > instruments;
     for (Size i=0; i<N; i++) {
         Date maturity = iiData[i].date;
-        Handle<Quote> quote(ext::shared_ptr<Quote>(
-                                new SimpleQuote(iiData[i].rate/100.0)));
+        Handle<Quote> quote(ext::make_shared<SimpleQuote>(iiData[i].rate/100.0));
         auto anInstrument = ext::make_shared<U>(quote, observationLag, maturity,
                                                 calendar, bdc, dc, ii, CPI::Flat);
         instruments.push_back(anInstrument);
@@ -372,21 +371,22 @@ BOOST_AUTO_TEST_CASE(cpicapfloorpricer) {
     
     CommonVars common;
     Real nominal = 1.0;
-    ext::shared_ptr<CPICapFloorTermPriceSurface> cpiCFpriceSurf(new InterpolatedCPICapFloorTermPriceSurface
-                                                    <Bilinear>(nominal,
-                                                               common.baseZeroRate,
-                                                               common.observationLag,
-                                                               common.calendar,
-                                                               common.convention,
-                                                               common.dcZCIIS,
-                                                               common.ii,
-                                                               CPI::Flat,
-                                                               common.nominalUK,
-                                                               common.cStrikesUK,
-                                                               common.fStrikesUK,
-                                                               common.cfMaturitiesUK,
-                                                               *(common.cPriceUK),
-                                                               *(common.fPriceUK)));
+    ext::shared_ptr<CPICapFloorTermPriceSurface> cpiCFpriceSurf =
+        ext::make_shared<InterpolatedCPICapFloorTermPriceSurface<Bilinear> >(
+            nominal,
+            common.baseZeroRate,
+            common.observationLag,
+            common.calendar,
+            common.convention,
+            common.dcZCIIS,
+            common.ii,
+            CPI::Flat,
+            common.nominalUK,
+            common.cStrikesUK,
+            common.fStrikesUK,
+            common.cfMaturitiesUK,
+            *(common.cPriceUK),
+            *(common.fPriceUK));
 
     common.cpiCFsurfUK = cpiCFpriceSurf;
 
@@ -415,7 +415,8 @@ BOOST_AUTO_TEST_CASE(cpicapfloorpricer) {
                      observationInterpolation);
 
     Handle<CPICapFloorTermPriceSurface> cpiCFsurfUKh(common.cpiCFsurfUK);
-    ext::shared_ptr<PricingEngine>engine(new InterpolatingCPICapFloorEngine(cpiCFsurfUKh));
+    ext::shared_ptr<PricingEngine>engine =
+        ext::make_shared<InterpolatingCPICapFloorEngine>(cpiCFsurfUKh);
 
     aCap.setPricingEngine(engine);
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -263,8 +263,8 @@ BOOST_AUTO_TEST_CASE(consistency) {
     DayCounter floatDayCount = Actual365Fixed();
     BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
     Natural fixingDays = 0;
-    ext::shared_ptr<IborIndex> floatIndex(new GBPLibor(Period(6,Months),
-                                                         common.nominalTS));
+    ext::shared_ptr<IborIndex> floatIndex = ext::make_shared<GBPLibor>(Period(6,Months),
+                                                         common.nominalTS);
 
     // fixed x inflation leg
     Rate fixedRate = 0.1;//1% would be 0.01
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(consistency) {
     }
 
     // simple structure so simple pricing engine - most work done by index
-    ext::shared_ptr<DiscountingSwapEngine> dse(new DiscountingSwapEngine(common.nominalTS));
+    ext::shared_ptr<DiscountingSwapEngine> dse = ext::make_shared<DiscountingSwapEngine>(common.nominalTS);
     zisV.setPricingEngine(dse);
     
     // get float+spread & fixed*inflation leg prices separately
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(zciisconsistency) {
 
     // simple structure so simple pricing engine - most work done by index
     ext::shared_ptr<DiscountingSwapEngine>
-    dse(new DiscountingSwapEngine(common.nominalTS));
+    dse = ext::make_shared<DiscountingSwapEngine>(common.nominalTS);
 
     zciis.setPricingEngine(dse);
     QL_REQUIRE(fabs(zciis.NPV())<1e-3,"zciis does not reprice to zero");
@@ -418,8 +418,8 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
     DayCounter floatDayCount = Actual365Fixed();
     BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
     Natural fixingDays = 0;
-    ext::shared_ptr<IborIndex> floatIndex(new GBPLibor(Period(6,Months),
-                                                         common.nominalTS));
+    ext::shared_ptr<IborIndex> floatIndex = ext::make_shared<GBPLibor>(Period(6,Months),
+                                                         common.nominalTS);
 
     // fixed x inflation leg
     Rate fixedRate = 0.1;//1% would be 0.01
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
 
 
     // simple structure so simple pricing engine - most work done by index
-    ext::shared_ptr<DiscountingSwapEngine> dse(new DiscountingSwapEngine(common.nominalTS));
+    ext::shared_ptr<DiscountingSwapEngine> dse = ext::make_shared<DiscountingSwapEngine>(common.nominalTS);
     zisV.setPricingEngine(dse);
 
     // now do the bond equivalent
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
                  observationInterpolation, fixedSchedule,
                  fixedRates, fixedDayCount, fixedPaymentConvention);
 
-    ext::shared_ptr<DiscountingBondEngine> dbe(new DiscountingBondEngine(common.nominalTS));
+    ext::shared_ptr<DiscountingBondEngine> dbe = ext::make_shared<DiscountingBondEngine>(common.nominalTS);
     cpiB.setPricingEngine(dbe);
 
     QL_REQUIRE(fabs(cpiB.NPV() - zisV.legNPV(0))<1e-5,"cpi bond does not equal equivalent cpi swap leg");

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -135,7 +135,7 @@ void setup() {
     }
 
     ext::shared_ptr<InterpolatedZeroCurve<Cubic> >
-        euriborTS(new InterpolatedZeroCurve<Cubic>(d, r, Actual365Fixed()));
+        euriborTS = ext::make_shared<InterpolatedZeroCurve<Cubic>>(d, r, Actual365Fixed());
     Handle<YieldTermStructure> nominalHeur(euriborTS, false);
     nominalEUR = nominalHeur;   // copy to global
 
@@ -150,7 +150,7 @@ void setup() {
     }
 
     ext::shared_ptr<InterpolatedZeroCurve<Cubic> >
-        gbpLiborTS(new InterpolatedZeroCurve<Cubic>(d, r, Actual365Fixed()));
+        gbpLiborTS = ext::make_shared<InterpolatedZeroCurve<Cubic>>(d, r, Actual365Fixed());
     Handle<YieldTermStructure> nominalHgbp(gbpLiborTS, false);
     nominalGBP = nominalHgbp;   // copy to global
 
@@ -223,8 +223,8 @@ void setup() {
         fStrikesEU.push_back(i);
     for (auto& i : capMaturitiesEU)
         cfMaturitiesEU.push_back(i);
-    ext::shared_ptr<Matrix> tcPriceEU(new Matrix(ncStrikesEU, ncfMaturitiesEU));
-    ext::shared_ptr<Matrix> tfPriceEU(new Matrix(nfStrikesEU, ncfMaturitiesEU));
+    ext::shared_ptr<Matrix> tcPriceEU = ext::make_shared<Matrix>(ncStrikesEU, ncfMaturitiesEU);
+    ext::shared_ptr<Matrix> tfPriceEU = ext::make_shared<Matrix>(nfStrikesEU, ncfMaturitiesEU);
     for(Size i = 0; i < ncStrikesEU; i++) {
         for(Size j = 0; j < ncfMaturitiesEU; j++) {
             (*tcPriceEU)[i][j] = capPricesEU[i][j];
@@ -283,12 +283,11 @@ BOOST_AUTO_TEST_CASE(testYoYPriceSurfaceToVol) {
     ext::shared_ptr<YoYOptionletVolatilitySurface> pVS;
     Handle<YoYOptionletVolatilitySurface> hVS(pVS, false); // pVS does NOT own whatever it points to later, hence the handle does not either
     ext::shared_ptr<YoYInflationUnitDisplacedBlackCapFloorEngine>
-        yoyPricerUD(new YoYInflationUnitDisplacedBlackCapFloorEngine(yoyIndexEU,hVS,nominalEUR)); //hVS
+        yoyPricerUD = ext::make_shared<YoYInflationUnitDisplacedBlackCapFloorEngine>(yoyIndexEU,hVS,nominalEUR); //hVS
     // N.B. the vol gets set in the stripper ... else no point!
 
     // cap stripper
-    ext::shared_ptr<YoYOptionletStripper> yoyOptionletStripper(
-                             new InterpolatedYoYOptionletStripper<Linear>() );
+    ext::shared_ptr<YoYOptionletStripper> yoyOptionletStripper = ext::make_shared<InterpolatedYoYOptionletStripper<Linear>>();
 
     // now set up all the variables for the stripping
     Natural settlementDays = 0;
@@ -311,10 +310,9 @@ BOOST_AUTO_TEST_CASE(testYoYPriceSurfaceToVol) {
 
     // Actually is doesn't matter what the interpolation is because we only
     // intend to use the K values that correspond to quotes ... for model fitting.
-    ext::shared_ptr<KInterpolatedYoYOptionletVolatilitySurface<Linear> > yoySurf(new
-                    KInterpolatedYoYOptionletVolatilitySurface<Linear>(settlementDays,
+    ext::shared_ptr<KInterpolatedYoYOptionletVolatilitySurface<Linear> > yoySurf = ext::make_shared<KInterpolatedYoYOptionletVolatilitySurface<Linear>>(settlementDays,
                 cal, bdc, dc, lag, capFloorPrices, yoyPricerUD, yoyOptionletStripper,
-                                                              slope) );
+                                                              slope);
 
     // now use it for something ... like stating what the T=const lines look like
     const Real volATyear1[] = {

--- a/test-suite/instruments.cpp
+++ b/test-suite/instruments.cpp
@@ -37,9 +37,9 @@ BOOST_AUTO_TEST_CASE(testObservable) {
 
     BOOST_TEST_MESSAGE("Testing observability of instruments...");
 
-    ext::shared_ptr<SimpleQuote> me1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> me1 = ext::make_shared<SimpleQuote>(0.0);
     RelinkableHandle<Quote> h(me1);
-    ext::shared_ptr<Instrument> s(new Stock(h));
+    ext::shared_ptr<Instrument> s = ext::make_shared<Stock>(h);
 
     Flag f;
     f.registerWith(s);
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(testObservable) {
 
     s->NPV();
     f.lower();
-    ext::shared_ptr<SimpleQuote> me2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> me2 = ext::make_shared<SimpleQuote>(0.0);
     h.linkTo(me2);
     if (!f.isUp())
         BOOST_FAIL("Observer was not notified of instrument change");
@@ -75,23 +75,21 @@ BOOST_AUTO_TEST_CASE(testCompositeWhenShiftingDates) {
     Date today = Date::todaysDate();
     DayCounter dc = Actual360();
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(Option::Call, 100.0));
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(today+30));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 100.0);
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(today+30);
 
-    ext::shared_ptr<Instrument> option(new EuropeanOption(payoff, exercise));
+    ext::shared_ptr<Instrument> option = ext::make_shared<EuropeanOption>(payoff, exercise);
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(100.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(100.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(0.0, dc);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(0.01, dc);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(0.1, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-        new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
-    ext::shared_ptr<PricingEngine> engine(new AnalyticEuropeanEngine(process));
+                                      Handle<BlackVolTermStructure>(volTS));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanEngine>(process);
 
     option->setPricingEngine(engine);
 

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -249,10 +249,8 @@ BOOST_AUTO_TEST_CASE(testTwoDimensionalIntegration) {
 
     const Size maxEvaluations = 1000;
     const Real calculated = TwoDimensionalIntegral(
-        ext::shared_ptr<Integrator>(
-            new TrapezoidIntegral<Default>(tolerance, maxEvaluations)),
-        ext::shared_ptr<Integrator>(
-            new TrapezoidIntegral<Default>(tolerance, maxEvaluations)))(
+        ext::make_shared<TrapezoidIntegral<Default>>(tolerance, maxEvaluations),
+        ext::make_shared<TrapezoidIntegral<Default>>(tolerance, maxEvaluations))(
         std::multiplies<>(),
         std::make_pair(0.0, 0.0), std::make_pair(1.0, 2.0));
 

--- a/test-suite/interpolatedsmilesection.cpp
+++ b/test-suite/interpolatedsmilesection.cpp
@@ -114,15 +114,15 @@ BOOST_AUTO_TEST_CASE(testHandlesUpdatePropagates) {
     std::vector<Rate> strikes{80.0, 90.0, 100.0};
 
     // create SimpleQuote instances
-    ext::shared_ptr<SimpleQuote> q0(new SimpleQuote(0.20 * sqrtT));
-    ext::shared_ptr<SimpleQuote> q1(new SimpleQuote(0.15 * sqrtT));
-    ext::shared_ptr<SimpleQuote> q2(new SimpleQuote(0.18 * sqrtT));
+    ext::shared_ptr<SimpleQuote> q0 = ext::make_shared<SimpleQuote>(0.20 * sqrtT);
+    ext::shared_ptr<SimpleQuote> q1 = ext::make_shared<SimpleQuote>(0.15 * sqrtT);
+    ext::shared_ptr<SimpleQuote> q2 = ext::make_shared<SimpleQuote>(0.18 * sqrtT);
     std::vector<Handle<Quote>> stdDevHandles;
     stdDevHandles.emplace_back(q0);
     stdDevHandles.emplace_back(q1);
     stdDevHandles.emplace_back(q2);
 
-    ext::shared_ptr<SimpleQuote> atm(new SimpleQuote(95.0));
+    ext::shared_ptr<SimpleQuote> atm = ext::make_shared<SimpleQuote>(95.0);
     Handle<Quote> atmHandle(atm);
 
     auto section = ext::make_shared<InterpolatedSmileSection<Linear>>(
@@ -154,15 +154,15 @@ BOOST_AUTO_TEST_CASE(testFlatStrikeExtrapolation) {
     std::vector<Rate> strikes{90.0, 100.0, 110.0};
 
     // create SimpleQuote instances
-    ext::shared_ptr<SimpleQuote> q0(new SimpleQuote(0.20 * sqrtT));
-    ext::shared_ptr<SimpleQuote> q1(new SimpleQuote(0.15 * sqrtT));
-    ext::shared_ptr<SimpleQuote> q2(new SimpleQuote(0.18 * sqrtT));
+    ext::shared_ptr<SimpleQuote> q0 = ext::make_shared<SimpleQuote>(0.20 * sqrtT);
+    ext::shared_ptr<SimpleQuote> q1 = ext::make_shared<SimpleQuote>(0.15 * sqrtT);
+    ext::shared_ptr<SimpleQuote> q2 = ext::make_shared<SimpleQuote>(0.18 * sqrtT);
     std::vector<Handle<Quote>> stdDevHandles;
     stdDevHandles.emplace_back(q0);
     stdDevHandles.emplace_back(q1);
     stdDevHandles.emplace_back(q2);
 
-    ext::shared_ptr<SimpleQuote> atm(new SimpleQuote(95.0));
+    ext::shared_ptr<SimpleQuote> atm = ext::make_shared<SimpleQuote>(95.0);
     Handle<Quote> atmHandle(atm);
 
     auto section = ext::make_shared<InterpolatedSmileSection<Linear>>(

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1385,12 +1385,11 @@ BOOST_AUTO_TEST_CASE(testSabrInterpolation){
     Real calibrationTolerance = 5.0e-8;
     // initialize optimization methods
     std::vector<ext::shared_ptr<OptimizationMethod>> methods_ = {
-        ext::shared_ptr<OptimizationMethod>(new Simplex(0.01)),
-        ext::shared_ptr<OptimizationMethod>(new LevenbergMarquardt(1e-8, 1e-8, 1e-8))
+        ext::make_shared<Simplex>(0.01),
+        ext::make_shared<LevenbergMarquardt>(1e-8, 1e-8, 1e-8)
     };
     // Initialize end criteria
-    ext::shared_ptr<EndCriteria> endCriteria(new
-                  EndCriteria(100000, 100, 1e-8, 1e-8, 1e-8));
+    ext::shared_ptr<EndCriteria> endCriteria = ext::make_shared<EndCriteria>(100000, 100, 1e-8, 1e-8, 1e-8);
     // Test looping over all possibilities
     for (auto& method : methods_) {
         for (bool i : vegaWeighted) {
@@ -2009,12 +2008,11 @@ BOOST_AUTO_TEST_CASE(testNoArbSabrInterpolation){
     Real calibrationTolerance = 5.0e-6;
     // initialize optimization methods
     std::vector<ext::shared_ptr<OptimizationMethod>> methods_ = {
-        ext::shared_ptr<OptimizationMethod>(new Simplex(0.01)),
-        ext::shared_ptr<OptimizationMethod>(new LevenbergMarquardt(1e-8, 1e-8, 1e-8))
+        ext::make_shared<Simplex>(0.01),
+        ext::make_shared<LevenbergMarquardt>(1e-8, 1e-8, 1e-8)
     };
     // Initialize end criteria
-    ext::shared_ptr<EndCriteria> endCriteria(new
-                  EndCriteria(100000, 100, 1e-8, 1e-8, 1e-8));
+    ext::shared_ptr<EndCriteria> endCriteria = ext::make_shared<EndCriteria>(100000, 100, 1e-8, 1e-8, 1e-8);
     // Test looping over all possibilities
     for (Size j=1; j<methods_.size(); ++j) { // skip simplex (gets caught in some cases)
         for (bool i : vegaWeighted) {

--- a/test-suite/jumpdiffusion.cpp
+++ b/test-suite/jumpdiffusion.cpp
@@ -270,35 +270,33 @@ BOOST_AUTO_TEST_CASE(testMerton76) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
-    ext::shared_ptr<SimpleQuote> jumpIntensity(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> meanLogJump(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> jumpVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> jumpIntensity = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> meanLogJump = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> jumpVol = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<Merton76Process> stochProcess(
-           new Merton76Process(Handle<Quote>(spot),
+    ext::shared_ptr<Merton76Process> stochProcess = ext::make_shared<Merton76Process>(Handle<Quote>(spot),
                                Handle<YieldTermStructure>(qTS),
                                Handle<YieldTermStructure>(rTS),
                                Handle<BlackVolTermStructure>(volTS),
                                Handle<Quote>(jumpIntensity),
                                Handle<Quote>(meanLogJump),
-                               Handle<Quote>(jumpVol)));
-    ext::shared_ptr<PricingEngine> engine(
-                                       new JumpDiffusionEngine(stochProcess));
+                               Handle<Quote>(jumpVol));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<JumpDiffusionEngine>(stochProcess);
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
@@ -369,31 +367,29 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
 
-    ext::shared_ptr<SimpleQuote> jumpIntensity(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> meanLogJump(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> jumpVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> jumpIntensity = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> meanLogJump = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> jumpVol = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<Merton76Process> stochProcess(
-          new Merton76Process(Handle<Quote>(spot), qTS, rTS, volTS,
+    ext::shared_ptr<Merton76Process> stochProcess = ext::make_shared<Merton76Process>(Handle<Quote>(spot), qTS, rTS, volTS,
                               Handle<Quote>(jumpIntensity),
                               Handle<Quote>(meanLogJump),
-                              Handle<Quote>(jumpVol)));
+                              Handle<Quote>(jumpVol));
 
     ext::shared_ptr<StrikedTypePayoff> payoff;
 
     // The jumpdiffusionengine greeks are very sensitive to the
     // convergence level.  A tolerance of 1.0e-08 is usually
     // sufficient to get reasonable results
-    ext::shared_ptr<PricingEngine> engine(
-                                 new JumpDiffusionEngine(stochProcess,1e-08));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<JumpDiffusionEngine>(stochProcess,1e-08);
 
     for (auto& type : types) {
         for (Real strike : strikes) {
@@ -405,15 +401,13 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
                         jumpVol->setValue(jj3);
                         for (Real residualTime : residualTimes) {
                             Date exDate = today + timeToDays(residualTime);
-                            ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
                             for (Size kk = 0; kk < 1; kk++) {
                                 // option to check
                                 if (kk == 0) {
-                                    payoff = ext::shared_ptr<StrikedTypePayoff>(
-                                        new PlainVanillaPayoff(type, strike));
+                                    payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
                                 } else if (kk == 1) {
-                                    payoff = ext::shared_ptr<StrikedTypePayoff>(
-                                        new CashOrNothingPayoff(type, strike, 100.0));
+                                    payoff = ext::make_shared<CashOrNothingPayoff>(type, strike, 100.0);
                                 }
                                 EuropeanOption option(payoff, exercise);
                                 option.setPricingEngine(engine);

--- a/test-suite/lazyobject.cpp
+++ b/test-suite/lazyobject.cpp
@@ -51,8 +51,8 @@ BOOST_AUTO_TEST_CASE(testDiscardingNotifications) {
 
     LazyObject::Defaults::instance().alwaysForwardNotifications();
 
-    ext::shared_ptr<SimpleQuote> q(new SimpleQuote(0.0));
-    ext::shared_ptr<Instrument> s(new Stock(Handle<Quote>(q)));
+    ext::shared_ptr<SimpleQuote> q = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<Instrument> s = ext::make_shared<Stock>(Handle<Quote>(q));
 
     Flag f;
     f.registerWith(s);
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE(testDiscardingNotificationsByDefault) {
 
     LazyObject::Defaults::instance().forwardFirstNotificationOnly();
 
-    ext::shared_ptr<SimpleQuote> q(new SimpleQuote(0.0));
-    ext::shared_ptr<Instrument> s(new Stock(Handle<Quote>(q)));
+    ext::shared_ptr<SimpleQuote> q = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<Instrument> s = ext::make_shared<Stock>(Handle<Quote>(q));
 
     Flag f;
     f.registerWith(s);
@@ -115,8 +115,8 @@ BOOST_AUTO_TEST_CASE(testForwardingNotificationsByDefault) {
 
     LazyObject::Defaults::instance().alwaysForwardNotifications();
 
-    ext::shared_ptr<SimpleQuote> q(new SimpleQuote(0.0));
-    ext::shared_ptr<Instrument> s(new Stock(Handle<Quote>(q)));
+    ext::shared_ptr<SimpleQuote> q = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<Instrument> s = ext::make_shared<Stock>(Handle<Quote>(q));
 
     Flag f;
     f.registerWith(s);
@@ -140,8 +140,8 @@ BOOST_AUTO_TEST_CASE(testForwardingNotifications) {
 
     LazyObject::Defaults::instance().forwardFirstNotificationOnly();
 
-    ext::shared_ptr<SimpleQuote> q(new SimpleQuote(0.0));
-    ext::shared_ptr<Instrument> s(new Stock(Handle<Quote>(q)));
+    ext::shared_ptr<SimpleQuote> q = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<Instrument> s = ext::make_shared<Stock>(Handle<Quote>(q));
 
     Flag f;
     f.registerWith(s);

--- a/test-suite/libormarketmodel.cpp
+++ b/test-suite/libormarketmodel.cpp
@@ -57,7 +57,7 @@ ext::shared_ptr<IborIndex> makeIndex(std::vector<Date> dates, const std::vector<
 
     RelinkableHandle<YieldTermStructure> termStructure;
 
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
 
     Date todaysDate =
         index->fixingCalendar().adjust(Date(4,September,2005));
@@ -66,8 +66,7 @@ ext::shared_ptr<IborIndex> makeIndex(std::vector<Date> dates, const std::vector<
     dates[0] = index->fixingCalendar().advance(todaysDate,
                                                index->fixingDays(), Days);
 
-    termStructure.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, rates, dayCounter)));
+    termStructure.linkTo(ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
 
     return index;
 }
@@ -88,8 +87,7 @@ makeCapVolCurve(const Date& todaysDate) {
 
     std::vector<Date> dates;
     std::vector<Volatility> capletVols;
-    ext::shared_ptr<LiborForwardModelProcess> process(
-                               new LiborForwardModelProcess(10, makeIndex()));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(10, makeIndex());
 
     for (Size i=0; i < 9; ++i) {
         capletVols.push_back(vols[i]/100);
@@ -109,8 +107,7 @@ BOOST_AUTO_TEST_CASE(testSimpleCovarianceModels) {
     const Real tolerance = 1e-14;
     Size i;
 
-    ext::shared_ptr<LmCorrelationModel> corrModel(
-                                new LmExponentialCorrelationModel(size, 0.1));
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmExponentialCorrelationModel>(size, 0.1);
 
     Matrix recon = corrModel->correlation(0.0)
         - corrModel->pseudoSqrt(0.0)*transpose(corrModel->pseudoSqrt(0.0));
@@ -134,17 +131,13 @@ BOOST_AUTO_TEST_CASE(testSimpleCovarianceModels) {
     const Real c=2.1;
     const Real d=0.3;
 
-    ext::shared_ptr<LmVolatilityModel> volaModel(
-             new LmLinearExponentialVolatilityModel(fixingTimes, a, b, c, d));
+    ext::shared_ptr<LmVolatilityModel> volaModel = ext::make_shared<LmLinearExponentialVolatilityModel>(fixingTimes, a, b, c, d);
 
-    ext::shared_ptr<LfmCovarianceProxy> covarProxy(
-                                new LfmCovarianceProxy(volaModel, corrModel));
+    ext::shared_ptr<LfmCovarianceProxy> covarProxy = ext::make_shared<LfmCovarianceProxy>(volaModel, corrModel);
 
-    ext::shared_ptr<LiborForwardModelProcess> process(
-                             new LiborForwardModelProcess(size, makeIndex()));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(size, makeIndex());
 
-    ext::shared_ptr<LiborForwardModel> liborModel(
-                        new LiborForwardModel(process, volaModel, corrModel));
+    ext::shared_ptr<LiborForwardModel> liborModel = ext::make_shared<LiborForwardModel>(process, volaModel, corrModel);
 
     for (Real t=0; t<4.6; t+=0.31) {
         recon = covarProxy->covariance(t)
@@ -185,8 +178,7 @@ BOOST_AUTO_TEST_CASE(testCapletPricing) {
     Real tolerance = usingAtParCoupons ? 1e-12 : 1e-5;
 
     ext::shared_ptr<IborIndex> index = makeIndex();
-    ext::shared_ptr<LiborForwardModelProcess> process(
-        new LiborForwardModelProcess(size, index));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(size, index);
 
     // set-up pricing engine
     const ext::shared_ptr<OptionletVolatilityStructure> capVolCurve =
@@ -195,21 +187,17 @@ BOOST_AUTO_TEST_CASE(testCapletPricing) {
     Array variances = LfmHullWhiteParameterization(process, capVolCurve)
         .covariance(0.0).diagonal();
 
-    ext::shared_ptr<LmVolatilityModel> volaModel(
-        new LmFixedVolatilityModel(Sqrt(variances),
-                                   process->fixingTimes()));
+    ext::shared_ptr<LmVolatilityModel> volaModel = ext::make_shared<LmFixedVolatilityModel>(Sqrt(variances),
+                                   process->fixingTimes());
 
-    ext::shared_ptr<LmCorrelationModel> corrModel(
-                                new LmExponentialCorrelationModel(size, 0.3));
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmExponentialCorrelationModel>(size, 0.3);
 
-    ext::shared_ptr<AffineModel> model(
-                        new LiborForwardModel(process, volaModel, corrModel));
+    ext::shared_ptr<AffineModel> model = ext::make_shared<LiborForwardModel>(process, volaModel, corrModel);
 
     const Handle<YieldTermStructure> termStructure =
         process->index()->forwardingTermStructure();
 
-    ext::shared_ptr<AnalyticCapFloorEngine> engine1(
-                            new AnalyticCapFloorEngine(model, termStructure));
+    ext::shared_ptr<AnalyticCapFloorEngine> engine1 = ext::make_shared<AnalyticCapFloorEngine>(model, termStructure);
 
     auto cap1 = Cap(process->cashFlows(),
                     std::vector<Rate>(size, 0.04));
@@ -249,20 +237,16 @@ BOOST_AUTO_TEST_CASE(testCalibration) {
                                  0.106996, 0.100064};
 
     ext::shared_ptr<IborIndex> index = makeIndex();
-    ext::shared_ptr<LiborForwardModelProcess> process(
-        new LiborForwardModelProcess(size, index));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(size, index);
     Handle<YieldTermStructure> termStructure = index->forwardingTermStructure();
 
     // set-up the model
-    ext::shared_ptr<LmVolatilityModel> volaModel(
-                    new LmExtLinearExponentialVolModel(process->fixingTimes(),
-                                                       0.5,0.6,0.1,0.1));
+    ext::shared_ptr<LmVolatilityModel> volaModel = ext::make_shared<LmExtLinearExponentialVolModel>(process->fixingTimes(),
+                                                       0.5,0.6,0.1,0.1);
 
-    ext::shared_ptr<LmCorrelationModel> corrModel(
-                     new LmLinearExponentialCorrelationModel(size, 0.5, 0.8));
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmLinearExponentialCorrelationModel>(size, 0.5, 0.8);
 
-    ext::shared_ptr<LiborForwardModel> model(
-                        new LiborForwardModel(process, volaModel, corrModel));
+    ext::shared_ptr<LiborForwardModel> model = ext::make_shared<LiborForwardModel>(process, volaModel, corrModel);
 
     Size swapVolIndex = 0;
     DayCounter dayCounter=index->forwardingTermStructure()->dayCounter();
@@ -274,15 +258,14 @@ BOOST_AUTO_TEST_CASE(testCalibration) {
     for (i=2; i < size; ++i) {
         const Period maturity = i*index->tenor();
         Handle<Quote> capVol(
-            ext::shared_ptr<Quote>(new SimpleQuote(capVols[i-2])));
+            ext::make_shared<SimpleQuote>(capVols[i-2]));
 
         auto caphelper =
             ext::make_shared<CapHelper>(maturity, capVol, index, Annual,
                                         index->dayCounter(), true, termStructure,
                                         BlackCalibrationHelper::ImpliedVolError);
 
-        caphelper->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                           new AnalyticCapFloorEngine(model, termStructure)));
+        caphelper->setPricingEngine(ext::make_shared<AnalyticCapFloorEngine>(model, termStructure));
 
         calibrationHelpers.push_back(caphelper);
 
@@ -291,8 +274,7 @@ BOOST_AUTO_TEST_CASE(testCalibration) {
             for (Size j=1; j <= size/2; ++j) {
                 const Period len = j*index->tenor();
                 Handle<Quote> swaptionVol(
-                    ext::shared_ptr<Quote>(
-                        new SimpleQuote(swaptionVols[swapVolIndex++])));
+                    ext::make_shared<SimpleQuote>(swaptionVols[swapVolIndex++]));
 
                 auto swaptionHelper =
                     ext::make_shared<SwaptionHelper>(maturity, len, swaptionVol, index,
@@ -302,8 +284,7 @@ BOOST_AUTO_TEST_CASE(testCalibration) {
                                                      BlackCalibrationHelper::ImpliedVolError);
 
                 swaptionHelper->setPricingEngine(
-                     ext::shared_ptr<PricingEngine>(
-                                 new LfmSwaptionEngine(model,termStructure)));
+                     ext::make_shared<LfmSwaptionEngine>(model,termStructure));
 
                 calibrationHelpers.push_back(swaptionHelper);
             }
@@ -341,19 +322,15 @@ BOOST_AUTO_TEST_CASE(testSwaptionPricing) {
 
     ext::shared_ptr<IborIndex> index = makeIndex(dates, rates);
 
-    ext::shared_ptr<LiborForwardModelProcess> process(
-                                   new LiborForwardModelProcess(size, index));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(size, index);
 
-    ext::shared_ptr<LmCorrelationModel> corrModel(
-                                new LmExponentialCorrelationModel(size, 0.5));
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmExponentialCorrelationModel>(size, 0.5);
 
-    ext::shared_ptr<LmVolatilityModel> volaModel(
-        new LmLinearExponentialVolatilityModel(process->fixingTimes(),
-                                               0.291, 1.483, 0.116, 0.00001));
+    ext::shared_ptr<LmVolatilityModel> volaModel = ext::make_shared<LmLinearExponentialVolatilityModel>(process->fixingTimes(),
+                                               0.291, 1.483, 0.116, 0.00001);
 
    // set-up pricing engine
-    process->setCovarParam(ext::shared_ptr<LfmCovarianceParameterization>(
-                               new LfmCovarianceProxy(volaModel, corrModel)));
+    process->setCovarParam(ext::make_shared<LfmCovarianceProxy>(volaModel, corrModel));
 
     // set-up a small Monte-Carlo simulation to price swations
     typedef PseudoRandom::rsg_type rsg_type;
@@ -377,7 +354,7 @@ BOOST_AUTO_TEST_CASE(testSwaptionPricing) {
     MultiPathGenerator<rsg_type> generator(process, grid, rsg, false);
 
     ext::shared_ptr<LiborForwardModel>
-        liborModel(new LiborForwardModel(process, volaModel, corrModel));
+        liborModel = ext::make_shared<LiborForwardModel>(process, volaModel, corrModel);
 
     Calendar calendar = index->fixingCalendar();
     DayCounter dayCounter = index->forwardingTermStructure()->dayCounter();
@@ -394,12 +371,10 @@ BOOST_AUTO_TEST_CASE(testSwaptionPricing) {
                                convention, convention, DateGeneration::Forward, false);
 
             Rate swapRate  = 0.0404;
-            ext::shared_ptr<VanillaSwap> forwardSwap(
-                new VanillaSwap(Swap::Receiver, 1.0,
+            ext::shared_ptr<VanillaSwap> forwardSwap = ext::make_shared<VanillaSwap>(Swap::Receiver, 1.0,
                                 schedule, swapRate, dayCounter,
-                                schedule, index, 0.0, index->dayCounter()));
-            forwardSwap->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new DiscountingSwapEngine(index->forwardingTermStructure())));
+                                schedule, index, 0.0, index->dayCounter());
+            forwardSwap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(index->forwardingTermStructure()));
 
             // check forward pricing first
             const Real expected = forwardSwap->fairRate();
@@ -415,15 +390,12 @@ BOOST_AUTO_TEST_CASE(testSwaptionPricing) {
                                 Swap::Receiver, 1.0,
                                 schedule, swapRate, dayCounter,
                                 schedule, index, 0.0, index->dayCounter());
-            forwardSwap->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                new DiscountingSwapEngine(index->forwardingTermStructure())));
+            forwardSwap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(index->forwardingTermStructure()));
 
             if (i == j && i<=size/2) {
-                ext::shared_ptr<PricingEngine> engine(
-                     new LfmSwaptionEngine(liborModel,
-                                           index->forwardingTermStructure()));
-                ext::shared_ptr<Exercise> exercise(
-                    new EuropeanExercise(process->fixingDates()[i]));
+                ext::shared_ptr<PricingEngine> engine = ext::make_shared<LfmSwaptionEngine>(liborModel,
+                                           index->forwardingTermStructure());
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(process->fixingDates()[i]);
 
                 auto swaption = ext::make_shared<Swaption>(forwardSwap, exercise);
                 swaption->setPricingEngine(engine);

--- a/test-suite/libormarketmodelprocess.cpp
+++ b/test-suite/libormarketmodelprocess.cpp
@@ -46,10 +46,9 @@ ext::shared_ptr<IborIndex> makeIndex() {
     std::vector<Rate> rates = {0.01, 0.08};
 
     RelinkableHandle<YieldTermStructure> termStructure(
-                      ext::shared_ptr<YieldTermStructure>(
-                                      new ZeroCurve(dates,rates,dayCounter)));
+                      ext::make_shared<ZeroCurve>(dates,rates,dayCounter));
 
-    ext::shared_ptr<IborIndex> index(new Euribor1Y(termStructure));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor1Y>(termStructure);
 
     Date todaysDate =
         index->fixingCalendar().adjust(Date(4,September,2005));
@@ -58,8 +57,7 @@ ext::shared_ptr<IborIndex> makeIndex() {
     dates[0] = index->fixingCalendar().advance(todaysDate,
                                                index->fixingDays(), Days);
 
-    termStructure.linkTo(ext::shared_ptr<YieldTermStructure>(
-                                    new ZeroCurve(dates, rates, dayCounter)));
+    termStructure.linkTo(ext::make_shared<ZeroCurve>(dates, rates, dayCounter));
 
     return index;
 }
@@ -71,8 +69,7 @@ makeCapVolCurve(const Date& todaysDate) {
 
     std::vector<Date> dates;
     std::vector<Volatility> capletVols;
-    ext::shared_ptr<LiborForwardModelProcess> process(
-                            new LiborForwardModelProcess(len+1, makeIndex()));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(len+1, makeIndex());
 
     for (Size i=0; i < len; ++i) {
         capletVols.push_back(vols[i]/100);
@@ -88,14 +85,12 @@ makeProcess(const Matrix& volaComp = Matrix()) {
     Size factors = (volaComp.empty() ? 1 : volaComp.columns());
 
     ext::shared_ptr<IborIndex> index = makeIndex();
-    ext::shared_ptr<LiborForwardModelProcess> process(
-                                    new LiborForwardModelProcess(len, index));
+    ext::shared_ptr<LiborForwardModelProcess> process = ext::make_shared<LiborForwardModelProcess>(len, index);
 
-    ext::shared_ptr<LfmCovarianceParameterization> fct(
-                new LfmHullWhiteParameterization(
+    ext::shared_ptr<LfmCovarianceParameterization> fct = ext::make_shared<LfmHullWhiteParameterization>(
                     process,
                     makeCapVolCurve(Settings::instance().evaluationDate()),
-                    volaComp * transpose(volaComp), factors));
+                    volaComp * transpose(volaComp), factors);
 
     process->setCovarParam(fct);
 
@@ -110,13 +105,12 @@ BOOST_AUTO_TEST_CASE(testInitialisation) {
     RelinkableHandle<YieldTermStructure> termStructure(
         flatRate(Date::todaysDate(), 0.04, dayCounter));
 
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
-    ext::shared_ptr<OptionletVolatilityStructure> capletVol(new
-        ConstantOptionletVolatility(termStructure->referenceDate(),
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
+    ext::shared_ptr<OptionletVolatilityStructure> capletVol = ext::make_shared<ConstantOptionletVolatility>(termStructure->referenceDate(),
                                     termStructure->calendar(),
                                     Following,
                                     0.2,
-                                    termStructure->dayCounter()));
+                                    termStructure->dayCounter());
 
     Calendar calendar = index->fixingCalendar();
 

--- a/test-suite/lookbackoptions.cpp
+++ b/test-suite/lookbackoptions.cpp
@@ -135,34 +135,32 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousFloatingLookback) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<FloatingTypePayoff> payoff(new FloatingTypePayoff(value.type));
+        ext::shared_ptr<FloatingTypePayoff> payoff = ext::make_shared<FloatingTypePayoff>(value.type);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                  new AnalyticContinuousFloatingLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousFloatingLookbackEngine>(stochProcess);
 
         ContinuousFloatingLookbackOption option(value.minmax, payoff, exercise);
         option.setPricingEngine(engine);
@@ -229,34 +227,32 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousFixedLookback) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                     new AnalyticContinuousFixedLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousFixedLookbackEngine>(stochProcess);
 
         ContinuousFixedLookbackOption option(value.minmax, payoff, exercise);
         option.setPricingEngine(engine);
@@ -334,34 +330,32 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousPartialFloatingLookback) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<FloatingTypePayoff> payoff(new FloatingTypePayoff(value.type));
+        ext::shared_ptr<FloatingTypePayoff> payoff = ext::make_shared<FloatingTypePayoff>(value.type);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                  new AnalyticContinuousPartialFloatingLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousPartialFloatingLookbackEngine>(stochProcess);
 
         Date lookbackEnd = today + timeToDays(value.t1);
         ContinuousPartialFloatingLookbackOption option(value.minmax, value.l, lookbackEnd, payoff,
@@ -439,34 +433,32 @@ BOOST_AUTO_TEST_CASE(testAnalyticContinuousPartialFixedLookback) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
         rRate->setValue(value.r);
         vol->setValue(value.v);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-                            new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                     new AnalyticContinuousPartialFixedLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousPartialFixedLookbackEngine>(stochProcess);
 
         Date lookbackStart = today + timeToDays(value.t1);
         ContinuousPartialFixedLookbackOption option(lookbackStart,
@@ -497,14 +489,14 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
     Real t1= 0.25;
 
     Date exDate = today + timeToDays(t);
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS = flatVol(today, vol, dc);
 
     spot ->setValue(100);
@@ -512,17 +504,16 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
     rRate->setValue(0.06);
     vol  ->setValue(0.1);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-        new BlackScholesMertonProcess(
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot),
             Handle<YieldTermStructure>(qTS),
             Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS)));
+            Handle<BlackVolTermStructure>(volTS));
 
     Option::Type types[] = { Option::Call, Option::Put };
 
     for (auto type : types) {
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
         /**
          * Partial Fixed
@@ -532,8 +523,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
         ContinuousPartialFixedLookbackOption partialFixedLookback(lookbackStart,
                                                                   payoff,
                                                                   exercise);
-        ext::shared_ptr<PricingEngine> engine(
-            new AnalyticContinuousPartialFixedLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticContinuousPartialFixedLookbackEngine>(stochProcess);
         partialFixedLookback.setPricingEngine(engine);
 
         Real analytical = partialFixedLookback.NPV();
@@ -564,8 +554,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
         ContinuousFixedLookbackOption fixedLookback(minMax,
                                                     payoff,
                                                     exercise);
-        ext::shared_ptr<PricingEngine> analyticalfixedengine(
-            new AnalyticContinuousFixedLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> analyticalfixedengine = ext::make_shared<AnalyticContinuousFixedLookbackEngine>(stochProcess);
         fixedLookback.setPricingEngine(analyticalfixedengine);
 
         analytical = fixedLookback.NPV();
@@ -594,15 +583,14 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
         Real lambda = 1;
         Date lookbackEnd = today + timeToDays(t1);
 
-        ext::shared_ptr<FloatingTypePayoff> floatingPayoff(new FloatingTypePayoff(type));
+        ext::shared_ptr<FloatingTypePayoff> floatingPayoff = ext::make_shared<FloatingTypePayoff>(type);
 
         ContinuousPartialFloatingLookbackOption partialFloating(minMax,
                                                                 lambda,
                                                                 lookbackEnd,
                                                                 floatingPayoff,
                                                                 exercise);
-        ext::shared_ptr<PricingEngine> analyticalpartialFloatingengine(
-            new AnalyticContinuousPartialFloatingLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> analyticalpartialFloatingengine = ext::make_shared<AnalyticContinuousPartialFloatingLookbackEngine>(stochProcess);
         partialFloating.setPricingEngine(analyticalpartialFloatingengine);
 
         analytical = partialFloating.NPV();
@@ -631,8 +619,7 @@ BOOST_AUTO_TEST_CASE(testMonteCarloLookback) {
         ContinuousFloatingLookbackOption floating(minMax,
                                                   floatingPayoff,
                                                   exercise);
-        ext::shared_ptr<PricingEngine> analyticalFloatingengine(
-            new AnalyticContinuousFloatingLookbackEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> analyticalFloatingengine = ext::make_shared<AnalyticContinuousFloatingLookbackEngine>(stochProcess);
         floating.setPricingEngine(analyticalFloatingengine);
 
         analytical = floating.NPV();

--- a/test-suite/margrabeoption.cpp
+++ b/test-suite/margrabeoption.cpp
@@ -163,26 +163,26 @@ BOOST_AUTO_TEST_CASE(testEuroExchangeTwoAssets) {
     DayCounter dc = Actual360();
     Date today = Settings::instance().evaluationDate();
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS1 = flatRate(today, qRate1, dc);
-    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, qRate2, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
 
     for (auto& value : values) {
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot1->setValue(value.s1);
         spot2->setValue(value.s2);
@@ -192,17 +192,15 @@ BOOST_AUTO_TEST_CASE(testEuroExchangeTwoAssets) {
         vol1->setValue(value.v1);
         vol2->setValue(value.v2);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1(new
-            BlackScholesMertonProcess(Handle<Quote>(spot1),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                       Handle<YieldTermStructure>(qTS1),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS1)));
+                                      Handle<BlackVolTermStructure>(volTS1));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2(new
-            BlackScholesMertonProcess(Handle<Quote>(spot2),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot2),
                                       Handle<YieldTermStructure>(qTS2),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS2)));
+                                      Handle<BlackVolTermStructure>(volTS2));
 
         std::vector<ext::shared_ptr<StochasticProcess1D> > procs = {stochProcess1, stochProcess2};
 
@@ -211,8 +209,7 @@ BOOST_AUTO_TEST_CASE(testEuroExchangeTwoAssets) {
             correlationMatrix[j][j] = 1.0;
         }
 
-        ext::shared_ptr<PricingEngine> engine(
-            new AnalyticEuropeanMargrabeEngine(stochProcess1, stochProcess2, value.rho));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanMargrabeEngine>(stochProcess1, stochProcess2, value.rho);
 
         MargrabeOption margrabeOption(value.Q1, value.Q2, exercise);
 
@@ -310,34 +307,34 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS1 = flatRate(qRate1, dc);
-    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(qRate2, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(vol2, dc);
 
     for (Real residualTime : residualTimes) {
         Date exDate = today + timeToDays(residualTime);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         // option to check
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1(new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot1), Handle<YieldTermStructure>(qTS1), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS1)));
+            Handle<BlackVolTermStructure>(volTS1));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2(new BlackScholesMertonProcess(
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2 = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot2), Handle<YieldTermStructure>(qTS2), Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(volTS2)));
+            Handle<BlackVolTermStructure>(volTS2));
 
         std::vector<ext::shared_ptr<StochasticProcess1D> > procs = {stochProcess1, stochProcess2};
 
@@ -347,8 +344,7 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
         for (Integer j = 0; j < 2; j++) {
             correlationMatrix[j][j] = 1.0;
 
-            ext::shared_ptr<PricingEngine> engine(
-                new AnalyticEuropeanMargrabeEngine(stochProcess1, stochProcess2, correlation));
+            ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticEuropeanMargrabeEngine>(stochProcess1, stochProcess2, correlation);
 
             // The quantities of S1 and S2 can be different from 1 & 1 for more tests
             MargrabeOption margrabeOption(1, 1, exercise);
@@ -481,26 +477,26 @@ BOOST_AUTO_TEST_CASE(testAmericanExchangeTwoAssets) {
 
     Date today = Settings::instance().evaluationDate();
     DayCounter dc = Actual360();
-    ext::shared_ptr<SimpleQuote> spot1(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> spot2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot1 = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> spot2 = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<SimpleQuote> qRate1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS1 = flatRate(today, qRate1, dc);
-    ext::shared_ptr<SimpleQuote> qRate2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> qRate2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, qRate2, dc);
 
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
 
     for (auto& value : values) {
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new AmericanExercise(today, exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<AmericanExercise>(today, exDate);
 
         spot1->setValue(value.s1);
         spot2->setValue(value.s2);
@@ -510,17 +506,15 @@ BOOST_AUTO_TEST_CASE(testAmericanExchangeTwoAssets) {
         vol1->setValue(value.v1);
         vol2->setValue(value.v2);
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1(new
-            BlackScholesMertonProcess(Handle<Quote>(spot1),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot1),
                                       Handle<YieldTermStructure>(qTS1),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS1)));
+                                      Handle<BlackVolTermStructure>(volTS1));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2(new
-            BlackScholesMertonProcess(Handle<Quote>(spot2),
+        ext::shared_ptr<BlackScholesMertonProcess> stochProcess2 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot2),
                                       Handle<YieldTermStructure>(qTS2),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS2)));
+                                      Handle<BlackVolTermStructure>(volTS2));
 
         std::vector<ext::shared_ptr<StochasticProcess1D> > procs = {stochProcess1,stochProcess2};
 
@@ -529,8 +523,7 @@ BOOST_AUTO_TEST_CASE(testAmericanExchangeTwoAssets) {
             correlationMatrix[j][j] = 1.0;
         }
 
-        ext::shared_ptr<PricingEngine> engine(
-            new AnalyticAmericanMargrabeEngine(stochProcess1, stochProcess2, value.rho));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticAmericanMargrabeEngine>(stochProcess1, stochProcess2, value.rho);
 
         MargrabeOption margrabeOption(value.Q1, value.Q2, exercise);
 

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -4268,7 +4268,8 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
     {
         forwardStrikes[i] = todaysForwards[i] + 0.01;
         optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
-        /* displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement); */
+        /* displacedPayoffs[i] = ext::shared_ptr<PlainVanillaPayoff>(new
+           PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement)); */
     }
 
     MultiStepForwards forwards(rateTimes, accruals,

--- a/test-suite/marketmodel.cpp
+++ b/test-suite/marketmodel.cpp
@@ -273,8 +273,7 @@ simulate(const ext::shared_ptr<MarketModelEvolver>& evolver,
     Real initialNumeraireValue = todaysDiscounts[initialNumeraire];
 
     AccountingEngine engine(evolver, product, initialNumeraireValue);
-    ext::shared_ptr<SequenceStatisticsInc> stats(
-            new SequenceStatisticsInc(product.numberOfProducts()));
+    ext::shared_ptr<SequenceStatisticsInc> stats = ext::make_shared<SequenceStatisticsInc>(product.numberOfProducts());
     engine.multiplePathValues(*stats, paths_);
     return stats;
 }
@@ -302,11 +301,9 @@ ext::shared_ptr<MarketModel> makeMarketModel(bool logNormal,
 
     std::vector<Time> fixingTimes(evolution.rateTimes());
     fixingTimes.pop_back();
-    ext::shared_ptr<LmVolatilityModel> volModel(new
-                LmExtLinearExponentialVolModel(fixingTimes,0.5, 0.6, 0.1, 0.1));
-    ext::shared_ptr<LmCorrelationModel> corrModel(
-                new LmLinearExponentialCorrelationModel(evolution.numberOfRates(),
-                longTermCorrelation, beta));
+    ext::shared_ptr<LmVolatilityModel> volModel = ext::make_shared<LmExtLinearExponentialVolModel>(fixingTimes,0.5, 0.6, 0.1, 0.1);
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmLinearExponentialCorrelationModel>(evolution.numberOfRates(),
+                longTermCorrelation, beta);
 
     std::vector<Rate> bumpedForwards(todaysForwards.size());
     std::transform(todaysForwards.begin(), todaysForwards.end(),
@@ -326,27 +323,24 @@ ext::shared_ptr<MarketModel> makeMarketModel(bool logNormal,
     Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                   longTermCorrelation,
                                                   beta);
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-                TimeHomogeneousForwardCorrelation(correlations,
-                evolution.rateTimes()));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(correlations,
+                evolution.rateTimes());
     switch (marketModelType) {
       case ExponentialCorrelationFlatVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                FlatVol(bumpedVols,
+        return ext::make_shared<FlatVol>(bumpedVols,
                 corr,
                 evolution,
                 numberOfFactors,
                 bumpedForwards,
-                std::vector<Spread>(bumpedForwards.size(), displacement)));
+                std::vector<Spread>(bumpedForwards.size(), displacement));
       case ExponentialCorrelationAbcdVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                AbcdVol(0.0,0.0,1.0,1.0,
+        return ext::make_shared<AbcdVol>(0.0,0.0,1.0,1.0,
                 bumpedVols,
                 corr,
                 evolution,
                 numberOfFactors,
                 bumpedForwards,
-                std::vector<Spread>(bumpedForwards.size(), displacement)));
+                std::vector<Spread>(bumpedForwards.size(), displacement));
         //case CalibratedMM:
         //    return ext::shared_ptr<MarketModel>(new
         //        CalibratedMarketModel(volModel, corrModel,
@@ -440,21 +434,17 @@ ext::shared_ptr<MarketModelEvolver> makeMarketModelEvolver(const ext::shared_ptr
                                                            Size initialStep = 0) {
     switch (evolverType) {
       case Ipc:
-        return ext::shared_ptr<MarketModelEvolver>(
-                  new LogNormalFwdRateIpc(marketModel, generatorFactory,
-                  numeraires, initialStep));
+        return ext::make_shared<LogNormalFwdRateIpc>(marketModel, generatorFactory,
+                  numeraires, initialStep);
       case Balland:
-        return ext::shared_ptr<MarketModelEvolver>(
-                  new LogNormalFwdRateBalland(marketModel, generatorFactory,
-                  numeraires, initialStep));
+        return ext::make_shared<LogNormalFwdRateBalland>(marketModel, generatorFactory,
+                  numeraires, initialStep);
       case Pc:
-        return ext::shared_ptr<MarketModelEvolver>(
-                  new LogNormalFwdRatePc(marketModel, generatorFactory,
-                  numeraires, initialStep));
+        return ext::make_shared<LogNormalFwdRatePc>(marketModel, generatorFactory,
+                  numeraires, initialStep);
       case NormalPc:
-        return ext::shared_ptr<MarketModelEvolver>(
-                  new NormalFwdRatePc(marketModel, generatorFactory,
-                  numeraires, initialStep));
+        return ext::make_shared<NormalFwdRatePc>(marketModel, generatorFactory,
+                  numeraires, initialStep);
       default:
         QL_FAIL("unknown MarketModelEvolver type");
     }
@@ -710,10 +700,8 @@ BOOST_AUTO_TEST_CASE(testOneStepForwardsAndOptionlets) {
         displacedPayoffs(todaysForwards.size());
     for (Size i=0; i<todaysForwards.size(); ++i) {
         forwardStrikes[i] = todaysForwards[i] + 0.01;
-        optionletPayoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]));
-        displacedPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement));
+        optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
+        displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
     }
 
     OneStepForwards forwards(rateTimes, accruals,
@@ -795,8 +783,7 @@ BOOST_AUTO_TEST_CASE(testOneStepNormalForwardsAndOptionlets) {
         displacedPayoffs(todaysForwards.size());
     for (Size i=0; i<todaysForwards.size(); ++i) {
         forwardStrikes[i] = todaysForwards[i] + 0.01;
-        optionletPayoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]));
+        optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
         displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
     }
 
@@ -1104,11 +1091,9 @@ void addOptionLets(MultiProductComposite& product,
         displacedPayoffs(todaysForwards.size());
 
     for (Size i=0; i<todaysForwards.size(); ++i) {
-        optionletPayoffs[i] = ext::shared_ptr<Payoff>(new
-                                                      PlainVanillaPayoff(Option::Call, todaysForwards[i]));
+        optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i], 0.01));
-        displacedPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-                                                                 PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement));
+        displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i]+displacement, 0.01));
     }
 
@@ -1157,8 +1142,7 @@ void addCoterminalSwapsAndSwaptions(MultiProductComposite& product,
 
     std::vector<ext::shared_ptr<StrikedTypePayoff> > payoffs(todaysForwards.size());
     for (Size i = 0; i < payoffs.size(); ++i)
-        payoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-                                                        PlainVanillaPayoff(Option::Call, todaysForwards[i]));
+        payoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
 
     MultiStepCoterminalSwaptions swaptions(rateTimes,
                                            rateTimes, payoffs);
@@ -1197,7 +1181,7 @@ void addCoterminalSwapsAndSwaptions(MultiProductComposite& product,
         const Matrix& forwardsCovariance = marketModel->totalCovariance(i);
         Matrix cotSwapsCovariance =
             jacobian * forwardsCovariance * transpose(jacobian);
-        ext::shared_ptr<PlainVanillaPayoff> payoff(new PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement));
+        ext::shared_ptr<PlainVanillaPayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
 
         Real expectedSwaption =
             BlackCalculator(payoff,
@@ -1257,14 +1241,10 @@ BOOST_AUTO_TEST_CASE(testPeriodAdapter) {
 
     for (Size i=0; i<numberBigRates; ++i)
     {
-        optionletPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, bigRateCS.forwardRate(i)));
-        swaptionPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, bigRateCS.coterminalSwapRate(i)));
-        displacedOptionletPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, bigRateCS.forwardRate(i)+displacement));
-        displacedSwaptionPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, bigRateCS.coterminalSwapRate(i)+displacement));
+        optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, bigRateCS.forwardRate(i));
+        swaptionPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, bigRateCS.coterminalSwapRate(i));
+        displacedOptionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, bigRateCS.forwardRate(i)+displacement);
+        displacedSwaptionPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, bigRateCS.coterminalSwapRate(i)+displacement);
 
     }
 
@@ -1289,13 +1269,12 @@ BOOST_AUTO_TEST_CASE(testPeriodAdapter) {
 
     std::vector<Spread> newDisplacements;
 
-    ext::shared_ptr<MarketModel> adaptedforwardModel(new FwdPeriodAdapter(originalModel,
+    ext::shared_ptr<MarketModel> adaptedforwardModel = ext::make_shared<FwdPeriodAdapter>(originalModel,
         period,
         offset,
-        newDisplacements));
+        newDisplacements);
 
-    ext::shared_ptr<MarketModel> adaptedSwapModel(new
-        FwdToCotSwapAdapter(adaptedforwardModel));
+    ext::shared_ptr<MarketModel> adaptedSwapModel = ext::make_shared<FwdToCotSwapAdapter>(adaptedforwardModel);
 
     Matrix finalForwardCovariances(adaptedforwardModel->totalCovariance(adaptedforwardModel->numberOfSteps()-1));
     Matrix finalSwapCovariances(adaptedSwapModel->totalCovariance(adaptedSwapModel->numberOfSteps()-1));
@@ -1921,8 +1900,7 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
                     ext::shared_ptr<MarketModel> marketModel =
                         makeMarketModel(logNormal, evolution, factors, j);
 
-                    ext::shared_ptr<MarketModelEvolver> evolver(
-                        new LogNormalFwdRateEuler(marketModel, generatorFactory, numeraires));
+                    ext::shared_ptr<MarketModelEvolver> evolver = ext::make_shared<LogNormalFwdRateEuler>(marketModel, generatorFactory, numeraires);
                     SequenceStatisticsInc stats(product.numberOfProducts());
 
 
@@ -1948,14 +1926,14 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
                     Spread forwardBump = 1.0e-6;
                     marketModel = makeMarketModel(logNormal, evolution, factors, j, -forwardBump);
                     deltaGammaEvolvers.push_back(
-                        ext::shared_ptr<ConstrainedEvolver>(new LogNormalFwdRateEulerConstrained(
-                            marketModel, generatorFactory, numeraires)));
+                        ext::make_shared<LogNormalFwdRateEulerConstrained>(
+                            marketModel, generatorFactory, numeraires));
                     deltaGammaEvolvers.back()->setConstraintType(startIndexOfConstraint,
                                                                  endIndexOfConstraint);
                     marketModel = makeMarketModel(logNormal, evolution, factors, j, forwardBump);
                     deltaGammaEvolvers.push_back(
-                        ext::shared_ptr<ConstrainedEvolver>(new LogNormalFwdRateEulerConstrained(
-                            marketModel, generatorFactory, numeraires)));
+                        ext::make_shared<LogNormalFwdRateEulerConstrained>(
+                            marketModel, generatorFactory, numeraires));
                     deltaGammaEvolvers.back()->setConstraintType(startIndexOfConstraint,
                                                                  endIndexOfConstraint);
 
@@ -1975,14 +1953,14 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
                     Volatility volBump = 1.0e-4;
                     marketModel = makeMarketModel(logNormal, evolution, factors, j, 0.0, -volBump);
                     vegaEvolvers.push_back(
-                        ext::shared_ptr<ConstrainedEvolver>(new LogNormalFwdRateEulerConstrained(
-                            marketModel, generatorFactory, numeraires)));
+                        ext::make_shared<LogNormalFwdRateEulerConstrained>(
+                            marketModel, generatorFactory, numeraires));
                     vegaEvolvers.back()->setConstraintType(startIndexOfConstraint,
                                                            endIndexOfConstraint);
                     marketModel = makeMarketModel(logNormal, evolution, factors, j, 0.0, volBump);
                     vegaEvolvers.push_back(
-                        ext::shared_ptr<ConstrainedEvolver>(new LogNormalFwdRateEulerConstrained(
-                            marketModel, generatorFactory, numeraires)));
+                        ext::make_shared<LogNormalFwdRateEulerConstrained>(
+                            marketModel, generatorFactory, numeraires));
                     vegaEvolvers.back()->setConstraintType(startIndexOfConstraint,
                                                            endIndexOfConstraint);
 
@@ -2097,11 +2075,9 @@ BOOST_AUTO_TEST_CASE(testPathwiseGreeks) {
     std::vector<ext::shared_ptr<StrikedTypePayoff> >
         displacedPayoffs(todaysForwards.size());
     for (Size i=0; i<todaysForwards.size(); ++i) {
-        payoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]));
+        payoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i], 0.01));
-        displacedPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement));
+        displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i]+displacement, 0.01));
     }
 
@@ -2333,11 +2309,9 @@ BOOST_AUTO_TEST_CASE(testPathwiseVegas) {
     std::vector<ext::shared_ptr<StrikedTypePayoff> >
         displacedPayoffs(todaysForwards.size());
     for (Size i=0; i<todaysForwards.size(); ++i) {
-        payoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]));
+        payoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i], 0.01));
-        displacedPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement));
+        displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement);
         //CashOrNothingPayoff(Option::Call, todaysForwards[i]+displacement, 0.01));
     }
 
@@ -2674,7 +2648,7 @@ BOOST_AUTO_TEST_CASE(testPathwiseVegas) {
 
                                 PseudoRootFacade bumpedUp(pseudoRoots,rateTimes,marketModel->initialRates(),marketModel->displacements());
 
-                                CapPseudoDerivative upDerivative(ext::shared_ptr<MarketModel>(new PseudoRootFacade(bumpedUp)),
+                                CapPseudoDerivative upDerivative(ext::make_shared<PseudoRootFacade>(bumpedUp),
                                     capStrike,
                                     startIndex,
                                     endIndex,initialNumeraireValue);
@@ -2690,7 +2664,7 @@ BOOST_AUTO_TEST_CASE(testPathwiseVegas) {
 
                                 PseudoRootFacade bumpedDown(pseudoRoots,rateTimes,marketModel->initialRates(),marketModel->displacements());
 
-                                CapPseudoDerivative downDerivative(ext::shared_ptr<MarketModel>(new PseudoRootFacade(bumpedDown)),
+                                CapPseudoDerivative downDerivative(ext::make_shared<PseudoRootFacade>(bumpedDown),
                                     capStrike,
                                     startIndex,
                                     endIndex,initialNumeraireValue);
@@ -3376,8 +3350,7 @@ BOOST_AUTO_TEST_CASE(testPathwiseVegas) {
                     Matrix totalCovariance(marketModel->totalCovariance(marketModel->numberOfSteps()-1));
 
                     std::vector<Real> trueCapletPrices(numberRates);
-                    ext::shared_ptr<StrikedTypePayoff> dispayoff( new
-                        PlainVanillaPayoff(Option::Call, capStrike+displacement));
+                    ext::shared_ptr<StrikedTypePayoff> dispayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, capStrike+displacement);
 
                     for (Size r =0; r < trueCapletPrices.size(); ++r)
                         trueCapletPrices[r] = BlackCalculator(dispayoff, todaysForwards[r], sqrt(totalCovariance[r][r]),
@@ -3484,11 +3457,9 @@ BOOST_AUTO_TEST_CASE(testPathwiseMarketVegas) {
     std::vector<ext::shared_ptr<StrikedTypePayoff> >
         displacedPayoffs(todaysForwards.size());
     for (Size i=0; i<todaysForwards.size(); ++i) {
-        payoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, cs.coterminalSwapRate(i)));
+        payoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, cs.coterminalSwapRate(i));
 
-        displacedPayoffs[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, cs.coterminalSwapRate(i)+displacement));
+        displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, cs.coterminalSwapRate(i)+displacement);
 
     }
 
@@ -4143,7 +4114,7 @@ BOOST_AUTO_TEST_CASE(testAbcdVolatilityIntegration) {
     const Size N = 10;
     const Real precision = 1e-04;
 
-    ext::shared_ptr<AbcdFunction> instVol(new AbcdFunction(a,b,c,d));
+    ext::shared_ptr<AbcdFunction> instVol = ext::make_shared<AbcdFunction>(a,b,c,d);
     SegmentIntegral SI(20000);
     for (Size i=0; i<N; i++) {
         Time T1 = 0.5*(1+i);     // expiry of forward 1: after T1 AbcdVol = 0
@@ -4206,9 +4177,8 @@ BOOST_AUTO_TEST_CASE(testAbcdVolatilityCompare) {
     Size i1; // index of forward 1
     Size i2; // index of forward 2
 
-    ext::shared_ptr<LmVolatilityModel> lmAbcd(
-        new LmExtLinearExponentialVolModel(rateTimes,b,c,d,a));
-    ext::shared_ptr<AbcdFunction> abcd(new AbcdFunction(a,b,c,d));
+    ext::shared_ptr<LmVolatilityModel> lmAbcd = ext::make_shared<LmExtLinearExponentialVolModel>(rateTimes,b,c,d,a);
+    ext::shared_ptr<AbcdFunction> abcd = ext::make_shared<AbcdFunction>(a,b,c,d);
     for (i1=0; i1<rateTimes.size(); i1++ ) {
         for (i2=0; i2<rateTimes.size(); i2++ ) {
             Time T = 0.;
@@ -4297,10 +4267,8 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
     for (Size i=0; i<todaysForwards.size(); ++i)
     {
         forwardStrikes[i] = todaysForwards[i] + 0.01;
-        optionletPayoffs[i] = ext::shared_ptr<Payoff>(new
-            PlainVanillaPayoff(Option::Call, todaysForwards[i]));
-        /* displacedPayoffs[i] = ext::shared_ptr<PlainVanillaPayoff>(new
-           PlainVanillaPayoff(Option::Call, todaysForwards[i]+displacement)); */
+        optionletPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]);
+        /* displacedPayoffs[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, todaysForwards[i]+displacement); */
     }
 
     MultiStepForwards forwards(rateTimes, accruals,
@@ -4333,8 +4301,7 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
     Real w2=0.5;
     Real cutPoint = 1.5;
 
-    ext::shared_ptr<MarketModelVolProcess> volProcess(new
-                        SquareRootAndersen(meanLevel,
+    ext::shared_ptr<MarketModelVolProcess> volProcess = ext::make_shared<SquareRootAndersen>(meanLevel,
                              reversionSpeed,
                              volVar,
                              v0,
@@ -4342,7 +4309,7 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
                              numberSubSteps,
                              w1,
                              w2,
-                             cutPoint));
+                             cutPoint);
 
     for (auto& j : marketModels) {
 
@@ -4362,13 +4329,13 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
                 {
                     MTBrownianGeneratorFactory generatorFactory(seed_);
 
-                    ext::shared_ptr<MarketModelEvolver> evolver(new SVDDFwdRatePc(marketModel,
+                    ext::shared_ptr<MarketModelEvolver> evolver = ext::make_shared<SVDDFwdRatePc>(marketModel,
                                           generatorFactory,
                                           volProcess,
                                           firstVolatilityFactor,
                                           volatilityFactorStep,
                                           numeraires
-                                          ));
+                                          );
 
 
                     std::ostringstream config;
@@ -4418,8 +4385,7 @@ BOOST_AUTO_TEST_CASE(testStochVolForwardsAndOptionlets) {
                               Real rho = 0.0;
                               Real v1 = v0*volCoeff*volCoeff;
 
-                              ext::shared_ptr<StrikedTypePayoff> payoff(
-                                              new PlainVanillaPayoff(Option::Call, forwardStrikes[i]));
+                              ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, forwardStrikes[i]);
 
                               Real trueValue = AnalyticHestonEngine(
                                   ext::make_shared<HestonModel>(
@@ -4611,8 +4577,7 @@ BOOST_AUTO_TEST_CASE(testCovariance) {
     std::vector<Real> vols(n-1,1.0);
 
     Matrix c = exponentialCorrelations(rateTimes,0.5,0.2,1.0,0.0);
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(
-                          new TimeHomogeneousForwardCorrelation(c,rateTimes));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(c,rateTimes);
 
     std::vector<std::string> modelNames;
     modelNames.emplace_back("FlatVol");
@@ -4624,13 +4589,11 @@ BOOST_AUTO_TEST_CASE(testCovariance) {
             ext::shared_ptr<MarketModel> model;
             switch(k) {
               case 0:
-                model = ext::shared_ptr<MarketModel>(
-                            new FlatVol(vols,corr,evolution,n-1,rates,displ));
+                model = ext::make_shared<FlatVol>(vols,corr,evolution,n-1,rates,displ);
                 break;
               case 1:
-                model = ext::shared_ptr<MarketModel>(
-                                 new AbcdVol(1.0,0.0,1.0E-50,0.0,ks,
-                                             corr,evolution,n-1,rates,displ));
+                model = ext::make_shared<AbcdVol>(1.0,0.0,1.0E-50,0.0,ks,
+                                             corr,evolution,n-1,rates,displ);
                 break;
               default:
                 BOOST_FAIL("Unknown model " << modelNames[k]);

--- a/test-suite/marketmodel_cms.cpp
+++ b/test-suite/marketmodel_cms.cpp
@@ -168,8 +168,7 @@ simulate(const ext::shared_ptr<MarketModelEvolver>& evolver,
     Real initialNumeraireValue = todaysDiscounts[initialNumeraire];
 
     AccountingEngine engine(evolver, product, initialNumeraireValue);
-    ext::shared_ptr<SequenceStatisticsInc> stats(
-                          new SequenceStatisticsInc(product.numberOfProducts()));
+    ext::shared_ptr<SequenceStatisticsInc> stats = ext::make_shared<SequenceStatisticsInc>(product.numberOfProducts());
     engine.multiplePathValues(*stats, paths_);
     return stats;
 }
@@ -202,11 +201,9 @@ ext::shared_ptr<MarketModel> makeMarketModel(
 
     std::vector<Time> fixingTimes(evolution.rateTimes());
     fixingTimes.pop_back();
-    ext::shared_ptr<LmVolatilityModel> volModel(new
-            LmExtLinearExponentialVolModel(fixingTimes, 0.5, 0.6, 0.1, 0.1));
-    ext::shared_ptr<LmCorrelationModel> corrModel(new
-            LmLinearExponentialCorrelationModel(evolution.numberOfRates(),
-                                                longTermCorrelation, beta));
+    ext::shared_ptr<LmVolatilityModel> volModel = ext::make_shared<LmExtLinearExponentialVolModel>(fixingTimes, 0.5, 0.6, 0.1, 0.1);
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmLinearExponentialCorrelationModel>(evolution.numberOfRates(),
+                                                longTermCorrelation, beta);
     std::vector<Rate> bumpedRates(todaysCMSwapRates.size());
     LMMCurveState curveState_lmm(rateTimes);
     curveState_lmm.setOnForwardRates(todaysForwards);
@@ -223,29 +220,26 @@ ext::shared_ptr<MarketModel> makeMarketModel(
     Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                   longTermCorrelation,
                                                   beta);
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-                                                       TimeHomogeneousForwardCorrelation(correlations,
-                                                                                         evolution.rateTimes()));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(correlations,
+                                                                                         evolution.rateTimes());
     switch (marketModelType) {
       case ExponentialCorrelationFlatVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                FlatVol(bumpedVols,
+        return ext::make_shared<FlatVol>(bumpedVols,
                                corr,
                                evolution,
                                numberOfFactors,
                                bumpedRates,
                                std::vector<Spread>(bumpedRates.size(),
-                                                   displacement)));
+                                                   displacement));
       case ExponentialCorrelationAbcdVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                AbcdVol(0.0,0.0,1.0,1.0,
+        return ext::make_shared<AbcdVol>(0.0,0.0,1.0,1.0,
                                bumpedVols,
                                corr,
                                evolution,
                                numberOfFactors,
                                bumpedRates,
                                std::vector<Spread>(bumpedRates.size(),
-                                                   displacement)));
+                                                   displacement));
         //case CalibratedMM:
         //    return ext::shared_ptr<MarketModel>(new
         //        CalibratedMarketModel(volModel, corrModel,
@@ -341,11 +335,10 @@ ext::shared_ptr<MarketModelEvolver> makeMarketModelEvolver(
                                                            Size initialStep = 0) {
     switch (evolverType) {
       case Pc:
-        return ext::shared_ptr<MarketModelEvolver>(new
-                LogNormalCmSwapRatePc(spanningForwards,
+        return ext::make_shared<LogNormalCmSwapRatePc>(spanningForwards,
                                     marketModel, generatorFactory,
                                     numeraires,
-                                    initialStep));
+                                    initialStep);
       default:
         QL_FAIL("unknown ConstantMaturitySwapMarketModelEvolver type");
     }
@@ -446,11 +439,9 @@ BOOST_AUTO_TEST_CASE(testMultiStepCmSwapsAndSwaptions) {
     std::vector<ext::shared_ptr<StrikedTypePayoff> >
         displacedPayoff(todaysForwards.size()), undisplacedPayoff(todaysForwards.size());
     for (Size i=0; i<undisplacedPayoff.size(); ++i) {
-        displacedPayoff[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, fixedRate+displacement));
+        displacedPayoff[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, fixedRate+displacement);
 
-        undisplacedPayoff[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, fixedRate));
+        undisplacedPayoff[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, fixedRate);
     }
 
     // until ConstantMaturitySwap is ready

--- a/test-suite/marketmodel_smm.cpp
+++ b/test-suite/marketmodel_smm.cpp
@@ -166,8 +166,7 @@ simulate(const ext::shared_ptr<MarketModelEvolver>& evolver,
     Real initialNumeraireValue = todaysDiscounts[initialNumeraire];
 
     AccountingEngine engine(evolver, product, initialNumeraireValue);
-    ext::shared_ptr<SequenceStatisticsInc> stats(
-                          new SequenceStatisticsInc(product.numberOfProducts()));
+    ext::shared_ptr<SequenceStatisticsInc> stats = ext::make_shared<SequenceStatisticsInc>(product.numberOfProducts());
     engine.multiplePathValues(*stats, paths_);
     return stats;
 }
@@ -201,11 +200,9 @@ ext::shared_ptr<MarketModel> makeMarketModel(
 
     std::vector<Time> fixingTimes(evolution.rateTimes());
     fixingTimes.pop_back();
-    ext::shared_ptr<LmVolatilityModel> volModel(new
-            LmExtLinearExponentialVolModel(fixingTimes, 0.5, 0.6, 0.1, 0.1));
-    ext::shared_ptr<LmCorrelationModel> corrModel(new
-            LmLinearExponentialCorrelationModel(evolution.numberOfRates(),
-                                                longTermCorrelation, beta));
+    ext::shared_ptr<LmVolatilityModel> volModel = ext::make_shared<LmExtLinearExponentialVolModel>(fixingTimes, 0.5, 0.6, 0.1, 0.1);
+    ext::shared_ptr<LmCorrelationModel> corrModel = ext::make_shared<LmLinearExponentialCorrelationModel>(evolution.numberOfRates(),
+                                                longTermCorrelation, beta);
     std::vector<Rate> bumpedRates(todaysForwards.size());
     LMMCurveState curveState_lmm(rateTimes);
     curveState_lmm.setOnForwardRates(todaysForwards);
@@ -221,27 +218,24 @@ ext::shared_ptr<MarketModel> makeMarketModel(
     Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
                                                   longTermCorrelation,
                                                   beta);
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-            TimeHomogeneousForwardCorrelation(correlations,
-                                              evolution.rateTimes()));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(correlations,
+                                              evolution.rateTimes());
     switch (marketModelType) {
       case ExponentialCorrelationFlatVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                FlatVol(bumpedVols,
+        return ext::make_shared<FlatVol>(bumpedVols,
                                corr,
                                evolution,
                                numberOfFactors,
                                bumpedRates,
-                               std::vector<Spread>(bumpedRates.size(), displacement)));
+                               std::vector<Spread>(bumpedRates.size(), displacement));
       case ExponentialCorrelationAbcdVolatility:
-        return ext::shared_ptr<MarketModel>(new
-                AbcdVol(0.0,0.0,1.0,1.0,
+        return ext::make_shared<AbcdVol>(0.0,0.0,1.0,1.0,
                                bumpedVols,
                                corr,
                                evolution,
                                numberOfFactors,
                                bumpedRates,
-                               std::vector<Spread>(bumpedRates.size(), displacement)));
+                               std::vector<Spread>(bumpedRates.size(), displacement));
         //case CalibratedMM:
         //    return ext::shared_ptr<MarketModel>(new
         //        CalibratedMarketModel(volModel, corrModel,
@@ -335,10 +329,9 @@ ext::shared_ptr<MarketModelEvolver> makeMarketModelEvolver(
                                                            Size initialStep = 0) {
     switch (evolverType) {
       case Pc:
-        return ext::shared_ptr<MarketModelEvolver>(new
-                LogNormalCotSwapRatePc(marketModel, generatorFactory,
+        return ext::make_shared<LogNormalCotSwapRatePc>(marketModel, generatorFactory,
                                             numeraires,
-                                            initialStep));
+                                            initialStep);
       default:
         QL_FAIL("unknown CoterminalSwapMarketModelEvolver type");
     }
@@ -439,11 +432,9 @@ BOOST_AUTO_TEST_CASE(testMultiStepCoterminalSwapsAndSwaptions) {
     std::vector<ext::shared_ptr<StrikedTypePayoff> >
         displacedPayoff(todaysForwards.size()), undisplacedPayoff(todaysForwards.size());
     for (Size i=0; i<undisplacedPayoff.size(); ++i) {
-        displacedPayoff[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, fixedRate+displacement));
+        displacedPayoff[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, fixedRate+displacement);
 
-        undisplacedPayoff[i] = ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(Option::Call, fixedRate));
+        undisplacedPayoff[i] = ext::make_shared<PlainVanillaPayoff>(Option::Call, fixedRate);
     }
 
     MultiStepCoterminalSwaptions swaptions(rateTimes,

--- a/test-suite/marketmodel_smmcapletalphacalibration.cpp
+++ b/test-suite/marketmodel_smmcapletalphacalibration.cpp
@@ -224,23 +224,20 @@ BOOST_AUTO_TEST_CASE(testFunction) {
     EvolutionDescription evolution(rateTimes_);
     // Size numberOfSteps = evolution.numberOfSteps();
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr(new
-        ExponentialForwardCorrelation(rateTimes_,
+    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr = ext::make_shared<ExponentialForwardCorrelation>(rateTimes_,
                                       longTermCorrelation_,
-                                      beta_));
+                                      beta_);
 
-    ext::shared_ptr<LMMCurveState> cs(new LMMCurveState(rateTimes_));
+    ext::shared_ptr<LMMCurveState> cs = ext::make_shared<LMMCurveState>(rateTimes_);
     cs->setOnForwardRates(todaysForwards_);
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-        CotSwapFromFwdCorrelation(fwdCorr, *cs, displacement_));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<CotSwapFromFwdCorrelation>(fwdCorr, *cs, displacement_);
 
     std::vector<ext::shared_ptr<PiecewiseConstantVariance> >
                                     swapVariances(numberOfRates);
     for (Size i=0; i<numberOfRates; ++i) {
-        swapVariances[i] = ext::shared_ptr<PiecewiseConstantVariance>(new
-            PiecewiseConstantAbcdVariance(a_, b_, c_, d_,
-                                          i, rateTimes_));
+        swapVariances[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(a_, b_, c_, d_,
+                                          i, rateTimes_);
     }
 
     // create calibrator
@@ -289,11 +286,10 @@ BOOST_AUTO_TEST_CASE(testFunction) {
         BOOST_ERROR("calibration failed");
 
     const std::vector<Matrix>& swapPseudoRoots = calibrator.swapPseudoRoots();
-    ext::shared_ptr<MarketModel> smm(new
-        PseudoRootFacade(swapPseudoRoots,
+    ext::shared_ptr<MarketModel> smm = ext::make_shared<PseudoRootFacade>(swapPseudoRoots,
                          rateTimes_,
                          cs->coterminalSwapRates(),
-                         std::vector<Spread>(numberOfRates, displacement_)));
+                         std::vector<Spread>(numberOfRates, displacement_));
     CotSwapToFwdAdapter flmm(smm);
     Matrix capletTotCovariance = flmm.totalCovariance(numberOfRates-1);
 

--- a/test-suite/marketmodel_smmcapletcalibration.cpp
+++ b/test-suite/marketmodel_smmcapletcalibration.cpp
@@ -222,23 +222,20 @@ BOOST_AUTO_TEST_CASE(testFunction) {
     EvolutionDescription evolution(rateTimes_);
     // Size numberOfSteps = evolution.numberOfSteps();
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr(new
-        ExponentialForwardCorrelation(rateTimes_,
+    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr = ext::make_shared<ExponentialForwardCorrelation>(rateTimes_,
                                       longTermCorrelation_,
-                                      beta_));
+                                      beta_);
 
-    ext::shared_ptr<LMMCurveState> cs(new LMMCurveState(rateTimes_));
+    ext::shared_ptr<LMMCurveState> cs = ext::make_shared<LMMCurveState>(rateTimes_);
     cs->setOnForwardRates(todaysForwards_);
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-        CotSwapFromFwdCorrelation(fwdCorr, *cs, displacement_));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<CotSwapFromFwdCorrelation>(fwdCorr, *cs, displacement_);
 
     std::vector<ext::shared_ptr<PiecewiseConstantVariance> >
                                     swapVariances(numberOfRates);
     for (Size i=0; i<numberOfRates; ++i) {
-        swapVariances[i] = ext::shared_ptr<PiecewiseConstantVariance>(new
-            PiecewiseConstantAbcdVariance(a_, b_, c_, d_,
-                                          i, rateTimes_));
+        swapVariances[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(a_, b_, c_, d_,
+                                          i, rateTimes_);
     }
 
     // create calibrator
@@ -280,11 +277,10 @@ BOOST_AUTO_TEST_CASE(testFunction) {
         BOOST_ERROR("calibration failed");
 
     const std::vector<Matrix>& swapPseudoRoots = calibrator.swapPseudoRoots();
-    ext::shared_ptr<MarketModel> smm(new
-        PseudoRootFacade(swapPseudoRoots,
+    ext::shared_ptr<MarketModel> smm = ext::make_shared<PseudoRootFacade>(swapPseudoRoots,
                          rateTimes_,
                          cs->coterminalSwapRates(),
-                         std::vector<Spread>(numberOfRates, displacement_)));
+                         std::vector<Spread>(numberOfRates, displacement_));
     CotSwapToFwdAdapter flmm(smm);
     Matrix capletTotCovariance = flmm.totalCovariance(numberOfRates-1);
 

--- a/test-suite/marketmodel_smmcaplethomocalibration.cpp
+++ b/test-suite/marketmodel_smmcaplethomocalibration.cpp
@@ -234,23 +234,20 @@ BOOST_AUTO_TEST_CASE(testFunction) {
     EvolutionDescription evolution(rateTimes_);
     // Size numberOfSteps = evolution.numberOfSteps();
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr(new
-        ExponentialForwardCorrelation(rateTimes_,
+    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr = ext::make_shared<ExponentialForwardCorrelation>(rateTimes_,
                                       longTermCorrelation_,
-                                      beta_));
+                                      beta_);
 
-    ext::shared_ptr<LMMCurveState> cs(new LMMCurveState(rateTimes_));
+    ext::shared_ptr<LMMCurveState> cs = ext::make_shared<LMMCurveState>(rateTimes_);
     cs->setOnForwardRates(todaysForwards_);
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-        CotSwapFromFwdCorrelation(fwdCorr, *cs, displacement_));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<CotSwapFromFwdCorrelation>(fwdCorr, *cs, displacement_);
 
     std::vector<ext::shared_ptr<PiecewiseConstantVariance> >
                                     swapVariances(numberOfRates);
     for (Size i=0; i<numberOfRates; ++i) {
-        swapVariances[i] = ext::shared_ptr<PiecewiseConstantVariance>(new
-            PiecewiseConstantAbcdVariance(a_, b_, c_, d_,
-                                          i, rateTimes_));
+        swapVariances[i] = ext::make_shared<PiecewiseConstantAbcdVariance>(a_, b_, c_, d_,
+                                          i, rateTimes_);
     }
 
     // create calibrator
@@ -288,12 +285,11 @@ BOOST_AUTO_TEST_CASE(testFunction) {
         BOOST_ERROR("calibration failed");
 
     const std::vector<Matrix>& swapPseudoRoots = calibrator.swapPseudoRoots();
-    ext::shared_ptr<MarketModel> smm(new
-        PseudoRootFacade(swapPseudoRoots,
+    ext::shared_ptr<MarketModel> smm = ext::make_shared<PseudoRootFacade>(swapPseudoRoots,
                          rateTimes_,
                          cs->coterminalSwapRates(),
-                         std::vector<Spread>(numberOfRates, displacement_)));
-    ext::shared_ptr<MarketModel> flmm(new CotSwapToFwdAdapter(smm));
+                         std::vector<Spread>(numberOfRates, displacement_));
+    ext::shared_ptr<MarketModel> flmm = ext::make_shared<CotSwapToFwdAdapter>(smm);
     Matrix capletTotCovariance = flmm->totalCovariance(numberOfRates-1);
 
     std::vector<Volatility> capletVols(numberOfRates);
@@ -342,7 +338,7 @@ BOOST_AUTO_TEST_CASE(testFunction) {
     Size period =2;
     Size offset =0;
     std::vector<Spread> adaptedDisplacements;
-    ext::shared_ptr<MarketModel> adapted(new FwdPeriodAdapter(flmm,period,offset,adaptedDisplacements));
+    ext::shared_ptr<MarketModel> adapted = ext::make_shared<FwdPeriodAdapter>(flmm,period,offset,adaptedDisplacements);
    // FwdToCotSwapAdapter newSwapMM(adapted);
    // for (Size i=0; i < newSwapMM.numberOfRates(); ++i)
      //      BOOST_TEST_MESSAGE("swap MM time dependent vols: "<< i << std::fixed <<
@@ -368,16 +364,14 @@ BOOST_AUTO_TEST_CASE(testPeriodFunction) {
     for (Size i=0; i <= numberBigRates; ++i)
         bigRateTimes[i] = rateTimes_[i*period+offset];
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr(new
-        ExponentialForwardCorrelation(rateTimes_,
+    ext::shared_ptr<PiecewiseConstantCorrelation> fwdCorr = ext::make_shared<ExponentialForwardCorrelation>(rateTimes_,
                                       longTermCorrelation_,
-                                      beta_));
+                                      beta_);
 
-    ext::shared_ptr<LMMCurveState> cs(new LMMCurveState(rateTimes_));
+    ext::shared_ptr<LMMCurveState> cs = ext::make_shared<LMMCurveState>(rateTimes_);
     cs->setOnForwardRates(todaysForwards_);
 
-    ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-        CotSwapFromFwdCorrelation(fwdCorr, *cs, displacement_));
+    ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<CotSwapFromFwdCorrelation>(fwdCorr, *cs, displacement_);
 
     std::vector<PiecewiseConstantAbcdVariance >
                                     swapVariances;
@@ -450,12 +444,11 @@ BOOST_AUTO_TEST_CASE(testPeriodFunction) {
         );
 
 
-    ext::shared_ptr<MarketModel> smm(new
-        PseudoRootFacade(swapPseudoRoots,
+    ext::shared_ptr<MarketModel> smm = ext::make_shared<PseudoRootFacade>(swapPseudoRoots,
                          rateTimes_,
                          cs->coterminalSwapRates(),
-                         std::vector<Spread>(numberOfRates, displacement_)));
-    ext::shared_ptr<MarketModel> flmm(new CotSwapToFwdAdapter(smm));
+                         std::vector<Spread>(numberOfRates, displacement_));
+    ext::shared_ptr<MarketModel> flmm = ext::make_shared<CotSwapToFwdAdapter>(smm);
     Matrix capletTotCovariance = flmm->totalCovariance(numberOfRates-1);
 
 
@@ -484,9 +477,9 @@ BOOST_AUTO_TEST_CASE(testPeriodFunction) {
 
 
     std::vector<Spread> adaptedDisplacements(numberBigRates,displacement_);
-    ext::shared_ptr<MarketModel> adaptedFlmm(new FwdPeriodAdapter(flmm,period,offset,adaptedDisplacements));
+    ext::shared_ptr<MarketModel> adaptedFlmm = ext::make_shared<FwdPeriodAdapter>(flmm,period,offset,adaptedDisplacements);
 
-     ext::shared_ptr<MarketModel> adaptedsmm(new FwdToCotSwapAdapter(adaptedFlmm));
+     ext::shared_ptr<MarketModel> adaptedsmm = ext::make_shared<FwdToCotSwapAdapter>(adaptedFlmm);
 
       // check perfect swaption fit
     Real  swapTolerance = 2e-5;

--- a/test-suite/markovfunctional.cpp
+++ b/test-suite/markovfunctional.cpp
@@ -65,8 +65,7 @@ BOOST_AUTO_TEST_SUITE(MarkovFunctionalTests)
 
 Handle<YieldTermStructure> flatYts() {
 
-    return Handle<YieldTermStructure>(ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(0, TARGET(), 0.03, Actual365Fixed())));
+    return Handle<YieldTermStructure>(ext::make_shared<FlatForward>(0, TARGET(), 0.03, Actual365Fixed()));
 }
 
 // Flat swaption volatility structure at 20%
@@ -74,9 +73,8 @@ Handle<YieldTermStructure> flatYts() {
 Handle<SwaptionVolatilityStructure> flatSwaptionVts() {
 
     return Handle<SwaptionVolatilityStructure>(
-            ext::shared_ptr<SwaptionVolatilityStructure>(
-                new ConstantSwaptionVolatility(0, TARGET(), ModifiedFollowing,
-                                               0.20, Actual365Fixed())));
+            ext::make_shared<ConstantSwaptionVolatility>(0, TARGET(), ModifiedFollowing,
+                                               0.20, Actual365Fixed()));
 }
 
 // Flat cap volatility structure at 20%
@@ -84,16 +82,15 @@ Handle<SwaptionVolatilityStructure> flatSwaptionVts() {
 Handle<OptionletVolatilityStructure> flatOptionletVts() {
 
     return Handle<OptionletVolatilityStructure>(
-            ext::shared_ptr<OptionletVolatilityStructure>(
-                new ConstantOptionletVolatility(0, TARGET(), ModifiedFollowing,
-                                                0.20, Actual365Fixed())));
+            ext::make_shared<ConstantOptionletVolatility>(0, TARGET(), ModifiedFollowing,
+                                                0.20, Actual365Fixed()));
 }
 
 // Yield term structure as of 14.11.2012 (6m discounting)
 
 Handle<YieldTermStructure> md0Yts() {
 
-    ext::shared_ptr<IborIndex> euribor6mEmpty(new Euribor(6 * Months));
+    ext::shared_ptr<IborIndex> euribor6mEmpty = ext::make_shared<Euribor>(6 * Months);
 
     std::vector<ext::shared_ptr<Quote> > q6m;
     std::vector<ext::shared_ptr<RateHelper> > r6m;
@@ -128,7 +125,7 @@ Handle<YieldTermStructure> md0Yts() {
 
     q6m.reserve(10 + 15 + 35);
     for (Real i : q6mh) {
-        q6m.push_back(ext::shared_ptr<Quote>(new SimpleQuote(i)));
+        q6m.push_back(ext::make_shared<SimpleQuote>(i));
     }
 
     r6m.reserve(10);
@@ -224,16 +221,15 @@ Handle<SwaptionVolatilityStructure> md0SwaptionVts() {
         qSwAtmTmp.reserve(14);
         for (int j = 0; j < 14; j++) {
             qSwAtmTmp.emplace_back(
-                    ext::shared_ptr<Quote>(new SimpleQuote(qSwAtmh[i * 14 + j])));
+                    ext::make_shared<SimpleQuote>(qSwAtmh[i * 14 + j]));
         }
         qSwAtm.push_back(qSwAtmTmp);
     }
 
     Handle<SwaptionVolatilityStructure> swaptionVolAtm(
-            ext::shared_ptr<SwaptionVolatilityStructure>(
-                new SwaptionVolatilityMatrix(TARGET(), ModifiedFollowing,
+            ext::make_shared<SwaptionVolatilityMatrix>(TARGET(), ModifiedFollowing,
                                              optionTenors, swapTenors, qSwAtm,
-                                             Actual365Fixed())));
+                                             Actual365Fixed()));
 
     std::vector<Period> optionTenorsSmile = { 3 * Months, 1 * Years,  5 * Years,
                                               10 * Years, 20 * Years, 30 * Years };
@@ -291,7 +287,7 @@ Handle<SwaptionVolatilityStructure> md0SwaptionVts() {
         qSwSmileTmp.reserve(9);
         for (int j = 0; j < 9; j++) {
             qSwSmileTmp.emplace_back(
-                    ext::shared_ptr<Quote>(new SimpleQuote(qSwSmileh[i * 9 + j])));
+                    ext::make_shared<SimpleQuote>(qSwSmileh[i * 9 + j]));
         }
         qSwSmile.push_back(qSwSmileTmp);
     }
@@ -317,19 +313,18 @@ Handle<SwaptionVolatilityStructure> md0SwaptionVts() {
         parameterGuessTmp.reserve(4);
         for (int j = 0; j < 4; j++) {
             parameterGuessTmp.emplace_back(
-                    ext::shared_ptr<Quote>(new SimpleQuote(qSwSmileh1[i * 4 + j])));
+                    ext::make_shared<SimpleQuote>(qSwSmileh1[i * 4 + j]));
         }
         parameterGuess.push_back(parameterGuessTmp);
     }
 
-    ext::shared_ptr<EndCriteria> ec(
-            new EndCriteria(50000, 250, 1E-6, 1E-6, 1E-6));
+    ext::shared_ptr<EndCriteria> ec = ext::make_shared<EndCriteria>(50000, 250, 1E-6, 1E-6, 1E-6);
 
-    ext::shared_ptr<SwapIndex> swapIndex(new EuriborSwapIsdaFixA(
-            30 * Years, Handle<YieldTermStructure>(md0Yts())));
-    ext::shared_ptr<SwapIndex> shortSwapIndex(new EuriborSwapIsdaFixA(
+    ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<EuriborSwapIsdaFixA>(
+            30 * Years, Handle<YieldTermStructure>(md0Yts()));
+    ext::shared_ptr<SwapIndex> shortSwapIndex = ext::make_shared<EuriborSwapIsdaFixA>(
             1 * Years,
-            Handle<YieldTermStructure>(md0Yts()))); // We assume that we have 6m
+            Handle<YieldTermStructure>(md0Yts())); // We assume that we have 6m
                                                     // vols (which we actually
                                                     // don't have for 1y
                                                     // underlying, but this is
@@ -339,11 +334,11 @@ Handle<SwaptionVolatilityStructure> md0SwaptionVts() {
     // InterpolatedSwaptionVolatilityCube(swaptionVolAtm,optionTenorsSmile,swapTenorsSmile,strikeSpreads,qSwSmile,swapIndex,shortSwapIndex,false));
     // // bilinear interpolation gives nasty digitals
     Handle<SwaptionVolatilityStructure> res(
-            ext::shared_ptr<SwaptionVolatilityStructure>(new SabrSwaptionVolatilityCube(
+            ext::make_shared<SabrSwaptionVolatilityCube>(
                 swaptionVolAtm, optionTenorsSmile, swapTenorsSmile,
                 strikeSpreads, qSwSmile, swapIndex, shortSwapIndex, true,
                 parameterGuess, parameterFixed, true, ec,
-                0.0050))); // put a big error tolerance here ... we just want a
+                0.0050)); // put a big error tolerance here ... we just want a
                            // smooth cube for testing
     res->enableExtrapolation();
     return res;
@@ -421,16 +416,13 @@ Handle<OptionletVolatilityStructure> md0OptionletVts() {
         }
     }
 
-    ext::shared_ptr<IborIndex> iborIndex(
-            new Euribor(6 * Months, md0Yts()));
-    ext::shared_ptr<CapFloorTermVolSurface> cf(new CapFloorTermVolSurface(
-            0, TARGET(), ModifiedFollowing, optionTenors, strikes, vols));
-    ext::shared_ptr<OptionletStripper> stripper(
-            new OptionletStripper1(cf, iborIndex));
+    ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor>(6 * Months, md0Yts());
+    ext::shared_ptr<CapFloorTermVolSurface> cf = ext::make_shared<CapFloorTermVolSurface>(
+            0, TARGET(), ModifiedFollowing, optionTenors, strikes, vols);
+    ext::shared_ptr<OptionletStripper> stripper = ext::make_shared<OptionletStripper1>(cf, iborIndex);
 
     return Handle<OptionletVolatilityStructure>(
-            ext::shared_ptr<OptionletVolatilityStructure>(
-                new StrippedOptionletAdapter(stripper)));
+            ext::make_shared<StrippedOptionletAdapter>(stripper));
 }
 
 // Calibration Basket 1: CMS10y Swaptions, 5 yearly fixings
@@ -660,13 +652,11 @@ BOOST_AUTO_TEST_CASE(testKahaleSmileSection) {
     }
 
     std::vector<Real> stdDevs0 = impliedStdDevs(atm, strikes, calls0);
-    ext::shared_ptr<SmileSection> sec1(
-        new InterpolatedSmileSection<Linear>(t, strikes, stdDevs0, atm));
+    ext::shared_ptr<SmileSection> sec1 = ext::make_shared<InterpolatedSmileSection<Linear>>(t, strikes, stdDevs0, atm);
 
     // test arbitrage free smile reproduction
 
-    ext::shared_ptr<KahaleSmileSection> ksec11(
-        new KahaleSmileSection(sec1, atm, false, false, false, money));
+    ext::shared_ptr<KahaleSmileSection> ksec11 = ext::make_shared<KahaleSmileSection>(sec1, atm, false, false, false, money);
 
     if (std::fabs(ksec11->leftCoreStrike() - 0.01) > tol)
         BOOST_ERROR("smile11 left af strike is " << ksec11->leftCoreStrike()
@@ -689,8 +679,7 @@ BOOST_AUTO_TEST_CASE(testKahaleSmileSection) {
 
     // test interpolation
 
-    ext::shared_ptr<KahaleSmileSection> ksec12(
-        new KahaleSmileSection(sec1, atm, true, false, false, money));
+    ext::shared_ptr<KahaleSmileSection> ksec12 = ext::make_shared<KahaleSmileSection>(sec1, atm, true, false, false, money);
 
     // sanity check for left point extrapolation may mark 0.01 as bad as well as
     // good depending
@@ -734,8 +723,7 @@ BOOST_AUTO_TEST_CASE(testKahaleSmileSection) {
 
     // test exponential extrapolation
 
-    ext::shared_ptr<KahaleSmileSection> ksec13(
-        new KahaleSmileSection(sec1, atm, false, true, false, money));
+    ext::shared_ptr<KahaleSmileSection> ksec13 = ext::make_shared<KahaleSmileSection>(sec1, atm, false, true, false, money);
 
     k = strikes.back();
     Real dig0 = ksec13->digitalOptionPrice(k - 0.0010);
@@ -753,13 +741,10 @@ BOOST_AUTO_TEST_CASE(testKahaleSmileSection) {
     calls1[0] = (atm - strikes[0]) +
                 0.0010; // introduce arbitrage by changing call price
     std::vector<Real> stdDevs1 = impliedStdDevs(atm, strikes, calls1);
-    ext::shared_ptr<SmileSection> sec2(
-        new InterpolatedSmileSection<Linear>(t, strikes, stdDevs1, atm));
+    ext::shared_ptr<SmileSection> sec2 = ext::make_shared<InterpolatedSmileSection<Linear>>(t, strikes, stdDevs1, atm);
 
-    ext::shared_ptr<KahaleSmileSection> ksec21(
-        new KahaleSmileSection(sec2, atm, false, false, false, money));
-    ext::shared_ptr<KahaleSmileSection> ksec22(
-        new KahaleSmileSection(sec2, atm, true, false, true, money));
+    ext::shared_ptr<KahaleSmileSection> ksec21 = ext::make_shared<KahaleSmileSection>(sec2, atm, false, false, false, money);
+    ext::shared_ptr<KahaleSmileSection> ksec22 = ext::make_shared<KahaleSmileSection>(sec2, atm, true, false, true, money);
 
     if (std::fabs(ksec21->leftCoreStrike() - 0.02) > tol)
         BOOST_ERROR("smile21 left af strike is " << ksec21->leftCoreStrike()
@@ -797,13 +782,10 @@ BOOST_AUTO_TEST_CASE(testKahaleSmileSection) {
     calls2[8] = 0.9 * calls2[9] +
                 0.1 * calls2[8]; // introduce arbitrage by changing call price
     std::vector<Real> stdDevs2 = impliedStdDevs(atm, strikes, calls2);
-    ext::shared_ptr<SmileSection> sec3(
-        new InterpolatedSmileSection<Linear>(t, strikes, stdDevs2, atm));
+    ext::shared_ptr<SmileSection> sec3 = ext::make_shared<InterpolatedSmileSection<Linear>>(t, strikes, stdDevs2, atm);
 
-    ext::shared_ptr<KahaleSmileSection> ksec31(
-        new KahaleSmileSection(sec3, atm, false, false, false, money));
-    ext::shared_ptr<KahaleSmileSection> ksec32(
-        new KahaleSmileSection(sec3, atm, true, false, true, money));
+    ext::shared_ptr<KahaleSmileSection> ksec31 = ext::make_shared<KahaleSmileSection>(sec3, atm, false, false, false, money);
+    ext::shared_ptr<KahaleSmileSection> ksec32 = ext::make_shared<KahaleSmileSection>(sec3, atm, true, false, true, money);
 
     if (std::fabs(ksec31->leftCoreStrike() - 0.01) > tol)
         BOOST_ERROR("smile31 left af strike is " << ksec31->leftCoreStrike()
@@ -872,8 +854,7 @@ BOOST_AUTO_TEST_CASE(testSmileSectionUtilsWShapedSmile) {
     }
 
     std::vector<Real> stdDevs = impliedStdDevs(atm, strikes, calls);
-    ext::shared_ptr<SmileSection> sec(
-        new InterpolatedSmileSection<Linear>(t, strikes, stdDevs, atm));
+    ext::shared_ptr<SmileSection> sec = ext::make_shared<InterpolatedSmileSection<Linear>>(t, strikes, stdDevs, atm);
 
     // SmileSectionUtils must construct without crashing.
     // The central index will be pushed rightward through the
@@ -910,9 +891,8 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
     Handle<OptionletVolatilityStructure> flatOptionletVts_ = flatOptionletVts();
     Handle<OptionletVolatilityStructure> md0OptionletVts_ = md0OptionletVts();
 
-    ext::shared_ptr<SwapIndex> swapIndexBase(
-        new EuriborSwapIsdaFixA(1 * Years));
-    ext::shared_ptr<IborIndex> iborIndex(new Euribor(6 * Months));
+    ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1 * Years);
+    ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor>(6 * Months);
 
     std::vector<Date> volStepDates;
     std::vector<Real> vols = {1.0};
@@ -924,7 +904,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
 
     // Calibration Basket 1 / flat yts, vts
 
-    ext::shared_ptr<MarkovFunctional> mf1(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf1 = ext::make_shared<MarkovFunctional>(
         flatYts_, 0.01, volStepDates, vols, flatSwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -940,7 +920,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
             .withAdjustments(
                  MarkovFunctional::ModelSettings::KahaleSmile |
                  MarkovFunctional::ModelSettings::SmileExponentialExtrapolation)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs1 =
         mf1->modelOutputs(); // this costs a lot of time, so only use it if you
@@ -977,7 +957,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
 
     // Calibration Basket 2 / flat yts, vts
 
-    ext::shared_ptr<MarkovFunctional> mf2(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf2 = ext::make_shared<MarkovFunctional>(
         flatYts_, 0.01, volStepDates, vols, flatOptionletVts_,
         expiriesCalBasket2(), iborIndex,
         MarkovFunctional::ModelSettings()
@@ -989,7 +969,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
             .withAdjustments(MarkovFunctional::ModelSettings::AdjustNone)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs2 = mf2->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs2);
@@ -1024,7 +1004,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
 
     // Calibration Basket 1 / real yts, vts
 
-    ext::shared_ptr<MarkovFunctional> mf3(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf3 = ext::make_shared<MarkovFunctional>(
         md0Yts_, 0.01, volStepDates, vols, md0SwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -1035,7 +1015,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs3 = mf3->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs3);
@@ -1071,8 +1051,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
 
     // Calibration Basket 2 / real yts, vts
 
-    ext::shared_ptr<MarkovFunctional> mf4(
-        new MarkovFunctional(md0Yts_, 0.01, volStepDates, vols,
+    ext::shared_ptr<MarkovFunctional> mf4 = ext::make_shared<MarkovFunctional>(md0Yts_, 0.01, volStepDates, vols,
                              md0OptionletVts_, expiriesCalBasket2(), iborIndex,
                              MarkovFunctional::ModelSettings()
                                  .withYGridPoints(64)
@@ -1082,7 +1061,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationOneInstrumentSet) {
                                  .withMarketRateAccuracy(1e-7)
                                  .withLowerRateBound(0.0)
                                  .withUpperRateBound(2.0)
-                                 .withSmileMoneynessCheckpoints(money)));
+                                 .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs4 = mf4->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs4);
@@ -1136,8 +1115,7 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
     Handle<OptionletVolatilityStructure> flatOptionletVts_ = flatOptionletVts();
     Handle<OptionletVolatilityStructure> md0OptionletVts_ = md0OptionletVts();
 
-    ext::shared_ptr<SwapIndex> swapIndexBase(
-        new EuriborSwapIsdaFixA(1 * Years));
+    ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1 * Years);
 
     std::vector<Date> volStepDates;
     std::vector<Real> vols = {1.0};
@@ -1147,9 +1125,9 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
 
     // Calibration Basket 1 / flat yts, vts
 
-    ext::shared_ptr<IborIndex> iborIndex1(new Euribor(6 * Months, flatYts_));
+    ext::shared_ptr<IborIndex> iborIndex1 = ext::make_shared<Euribor>(6 * Months, flatYts_);
 
-    ext::shared_ptr<MarkovFunctional> mf1(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf1 = ext::make_shared<MarkovFunctional>(
         flatYts_, 0.01, volStepDates, vols, flatSwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -1160,15 +1138,13 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs1 = mf1->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs1);
 
-    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine1(
-        new Gaussian1dSwaptionEngine(mf1, 64, 7.0));
-    ext::shared_ptr<BlackSwaptionEngine> blackSwaptionEngine1(
-        new BlackSwaptionEngine(flatYts_, flatSwaptionVts_));
+    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine1 = ext::make_shared<Gaussian1dSwaptionEngine>(mf1, 64, 7.0);
+    ext::shared_ptr<BlackSwaptionEngine> blackSwaptionEngine1 = ext::make_shared<BlackSwaptionEngine>(flatYts_, flatSwaptionVts_);
 
     for (Size i = 0; i < outputs1.expiries_.size(); i++) {
         for (Size j = 0; j < outputs1.smileStrikes_[0].size(); j++) {
@@ -1184,8 +1160,7 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
                     .withEffectiveDate(
                          TARGET().advance(outputs1.expiries_[i], 2, Days))
                     .receiveFixed(true);
-            ext::shared_ptr<Exercise> exercise(
-                new EuropeanExercise(outputs1.expiries_[i]));
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(outputs1.expiries_[i]);
             Swaption swaptionC(underlyingCall, exercise);
             Swaption swaptionP(underlyingPut, exercise);
             swaptionC.setPricingEngine(blackSwaptionEngine1);
@@ -1211,9 +1186,9 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
 
     // Calibration Basket 2 / flat yts, vts
 
-    ext::shared_ptr<IborIndex> iborIndex2(new Euribor(6 * Months, flatYts_));
+    ext::shared_ptr<IborIndex> iborIndex2 = ext::make_shared<Euribor>(6 * Months, flatYts_);
 
-    ext::shared_ptr<MarkovFunctional> mf2(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf2 = ext::make_shared<MarkovFunctional>(
         flatYts_, 0.01, volStepDates, vols, flatOptionletVts_,
         expiriesCalBasket2(), iborIndex2,
         MarkovFunctional::ModelSettings()
@@ -1224,15 +1199,13 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     MarkovFunctional::ModelOutputs outputs2 = mf2->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs2);
 
-    ext::shared_ptr<BlackCapFloorEngine> blackCapFloorEngine2(
-        new BlackCapFloorEngine(flatYts_, flatOptionletVts_));
-    ext::shared_ptr<Gaussian1dCapFloorEngine> mfCapFloorEngine2(
-        new Gaussian1dCapFloorEngine(mf2, 64, 7.0));
+    ext::shared_ptr<BlackCapFloorEngine> blackCapFloorEngine2 = ext::make_shared<BlackCapFloorEngine>(flatYts_, flatOptionletVts_);
+    ext::shared_ptr<Gaussian1dCapFloorEngine> mfCapFloorEngine2 = ext::make_shared<Gaussian1dCapFloorEngine>(mf2, 64, 7.0);
     std::vector<CapFloor> c2 = {
         MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.01),
         MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex2, 0.02),
@@ -1264,9 +1237,9 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
 
     // Calibration Basket 1 / real yts, vts
 
-    ext::shared_ptr<IborIndex> iborIndex3(new Euribor(6 * Months, md0Yts_));
+    ext::shared_ptr<IborIndex> iborIndex3 = ext::make_shared<Euribor>(6 * Months, md0Yts_);
 
-    ext::shared_ptr<MarkovFunctional> mf3(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf3 = ext::make_shared<MarkovFunctional>(
         md0Yts_, 0.01, volStepDates, vols, md0SwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -1277,12 +1250,10 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
-    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine3(
-        new Gaussian1dSwaptionEngine(mf3, 64, 7.0));
-    ext::shared_ptr<BlackSwaptionEngine> blackSwaptionEngine3(
-        new BlackSwaptionEngine(md0Yts_, md0SwaptionVts_));
+    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine3 = ext::make_shared<Gaussian1dSwaptionEngine>(mf3, 64, 7.0);
+    ext::shared_ptr<BlackSwaptionEngine> blackSwaptionEngine3 = ext::make_shared<BlackSwaptionEngine>(md0Yts_, md0SwaptionVts_);
 
     MarkovFunctional::ModelOutputs outputs3 = mf3->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs3);
@@ -1301,8 +1272,7 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
                     .withEffectiveDate(
                          TARGET().advance(outputs3.expiries_[i], 2, Days))
                     .receiveFixed(true);
-            ext::shared_ptr<Exercise> exercise(
-                new EuropeanExercise(outputs3.expiries_[i]));
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(outputs3.expiries_[i]);
             Swaption swaptionC(underlyingCall, exercise);
             Swaption swaptionP(underlyingPut, exercise);
             swaptionC.setPricingEngine(blackSwaptionEngine3);
@@ -1336,9 +1306,9 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
 
     // Calibration Basket 2 / real yts, vts
 
-    ext::shared_ptr<IborIndex> iborIndex4(new Euribor(6 * Months, md0Yts_));
+    ext::shared_ptr<IborIndex> iborIndex4 = ext::make_shared<Euribor>(6 * Months, md0Yts_);
 
-    ext::shared_ptr<MarkovFunctional> mf4(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf4 = ext::make_shared<MarkovFunctional>(
         md0Yts_, 0.01, volStepDates, vols, md0OptionletVts_,
         expiriesCalBasket2(), iborIndex4,
         MarkovFunctional::ModelSettings()
@@ -1355,15 +1325,13 @@ BOOST_AUTO_TEST_CASE(testVanillaEngines) {
         // MarkovFunctional::ModelSettings::KahaleInterpolation
         //| MarkovFunctional::ModelSettings::KahaleExponentialExtrapolation
         //)
-        ));
+        );
 
     MarkovFunctional::ModelOutputs outputs4 = mf4->modelOutputs();
     // BOOST_TEST_MESSAGE(outputs4);
 
-    ext::shared_ptr<BlackCapFloorEngine> blackCapFloorEngine4(
-        new BlackCapFloorEngine(md0Yts_, md0OptionletVts_));
-    ext::shared_ptr<Gaussian1dCapFloorEngine> mfCapFloorEngine4(
-        new Gaussian1dCapFloorEngine(mf4, 64, 7.0));
+    ext::shared_ptr<BlackCapFloorEngine> blackCapFloorEngine4 = ext::make_shared<BlackCapFloorEngine>(md0Yts_, md0OptionletVts_);
+    ext::shared_ptr<Gaussian1dCapFloorEngine> mfCapFloorEngine4 = ext::make_shared<Gaussian1dCapFloorEngine>(mf4, 64, 7.0);
 
     std::vector<CapFloor> c4 = {
         MakeCapFloor(CapFloor::Cap, 5 * Years, iborIndex4, 0.01),
@@ -1414,8 +1382,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
     Handle<OptionletVolatilityStructure> flatOptionletVts_ = flatOptionletVts();
     Handle<OptionletVolatilityStructure> md0OptionletVts_ = md0OptionletVts();
 
-    ext::shared_ptr<SwapIndex> swapIndexBase(
-        new EuriborSwapIsdaFixA(1 * Years));
+    ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1 * Years);
 
     std::vector<Date> volStepDates = {
         TARGET().advance(referenceDate, 1 * Years),
@@ -1433,37 +1400,29 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
     // Calibration Basket 1 / flat yts, vts / Secondary calibration set consists
     // of coterminal swaptions
 
-    ext::shared_ptr<IborIndex> iborIndex1(new Euribor(6 * Months, flatYts_));
+    ext::shared_ptr<IborIndex> iborIndex1 = ext::make_shared<Euribor>(6 * Months, flatYts_);
 
     std::vector<ext::shared_ptr<BlackCalibrationHelper> > calibrationHelper1;
     std::vector<Real> calibrationHelperVols1 = {0.20, 0.20, 0.20, 0.20};
 
-    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(1 * Years, 4 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols1[0]))),
+    calibrationHelper1.push_back(ext::make_shared<SwaptionHelper>(1 * Years, 4 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols1[0])),
                            iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(2 * Years, 3 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols1[1]))),
+                           flatYts_));
+    calibrationHelper1.push_back(ext::make_shared<SwaptionHelper>(2 * Years, 3 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols1[1])),
                            iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(3 * Years, 2 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols1[2]))),
+                           flatYts_));
+    calibrationHelper1.push_back(ext::make_shared<SwaptionHelper>(3 * Years, 2 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols1[2])),
                            iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           flatYts_)));
-    calibrationHelper1.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(4 * Years, 1 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols1[3]))),
+                           flatYts_));
+    calibrationHelper1.push_back(ext::make_shared<SwaptionHelper>(4 * Years, 1 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols1[3])),
                            iborIndex1, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           flatYts_)));
+                           flatYts_));
 
-    ext::shared_ptr<MarkovFunctional> mf1(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf1 = ext::make_shared<MarkovFunctional>(
         flatYts_, 0.01, volStepDates, vols, flatSwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -1474,10 +1433,9 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
-    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine1(
-        new Gaussian1dSwaptionEngine(mf1, 64, 7.0));
+    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine1 = ext::make_shared<Gaussian1dSwaptionEngine>(mf1, 64, 7.0);
     calibrationHelper1[0]->setPricingEngine(mfSwaptionEngine1);
     calibrationHelper1[1]->setPricingEngine(mfSwaptionEngine1);
     calibrationHelper1[2]->setPricingEngine(mfSwaptionEngine1);
@@ -1492,25 +1450,20 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
 
     std::vector<Swaption> ch1;
     ch1.push_back(
-        MakeSwaption(ext::shared_ptr<SwapIndex>(
-                         new EuriborSwapIsdaFixA(4 * Years, flatYts_)),
+        MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(4 * Years, flatYts_),
                      1 * Years));
     ch1.push_back(
-        MakeSwaption(ext::shared_ptr<SwapIndex>(
-                         new EuriborSwapIsdaFixA(3 * Years, flatYts_)),
+        MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(3 * Years, flatYts_),
                      2 * Years));
     ch1.push_back(
-        MakeSwaption(ext::shared_ptr<SwapIndex>(
-                         new EuriborSwapIsdaFixA(2 * Years, flatYts_)),
+        MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(2 * Years, flatYts_),
                      3 * Years));
     ch1.push_back(
-        MakeSwaption(ext::shared_ptr<SwapIndex>(
-                         new EuriborSwapIsdaFixA(1 * Years, flatYts_)),
+        MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(1 * Years, flatYts_),
                      4 * Years));
 
     for (Size i = 0; i < ch1.size(); i++) {
-        ext::shared_ptr<BlackSwaptionEngine> blackEngine(
-            new BlackSwaptionEngine(flatYts_, calibrationHelperVols1[i]));
+        ext::shared_ptr<BlackSwaptionEngine> blackEngine = ext::make_shared<BlackSwaptionEngine>(flatYts_, calibrationHelperVols1[i]);
         ch1[i].setPricingEngine(blackEngine);
         Real blackPrice = ch1[i].NPV();
         Real blackVega = ch1[i].result<Real>("vega");
@@ -1530,9 +1483,9 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
     // Calibration Basket 1 / real yts, vts / Secondary calibration set consists
     // of coterminal swaptions
 
-    ext::shared_ptr<IborIndex> iborIndex2(new Euribor(6 * Months, md0Yts_));
+    ext::shared_ptr<IborIndex> iborIndex2 = ext::make_shared<Euribor>(6 * Months, md0Yts_);
 
-    ext::shared_ptr<MarkovFunctional> mf2(new MarkovFunctional(
+    ext::shared_ptr<MarkovFunctional> mf2 = ext::make_shared<MarkovFunctional>(
         md0Yts_, 0.01, volStepDates, vols, md0SwaptionVts_,
         expiriesCalBasket1(), tenorsCalBasket1(), swapIndexBase,
         MarkovFunctional::ModelSettings()
@@ -1543,7 +1496,7 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
             .withMarketRateAccuracy(1e-7)
             .withLowerRateBound(0.0)
             .withUpperRateBound(2.0)
-            .withSmileMoneynessCheckpoints(money)));
+            .withSmileMoneynessCheckpoints(money));
 
     std::vector<ext::shared_ptr<BlackCalibrationHelper> > calibrationHelper2;
     std::vector<Real> calibrationHelperVols2;
@@ -1564,33 +1517,24 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
         ext::dynamic_pointer_cast<SwaptionVolatilityCube>(
             md0SwaptionVts_.currentLink())->atmStrike(4 * Years, 1 * Years)));
 
-    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(1 * Years, 4 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols2[0]))),
+    calibrationHelper2.push_back(ext::make_shared<SwaptionHelper>(1 * Years, 4 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols2[0])),
                            iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(2 * Years, 3 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols2[1]))),
+                           md0Yts_));
+    calibrationHelper2.push_back(ext::make_shared<SwaptionHelper>(2 * Years, 3 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols2[1])),
                            iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(3 * Years, 2 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols2[2]))),
+                           md0Yts_));
+    calibrationHelper2.push_back(ext::make_shared<SwaptionHelper>(3 * Years, 2 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols2[2])),
                            iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           md0Yts_)));
-    calibrationHelper2.push_back(ext::shared_ptr<BlackCalibrationHelper>(
-        new SwaptionHelper(4 * Years, 1 * Years,
-                           Handle<Quote>(ext::shared_ptr<Quote>(
-                               new SimpleQuote(calibrationHelperVols2[3]))),
+                           md0Yts_));
+    calibrationHelper2.push_back(ext::make_shared<SwaptionHelper>(4 * Years, 1 * Years,
+                           Handle<Quote>(ext::make_shared<SimpleQuote>(calibrationHelperVols2[3])),
                            iborIndex2, 1 * Years, Thirty360(Thirty360::BondBasis), Actual360(),
-                           md0Yts_)));
+                           md0Yts_));
 
-    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine2(
-        new Gaussian1dSwaptionEngine(mf2, 64, 7.0));
+    ext::shared_ptr<Gaussian1dSwaptionEngine> mfSwaptionEngine2 = ext::make_shared<Gaussian1dSwaptionEngine>(mf2, 64, 7.0);
     calibrationHelper2[0]->setPricingEngine(mfSwaptionEngine2);
     calibrationHelper2[1]->setPricingEngine(mfSwaptionEngine2);
     calibrationHelper2[2]->setPricingEngine(mfSwaptionEngine2);
@@ -1604,22 +1548,17 @@ BOOST_AUTO_TEST_CASE(testCalibrationTwoInstrumentSets) {
     // std::cout << std::endl;
 
     std::vector<Swaption> ch2;
-    ch2.push_back(MakeSwaption(ext::shared_ptr<SwapIndex>(
-                                   new EuriborSwapIsdaFixA(4 * Years, md0Yts_)),
+    ch2.push_back(MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(4 * Years, md0Yts_),
                                1 * Years));
-    ch2.push_back(MakeSwaption(ext::shared_ptr<SwapIndex>(
-                                   new EuriborSwapIsdaFixA(3 * Years, md0Yts_)),
+    ch2.push_back(MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(3 * Years, md0Yts_),
                                2 * Years));
-    ch2.push_back(MakeSwaption(ext::shared_ptr<SwapIndex>(
-                                   new EuriborSwapIsdaFixA(2 * Years, md0Yts_)),
+    ch2.push_back(MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(2 * Years, md0Yts_),
                                3 * Years));
-    ch2.push_back(MakeSwaption(ext::shared_ptr<SwapIndex>(
-                                   new EuriborSwapIsdaFixA(1 * Years, md0Yts_)),
+    ch2.push_back(MakeSwaption(ext::make_shared<EuriborSwapIsdaFixA>(1 * Years, md0Yts_),
                                4 * Years));
 
     for (Size i = 0; i < ch2.size(); i++) {
-        ext::shared_ptr<BlackSwaptionEngine> blackEngine(
-            new BlackSwaptionEngine(md0Yts_, calibrationHelperVols2[i]));
+        ext::shared_ptr<BlackSwaptionEngine> blackEngine = ext::make_shared<BlackSwaptionEngine>(md0Yts_, calibrationHelperVols2[i]);
         ch2[i].setPricingEngine(blackEngine);
         Real blackPrice = ch2[i].NPV();
         Real blackVega = ch2[i].result<Real>("vega");
@@ -1653,16 +1592,14 @@ BOOST_AUTO_TEST_CASE(testBermudanSwaption) {
     Handle<OptionletVolatilityStructure> flatOptionletVts_ = flatOptionletVts();
     Handle<OptionletVolatilityStructure> md0OptionletVts_ = md0OptionletVts();
 
-    ext::shared_ptr<SwapIndex> swapIndexBase(
-        new EuriborSwapIsdaFixA(1 * Years));
+    ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1 * Years);
 
     std::vector<Date> volStepDates;
     std::vector<Real> vols = {1.0};
 
-    ext::shared_ptr<IborIndex> iborIndex1(new Euribor(6 * Months, md0Yts_));
+    ext::shared_ptr<IborIndex> iborIndex1 = ext::make_shared<Euribor>(6 * Months, md0Yts_);
 
-    ext::shared_ptr<MarkovFunctional> mf1(
-        new MarkovFunctional(md0Yts_, 0.01, volStepDates, vols, md0SwaptionVts_,
+    ext::shared_ptr<MarkovFunctional> mf1 = ext::make_shared<MarkovFunctional>(md0Yts_, 0.01, volStepDates, vols, md0SwaptionVts_,
                              expiriesCalBasket3(), tenorsCalBasket3(),
                              swapIndexBase, MarkovFunctional::ModelSettings()
                                                 .withYGridPoints(32)
@@ -1671,10 +1608,9 @@ BOOST_AUTO_TEST_CASE(testBermudanSwaption) {
                                                 .withMarketRateAccuracy(1e-7)
                                                 .withDigitalGap(1e-5)
                                                 .withLowerRateBound(0.0)
-                                                .withUpperRateBound(2.0)));
+                                                .withUpperRateBound(2.0));
 
-    ext::shared_ptr<PricingEngine> mfSwaptionEngine1(
-        new Gaussian1dSwaptionEngine(mf1, 64, 7.0));
+    ext::shared_ptr<PricingEngine> mfSwaptionEngine1 = ext::make_shared<Gaussian1dSwaptionEngine>(mf1, 64, 7.0);
 
     ext::shared_ptr<VanillaSwap> underlyingCall =
         MakeVanillaSwap(10 * Years, iborIndex1, 0.03)
@@ -1687,13 +1623,12 @@ BOOST_AUTO_TEST_CASE(testBermudanSwaption) {
     std::vector<Swaption> europeanSwaptions;
     for (Size i = 0; i < expiries.size(); i++) {
         europeanExercises.push_back(
-            ext::shared_ptr<Exercise>(new EuropeanExercise(expiries[i])));
+            ext::make_shared<EuropeanExercise>(expiries[i]));
         europeanSwaptions.emplace_back(underlyingCall, europeanExercises[i]);
         europeanSwaptions.back().setPricingEngine(mfSwaptionEngine1);
     }
 
-    ext::shared_ptr<Exercise> bermudanExercise(
-        new BermudanExercise(expiries));
+    ext::shared_ptr<Exercise> bermudanExercise = ext::make_shared<BermudanExercise>(expiries);
     Swaption bermudanSwaption(underlyingCall, bermudanExercise);
     bermudanSwaption.setPricingEngine(mfSwaptionEngine1);
 

--- a/test-suite/mclongstaffschwartzengine.cpp
+++ b/test-suite/mclongstaffschwartzengine.cpp
@@ -108,8 +108,7 @@ class MCAmericanMaxEngine
                                                     processArray->process(0));
         QL_REQUIRE(process, "generalized Black-Scholes proces required");
 
-        ext::shared_ptr<AmericanMaxPathPricer> earlyExercisePathPricer(
-                          new AmericanMaxPathPricer(this->arguments_.payoff));
+        ext::shared_ptr<AmericanMaxPathPricer> earlyExercisePathPricer = ext::make_shared<AmericanMaxPathPricer>(this->arguments_.payoff);
 
         return ext::make_shared<LongstaffSchwartzPathPricer<MultiPath> > (
                 
@@ -137,16 +136,13 @@ BOOST_AUTO_TEST_CASE(testAmericanOption) {
     const Date maturity(17, May, 1999);
     const DayCounter dayCounter = Actual365Fixed();
 
-    ext::shared_ptr<Exercise> americanExercise(
-        new AmericanExercise(settlementDate, maturity));
+    ext::shared_ptr<Exercise> americanExercise = ext::make_shared<AmericanExercise>(settlementDate, maturity);
 
     // bootstrap the yield/dividend/vol curves
     Handle<YieldTermStructure> flatTermStructure(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
     Handle<YieldTermStructure> flatDividendTS(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(settlementDate, dividendYield, dayCounter)));
+            ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
 
     // expected results for exercise probability, evaluated with third-party
     // product (using Cox-Rubinstein binomial tree)
@@ -166,20 +162,18 @@ BOOST_AUTO_TEST_CASE(testAmericanOption) {
     for (Integer i=0; i<2; ++i) {
         for (Integer j=0; j<3; ++j) {
             Handle<BlackVolTermStructure> flatVolTS(
-                ext::shared_ptr<BlackVolTermStructure>(
-                    new BlackConstantVol(settlementDate, NullCalendar(),
-                                         volatility+0.1*j, dayCounter)));
+                ext::make_shared<BlackConstantVol>(settlementDate, NullCalendar(),
+                                         volatility+0.1*j, dayCounter));
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(
-                new PlainVanillaPayoff(type, underlying+4*i));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, underlying+4*i);
 
             Handle<Quote> underlyingH(
-                ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+                ext::make_shared<SimpleQuote>(underlying));
 
             ext::shared_ptr<GeneralizedBlackScholesProcess>
-                stochasticProcess(new GeneralizedBlackScholesProcess(
+                stochasticProcess = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       underlyingH, flatDividendTS,
-                                      flatTermStructure, flatVolTS));
+                                      flatTermStructure, flatVolTS);
 
             VanillaOption americanOption(payoff, americanExercise);
 
@@ -198,8 +192,7 @@ BOOST_AUTO_TEST_CASE(testAmericanOption) {
             const Real exerciseProbability =
                 americanOption.result<QuantLib::Real>("exerciseProbability");
 
-            americanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                        new FdBlackScholesVanillaEngine(stochasticProcess, 401, 200)));
+            americanOption.setPricingEngine(ext::make_shared<FdBlackScholesVanillaEngine>(stochasticProcess, 401, 200));
             const Real expected = americanOption.NPV();
 
             // Check price
@@ -243,30 +236,24 @@ BOOST_AUTO_TEST_CASE(testAmericanMaxOption) {
     const Date maturity(16, May, 2001);
     const DayCounter dayCounter = Actual365Fixed();
 
-    ext::shared_ptr<Exercise> americanExercise(
-        new AmericanExercise(settlementDate, maturity));
+    ext::shared_ptr<Exercise> americanExercise = ext::make_shared<AmericanExercise>(settlementDate, maturity);
 
     // bootstrap the yield/dividend/vol curves
     Handle<YieldTermStructure> flatTermStructure(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(settlementDate, riskFreeRate, dayCounter)));
+        ext::make_shared<FlatForward>(settlementDate, riskFreeRate, dayCounter));
     Handle<YieldTermStructure> flatDividendTS(
-        ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(settlementDate, dividendYield, dayCounter)));
+        ext::make_shared<FlatForward>(settlementDate, dividendYield, dayCounter));
 
     Handle<BlackVolTermStructure> flatVolTS(
-        ext::shared_ptr<BlackVolTermStructure>(new
-            BlackConstantVol(settlementDate, NullCalendar(),
-                             volatility, dayCounter)));
+        ext::make_shared<BlackConstantVol>(settlementDate, NullCalendar(),
+                             volatility, dayCounter));
 
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(type, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
     RelinkableHandle<Quote> underlyingH;
 
-    ext::shared_ptr<GeneralizedBlackScholesProcess> stochasticProcess(new
-        GeneralizedBlackScholesProcess(
-            underlyingH, flatDividendTS, flatTermStructure, flatVolTS));
+    ext::shared_ptr<GeneralizedBlackScholesProcess> stochasticProcess = ext::make_shared<GeneralizedBlackScholesProcess>(
+            underlyingH, flatDividendTS, flatTermStructure, flatVolTS);
 
     const Size numberAssets = 2;
     Matrix corr(numberAssets, numberAssets, 0.0);
@@ -277,15 +264,13 @@ BOOST_AUTO_TEST_CASE(testAmericanMaxOption) {
         corr[i][i] = 1.0;
     }
 
-    ext::shared_ptr<StochasticProcessArray> process(
-        new StochasticProcessArray(v, corr));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(v, corr);
     VanillaOption americanMaxOption(payoff, americanExercise);
 
-    ext::shared_ptr<PricingEngine> mcengine(
-        new MCAmericanMaxEngine<PseudoRandom>(process, 25, Null<Size>(), false,
+    ext::shared_ptr<PricingEngine> mcengine = ext::make_shared<MCAmericanMaxEngine<PseudoRandom>>(process, 25, Null<Size>(), false,
                                               true, false, 4096,
                                               Null<Real>(), Null<Size>(),
-                                              42, 1024));
+                                              42, 1024);
     americanMaxOption.setPricingEngine(mcengine);
 
     const Real expected[] = {8.08, 13.90, 21.34};
@@ -293,7 +278,7 @@ BOOST_AUTO_TEST_CASE(testAmericanMaxOption) {
 
         const Real underlying = 90.0 + i*10.0;
         underlyingH.linkTo(
-            ext::shared_ptr<Quote>(new SimpleQuote(underlying)));
+            ext::make_shared<SimpleQuote>(underlying));
 
         const Real calculated  = americanMaxOption.NPV();
         const Real errorEstimate = americanMaxOption.errorEstimate();

--- a/test-suite/nthtodefault.cpp
+++ b/test-suite/nthtodefault.cpp
@@ -135,27 +135,24 @@ BOOST_AUTO_TEST_CASE(testGauss) {
         TARGET().advance (asofDate, Period (7, Years))
     };
 
-    ext::shared_ptr<YieldTermStructure> yieldPtr (
-                                   new FlatForward (asofDate, rate, dc, cmp));
+    ext::shared_ptr<YieldTermStructure> yieldPtr = ext::make_shared<FlatForward>(asofDate, rate, dc, cmp);
     Handle<YieldTermStructure> yieldHandle (yieldPtr);
 
     std::vector<Handle<DefaultProbabilityTermStructure> > probabilities;
     Period maxTerm (10, Years);
     for (Real i : lambda) {
-        Handle<Quote> h(ext::shared_ptr<Quote>(new SimpleQuote(i)));
-        ext::shared_ptr<DefaultProbabilityTermStructure> ptr (
-                                         new FlatHazardRate(asofDate, h, dc));
+        Handle<Quote> h(ext::make_shared<SimpleQuote>(i));
+        ext::shared_ptr<DefaultProbabilityTermStructure> ptr = ext::make_shared<FlatHazardRate>(asofDate, h, dc);
         probabilities.emplace_back(ptr);
     }
 
-    ext::shared_ptr<SimpleQuote> simpleQuote (new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> simpleQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> correlationHandle (simpleQuote);
 
-    ext::shared_ptr<DefaultLossModel> copula( new
-        ConstantLossModel<GaussianCopulaPolicy>( correlationHandle,
+    ext::shared_ptr<DefaultLossModel> copula = ext::make_shared<ConstantLossModel<GaussianCopulaPolicy>>( correlationHandle,
         std::vector<Real>(names, recovery),
         LatentModelIntegrationType::GaussianQuadrature, names,
-        GaussianCopulaPolicy::initTraits()));
+        GaussianCopulaPolicy::initTraits());
 
     /* If you like the action you can price with the simulation engine below
     instead below. But you need at least 1e6 simulations to pass the pricing
@@ -198,11 +195,10 @@ BOOST_AUTO_TEST_CASE(testGauss) {
     std::vector<DefaultProbKey> defaultKeys(probabilities.size(),
         NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
 
-    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds,
-        std::vector<Real>(names, namesNotional/names), thePool, 0., 1.));
+    ext::shared_ptr<Basket> basket = ext::make_shared<Basket>(asofDate, namesIds,
+        std::vector<Real>(names, namesNotional/names), thePool, 0., 1.);
 
-    ext::shared_ptr<PricingEngine> engine(
-        new IntegralNtdEngine(timeUnit, yieldHandle));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<IntegralNtdEngine>(timeUnit, yieldHandle);
 
     std::vector<NthToDefault> ntd;
     for (Size i = 1; i <= probabilities.size(); i++) {
@@ -273,28 +269,25 @@ BOOST_AUTO_TEST_CASE(testStudent) {
         TARGET().advance (asofDate, Period (7, Years))
     };
 
-    ext::shared_ptr<YieldTermStructure> yieldPtr (
-                                new FlatForward (asofDate, rate, dc, cmp));
+    ext::shared_ptr<YieldTermStructure> yieldPtr = ext::make_shared<FlatForward>(asofDate, rate, dc, cmp);
     Handle<YieldTermStructure> yieldHandle (yieldPtr);
 
     std::vector<Handle<DefaultProbabilityTermStructure> > probabilities;
     Period maxTerm (10, Years);
     for (Real i : lambda) {
-        Handle<Quote> h(ext::shared_ptr<Quote>(new SimpleQuote(i)));
-        ext::shared_ptr<DefaultProbabilityTermStructure> ptr (
-                                         new FlatHazardRate(asofDate, h, dc));
+        Handle<Quote> h(ext::make_shared<SimpleQuote>(i));
+        ext::shared_ptr<DefaultProbabilityTermStructure> ptr = ext::make_shared<FlatHazardRate>(asofDate, h, dc);
         probabilities.emplace_back(ptr);
     }
 
-    ext::shared_ptr<SimpleQuote> simpleQuote (new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> simpleQuote = ext::make_shared<SimpleQuote>(0.0);
     Handle<Quote> correlationHandle (simpleQuote);
 
     TCopulaPolicy::initTraits iniT;
     iniT.tOrders = std::vector<QuantLib::Integer>(2,5);
-    ext::shared_ptr<DefaultLossModel> copula( new
-        ConstantLossModel<TCopulaPolicy>( correlationHandle,
+    ext::shared_ptr<DefaultLossModel> copula = ext::make_shared<ConstantLossModel<TCopulaPolicy>>( correlationHandle,
         std::vector<Real>(names, recovery),
-        LatentModelIntegrationType::GaussianQuadrature, names, iniT));
+        LatentModelIntegrationType::GaussianQuadrature, names, iniT);
 
     // Set up pool and basket
     std::vector<std::string> namesIds;
@@ -320,11 +313,10 @@ BOOST_AUTO_TEST_CASE(testStudent) {
     std::vector<DefaultProbKey> defaultKeys(probabilities.size(),
         NorthAmericaCorpDefaultKey(EURCurrency(), SeniorSec, Period(), 1.));
 
-    ext::shared_ptr<Basket> basket(new Basket(asofDate, namesIds,
-        std::vector<Real>(names, namesNotional/names), thePool, 0., 1.));
+    ext::shared_ptr<Basket> basket = ext::make_shared<Basket>(asofDate, namesIds,
+        std::vector<Real>(names, namesNotional/names), thePool, 0., 1.);
 
-    ext::shared_ptr<PricingEngine> engine(
-        new IntegralNtdEngine(timeUnit, yieldHandle));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<IntegralNtdEngine>(timeUnit, yieldHandle);
 
     std::vector<NthToDefault> ntd;
     for (Size i = 1; i <= probabilities.size(); i++) {

--- a/test-suite/observable.cpp
+++ b/test-suite/observable.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(testObservableSettings) {
 
     BOOST_TEST_MESSAGE("Testing observable settings...");
 
-    const ext::shared_ptr<SimpleQuote> quote(new SimpleQuote(100.0));
+    const ext::shared_ptr<SimpleQuote> quote = ext::make_shared<SimpleQuote>(100.0);
     UpdateCounter updateCounter;
 
     updateCounter.registerWith(quote);
@@ -197,13 +197,13 @@ BOOST_AUTO_TEST_CASE(testAsyncGarbagCollector) {
     // of the observer pattern (comparable situation
     // in JVM or .NET eco systems).
 
-    const ext::shared_ptr<SimpleQuote> quote(new SimpleQuote(-1.0));
+    const ext::shared_ptr<SimpleQuote> quote = ext::make_shared<SimpleQuote>(-1.0);
 
     GarbageCollector gc;
     std::thread workerThread(&GarbageCollector::run, &gc);
 
     for (Size i=0; i < 10000; ++i) {
-        const ext::shared_ptr<MTUpdateCounter> observer(new MTUpdateCounter);
+        const ext::shared_ptr<MTUpdateCounter> observer = ext::make_shared<MTUpdateCounter>();
         observer->registerWith(quote);
         gc.addObj(observer);
 
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(testMultiThreadingGlobalSettings) {
 	BOOST_TEST_MESSAGE("Testing observer global settings in a "
 		               "multithreading environment...");
 	
-	const ext::shared_ptr<SimpleQuote> quote(new SimpleQuote(-1.0));
+	const ext::shared_ptr<SimpleQuote> quote = ext::make_shared<SimpleQuote>(-1.0);
 
     ObservableSettings::instance().disableUpdates(true);
 
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(testMultiThreadingGlobalSettings) {
     local_list_type localList;
 
     for (Size i=0; i < 4000; ++i) {
-        const ext::shared_ptr<MTUpdateCounter> observer(new MTUpdateCounter);
+        const ext::shared_ptr<MTUpdateCounter> observer = ext::make_shared<MTUpdateCounter>();
         observer->registerWith(quote);
 
         if ((i%4) == 0) {

--- a/test-suite/optimizers.cpp
+++ b/test-suite/optimizers.cpp
@@ -154,19 +154,16 @@ ext::shared_ptr<OptimizationMethod> makeOptimizationMethod(
                                                            Real levenbergMarquardtGtol) {
     switch (optimizationMethodType) {
       case simplex:
-        return ext::shared_ptr<OptimizationMethod>(
-                new Simplex(simplexLambda));
+        return ext::make_shared<Simplex>(simplexLambda);
       case levenbergMarquardt:
-        return ext::shared_ptr<OptimizationMethod>(
-                new LevenbergMarquardt(levenbergMarquardtEpsfcn,
+        return ext::make_shared<LevenbergMarquardt>(levenbergMarquardtEpsfcn,
                                        levenbergMarquardtXtol,
-                                       levenbergMarquardtGtol));
+                                       levenbergMarquardtGtol);
       case levenbergMarquardt2:
-        return ext::shared_ptr<OptimizationMethod>(
-                new LevenbergMarquardt(levenbergMarquardtEpsfcn,
+        return ext::make_shared<LevenbergMarquardt>(levenbergMarquardtEpsfcn,
                                        levenbergMarquardtXtol,
                                        levenbergMarquardtGtol,
-                                       true));
+                                       true);
       case conjugateGradient:
         return ext::make_shared<ConjugateGradient>();
       case steepestDescent:
@@ -174,11 +171,11 @@ ext::shared_ptr<OptimizationMethod> makeOptimizationMethod(
       case bfgs:
         return ext::make_shared<BFGS>();
       case conjugateGradient_goldstein:
-        return ext::shared_ptr<OptimizationMethod>(new ConjugateGradient(ext::make_shared<GoldsteinLineSearch>()));
+        return ext::make_shared<ConjugateGradient>(ext::make_shared<GoldsteinLineSearch>());
       case steepestDescent_goldstein:
-        return ext::shared_ptr<OptimizationMethod>(new SteepestDescent(ext::make_shared<GoldsteinLineSearch>()));
+        return ext::make_shared<SteepestDescent>(ext::make_shared<GoldsteinLineSearch>());
       case bfgs_goldstein:
-        return ext::shared_ptr<OptimizationMethod>(new BFGS(ext::make_shared<GoldsteinLineSearch>()));
+        return ext::make_shared<BFGS>(ext::make_shared<GoldsteinLineSearch>());
       default:
         QL_FAIL("unknown OptimizationMethod type");
     }
@@ -476,12 +473,12 @@ BOOST_AUTO_TEST_CASE(testDifferentialEvolution) {
         deOptim2
     };
 
-    std::vector<ext::shared_ptr<CostFunction> > costFunctions = {
-        ext::shared_ptr<CostFunction>(new FirstDeJong),
-        ext::shared_ptr<CostFunction>(new SecondDeJong),
-        ext::shared_ptr<CostFunction>(new ModThirdDeJong),
-        ext::shared_ptr<CostFunction>(new ModFourthDeJong),
-        ext::shared_ptr<CostFunction>(new Griewangk)
+    std::vector<ext::shared_ptr<CostFunction>> costFunctions = {
+        ext::make_shared<FirstDeJong>(),
+        ext::make_shared<SecondDeJong>(),
+        ext::make_shared<ModThirdDeJong>(),
+        ext::make_shared<ModFourthDeJong>(),
+        ext::make_shared<Griewangk>()
     };
 
     std::vector<BoundaryConstraint> constraints = {

--- a/test-suite/optionletstripper.cpp
+++ b/test-suite/optionletstripper.cpp
@@ -165,8 +165,7 @@ struct CommonVars {
 
         std::vector<Handle<Quote> >  curveVHandle(optionTenors.size());
         for (Size i=0; i<optionTenors.size(); ++i)
-            curveVHandle[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                                                        SimpleQuote(flatVol)));
+            curveVHandle[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(flatVol));
 
         flatTermVolCurve = Handle<CapFloorTermVolCurve>(
               ext::make_shared<CapFloorTermVolCurve>(0, calendar, Following, optionTenors,
@@ -240,8 +239,7 @@ struct CommonVars {
 
         atmTermVolHandle.resize(optionTenors.size());
         for (Size i=0; i<optionTenors.size(); ++i) {
-            atmTermVolHandle[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                            SimpleQuote(atmTermV[i])));
+            atmTermVolHandle[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(atmTermV[i]));
         }
 
         capFloorVolCurve = Handle<CapFloorTermVolCurve>(
@@ -449,8 +447,7 @@ struct CommonVarsON {
             3.221372 / 100.0
         };
 
-        ext::shared_ptr<YieldTermStructure> sofrCurve(
-            new ZeroCurve(dates, zeroRates, Actual365Fixed(), calendar));
+        ext::shared_ptr<YieldTermStructure> sofrCurve = ext::make_shared<ZeroCurve>(dates, zeroRates, Actual365Fixed(), calendar);
         sofrCurveHandle.linkTo(sofrCurve);
     }
 
@@ -497,24 +494,21 @@ BOOST_AUTO_TEST_CASE(testFlatTermVolatilityStripping1) {
 
     vars.setFlatTermVolSurface();
 
-    ext::shared_ptr<IborIndex> iborIndex(new Euribor6M(vars.yieldTermStructure));
+    ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor6M>(vars.yieldTermStructure);
 
-    ext::shared_ptr<OptionletStripper> optionletStripper1(new
-        OptionletStripper1(vars.flatTermVolSurface,
+    ext::shared_ptr<OptionletStripper> optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.flatTermVolSurface,
                            iborIndex,
                            Null<Rate>(),
-                           vars.accuracy));
+                           vars.accuracy);
 
-    ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter(new
-        StrippedOptionletAdapter(optionletStripper1));
+    ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter = ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
 
     Handle<OptionletVolatilityStructure> vol(strippedOptionletAdapter);
 
     vol->enableExtrapolation();
 
-    ext::shared_ptr<BlackCapFloorEngine> strippedVolEngine(new
-        BlackCapFloorEngine(vars.yieldTermStructure,
-                            vol));
+    ext::shared_ptr<BlackCapFloorEngine> strippedVolEngine = ext::make_shared<BlackCapFloorEngine>(vars.yieldTermStructure,
+                            vol);
 
     ext::shared_ptr<CapFloor> cap;
     for (Size tenorIndex=0; tenorIndex<vars.optionTenors.size(); ++tenorIndex) {
@@ -528,9 +522,8 @@ BOOST_AUTO_TEST_CASE(testFlatTermVolatilityStripping1) {
 
             Real priceFromStrippedVolatility = cap->NPV();
 
-            ext::shared_ptr<PricingEngine> blackCapFloorEngineConstantVolatility(new
-                BlackCapFloorEngine(vars.yieldTermStructure,
-                                    vars.termV[tenorIndex][strikeIndex]));
+            ext::shared_ptr<PricingEngine> blackCapFloorEngineConstantVolatility = ext::make_shared<BlackCapFloorEngine>(vars.yieldTermStructure,
+                                    vars.termV[tenorIndex][strikeIndex]);
 
             cap->setPricingEngine(blackCapFloorEngineConstantVolatility);
             Real priceFromConstantVolatility = cap->NPV();
@@ -558,13 +551,12 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1) {
 
     vars.setCapFloorTermVolSurface();
 
-    ext::shared_ptr<IborIndex> iborIndex(new Euribor6M(vars.yieldTermStructure));
+    ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor6M>(vars.yieldTermStructure);
 
-    ext::shared_ptr<OptionletStripper> optionletStripper1(new
-        OptionletStripper1(vars.capFloorVolSurface,
+    ext::shared_ptr<OptionletStripper> optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.capFloorVolSurface,
                            iborIndex,
                            Null<Rate>(),
-                           vars.accuracy));
+                           vars.accuracy);
 
     ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter =
         ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
@@ -573,9 +565,8 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1) {
 
     vol->enableExtrapolation();
 
-    ext::shared_ptr<BlackCapFloorEngine> strippedVolEngine(new
-        BlackCapFloorEngine(vars.yieldTermStructure,
-                            vol));
+    ext::shared_ptr<BlackCapFloorEngine> strippedVolEngine = ext::make_shared<BlackCapFloorEngine>(vars.yieldTermStructure,
+                            vol);
 
     ext::shared_ptr<CapFloor> cap;
     for (Size tenorIndex=0; tenorIndex<vars.optionTenors.size(); ++tenorIndex) {
@@ -589,9 +580,8 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1) {
 
             Real priceFromStrippedVolatility = cap->NPV();
 
-            ext::shared_ptr<PricingEngine> blackCapFloorEngineConstantVolatility(new
-                BlackCapFloorEngine(vars.yieldTermStructure,
-                                    vars.termV[tenorIndex][strikeIndex]));
+            ext::shared_ptr<PricingEngine> blackCapFloorEngineConstantVolatility = ext::make_shared<BlackCapFloorEngine>(vars.yieldTermStructure,
+                                    vars.termV[tenorIndex][strikeIndex]);
 
             cap->setPricingEngine(blackCapFloorEngineConstantVolatility);
             Real priceFromConstantVolatility = cap->NPV();
@@ -619,12 +609,11 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingNormalVol) {
 
     vars.setRealCapFloorTermVolSurface();
 
-    ext::shared_ptr< IborIndex > iborIndex(new Euribor6M(vars.forwardingYTS));
+    ext::shared_ptr< IborIndex > iborIndex = ext::make_shared<Euribor6M>(vars.forwardingYTS);
 
-    ext::shared_ptr< OptionletStripper > optionletStripper1(
-        new OptionletStripper1(vars.capFloorVolRealSurface, iborIndex,
+    ext::shared_ptr< OptionletStripper > optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.capFloorVolRealSurface, iborIndex,
                                Null< Rate >(), vars.accuracy, 100,
-                               vars.discountingYTS, Normal));
+                               vars.discountingYTS, Normal);
 
     ext::shared_ptr< StrippedOptionletAdapter > strippedOptionletAdapter =
         ext::make_shared< StrippedOptionletAdapter >(
@@ -634,8 +623,7 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingNormalVol) {
 
     vol->enableExtrapolation();
 
-    ext::shared_ptr< BachelierCapFloorEngine > strippedVolEngine(
-        new BachelierCapFloorEngine(vars.discountingYTS, vol));
+    ext::shared_ptr< BachelierCapFloorEngine > strippedVolEngine = ext::make_shared<BachelierCapFloorEngine>(vars.discountingYTS, vol);
 
     ext::shared_ptr< CapFloor > cap;
     for (Size tenorIndex = 0; tenorIndex < vars.optionTenors.size();
@@ -649,10 +637,9 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingNormalVol) {
             Real priceFromStrippedVolatility = cap->NPV();
 
             ext::shared_ptr< PricingEngine >
-                bachelierCapFloorEngineConstantVolatility(
-                    new BachelierCapFloorEngine(
+                bachelierCapFloorEngineConstantVolatility = ext::make_shared<BachelierCapFloorEngine>(
                         vars.discountingYTS,
-                        vars.termV[tenorIndex][strikeIndex]));
+                        vars.termV[tenorIndex][strikeIndex]);
 
             cap->setPricingEngine(bachelierCapFloorEngineConstantVolatility);
             Real priceFromConstantVolatility = cap->NPV();
@@ -686,13 +673,12 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingShiftedLogNormalVol) {
 
     vars.setRealCapFloorTermVolSurface();
 
-    ext::shared_ptr< IborIndex > iborIndex(new Euribor6M(vars.forwardingYTS));
+    ext::shared_ptr< IborIndex > iborIndex = ext::make_shared<Euribor6M>(vars.forwardingYTS);
 
-    ext::shared_ptr< OptionletStripper > optionletStripper1(
-        new OptionletStripper1(vars.capFloorVolRealSurface, iborIndex,
+    ext::shared_ptr< OptionletStripper > optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.capFloorVolRealSurface, iborIndex,
                                Null< Rate >(), vars.accuracy, 100,
                                vars.discountingYTS, ShiftedLognormal, shift,
-                               true));
+                               true);
 
     ext::shared_ptr< StrippedOptionletAdapter > strippedOptionletAdapter =
         ext::make_shared< StrippedOptionletAdapter >(
@@ -702,8 +688,7 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingShiftedLogNormalVol) {
 
     vol->enableExtrapolation();
 
-    ext::shared_ptr< BlackCapFloorEngine > strippedVolEngine(
-        new BlackCapFloorEngine(vars.discountingYTS, vol));
+    ext::shared_ptr< BlackCapFloorEngine > strippedVolEngine = ext::make_shared<BlackCapFloorEngine>(vars.discountingYTS, vol);
 
     ext::shared_ptr< CapFloor > cap;
     for (Size strikeIndex = 0; strikeIndex < vars.strikes.size();
@@ -717,9 +702,9 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStrippingShiftedLogNormalVol) {
             Real priceFromStrippedVolatility = cap->NPV();
 
             ext::shared_ptr< PricingEngine >
-                blackCapFloorEngineConstantVolatility(new BlackCapFloorEngine(
+                blackCapFloorEngineConstantVolatility = ext::make_shared<BlackCapFloorEngine>(
                     vars.discountingYTS, vars.termV[tenorIndex][strikeIndex],
-                    vars.capFloorVolRealSurface->dayCounter(), shift));
+                    vars.capFloorVolRealSurface->dayCounter(), shift);
 
             cap->setPricingEngine(blackCapFloorEngineConstantVolatility);
             Real priceFromConstantVolatility = cap->NPV();
@@ -753,28 +738,24 @@ BOOST_AUTO_TEST_CASE(testFlatTermVolatilityStripping2) {
   vars.setFlatTermVolCurve();
   vars.setFlatTermVolSurface();
 
-  ext::shared_ptr<IborIndex> iborIndex(new Euribor6M(vars.yieldTermStructure));
+  ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor6M>(vars.yieldTermStructure);
 
   // optionletstripper1
-  ext::shared_ptr<OptionletStripper1> optionletStripper1(new
-        OptionletStripper1(vars.flatTermVolSurface,
+  ext::shared_ptr<OptionletStripper1> optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.flatTermVolSurface,
                            iborIndex,
                            Null<Rate>(),
-                           vars.accuracy));
+                           vars.accuracy);
 
-  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter1(new
-        StrippedOptionletAdapter(optionletStripper1));
+  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter1 = ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
 
   Handle<OptionletVolatilityStructure> vol1(strippedOptionletAdapter1);
 
   vol1->enableExtrapolation();
 
   // optionletstripper2
-  ext::shared_ptr<OptionletStripper> optionletStripper2(new
-        OptionletStripper2(optionletStripper1, vars.flatTermVolCurve));
+  ext::shared_ptr<OptionletStripper> optionletStripper2 = ext::make_shared<OptionletStripper2>(optionletStripper1, vars.flatTermVolCurve);
 
-  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter2(new
-        StrippedOptionletAdapter(optionletStripper2));
+  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter2 = ext::make_shared<StrippedOptionletAdapter>(optionletStripper2);
 
   Handle<OptionletVolatilityStructure> vol2(strippedOptionletAdapter2);
 
@@ -820,14 +801,13 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping2) {
   vars.setCapFloorTermVolCurve();
   vars.setCapFloorTermVolSurface();
 
-  ext::shared_ptr<IborIndex> iborIndex(new Euribor6M(vars.yieldTermStructure));
+  ext::shared_ptr<IborIndex> iborIndex = ext::make_shared<Euribor6M>(vars.yieldTermStructure);
 
   // optionletstripper1
-  ext::shared_ptr<OptionletStripper1> optionletStripper1(new
-        OptionletStripper1(vars.capFloorVolSurface,
+  ext::shared_ptr<OptionletStripper1> optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.capFloorVolSurface,
                            iborIndex,
                            Null<Rate>(),
-                           vars.accuracy));
+                           vars.accuracy);
 
   ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter1 =
         ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
@@ -836,12 +816,10 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping2) {
   vol1->enableExtrapolation();
 
   // optionletstripper2
-  ext::shared_ptr<OptionletStripper> optionletStripper2(new
-                OptionletStripper2(optionletStripper1,
-                                   vars.capFloorVolCurve));
+  ext::shared_ptr<OptionletStripper> optionletStripper2 = ext::make_shared<OptionletStripper2>(optionletStripper1,
+                                   vars.capFloorVolCurve);
 
-  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter2(new
-        StrippedOptionletAdapter(optionletStripper2));
+  ext::shared_ptr<StrippedOptionletAdapter> strippedOptionletAdapter2 = ext::make_shared<StrippedOptionletAdapter>(optionletStripper2);
 
   Handle<OptionletVolatilityStructure> vol2(strippedOptionletAdapter2);
   vol2->enableExtrapolation();
@@ -887,11 +865,10 @@ BOOST_AUTO_TEST_CASE(testSwitchStrike) {
     yieldTermStructure.linkTo(ext::make_shared< FlatForward >(
         0, vars.calendar, 0.03, vars.dayCounter));
 
-    ext::shared_ptr< IborIndex > iborIndex(new Euribor6M(yieldTermStructure));
+    ext::shared_ptr< IborIndex > iborIndex = ext::make_shared<Euribor6M>(yieldTermStructure);
 
-    ext::shared_ptr< OptionletStripper1 > optionletStripper1(
-        new OptionletStripper1(vars.capFloorVolSurface, iborIndex,
-                               Null< Rate >(), vars.accuracy));
+    ext::shared_ptr< OptionletStripper1 > optionletStripper1 = ext::make_shared<OptionletStripper1>(vars.capFloorVolSurface, iborIndex,
+                               Null< Rate >(), vars.accuracy);
 
     Real expected = usingAtParCoupons ? 0.02981223 : 0.02981258;
 
@@ -929,7 +906,7 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1ON) {
     vars.setSofrHandle();
     vars.setRealCapFloorVolSurface();
 
-    ext::shared_ptr<OvernightIndex> sofrIndex(new Sofr(vars.sofrCurveHandle));
+    ext::shared_ptr<OvernightIndex> sofrIndex = ext::make_shared<Sofr>(vars.sofrCurveHandle);
     sofrIndex->addFixing(Date(15, April, 2025), 3.04/100.0);
 
     Real notional = 1'000'000;
@@ -943,37 +920,29 @@ BOOST_AUTO_TEST_CASE(testTermVolatilityStripping1ON) {
     Cap cap(sofrLeg, strikes);
     Cap cap1(sofrLeg, strikes);
 
-    ext::shared_ptr<OptionletStripper1> optionletSurf(
-            new OptionletStripper1(vars.capfloorVol, sofrIndex,
+    ext::shared_ptr<OptionletStripper1> optionletSurf = ext::make_shared<OptionletStripper1>(vars.capfloorVol, sofrIndex,
                                    Null<Real>(), 1e-6, 100,
                                    vars.sofrCurveHandle, Normal,
-                                   0.0, true, Period(3, Months)));
+                                   0.0, true, Period(3, Months));
 
     Handle<OptionletVolatilityStructure> ovsHandle(
-        ext::shared_ptr<OptionletVolatilityStructure>(
-            new StrippedOptionletAdapter(optionletSurf)));
+        ext::make_shared<StrippedOptionletAdapter>(optionletSurf));
 
-     ext::shared_ptr<IborIndex> sofr3m(new IborIndex(
+     ext::shared_ptr<IborIndex> sofr3m = ext::make_shared<IborIndex>(
         "SOFR", Period(3, Months), 2,
         USDCurrency(), vars.calendar, vars.convention, false, vars.dc, vars.sofrCurveHandle
-    ));
-
-    ext::shared_ptr<OptionletStripper1> optionletSurf1(
-        new OptionletStripper1(vars.capfloorVol, sofr3m,
-                               Null<Real>(), 1e-6, 100, vars.sofrCurveHandle, Normal)
     );
 
-    ext::shared_ptr<OptionletVolatilityStructure> ovs(
-        new StrippedOptionletAdapter(optionletSurf)
-    );
+    ext::shared_ptr<OptionletStripper1> optionletSurf1 = ext::make_shared<OptionletStripper1>(vars.capfloorVol, sofr3m,
+                               Null<Real>(), 1e-6, 100, vars.sofrCurveHandle, Normal);
+
+    ext::shared_ptr<OptionletVolatilityStructure> ovs = ext::make_shared<StrippedOptionletAdapter>(optionletSurf);
     Handle<OptionletVolatilityStructure> ovsHandle1(ovs);
 
     // Use optionlet surface for pricing
-    ext::shared_ptr<PricingEngine> engineOvs(
-        new BachelierCapFloorEngine(vars.sofrCurveHandle, ovsHandle));
+    ext::shared_ptr<PricingEngine> engineOvs = ext::make_shared<BachelierCapFloorEngine>(vars.sofrCurveHandle, ovsHandle);
     cap.setPricingEngine(engineOvs);
-    ext::shared_ptr<PricingEngine> engineOvs1(
-        new BachelierCapFloorEngine(vars.sofrCurveHandle, ovsHandle1));
+    ext::shared_ptr<PricingEngine> engineOvs1 = ext::make_shared<BachelierCapFloorEngine>(vars.sofrCurveHandle, ovsHandle1);
     cap1.setPricingEngine(engineOvs1);
     
     Real tolerance = 2.5e-8;

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -115,16 +115,16 @@ struct CommonVars {
             Date(22, November, 2021)
         };
         std::vector<Rate> pastRates = {
-            0.0237, 0.0239, 0.0241, 
-            0.0243, 0.0242, 0.025,  
-            0.0242, 0.0251, 0.0256, 
-            0.0259, 0.0248, 0.0245, 
-            0.0246, 0.0241, 0.0236, 
-            0.0246, 0.0247, 0.0247, 
-            0.0246, 0.0241, 0.024,  
-            0.024,  0.0241, 0.0242, 
-            0.0241, 0.024,  0.0239, 
-            0.0255, 0.0219, 0.0219, 
+            0.0237, 0.0239, 0.0241,
+            0.0243, 0.0242, 0.025,
+            0.0242, 0.0251, 0.0256,
+            0.0259, 0.0248, 0.0245,
+            0.0246, 0.0241, 0.0236,
+            0.0246, 0.0247, 0.0247,
+            0.0246, 0.0241, 0.024,
+            0.024,  0.0241, 0.0242,
+            0.0241, 0.024,  0.0239,
+            0.0255, 0.0219, 0.0219,
             0.0213,
 
             0.0008, 0.0009, 0.0008,
@@ -170,7 +170,7 @@ struct BlackONPricerVars {
                                                            RateAveraging::Type avgMethod = RateAveraging::Compound) {
         auto onCoupon = ext::make_shared<OvernightIndexedCoupon>(
             end, notional, start, end, sofr, 1.0, 0.0, Date(), Date(), dc,
-            false, avgMethod, Null<Natural>(), 0, false, 
+            false, avgMethod, Null<Natural>(), 0, false,
             false);
 
         if (avgMethod == RateAveraging::Compound)
@@ -213,7 +213,7 @@ struct CommonVarsONLeg {
                 const std::vector<Spread>& spreads = std::vector<Spread>(),
                 const std::vector<Rate>& caps = std::vector<Rate>(),
                 const std::vector<Rate>& floors = std::vector<Rate>()) {
-        
+
         OvernightLeg leg(legSchedule, sofr);
         leg.withNotionals(notional)
            .withPaymentDayCounter(dc)
@@ -221,23 +221,23 @@ struct CommonVarsONLeg {
            .withLockoutDays(lockoutDays)
            .withObservationShift(applyObservationShift)
            .withTelescopicValueDates(telescopicValueDates);
-           
+
         if (fixingDays != Null<Natural>()) {
             leg.withLookbackDays(fixingDays);
         }
-        
+
         if (!gearings.empty()) {
             leg.withGearings(gearings);
         }
-        
+
         if (!spreads.empty()) {
             leg.withSpreads(spreads);
         }
-        
+
         if (!caps.empty()) {
             leg.withCaps(caps);
         }
-        
+
         if (!floors.empty()) {
             leg.withFloors(floors);
         }
@@ -249,7 +249,7 @@ struct CommonVarsONLeg {
             else
                 leg.withCouponPricer(ext::make_shared<BlackAveragingOvernightIndexedCouponPricer>(rateVolTS));
         }
-        
+
         return leg;
     }
 
@@ -260,10 +260,10 @@ struct CommonVarsONLeg {
         Settings::instance().evaluationDate() = today;
 
         sofr = ext::make_shared<Sofr>(forecastCurve);
-        
+
         // Create a quarterly schedule for testing
         legSchedule = Schedule(Date(1, July, 2025), Date(1, July, 2026),
-                              Period(3, Months), 
+                              Period(3, Months),
                               UnitedStates(UnitedStates::GovernmentBond),
                               ModifiedFollowing, ModifiedFollowing,
                               DateGeneration::Forward, false);
@@ -297,13 +297,13 @@ struct CommonVarsONLeg {
         std::vector<Date> curveDates = {
             today,
             Date(30, July, 2025),
-            Date(29, August, 2025), 
+            Date(29, August, 2025),
             Date(30, September, 2025),
             Date(30, December, 2025),
             Date(30, March, 2026),
             Date(30, June, 2026)
         };
-        
+
         std::vector<Rate> zeroRates = {
             0.0434,
             0.0436,
@@ -313,14 +313,12 @@ struct CommonVarsONLeg {
             0.0370,
             0.0348
         };
-        
-        ext::shared_ptr<InterpolatedZeroCurve<Cubic>> zeroCurve(
-            new InterpolatedZeroCurve<Cubic>(curveDates, zeroRates, 
-                dc, UnitedStates(UnitedStates::SOFR))
-        );
+
+        ext::shared_ptr<InterpolatedZeroCurve<Cubic>> zeroCurve = ext::make_shared<InterpolatedZeroCurve<Cubic>>(curveDates, zeroRates,
+                dc, UnitedStates(UnitedStates::SOFR));
 
         zeroCurve->enableExtrapolation();
-        
+
         forecastCurve.linkTo(zeroCurve);
     }
 
@@ -658,7 +656,7 @@ BOOST_AUTO_TEST_CASE(testFutureCouponRateWithLookout) {
 
     auto coupon15July =
         vars.makeCoupon(Date(1, July, 2019), Date(15, July, 2019), Null<Natural>(), 2, false);
-    
+
     // expected = 0.025011784374543
     Rate lockoutFixing = vars.sofr->fixing(Date(10, July, 2019));
     Rate expectedRate15July =
@@ -693,7 +691,7 @@ BOOST_AUTO_TEST_CASE(testPartiallyAccruedAmountOfFutureCouponWithLookout) {
     Real expectedAccruedAmount = coupon15July->nominal() *
                                  coupon15July->accruedPeriod(Date(14, July, 2019)) *
                                  expectedRate15July;
-    
+
     CHECK_OIS_COUPON_RESULT("accrued amount", coupon15July->accruedAmount(Date(14, July, 2019)),
                             expectedAccruedAmount, 1e-12);
 }
@@ -727,7 +725,7 @@ BOOST_AUTO_TEST_CASE(testTelescopicFormulaWhenLookbackWithObservationShiftAndNoI
     const auto& fixingDates = coupon15July->fixingDates();
     const auto& dts = coupon15July->dt();
     Size n = fixingDates.size();
-    
+
     Rate expectedRateIterativeFormula = 1.0;
     for (Size i = 0; i < n; ++i) {
         expectedRateIterativeFormula *=
@@ -923,10 +921,10 @@ BOOST_AUTO_TEST_CASE(testOvernightLegBasicFunctionality) {
     vars.forecastCurve.linkTo(flatRate(0.0010, Actual360()));
 
     Leg leg = vars.makeLeg();
-    
+
     // Check that we have the expected number of coupons (monthly over 1 year = 12 coupons)
     BOOST_CHECK_EQUAL(leg.size(), 4);
-    
+
     // Check that all cash flows are OvernightIndexedCoupons
     for (const auto& cf : leg) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(cf);
@@ -948,13 +946,13 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithLookback) {
 
     Natural lookbackDays = 5;
     Leg leg = vars.makeLeg(lookbackDays);
-    
+
     for (const auto& cf : leg) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(cf);
         BOOST_CHECK(oisCoupon != nullptr);
         if (oisCoupon) {
             // The coupon should have lookback configured
-            BOOST_CHECK(oisCoupon->fixingDays() == lookbackDays || 
+            BOOST_CHECK(oisCoupon->fixingDays() == lookbackDays ||
                        oisCoupon->fixingDays() == oisCoupon->index()->fixingDays());
         }
     }
@@ -968,7 +966,7 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithLockout) {
 
     Natural lockoutDays = 3;
     Leg leg = vars.makeLeg(Null<Natural>(), lockoutDays);
-    
+
     for (const auto& cf : leg) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(cf);
         BOOST_CHECK(oisCoupon != nullptr);
@@ -985,7 +983,7 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithObservationShift) {
     vars.forecastCurve.linkTo(flatRate(0.0010, Actual360()));
 
     Leg leg = vars.makeLeg(Null<Natural>(), 0, true);
-    
+
     for (const auto& cf : leg) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(cf);
         BOOST_CHECK(oisCoupon != nullptr);
@@ -1003,12 +1001,12 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithGearingsAndSpreads) {
 
     std::vector<Real> gearings = {1.0, 1.25, 2.0, 0.5};
     std::vector<Spread> spreads = {0.0001, 0.0001, 0.0002, 0.0002};
-    
-    Leg leg = vars.makeLeg(Null<Natural>(), 0, false, false, 
+
+    Leg leg = vars.makeLeg(Null<Natural>(), 0, false, false,
                           RateAveraging::Compound, gearings, spreads);
-    
+
     BOOST_CHECK_EQUAL(leg.size(), 4);
-    
+
     for (Size i = 0; i < leg.size(); ++i) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(leg[i]);
         BOOST_CHECK(oisCoupon != nullptr);
@@ -1026,16 +1024,16 @@ BOOST_AUTO_TEST_CASE(testOvernightLegNPV) {
     vars.setupForecastCurve();
 
     Leg leg = vars.makeLeg(Null<Natural>(), 3, false, true, RateAveraging::Compound);
-    
+
     Handle<YieldTermStructure> discountCurve(flatRate(0.0015, Actual360()));
-    
+
     // Calculate NPV
     Real expectedNpv = 34883.949669756257;
     Real npv = 0.0;
     for (const auto& cf : leg) {
         npv += cf->amount() * discountCurve->discount(cf->date());
     }
-    
+
     CHECK_OIS_COUPON_RESULT("OvernightLeg NPV", npv, expectedNpv, 1e-8);
 }
 
@@ -1048,17 +1046,17 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithCapsAndFloors) {
 
     std::vector<Rate> caps = {0.0435, 0.0435, 0.04, 0.04};
     std::vector<Rate> floors = {0.025, 0.025, 0.025, 0.025};
-    
-    Leg leg = vars.makeLeg(Null<Natural>(), 0, false, false, 
-                          RateAveraging::Compound, 
+
+    Leg leg = vars.makeLeg(Null<Natural>(), 0, false, false,
+                          RateAveraging::Compound,
                           std::vector<Real>(), std::vector<Spread>(),
                           caps, floors);
-    
+
     BOOST_CHECK_EQUAL(leg.size(), 4);
 
     Real expectedNpv = 34648.328606210489;
     Real npv = 0.0;
-    
+
     for (Size i = 0; i < leg.size(); ++i) {
         auto cappedFlooredCoupon = ext::dynamic_pointer_cast<CappedFlooredOvernightIndexedCoupon>(leg[i]);
         BOOST_CHECK(cappedFlooredCoupon != nullptr);
@@ -1081,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(testOvernightLegSimpleAveraging) {
     vars.forecastCurve.linkTo(flatRate(0.0010, Actual360()));
 
     Leg leg = vars.makeLeg(Null<Natural>(), 0, false, false, RateAveraging::Simple);
-    
+
     for (const auto& cf : leg) {
         auto oisCoupon = ext::dynamic_pointer_cast<OvernightIndexedCoupon>(cf);
         BOOST_CHECK(oisCoupon != nullptr);
@@ -1099,10 +1097,10 @@ BOOST_AUTO_TEST_CASE(testOvernightLegErrorConditions) {
 
     // Test that lookback with simple averaging throws an error
     BOOST_CHECK_THROW(vars.makeLeg(5, 0, false, false, RateAveraging::Simple), Error);
-    
-    // Test that lockout with simple averaging throws an error  
+
+    // Test that lockout with simple averaging throws an error
     BOOST_CHECK_THROW(vars.makeLeg(Null<Natural>(), 3, false, false, RateAveraging::Simple), Error);
-    
+
     // Test that observation shift with simple averaging throws an error
     BOOST_CHECK_THROW(vars.makeLeg(Null<Natural>(), 0, true, false, RateAveraging::Simple), Error);
 }

--- a/test-suite/pagodaoption.cpp
+++ b/test-suite/pagodaoption.cpp
@@ -51,30 +51,26 @@ BOOST_AUTO_TEST_CASE(testCached) {
     Handle<YieldTermStructure> riskFreeRate(flatRate(today, 0.05, dc));
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > processes(4);
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.15))),
+    processes[0] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(0.15)),
               Handle<YieldTermStructure>(flatRate(today, 0.01, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc))));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.20))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.30, dc)));
+    processes[1] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(0.20)),
               Handle<YieldTermStructure>(flatRate(today, 0.05, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc))));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.35))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.35, dc)));
+    processes[2] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(0.35)),
               Handle<YieldTermStructure>(flatRate(today, 0.04, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc))));
-    processes[3] = ext::shared_ptr<StochasticProcess1D>(
-        new BlackScholesMertonProcess(
-              Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.30))),
+              Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc)));
+    processes[3] = ext::make_shared<BlackScholesMertonProcess>(
+              Handle<Quote>(ext::make_shared<SimpleQuote>(0.30)),
               Handle<YieldTermStructure>(flatRate(today, 0.03, dc)),
               riskFreeRate,
-              Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc))));
+              Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc)));
 
     Matrix correlation(4,4);
     correlation[0][0] = 1.00;
@@ -97,8 +93,7 @@ BOOST_AUTO_TEST_CASE(testCached) {
     BigNatural seed = 86421;
     Size fixedSamples = 1023;
 
-    ext::shared_ptr<StochasticProcessArray> process(
-                          new StochasticProcessArray(processes, correlation));
+    ext::shared_ptr<StochasticProcessArray> process = ext::make_shared<StochasticProcessArray>(processes, correlation);
 
     option.setPricingEngine(MakeMCPagodaEngine<PseudoRandom>(process)
                             .withSamples(fixedSamples)

--- a/test-suite/pathgenerator.cpp
+++ b/test-suite/pathgenerator.cpp
@@ -147,31 +147,26 @@ BOOST_AUTO_TEST_CASE(testPathGenerator) {
 
     Settings::instance().evaluationDate() = Date(26,April,2005);
 
-    Handle<Quote> x0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> x0(ext::make_shared<SimpleQuote>(100.0));
     Handle<YieldTermStructure> r(flatRate(0.05, Actual360()));
     Handle<YieldTermStructure> q(flatRate(0.02, Actual360()));
     Handle<BlackVolTermStructure> sigma(flatVol(0.20, Actual360()));
     // commented values must be used when Halley's correction is enabled
-    testSingle(ext::shared_ptr<StochasticProcess1D>(
-                                 new BlackScholesMertonProcess(x0,q,r,sigma)),
+    testSingle(ext::make_shared<BlackScholesMertonProcess>(x0,q,r,sigma),
                "Black-Scholes", false, 26.13784357783, 467.2928561411);
                                     // 26.13784357783, 467.2928562519);
-    testSingle(ext::shared_ptr<StochasticProcess1D>(
-                                 new BlackScholesMertonProcess(x0,q,r,sigma)),
+    testSingle(ext::make_shared<BlackScholesMertonProcess>(x0,q,r,sigma),
                "Black-Scholes", true, 60.28215549393, 202.6143139999);
                                    // 60.28215551021, 202.6143139437);
 
-    testSingle(ext::shared_ptr<StochasticProcess1D>(
-                       new GeometricBrownianMotionProcess(100.0, 0.03, 0.20)),
+    testSingle(ext::make_shared<GeometricBrownianMotionProcess>(100.0, 0.03, 0.20),
                "geometric Brownian", false, 27.62223714065, 483.6026514084);
                                          // 27.62223714065, 483.602651493);
 
-    testSingle(ext::shared_ptr<StochasticProcess1D>(
-                                     new OrnsteinUhlenbeckProcess(0.1, 0.20)),
+    testSingle(ext::make_shared<OrnsteinUhlenbeckProcess>(0.1, 0.20),
                "Ornstein-Uhlenbeck", false, -0.8372003433557, 0.8372003433557);
 
-    testSingle(ext::shared_ptr<StochasticProcess1D>(
-                                 new SquareRootProcess(0.1, 0.1, 0.20, 10.0)),
+    testSingle(ext::make_shared<SquareRootProcess>(0.1, 0.1, 0.20, 10.0),
                "square-root", false, 1.70608664108, 6.024200546031);
 }
 
@@ -181,7 +176,7 @@ BOOST_AUTO_TEST_CASE(testMultiPathGenerator) {
 
     Settings::instance().evaluationDate() = Date(26,April,2005);
 
-    Handle<Quote> x0(ext::shared_ptr<Quote>(new SimpleQuote(100.0)));
+    Handle<Quote> x0(ext::make_shared<SimpleQuote>(100.0));
     Handle<YieldTermStructure> r(flatRate(0.05, Actual360()));
     Handle<YieldTermStructure> q(flatRate(0.02, Actual360()));
     Handle<BlackVolTermStructure> sigma(flatVol(0.20, Actual360()));
@@ -194,14 +189,10 @@ BOOST_AUTO_TEST_CASE(testMultiPathGenerator) {
     std::vector<ext::shared_ptr<StochasticProcess1D> > processes(3);
     ext::shared_ptr<StochasticProcess> process;
 
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-                                 new BlackScholesMertonProcess(x0,q,r,sigma));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-                                 new BlackScholesMertonProcess(x0,q,r,sigma));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-                                 new BlackScholesMertonProcess(x0,q,r,sigma));
-    process = ext::shared_ptr<StochasticProcess>(
-                           new StochasticProcessArray(processes,correlation));
+    processes[0] = ext::make_shared<BlackScholesMertonProcess>(x0,q,r,sigma);
+    processes[1] = ext::make_shared<BlackScholesMertonProcess>(x0,q,r,sigma);
+    processes[2] = ext::make_shared<BlackScholesMertonProcess>(x0,q,r,sigma);
+    process = ext::make_shared<StochasticProcessArray>(processes,correlation);
     // commented values must be used when Halley's correction is enabled
     Real result1[] = {
         188.2235868185,
@@ -221,14 +212,10 @@ BOOST_AUTO_TEST_CASE(testMultiPathGenerator) {
     //     108.0475146914 };
     testMultiple(process, "Black-Scholes", result1, result1a);
 
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-                       new GeometricBrownianMotionProcess(100.0, 0.03, 0.20));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-                       new GeometricBrownianMotionProcess(100.0, 0.03, 0.20));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-                       new GeometricBrownianMotionProcess(100.0, 0.03, 0.20));
-    process = ext::shared_ptr<StochasticProcess>(
-                           new StochasticProcessArray(processes,correlation));
+    processes[0] = ext::make_shared<GeometricBrownianMotionProcess>(100.0, 0.03, 0.20);
+    processes[1] = ext::make_shared<GeometricBrownianMotionProcess>(100.0, 0.03, 0.20);
+    processes[2] = ext::make_shared<GeometricBrownianMotionProcess>(100.0, 0.03, 0.20);
+    process = ext::make_shared<StochasticProcessArray>(processes,correlation);
     Real result2[] = {
         174.8266131680,
         237.2692443633,
@@ -247,14 +234,10 @@ BOOST_AUTO_TEST_CASE(testMultiPathGenerator) {
     //     116.4056510107 };
     testMultiple(process, "geometric Brownian", result2, result2a);
 
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-                                     new OrnsteinUhlenbeckProcess(0.1, 0.20));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-                                     new OrnsteinUhlenbeckProcess(0.1, 0.20));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-                                     new OrnsteinUhlenbeckProcess(0.1, 0.20));
-    process = ext::shared_ptr<StochasticProcess>(
-                           new StochasticProcessArray(processes,correlation));
+    processes[0] = ext::make_shared<OrnsteinUhlenbeckProcess>(0.1, 0.20);
+    processes[1] = ext::make_shared<OrnsteinUhlenbeckProcess>(0.1, 0.20);
+    processes[2] = ext::make_shared<OrnsteinUhlenbeckProcess>(0.1, 0.20);
+    process = ext::make_shared<StochasticProcessArray>(processes,correlation);
     Real result3[] = {
         0.2942058437284,
         0.5525006418386,
@@ -265,14 +248,10 @@ BOOST_AUTO_TEST_CASE(testMultiPathGenerator) {
         -0.02650931054575 };
     testMultiple(process, "Ornstein-Uhlenbeck", result3, result3a);
 
-    processes[0] = ext::shared_ptr<StochasticProcess1D>(
-                                 new SquareRootProcess(0.1, 0.1, 0.20, 10.0));
-    processes[1] = ext::shared_ptr<StochasticProcess1D>(
-                                 new SquareRootProcess(0.1, 0.1, 0.20, 10.0));
-    processes[2] = ext::shared_ptr<StochasticProcess1D>(
-                                 new SquareRootProcess(0.1, 0.1, 0.20, 10.0));
-    process = ext::shared_ptr<StochasticProcess>(
-                           new StochasticProcessArray(processes,correlation));
+    processes[0] = ext::make_shared<SquareRootProcess>(0.1, 0.1, 0.20, 10.0);
+    processes[1] = ext::make_shared<SquareRootProcess>(0.1, 0.1, 0.20, 10.0);
+    processes[2] = ext::make_shared<SquareRootProcess>(0.1, 0.1, 0.20, 10.0);
+    process = ext::make_shared<StochasticProcessArray>(processes,correlation);
     Real result4[] = {
         4.279510844897,
         4.943783503533,

--- a/test-suite/perpetualfutures.cpp
+++ b/test-suite/perpetualfutures.cpp
@@ -89,8 +89,8 @@ BOOST_AUTO_TEST_CASE(testPerpetualFuturesValues) {
         Handle<YieldTermStructure> forCurve(flatRate(today, value.q, dc));
         Handle<Quote> spot(ext::make_shared<SimpleQuote>(value.s));
         std::vector<Real> fundingTimes = { 0.0 }, fundingRates = { value.k }, interestRateDiffs = { value.iDiff };
-        ext::shared_ptr<PricingEngine> engine(new DiscountingPerpetualFuturesEngine(
-            domCurve, forCurve, spot, fundingTimes, fundingRates, interestRateDiffs));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<DiscountingPerpetualFuturesEngine>(
+            domCurve, forCurve, spot, fundingTimes, fundingRates, interestRateDiffs);
         trade.setPricingEngine(engine);
         Real calculated = trade.NPV();
 

--- a/test-suite/quantooption.cpp
+++ b/test-suite/quantooption.cpp
@@ -239,25 +239,24 @@ BOOST_AUTO_TEST_CASE(testValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(today, fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(today, fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<VanillaOption, AnalyticEuropeanEngine>(
                                                  stochProcess, fxrTS, fxVolTS,
@@ -265,9 +264,9 @@ BOOST_AUTO_TEST_CASE(testValues) {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
@@ -320,21 +319,20 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<VanillaOption,AnalyticEuropeanEngine>(
@@ -346,9 +344,9 @@ BOOST_AUTO_TEST_CASE(testGreeks) {
             for (int length : lengths) {
 
                 Date exDate = today + length * Years;
-                ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
-                ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, strike));
+                ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, strike);
 
                 QuantoVanillaOption option(payoff, exercise);
                 option.setPricingEngine(engine);
@@ -504,25 +502,24 @@ BOOST_AUTO_TEST_CASE(testForwardValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(today, fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(today, fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<ForwardVanillaOption,
@@ -532,9 +529,9 @@ BOOST_AUTO_TEST_CASE(testForwardValues) {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, 0.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, 0.0);
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         Date reset = today + timeToDays(value.start);
 
         spot->setValue(value.s);
@@ -590,21 +587,20 @@ BOOST_AUTO_TEST_CASE(testForwardGreeks) {
     Date today = Date::todaysDate();
     Settings::instance().evaluationDate() = today;
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(vol, dc));
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot), qTS, rTS, volTS));
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot), qTS, rTS, volTS);
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<ForwardVanillaOption,
@@ -618,11 +614,11 @@ BOOST_AUTO_TEST_CASE(testForwardGreeks) {
                 for (int startMonth : startMonths) {
 
                     Date exDate = today + length * Years;
-                    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+                    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
                     Date reset = today + startMonth * Months;
 
-                    ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(type, 0.0));
+                    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(type, 0.0);
 
                     QuantoForwardVanillaOption option(moneynes, reset, payoff, exercise);
                     option.setPricingEngine(engine);
@@ -788,25 +784,24 @@ BOOST_AUTO_TEST_CASE(testForwardPerformanceValues) {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(today, fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(today, fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<ForwardVanillaOption,
@@ -821,7 +816,7 @@ BOOST_AUTO_TEST_CASE(testForwardPerformanceValues) {
             //                               values[i].moneyness));
             new PlainVanillaPayoff(value.type, 0.0));
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         Date reset = today + timeToDays(value.start);
 
         spot->setValue(value.s);
@@ -867,25 +862,24 @@ BOOST_AUTO_TEST_CASE(testBarrierValues)  {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(today, fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(today, fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-         new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<BarrierOption, AnalyticBarrierEngine>(
@@ -894,10 +888,10 @@ BOOST_AUTO_TEST_CASE(testBarrierValues)  {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);
@@ -991,13 +985,12 @@ BOOST_AUTO_TEST_CASE(testFDMQuantoHelper)  {
     const Real eps = 0.0002;
     const Real scalingFactor = 1.25;
 
-    const ext::shared_ptr<FdmBlackScholesMesher> mesher(
-        new FdmBlackScholesMesher(
+    const ext::shared_ptr<FdmBlackScholesMesher> mesher = ext::make_shared<FdmBlackScholesMesher>(
             3, bsmProcess, maturityTime, s,
             Null<Real>(), Null<Real>(), eps, scalingFactor,
             std::pair<Real, Real>(Null<Real>(), Null<Real>()),
             DividendSchedule(),
-            fdmQuantoHelper));
+            fdmQuantoHelper);
 
     const Real normInvEps = InverseCumulativeNormal()(1-eps);
     const Real sigmaSqrtT = vol * std::sqrt(maturityTime);
@@ -1074,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(testPDEOptionValues)  {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::make_shared<PlainVanillaPayoff>(value.type, strike);
         const Date exDate = today + timeToDays(value.t);
-        const ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         VanillaOption option(payoff, exercise);
 
@@ -1281,25 +1274,24 @@ BOOST_AUTO_TEST_CASE(testDoubleBarrierValues)  {
     DayCounter dc = Actual360();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> qTS(flatRate(today, qRate, dc));
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
-    ext::shared_ptr<SimpleQuote> vol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> vol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> volTS(flatVol(today, vol, dc));
 
-    ext::shared_ptr<SimpleQuote> fxRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> fxrTS(flatRate(today, fxRate, dc));
-    ext::shared_ptr<SimpleQuote> fxVol(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> fxVol = ext::make_shared<SimpleQuote>(0.0);
     Handle<BlackVolTermStructure> fxVolTS(flatVol(today, fxVol, dc));
-    ext::shared_ptr<SimpleQuote> correlation(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> correlation = ext::make_shared<SimpleQuote>(0.0);
 
-    ext::shared_ptr<BlackScholesMertonProcess> stochProcess(
-        new BlackScholesMertonProcess(Handle<Quote>(spot),
+    ext::shared_ptr<BlackScholesMertonProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
     ext::shared_ptr<PricingEngine> engine(
         new QuantoEngine<DoubleBarrierOption, AnalyticDoubleBarrierEngine>(
@@ -1308,10 +1300,10 @@ BOOST_AUTO_TEST_CASE(testDoubleBarrierValues)  {
 
     for (auto& value : values) {
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         Date exDate = today + timeToDays(value.t);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
         spot->setValue(value.s);
         qRate->setValue(value.q);

--- a/test-suite/quotes.cpp
+++ b/test-suite/quotes.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(testObservable) {
 
     BOOST_TEST_MESSAGE("Testing observability of quotes...");
 
-    ext::shared_ptr<SimpleQuote> me(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> me = ext::make_shared<SimpleQuote>(0.0);
     Flag f;
     f.registerWith(me);
     me->setValue(3.14);
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(testObservableHandle) {
 
     BOOST_TEST_MESSAGE("Testing observability of quote handles...");
 
-    ext::shared_ptr<SimpleQuote> me1(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> me1 = ext::make_shared<SimpleQuote>(0.0);
     RelinkableHandle<Quote> h(me1);
     Flag f;
     f.registerWith(h);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(testObservableHandle) {
         BOOST_FAIL("Observer was not notified of quote change");
 
     f.lower();
-    ext::shared_ptr<SimpleQuote> me2(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> me2 = ext::make_shared<SimpleQuote>(0.0);
     h.linkTo(me2);
     if (!f.isUp())
         BOOST_FAIL("Observer was not notified of quote change");
@@ -172,17 +172,16 @@ BOOST_AUTO_TEST_CASE(testForwardValueQuoteAndImpliedStdevQuote){
     Real forwardRate = .05;
     DayCounter dc = ActualActual(ActualActual::ISDA);
     Calendar calendar = TARGET();
-    ext::shared_ptr<SimpleQuote> forwardQuote(new SimpleQuote(forwardRate));
+    ext::shared_ptr<SimpleQuote> forwardQuote = ext::make_shared<SimpleQuote>(forwardRate);
     Handle<Quote> forwardHandle(forwardQuote);
     Date evaluationDate = Settings::instance().evaluationDate();
-    ext::shared_ptr<YieldTermStructure>yc (new FlatForward(
-        evaluationDate, forwardHandle, dc));
+    ext::shared_ptr<YieldTermStructure>yc =
+        ext::make_shared<FlatForward>(evaluationDate, forwardHandle, dc);
     Handle<YieldTermStructure> ycHandle(yc);
     Period euriborTenor(1,Years);
-    ext::shared_ptr<Index> euribor(new Euribor(euriborTenor, ycHandle));
+    ext::shared_ptr<Index> euribor = ext::make_shared<Euribor>(euriborTenor, ycHandle);
     Date fixingDate = calendar.advance(evaluationDate, euriborTenor);
-    ext::shared_ptr<ForwardValueQuote> forwardValueQuote( new
-        ForwardValueQuote(euribor, fixingDate));
+    ext::shared_ptr<ForwardValueQuote> forwardValueQuote = ext::make_shared<ForwardValueQuote>(euribor, fixingDate);
     Rate forwardValue =  forwardValueQuote->value();
     Rate expectedForwardValue = euribor->fixing(fixingDate, true);
     // we test if the forward value given by the quote is consistent
@@ -211,11 +210,10 @@ BOOST_AUTO_TEST_CASE(testForwardValueQuoteAndImpliedStdevQuote){
     Volatility guess = .15;
     Real accuracy = 1.0e-6;
     Option::Type optionType = Option::Call;
-    ext::shared_ptr<SimpleQuote> priceQuote(new SimpleQuote(price));
+    ext::shared_ptr<SimpleQuote> priceQuote = ext::make_shared<SimpleQuote>(price);
     Handle<Quote> priceHandle(priceQuote);
-    ext::shared_ptr<ImpliedStdDevQuote> impliedStdevQuote(new
-        ImpliedStdDevQuote(optionType, forwardHandle, priceHandle,
-                           strike, guess, accuracy));
+    ext::shared_ptr<ImpliedStdDevQuote> impliedStdevQuote = ext::make_shared<ImpliedStdDevQuote>(optionType, forwardHandle, priceHandle,
+                           strike, guess, accuracy);
     Real impliedStdev = impliedStdevQuote->value();
     Real expectedImpliedStdev =
         blackFormulaImpliedStdDev(optionType, strike,

--- a/test-suite/rangeaccrual.cpp
+++ b/test-suite/rangeaccrual.cpp
@@ -129,8 +129,7 @@ struct CommonVars {
             0.04476692489, 0.04473779454, 0.04468646066, 0.04430951558, 0.04363922313,
             0.04363601992};
 
-        termStructure.linkTo( ext::shared_ptr<YieldTermStructure>(
-                new ZeroCurve(dates, zeroRates, Actual365Fixed())));
+        termStructure.linkTo( ext::make_shared<ZeroCurve>(dates, zeroRates, Actual365Fixed()));
     }
 
     void createVolatilityStructures() {
@@ -213,11 +212,9 @@ struct CommonVars {
         fixedLegFrequency = Annual;
         fixedLegConvention = Unadjusted;
         fixedLegDayCounter = Thirty360(Thirty360::BondBasis);
-        ext::shared_ptr<SwapIndex> swapIndexBase(new
-                EuriborSwapIsdaFixA(2*Years, termStructure));
+        ext::shared_ptr<SwapIndex> swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(2*Years, termStructure);
 
-        ext::shared_ptr<SwapIndex> shortSwapIndexBase(new
-                EuriborSwapIsdaFixA(1*Years, termStructure));
+        ext::shared_ptr<SwapIndex> shortSwapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1*Years, termStructure);
 
         vegaWeightedSmileFit = false;
 
@@ -230,21 +227,19 @@ struct CommonVars {
             atmVolsHandle[i] = std::vector<Handle<Quote> >(nColsAtmVols);
             for (Size j=0; j<nColsAtmVols; j++) {
                 atmVolsHandle[i][j] =
-                    Handle<Quote>(ext::shared_ptr<Quote>(new
-                            SimpleQuote(atmVolMatrix[i][j])));
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolMatrix[i][j]));
             }
         }
 
         dayCounter = Actual365Fixed();
 
         atmVol = Handle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    SwaptionVolatilityMatrix(calendar,
+                ext::make_shared<SwaptionVolatilityMatrix>(calendar,
                                              optionBDC,
                                              atmOptionTenors,
                                              atmSwapTenors,
                                              atmVolsHandle,
-                                             dayCounter)));
+                                             dayCounter));
 
         // Volatility Cube without smile
         std::vector<std::vector<Handle<Quote> > > parametersGuess(
@@ -252,13 +247,13 @@ struct CommonVars {
         for (i=0; i<optionTenors.size()*swapTenors.size(); i++) {
             parametersGuess[i] = std::vector<Handle<Quote> >(4);
             parametersGuess[i][0] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
             parametersGuess[i][1] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
             parametersGuess[i][2] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
             parametersGuess[i][3] =
-                Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+                Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
         }
         std::vector<bool> isParameterFixed(4, false);
         isParameterFixed[1]=true;
@@ -268,12 +263,12 @@ struct CommonVars {
             nullVolSpreads[i] = std::vector<Handle<Quote> >(nCols);
             for (Size j=0; j<strikeSpreads.size(); j++) {
                 nullVolSpreads[i][j] =
-                    Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.)));
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(0.));
             }
         }
 
         ext::shared_ptr<SabrSwaptionVolatilityCube>
-            flatSwaptionVolatilityCube1ptr(new SabrSwaptionVolatilityCube(
+            flatSwaptionVolatilityCube1ptr = ext::make_shared<SabrSwaptionVolatilityCube>(
                 atmVol,
                 optionTenors,
                 swapTenors,
@@ -284,21 +279,21 @@ struct CommonVars {
                 vegaWeightedSmileFit,
                 parametersGuess,
                 isParameterFixed,
-                false));
+                false);
         flatSwaptionVolatilityCube1 = Handle<SwaptionVolatilityStructure>(
                 ext::shared_ptr<SwaptionVolatilityStructure>(
                                              flatSwaptionVolatilityCube1ptr));
         flatSwaptionVolatilityCube1->enableExtrapolation();
 
         ext::shared_ptr<InterpolatedSwaptionVolatilityCube>
-            flatSwaptionVolatilityCube2ptr(new InterpolatedSwaptionVolatilityCube(atmVol,
+            flatSwaptionVolatilityCube2ptr = ext::make_shared<InterpolatedSwaptionVolatilityCube>(atmVol,
                                                              optionTenors,
                                                              swapTenors,
                                                              strikeSpreads,
                                                              nullVolSpreads,
                                                              swapIndexBase,
                                                              shortSwapIndexBase,
-                                                             vegaWeightedSmileFit));
+                                                             vegaWeightedSmileFit);
         flatSwaptionVolatilityCube2 = Handle<SwaptionVolatilityStructure>(
                 ext::shared_ptr<SwaptionVolatilityStructure>(flatSwaptionVolatilityCube2ptr));
         flatSwaptionVolatilityCube2->enableExtrapolation();
@@ -310,13 +305,12 @@ struct CommonVars {
             volSpreads[i] = std::vector<Handle<Quote> >(nCols);
             for (Size j=0; j<strikeSpreads.size(); j++) {
                 volSpreads[i][j] =
-                    Handle<Quote>(ext::shared_ptr<Quote>(new
-                            SimpleQuote(volSpreadsMatrix[i][j])));
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(volSpreadsMatrix[i][j]));
             }
         }
 
         ext::shared_ptr<SabrSwaptionVolatilityCube>
-            swaptionVolatilityCubeBySabrPtr(new SabrSwaptionVolatilityCube(
+            swaptionVolatilityCubeBySabrPtr = ext::make_shared<SabrSwaptionVolatilityCube>(
                 atmVol,
                 optionTenors,
                 swapTenors,
@@ -327,7 +321,7 @@ struct CommonVars {
                 vegaWeightedSmileFit,
                 parametersGuess,
                 isParameterFixed,
-                false));
+                false);
         swaptionVolatilityCubeBySabr = Handle<SwaptionVolatilityStructure>(
             ext::shared_ptr<SwaptionVolatilityStructure>(swaptionVolatilityCubeBySabrPtr));
         swaptionVolatilityCubeBySabr->enableExtrapolation();
@@ -494,28 +488,24 @@ struct CommonVars {
 
         //Create smiles on Expiry Date
         smilesOnExpiry = std::vector<ext::shared_ptr<SmileSection> >();
-        smilesOnExpiry.push_back(ext::shared_ptr<SmileSection>(
-                                                               new FlatSmileSection(startDate, flatVol, rangeCouponDayCount)));
+        smilesOnExpiry.push_back(ext::make_shared<FlatSmileSection>(startDate, flatVol, rangeCouponDayCount));
         Real dummyAtmLevel = 0;
-        smilesOnExpiry.push_back(ext::shared_ptr<SmileSection>(new
-                InterpolatedSmileSection<Linear>(startDate,
+        smilesOnExpiry.push_back(ext::make_shared<InterpolatedSmileSection<Linear>>(startDate,
                                                  strikes,
                                                  stdDevsOnExpiry,
                                                  dummyAtmLevel,
-                                                 rangeCouponDayCount)));
+                                                 rangeCouponDayCount));
         //smilesOnExpiry.push_back(
         //    swaptionVolatilityStructures_[0]->smileSection(startDate,
         //                                                   Period(6, Months)));
         //Create smiles on Payment Date
         smilesOnPayment = std::vector<ext::shared_ptr<SmileSection> >();
-        smilesOnPayment.push_back(ext::shared_ptr<SmileSection>(
-                new FlatSmileSection(endDate, flatVol, rangeCouponDayCount)));
-        smilesOnPayment.push_back(ext::shared_ptr<SmileSection>(new
-                InterpolatedSmileSection<Linear>(endDate,
+        smilesOnPayment.push_back(ext::make_shared<FlatSmileSection>(endDate, flatVol, rangeCouponDayCount));
+        smilesOnPayment.push_back(ext::make_shared<InterpolatedSmileSection<Linear>>(endDate,
                                                  strikes,
                                                  stdDevsOnPayment,
                                                  dummyAtmLevel,
-                                                 rangeCouponDayCount)));
+                                                 rangeCouponDayCount));
         //vars.smilesOnPayment.push_back(
         //    swaptionVolatilityStructures_[0]->smileSection(vars.endDate,
         //                                                   Period(6, Months)));
@@ -536,7 +526,7 @@ struct CommonVars {
         referenceDate = termStructure->referenceDate();
         // Ibor index
         iborIndex =
-            ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+            ext::make_shared<Euribor6M>(termStructure);
 
         // create Volatility Structures
         flatVol = 0.1;
@@ -605,12 +595,11 @@ BOOST_AUTO_TEST_CASE(testInfiniteRange)  {
 
     for (Size z = 0; z < vars.smilesOnPayment.size(); z++) {
         for (Size i = 0; i < vars.byCallSpread.size(); i++){
-            ext::shared_ptr<RangeAccrualPricer> bgmPricer(new
-                RangeAccrualPricerByBgm(vars.correlation,
+            ext::shared_ptr<RangeAccrualPricer> bgmPricer = ext::make_shared<RangeAccrualPricerByBgm>(vars.correlation,
                                         vars.smilesOnExpiry[z],
                                         vars.smilesOnPayment[z],
                                         true,
-                                        vars.byCallSpread[i]));
+                                        vars.byCallSpread[i]);
 
                 coupon.setPricer(bgmPricer);
 
@@ -642,12 +631,11 @@ BOOST_AUTO_TEST_CASE(testPriceMonotonicityWithRespectToLowerStrike) {
 
     for (Size z = 0; z < vars.smilesOnPayment.size(); z++) {
         for (Size i = 0; i < vars.byCallSpread.size(); i++){
-            ext::shared_ptr<RangeAccrualPricer> bgmPricer(new
-                RangeAccrualPricerByBgm(vars.correlation,
+            ext::shared_ptr<RangeAccrualPricer> bgmPricer = ext::make_shared<RangeAccrualPricerByBgm>(vars.correlation,
                                         vars.smilesOnExpiry[z],
                                         vars.smilesOnPayment[z],
                                         true,
-                                        vars.byCallSpread[i]));
+                                        vars.byCallSpread[i]);
 
             Real effectiveLowerStrike;
             Real previousPrice = 100.;
@@ -697,12 +685,11 @@ BOOST_AUTO_TEST_CASE(testPriceMonotonicityWithRespectToUpperStrike) {
 
     for (Size z = 0; z < vars.smilesOnPayment.size(); z++) {
         for (Size i = 0; i < vars.byCallSpread.size(); i++){
-            ext::shared_ptr<RangeAccrualPricer> bgmPricer(new
-                RangeAccrualPricerByBgm(vars.correlation,
+            ext::shared_ptr<RangeAccrualPricer> bgmPricer = ext::make_shared<RangeAccrualPricerByBgm>(vars.correlation,
                                         vars.smilesOnExpiry[z],
                                         vars.smilesOnPayment[z],
                                         true,
-                                        vars.byCallSpread[i]));
+                                        vars.byCallSpread[i]);
 
             Real effectiveUpperStrike;
             Real previousPrice = 0.;

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -68,10 +68,9 @@ BOOST_AUTO_TEST_CASE(testDensityAgainstOptionPrices) {
 
     const Handle<YieldTermStructure> qTS(flatRate(todaysDate, q, dayCounter));
 
-    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
             spot, qTS, rTS,
-            Handle<BlackVolTermStructure>(flatVol(v, dayCounter))));
+            Handle<BlackVolTermStructure>(flatVol(v, dayCounter)));
 
     const BSMRNDCalculator bsm(bsmProcess);
     const Time times[] = { 0.5, 1.0, 2.0 };
@@ -144,10 +143,9 @@ BOOST_AUTO_TEST_CASE(testBSMagainstHestonRND) {
 
     const Handle<YieldTermStructure> qTS(flatRate(todaysDate, q, dayCounter));
 
-    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
             spot, qTS, rTS,
-            Handle<BlackVolTermStructure>(flatVol(v, dayCounter))));
+            Handle<BlackVolTermStructure>(flatVol(v, dayCounter)));
 
     const BSMRNDCalculator bsm(bsmProcess);
     const HestonRNDCalculator heston(
@@ -302,13 +300,12 @@ BOOST_AUTO_TEST_CASE(testLocalVolatilityRND) {
     const ext::shared_ptr<YieldTermStructure> qTS(
         flatRate(todaysDate, q, dayCounter));
 
-    const ext::shared_ptr<TimeGrid> timeGrid(new TimeGrid(1.0, 101));
+    const ext::shared_ptr<TimeGrid> timeGrid = ext::make_shared<TimeGrid>(1.0, 101);
 
-    const ext::shared_ptr<LocalVolRNDCalculator> constVolCalc(
-        new LocalVolRNDCalculator(
+    const ext::shared_ptr<LocalVolRNDCalculator> constVolCalc = ext::make_shared<LocalVolRNDCalculator>(
             spot, rTS, qTS,
             ext::make_shared<LocalConstantVol>(todaysDate, v, dayCounter),
-            timeGrid, 201));
+            timeGrid, 201);
 
     const Real rTol = 0.01, atol = 0.005;
     for (Time t=0.1; t < 0.99; t+=0.015) {
@@ -382,15 +379,13 @@ BOOST_AUTO_TEST_CASE(testLocalVolatilityRND) {
     const Real b4 = -0.02;
     const Real b5 = -0.005;
 
-    const ext::shared_ptr<DumasParametricVolSurface> dumasVolSurface(
-        new DumasParametricVolSurface(b1, b2, b3, b4, b5, spot, rTS, qTS));
+    const ext::shared_ptr<DumasParametricVolSurface> dumasVolSurface = ext::make_shared<DumasParametricVolSurface>(b1, b2, b3, b4, b5, spot, rTS, qTS);
 
-    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess(
-        new BlackScholesMertonProcess(
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess = ext::make_shared<BlackScholesMertonProcess>(
             Handle<Quote>(spot),
             Handle<YieldTermStructure>(qTS),
             Handle<YieldTermStructure>(rTS),
-            Handle<BlackVolTermStructure>(dumasVolSurface)));
+            Handle<BlackVolTermStructure>(dumasVolSurface));
 
     const ext::shared_ptr<LocalVolTermStructure> localVolSurface
         = ext::make_shared<NoExceptLocalVolSurface>(
@@ -402,12 +397,10 @@ BOOST_AUTO_TEST_CASE(testLocalVolatilityRND) {
     const std::vector<Time> adaptiveGrid
         = adaptiveTimeGrid(400, 50, 5.0, 3.0);
 
-    const ext::shared_ptr<TimeGrid> dumasTimeGrid(
-        new TimeGrid(adaptiveGrid.begin(), adaptiveGrid.end()));
+    const ext::shared_ptr<TimeGrid> dumasTimeGrid = ext::make_shared<TimeGrid>(adaptiveGrid.begin(), adaptiveGrid.end());
 
-    const ext::shared_ptr<LocalVolRNDCalculator> dumasVolCalc(
-        new LocalVolRNDCalculator(
-            spot, rTS, qTS, localVolSurface, dumasTimeGrid, 401, 0.1, 1e-8));
+    const ext::shared_ptr<LocalVolRNDCalculator> dumasVolCalc = ext::make_shared<LocalVolRNDCalculator>(
+            spot, rTS, qTS, localVolSurface, dumasTimeGrid, 401, 0.1, 1e-8);
 
     const Real strikes[] = { 25, 50, 95, 100, 105, 150, 200, 400 };
     const std::vector<Date> maturities = {
@@ -421,16 +414,15 @@ BOOST_AUTO_TEST_CASE(testLocalVolatilityRND) {
         const Time expiry
             = rTS->dayCounter().yearFraction(todaysDate, maturity);
 
-        const ext::shared_ptr<PricingEngine> engine(
-            new FdBlackScholesVanillaEngine(
+        const ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdBlackScholesVanillaEngine>(
                 bsmProcess, std::max(Size(51), Size(expiry*101)),
-                201, 0, FdmSchemeDesc::Douglas(), true, b1));
+                201, 0, FdmSchemeDesc::Douglas(), true, b1);
 
-        const ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
+        const ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
         for (Real strike : strikes) {
-            const ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(
-                (strike > spot->value()) ? Option::Call : Option::Put, strike));
+            const ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(
+                (strike > spot->value()) ? Option::Call : Option::Put, strike);
 
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(engine);
@@ -589,7 +581,7 @@ BOOST_AUTO_TEST_CASE(testBlackScholesWithSkew) {
             AnalyticHestonEngine::AndersenPiterbarg,
             AnalyticHestonEngine::Integration::discreteTrapezoid(128)));
 
-    const ext::shared_ptr<TimeGrid> timeGrid(new TimeGrid(maturity, 51));
+    const ext::shared_ptr<TimeGrid> timeGrid = ext::make_shared<TimeGrid>(maturity, 51);
 
     const ext::shared_ptr<LocalVolTermStructure> localVol(
         ext::make_shared<NoExceptLocalVolSurface>(

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -65,23 +65,21 @@ BOOST_AUTO_TEST_CASE(testCachedHullWhite) {
     Settings::instance().evaluationDate() = today;
     Handle<YieldTermStructure> termStructure(flatRate(settlement,0.04875825,
                                                       Actual365Fixed()));
-    ext::shared_ptr<HullWhite> model(new HullWhite(termStructure));
+    ext::shared_ptr<HullWhite> model = ext::make_shared<HullWhite>(termStructure);
     CalibrationData data[] = {{ 1, 5, 0.1148 },
                               { 2, 4, 0.1108 },
                               { 3, 3, 0.1070 },
                               { 4, 2, 0.1021 },
                               { 5, 1, 0.1000 }};
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
 
-    ext::shared_ptr<PricingEngine> engine(
-                                     new JamshidianSwaptionEngine(model));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<JamshidianSwaptionEngine>(model);
 
     std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
     for (auto& i : data) {
-        ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
-        ext::shared_ptr<BlackCalibrationHelper> helper(
-            new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
-                               index, Period(1, Years), Thirty360(Thirty360::BondBasis), Actual360(), termStructure));
+        ext::shared_ptr<Quote> vol = ext::make_shared<SimpleQuote>(i.volatility);
+        ext::shared_ptr<BlackCalibrationHelper> helper = ext::make_shared<SwaptionHelper>(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
+                               index, Period(1, Years), Thirty360(Thirty360::BondBasis), Actual360(), termStructure);
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -137,24 +135,22 @@ BOOST_AUTO_TEST_CASE(testCachedHullWhiteFixedReversion) {
     Settings::instance().evaluationDate() = today;
     Handle<YieldTermStructure> termStructure(flatRate(settlement,0.04875825,
                                                       Actual365Fixed()));
-    ext::shared_ptr<HullWhite> model(new HullWhite(termStructure,0.05,0.01));
+    ext::shared_ptr<HullWhite> model = ext::make_shared<HullWhite>(termStructure,0.05,0.01);
     CalibrationData data[] = {{ 1, 5, 0.1148 },
                               { 2, 4, 0.1108 },
                               { 3, 3, 0.1070 },
                               { 4, 2, 0.1021 },
                               { 5, 1, 0.1000 }};
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
 
-    ext::shared_ptr<PricingEngine> engine(
-                                     new JamshidianSwaptionEngine(model));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<JamshidianSwaptionEngine>(model);
 
     std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
     for (auto& i : data) {
-        ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
-        ext::shared_ptr<BlackCalibrationHelper> helper(
-            new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
+        ext::shared_ptr<Quote> vol = ext::make_shared<SimpleQuote>(i.volatility);
+        ext::shared_ptr<BlackCalibrationHelper> helper = ext::make_shared<SwaptionHelper>(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
                                index, Period(1, Years), Thirty360(Thirty360::BondBasis),
-                               Actual360(), termStructure));
+                               Actual360(), termStructure);
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -212,27 +208,25 @@ BOOST_AUTO_TEST_CASE(testCachedHullWhite2) {
     Settings::instance().evaluationDate() = today;
     Handle<YieldTermStructure> termStructure(flatRate(settlement,0.04875825,
                                                       Actual365Fixed()));
-    ext::shared_ptr<HullWhite> model(new HullWhite(termStructure));
+    ext::shared_ptr<HullWhite> model = ext::make_shared<HullWhite>(termStructure);
     CalibrationData data[] = {{ 1, 5, 0.1148 },
                               { 2, 4, 0.1108 },
                               { 3, 3, 0.1070 },
                               { 4, 2, 0.1021 },
                               { 5, 1, 0.1000 }};
-    ext::shared_ptr<IborIndex> index(new Euribor6M(termStructure));
-    ext::shared_ptr<IborIndex> index0(new IborIndex(
+    ext::shared_ptr<IborIndex> index = ext::make_shared<Euribor6M>(termStructure);
+    ext::shared_ptr<IborIndex> index0 = ext::make_shared<IborIndex>(
         index->familyName(),index->tenor(),0,index->currency(),index->fixingCalendar(),
-        index->businessDayConvention(),index->endOfMonth(),index->dayCounter(),termStructure)); // Euribor 6m with zero fixing days
+        index->businessDayConvention(),index->endOfMonth(),index->dayCounter(),termStructure); // Euribor 6m with zero fixing days
 
-    ext::shared_ptr<PricingEngine> engine(
-                                     new JamshidianSwaptionEngine(model));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<JamshidianSwaptionEngine>(model);
 
     std::vector<ext::shared_ptr<CalibrationHelper> > swaptions;
     for (auto& i : data) {
-        ext::shared_ptr<Quote> vol(new SimpleQuote(i.volatility));
-        ext::shared_ptr<BlackCalibrationHelper> helper(
-            new SwaptionHelper(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
+        ext::shared_ptr<Quote> vol = ext::make_shared<SimpleQuote>(i.volatility);
+        ext::shared_ptr<BlackCalibrationHelper> helper = ext::make_shared<SwaptionHelper>(Period(i.start, Years), Period(i.length, Years), Handle<Quote>(vol),
                                index0, Period(1, Years), Thirty360(Thirty360::BondBasis),
-                               Actual360(), termStructure));
+                               Actual360(), termStructure);
         helper->setPricingEngine(engine);
         swaptions.push_back(helper);
     }
@@ -322,18 +316,16 @@ BOOST_AUTO_TEST_CASE(testSwaps) {
     };
 
     Handle<YieldTermStructure> termStructure(
-       ext::shared_ptr<YieldTermStructure>(
-           new DiscountCurve(dates, discounts, Actual365Fixed())));
+       ext::make_shared<DiscountCurve>(dates, discounts, Actual365Fixed()));
 
-    ext::shared_ptr<HullWhite> model(new HullWhite(termStructure));
+    ext::shared_ptr<HullWhite> model = ext::make_shared<HullWhite>(termStructure);
 
     Integer start[] = { -3, 0, 3 };
     Integer length[] = { 2, 5, 10 };
     Rate rates[] = { 0.02, 0.04, 0.06 };
-    ext::shared_ptr<IborIndex> euribor(new Euribor6M(termStructure));
+    ext::shared_ptr<IborIndex> euribor = ext::make_shared<Euribor6M>(termStructure);
 
-    ext::shared_ptr<PricingEngine> engine(
-                                     new TreeVanillaSwapEngine(model,120));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<TreeVanillaSwapEngine>(model,120);
 
     Real tolerance = usingAtParCoupons ? 1.0e-8 : 4.0e-3;
 
@@ -359,8 +351,7 @@ BOOST_AUTO_TEST_CASE(testSwaps) {
                 VanillaSwap swap(Swap::Payer, 1000000.0, fixedSchedule, rate,
                                  Thirty360(Thirty360::BondBasis),
                                  floatSchedule, euribor, 0.0, Actual360());
-                swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                     new DiscountingSwapEngine(termStructure)));
+                swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(termStructure));
                 Real expected = swap.NPV();
                 swap.setPricingEngine(engine);
                 Real calculated = swap.NPV();

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -70,13 +70,11 @@ struct CommonVars {
                                Period(floatingFrequency),
                                calendar,floatingConvention,
                                floatingConvention, rule, false);
-        ext::shared_ptr<VanillaSwap> swap(
-                new VanillaSwap(type, nominal,
+        ext::shared_ptr<VanillaSwap> swap = ext::make_shared<VanillaSwap>(type, nominal,
                                 fixedSchedule, fixedRate, fixedDayCount,
                                 floatSchedule, index, floatingSpread,
-                                index->dayCounter()));
-        swap->setPricingEngine(ext::shared_ptr<PricingEngine>(
-                                  new DiscountingSwapEngine(termStructure)));
+                                index->dayCounter());
+        swap->setPricingEngine(ext::make_shared<DiscountingSwapEngine>(termStructure));
         return swap;
     }
 
@@ -89,8 +87,7 @@ struct CommonVars {
         fixedFrequency = Annual;
         floatingFrequency = Semiannual;
         fixedDayCount = Thirty360(Thirty360::BondBasis);
-        index = ext::shared_ptr<IborIndex>(new
-                Euribor(Period(floatingFrequency), termStructure));
+        index = ext::make_shared<Euribor>(Period(floatingFrequency), termStructure);
         calendar = index->fixingCalendar();
         today = calendar.adjust(Settings::instance().evaluationDate());
         settlement = calendar.advance(today,settlementDays,Days);
@@ -233,10 +230,10 @@ BOOST_AUTO_TEST_CASE(testInArrears) {
                       DateGeneration::Forward,false);
     DayCounter dayCounter = SimpleDayCounter();
     std::vector<Real> nominals(1, 100000000.0);
-    ext::shared_ptr<IborIndex> index(new IborIndex("dummy", 1*Years, 0,
+    ext::shared_ptr<IborIndex> index = ext::make_shared<IborIndex>("dummy", 1*Years, 0,
                                              EURCurrency(), calendar,
                                              Following, false, dayCounter,
-                                             vars.termStructure));
+                                             vars.termStructure);
     Rate oneYear = 0.05;
     Rate r = std::log(1.0+oneYear);
     vars.termStructure.linkTo(flatRate(vars.today,r,dayCounter));
@@ -253,11 +250,9 @@ BOOST_AUTO_TEST_CASE(testInArrears) {
 
     Volatility capletVolatility = 0.22;
     Handle<OptionletVolatilityStructure> vol(
-        ext::shared_ptr<OptionletVolatilityStructure>(new
-            ConstantOptionletVolatility(vars.today, NullCalendar(), Following,
-                                        capletVolatility, dayCounter)));
-    ext::shared_ptr<IborCouponPricer> pricer(new
-        BlackIborCouponPricer(vol));
+        ext::make_shared<ConstantOptionletVolatility>(vars.today, NullCalendar(), Following,
+                                        capletVolatility, dayCounter));
+    ext::shared_ptr<IborCouponPricer> pricer = ext::make_shared<BlackIborCouponPricer>(vol);
 
     Leg floatingLeg = IborLeg(schedule, index)
         .withNotionals(nominals)
@@ -269,8 +264,7 @@ BOOST_AUTO_TEST_CASE(testInArrears) {
     setCouponPricer(floatingLeg, pricer);
 
     Swap swap(floatingLeg,fixedLeg);
-    swap.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                              new DiscountingSwapEngine(vars.termStructure)));
+    swap.setPricingEngine(ext::make_shared<DiscountingSwapEngine>(vars.termStructure));
 
     Decimal storedValue = -144813.0;
     Real tolerance = 1.0;

--- a/test-suite/swapforwardmappings.cpp
+++ b/test-suite/swapforwardmappings.cpp
@@ -156,8 +156,7 @@ simulate(const std::vector<Real>& todaysDiscounts,
     Real initialNumeraireValue = todaysDiscounts[initialNumeraire];
 
     AccountingEngine engine(evolver, product, initialNumeraireValue);
-    ext::shared_ptr<SequenceStatisticsInc> stats(new
-            SequenceStatisticsInc(product.numberOfProducts()));
+    ext::shared_ptr<SequenceStatisticsInc> stats = ext::make_shared<SequenceStatisticsInc>(product.numberOfProducts());
     engine.multiplePathValues(*stats, paths_);
     return stats;
 }
@@ -379,8 +378,7 @@ BOOST_AUTO_TEST_CASE(testSwaptionImpliedVolatility)
         
         Size endIndex = nbRates-2;
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new   
-            PlainVanillaPayoff(Option::Call, strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strike);
         MultiStepSwaption product(rateTimes, startIndex, endIndex,payoff );
 
         const EvolutionDescription& evolution = product.evolution();
@@ -393,23 +391,20 @@ BOOST_AUTO_TEST_CASE(testSwaptionImpliedVolatility)
         Matrix correlations = exponentialCorrelations(evolution.rateTimes(),
             longTermCorr,
             beta);
-        ext::shared_ptr<PiecewiseConstantCorrelation> corr(new
-            TimeHomogeneousForwardCorrelation(correlations,
-            rateTimes));
-        ext::shared_ptr<MarketModel> lmmMarketModel(new
-            FlatVol(marketData.volatilities(),
+        ext::shared_ptr<PiecewiseConstantCorrelation> corr = ext::make_shared<TimeHomogeneousForwardCorrelation>(correlations,
+            rateTimes);
+        ext::shared_ptr<MarketModel> lmmMarketModel = ext::make_shared<FlatVol>(marketData.volatilities(),
             corr,
             evolution,
             numberOfFactors,
             lmmCurveState.forwardRates(),
-            marketData.displacements()));
+            marketData.displacements());
 
 
         SobolBrownianGeneratorFactory generatorFactory(SobolBrownianGenerator::Diagonal);
         std::vector<Size> numeraires(nbRates,
             nbRates);
-        ext::shared_ptr<MarketModelEvolver> evolver(new LogNormalFwdRatePc
-            (lmmMarketModel, generatorFactory, numeraires));
+        ext::shared_ptr<MarketModelEvolver> evolver = ext::make_shared<LogNormalFwdRatePc>(lmmMarketModel, generatorFactory, numeraires);
 
         ext::shared_ptr<SequenceStatisticsInc> stats =
             simulate(marketData.discountFactors(), evolver, product);
@@ -422,7 +417,7 @@ BOOST_AUTO_TEST_CASE(testSwaptionImpliedVolatility)
         Real swapRate = lmmCurveState.cmSwapRate(startIndex,endIndex-startIndex);
         Real swapAnnuity = lmmCurveState.cmSwapAnnuity(startIndex,startIndex,endIndex-startIndex)*marketData.discountFactors()[startIndex];
 
-        ext::shared_ptr<PlainVanillaPayoff> payoffDis( new PlainVanillaPayoff(Option::Call, strike+displacement));
+        ext::shared_ptr<PlainVanillaPayoff> payoffDis = ext::make_shared<PlainVanillaPayoff>(Option::Call, strike+displacement);
 
         Real expectedSwaption = BlackCalculator(payoffDis,
             swapRate+displacement, estimatedImpliedVol *sqrt(rateTimes[startIndex]),

--- a/test-suite/swaption.cpp
+++ b/test-suite/swaption.cpp
@@ -83,15 +83,13 @@ struct CommonVars {
                                            Settlement::Type settlementType = Settlement::Physical,
                                            Settlement::Method settlementMethod = Settlement::PhysicalOTC,
                                            BlackSwaptionEngine::CashAnnuityModel model = BlackSwaptionEngine::SwapRate) const {
-        Handle<Quote> vol(ext::shared_ptr<Quote>(new SimpleQuote(volatility)));
-        ext::shared_ptr<PricingEngine> engine(new BlackSwaptionEngine(
-                termStructure, vol, Actual365Fixed(), 0.0, model));
+        Handle<Quote> vol(ext::make_shared<SimpleQuote>(volatility));
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<BlackSwaptionEngine>(
+                termStructure, vol, Actual365Fixed(), 0.0, model);
 
-        ext::shared_ptr<Swaption> result(new
-                Swaption(swap,
-                         ext::shared_ptr<Exercise>(
-                                              new EuropeanExercise(exercise)),
-                         settlementType, settlementMethod));
+        ext::shared_ptr<Swaption> result = ext::make_shared<Swaption>(swap,
+                         ext::make_shared<EuropeanExercise>(exercise),
+                         settlementType, settlementMethod);
         result->setPricingEngine(engine);
         return result;
     }
@@ -127,7 +125,7 @@ struct CommonVars {
         fixedFrequency = Annual;
         fixedDayCount = Thirty360(Thirty360::BondBasis);
 
-        index = ext::shared_ptr<IborIndex>(new Euribor6M(termStructure));
+        index = ext::make_shared<Euribor6M>(termStructure);
         oisIndex = ext::make_shared<Eonia>(
                 Handle<YieldTermStructure>(
                     ext::make_shared<ZeroSpreadedTermStructure>(
@@ -550,18 +548,16 @@ BOOST_AUTO_TEST_CASE(testCashSettledSwaptions) {
                                      Period(vars.fixedFrequency),
                                      vars.calendar, Unadjusted, Unadjusted,
                                      DateGeneration::Forward, true);
-            ext::shared_ptr<VanillaSwap> swap_u360(
-                new VanillaSwap(type[0], vars.nominal,
+            ext::shared_ptr<VanillaSwap> swap_u360 = ext::make_shared<VanillaSwap>(type[0], vars.nominal,
                                 fixedSchedule_u,strike,Thirty360(Thirty360::BondBasis),
                                 floatSchedule,vars.index,0.0,
-                                vars.index->dayCounter()));
+                                vars.index->dayCounter());
 
             // Swap with fixed leg conventions: Business Days = Unadjusted, DayCount = Act/365
-            ext::shared_ptr<VanillaSwap> swap_u365(
-                new VanillaSwap(type[0],vars.nominal,
+            ext::shared_ptr<VanillaSwap> swap_u365 = ext::make_shared<VanillaSwap>(type[0],vars.nominal,
                                 fixedSchedule_u,strike,Actual365Fixed(),
                                 floatSchedule,vars.index,0.0,
-                                vars.index->dayCounter()));
+                                vars.index->dayCounter());
 
             // Swap with fixed leg conventions: Business Days = Modified Following, DayCount = 30/360
             Schedule fixedSchedule_a(startDate,maturity,
@@ -569,21 +565,18 @@ BOOST_AUTO_TEST_CASE(testCashSettledSwaptions) {
                                      vars.calendar,ModifiedFollowing,
                                      ModifiedFollowing,
                                      DateGeneration::Forward, true);
-            ext::shared_ptr<VanillaSwap> swap_a360(
-                new VanillaSwap(type[0],vars.nominal,
+            ext::shared_ptr<VanillaSwap> swap_a360 = ext::make_shared<VanillaSwap>(type[0],vars.nominal,
                                 fixedSchedule_a,strike,Thirty360(Thirty360::BondBasis),
                                 floatSchedule,vars.index,0.0,
-                                vars.index->dayCounter()));
+                                vars.index->dayCounter());
 
             // Swap with fixed leg conventions: Business Days = Modified Following, DayCount = Act/365
-            ext::shared_ptr<VanillaSwap> swap_a365(
-                new VanillaSwap(type[0],vars.nominal,
+            ext::shared_ptr<VanillaSwap> swap_a365 = ext::make_shared<VanillaSwap>(type[0],vars.nominal,
                                 fixedSchedule_a,strike,Actual365Fixed(),
                                 floatSchedule,vars.index,0.0,
-                                vars.index->dayCounter()));
+                                vars.index->dayCounter());
 
-            ext::shared_ptr<PricingEngine> swapEngine(
-                               new DiscountingSwapEngine(vars.termStructure));
+            ext::shared_ptr<PricingEngine> swapEngine = ext::make_shared<DiscountingSwapEngine>(vars.termStructure);
 
             swap_u360->setPricingEngine(swapEngine);
             swap_a360->setPricingEngine(swapEngine);
@@ -597,25 +590,21 @@ BOOST_AUTO_TEST_CASE(testCashSettledSwaptions) {
 
             // FlatForward curves
             Handle<YieldTermStructure> termStructure_u360(
-                ext::shared_ptr<YieldTermStructure>(
-                    new FlatForward(vars.settlement,swap_u360->fairRate(),
+                ext::make_shared<FlatForward>(vars.settlement,swap_u360->fairRate(),
                                     Thirty360(Thirty360::BondBasis),Compounded,
-                                    vars.fixedFrequency)));
+                                    vars.fixedFrequency));
             Handle<YieldTermStructure> termStructure_a360(
-                ext::shared_ptr<YieldTermStructure>(
-                    new FlatForward(vars.settlement,swap_a360->fairRate(),
+                ext::make_shared<FlatForward>(vars.settlement,swap_a360->fairRate(),
                                     Thirty360(Thirty360::BondBasis),Compounded,
-                                    vars.fixedFrequency)));
+                                    vars.fixedFrequency));
             Handle<YieldTermStructure> termStructure_u365(
-                ext::shared_ptr<YieldTermStructure>(
-                    new FlatForward(vars.settlement,swap_u365->fairRate(),
+                ext::make_shared<FlatForward>(vars.settlement,swap_u365->fairRate(),
                                     Actual365Fixed(),Compounded,
-                                    vars.fixedFrequency)));
+                                    vars.fixedFrequency));
             Handle<YieldTermStructure> termStructure_a365(
-                ext::shared_ptr<YieldTermStructure>(
-                    new FlatForward(vars.settlement,swap_a365->fairRate(),
+                ext::make_shared<FlatForward>(vars.settlement,swap_a365->fairRate(),
                                     Actual365Fixed(),Compounded,
-                                    vars.fixedFrequency)));
+                                    vars.fixedFrequency));
 
             // Annuity calculated by swap method fixedLegBPS().
             // Fixed leg conventions: Unadjusted, 30/360

--- a/test-suite/swaptionvolatilitycube.cpp
+++ b/test-suite/swaptionvolatilitycube.cpp
@@ -137,28 +137,25 @@ struct CommonVars {
         atm.setMarketData();
 
         atmVolMatrix = RelinkableHandle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    SwaptionVolatilityMatrix(conventions.calendar,
+                ext::make_shared<SwaptionVolatilityMatrix>(conventions.calendar,
                                              conventions.optionBdc,
                                              atm.tenors.options,
                                              atm.tenors.swaps,
                                              atm.volsHandle,
-                                             conventions.dayCounter)));
+                                             conventions.dayCounter));
 
         normalVolMatrix = RelinkableHandle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new SwaptionVolatilityMatrix(
+                ext::make_shared<SwaptionVolatilityMatrix>(
                     conventions.calendar, conventions.optionBdc, atm.tenors.options,
-                    atm.tenors.swaps, atm.volsHandle, conventions.dayCounter, false, VolatilityType::Normal)));
+                    atm.tenors.swaps, atm.volsHandle, conventions.dayCounter, false, VolatilityType::Normal));
 
         // Swaptionvolcube
         cube.setMarketData();
 
         termStructure.linkTo(flatRate(0.05, Actual365Fixed()));
 
-        swapIndexBase = ext::shared_ptr<SwapIndex>(new
-                EuriborSwapIsdaFixA(2*Years, termStructure));
-        shortSwapIndexBase = ext::shared_ptr<SwapIndex>(new
-                EuriborSwapIsdaFixA(1*Years, termStructure));
+        swapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(2*Years, termStructure);
+        shortSwapIndexBase = ext::make_shared<EuriborSwapIsdaFixA>(1*Years, termStructure);
 
         vegaWeighedSmileFit=false;
     }
@@ -175,10 +172,10 @@ BOOST_AUTO_TEST_CASE(testSabrNormalVolatility) {
                                                               vars.cube.tenors.swaps.size());
     for (Size i = 0; i < vars.cube.tenors.options.size() * vars.cube.tenors.swaps.size(); i++) {
         parametersGuess[i] = std::vector<Handle<Quote> >(4);
-        parametersGuess[i][0] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
-        parametersGuess[i][1] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
-        parametersGuess[i][2] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
-        parametersGuess[i][3] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+        parametersGuess[i][0] = Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
+        parametersGuess[i][1] = Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
+        parametersGuess[i][2] = Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
+        parametersGuess[i][3] = Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
     }
     std::vector<bool> isParameterFixed(4, false);
 
@@ -243,13 +240,13 @@ BOOST_AUTO_TEST_CASE(testSabrVols) {
     for (Size i=0; i<vars.cube.tenors.options.size()*vars.cube.tenors.swaps.size(); i++) {
         parametersGuess[i] = std::vector<Handle<Quote> >(4);
         parametersGuess[i][0] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
         parametersGuess[i][1] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
         parametersGuess[i][2] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
         parametersGuess[i][3] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
     }
     std::vector<bool> isParameterFixed(4, false);
 
@@ -282,18 +279,17 @@ BOOST_AUTO_TEST_CASE(testSpreadedCube) {
     for (Size i=0; i<vars.cube.tenors.options.size()*vars.cube.tenors.swaps.size(); i++) {
         parametersGuess[i] = std::vector<Handle<Quote> >(4);
         parametersGuess[i][0] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
         parametersGuess[i][1] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
         parametersGuess[i][2] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
         parametersGuess[i][3] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
     }
     std::vector<bool> isParameterFixed(4, false);
 
-    Handle<SwaptionVolatilityStructure> volCube( ext::shared_ptr<SwaptionVolatilityStructure>(new
-        SabrSwaptionVolatilityCube(vars.atmVolMatrix,
+    Handle<SwaptionVolatilityStructure> volCube( ext::make_shared<SabrSwaptionVolatilityCube>(vars.atmVolMatrix,
                          vars.cube.tenors.options,
                          vars.cube.tenors.swaps,
                          vars.cube.strikeSpreads,
@@ -303,12 +299,11 @@ BOOST_AUTO_TEST_CASE(testSpreadedCube) {
                          vars.vegaWeighedSmileFit,
                          parametersGuess,
                          isParameterFixed,
-                         true)));
+                         true));
 
-    ext::shared_ptr<SimpleQuote> spread (new SimpleQuote(0.0001));
+    ext::shared_ptr<SimpleQuote> spread = ext::make_shared<SimpleQuote>(0.0001);
     Handle<Quote> spreadHandle(spread);
-    ext::shared_ptr<SwaptionVolatilityStructure> spreadedVolCube(new
-        SpreadedSwaptionVolatility(volCube, spreadHandle));
+    ext::shared_ptr<SwaptionVolatilityStructure> spreadedVolCube = ext::make_shared<SpreadedSwaptionVolatility>(volCube, spreadHandle);
     std::vector<Real> strikes;
     for (Size k=1; k<100; k++)
         strikes.push_back(k*.01);
@@ -368,13 +363,13 @@ BOOST_AUTO_TEST_CASE(testObservability) {
     for (Size i=0; i<vars.cube.tenors.options.size()*vars.cube.tenors.swaps.size(); i++) {
         parametersGuess[i] = std::vector<Handle<Quote> >(4);
         parametersGuess[i][0] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
         parametersGuess[i][1] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
         parametersGuess[i][2] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
         parametersGuess[i][3] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
     }
     std::vector<bool> isParameterFixed(4, false);
 
@@ -498,13 +493,13 @@ BOOST_AUTO_TEST_CASE(testSabrParameters) {
     for (Size i=0; i<vars.cube.tenors.options.size()*vars.cube.tenors.swaps.size(); i++) {
         parametersGuess[i] = std::vector<Handle<Quote> >(4);
         parametersGuess[i][0] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.2)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.2));
         parametersGuess[i][1] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.5)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.5));
         parametersGuess[i][2] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.4)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.4));
         parametersGuess[i][3] =
-            Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(0.0)));
+            Handle<Quote>(ext::make_shared<SimpleQuote>(0.0));
     }
     std::vector<bool> isParameterFixed(4, false);
 

--- a/test-suite/swaptionvolatilitymatrix.cpp
+++ b/test-suite/swaptionvolatilitymatrix.cpp
@@ -53,17 +53,15 @@ struct CommonVars {
         Settings::instance().evaluationDate() =
             conventions.calendar.adjust(Date::todaysDate());
         atmVolMatrix = RelinkableHandle<SwaptionVolatilityStructure>(
-                ext::shared_ptr<SwaptionVolatilityStructure>(new
-                    SwaptionVolatilityMatrix(conventions.calendar,
+                ext::make_shared<SwaptionVolatilityMatrix>(conventions.calendar,
                                              conventions.optionBdc,
                                              atm.tenors.options,
                                              atm.tenors.swaps,
                                              atm.volsHandle,
-                                             conventions.dayCounter)));
+                                             conventions.dayCounter));
         termStructure.linkTo(
-                ext::shared_ptr<YieldTermStructure>(new
-                    FlatForward(0, conventions.calendar,
-                                0.05, Actual365Fixed())));
+                ext::make_shared<FlatForward>(0, conventions.calendar,
+                                0.05, Actual365Fixed()));
     }
 
     // utilities
@@ -131,9 +129,8 @@ struct CommonVars {
                            "\n  exp. option time : " << vol->optionTimes()[i]);
         }
 
-        ext::shared_ptr<BlackSwaptionEngine> engine(new
-                BlackSwaptionEngine(termStructure,
-                                    Handle<SwaptionVolatilityStructure>(vol)));
+        ext::shared_ptr<BlackSwaptionEngine> engine = ext::make_shared<BlackSwaptionEngine>(termStructure,
+                                    Handle<SwaptionVolatilityStructure>(vol));
 
         for (Size j=0; j<atm.tenors.swaps.size(); j++) {
             Time swapLength = vol->swapLength(atm.tenors.swaps[j]);
@@ -144,8 +141,7 @@ struct CommonVars {
                            "\n actual swap length: " << swapLength <<
                            "\n   exp. swap length: " << years(atm.tenors.swaps[j]));
 
-            ext::shared_ptr<SwapIndex> swapIndex(new
-                    EuriborSwapIsdaFixA(atm.tenors.swaps[j], termStructure));
+            ext::shared_ptr<SwapIndex> swapIndex = ext::make_shared<EuriborSwapIsdaFixA>(atm.tenors.swaps[j], termStructure);
 
             for (Size i=0; i<atm.tenors.options.size(); ++i) {
                 Real error, tolerance = 1.0e-16;

--- a/test-suite/swaptionvolstructuresutilities.hpp
+++ b/test-suite/swaptionvolstructuresutilities.hpp
@@ -79,8 +79,7 @@ namespace QuantLib {
                 for (Size j=0; j<tenors.swaps.size(); j++)
                     // every handle must be reassigned, as the ones created by
                     // default are all linked together.
-                    volsHandle[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                        SimpleQuote(vols[i][j])));
+                    volsHandle[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
             }
         };
     };
@@ -138,8 +137,7 @@ namespace QuantLib {
                 for (Size j=0; j<strikeSpreads.size(); j++) {
                     // every handle must be reassigned, as the ones created by
                     // default are all linked together.
-                    volSpreadsHandle[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                        SimpleQuote(volSpreads[i][j])));
+                    volSpreadsHandle[i][j] = Handle<Quote>(ext::make_shared<SimpleQuote>(volSpreads[i][j]));
                 }
             }
         };
@@ -153,13 +151,12 @@ namespace QuantLib {
         atm_.setMarketData();
         cube_.setMarketData();
         atmVolMatrix_ = RelinkableHandle<SwaptionVolatilityStructure>(
-            ext::shared_ptr<SwaptionVolatilityStructure>(new
-                SwaptionVolatilityMatrix(conventions_.calendar,
+            ext::make_shared<SwaptionVolatilityMatrix>(conventions_.calendar,
                                          atm_.tenors.options,
                                          atm_.tenors.swaps,
                                          atm_.volsHandle,
                                          conventions_.dayCounter,
-                                         conventions_.optionBdc)));
+                                         conventions_.optionBdc));
     }*/
 
 }

--- a/test-suite/swingoption.cpp
+++ b/test-suite/swingoption.cpp
@@ -66,9 +66,8 @@ ext::shared_ptr<ExtOUWithJumpsProcess> createKlugeProcess() {
     const Real speed = 1.0;
     const Real volatility = 2.0;
 
-    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
-            new ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0[0],
-                                                 constant_b(x0[0])));
+    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(speed, volatility, x0[0],
+                                                 constant_b(x0[0]));
     return ext::make_shared<ExtOUWithJumpsProcess>(
                                                    ouProcess, x0[1], beta, jumpIntensity, eta);
 }
@@ -168,11 +167,9 @@ BOOST_AUTO_TEST_CASE(testFdmExponentialJump1dMesher) {
 
     ExponentialJump1dMesher mesher(dummySteps, beta, jumpIntensity, eta);
 
-    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
-        new ExtendedOrnsteinUhlenbeckProcess(1.0, 1.0, x[0],
-                                             constant_b(1.0)));
-    ext::shared_ptr<ExtOUWithJumpsProcess> jumpProcess(
-        new ExtOUWithJumpsProcess(ouProcess, x[1], beta, jumpIntensity, eta));
+    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(1.0, 1.0, x[0],
+                                             constant_b(1.0));
+    ext::shared_ptr<ExtOUWithJumpsProcess> jumpProcess = ext::make_shared<ExtOUWithJumpsProcess>(ouProcess, x[1], beta, jumpIntensity, eta);
 
     const Time dt = 1.0/(10.0*beta);
     const Size n = 1000000;
@@ -218,12 +215,10 @@ BOOST_AUTO_TEST_CASE(testExtOUJumpVanillaEngine) {
 
     const Rate irRate = 0.1;
     ext::shared_ptr<YieldTermStructure> rTS(flatRate(today, irRate, dc));
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-                                     new PlainVanillaPayoff(Option::Call, 30));
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturityDate));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 30);
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
 
-    ext::shared_ptr<PricingEngine> engine(
-                 new FdExtOUJumpVanillaEngine(jumpProcess, rTS, 25, 200, 50));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdExtOUJumpVanillaEngine>(jumpProcess, rTS, 25, 200, 50);
 
     VanillaOption option(payoff, exercise);
     option.setPricingEngine(engine);
@@ -272,34 +267,28 @@ BOOST_AUTO_TEST_CASE(testFdBSSwingOption) {
     Date maturityDate = settlementDate + Period(12, Months);
 
     Real strike = 30;
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(Option::Put, strike));
-    ext::shared_ptr<StrikedTypePayoff> forward(
-        new VanillaForwardPayoff(Option::Put, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, strike);
+    ext::shared_ptr<StrikedTypePayoff> forward = ext::make_shared<VanillaForwardPayoff>(Option::Put, strike);
 
     std::vector<Date> exerciseDates(1, settlementDate+Period(1, Months));
     while (exerciseDates.back() < maturityDate) {
         exerciseDates.push_back(exerciseDates.back()+Period(1, Months));
     }
 
-    ext::shared_ptr<SwingExercise> swingExercise(
-                                            new SwingExercise(exerciseDates));
+    ext::shared_ptr<SwingExercise> swingExercise = ext::make_shared<SwingExercise>(exerciseDates);
 
     Handle<YieldTermStructure> riskFreeTS(flatRate(0.14, dayCounter));
     Handle<YieldTermStructure> dividendTS(flatRate(0.02, dayCounter));
     Handle<BlackVolTermStructure> volTS(
                                     flatVol(settlementDate, 0.4, dayCounter));
 
-    Handle<Quote> s0(ext::shared_ptr<Quote>(new SimpleQuote(30.0)));
+    Handle<Quote> s0(ext::make_shared<SimpleQuote>(30.0));
 
-    ext::shared_ptr<BlackScholesMertonProcess> process(
-            new BlackScholesMertonProcess(s0, dividendTS, riskFreeTS, volTS));
-    ext::shared_ptr<PricingEngine> engine(
-                                new FdSimpleBSSwingEngine(process, 50, 200));
+    ext::shared_ptr<BlackScholesMertonProcess> process = ext::make_shared<BlackScholesMertonProcess>(s0, dividendTS, riskFreeTS, volTS);
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdSimpleBSSwingEngine>(process, 50, 200);
     
     VanillaOption bermudanOption(payoff, swingExercise);
-    bermudanOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-                          new FdBlackScholesVanillaEngine(process, 50, 200)));
+    bermudanOption.setPricingEngine(ext::make_shared<FdBlackScholesVanillaEngine>(process, 50, 200));
     const Real bermudanOptionPrices = bermudanOption.NPV();
     
     for (Size i=0; i < exerciseDates.size(); ++i) {
@@ -321,11 +310,9 @@ BOOST_AUTO_TEST_CASE(testFdBSSwingOption) {
         
         Real lowerBound = 0.0;
         for (Size j=exerciseDates.size()-i-1; j < exerciseDates.size(); ++j) {
-            VanillaOption europeanOption(payoff, ext::shared_ptr<Exercise>(
-                                     new EuropeanExercise(exerciseDates[j])));
+            VanillaOption europeanOption(payoff, ext::make_shared<EuropeanExercise>(exerciseDates[j]));
             europeanOption.setPricingEngine(
-                ext::shared_ptr<PricingEngine>(
-                                          new AnalyticEuropeanEngine(process)));
+                ext::make_shared<AnalyticEuropeanEngine>(process));
             lowerBound += europeanOption.NPV();
         }
 
@@ -348,17 +335,14 @@ BOOST_AUTO_TEST_CASE(testExtOUJumpSwingOption) {
     Date maturityDate = settlementDate + Period(12, Months);
 
     Real strike = 30;
-    ext::shared_ptr<StrikedTypePayoff> payoff(
-        new PlainVanillaPayoff(Option::Put, strike));
-    ext::shared_ptr<StrikedTypePayoff> forward(
-        new VanillaForwardPayoff(Option::Put, strike));
+    ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, strike);
+    ext::shared_ptr<StrikedTypePayoff> forward = ext::make_shared<VanillaForwardPayoff>(Option::Put, strike);
 
     std::vector<Date> exerciseDates(1, settlementDate+Period(1, Months));
     while (exerciseDates.back() < maturityDate) {
         exerciseDates.push_back(exerciseDates.back()+Period(1, Months));
     }
-    ext::shared_ptr<SwingExercise> swingExercise(
-                                            new SwingExercise(exerciseDates));
+    ext::shared_ptr<SwingExercise> swingExercise = ext::make_shared<SwingExercise>(exerciseDates);
 
     std::vector<Time> exerciseTimes(exerciseDates.size());
     for (Size i=0; i < exerciseTimes.size(); ++i) {
@@ -378,11 +362,9 @@ BOOST_AUTO_TEST_CASE(testExtOUJumpSwingOption) {
     ext::shared_ptr<YieldTermStructure> rTS(
                                 flatRate(settlementDate, irRate, dayCounter));
 
-    ext::shared_ptr<PricingEngine> swingEngine(
-                new FdSimpleExtOUJumpSwingEngine(jumpProcess, rTS, 25, 50, 25));
+    ext::shared_ptr<PricingEngine> swingEngine = ext::make_shared<FdSimpleExtOUJumpSwingEngine>(jumpProcess, rTS, 25, 50, 25);
 
-    ext::shared_ptr<PricingEngine> vanillaEngine(
-                new FdExtOUJumpVanillaEngine(jumpProcess, rTS, 25, 50, 25));
+    ext::shared_ptr<PricingEngine> vanillaEngine = ext::make_shared<FdExtOUJumpVanillaEngine>(jumpProcess, rTS, 25, 50, 25);
 
     VanillaOption bermudanOption(payoff, swingExercise);
     bermudanOption.setPricingEngine(vanillaEngine);
@@ -414,8 +396,7 @@ BOOST_AUTO_TEST_CASE(testExtOUJumpSwingOption) {
 
         Real lowerBound = 0.0;
         for (Size j=exerciseDates.size()-i-1; j < exerciseDates.size(); ++j) {
-            VanillaOption europeanOption(payoff, ext::shared_ptr<Exercise>(
-                                     new EuropeanExercise(exerciseDates[j])));
+            VanillaOption europeanOption(payoff, ext::make_shared<EuropeanExercise>(exerciseDates[j]));
             europeanOption.setPricingEngine(
                 ext::shared_ptr<PricingEngine>(vanillaEngine));
             lowerBound += europeanOption.NPV();

--- a/test-suite/termstructures.cpp
+++ b/test-suite/termstructures.cpp
@@ -84,28 +84,26 @@ struct CommonVars {
 
         std::vector<ext::shared_ptr<RateHelper> > instruments(deposits+swaps);
         for (Size i=0; i<deposits; i++) {
-            instruments[i] = ext::shared_ptr<RateHelper>(new
-                    DepositRateHelper(depositData[i].rate/100,
+            instruments[i] = ext::make_shared<DepositRateHelper>(depositData[i].rate/100,
                                       depositData[i].n*depositData[i].units,
                                       settlementDays, calendar,
                                       ModifiedFollowing, true,
-                                      Actual360()));
+                                      Actual360());
         }
-        ext::shared_ptr<IborIndex> index(new IborIndex("dummy",
+        ext::shared_ptr<IborIndex> index = ext::make_shared<IborIndex>("dummy",
                                                        6*Months,
                                                        settlementDays,
                                                        Currency(),
                                                        calendar,
                                                        ModifiedFollowing,
                                                        false,
-                                                       Actual360()));
+                                                       Actual360());
         for (Size i=0; i<swaps; ++i) {
-            instruments[i+deposits] = ext::shared_ptr<RateHelper>(new
-                    SwapRateHelper(swapData[i].rate/100,
+            instruments[i+deposits] = ext::make_shared<SwapRateHelper>(swapData[i].rate/100,
                                    swapData[i].n*swapData[i].units,
                                    calendar,
                                    Annual, Unadjusted, Thirty360(Thirty360::BondBasis),
-                                   index));
+                                   index);
         }
         termStructure = ext::shared_ptr<YieldTermStructure>(new
                 PiecewiseYieldCurve<Discount,LogLinear>(settlement,
@@ -125,11 +123,10 @@ BOOST_AUTO_TEST_CASE(testReferenceChange) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SimpleQuote> flatRate (new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> flatRate = ext::make_shared<SimpleQuote>();
     Handle<Quote> flatRateHandle(flatRate);
-    vars.termStructure = ext::shared_ptr<YieldTermStructure>(
-                          new FlatForward(vars.settlementDays, NullCalendar(),
-                                          flatRateHandle, Actual360()));
+    vars.termStructure = ext::make_shared<FlatForward>(vars.settlementDays, NullCalendar(),
+                                          flatRateHandle, Actual360());
     Date today = Settings::instance().evaluationDate();
     flatRate->setValue(.03);
     Integer days[] = { 10, 30, 60, 120, 360, 720 };
@@ -168,9 +165,8 @@ BOOST_AUTO_TEST_CASE(testImplied) {
     Date newSettlement = vars.calendar.advance(newToday,
                                                vars.settlementDays,Days);
     Date testDate = newSettlement + 5*Years;
-    ext::shared_ptr<YieldTermStructure> implied(
-        new ImpliedTermStructure(Handle<YieldTermStructure>(vars.termStructure),
-                                 newSettlement));
+    ext::shared_ptr<YieldTermStructure> implied = ext::make_shared<ImpliedTermStructure>(Handle<YieldTermStructure>(vars.termStructure),
+                                 newSettlement);
     for (int i = 1; i < 4; i++) {
         flatRate->setValue(i / 100.0);
         DiscountFactor baseDiscount = vars.termStructure->discount(newSettlement);
@@ -196,8 +192,7 @@ BOOST_AUTO_TEST_CASE(testImpliedObs) {
     Date newSettlement = vars.calendar.advance(newToday,
                                                vars.settlementDays,Days);
     RelinkableHandle<YieldTermStructure> h;
-    ext::shared_ptr<YieldTermStructure> implied(
-                                  new ImpliedTermStructure(h, newSettlement));
+    ext::shared_ptr<YieldTermStructure> implied = ext::make_shared<ImpliedTermStructure>(h, newSettlement);
     Flag flag;
     flag.registerWith(implied);
     h.linkTo(vars.termStructure);
@@ -212,11 +207,10 @@ BOOST_AUTO_TEST_CASE(testFSpreaded) {
     CommonVars vars;
 
     Real tolerance = 1.0e-10;
-    ext::shared_ptr<Quote> me(new SimpleQuote(0.01));
+    ext::shared_ptr<Quote> me = ext::make_shared<SimpleQuote>(0.01);
     Handle<Quote> mh(me);
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ForwardSpreadedTermStructure(
-            Handle<YieldTermStructure>(vars.termStructure),mh));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ForwardSpreadedTermStructure>(
+            Handle<YieldTermStructure>(vars.termStructure),mh);
     Date testDate = vars.termStructure->referenceDate() + 5*Years;
     DayCounter tsdc  = vars.termStructure->dayCounter();
     DayCounter sprdc = spreaded->dayCounter();
@@ -240,11 +234,10 @@ BOOST_AUTO_TEST_CASE(testFSpreadedObs) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SimpleQuote> me(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> me = ext::make_shared<SimpleQuote>(0.01);
     Handle<Quote> mh(me);
     RelinkableHandle<YieldTermStructure> h; //(vars.dummyTermStructure);
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ForwardSpreadedTermStructure(h,mh));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ForwardSpreadedTermStructure>(h,mh);
     Flag flag;
     flag.registerWith(spreaded);
     h.linkTo(vars.termStructure);
@@ -263,11 +256,10 @@ BOOST_AUTO_TEST_CASE(testZSpreaded) {
     CommonVars vars;
 
     Real tolerance = 1.0e-10;
-    ext::shared_ptr<Quote> me(new SimpleQuote(0.01));
+    ext::shared_ptr<Quote> me = ext::make_shared<SimpleQuote>(0.01);
     Handle<Quote> mh(me);
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ZeroSpreadedTermStructure(
-            Handle<YieldTermStructure>(vars.termStructure),mh));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ZeroSpreadedTermStructure>(
+            Handle<YieldTermStructure>(vars.termStructure),mh);
     Date testDate = vars.termStructure->referenceDate() + 5*Years;
     DayCounter rfdc  = vars.termStructure->dayCounter();
     Rate zero = vars.termStructure->zeroRate(testDate, rfdc,
@@ -288,12 +280,11 @@ BOOST_AUTO_TEST_CASE(testZSpreadedObs) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SimpleQuote> me(new SimpleQuote(0.01));
+    ext::shared_ptr<SimpleQuote> me = ext::make_shared<SimpleQuote>(0.01);
     Handle<Quote> mh(me);
     RelinkableHandle<YieldTermStructure> h(vars.dummyTermStructure);
 
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ZeroSpreadedTermStructure(h,mh));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ZeroSpreadedTermStructure>(h,mh);
     Flag flag;
     flag.registerWith(spreaded);
     h.linkTo(vars.termStructure);
@@ -312,11 +303,10 @@ BOOST_AUTO_TEST_CASE(testCreateWithNullUnderlying) {
 
     CommonVars vars;
 
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.01)));
+    Handle<Quote> spread(ext::make_shared<SimpleQuote>(0.01));
     RelinkableHandle<YieldTermStructure> underlying;
     // this shouldn't throw
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ZeroSpreadedTermStructure(underlying,spread));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ZeroSpreadedTermStructure>(underlying,spread);
     // if we do this, the curve can work.
     underlying.linkTo(vars.termStructure);
     // check that we can use it
@@ -528,10 +518,9 @@ BOOST_AUTO_TEST_CASE(testLinkToNullUnderlying) {
 
     CommonVars vars;
 
-    Handle<Quote> spread(ext::shared_ptr<Quote>(new SimpleQuote(0.01)));
+    Handle<Quote> spread(ext::make_shared<SimpleQuote>(0.01));
     RelinkableHandle<YieldTermStructure> underlying(vars.termStructure);
-    ext::shared_ptr<YieldTermStructure> spreaded(
-        new ZeroSpreadedTermStructure(underlying,spread));
+    ext::shared_ptr<YieldTermStructure> spreaded = ext::make_shared<ZeroSpreadedTermStructure>(underlying,spread);
     // check that we can use it
     spreaded->referenceDate();
     // if we do this, the curve can't work anymore. But it shouldn't
@@ -560,8 +549,7 @@ BOOST_AUTO_TEST_CASE(testCompositeZeroYieldStructures) {
                                0.109824660896137,  0.109231572878364,  0.119218123236241,
                                0.128647300167664,  0.0506086995288751};
 
-    ext::shared_ptr<YieldTermStructure> termStructure1 = ext::shared_ptr<YieldTermStructure>(
-        new ForwardCurve(dates, rates, Actual365Fixed(), NullCalendar()));
+    ext::shared_ptr<YieldTermStructure> termStructure1 = ext::make_shared<ForwardCurve>(dates, rates, Actual365Fixed(), NullCalendar());
 
     // Second curve
     dates = {Date(10, Nov, 2017), Date(13, Nov, 2017), Date(11, Dec, 2017), Date(12, Feb, 2018),
@@ -574,13 +562,11 @@ BOOST_AUTO_TEST_CASE(testCompositeZeroYieldStructures) {
              0.0263943927922053, 0.0291924526539802, 0.0270049276163556, 0.028775807327614,
              0.0293567711641792, 0.010518655099659};
 
-    ext::shared_ptr<YieldTermStructure> termStructure2 = ext::shared_ptr<YieldTermStructure>(
-        new ForwardCurve(dates, rates, Actual365Fixed(), NullCalendar()));
+    ext::shared_ptr<YieldTermStructure> termStructure2 = ext::make_shared<ForwardCurve>(dates, rates, Actual365Fixed(), NullCalendar());
 
     typedef Real(*binary_f)(Real, Real);
 
-    ext::shared_ptr<YieldTermStructure> compoundCurve = ext::shared_ptr<YieldTermStructure>(
-        new CompositeZeroYieldStructure<binary_f>(Handle<YieldTermStructure>(termStructure1), Handle<YieldTermStructure>(termStructure2), sub));
+    ext::shared_ptr<YieldTermStructure> compoundCurve = ext::make_shared<CompositeZeroYieldStructure<binary_f>>(Handle<YieldTermStructure>(termStructure1), Handle<YieldTermStructure>(termStructure2), sub);
 
     // Expected values
     dates = {Date(10, Nov, 2017), Date(15, Dec, 2017), Date(15, Jun, 2018), Date(15, Sep, 2029),

--- a/test-suite/twoassetbarrieroption.cpp
+++ b/test-suite/twoassetbarrieroption.cpp
@@ -71,40 +71,37 @@ BOOST_AUTO_TEST_CASE(testHaugValues) {
     Calendar calendar = TARGET();
     Date today = Date::todaysDate();
     Date maturity = today + 180;
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturity));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturity);
 
-    ext::shared_ptr<SimpleQuote> r(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> r = ext::make_shared<SimpleQuote>();
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, r, dc);
 
-    ext::shared_ptr<SimpleQuote> s1(new SimpleQuote);
-    ext::shared_ptr<SimpleQuote> q1(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> s1 = ext::make_shared<SimpleQuote>();
+    ext::shared_ptr<SimpleQuote> q1 = ext::make_shared<SimpleQuote>();
     ext::shared_ptr<YieldTermStructure> qTS1 = flatRate(today, q1, dc);
-    ext::shared_ptr<SimpleQuote> vol1(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> vol1 = ext::make_shared<SimpleQuote>();
     ext::shared_ptr<BlackVolTermStructure> volTS1 = flatVol(today, vol1, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process1(
-        new BlackScholesMertonProcess(Handle<Quote>(s1),
+    ext::shared_ptr<BlackScholesMertonProcess> process1 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(s1),
                                       Handle<YieldTermStructure>(qTS1),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS1)));
+                                      Handle<BlackVolTermStructure>(volTS1));
 
-    ext::shared_ptr<SimpleQuote> s2(new SimpleQuote);
-    ext::shared_ptr<SimpleQuote> q2(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> s2 = ext::make_shared<SimpleQuote>();
+    ext::shared_ptr<SimpleQuote> q2 = ext::make_shared<SimpleQuote>();
     ext::shared_ptr<YieldTermStructure> qTS2 = flatRate(today, q2, dc);
-    ext::shared_ptr<SimpleQuote> vol2(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> vol2 = ext::make_shared<SimpleQuote>();
     ext::shared_ptr<BlackVolTermStructure> volTS2 = flatVol(today, vol2, dc);
 
-    ext::shared_ptr<BlackScholesMertonProcess> process2(
-        new BlackScholesMertonProcess(Handle<Quote>(s2),
+    ext::shared_ptr<BlackScholesMertonProcess> process2 = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(s2),
                                       Handle<YieldTermStructure>(qTS2),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS2)));
+                                      Handle<BlackVolTermStructure>(volTS2));
 
-    ext::shared_ptr<SimpleQuote> rho(new SimpleQuote);
+    ext::shared_ptr<SimpleQuote> rho = ext::make_shared<SimpleQuote>();
 
-    ext::shared_ptr<PricingEngine> engine(
-                       new AnalyticTwoAssetBarrierEngine(process1, process2,
-                                                         Handle<Quote>(rho)));
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<AnalyticTwoAssetBarrierEngine>(process1, process2,
+                                                         Handle<Quote>(rho));
 
     for (auto& value : values) {
 
@@ -120,7 +117,7 @@ BOOST_AUTO_TEST_CASE(testHaugValues) {
 
         r->setValue(value.r);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(new PlainVanillaPayoff(value.type, value.strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(value.type, value.strike);
 
         TwoAssetBarrierOption barrierOption(value.barrierType, value.barrier, payoff, exercise);
         barrierOption.setPricingEngine(engine);

--- a/test-suite/ultimateforwardtermstructure.cpp
+++ b/test-suite/ultimateforwardtermstructure.cpp
@@ -92,8 +92,7 @@ struct CommonVars {
                             {40, Years, 0.0103},  {50, Years, 0.0103}};
 
         InterestRate ufr(0.023, dayCount, Compounded, Annual);
-        ufrRate = ext::shared_ptr<Quote>(
-                new SimpleQuote(ufr.equivalentRate(Continuous, Annual, 1.0)));
+        ufrRate = ext::make_shared<SimpleQuote>(ufr.equivalentRate(Continuous, Annual, 1.0));
         fsp = 20 * Years;
         alpha = 0.1;
 
@@ -104,9 +103,9 @@ struct CommonVars {
         Size nInstruments = std::size(swapData);
         std::vector<ext::shared_ptr<RateHelper> > instruments(nInstruments);
         for (Size i = 0; i < nInstruments; i++) {
-            instruments[i] = ext::shared_ptr<RateHelper>(new SwapRateHelper(
+            instruments[i] = ext::make_shared<SwapRateHelper>(
                     swapData[i].rate, Period(swapData[i].n, swapData[i].units), calendar,
-                    fixedFrequency, businessConvention, dayCount, index));
+                    fixedFrequency, businessConvention, dayCount, index);
         }
 
         ext::shared_ptr<YieldTermStructure> ftkCurve(
@@ -128,7 +127,7 @@ ext::shared_ptr<Quote> calculateLLFR(const Handle<YieldTermStructure>& ts, const
         LLFRWeight w = llfrWeights[j];
         llfr += w.weight * ts->forwardRate(cutOff, w.ttm, Continuous, NoFrequency, true);
     }
-    return ext::shared_ptr<Quote>(new SimpleQuote(omega * llfr));
+    return ext::make_shared<SimpleQuote>(omega * llfr);
 }
 
 Rate calculateExtrapolatedForward(Time t, Time fsp, Rate llfr, Rate ufr, Real alpha) {
@@ -146,9 +145,9 @@ void checkDutchBankRates(const std::vector<Datum>& expectedRates,
 
     ext::shared_ptr<Quote> llfr = calculateLLFR(vars.ftkCurveHandle, vars.fsp);
 
-    ext::shared_ptr<YieldTermStructure> ufrTs(new UltimateForwardTermStructure(
+    ext::shared_ptr<YieldTermStructure> ufrTs = ext::make_shared<UltimateForwardTermStructure>(
         vars.ftkCurveHandle, Handle<Quote>(llfr), Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha,
-        rounding, compounding, frequency));
+        rounding, compounding, frequency);
 
     Size nRates = std::size(expectedRates);
 
@@ -204,11 +203,10 @@ BOOST_AUTO_TEST_CASE(testExtrapolatedForward) {
 
     CommonVars vars;
 
-    ext::shared_ptr<Quote> llfr(new SimpleQuote(0.0125));
+    ext::shared_ptr<Quote> llfr = ext::make_shared<SimpleQuote>(0.0125);
 
-    ext::shared_ptr<YieldTermStructure> ufrTs(
-        new UltimateForwardTermStructure(vars.ftkCurveHandle, Handle<Quote>(llfr),
-                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha));
+    ext::shared_ptr<YieldTermStructure> ufrTs = ext::make_shared<UltimateForwardTermStructure>(vars.ftkCurveHandle, Handle<Quote>(llfr),
+                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha);
     Time cutOff = ufrTs->timeFromReference(ufrTs->referenceDate() + vars.fsp);
 
     Period tenors[] = {
@@ -229,7 +227,7 @@ BOOST_AUTO_TEST_CASE(testExtrapolatedForward) {
         Real tolerance = 1.0e-10;
         if (std::fabs(actual - expected) > tolerance)
             BOOST_ERROR("unable to replicate the forward rate from the UFR curve\n"
-                        << std::setprecision(5) 
+                        << std::setprecision(5)
                         << "    calculated: " << actual << "\n"
                         << "    expected:   " << expected << "\n"
                         << "    tenor:       " << tenors[i] << "\n");
@@ -241,11 +239,10 @@ BOOST_AUTO_TEST_CASE(testZeroRateAtFirstSmoothingPoint) {
 
     CommonVars vars;
 
-    ext::shared_ptr<Quote> llfr(new SimpleQuote(0.0125));
+    ext::shared_ptr<Quote> llfr = ext::make_shared<SimpleQuote>(0.0125);
 
-    ext::shared_ptr<YieldTermStructure> ufrTs(
-        new UltimateForwardTermStructure(vars.ftkCurveHandle, Handle<Quote>(llfr),
-                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha));
+    ext::shared_ptr<YieldTermStructure> ufrTs = ext::make_shared<UltimateForwardTermStructure>(vars.ftkCurveHandle, Handle<Quote>(llfr),
+                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha);
     Time cutOff = ufrTs->timeFromReference(ufrTs->referenceDate() + vars.fsp);
 
     Rate actual = ufrTs->zeroRate(cutOff, Continuous, NoFrequency, true).rate();
@@ -254,7 +251,7 @@ BOOST_AUTO_TEST_CASE(testZeroRateAtFirstSmoothingPoint) {
     Real tolerance = 1.0e-10;
     if (std::fabs(actual - expected) > tolerance)
         BOOST_ERROR("unable to replicate the zero rate on the First Smoothing Point\n"
-                    << std::setprecision(5) 
+                    << std::setprecision(5)
                     << "    calculated: " << actual << "\n"
                     << "    expected:   " << expected << "\n"
                     << "    FSP:       " << vars.fsp << "\n");
@@ -265,11 +262,10 @@ BOOST_AUTO_TEST_CASE(testThatInspectorsEqualToBaseCurve) {
 
     CommonVars vars;
 
-    ext::shared_ptr<Quote> llfr(new SimpleQuote(0.0125));
+    ext::shared_ptr<Quote> llfr = ext::make_shared<SimpleQuote>(0.0125);
 
-    ext::shared_ptr<YieldTermStructure> ufrTs(
-        new UltimateForwardTermStructure(vars.ftkCurveHandle, Handle<Quote>(llfr),
-                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha));
+    ext::shared_ptr<YieldTermStructure> ufrTs = ext::make_shared<UltimateForwardTermStructure>(vars.ftkCurveHandle, Handle<Quote>(llfr),
+                                         Handle<Quote>(vars.ufrRate), vars.fsp, vars.alpha);
 
     if (ufrTs->dayCounter() != vars.ftkCurveHandle->dayCounter())
         BOOST_ERROR("different day counter on the UFR curve than on the base curve\n"
@@ -297,7 +293,7 @@ BOOST_AUTO_TEST_CASE(testExceptionWhenFspLessOrEqualZero) {
 
     CommonVars vars;
 
-    ext::shared_ptr<Quote> llfr(new SimpleQuote(0.0125));
+    ext::shared_ptr<Quote> llfr = ext::make_shared<SimpleQuote>(0.0125);
 
     BOOST_CHECK_THROW(
         ext::shared_ptr<YieldTermStructure> ufrTsZeroPeriod(
@@ -317,12 +313,12 @@ BOOST_AUTO_TEST_CASE(testObservability) {
 
     CommonVars vars;
 
-    ext::shared_ptr<SimpleQuote> llfr(new SimpleQuote(0.0125));
+    ext::shared_ptr<SimpleQuote> llfr = ext::make_shared<SimpleQuote>(0.0125);
     Handle<Quote> llfr_quote(llfr);
-    ext::shared_ptr<SimpleQuote> ufr(new SimpleQuote(0.02));
+    ext::shared_ptr<SimpleQuote> ufr = ext::make_shared<SimpleQuote>(0.02);
     Handle<Quote> ufr_handle(ufr);
-    ext::shared_ptr<YieldTermStructure> ufrTs(new UltimateForwardTermStructure(
-        vars.ftkCurveHandle, llfr_quote, ufr_handle, vars.fsp, vars.alpha));
+    ext::shared_ptr<YieldTermStructure> ufrTs = ext::make_shared<UltimateForwardTermStructure>(
+        vars.ftkCurveHandle, llfr_quote, ufr_handle, vars.fsp, vars.alpha);
 
     Flag flag;
     flag.registerWith(ufrTs);

--- a/test-suite/utilities.cpp
+++ b/test-suite/utilities.cpp
@@ -75,26 +75,24 @@ namespace QuantLib {
     flatRate(const Date& today,
              const ext::shared_ptr<Quote>& forward,
              const DayCounter& dc) {
-        return ext::shared_ptr<YieldTermStructure>(
-                          new FlatForward(today, Handle<Quote>(forward), dc));
+        return ext::make_shared<FlatForward>(today, Handle<Quote>(forward), dc);
     }
 
     ext::shared_ptr<YieldTermStructure>
     flatRate(const Date& today, Rate forward, const DayCounter& dc) {
         return flatRate(
-               today, ext::shared_ptr<Quote>(new SimpleQuote(forward)), dc);
+               today, ext::make_shared<SimpleQuote>(forward), dc);
     }
 
     ext::shared_ptr<YieldTermStructure>
     flatRate(const ext::shared_ptr<Quote>& forward,
              const DayCounter& dc) {
-        return ext::shared_ptr<YieldTermStructure>(
-              new FlatForward(0, NullCalendar(), Handle<Quote>(forward), dc));
+        return ext::make_shared<FlatForward>(0, NullCalendar(), Handle<Quote>(forward), dc);
     }
 
     ext::shared_ptr<YieldTermStructure>
     flatRate(Rate forward, const DayCounter& dc) {
-        return flatRate(ext::shared_ptr<Quote>(new SimpleQuote(forward)),
+        return flatRate(ext::make_shared<SimpleQuote>(forward),
                         dc);
     }
 
@@ -103,29 +101,27 @@ namespace QuantLib {
     flatVol(const Date& today,
             const ext::shared_ptr<Quote>& vol,
             const DayCounter& dc) {
-        return ext::shared_ptr<BlackVolTermStructure>(new
-            BlackConstantVol(today, NullCalendar(), Handle<Quote>(vol), dc));
+        return ext::make_shared<BlackConstantVol>(today, NullCalendar(), Handle<Quote>(vol), dc);
     }
 
     ext::shared_ptr<BlackVolTermStructure>
     flatVol(const Date& today, Volatility vol,
             const DayCounter& dc) {
         return flatVol(today,
-                       ext::shared_ptr<Quote>(new SimpleQuote(vol)),
+                       ext::make_shared<SimpleQuote>(vol),
                        dc);
     }
 
     ext::shared_ptr<BlackVolTermStructure>
     flatVol(const ext::shared_ptr<Quote>& vol,
             const DayCounter& dc) {
-        return ext::shared_ptr<BlackVolTermStructure>(new
-            BlackConstantVol(0, NullCalendar(), Handle<Quote>(vol), dc));
+        return ext::make_shared<BlackConstantVol>(0, NullCalendar(), Handle<Quote>(vol), dc);
     }
 
     ext::shared_ptr<BlackVolTermStructure>
     flatVol(Volatility vol,
             const DayCounter& dc) {
-        return flatVol(ext::shared_ptr<Quote>(new SimpleQuote(vol)), dc);
+        return flatVol(ext::make_shared<SimpleQuote>(vol), dc);
     }
 
 

--- a/test-suite/variancegamma.cpp
+++ b/test-suite/variancegamma.cpp
@@ -130,27 +130,24 @@ BOOST_AUTO_TEST_CASE(testVarianceGamma) {
     Date today = Date::todaysDate();
 
     for (Size i=0; i<std::size(processes); i++) {
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(processes[i].s));
-        ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(processes[i].q));
+        ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(processes[i].s);
+        ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(processes[i].q);
         ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-        ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(processes[i].r));
+        ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(processes[i].r);
         ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
-        ext::shared_ptr<VarianceGammaProcess> stochProcess(
-            new VarianceGammaProcess(Handle<Quote>(spot),
+        ext::shared_ptr<VarianceGammaProcess> stochProcess = ext::make_shared<VarianceGammaProcess>(Handle<Quote>(spot),
             Handle<YieldTermStructure>(qTS),
             Handle<YieldTermStructure>(rTS),
             processes[i].sigma,
             processes[i].nu,
-            processes[i].theta));
+            processes[i].theta);
 
         // Analytic engine
-        ext::shared_ptr<PricingEngine> analyticEngine(
-            new VarianceGammaEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> analyticEngine = ext::make_shared<VarianceGammaEngine>(stochProcess);
 
         // FFT engine
-        ext::shared_ptr<FFTVarianceGammaEngine> fftEngine(
-            new FFTVarianceGammaEngine(stochProcess));
+        ext::shared_ptr<FFTVarianceGammaEngine> fftEngine = ext::make_shared<FFTVarianceGammaEngine>(stochProcess);
 
         // which requires a list of options
         std::vector<ext::shared_ptr<Instrument> > optionList;
@@ -159,14 +156,13 @@ BOOST_AUTO_TEST_CASE(testVarianceGamma) {
         for (Size j=0; j<std::size(options); j++)
         {
             Date exDate = today + timeToDays(options[j].t);
-            ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+            ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new
-                PlainVanillaPayoff(options[j].type, options[j].strike));
+            ext::shared_ptr<StrikedTypePayoff> payoff = ext::make_shared<PlainVanillaPayoff>(options[j].type, options[j].strike);
             payoffs.push_back(payoff);
 
             // Test analytic engine
-            ext::shared_ptr<EuropeanOption> option(new EuropeanOption(payoff, exercise));
+            ext::shared_ptr<EuropeanOption> option = ext::make_shared<EuropeanOption>(payoff, exercise);
             option->setPricingEngine(analyticEngine);
 
             Real calculated = option->NPV();

--- a/test-suite/varianceoption.cpp
+++ b/test-suite/varianceoption.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(testIntegralHeston) {
 
     Handle<Quote> s0(ext::make_shared<SimpleQuote>(1.0));
     Handle<YieldTermStructure> qTS;
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     Handle<YieldTermStructure> rTS(flatRate(today, rRate, dc));
 
     Real v0 = 2.0;
@@ -49,19 +49,18 @@ BOOST_AUTO_TEST_CASE(testIntegralHeston) {
     Real sigma = 0.1;
     Real rho = -0.5;
 
-    ext::shared_ptr<HestonProcess> process(new HestonProcess(rTS, qTS, s0,
+    ext::shared_ptr<HestonProcess> process = ext::make_shared<HestonProcess>(rTS, qTS, s0,
                                                                v0, kappa, theta,
-                                                               sigma, rho));
-    ext::shared_ptr<PricingEngine> engine(
-                               new IntegralHestonVarianceOptionEngine(process));
+                                                               sigma, rho);
+    ext::shared_ptr<PricingEngine> engine = ext::make_shared<IntegralHestonVarianceOptionEngine>(process);
 
     Real strike = 0.05;
     Real nominal = 1.0;
     Time T = 1.5;
     Date exDate = today + int(360*T);
 
-    ext::shared_ptr<Payoff> payoff(new PlainVanillaPayoff(Option::Call,
-                                                            strike));
+    ext::shared_ptr<Payoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call,
+                                                            strike);
 
     VarianceOption varianceOption1(payoff, nominal, today, exDate);
     varianceOption1.setPricingEngine(engine);
@@ -86,16 +85,15 @@ BOOST_AUTO_TEST_CASE(testIntegralHeston) {
 
     process = ext::make_shared<HestonProcess>(
                rTS, qTS, s0, v0, kappa, theta, sigma, rho);
-    engine = ext::shared_ptr<PricingEngine>(
-                               new IntegralHestonVarianceOptionEngine(process));
+    engine = ext::make_shared<IntegralHestonVarianceOptionEngine>(process);
 
     strike = 0.7;
     nominal = 1.0;
     T = 1.0;
     exDate = today + int(360*T);
 
-    payoff = ext::shared_ptr<Payoff>(new PlainVanillaPayoff(Option::Put,
-                                                              strike));
+    payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put,
+                                                              strike);
 
     VarianceOption varianceOption2(payoff, nominal, today, exDate);
     varianceOption2.setPricingEngine(engine);

--- a/test-suite/varianceswaps.cpp
+++ b/test-suite/varianceswaps.cpp
@@ -140,10 +140,10 @@ BOOST_AUTO_TEST_CASE(testReplicatingVarianceSwap) {
     DayCounter dc = Actual365Fixed();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
 
     for (auto& value : values) {
@@ -185,22 +185,19 @@ BOOST_AUTO_TEST_CASE(testReplicatingVarianceSwap) {
             strikes.push_back(callStrikes[k]);
         }
 
-        ext::shared_ptr<BlackVolTermStructure> volTS(new
-            BlackVarianceSurface(today, NullCalendar(),
-                                 dates, strikes, vols, dc));
+        ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackVarianceSurface>(today, NullCalendar(),
+                                 dates, strikes, vols, dc);
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> stochProcess(
-                             new BlackScholesMertonProcess(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
 
-        ext::shared_ptr<PricingEngine> engine(
-                          new ReplicatingVarianceSwapEngine(stochProcess, 5.0,
+        ext::shared_ptr<PricingEngine> engine = ext::make_shared<ReplicatingVarianceSwapEngine>(stochProcess, 5.0,
                                                             callStrikes,
-                                                            putStrikes));
+                                                            putStrikes);
 
         VarianceSwap varianceSwap(value.type, value.varStrike, value.nominal, today, exDate);
         varianceSwap.setPricingEngine(engine);
@@ -238,10 +235,10 @@ BOOST_AUTO_TEST_CASE(testMCVarianceSwap) {
     DayCounter dc = Actual365Fixed();
     Date today = Date::todaysDate();
 
-    ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(0.0));
-    ext::shared_ptr<SimpleQuote> qRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> spot = ext::make_shared<SimpleQuote>(0.0);
+    ext::shared_ptr<SimpleQuote> qRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> qTS = flatRate(today, qRate, dc);
-    ext::shared_ptr<SimpleQuote> rRate(new SimpleQuote(0.0));
+    ext::shared_ptr<SimpleQuote> rRate = ext::make_shared<SimpleQuote>(0.0);
     ext::shared_ptr<YieldTermStructure> rTS = flatRate(today, rRate, dc);
     std::vector<Volatility> vols(2);
     std::vector<Date> dates(2);
@@ -249,7 +246,7 @@ BOOST_AUTO_TEST_CASE(testMCVarianceSwap) {
     for (auto& value : values) {
         Date exDate = today + timeToDays(value.t, 365);
         Date intermDate = today + timeToDays(value.t1, 365);
-        ext::shared_ptr<Exercise> exercise(new EuropeanExercise(exDate));
+        ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(exDate);
         dates[0] = intermDate;
         dates[1] = exDate;
 
@@ -259,15 +256,13 @@ BOOST_AUTO_TEST_CASE(testMCVarianceSwap) {
         vols[0] = value.v1;
         vols[1] = value.v;
 
-        ext::shared_ptr<BlackVolTermStructure> volTS(
-                        new BlackVarianceCurve(today, dates, vols, dc, true));
+        ext::shared_ptr<BlackVolTermStructure> volTS = ext::make_shared<BlackVarianceCurve>(today, dates, vols, dc, true);
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> stochProcess(
-                    new BlackScholesMertonProcess(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> stochProcess = ext::make_shared<BlackScholesMertonProcess>(
                                        Handle<Quote>(spot),
                                        Handle<YieldTermStructure>(qTS),
                                        Handle<YieldTermStructure>(rTS),
-                                       Handle<BlackVolTermStructure>(volTS)));
+                                       Handle<BlackVolTermStructure>(volTS));
 
         ext::shared_ptr<PricingEngine> engine;
         engine =

--- a/test-suite/vpp.cpp
+++ b/test-suite/vpp.cpp
@@ -75,9 +75,8 @@ ext::shared_ptr<ExtOUWithJumpsProcess> createKlugeProcess() {
     const Real speed = 1.0;
     const Real volatility = 2.0;
 
-    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
-            new ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0[0],
-                                                 constant_b(x0[0])));
+    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(speed, volatility, x0[0],
+                                                 constant_b(x0[0]));
     return ext::make_shared<ExtOUWithJumpsProcess>(
             ouProcess, x0[1], beta, jumpIntensity, eta);
 }
@@ -216,19 +215,15 @@ ext::shared_ptr<KlugeExtOUProcess> createKlugeExtOUProcess() {
     Array x0(2);
     x0[0] = 0.0; x0[1] = 0.0;
 
-    const ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
-            new ExtendedOrnsteinUhlenbeckProcess(alpha, volatility_x, x0[0],
-                                                 constant_b(x0[0])));
-    const ext::shared_ptr<ExtOUWithJumpsProcess> lnPowerProcess(
-            new ExtOUWithJumpsProcess(ouProcess, x0[1], beta, lambda, eta));
+    const ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(alpha, volatility_x, x0[0],
+                                                 constant_b(x0[0]));
+    const ext::shared_ptr<ExtOUWithJumpsProcess> lnPowerProcess = ext::make_shared<ExtOUWithJumpsProcess>(ouProcess, x0[1], beta, lambda, eta);
 
     const Real u=0.0;
-    const ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> lnGasProcess(
-            new ExtendedOrnsteinUhlenbeckProcess(kappa, volatility_u, u,
-                                                 constant_b(u)));
+    const ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> lnGasProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(kappa, volatility_u, u,
+                                                 constant_b(u));
 
-    ext::shared_ptr<KlugeExtOUProcess> klugeOUProcess(
-            new KlugeExtOUProcess(rho, lnPowerProcess, lnGasProcess));
+    ext::shared_ptr<KlugeExtOUProcess> klugeOUProcess = ext::make_shared<KlugeExtOUProcess>(rho, lnPowerProcess, lnGasProcess);
 
     return klugeOUProcess;
 }
@@ -269,10 +264,9 @@ BOOST_AUTO_TEST_CASE(testGemanRoncoroniProcess) {
     const Real theta3 = 0.10;
     const Real psi    = 1.9;
 
-    ext::shared_ptr<GemanRoncoroniProcess> grProcess(
-                new GemanRoncoroniProcess(x0, alpha, beta, gamma, delta,
+    ext::shared_ptr<GemanRoncoroniProcess> grProcess = ext::make_shared<GemanRoncoroniProcess>(x0, alpha, beta, gamma, delta,
                                           eps, zeta, d, k, tau, sig2, a, b,
-                                          theta1, theta2, theta3, psi));
+                                          theta1, theta2, theta3, psi);
 
 
     const Real speed     = 5.0;
@@ -283,17 +277,15 @@ BOOST_AUTO_TEST_CASE(testGemanRoncoroniProcess) {
 
     std::function<Real (Real)> f = linear(alphaG, betaG);
 
-    ext::shared_ptr<StochasticProcess1D> eouProcess(
-        new ExtendedOrnsteinUhlenbeckProcess(speed, vol, x0G, f,
-                           ExtendedOrnsteinUhlenbeckProcess::Trapezodial));
+    ext::shared_ptr<StochasticProcess1D> eouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(speed, vol, x0G, f,
+                           ExtendedOrnsteinUhlenbeckProcess::Trapezodial);
 
     std::vector<ext::shared_ptr<StochasticProcess1D> > processes = {grProcess, eouProcess};
 
     Matrix correlation(2, 2, 1.0);
     correlation[0][1] = correlation[1][0] = 0.25;
 
-    ext::shared_ptr<StochasticProcess> pArray(
-                           new StochasticProcessArray(processes, correlation));
+    ext::shared_ptr<StochasticProcess> pArray = ext::make_shared<StochasticProcessArray>(processes, correlation);
 
     const Time T = 10.0;
     const Size stepsPerYear = 250;
@@ -368,23 +360,20 @@ BOOST_AUTO_TEST_CASE(testSimpleExtOUStorageEngine) {
     while (exerciseDates.back() < maturityDate) {
         exerciseDates.push_back(exerciseDates.back()+Period(1, Days));
     }
-    ext::shared_ptr<BermudanExercise> bermudanExercise(
-                                        new BermudanExercise(exerciseDates));
+    ext::shared_ptr<BermudanExercise> bermudanExercise = ext::make_shared<BermudanExercise>(exerciseDates);
 
     const Real x0 = 3.0;
     const Real speed = 1.0;
     const Real volatility = 0.5;
     const Rate irRate = 0.1;
 
-    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess(
-        new ExtendedOrnsteinUhlenbeckProcess(speed, volatility, x0,
-                                             constant_b(x0)));
+    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> ouProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(speed, volatility, x0,
+                                             constant_b(x0));
 
     ext::shared_ptr<YieldTermStructure> rTS(
                                 flatRate(settlementDate, irRate, dayCounter));
 
-    ext::shared_ptr<PricingEngine> storageEngine(
-               new FdSimpleExtOUStorageEngine(ouProcess, rTS, 1, 25));
+    ext::shared_ptr<PricingEngine> storageEngine = ext::make_shared<FdSimpleExtOUStorageEngine>(ouProcess, rTS, 1, 25);
 
     VanillaStorageOption storageOption(bermudanExercise, 50, 0, 1);
 
@@ -425,30 +414,26 @@ BOOST_AUTO_TEST_CASE(testKlugeExtOUSpreadOption) {
                                            klugeProcess = createKlugeProcess();
     std::function<Real (Real)> f = linear(alphaG, betaG);
 
-    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> extOUProcess(
-        new ExtendedOrnsteinUhlenbeckProcess(speed, vol, x0G, f,
-                           ExtendedOrnsteinUhlenbeckProcess::Trapezodial));
+    ext::shared_ptr<ExtendedOrnsteinUhlenbeckProcess> extOUProcess = ext::make_shared<ExtendedOrnsteinUhlenbeckProcess>(speed, vol, x0G, f,
+                           ExtendedOrnsteinUhlenbeckProcess::Trapezodial);
 
     ext::shared_ptr<YieldTermStructure> rTS(
                                 flatRate(settlementDate, irRate, dayCounter));
 
-    ext::shared_ptr<KlugeExtOUProcess> klugeOUProcess(
-                    new KlugeExtOUProcess(rho, klugeProcess, extOUProcess));
+    ext::shared_ptr<KlugeExtOUProcess> klugeOUProcess = ext::make_shared<KlugeExtOUProcess>(rho, klugeProcess, extOUProcess);
 
 
-    ext::shared_ptr<Payoff> payoff(new PlainVanillaPayoff(Option::Call, 0.0));
+    ext::shared_ptr<Payoff> payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 0.0);
 
     Array spreadFactors(2);
     spreadFactors[0] = 1.0; spreadFactors[1] = -heatRate;
-    ext::shared_ptr<BasketPayoff> basketPayoff(
-                               new AverageBasketPayoff(payoff, spreadFactors));
+    ext::shared_ptr<BasketPayoff> basketPayoff = ext::make_shared<AverageBasketPayoff>(payoff, spreadFactors);
 
-    ext::shared_ptr<Exercise> exercise(new EuropeanExercise(maturityDate));
+    ext::shared_ptr<Exercise> exercise = ext::make_shared<EuropeanExercise>(maturityDate);
 
     BasketOption option(basketPayoff, exercise);
-    option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new FdKlugeExtOUSpreadEngine(klugeOUProcess, rTS,
-                                     5, 200, 50, 20)));
+    option.setPricingEngine(ext::make_shared<FdKlugeExtOUSpreadEngine>(klugeOUProcess, rTS,
+                                     5, 200, 50, 20));
 
     TimeGrid grid(maturity, 50);
     typedef PseudoRandom::rsg_type rsg_type;
@@ -500,7 +485,7 @@ BOOST_AUTO_TEST_CASE(testVPPIntrinsicValue) {
     const Real startUpFixCost = 100;
     const Real fuelCostAddon    = 3.0;
 
-    const ext::shared_ptr<SwingExercise> exercise(new SwingExercise(today, today + 6, 3600U));
+    const ext::shared_ptr<SwingExercise> exercise = ext::make_shared<SwingExercise>(today, today + 6, 3600U);
 
     // Expected values are calculated using mixed integer programming
     // based on the gnu linear programming toolkit. For details please see:
@@ -516,9 +501,8 @@ BOOST_AUTO_TEST_CASE(testVPPIntrinsicValue) {
         VanillaVPPOption option(heatRate, pMin, pMax, tMinUp, tMinDown,
                                 startUpFuel, startUpFixCost, exercise);
 
-        option.setPricingEngine(ext::shared_ptr<PricingEngine>(
-            new DynProgVPPIntrinsicValueEngine(fuelPrices, powerPrices,
-                                               fuelCostAddon, flatRate(0.0, dc))));
+        option.setPricingEngine(ext::make_shared<DynProgVPPIntrinsicValueEngine>(fuelPrices, powerPrices,
+                                               fuelCostAddon, flatRate(0.0, dc)));
 
         const Real calculated = option.NPV();
 
@@ -547,7 +531,7 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
     const Real startUpFuel    = 20;
     const Real startUpFixCost = 100;
 
-    const ext::shared_ptr<SwingExercise> exercise(new SwingExercise(today, today + 6, 3600U));
+    const ext::shared_ptr<SwingExercise> exercise = ext::make_shared<SwingExercise>(today, today + 6, 3600U);
 
     VanillaVPPOption vppOption(heatRate, pMin, pMax, tMinUp, tMinDown,
                                startUpFuel, startUpFixCost, exercise);
@@ -578,8 +562,8 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
     const Size nHours = powerPrices.size();
 
     typedef FdSimpleKlugeExtOUVPPEngine::Shape Shape;
-    ext::shared_ptr<Shape> fuelShape(new Shape(nHours));
-    ext::shared_ptr<Shape> powerShape(new Shape(nHours));
+    ext::shared_ptr<Shape> fuelShape = ext::make_shared<Shape>(nHours);
+    ext::shared_ptr<Shape> powerShape = ext::make_shared<Shape>(nHours);
 
     for (Size i=0; i < nHours; ++i) {
         const Time t = (i+1)/(365*24.);
@@ -598,9 +582,8 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
     }
 
     // Test: intrinsic value
-    vppOption.setPricingEngine(ext::shared_ptr<PricingEngine>(
-        new DynProgVPPIntrinsicValueEngine(fuelPrices, powerPrices,
-                                           fuelCostAddon, flatRate(0.0, dc))));
+    vppOption.setPricingEngine(ext::make_shared<DynProgVPPIntrinsicValueEngine>(fuelPrices, powerPrices,
+                                           fuelCostAddon, flatRate(0.0, dc)));
 
     const Real intrinsic = vppOption.NPV();
     const Real expectedIntrinsic = 2056.04;
@@ -611,10 +594,9 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
     }
 
     // Test: finite difference price
-    const ext::shared_ptr<PricingEngine> engine(
-        new FdSimpleKlugeExtOUVPPEngine(klugeOUProcess, rTS,
+    const ext::shared_ptr<PricingEngine> engine = ext::make_shared<FdSimpleKlugeExtOUVPPEngine>(klugeOUProcess, rTS,
                                         fuelShape, powerShape, fuelCostAddon,
-                                        1, 25, 11, 10));
+                                        1, 25, 11, 10);
 
     vppOption.setPricingEngine(engine);
 
@@ -632,8 +614,8 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
 
     const FdmVPPStepConditionFactory stepConditionFactory(args);
 
-    const ext::shared_ptr<FdmMesher> oneDimMesher(new FdmMesherComposite(
-        stepConditionFactory.stateMesher()));
+    const ext::shared_ptr<FdmMesher> oneDimMesher = ext::make_shared<FdmMesherComposite>(
+        stepConditionFactory.stateMesher());
     const Size nStates = oneDimMesher->layout()->dim()[0];
 
     const FdmVPPStepConditionMesher vppMesh = {0U, oneDimMesher};
@@ -655,11 +637,9 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
         const ext::shared_ptr<FdmVPPStepCondition> stepCondition(
             stepConditionFactory.build(
                 vppMesh, fuelCostAddon,
-                ext::shared_ptr<FdmInnerValueCalculator>(
-                    new PathFuelPrice(path.value, fuelShape)),
-                ext::shared_ptr<FdmInnerValueCalculator>(
-                    new PathSparkSpreadPrice(heatRate, path.value,
-                                             fuelShape, powerShape))));
+                ext::make_shared<PathFuelPrice>(path.value, fuelShape),
+                ext::make_shared<PathSparkSpreadPrice>(heatRate, path.value,
+                                             fuelShape, powerShape)));
 
         Array state(nStates, 0.0);
         for (Size j=exercise->dates().size(); j > 0; --j) {
@@ -694,13 +674,11 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
     for (Size i=0; i < nCalibrationTrails; ++i) {
         calibrationPaths.push_back(generator.next());
 
-        sparkSpreads.push_back(ext::shared_ptr<FdmInnerValueCalculator>(
-            new PathSparkSpreadPrice(heatRate, calibrationPaths.back().value,
-                                     fuelShape, powerShape)));
+        sparkSpreads.push_back(ext::make_shared<PathSparkSpreadPrice>(heatRate, calibrationPaths.back().value,
+                                     fuelShape, powerShape));
         stepConditions.push_back(stepConditionFactory.build(
             vppMesh, fuelCostAddon,
-            ext::shared_ptr<FdmInnerValueCalculator>(
-                new PathFuelPrice(calibrationPaths.back().value, fuelShape)),
+            ext::make_shared<PathFuelPrice>(calibrationPaths.back().value, fuelShape),
             sparkSpreads.back()));
     }
 
@@ -755,12 +733,10 @@ BOOST_AUTO_TEST_CASE(testVPPPricing) {
 
         const sample_type& path = (i % 2) != 0U ? generator.antithetic() : generator.next();
 
-        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrices(
-            new PathFuelPrice(path.value, fuelShape));
+        const ext::shared_ptr<FdmInnerValueCalculator> fuelPrices = ext::make_shared<PathFuelPrice>(path.value, fuelShape);
 
-        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpreads(
-            new PathSparkSpreadPrice(heatRate, path.value,
-                                     fuelShape, powerShape));
+        const ext::shared_ptr<FdmInnerValueCalculator> sparkSpreads = ext::make_shared<PathSparkSpreadPrice>(heatRate, path.value,
+                                     fuelShape, powerShape);
 
         for (Size j = exercise->dates().size(); j > 0U; --j) {
             const Time t = grid.at(j);
@@ -863,24 +839,19 @@ BOOST_AUTO_TEST_CASE(testKlugeExtOUMatrixDecomposition) {
     const ext::shared_ptr<StochasticProcess1D> ouProcess
         = klugeProcess->getExtendedOrnsteinUhlenbeckProcess();
 
-    const ext::shared_ptr<FdmMesher> mesher(
-        new FdmMesherComposite(
-            ext::shared_ptr<Fdm1dMesher>(
-                new FdmSimpleProcess1dMesher(xGrid, ouProcess, maturity)),
-            ext::shared_ptr<Fdm1dMesher>(
-                new ExponentialJump1dMesher(yGrid,
+    const ext::shared_ptr<FdmMesher> mesher = ext::make_shared<FdmMesherComposite>(
+            ext::make_shared<FdmSimpleProcess1dMesher>(xGrid, ouProcess, maturity),
+            ext::make_shared<ExponentialJump1dMesher>(yGrid,
                                             klugeProcess->beta(),
                                             klugeProcess->jumpIntensity(),
-                                            klugeProcess->eta())),
-            ext::shared_ptr<Fdm1dMesher>(
-                new FdmSimpleProcess1dMesher(uGrid,
+                                            klugeProcess->eta()),
+            ext::make_shared<FdmSimpleProcess1dMesher>(uGrid,
                                              klugeOUProcess->getExtOUProcess(),
-                                             maturity))));
+                                             maturity));
 
-    const ext::shared_ptr<FdmLinearOpComposite> op(
-        new FdmKlugeExtOUOp(mesher, klugeOUProcess,
+    const ext::shared_ptr<FdmLinearOpComposite> op = ext::make_shared<FdmKlugeExtOUOp>(mesher, klugeOUProcess,
                             flatRate(today, 0.0, ActualActual(ActualActual::ISDA)),
-                            FdmBoundaryConditionSet(), 16));
+                            FdmBoundaryConditionSet(), 16);
     op->setTime(0.1, 0.2);
 
     Array x(mesher->layout()->size());

--- a/test-suite/zerocouponswap.cpp
+++ b/test-suite/zerocouponswap.cpp
@@ -55,7 +55,7 @@ struct CommonVars {
         baseNominal = 1.0e6;
         finalPayment = 1.2e6;
 
-        euribor = ext::shared_ptr<IborIndex>(new Euribor6M(euriborHandle));
+        euribor = ext::make_shared<Euribor6M>(euriborHandle);
         euribor->addFixing(Date(10, February, 2021), 0.0085);
 
         today = calendar.adjust(Date(15, March, 2021));
@@ -64,7 +64,7 @@ struct CommonVars {
 
         euriborHandle.linkTo(flatRate(settlement, 0.007, dayCount));
         discountEngine =
-            ext::shared_ptr<PricingEngine>(new DiscountingSwapEngine(euriborHandle));
+            ext::make_shared<DiscountingSwapEngine>(euriborHandle);
     }
 
     ext::shared_ptr<CashFlow> createMultipleResetsCoupon(const Date& start, const Date& end) const {


### PR DESCRIPTION
Mechanically replace raw `new`-based smart pointer construction with `ext::make_shared<T>` and `std::make_unique<T>`