### PR TITLE
Use `make_unique` for `unique_ptr` construction

### DIFF
--- a/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -57,27 +57,26 @@ namespace QuantLib {
     Real IvopOneDim(Real eps, Real chi, Real theta, Real /*rho*/,
                       Real v0, Real eprice, Time tau, Real rtax)
     {
-        Real ss=0.0;
-        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
-        double nris=0.0;
-        int j=0,mm=0;
-        double pi=0,pi2=0;
-        double dstep=0;
-        Real option=0, impart=0;
+        auto ss = 0.0;
+        auto xiv = std::make_unique<double[]>(2048*2048+1);
+        auto nris = 0.0;
+        auto j = 0, mm = 0;
+        auto pi = 0.0, pi2 = 0.0;
+        auto dstep = 0.0;
+        auto option = 0.0, impart = 0.0;
 
-        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
+        auto ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
-        Complex ui,beta,zita,gamma,csum,vero;
+        const auto ui = Complex(0.0,1.0);
+        Complex beta,zita,gamma,csum,vero;
         Complex contrib, caux, caux1,caux2,caux3;
-
-        ui=Complex(0.0,1.0);
 
         /*
          **********************************************************
          **   i0: initial integrated variance i0=0
          **********************************************************
          */
-        Real i0=0.0;
+        const auto i0 = 0.0;
         //s=2.0*chi*theta/(eps*eps)-1.0;
 
         //s=s+1;
@@ -90,7 +89,7 @@ namespace QuantLib {
 
         pi= 3.14159265358979324;
         pi2=2.0*pi;
-        Real s=2.0*chi*theta/(eps*eps)-1.0;
+        const auto s = 2.0*chi*theta/(eps*eps)-1.0;
         /*
          ****************************************
          ** Note that s must be greater than zero
@@ -202,34 +201,33 @@ namespace QuantLib {
                     Real v0, Time tau, Real rtax,
                     const std::function<Real(Real)>& payoff) {
 
-        Real ss=0.0;
-        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
-        std::unique_ptr<double[]> ivet = std::make_unique<double[]>(2048 * 2048 + 1);
-        double nris=0.0;
-        int j=0,mm=0,k=0;
-        double pi=0,pi2=0;
+        auto ss = 0.0;
+        auto xiv = std::make_unique<double[]>(2048*2048+1);
+        auto ivet = std::make_unique<double[]>(2048 * 2048 + 1);
+        auto nris = 0.0;
+        auto j = 0, mm = 0, k = 0;
+        auto pi = 0.0, pi2 = 0.0;
 
-        double dstep=0;
-        Real ip=0;
-        Real payoffval=0;
-        Real option=0/*, impart=0*/;
+        auto dstep = 0.0;
+        auto ip = 0.0;
+        auto payoffval = 0.0;
+        auto option = 0.0/*, impart=0*/;
 
-        Real sumr=0;//,sumi=0;
+        auto sumr = 0.0;//,sumi=0;
         Complex dxi,z;
 
-        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
+        auto ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
-        Complex ui,beta,zita,gamma,csum;
+        const auto ui = Complex(0.0,1.0);
+        Complex beta,zita,gamma,csum;
         Complex caux,caux1,caux2,caux3;
-
-        ui=Complex(0.0,1.0);
 
         /*
          **********************************************************
          **   i0: initial integrated variance i0=0
          **********************************************************
          */
-        Real i0=0.0;
+        const auto i0 = 0.0;
 
         /*
          *************************************************
@@ -240,7 +238,7 @@ namespace QuantLib {
         pi= 3.14159265358979324;
         pi2=2.0*pi;
 
-        Real s=2.0*chi*theta/(eps*eps)-1.0;
+        const auto s = 2.0*chi*theta/(eps*eps)-1.0;
         /*
          ****************************************
          ** Note that s must be greater than zero
@@ -368,26 +366,26 @@ namespace QuantLib {
         QL_REQUIRE(process_->dividendYield().empty(),
                    "this engine does not manage dividend yields");
 
-        Handle<YieldTermStructure> riskFreeRate = process_->riskFreeRate();
+        const auto riskFreeRate = process_->riskFreeRate();
 
-        Real epsilon = process_->sigma();
-        Real chi = process_->kappa();
-        Real theta = process_->theta();
-        Real rho = process_->rho();
-        Real v0 = process_->v0();
+        const auto epsilon = process_->sigma();
+        const auto chi = process_->kappa();
+        const auto theta = process_->theta();
+        const auto rho = process_->rho();
+        const auto v0 = process_->v0();
 
-        Time tau = riskFreeRate->dayCounter().yearFraction(
+        const auto tau = riskFreeRate->dayCounter().yearFraction(
                                         Settings::instance().evaluationDate(),
                                         arguments_.maturityDate);
-        Rate r = riskFreeRate->zeroRate(arguments_.maturityDate,
+        const auto r = riskFreeRate->zeroRate(arguments_.maturityDate,
                                         riskFreeRate->dayCounter(),
                                         Continuous);
 
-        ext::shared_ptr<PlainVanillaPayoff> plainPayoff =
+        const auto plainPayoff =
             ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
         if ((plainPayoff != nullptr) && plainPayoff->optionType() == Option::Call) {
             // a specialization for Call options is available
-            Real strike = plainPayoff->strike();
+            const auto strike = plainPayoff->strike();
             results_.value = IvopOneDim(epsilon, chi, theta, rho,
                                         v0, strike, tau, r)
                 * arguments_.notional;
@@ -399,4 +397,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
+++ b/ql/experimental/varianceoption/integralhestonvarianceoptionengine.cpp
@@ -58,14 +58,14 @@ namespace QuantLib {
                       Real v0, Real eprice, Time tau, Real rtax)
     {
         Real ss=0.0;
-        std::unique_ptr<double[]> xiv(new double[2048*2048+1]);
+        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
         double nris=0.0;
         int j=0,mm=0;
         double pi=0,pi2=0;
         double dstep=0;
         Real option=0, impart=0;
 
-        std::unique_ptr<Complex[]> ff(new Complex[2048*2048]);
+        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
         Complex ui,beta,zita,gamma,csum,vero;
         Complex contrib, caux, caux1,caux2,caux3;
@@ -203,8 +203,8 @@ namespace QuantLib {
                     const std::function<Real(Real)>& payoff) {
 
         Real ss=0.0;
-        std::unique_ptr<double[]> xiv(new double[2048*2048+1]);
-        std::unique_ptr<double[]> ivet(new double[2048 * 2048 + 1]);
+        std::unique_ptr<double[]> xiv = std::make_unique<double[]>(2048*2048+1);
+        std::unique_ptr<double[]> ivet = std::make_unique<double[]>(2048 * 2048 + 1);
         double nris=0.0;
         int j=0,mm=0,k=0;
         double pi=0,pi2=0;
@@ -217,7 +217,7 @@ namespace QuantLib {
         Real sumr=0;//,sumi=0;
         Complex dxi,z;
 
-        std::unique_ptr<Complex[]> ff(new Complex[2048*2048]);
+        std::unique_ptr<Complex[]> ff = std::make_unique<Complex[]>(2048*2048);
         Complex xi;
         Complex ui,beta,zita,gamma,csum;
         Complex caux,caux1,caux2,caux3;

--- a/ql/math/matrixutilities/qrdecomposition.cpp
+++ b/ql/math/matrixutilities/qrdecomposition.cpp
@@ -35,9 +35,9 @@ namespace QuantLib {
         const Size m = M.rows();
         const Size n = M.columns();
 
-        std::unique_ptr<int[]> lipvt(new int[n]);
-        std::unique_ptr<Real[]> rdiag(new Real[n]);
-        std::unique_ptr<Real[]> wa(new Real[n]);
+        std::unique_ptr<int[]> lipvt = std::make_unique<int[]>(n);
+        std::unique_ptr<Real[]> rdiag = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
 
         MINPACK::qrfac(m, n, mT.begin(), 0, (pivot)?1:0,
                        lipvt.get(), n, rdiag.get(), rdiag.get(), wa.get());
@@ -135,13 +135,13 @@ namespace QuantLib {
 
         std::vector<Size> lipvt = qrDecomposition(a, q, r, pivot);
 
-        std::unique_ptr<int[]> ipvt(new int[n]);
+        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
         std::copy(lipvt.begin(), lipvt.end(), ipvt.get());
 
         Matrix rT = transpose(r);
 
-        std::unique_ptr<Real[]> sdiag(new Real[n]);
-        std::unique_ptr<Real[]> wa(new Real[n]);
+        std::unique_ptr<Real[]> sdiag = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
 
         Array ld(n, 0.0);
         if (!d.empty()) {

--- a/ql/math/matrixutilities/qrdecomposition.cpp
+++ b/ql/math/matrixutilities/qrdecomposition.cpp
@@ -35,9 +35,9 @@ namespace QuantLib {
         const Size m = M.rows();
         const Size n = M.columns();
 
-        std::unique_ptr<int[]> lipvt = std::make_unique<int[]>(n);
-        std::unique_ptr<Real[]> rdiag = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
+        auto lipvt = std::make_unique<int[]>(n);
+        auto rdiag = std::make_unique<Real[]>(n);
+        auto wa = std::make_unique<Real[]>(n);
 
         MINPACK::qrfac(m, n, mT.begin(), 0, (pivot)?1:0,
                        lipvt.get(), n, rdiag.get(), rdiag.get(), wa.get());
@@ -135,13 +135,13 @@ namespace QuantLib {
 
         std::vector<Size> lipvt = qrDecomposition(a, q, r, pivot);
 
-        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
+        auto ipvt = std::make_unique<int[]>(n);
         std::copy(lipvt.begin(), lipvt.end(), ipvt.get());
 
         Matrix rT = transpose(r);
 
-        std::unique_ptr<Real[]> sdiag = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa = std::make_unique<Real[]>(n);
+        auto sdiag = std::make_unique<Real[]>(n);
+        auto wa = std::make_unique<Real[]>(n);
 
         Array ld(n, 0.0);
         if (!d.empty()) {

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -48,8 +48,8 @@ namespace QuantLib {
             P.costFunction().jacobian(initJacobian_, initX);
         }
         Array xx = initX;
-        std::unique_ptr<Real[]> fvec(new Real[m]);
-        std::unique_ptr<Real[]> diag(new Real[n]);
+        std::unique_ptr<Real[]> fvec = std::make_unique<Real[]>(m);
+        std::unique_ptr<Real[]> diag = std::make_unique<Real[]>(n);
         int mode = 1;
         // magic number recommended by the documentation
         Real factor = 100;
@@ -59,14 +59,14 @@ namespace QuantLib {
         int nprint = 0;
         int info = 0;
         int nfev = 0;
-        std::unique_ptr<Real[]> fjac(new Real[m*n]);
+        std::unique_ptr<Real[]> fjac = std::make_unique<Real[]>(m*n);
         int ldfjac = m;
-        std::unique_ptr<int[]> ipvt(new int[n]);
-        std::unique_ptr<Real[]> qtf(new Real[n]);
-        std::unique_ptr<Real[]> wa1(new Real[n]);
-        std::unique_ptr<Real[]> wa2(new Real[n]);
-        std::unique_ptr<Real[]> wa3(new Real[n]);
-        std::unique_ptr<Real[]> wa4(new Real[m]);
+        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
+        std::unique_ptr<Real[]> qtf = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa1 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa2 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa3 = std::make_unique<Real[]>(n);
+        std::unique_ptr<Real[]> wa4 = std::make_unique<Real[]>(m);
         // requirements; check here to get more detailed error messages.
         QL_REQUIRE(n > 0, "no variables given");
         QL_REQUIRE(m >= n,

--- a/ql/math/optimization/levenbergmarquardt.cpp
+++ b/ql/math/optimization/levenbergmarquardt.cpp
@@ -48,8 +48,8 @@ namespace QuantLib {
             P.costFunction().jacobian(initJacobian_, initX);
         }
         Array xx = initX;
-        std::unique_ptr<Real[]> fvec = std::make_unique<Real[]>(m);
-        std::unique_ptr<Real[]> diag = std::make_unique<Real[]>(n);
+        auto fvec = std::make_unique<Real[]>(m);
+        auto diag = std::make_unique<Real[]>(n);
         int mode = 1;
         // magic number recommended by the documentation
         Real factor = 100;
@@ -59,14 +59,14 @@ namespace QuantLib {
         int nprint = 0;
         int info = 0;
         int nfev = 0;
-        std::unique_ptr<Real[]> fjac = std::make_unique<Real[]>(m*n);
+        auto fjac = std::make_unique<Real[]>(m*n);
         int ldfjac = m;
-        std::unique_ptr<int[]> ipvt = std::make_unique<int[]>(n);
-        std::unique_ptr<Real[]> qtf = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa1 = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa2 = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa3 = std::make_unique<Real[]>(n);
-        std::unique_ptr<Real[]> wa4 = std::make_unique<Real[]>(m);
+        auto ipvt = std::make_unique<int[]>(n);
+        auto qtf = std::make_unique<Real[]>(n);
+        auto wa1 = std::make_unique<Real[]>(n);
+        auto wa2 = std::make_unique<Real[]>(n);
+        auto wa3 = std::make_unique<Real[]>(n);
+        auto wa4 = std::make_unique<Real[]>(m);
         // requirements; check here to get more detailed error messages.
         QL_REQUIRE(n > 0, "no variables given");
         QL_REQUIRE(m >= n,

--- a/ql/models/marketmodels/callability/bermudanswaptionexercisevalue.cpp
+++ b/ql/models/marketmodels/callability/bermudanswaptionexercisevalue.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelExerciseValue>
     BermudanSwaptionExerciseValue::clone() const {
-        return std::unique_ptr<MarketModelExerciseValue>(new BermudanSwaptionExerciseValue(*this));
+        return std::make_unique<BermudanSwaptionExerciseValue>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/lsstrategy.cpp
+++ b/ql/models/marketmodels/callability/lsstrategy.cpp
@@ -156,7 +156,7 @@ namespace QuantLib {
 
     std::unique_ptr<ExerciseStrategy<CurveState>>
     LongstaffSchwartzExerciseStrategy::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new LongstaffSchwartzExerciseStrategy(*this));
+        return std::make_unique<LongstaffSchwartzExerciseStrategy>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/nothingexercisevalue.cpp
+++ b/ql/models/marketmodels/callability/nothingexercisevalue.cpp
@@ -86,7 +86,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelExerciseValue>
     NothingExerciseValue::clone() const {
-        return std::unique_ptr<MarketModelExerciseValue>(new NothingExerciseValue(*this));
+        return std::make_unique<NothingExerciseValue>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/parametricexerciseadapter.cpp
+++ b/ql/models/marketmodels/callability/parametricexerciseadapter.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<ExerciseStrategy<CurveState>> ParametricExerciseAdapter::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new ParametricExerciseAdapter(*this));
+        return std::make_unique<ParametricExerciseAdapter>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapbasissystem.cpp
+++ b/ql/models/marketmodels/callability/swapbasissystem.cpp
@@ -77,7 +77,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelBasisSystem>
     SwapBasisSystem::clone() const {
-        return std::unique_ptr<MarketModelBasisSystem>(new SwapBasisSystem(*this));
+        return std::make_unique<SwapBasisSystem>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapforwardbasissystem.cpp
+++ b/ql/models/marketmodels/callability/swapforwardbasissystem.cpp
@@ -129,7 +129,7 @@ namespace QuantLib
 
     std::unique_ptr<MarketModelBasisSystem>
     SwapForwardBasisSystem::clone() const {
-        return std::unique_ptr<MarketModelBasisSystem>(new SwapForwardBasisSystem(*this));
+        return std::make_unique<SwapForwardBasisSystem>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/swapratetrigger.cpp
+++ b/ql/models/marketmodels/callability/swapratetrigger.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
 
     std::unique_ptr<ExerciseStrategy<CurveState>>
     SwapRateTrigger::clone() const {
-        return std::unique_ptr<ExerciseStrategy<CurveState>>(new SwapRateTrigger(*this));
+        return std::make_unique<SwapRateTrigger>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/triggeredswapexercise.cpp
+++ b/ql/models/marketmodels/callability/triggeredswapexercise.cpp
@@ -87,7 +87,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelParametricExercise>
     TriggeredSwapExercise::clone() const {
-        return std::unique_ptr<MarketModelParametricExercise>(new TriggeredSwapExercise(*this));
+        return std::make_unique<TriggeredSwapExercise>(*this);
     }
 
 }

--- a/ql/models/marketmodels/callability/upperboundengine.cpp
+++ b/ql/models/marketmodels/callability/upperboundengine.cpp
@@ -74,7 +74,7 @@ namespace QuantLib {
             }
 
             std::unique_ptr<MarketModelMultiProduct> clone() const override {
-                return std::unique_ptr<MarketModelMultiProduct>(new DecoratedHedge(*this));
+                return std::make_unique<DecoratedHedge>(*this);
             }
 
             void save() {

--- a/ql/models/marketmodels/curvestates/cmswapcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/cmswapcurvestate.cpp
@@ -179,7 +179,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<CurveState> CMSwapCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new CMSwapCurveState(*this));
+        return std::make_unique<CMSwapCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/curvestates/coterminalswapcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/coterminalswapcurvestate.cpp
@@ -142,7 +142,7 @@ namespace QuantLib {
 
     std::unique_ptr<CurveState>
     CoterminalSwapCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new CoterminalSwapCurveState(*this));
+        return std::make_unique<CoterminalSwapCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/curvestates/lmmcurvestate.cpp
+++ b/ql/models/marketmodels/curvestates/lmmcurvestate.cpp
@@ -196,7 +196,7 @@ namespace QuantLib {
     }
 
     std::unique_ptr<CurveState> LMMCurveState::clone() const {
-        return std::unique_ptr<CurveState>(new LMMCurveState(*this));
+        return std::make_unique<LMMCurveState>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multiproductcomposite.cpp
+++ b/ql/models/marketmodels/products/multiproductcomposite.cpp
@@ -80,7 +80,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiProductComposite::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiProductComposite(*this));
+        return std::make_unique<MultiProductComposite>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
+++ b/ql/models/marketmodels/products/multistep/callspecifiedmultiproduct.cpp
@@ -170,7 +170,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     CallSpecifiedMultiProduct::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new CallSpecifiedMultiProduct(*this));
+        return std::make_unique<CallSpecifiedMultiProduct>(*this);
     }
 
     const MarketModelMultiProduct&

--- a/ql/models/marketmodels/products/multistep/cashrebate.cpp
+++ b/ql/models/marketmodels/products/multistep/cashrebate.cpp
@@ -96,7 +96,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     MarketModelCashRebate::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new MarketModelCashRebate(*this));
+        return std::make_unique<MarketModelCashRebate>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/exerciseadapter.cpp
+++ b/ql/models/marketmodels/products/multistep/exerciseadapter.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     ExerciseAdapter::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new ExerciseAdapter(*this));
+        return std::make_unique<ExerciseAdapter>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoinitialswaps.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoinitialSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoinitialSwaps(*this));
+        return std::make_unique<MultiStepCoinitialSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoterminalswaps.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoterminalSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoterminalSwaps(*this));
+        return std::make_unique<MultiStepCoterminalSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepcoterminalswaptions.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepcoterminalswaptions.cpp
@@ -56,7 +56,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepCoterminalSwaptions::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepCoterminalSwaptions(*this));
+        return std::make_unique<MultiStepCoterminalSwaptions>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepforwards.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepforwards.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepForwards::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepForwards(*this));
+        return std::make_unique<MultiStepForwards>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepinversefloater.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepinversefloater.cpp
@@ -68,7 +68,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepInverseFloater::clone() const 
     {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepInverseFloater(*this));
+        return std::make_unique<MultiStepInverseFloater>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepnothing.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepnothing.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepNothing::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepNothing(*this));
+        return std::make_unique<MultiStepNothing>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepoptionlets.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepoptionlets.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepOptionlets::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepOptionlets(*this));
+        return std::make_unique<MultiStepOptionlets>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
+++ b/ql/models/marketmodels/products/multistep/multisteppathwisewrapper.cpp
@@ -86,7 +86,7 @@ namespace QuantLib
         std::unique_ptr<MarketModelMultiProduct>
         MultiProductPathwiseWrapper::clone() const
         {
-            return std::unique_ptr<MarketModelMultiProduct>(new MultiProductPathwiseWrapper(*this));
+            return std::make_unique<MultiProductPathwiseWrapper>(*this);
         }
 
       

--- a/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepperiodcapletswaptions.cpp
@@ -132,7 +132,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepPeriodCapletSwaptions::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepPeriodCapletSwaptions(*this));
+        return std::make_unique<MultiStepPeriodCapletSwaptions>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepratchet.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepratchet.cpp
@@ -67,7 +67,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepRatchet::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepRatchet(*this));
+        return std::make_unique<MultiStepRatchet>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepswap.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepswap.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepSwap::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepSwap(*this));
+        return std::make_unique<MultiStepSwap>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multistepswaption.cpp
+++ b/ql/models/marketmodels/products/multistep/multistepswaption.cpp
@@ -70,7 +70,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepSwaption::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepSwaption(*this));
+        return std::make_unique<MultiStepSwaption>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/multistep/multisteptarn.cpp
+++ b/ql/models/marketmodels/products/multistep/multisteptarn.cpp
@@ -85,7 +85,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     MultiStepTarn::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new MultiStepTarn(*this));
+        return std::make_unique<MultiStepTarn>(*this);
     }
 
 

--- a/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoinitialswaps.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepCoinitialSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepCoinitialSwaps(*this));
+        return std::make_unique<OneStepCoinitialSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepcoterminalswaps.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepCoterminalSwaps::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepCoterminalSwaps(*this));
+        return std::make_unique<OneStepCoterminalSwaps>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepforwards.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepforwards.cpp
@@ -52,7 +52,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepForwards::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepForwards(*this));
+        return std::make_unique<OneStepForwards>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/onestep/onestepoptionlets.cpp
+++ b/ql/models/marketmodels/products/onestep/onestepoptionlets.cpp
@@ -57,7 +57,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     OneStepOptionlets::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new OneStepOptionlets(*this));
+        return std::make_unique<OneStepOptionlets>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcallspecified.cpp
@@ -155,7 +155,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     CallSpecifiedPathwiseMultiProduct::clone() const {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new CallSpecifiedPathwiseMultiProduct(*this));
+        return std::make_unique<CallSpecifiedPathwiseMultiProduct>(*this);
     }
 
     const MarketModelPathwiseMultiProduct& CallSpecifiedPathwiseMultiProduct::underlying() const {

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcaplet.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcaplet.cpp
@@ -94,7 +94,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiCaplet::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiCaplet(*this));
+        return std::make_unique<MarketModelPathwiseMultiCaplet>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseMultiCaplet::suggestedNumeraires() const
@@ -241,7 +241,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiDeflatedCaplet::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiDeflatedCaplet(*this));
+        return std::make_unique<MarketModelPathwiseMultiDeflatedCaplet>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseMultiDeflatedCaplet::suggestedNumeraires() const
@@ -375,7 +375,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseMultiDeflatedCap::clone() const
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseMultiDeflatedCap(*this));
+        return std::make_unique<MarketModelPathwiseMultiDeflatedCap>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductcashrebate.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductcashrebate.cpp
@@ -108,7 +108,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCashRebate::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseCashRebate(*this));
+        return std::make_unique<MarketModelPathwiseCashRebate>(*this);
     }
 
 }

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductinversefloater.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductinversefloater.cpp
@@ -101,7 +101,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseInverseFloater::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseInverseFloater(*this));
+        return std::make_unique<MarketModelPathwiseInverseFloater>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseInverseFloater::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductswap.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductswap.cpp
@@ -88,7 +88,7 @@ namespace QuantLib
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseSwap::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseSwap(*this));
+        return std::make_unique<MarketModelPathwiseSwap>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseSwap::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/pathwise/pathwiseproductswaption.cpp
+++ b/ql/models/marketmodels/products/pathwise/pathwiseproductswaption.cpp
@@ -89,7 +89,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCoterminalSwaptionsDeflated::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(new MarketModelPathwiseCoterminalSwaptionsDeflated(*this));
+        return std::make_unique<MarketModelPathwiseCoterminalSwaptionsDeflated>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseCoterminalSwaptionsDeflated::suggestedNumeraires() const
@@ -210,8 +210,7 @@ namespace QuantLib {
     std::unique_ptr<MarketModelPathwiseMultiProduct>
     MarketModelPathwiseCoterminalSwaptionsNumericalDeflated::clone() const 
     {
-        return std::unique_ptr<MarketModelPathwiseMultiProduct>(
-          new MarketModelPathwiseCoterminalSwaptionsNumericalDeflated(*this));
+        return std::make_unique<MarketModelPathwiseCoterminalSwaptionsNumericalDeflated>(*this);
     }
 
     std::vector<Size> MarketModelPathwiseCoterminalSwaptionsNumericalDeflated::suggestedNumeraires() const

--- a/ql/models/marketmodels/products/singleproductcomposite.cpp
+++ b/ql/models/marketmodels/products/singleproductcomposite.cpp
@@ -72,7 +72,7 @@ namespace QuantLib {
 
     std::unique_ptr<MarketModelMultiProduct>
     SingleProductComposite::clone() const {
-        return std::unique_ptr<MarketModelMultiProduct>(new SingleProductComposite(*this));
+        return std::make_unique<SingleProductComposite>(*this);
     }
 
 }

--- a/ql/patterns/observable.hpp
+++ b/ql/patterns/observable.hpp
@@ -503,7 +503,7 @@ namespace QuantLib {
     }
 
     inline Observer::Observer(const Observer& o) {
-        proxy_.reset(new Proxy(this));
+        proxy_ = std::make_unique<Proxy>(this);
 
         {
              std::lock_guard<std::recursive_mutex> lock(o.mutex_);
@@ -517,7 +517,7 @@ namespace QuantLib {
     inline Observer& Observer::operator=(const Observer& o) {
         std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
-            proxy_.reset(new Proxy(this));
+            proxy_ = std::make_unique<Proxy>(this);
         }
 
         for (const auto& observable : observables_)
@@ -546,7 +546,7 @@ namespace QuantLib {
     Observer::registerWith(const ext::shared_ptr<Observable>& h) {
         std::lock_guard<std::recursive_mutex> lock(mutex_);
         if (!proxy_) {
-            proxy_.reset(new Proxy(this));
+            proxy_ = std::make_unique<Proxy>(this);
         }
 
         if (h) {

--- a/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
+++ b/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
@@ -137,9 +137,9 @@ namespace QuantLib {
             m1 = m1_; m2 = m2_; m3 = m3_; 
             v1 = v1_; v2 = v2_; /*v3 = v3_;*/ z1 = z1_; /*z2 = z2_;*/ x1 = x1_;
 
-            std::unique_ptr<Real[]> m1ai = std::make_unique<Real[]>(T);
-            std::unique_ptr<Real[]> m2ai = std::make_unique<Real[]>(T);
-            std::unique_ptr<Real[]> m3ai = std::make_unique<Real[]>(T);
+            auto m1ai = std::make_unique<Real[]>(T);
+            auto m2ai = std::make_unique<Real[]>(T);
+            auto m3ai = std::make_unique<Real[]>(T);
             m1ai[0] = m2ai[0] = m3ai[0] = 1.0;
             for (i=1; i < T; ++i) {
                 m1ai[i] = m1ai[i-1]*m1;

--- a/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
+++ b/ql/pricingengines/vanilla/analyticgjrgarchengine.cpp
@@ -137,9 +137,9 @@ namespace QuantLib {
             m1 = m1_; m2 = m2_; m3 = m3_; 
             v1 = v1_; v2 = v2_; /*v3 = v3_;*/ z1 = z1_; /*z2 = z2_;*/ x1 = x1_;
 
-            std::unique_ptr<Real[]> m1ai(new Real[T]);
-            std::unique_ptr<Real[]> m2ai(new Real[T]);
-            std::unique_ptr<Real[]> m3ai(new Real[T]);
+            std::unique_ptr<Real[]> m1ai = std::make_unique<Real[]>(T);
+            std::unique_ptr<Real[]> m2ai = std::make_unique<Real[]>(T);
+            std::unique_ptr<Real[]> m3ai = std::make_unique<Real[]>(T);
             m1ai[0] = m2ai[0] = m3ai[0] = 1.0;
             for (i=1; i < T; ++i) {
                 m1ai[i] = m1ai[i-1]*m1;


### PR DESCRIPTION
Mechanically replace raw `new`-based `std::unique_ptr` construction and `reset(new ...)` with `std::make_unique`.