### PR TITLE
Override `atmLevel(Time)` on Heston and Andreasen-Huge vol surfaces

### DIFF
--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.cpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.cpp
@@ -66,4 +66,7 @@ namespace QuantLib {
     Natural AndreasenHugeVolatilityAdapter::settlementDays() const {
         return volInterpl_->riskFreeRate()->settlementDays();
     }
+    Real AndreasenHugeVolatilityAdapter::atmLevel(Time t) const {
+        return volInterpl_->fwd(t);
+    }
 }

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.hpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityadapter.hpp
@@ -43,6 +43,7 @@ namespace QuantLib {
         DayCounter dayCounter() const override;
         Natural settlementDays() const override;
         const Date& referenceDate() const override;
+        Real atmLevel(Time t) const override;
 
       protected:
         Real blackVarianceImpl(Time t, Real strike) const override;

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.cpp
@@ -69,6 +69,13 @@ namespace QuantLib {
         return std::numeric_limits<Real>::max();
     }
 
+    Real HestonBlackVolSurface::atmLevel(Time t) const {
+        const ext::shared_ptr<HestonProcess>& process = hestonModel_->process();
+        return process->s0()->value()
+            * process->dividendYield()->discount(t, true)
+            / process->riskFreeRate()->discount(t, true);
+    }
+
     Real HestonBlackVolSurface::blackVarianceImpl(Time t, Real strike) const {
         return squared(blackVolImpl(t, strike))*t;
     }

--- a/ql/termstructures/volatility/equityfx/hestonblackvolsurface.hpp
+++ b/ql/termstructures/volatility/equityfx/hestonblackvolsurface.hpp
@@ -44,6 +44,7 @@ namespace QuantLib {
         Date maxDate() const override;
         Real minStrike() const override;
         Real maxStrike() const override;
+        Real atmLevel(Time t) const override;
 
       protected:
         Real blackVarianceImpl(Time t, Real strike) const override;

--- a/test-suite/andreasenhugevolatilityinterpl.cpp
+++ b/test-suite/andreasenhugevolatilityinterpl.cpp
@@ -1014,6 +1014,49 @@ BOOST_AUTO_TEST_CASE(testFlatVolCalibration) {
     testAndreasenHugeVolatilityInterpolation(flatVolData, expected);
 }
 
+BOOST_AUTO_TEST_CASE(testAndreasenHugeVolatilityAdapterAtmLevel) {
+    BOOST_TEST_MESSAGE("Testing atmLevel on AndreasenHugeVolatilityAdapter...");
+
+    const Date today(4, March, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc = Actual365Fixed();
+
+    const Real s0 = 100.0;
+    const Rate r = 0.05, q = 0.02;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(s0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, r, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, q, dc));
+    const ext::shared_ptr<Quote> vol = ext::make_shared<SimpleQuote>(0.20);
+
+    AndreasenHugeVolatilityInterpl::CalibrationSet calibrationSet;
+    const auto exercise = ext::make_shared<EuropeanExercise>(today + 1 * Years);
+    for (Real strike : { 80.0, 100.0, 120.0 }) {
+        calibrationSet.emplace_back(
+            ext::make_shared<VanillaOption>(
+                ext::make_shared<PlainVanillaPayoff>(Option::Call, strike),
+                exercise),
+            vol);
+    }
+
+    const auto interpl = ext::make_shared<AndreasenHugeVolatilityInterpl>(
+        calibrationSet, spot, rTS, qTS);
+    const AndreasenHugeVolatilityAdapter surface(interpl);
+
+    const Real tol = 1e-12;
+    for (Time t : { 0.25, 0.5, 1.0 }) {
+        const Real expected = s0 * qTS->discount(t) / rTS->discount(t);
+        const Real calculated = surface.atmLevel(t);
+        if (std::fabs(calculated - expected) > tol)
+            BOOST_FAIL("AndreasenHugeVolatilityAdapter::atmLevel mismatch"
+                       << "\n   t:          " << t
+                       << "\n   calculated: " << calculated
+                       << "\n   expected:   " << expected
+                       << "\n   diff:       " << calculated - expected
+                       << "\n   tolerance:  " << tol);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/hestonmodel.cpp
+++ b/test-suite/hestonmodel.cpp
@@ -3350,6 +3350,40 @@ BOOST_AUTO_TEST_CASE(testOptimalAlphaKmax) {
             .alphaGreaterZero(strike).first;
     QL_CHECK_SMALL(alphaStar - 0.28006, 1e-4);
 }
+
+BOOST_AUTO_TEST_CASE(testHestonBlackVolSurfaceAtmLevel) {
+    BOOST_TEST_MESSAGE("Testing atmLevel on HestonBlackVolSurface...");
+
+    const Date today(4, March, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc = Actual365Fixed();
+
+    const Real s0 = 100.0;
+    const Rate r = 0.05, q = 0.02;
+
+    const Handle<Quote> spot(ext::make_shared<SimpleQuote>(s0));
+    const Handle<YieldTermStructure> rTS(flatRate(today, r, dc));
+    const Handle<YieldTermStructure> qTS(flatRate(today, q, dc));
+
+    const auto process = ext::make_shared<HestonProcess>(
+        rTS, qTS, spot, 0.04, 1.0, 0.04, 0.3, -0.5);
+    const auto model = ext::make_shared<HestonModel>(process);
+    const Handle<HestonModel> modelH(model);
+    const HestonBlackVolSurface surface(modelH);
+
+    const Real tol = 1e-12;
+    for (Time t : { 0.25, 1.0, 5.0 }) {
+        const Real expected = s0 * qTS->discount(t) / rTS->discount(t);
+        const Real calculated = surface.atmLevel(t);
+        if (std::fabs(calculated - expected) > tol)
+            BOOST_FAIL("HestonBlackVolSurface::atmLevel mismatch"
+                       << "\n   t:          " << t
+                       << "\n   calculated: " << calculated
+                       << "\n   expected:   " << expected
+                       << "\n   diff:       " << calculated - expected
+                       << "\n   tolerance:  " << tol);
+    }
+}
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(HestonModelExperimentalTest)


### PR DESCRIPTION
Overrides the `atmLevel(Time t)` virtual on two `BlackVolTermStructure` subclasses that already hold everything they need to return the forward.

Tests:

- `HestonModelTests/testHestonBlackVolSurfaceAtmLevel` asserts `surface.atmLevel(t) == s0 * qDisc(t) / rDisc(t)`.
- `AndreasenHugeVolatilityInterplTests/testAndreasenHugeVolatilityAdapterAtmLevel` same check on the AH adapter.