### PR TITLE
Add `SmileSectionRNDCalculator` for smile-implied marginals

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1273,6 +1273,7 @@
     <ClInclude Include="ql\methods\finitedifferences\utilities\hestonrndcalculator.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\utilities\localvolrndcalculator.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\utilities\riskneutraldensitycalculator.hpp" />
+    <ClInclude Include="ql\methods\finitedifferences\utilities\smilesectionrndcalculator.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\utilities\squarerootprocessrndcalculator.hpp" />
     <ClInclude Include="ql\methods\finitedifferences\zerocondition.hpp" />
     <ClInclude Include="ql\methods\lattices\all.hpp" />
@@ -2445,6 +2446,7 @@
     <ClCompile Include="ql\methods\finitedifferences\utilities\hestonrndcalculator.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\utilities\localvolrndcalculator.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\utilities\riskneutraldensitycalculator.cpp" />
+    <ClCompile Include="ql\methods\finitedifferences\utilities\smilesectionrndcalculator.cpp" />
     <ClCompile Include="ql\methods\finitedifferences\utilities\squarerootprocessrndcalculator.cpp" />
     <ClCompile Include="ql\methods\lattices\binomialtree.cpp" />
     <ClCompile Include="ql\methods\lattices\trinomialtree.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -4365,6 +4365,9 @@
     <ClInclude Include="ql\methods\finitedifferences\utilities\riskneutraldensitycalculator.hpp">
       <Filter>methods\finitedifferences\utilities</Filter>
     </ClInclude>
+    <ClInclude Include="ql\methods\finitedifferences\utilities\smilesectionrndcalculator.hpp">
+      <Filter>methods\finitedifferences\utilities</Filter>
+    </ClInclude>
     <ClInclude Include="ql\methods\finitedifferences\utilities\squarerootprocessrndcalculator.hpp">
       <Filter>methods\finitedifferences\utilities</Filter>
     </ClInclude>
@@ -7253,6 +7256,9 @@
       <Filter>methods\finitedifferences\utilities</Filter>
     </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\utilities\riskneutraldensitycalculator.cpp">
+      <Filter>methods\finitedifferences\utilities</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\methods\finitedifferences\utilities\smilesectionrndcalculator.cpp">
       <Filter>methods\finitedifferences\utilities</Filter>
     </ClCompile>
     <ClCompile Include="ql\methods\finitedifferences\utilities\squarerootprocessrndcalculator.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -512,6 +512,7 @@ set(QL_SOURCES
     methods/finitedifferences/utilities/hestonrndcalculator.cpp
     methods/finitedifferences/utilities/localvolrndcalculator.cpp
     methods/finitedifferences/utilities/riskneutraldensitycalculator.cpp
+    methods/finitedifferences/utilities/smilesectionrndcalculator.cpp
     methods/finitedifferences/utilities/squarerootprocessrndcalculator.cpp
     methods/lattices/binomialtree.cpp
     methods/lattices/trinomialtree.cpp
@@ -1699,6 +1700,7 @@ set(QL_HEADERS
     methods/finitedifferences/utilities/hestonrndcalculator.hpp
     methods/finitedifferences/utilities/localvolrndcalculator.hpp
     methods/finitedifferences/utilities/riskneutraldensitycalculator.hpp
+    methods/finitedifferences/utilities/smilesectionrndcalculator.hpp
     methods/finitedifferences/utilities/squarerootprocessrndcalculator.hpp
     methods/finitedifferences/zerocondition.hpp
     methods/lattices/binomialtree.hpp

--- a/ql/methods/finitedifferences/utilities/Makefile.am
+++ b/ql/methods/finitedifferences/utilities/Makefile.am
@@ -25,6 +25,7 @@ this_include_HEADERS = \
     hestonrndcalculator.hpp \
     localvolrndcalculator.hpp \
     riskneutraldensitycalculator.hpp \
+    smilesectionrndcalculator.hpp \
     squarerootprocessrndcalculator.hpp
 
 cpp_files = \
@@ -48,6 +49,7 @@ cpp_files = \
     hestonrndcalculator.cpp \
     localvolrndcalculator.cpp \
     riskneutraldensitycalculator.cpp \
+    smilesectionrndcalculator.cpp \
     squarerootprocessrndcalculator.cpp
 
 if UNITY_BUILD

--- a/ql/methods/finitedifferences/utilities/all.hpp
+++ b/ql/methods/finitedifferences/utilities/all.hpp
@@ -22,5 +22,6 @@
 #include <ql/methods/finitedifferences/utilities/hestonrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/localvolrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.hpp>
+#include <ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/squarerootprocessrndcalculator.hpp>
 

--- a/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.cpp
+++ b/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.cpp
@@ -1,0 +1,132 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/errors.hpp>
+#include <ql/math/comparison.hpp>
+#include <ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp>
+#include <ql/termstructures/volatility/smilesection.hpp>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace QuantLib {
+
+    SmileSectionRNDCalculator::SmileSectionRNDCalculator(
+        ext::shared_ptr<SmileSection> smile,
+        Size nStrikes,
+        Real nStd)
+    : smile_(std::move(smile)), nStrikes_(nStrikes), nStd_(nStd) {
+        QL_REQUIRE(smile_, "null SmileSection");
+        QL_REQUIRE(nStrikes_ >= 4,
+                   "at least 4 strikes required, got " << nStrikes_);
+        QL_REQUIRE(nStd_ > 0.0,
+                   "nStd must be positive, got " << nStd_);
+    }
+
+    void SmileSectionRNDCalculator::checkTime(Time t) const {
+        const Time tRef = smile_->exerciseTime();
+        QL_REQUIRE(close_enough(t, tRef),
+                   "SmileSectionRNDCalculator: requested t=" << t
+                   << " does not match smile exercise time " << tRef);
+    }
+
+    void SmileSectionRNDCalculator::initialize() const {
+        if (initialized_)
+            return;
+
+        const Real forward = smile_->atmLevel();
+        QL_REQUIRE(forward != Null<Real>(),
+                   "SmileSectionRNDCalculator: smile->atmLevel() returned "
+                   "Null<Real>(); wrap with AtmSmileSection to supply one");
+
+        const Time T = smile_->exerciseTime();
+        const Real sigmaAtm = smile_->volatility(forward);
+        const Real logStd = sigmaAtm * std::sqrt(T);
+        const Real kMin = std::max(forward * std::exp(-nStd_ * logStd), QL_EPSILON);
+        const Real kMax = forward * std::exp( nStd_ * logStd);
+
+        // Build a strictly-increasing (cdf, strike) grid via 
+        // Breeden-Litzenberger:  CDF(K) = 1 - C'(K).
+        // The undiscounted digital call (discount=1) gives the risk-neutral
+        // probability P(S > K). BL output may be slightly non-monotone
+        // near the wings, so we take a running max and drop
+        // near-duplicates to give the spline a strict abscissa.
+        strikes_.clear();
+        cdf_.clear();
+        strikes_.reserve(nStrikes_);
+        cdf_.reserve(nStrikes_);
+        constexpr Real dedupTol = 1e-12;
+        Real lastCdf = -1.0;
+        for (Size i = 0; i < nStrikes_; ++i) {
+            const Real K = kMin + (kMax - kMin) * i / (nStrikes_ - 1);
+            const Real c = std::clamp(
+                1.0 - smile_->digitalOptionPrice(K, Option::Call, 1.0),
+                0.0, 1.0);
+            const Real cMono = std::max(c, lastCdf);
+            if (cMono - lastCdf > dedupTol) {
+                strikes_.push_back(K);
+                cdf_.push_back(cMono);
+                lastCdf = cMono;
+            }
+        }
+        QL_REQUIRE(cdf_.size() >= 4,
+                   "SmileSectionRNDCalculator: too few unique CDF points ("
+                   << cdf_.size() << ") after deduplication");
+
+        quantileFn_ = ext::make_shared<MonotonicCubicNaturalSpline>(
+            cdf_.begin(), cdf_.end(), strikes_.begin());
+
+        initialized_ = true;
+    }
+
+    Real SmileSectionRNDCalculator::pdf(Real x, Time t) const {
+        checkTime(t);
+        const Real S = std::exp(x);
+        return S * smile_->density(S, 1.0);
+    }
+
+    Real SmileSectionRNDCalculator::cdf(Real x, Time t) const {
+        checkTime(t);
+        const Real S = std::exp(x);
+        return 1.0 - smile_->digitalOptionPrice(S, Option::Call, 1.0);
+    }
+
+    Real SmileSectionRNDCalculator::invcdf(Real p, Time t) const {
+        checkTime(t);
+        initialize();
+        QL_REQUIRE(p > 0.0 && p < 1.0,
+                   "p must be in (0, 1), got " << p);
+        const Real pClamped = std::min(std::max(p, cdf_.front()), cdf_.back());
+        const Real K = (*quantileFn_)(pClamped);
+        return std::log(K);
+    }
+
+    Real SmileSectionRNDCalculator::pdf(Real x) const {
+        return pdf(x, smile_->exerciseTime());
+    }
+
+    Real SmileSectionRNDCalculator::cdf(Real x) const {
+        return cdf(x, smile_->exerciseTime());
+    }
+
+    Real SmileSectionRNDCalculator::invcdf(Real p) const {
+        return invcdf(p, smile_->exerciseTime());
+    }
+
+}

--- a/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp
+++ b/ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp
@@ -1,0 +1,69 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file smilesectionrndcalculator.hpp
+    \brief risk-neutral terminal density from a \c SmileSection via
+           the Breeden-Litzenberger identity
+*/
+
+#ifndef quantlib_smilesection_rnd_calculator_hpp
+#define quantlib_smilesection_rnd_calculator_hpp
+
+#include <ql/math/interpolations/cubicinterpolation.hpp>
+#include <ql/methods/finitedifferences/utilities/riskneutraldensitycalculator.hpp>
+#include <ql/shared_ptr.hpp>
+#include <vector>
+
+namespace QuantLib {
+
+    class SmileSection;
+
+    class SmileSectionRNDCalculator : public RiskNeutralDensityCalculator {
+      public:
+        explicit SmileSectionRNDCalculator(
+            ext::shared_ptr<SmileSection> smile,
+            Size nStrikes = 200,
+            Real nStd = 5.0);
+
+        // x = ln(S)
+        Real pdf(Real x, Time t) const override;
+        Real cdf(Real x, Time t) const override;
+        Real invcdf(Real p, Time t) const override;
+
+        // t = smile->exerciseTime()
+        Real pdf(Real x) const;
+        Real cdf(Real x) const;
+        Real invcdf(Real p) const;
+
+      private:
+        void initialize() const;
+        void checkTime(Time t) const;
+
+        ext::shared_ptr<SmileSection> smile_;
+        Size nStrikes_;
+        Real nStd_;
+
+        mutable bool initialized_ = false;
+        mutable std::vector<Real> strikes_, cdf_;
+        mutable ext::shared_ptr<MonotonicCubicNaturalSpline> quantileFn_;
+    };
+
+}
+
+#endif

--- a/test-suite/riskneutraldensitycalculator.cpp
+++ b/test-suite/riskneutraldensitycalculator.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2015 Johannes Göttker-Schnetmann
  Copyright (C) 2015, 2016 Klaus Spanderen
+ Copyright (C) 2026 Yassine Idyiahia
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -28,6 +29,7 @@
 #include <ql/methods/finitedifferences/utilities/gbsmrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/hestonrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/localvolrndcalculator.hpp>
+#include <ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp>
 #include <ql/methods/finitedifferences/utilities/squarerootprocessrndcalculator.hpp>
 #include <ql/models/equity/hestonmodel.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
@@ -35,9 +37,11 @@
 #include <ql/processes/blackscholesprocess.hpp>
 #include <ql/processes/hestonprocess.hpp>
 #include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/atmsmilesection.hpp>
 #include <ql/termstructures/volatility/equityfx/hestonblackvolsurface.hpp>
 #include <ql/termstructures/volatility/equityfx/localconstantvol.hpp>
 #include <ql/termstructures/volatility/equityfx/noexceptlocalvolsurface.hpp>
+#include <ql/termstructures/volatility/flatsmilesection.hpp>
 #include <ql/time/calendars/nullcalendar.hpp>
 #include <ql/timegrid.hpp>
 #include <ql/types.hpp>
@@ -778,6 +782,160 @@ BOOST_AUTO_TEST_CASE(testCEVCDF) {
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDvsBSM) {
+    BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator on a flat-vol "
+                       "smile against BSMRNDCalculator...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Settings::instance().evaluationDate();
+    const Date maturity = today + 1 * Years;
+
+    const Real s0 = 100.0;
+    const Rate r = 0.05;
+    const Rate q = 0.02;
+    const Volatility v = 0.20;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(s0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, r, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, q, dc));
+
+    const ext::shared_ptr<BlackScholesMertonProcess> bsmProcess =
+        ext::make_shared<BlackScholesMertonProcess>(
+            spot, qTS, rTS,
+            Handle<BlackVolTermStructure>(flatVol(today, v, dc)));
+
+    const BSMRNDCalculator bsmRnd(bsmProcess);
+
+    const Real fwd = s0 * qTS->discount(maturity) / rTS->discount(maturity);
+    const auto smile = ext::make_shared<FlatSmileSection>(
+        maturity, v, dc, today, fwd);
+    const SmileSectionRNDCalculator smileRnd(smile);
+    const Time T = smile->exerciseTime();
+
+    const Real logFwd = std::log(fwd);
+    const Real tol = 1e-3;
+
+    for (Real offset : { -0.30, -0.15, 0.0, 0.15, 0.30 }) {
+        const Real x = logFwd + offset;
+
+        const Real expectedCDF = bsmRnd.cdf(x, T);
+        const Real calculatedCDF = smileRnd.cdf(x, T);
+        if (std::fabs(expectedCDF - calculatedCDF) > tol) {
+            BOOST_FAIL("failed to reproduce BSM cdf with SmileSection RND"
+                    << "\n   x:          " << x
+                    << "\n   calculated: " << calculatedCDF
+                    << "\n   expected:   " << expectedCDF
+                    << "\n   diff:       " << calculatedCDF - expectedCDF
+                    << "\n   tolerance:  " << tol);
+        }
+
+        const Real expectedPDF = bsmRnd.pdf(x, T);
+        const Real calculatedPDF = smileRnd.pdf(x, T);
+        if (std::fabs(expectedPDF - calculatedPDF) > tol) {
+            BOOST_FAIL("failed to reproduce BSM pdf with SmileSection RND"
+                    << "\n   x:          " << x
+                    << "\n   calculated: " << calculatedPDF
+                    << "\n   expected:   " << expectedPDF
+                    << "\n   diff:       " << calculatedPDF - expectedPDF
+                    << "\n   tolerance:  " << tol);
+        }
+    }
+
+    for (Real prob : { 0.05, 0.25, 0.5, 0.75, 0.95 }) {
+        const Real expectedInvCDF = bsmRnd.invcdf(prob, T);
+        const Real calculatedInvCDF = smileRnd.invcdf(prob, T);
+        if (std::fabs(expectedInvCDF - calculatedInvCDF) > tol) {
+            BOOST_FAIL("failed to reproduce BSM invcdf with SmileSection RND"
+                    << "\n   prob:       " << prob
+                    << "\n   calculated: " << calculatedInvCDF
+                    << "\n   expected:   " << expectedInvCDF
+                    << "\n   diff:       " << calculatedInvCDF - expectedInvCDF
+                    << "\n   tolerance:  " << tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDvsHeston) {
+    BOOST_TEST_MESSAGE("Testing SmileSectionRNDCalculator on a Heston-implied "
+                       "smile against HestonRNDCalculator...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Settings::instance().evaluationDate();
+    const Date maturity = today + 1 * Years;
+
+    const Real s0 = 100.0;
+    const Rate r = 0.05;
+    const Rate q = 0.02;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(s0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, r, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, q, dc));
+
+    const Real v0 = 0.04, kappa = 1.0, theta = 0.04;
+    const Real sigma = 0.3, rho = -0.5;
+
+    const auto hestonProcess = ext::make_shared<HestonProcess>(
+        rTS, qTS, spot, v0, kappa, theta, sigma, rho);
+    const auto hestonModel = ext::make_shared<HestonModel>(hestonProcess);
+
+    const HestonRNDCalculator hestonRnd(hestonProcess);
+
+    const auto hestonVolSurface = ext::make_shared<HestonBlackVolSurface>(
+        Handle<HestonModel>(hestonModel));
+    const Time T = hestonVolSurface->timeFromReference(maturity);
+    const Real fwd = s0 * qTS->discount(maturity) / rTS->discount(maturity);
+    const auto smile = ext::make_shared<AtmSmileSection>(
+        hestonVolSurface->smileSection(T), fwd);
+    const SmileSectionRNDCalculator smileRnd(smile);
+
+    const Real logFwd = std::log(fwd);
+    const Real cdfTol = 5e-3;
+    const Real pdfTol = 1e-3;
+
+    for (Real offset : { -0.30, -0.15, 0.0, 0.15, 0.30 }) {
+        const Real x = logFwd + offset;
+
+        const Real expectedCDF = hestonRnd.cdf(x, T);
+        const Real calculatedCDF = smileRnd.cdf(x, T);
+        if (std::fabs(expectedCDF - calculatedCDF) > cdfTol) {
+            BOOST_FAIL("failed to reproduce Heston cdf with SmileSection RND"
+                    << "\n   x:          " << x
+                    << "\n   calculated: " << calculatedCDF
+                    << "\n   expected:   " << expectedCDF
+                    << "\n   diff:       " << calculatedCDF - expectedCDF
+                    << "\n   tolerance:  " << cdfTol);
+        }
+
+        const Real expectedPDF = hestonRnd.pdf(x, T);
+        const Real calculatedPDF = smileRnd.pdf(x, T);
+        if (std::fabs(expectedPDF - calculatedPDF) > pdfTol) {
+            BOOST_FAIL("failed to reproduce Heston pdf with SmileSection RND"
+                    << "\n   x:          " << x
+                    << "\n   calculated: " << calculatedPDF
+                    << "\n   expected:   " << expectedPDF
+                    << "\n   diff:       " << calculatedPDF - expectedPDF
+                    << "\n   tolerance:  " << pdfTol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSmileSectionRNDMissingAtmLevel) {
+    BOOST_TEST_MESSAGE("Testing that SmileSectionRNDCalculator raises "
+                       "when the smile has no atmLevel...");
+
+    const Date today = Settings::instance().evaluationDate();
+    const Date maturity = today + 1 * Years;
+    const auto smile = ext::make_shared<FlatSmileSection>(
+        maturity, 0.20, Actual365Fixed(), today);
+    SmileSectionRNDCalculator rnd(smile);
+
+    const Time T = smile->exerciseTime();
+    BOOST_CHECK_EXCEPTION(
+        rnd.invcdf(0.5, T), QuantLib::Error,
+        ExpectedErrorMessage("AtmSmileSection"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds `SmileSectionRNDCalculator`, a `RiskNeutralDensityCalculator` that extracts the risk-neutral terminal density of the underlying from any `SmileSection`. Operates on an arbitrary smile unlike the existing parametric models versions.

Tests:

3 tests added to `RiskNeutralDensityCalculatorTests`:
- `testSmileSectionRNDvsBSM`, flat-vol smile vs `BSMRNDCalculator` (pdf + cdf + invcdf).
- `testSmileSectionRNDvsHeston`, Heston-implied smile vs `HestonRNDCalculator` (pdf + cdf).
- `testSmileSectionRNDMissingAtmLevel`, error path documenting the `atmLevel` requirement.