### PR TITLE
Added India (NSE) clearing holidays for 2026

### DIFF
--- a/ql/time/calendars/india.cpp
+++ b/ql/time/calendars/india.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
             // Republic Day
             || (d == 26 && m == January)
             // Good Friday
-            || (dd == em-3)
+            || (dd == em - 3)
             // Ambedkar Jayanti
             || (d == 14 && m == April)
             // May Day
@@ -50,14 +50,14 @@ namespace QuantLib {
             // Gandhi Jayanti
             || (d == 2 && m == October)
             // Christmas
-            || (d == 25 && m == December)
-            )
+            || (d == 25 && m == December))
             return false;
+
 
         if (y == 2005) {
             // Moharram, Holi, Maharashtra Day, and Ramzan Id fall
             // on Saturday or Sunday in 2005
-            if (// Bakri Id
+            if ( // Bakri Id
                 (d == 21 && m == January)
                 // Ganesh Chaturthi
                 || (d == 7 && m == September)
@@ -68,13 +68,12 @@ namespace QuantLib {
                 // Bhaubeej
                 || (d == 3 && m == November)
                 // Guru Nanak Jayanti
-                || (d == 15 && m == November)
-                )
+                || (d == 15 && m == November))
                 return false;
         }
 
         if (y == 2006) {
-            if (// Bakri Id
+            if ( // Bakri Id
                 (d == 11 && m == January)
                 // Moharram
                 || (d == 9 && m == February)
@@ -89,13 +88,12 @@ namespace QuantLib {
                 // Bhaubeej
                 || (d == 24 && m == October)
                 // Ramzan Id
-                || (d == 25 && m == October)
-                )
+                || (d == 25 && m == October))
                 return false;
         }
 
         if (y == 2007) {
-            if (// Bakri Id
+            if ( // Bakri Id
                 (d == 1 && m == January)
                 // Moharram
                 || (d == 30 && m == January)
@@ -110,13 +108,12 @@ namespace QuantLib {
                 // Laxmi Puja
                 || (d == 9 && m == November)
                 // Bakri Id (again)
-                || (d == 21 && m == December)
-                )
+                || (d == 21 && m == December))
                 return false;
         }
 
         if (y == 2008) {
-            if (// Mahashivratri
+            if ( // Mahashivratri
                 (d == 6 && m == March)
                 // Id-E-Milad
                 || (d == 20 && m == March)
@@ -139,13 +136,12 @@ namespace QuantLib {
                 // Gurunanak Jayanti
                 || (d == 13 && m == November)
                 // Bakri Id
-                || (d == 9 && m == December)
-                )
+                || (d == 9 && m == December))
                 return false;
         }
 
         if (y == 2009) {
-            if (// Moharram
+            if ( // Moharram
                 (d == 8 && m == January)
                 // Mahashivratri
                 || (d == 23 && m == February)
@@ -168,13 +164,12 @@ namespace QuantLib {
                 // Gurunanak Jayanti
                 || (d == 2 && m == November)
                 // Moharram (again)
-                || (d == 28 && m == December)
-                )
+                || (d == 28 && m == December))
                 return false;
         }
 
         if (y == 2010) {
-            if (// New Year's Day
+            if ( // New Year's Day
                 (d == 1 && m == January)
                 // Mahashivratri
                 || (d == 12 && m == February)
@@ -189,13 +184,12 @@ namespace QuantLib {
                 // Bakri Id
                 || (d == 17 && m == November)
                 // Moharram
-                || (d == 17 && m == December)
-                )
+                || (d == 17 && m == December))
                 return false;
         }
 
         if (y == 2011) {
-            if (// Mahashivratri
+            if ( // Mahashivratri
                 (d == 2 && m == March)
                 // Ram Navmi
                 || (d == 12 && m == April)
@@ -214,13 +208,12 @@ namespace QuantLib {
                 // Gurunanak Jayanti
                 || (d == 10 && m == November)
                 // Moharram
-                || (d == 6 && m == December)
-                )
+                || (d == 6 && m == December))
                 return false;
         }
 
         if (y == 2012) {
-            if (// Mahashivratri
+            if ( // Mahashivratri
                 (d == 20 && m == February)
                 // Holi
                 || (d == 8 && m == March)
@@ -235,13 +228,12 @@ namespace QuantLib {
                 // Diwali - Balipratipada
                 || (d == 14 && m == November)
                 // Gurunanak Jayanti
-                || (d == 28 && m == November)
-                )
+                || (d == 28 && m == November))
                 return false;
         }
 
         if (y == 2013) {
-            if (// Holi
+            if ( // Holi
                 (d == 27 && m == March)
                 // Ram Navmi
                 || (d == 19 && m == April)
@@ -256,13 +248,12 @@ namespace QuantLib {
                 // Diwali - Balipratipada
                 || (d == 4 && m == November)
                 // Moharram
-                || (d == 14 && m == November)
-                )
+                || (d == 14 && m == November))
                 return false;
         }
 
         if (y == 2014) {
-            if (// Mahashivratri
+            if ( // Mahashivratri
                 (d == 27 && m == February)
                 // Holi
                 || (d == 17 && m == March)
@@ -281,80 +272,77 @@ namespace QuantLib {
                 // Moharram
                 || (d == 4 && m == November)
                 // Gurunank Jayanti
-                || (d == 6 && m == November)
-                )
+                || (d == 6 && m == November))
                 return false;
         }
 
-      if (y == 2019) {
-          if (// Chatrapati Shivaji Jayanti
-              (d == 19 && m == February)
-              // Mahashivratri
-              || (d == 4 && m == March)
-              // Holi
-              || (d == 21 && m == March)
-              // Annual Bank Closing
-              || (d == 1 && m == April)
-              // Mahavir Jayanti
-              || (d == 17 && m == April)
-              // Parliamentary Elections
-              || (d == 29 && m == April)
-              // Ramzan Id
-              || (d == 05 && m == June)
-              // Bakri Id
-              || (d == 12 && m == August)
-              // Ganesh Chaturthi
-              || (d == 2 && m == September)
-              // Moharram
-              || (d == 10 && m == September)
-              // Dasera
-              || (d == 8 && m == October)
-              // General Assembly Elections in Maharashtra
-              || (d == 21 && m == October)
-              // Diwali - Balipratipada
-              || (d == 28 && m == October)
-              // Gurunank Jayanti
-              || (d == 12 && m == November)
-              )
-              return false;
-      }
+        if (y == 2019) {
+            if ( // Chatrapati Shivaji Jayanti
+                (d == 19 && m == February)
+                // Mahashivratri
+                || (d == 4 && m == March)
+                // Holi
+                || (d == 21 && m == March)
+                // Annual Bank Closing
+                || (d == 1 && m == April)
+                // Mahavir Jayanti
+                || (d == 17 && m == April)
+                // Parliamentary Elections
+                || (d == 29 && m == April)
+                // Ramzan Id
+                || (d == 05 && m == June)
+                // Bakri Id
+                || (d == 12 && m == August)
+                // Ganesh Chaturthi
+                || (d == 2 && m == September)
+                // Moharram
+                || (d == 10 && m == September)
+                // Dasera
+                || (d == 8 && m == October)
+                // General Assembly Elections in Maharashtra
+                || (d == 21 && m == October)
+                // Diwali - Balipratipada
+                || (d == 28 && m == October)
+                // Gurunank Jayanti
+                || (d == 12 && m == November))
+                return false;
+        }
 
-      if (y == 2020) {
-          if (// Chatrapati Shivaji Jayanti
-              (d == 19 && m == February)
-              // Mahashivratri
-              || (d == 21 && m == February)
-              // Holi
-              || (d == 10 && m == March)
-              // Gudi Padwa
-              || (d == 25 && m == March)
-              // Annual Bank Closing
-              || (d == 1 && m == April)
-              // Ram Navami
-              || (d == 2 && m == April)
-              // Mahavir Jayanti
-              || (d == 6 && m == April)
-              // Buddha Pournima
-              || (d == 7 && m == May)
-              // Ramzan Id
-              || (d == 25 && m == May)
-              // Id-E-Milad
-              || (d == 30 && m == October)
-              // Diwali - Balipratipada
-              || (d == 16 && m == November)
-              // Gurunank Jayanti
-              || (d == 30 && m == November)
-              )
-              return false;
-      }
+        if (y == 2020) {
+            if ( // Chatrapati Shivaji Jayanti
+                (d == 19 && m == February)
+                // Mahashivratri
+                || (d == 21 && m == February)
+                // Holi
+                || (d == 10 && m == March)
+                // Gudi Padwa
+                || (d == 25 && m == March)
+                // Annual Bank Closing
+                || (d == 1 && m == April)
+                // Ram Navami
+                || (d == 2 && m == April)
+                // Mahavir Jayanti
+                || (d == 6 && m == April)
+                // Buddha Pournima
+                || (d == 7 && m == May)
+                // Ramzan Id
+                || (d == 25 && m == May)
+                // Id-E-Milad
+                || (d == 30 && m == October)
+                // Diwali - Balipratipada
+                || (d == 16 && m == November)
+                // Gurunank Jayanti
+                || (d == 30 && m == November))
+                return false;
+        }
 
         if (y == 2021) {
-            if (// Chatrapati Shivaji Jayanti
+            if ( // Chatrapati Shivaji Jayanti
                 (d == 19 && m == February)
                 // Mahashivratri
                 || (d == 11 && m == March)
                 // Holi
-                || (d == 29 && m == March) 
+                || (d == 29 && m == March)
                 // Gudi Padwa
                 || (d == 13 && m == April)
                 // Mahavir Jayanti
@@ -399,7 +387,7 @@ namespace QuantLib {
         }
 
         if (y == 2023) {
-            if ( 
+            if (
                 // Holi
                 (d == 7 && m == March)
                 // Gudi Padwa
@@ -471,7 +459,7 @@ namespace QuantLib {
                 // Holi
                 || (d == 14 && m == March)
                 // Ramzan Id (estimated Sunday 30th or Monday 31st)
-                || (d == 31  && m == March)
+                || (d == 31 && m == March)
                 // Mahavir Jayanti
                 || (d == 10 && m == April)
                 // Buddha Pournima
@@ -485,8 +473,39 @@ namespace QuantLib {
                 return false;
         }
 
-     return true;
+        if (y == 2026) {
+            if ( // Municipal Corporation Election - Maharashtra
+                (d == 15 && m == January)
+                // Chatrapati Shivaji Jayanti
+                || (d == 19 && m == February)
+                // Holi
+                || (d == 3 && m == March)
+                // Gudi Padwa
+                || (d == 19 && m == March)
+                // Ram Navami
+                || (d == 26 && m == March)
+                // Mahavir Jayanti
+                || (d == 31 && m == March)
+                // Annual Bank Closing
+                || (d == 1 && m == April)
+                // Bakri Id
+                || (d == 28 && m == May)
+                // Moharram
+                || (d == 26 && m == June)
+                // Id-E-Milad
+                || (d == 26 && m == August)
+                // Ganesh Chaturthi
+                || (d == 14 && m == September)
+                // Dussehra
+                || (d == 20 && m == October)
+                // Diwali - Balipratipada
+                || (d == 10 && m == November)
+                // Gurunank Jayanti
+                || (d == 24 && m == November))
+                return false;
+        }
+
+        return true;
     }
 
 }
-

--- a/ql/time/calendars/india.hpp
+++ b/ql/time/calendars/india.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2005-2014, 2019-2025 only:)
+        (data available for 2005-2014, 2019-2026 only:)
         <ul>
         <li>Bakri Id</li>
         <li>Moharram</li>

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -528,65 +528,6 @@ BOOST_AUTO_TEST_CASE(testGermanyXetra) {
     checkHolidays(c.holidayList(Date(1, January, 2003), Date(31, December, 2004)), expectedHol);
 }
 
-BOOST_AUTO_TEST_CASE(testIndia) {
-
-    BOOST_TEST_MESSAGE("Testing India (NSE) clearing holiday list...");
-
-    std::vector<Date> expectedHol;
-
-    // 2026
-    // Municipal Corporation Election - Maharashtra
-    expectedHol.emplace_back(15, January, 2026);
-    // Republic Day
-    expectedHol.emplace_back(26, January, 2026);
-    // Chatrapati Shivaji Jayanti
-    expectedHol.emplace_back(19, February, 2026);
-    // Holi
-    expectedHol.emplace_back(3, March, 2026);
-    // Gudi Padwa
-    expectedHol.emplace_back(19, March, 2026);
-    // Ram Navami
-    expectedHol.emplace_back(26, March, 2026);
-    // Mahavir Jayanti
-    expectedHol.emplace_back(31, March, 2026);
-    // Annual Bank Closing
-    expectedHol.emplace_back(1, April, 2026);
-    // Good Friday
-    expectedHol.emplace_back(3, April, 2026);
-    // Ambedkar Jayanti
-    expectedHol.emplace_back(14, April, 2026);
-    // May Day
-    expectedHol.emplace_back(1, May, 2026);
-    // Bakri Id
-    expectedHol.emplace_back(28, May, 2026);
-    // Muharram
-    expectedHol.emplace_back(26, June, 2026);
-    // Id-E-Milad
-    expectedHol.emplace_back(26, August, 2026);
-    // Ganesh Chaturthi
-    expectedHol.emplace_back(14, September, 2026);
-    // Gandhi Jayanti
-    expectedHol.emplace_back(2, October, 2026);
-    // Dussehra
-    expectedHol.emplace_back(20, October, 2026);
-    // Diwali - Balipratipada
-    expectedHol.emplace_back(10, November, 2026);
-    // Gurunank Jayanti
-    expectedHol.emplace_back(24, November, 2026);
-    // Christmas
-    expectedHol.emplace_back(25, December, 2026);
-
-    // The following 2026 holidays fall on weekends and are
-    // therefore not included above:
-    // Mahashivratri:      15-Feb-2026 (Sunday)
-    // Id-Ul-Fitr:         21-Mar-2026 (Saturday)
-    // Independence Day:   15-Aug-2026 (Saturday)
-    // Diwali Laxmi Pujan: 08-Nov-2026 (Sunday)
-
-    Calendar c = India();
-    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2026)), expectedHol);
-}
-
 BOOST_AUTO_TEST_CASE(testUKSettlement) {
     BOOST_TEST_MESSAGE("Testing UK settlement holiday list...");
 
@@ -4144,6 +4085,65 @@ BOOST_AUTO_TEST_CASE(testUzbekistanQurbonHayit) {
     BOOST_CHECK(c.isHoliday(Date(5, January, 2039)));
     BOOST_CHECK(c.isHoliday(Date(26, December, 2039)));
     BOOST_CHECK(c.isHoliday(Date(15, December, 2040)));
+}
+
+BOOST_AUTO_TEST_CASE(testIndia) {
+
+    BOOST_TEST_MESSAGE("Testing India (NSE) clearing holiday list...");
+
+    std::vector<Date> expectedHol;
+
+    // 2026
+    // Municipal Corporation Election - Maharashtra
+    expectedHol.emplace_back(15, January, 2026);
+    // Republic Day
+    expectedHol.emplace_back(26, January, 2026);
+    // Chatrapati Shivaji Jayanti
+    expectedHol.emplace_back(19, February, 2026);
+    // Holi
+    expectedHol.emplace_back(3, March, 2026);
+    // Gudi Padwa
+    expectedHol.emplace_back(19, March, 2026);
+    // Ram Navami
+    expectedHol.emplace_back(26, March, 2026);
+    // Mahavir Jayanti
+    expectedHol.emplace_back(31, March, 2026);
+    // Annual Bank Closing
+    expectedHol.emplace_back(1, April, 2026);
+    // Good Friday
+    expectedHol.emplace_back(3, April, 2026);
+    // Ambedkar Jayanti
+    expectedHol.emplace_back(14, April, 2026);
+    // May Day
+    expectedHol.emplace_back(1, May, 2026);
+    // Bakri Id
+    expectedHol.emplace_back(28, May, 2026);
+    // Muharram
+    expectedHol.emplace_back(26, June, 2026);
+    // Id-E-Milad
+    expectedHol.emplace_back(26, August, 2026);
+    // Ganesh Chaturthi
+    expectedHol.emplace_back(14, September, 2026);
+    // Gandhi Jayanti
+    expectedHol.emplace_back(2, October, 2026);
+    // Dussehra
+    expectedHol.emplace_back(20, October, 2026);
+    // Diwali - Balipratipada
+    expectedHol.emplace_back(10, November, 2026);
+    // Gurunank Jayanti
+    expectedHol.emplace_back(24, November, 2026);
+    // Christmas
+    expectedHol.emplace_back(25, December, 2026);
+
+    // The following 2026 holidays fall on weekends and are
+    // therefore not included above:
+    // Mahashivratri:      15-Feb-2026 (Sunday)
+    // Id-Ul-Fitr:         21-Mar-2026 (Saturday)
+    // Independence Day:   15-Aug-2026 (Saturday)
+    // Diwali Laxmi Pujan: 08-Nov-2026 (Sunday)
+
+    Calendar c = India();
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2026)), expectedHol);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -4091,50 +4091,50 @@ BOOST_AUTO_TEST_CASE(testIndia) {
 
     BOOST_TEST_MESSAGE("Testing India (NSE) clearing holiday list...");
 
-    std::vector<Date> expectedHol;
-
-    // 2026
-    // Municipal Corporation Election - Maharashtra
-    expectedHol.emplace_back(15, January, 2026);
-    // Republic Day
-    expectedHol.emplace_back(26, January, 2026);
-    // Chatrapati Shivaji Jayanti
-    expectedHol.emplace_back(19, February, 2026);
-    // Holi
-    expectedHol.emplace_back(3, March, 2026);
-    // Gudi Padwa
-    expectedHol.emplace_back(19, March, 2026);
-    // Ram Navami
-    expectedHol.emplace_back(26, March, 2026);
-    // Mahavir Jayanti
-    expectedHol.emplace_back(31, March, 2026);
-    // Annual Bank Closing
-    expectedHol.emplace_back(1, April, 2026);
-    // Good Friday
-    expectedHol.emplace_back(3, April, 2026);
-    // Ambedkar Jayanti
-    expectedHol.emplace_back(14, April, 2026);
-    // May Day
-    expectedHol.emplace_back(1, May, 2026);
-    // Bakri Id
-    expectedHol.emplace_back(28, May, 2026);
-    // Muharram
-    expectedHol.emplace_back(26, June, 2026);
-    // Id-E-Milad
-    expectedHol.emplace_back(26, August, 2026);
-    // Ganesh Chaturthi
-    expectedHol.emplace_back(14, September, 2026);
-    // Gandhi Jayanti
-    expectedHol.emplace_back(2, October, 2026);
-    // Dussehra
-    expectedHol.emplace_back(20, October, 2026);
-    // Diwali - Balipratipada
-    expectedHol.emplace_back(10, November, 2026);
-    // Gurunank Jayanti
-    expectedHol.emplace_back(24, November, 2026);
-    // Christmas
-    expectedHol.emplace_back(25, December, 2026);
-
+    std::vector<Date> expectedHol = {
+        // 2026
+        // Municipal Corporation Election - Maharashtra
+        Date(15, January, 2026),
+        // Republic Day
+        Date(26, January, 2026),
+        // Chatrapati Shivaji Jayanti
+        Date(19, February, 2026),
+        // Holi
+        Date(3, March, 2026),
+        // Gudi Padwa
+        Date(19, March, 2026),
+        // Ram Navami
+        Date(26, March, 2026),
+        // Mahavir Jayanti
+        Date(31, March, 2026),
+        // Annual Bank Closing
+        Date(1, April, 2026),
+        // Good Friday
+        Date(3, April, 2026),
+        // Ambedkar Jayanti
+        Date(14, April, 2026),
+        // May Day
+        Date(1, May, 2026),
+        // Bakri Id
+        Date(28, May, 2026),
+        // Muharram
+        Date(26, June, 2026),
+        // Id-E-Milad
+        Date(26, August, 2026),
+        // Ganesh Chaturthi
+        Date(14, September, 2026),
+        // Gandhi Jayanti
+        Date(2, October, 2026),
+        // Dussehra
+        Date(20, October, 2026),
+        // Diwali - Balipratipada
+        Date(10, November, 2026),
+        // Gurunank Jayanti
+        Date(24, November, 2026),
+        // Christmas
+        Date(25, December, 2026),
+    };
+    
     // The following 2026 holidays fall on weekends and are
     // therefore not included above:
     // Mahashivratri:      15-Feb-2026 (Sunday)

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -29,6 +29,7 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <ql/errors.hpp>
+#include <ql/indexes/ibor/sofr.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/calendars/bespokecalendar.hpp>
 #include <ql/time/calendars/brazil.hpp>
@@ -36,6 +37,7 @@
 #include <ql/time/calendars/croatia.hpp>
 #include <ql/time/calendars/denmark.hpp>
 #include <ql/time/calendars/germany.hpp>
+#include <ql/time/calendars/india.hpp>
 #include <ql/time/calendars/israel.hpp>
 #include <ql/time/calendars/italy.hpp>
 #include <ql/time/calendars/japan.hpp>
@@ -53,7 +55,6 @@
 #include <ql/time/calendars/unitedkingdom.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/time/calendars/uzbekistan.hpp>
-#include <ql/indexes/ibor/sofr.hpp>
 #include <fstream>
 
 using namespace QuantLib;
@@ -239,9 +240,7 @@ BOOST_AUTO_TEST_CASE(testUSSettlement) {
     expectedHol.emplace_back(26, December, 2005);
 
     Calendar c = UnitedStates(UnitedStates::Settlement);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2005)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2005)), expectedHol);
 
     // before Uniform Monday Holiday Act
     expectedHol = std::vector<Date>();
@@ -254,9 +253,7 @@ BOOST_AUTO_TEST_CASE(testUSSettlement) {
     expectedHol.emplace_back(23, November, 1961);
     expectedHol.emplace_back(25, December, 1961);
 
-    checkHolidays(
-        c.holidayList(Date(1, January, 1961), Date(31, December, 1961)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 1961), Date(31, December, 1961)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUSGovernmentBondMarket) {
@@ -277,9 +274,7 @@ BOOST_AUTO_TEST_CASE(testUSGovernmentBondMarket) {
     expectedHol.emplace_back(24, December, 2004);
 
     Calendar c = UnitedStates(UnitedStates::GovernmentBond);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2004)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2004)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUSNewYorkStockExchange) {
@@ -317,9 +312,7 @@ BOOST_AUTO_TEST_CASE(testUSNewYorkStockExchange) {
     expectedHol.emplace_back(25, December, 2006);
 
     Calendar c = UnitedStates(UnitedStates::NYSE);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2006)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2006)), expectedHol);
 
     std::vector<Date> histClose;
     histClose.emplace_back(30, October, 2012);   // Hurricane Sandy
@@ -384,7 +377,8 @@ BOOST_AUTO_TEST_CASE(testSOFR) {
 }
 
 BOOST_AUTO_TEST_CASE(testUSFederalReserveJuneteenth) {
-    BOOST_TEST_MESSAGE("Testing holiday occurrence of Juneteenth for US Federal Reserve calendar...");
+    BOOST_TEST_MESSAGE(
+        "Testing holiday occurrence of Juneteenth for US Federal Reserve calendar...");
 
     auto fedCalendar = UnitedStates(UnitedStates::FederalReserve);
 
@@ -463,9 +457,7 @@ BOOST_AUTO_TEST_CASE(testTARGET) {
     expectedHol.emplace_back(26, December, 2006);
 
     Calendar c = TARGET();
-    checkHolidays(
-        c.holidayList(Date(1, January, 1999), Date(31, December, 2006)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 1999), Date(31, December, 2006)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testGermanyFrankfurt) {
@@ -487,9 +479,7 @@ BOOST_AUTO_TEST_CASE(testGermanyFrankfurt) {
     expectedHol.emplace_back(24, December, 2004);
 
     Calendar c = Germany(Germany::FrankfurtStockExchange);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2003), Date(31, December, 2004)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2003), Date(31, December, 2004)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testGermanyEurex) {
@@ -513,9 +503,7 @@ BOOST_AUTO_TEST_CASE(testGermanyEurex) {
     expectedHol.emplace_back(31, December, 2004);
 
     Calendar c = Germany(Germany::Eurex);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2003), Date(31, December, 2004)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2003), Date(31, December, 2004)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testGermanyXetra) {
@@ -537,9 +525,66 @@ BOOST_AUTO_TEST_CASE(testGermanyXetra) {
     expectedHol.emplace_back(24, December, 2004);
 
     Calendar c = Germany(Germany::Xetra);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2003), Date(31, December, 2004)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2003), Date(31, December, 2004)), expectedHol);
+}
+
+BOOST_AUTO_TEST_CASE(testIndia) {
+
+    BOOST_TEST_MESSAGE("Testing India (NSE) clearing holiday list...");
+
+    std::vector<Date> expectedHol;
+
+    // 2026
+    // Municipal Corporation Election - Maharashtra
+    expectedHol.emplace_back(15, January, 2026);
+    // Republic Day
+    expectedHol.emplace_back(26, January, 2026);
+    // Chatrapati Shivaji Jayanti
+    expectedHol.emplace_back(19, February, 2026);
+    // Holi
+    expectedHol.emplace_back(3, March, 2026);
+    // Gudi Padwa
+    expectedHol.emplace_back(19, March, 2026);
+    // Ram Navami
+    expectedHol.emplace_back(26, March, 2026);
+    // Mahavir Jayanti
+    expectedHol.emplace_back(31, March, 2026);
+    // Annual Bank Closing
+    expectedHol.emplace_back(1, April, 2026);
+    // Good Friday
+    expectedHol.emplace_back(3, April, 2026);
+    // Ambedkar Jayanti
+    expectedHol.emplace_back(14, April, 2026);
+    // May Day
+    expectedHol.emplace_back(1, May, 2026);
+    // Bakri Id
+    expectedHol.emplace_back(28, May, 2026);
+    // Muharram
+    expectedHol.emplace_back(26, June, 2026);
+    // Id-E-Milad
+    expectedHol.emplace_back(26, August, 2026);
+    // Ganesh Chaturthi
+    expectedHol.emplace_back(14, September, 2026);
+    // Gandhi Jayanti
+    expectedHol.emplace_back(2, October, 2026);
+    // Dussehra
+    expectedHol.emplace_back(20, October, 2026);
+    // Diwali - Balipratipada
+    expectedHol.emplace_back(10, November, 2026);
+    // Gurunank Jayanti
+    expectedHol.emplace_back(24, November, 2026);
+    // Christmas
+    expectedHol.emplace_back(25, December, 2026);
+
+    // The following 2026 holidays fall on weekends and are
+    // therefore not included above:
+    // Mahashivratri:      15-Feb-2026 (Sunday)
+    // Id-Ul-Fitr:         21-Mar-2026 (Saturday)
+    // Independence Day:   15-Aug-2026 (Saturday)
+    // Diwali Laxmi Pujan: 08-Nov-2026 (Sunday)
+
+    Calendar c = India();
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2026)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUKSettlement) {
@@ -584,9 +629,7 @@ BOOST_AUTO_TEST_CASE(testUKSettlement) {
     expectedHol.emplace_back(26, December, 2007);
 
     Calendar c = UnitedKingdom(UnitedKingdom::Settlement);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2007)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2007)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUKExchange) {
@@ -631,9 +674,7 @@ BOOST_AUTO_TEST_CASE(testUKExchange) {
     expectedHol.emplace_back(26, December, 2007);
 
     Calendar c = UnitedKingdom(UnitedKingdom::Exchange);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2007)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2007)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUKMetals) {
@@ -678,9 +719,7 @@ BOOST_AUTO_TEST_CASE(testUKMetals) {
     expectedHol.emplace_back(26, December, 2007);
 
     Calendar c = UnitedKingdom(UnitedKingdom::Metals);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2007)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2007)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testItalyExchange) {
@@ -715,9 +754,7 @@ BOOST_AUTO_TEST_CASE(testItalyExchange) {
     expectedHol.emplace_back(31, December, 2004);
 
     Calendar c = Italy(Italy::Exchange);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2002), Date(31, December, 2004)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2002), Date(31, December, 2004)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testRussia) {
@@ -1305,9 +1342,8 @@ BOOST_AUTO_TEST_CASE(testRussia) {
     expectedHol.emplace_back(31, December, 2016);
 
     Calendar c = Russia(Russia::MOEX);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2012), Date(31, December, 2016), true),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2012), Date(31, December, 2016), true),
+                  expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testBrazil) {
@@ -1342,9 +1378,7 @@ BOOST_AUTO_TEST_CASE(testBrazil) {
     expectedHol.emplace_back(25, December, 2006);
 
     Calendar c = Brazil();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2005), Date(31, December, 2006)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2005), Date(31, December, 2006)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testDenmark) {
@@ -1395,9 +1429,7 @@ BOOST_AUTO_TEST_CASE(testDenmark) {
     // Saturday: expectedHol.emplace_back(31, December, 2022);
 
     Calendar c = Denmark();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2020), Date(31, December, 2022)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2020), Date(31, December, 2022)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
@@ -2115,9 +2147,7 @@ BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
     expectedHol.emplace_back(26, December, 2050);
 
     Calendar c = SouthKorea(SouthKorea::Settlement);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2050)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2050)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
@@ -2386,7 +2416,7 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(20, September, 2021);
     expectedHol.emplace_back(21, September, 2021);
     expectedHol.emplace_back(22, September, 2021);
-    expectedHol.emplace_back( 4, October, 2021);
+    expectedHol.emplace_back(4, October, 2021);
     expectedHol.emplace_back(11, October, 2021);
     expectedHol.emplace_back(31, December, 2021);
     expectedHol.emplace_back(31, January, 2022);
@@ -2884,9 +2914,7 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(30, December, 2050);
 
     Calendar c = SouthKorea(SouthKorea::KRX);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2004), Date(31, December, 2050)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2004), Date(31, December, 2050)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testChinaSSE) {
@@ -3152,9 +3180,7 @@ BOOST_AUTO_TEST_CASE(testChinaSSE) {
     expectedHol.emplace_back(7, Oct, 2026);
 
     Calendar c = China(China::SSE);
-    checkHolidays(
-        c.holidayList(Date(1, January, 2014), Date(31, December, 2026)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2014), Date(31, December, 2026)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testChinaIB) {
@@ -3318,7 +3344,9 @@ BOOST_AUTO_TEST_CASE(testMexicoInaugurationDay) {
     Calendar mexico = Mexico();
     for (auto holiday : expectedHol) {
         if (!mexico.isHoliday(holiday)) {
-            BOOST_FAIL("Expected to have an Inauguration Day holiday in the Mexican calendar for date " << holiday);
+            BOOST_FAIL(
+                "Expected to have an Inauguration Day holiday in the Mexican calendar for date "
+                << holiday);
         }
     }
     for (auto workingDay : expectedWorkingDays) {
@@ -3336,7 +3364,7 @@ BOOST_AUTO_TEST_CASE(testNewZealand) {
     auto auckland = NewZealand(NewZealand::Auckland);
     auto wellington = NewZealand(NewZealand::Wellington);
 
-    for (const auto& calendar: { auckland, wellington }) {
+    for (const auto& calendar : {auckland, wellington}) {
         // mid-week New Year's day
         BOOST_TEST(calendar.isHoliday({1, January, 2025}));
         BOOST_TEST(calendar.isHoliday({2, January, 2025}));
@@ -3414,120 +3442,53 @@ BOOST_AUTO_TEST_CASE(testTASECalendar) {
     BOOST_TEST_MESSAGE("Testing TASE calendar...");
 
     std::vector<Date> expected2013 = {
-        {24, February, 2013},
-        {25, March, 2013},
-        {26, March, 2013},
-        {31, March, 2013},
-        {1, April, 2013},
-        {15, April, 2013},
-        {16, April, 2013},
-        {14, May, 2013},
-        {15, May, 2013},
-        {16, July, 2013},
-        {4, September, 2013},
-        {5, September, 2013},
-        {18, September, 2013},
-        {19, September, 2013},
-        {25, September, 2013},
-        {26, September, 2013},
+        {24, February, 2013},  {25, March, 2013},     {26, March, 2013},     {31, March, 2013},
+        {1, April, 2013},      {15, April, 2013},     {16, April, 2013},     {14, May, 2013},
+        {15, May, 2013},       {16, July, 2013},      {4, September, 2013},  {5, September, 2013},
+        {18, September, 2013}, {19, September, 2013}, {25, September, 2013}, {26, September, 2013},
     };
 
     auto c = Israel();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2013), Date(31, December, 2013)),
-        expected2013);
+    checkHolidays(c.holidayList(Date(1, January, 2013), Date(31, December, 2013)), expected2013);
 
     std::vector<Date> expected2025 = {
-        {13, April, 2025},
-        {30, April, 2025},
-        {1, May, 2025},
-        {2, June, 2025},
-        {3, August, 2025},
-        {23, September, 2025},
-        {24, September, 2025},
-        {1, October, 2025},
-        {2, October, 2025},
-        {6, October, 2025},
-        {7, October, 2025},
-        {13, October, 2025},
+        {13, April, 2025},   {30, April, 2025},     {1, May, 2025},        {2, June, 2025},
+        {3, August, 2025},   {23, September, 2025}, {24, September, 2025}, {1, October, 2025},
+        {2, October, 2025},  {6, October, 2025},    {7, October, 2025},    {13, October, 2025},
         {14, October, 2025},
     };
 
-    checkHolidays(
-        c.holidayList(Date(1, January, 2025), Date(31, December, 2025)),
-        expected2025);
+    checkHolidays(c.holidayList(Date(1, January, 2025), Date(31, December, 2025)), expected2025);
 }
 
 BOOST_AUTO_TEST_CASE(testSHIRCalendar) {
     BOOST_TEST_MESSAGE("Testing SHIR calendar...");
 
     std::vector<Date> expected = {
-        Date(5, May, 2022),
-        Date(3, June, 2022),
-        Date(26, September, 2022),
-        Date(27, September, 2022),
-        Date(4, October, 2022),
-        Date(5, October, 2022),
-        Date(10, October, 2022),
-        Date(17, October, 2022),
-        Date(1, November, 2022),
-        Date(26, December, 2022),
-        Date(2, January, 2023),
-        Date(7, March, 2023),
-        Date(8, March, 2023),
-        Date(5, April, 2023),
-        Date(6, April, 2023),
-        Date(7, April, 2023),
-        Date(10, April, 2023),
-        Date(12, April, 2023),
-        Date(26, April, 2023),
-        Date(26, May, 2023),
-        Date(29, May, 2023),
-        Date(27, July, 2023),
-        Date(15, September, 2023),
-        Date(25, September, 2023),
-        Date(25, December, 2023),
-        Date(26, December, 2023),
-        Date(1, January, 2024),
-        Date(27, February, 2024),
-        Date(25, March, 2024),
-        Date(29, March, 2024),
-        Date(22, April, 2024),
-        Date(23, April, 2024),
-        Date(29, April, 2024),
-        Date(14, May, 2024),
-        Date(27, May, 2024),
-        Date(12, June, 2024),
-        Date(13, August, 2024),
-        Date(2, October, 2024),
-        Date(3, October, 2024),
-        Date(4, October, 2024),
-        Date(11, October, 2024),
-        Date(17, October, 2024),
-        Date(24, October, 2024),
-        Date(25, December, 2024),
-        Date(26, December, 2024),
-        Date(1, January, 2025),
-        Date(14, March, 2025),
-        Date(18, April, 2025),
-        Date(1, May, 2025),
-        Date(26, May, 2025),
-        Date(2, June, 2025),
-        Date(22, September, 2025),
-        Date(23, September, 2025),
-        Date(24, September, 2025),
-        Date(1, October, 2025),
-        Date(2, October, 2025),
-        Date(7, October, 2025),
-        Date(14, October, 2025),
-        Date(25, December, 2025),
-        Date(26, December, 2025),
+        Date(5, May, 2022),        Date(3, June, 2022),       Date(26, September, 2022),
+        Date(27, September, 2022), Date(4, October, 2022),    Date(5, October, 2022),
+        Date(10, October, 2022),   Date(17, October, 2022),   Date(1, November, 2022),
+        Date(26, December, 2022),  Date(2, January, 2023),    Date(7, March, 2023),
+        Date(8, March, 2023),      Date(5, April, 2023),      Date(6, April, 2023),
+        Date(7, April, 2023),      Date(10, April, 2023),     Date(12, April, 2023),
+        Date(26, April, 2023),     Date(26, May, 2023),       Date(29, May, 2023),
+        Date(27, July, 2023),      Date(15, September, 2023), Date(25, September, 2023),
+        Date(25, December, 2023),  Date(26, December, 2023),  Date(1, January, 2024),
+        Date(27, February, 2024),  Date(25, March, 2024),     Date(29, March, 2024),
+        Date(22, April, 2024),     Date(23, April, 2024),     Date(29, April, 2024),
+        Date(14, May, 2024),       Date(27, May, 2024),       Date(12, June, 2024),
+        Date(13, August, 2024),    Date(2, October, 2024),    Date(3, October, 2024),
+        Date(4, October, 2024),    Date(11, October, 2024),   Date(17, October, 2024),
+        Date(24, October, 2024),   Date(25, December, 2024),  Date(26, December, 2024),
+        Date(1, January, 2025),    Date(14, March, 2025),     Date(18, April, 2025),
+        Date(1, May, 2025),        Date(26, May, 2025),       Date(2, June, 2025),
+        Date(22, September, 2025), Date(23, September, 2025), Date(24, September, 2025),
+        Date(1, October, 2025),    Date(2, October, 2025),    Date(7, October, 2025),
+        Date(14, October, 2025),   Date(25, December, 2025),  Date(26, December, 2025),
     };
 
     auto c = Israel(Israel::SHIR);
-    checkHolidays(
-        c.holidayList(Date(5, May, 2022), Date(31, December, 2025)),
-        expected);
+    checkHolidays(c.holidayList(Date(5, May, 2022), Date(31, December, 2025)), expected);
 }
 
 BOOST_AUTO_TEST_CASE(testStartOfMonth) {
@@ -3549,8 +3510,7 @@ BOOST_AUTO_TEST_CASE(testStartOfMonth) {
             BOOST_FAIL("\n  " << som << " is not in the same month as " << counter);
         // Check that previous business day is in a different month
         if (c.advance(som, -1, Days, Unadjusted).month() == som.month())
-            BOOST_FAIL("\n  " << c.advance(som, -1, Days, Unadjusted)
-                              << " is in the same month as "
+            BOOST_FAIL("\n  " << c.advance(som, -1, Days, Unadjusted) << " is in the same month as "
                               << som);
         counter = counter + 1;
     }
@@ -3575,8 +3535,7 @@ BOOST_AUTO_TEST_CASE(testEndOfMonth) {
             BOOST_FAIL("\n  " << eom << " is not in the same month as " << counter);
         // Check that next business day is in a different month
         if (c.advance(eom, 1, Days, Unadjusted).month() == eom.month())
-            BOOST_FAIL("\n  " << c.advance(eom, 1, Days, Unadjusted) 
-                              << " is in the same month as "
+            BOOST_FAIL("\n  " << c.advance(eom, 1, Days, Unadjusted) << " is in the same month as "
                               << eom);
         counter = counter + 1;
     }
@@ -3927,9 +3886,7 @@ BOOST_AUTO_TEST_CASE(testMalta) {
     expectedHol.emplace_back(26, December, 2027);
 
     Calendar c = Malta();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testMontenegro) {
@@ -3953,9 +3910,7 @@ BOOST_AUTO_TEST_CASE(testMontenegro) {
     expectedHol.emplace_back(14, July, 2027);
 
     Calendar c = Montenegro();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testNorthMacedonia) {
@@ -3986,9 +3941,7 @@ BOOST_AUTO_TEST_CASE(testNorthMacedonia) {
     expectedHol.emplace_back(8, December, 2027);
 
     Calendar c = NorthMacedonia();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testNorthMacedoniaRamazanBajram) {
@@ -4061,9 +4014,7 @@ BOOST_AUTO_TEST_CASE(testSerbia) {
     expectedHol.emplace_back(31, December, 2027);
 
     Calendar c = Serbia();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testSlovenia) {
@@ -4090,9 +4041,7 @@ BOOST_AUTO_TEST_CASE(testSlovenia) {
     expectedHol.emplace_back(31, December, 2027);
 
     Calendar c = Slovenia();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testCroatia) {
@@ -4126,9 +4075,7 @@ BOOST_AUTO_TEST_CASE(testCroatia) {
     expectedHol.emplace_back(31, December, 2027);
 
     Calendar c = Croatia();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUzbekistan) {
@@ -4152,9 +4099,7 @@ BOOST_AUTO_TEST_CASE(testUzbekistan) {
     expectedHol.emplace_back(8, December, 2027);
 
     Calendar c = Uzbekistan();
-    checkHolidays(
-        c.holidayList(Date(1, January, 2026), Date(31, December, 2027)),
-        expectedHol);
+    checkHolidays(c.holidayList(Date(1, January, 2026), Date(31, December, 2027)), expectedHol);
 }
 
 BOOST_AUTO_TEST_CASE(testUzbekistanRamazonHayit) {


### PR DESCRIPTION
Added India (NSE) clearing holidays for 2026

Source: NSE official clearing holiday circular
https://nsearchives.nseindia.com/content/circulars/CMTR71775.pdf

Data taken from the **Clearing Holidays** tab (not Trading Holidays),
consistent with the "Clearing holidays" description already in india.hpp.

Dates added to the y == 2026 block (14 conditions):
- 15 Jan: Municipal Corporation Election – Maharashtra
- 19 Feb: Chatrapati Shivaji Jayanti
- 03 Mar: Holi
- 19 Mar: Gudi Padwa
- 26 Mar: Ram Navami
- 31 Mar: Mahavir Jayanti
- 01 Apr: Annual Bank Closing
- 28 May: Bakri Id
- 26 Jun: Moharram
- 26 Aug: Id-E-Milad
- 14 Sep: Ganesh Chaturthi
- 20 Oct: Dussehra
- 10 Nov: Diwali – Balipratipada
- 24 Nov: Gurunank Jayanti

Already handled (not added):
- 26 Jan Republic Day, 03 Apr Good Friday, 14 Apr Ambedkar Jayanti,
  01 May May Day, 02 Oct Gandhi Jayanti, 25 Dec Christmas → Tier 1 rules
- 15 Feb Mahashivratri (Sun), 21 Mar Id-Ul-Fitr (Sat),
  15 Aug Independence Day (Sat), 08 Nov Diwali Laxmi Pujan (Sun) → weekends

Also updated the data range comment in india.hpp: 2019-2025 → 2019-2026.
A new testIndia test case is added to test-suite/calendars.cpp.