### PR TITLE
Review default arguments in cross-currency swap constructors

### DIFF
--- a/ql/instruments/constnotionalcrosscurrencybasisswap.cpp
+++ b/ql/instruments/constnotionalcrosscurrencybasisswap.cpp
@@ -26,22 +26,26 @@
 
 namespace QuantLib  {
 
-ConstNotionalCrossCurrencyBasisSwap::ConstNotionalCrossCurrencyBasisSwap(Real payNominal, const Currency& payCurrency, const Schedule& paySchedule,
+ConstNotionalCrossCurrencyBasisSwap::ConstNotionalCrossCurrencyBasisSwap(
+                                     Real payNominal, const Currency& payCurrency, const Schedule& paySchedule,
                                      const ext::shared_ptr<IborIndex>& payIndex, Spread paySpread, Real payGearing,
                                      Real recNominal, const Currency& recCurrency, const Schedule& recSchedule,
                                      const ext::shared_ptr<IborIndex>& recIndex, Spread recSpread, Real recGearing,
-                                     Size payPaymentLag, Size recPaymentLag, ext::optional<bool> payIncludeSpread,
-                                     ext::optional<Natural> payLookback, ext::optional<Size> payLockoutDays,
-                                     ext::optional<bool> payIsAveraged, ext::optional<bool> recIncludeSpread,
-                                     ext::optional<Natural> recLookback, ext::optional<Size> recLockoutDays,
-                                     ext::optional<bool> recIsAveraged, const bool telescopicValueDates)
+                                     Integer payPaymentLag, Integer recPaymentLag,
+                                     bool payCompoundSpread, Natural payLookbackDays, bool payObservationShift,
+                                     Natural payLockoutDays, RateAveraging::Type payAveragingMethod,
+                                     bool recCompoundSpread, Natural recLookbackDays, bool recObservationShift,
+                                     Natural recLockoutDays, RateAveraging::Type recAveragingMethod,
+                                     const bool telescopicValueDates)
     : ConstNotionalCrossCurrencySwap(2), payNominal_(payNominal), payCurrency_(payCurrency), paySchedule_(paySchedule),
       payIndex_(payIndex), paySpread_(paySpread), payGearing_(payGearing), recNominal_(recNominal),
       recCurrency_(recCurrency), recSchedule_(recSchedule), recIndex_(recIndex), recSpread_(recSpread),
       recGearing_(recGearing), payPaymentLag_(payPaymentLag), recPaymentLag_(recPaymentLag),
-      payIncludeSpread_(payIncludeSpread), payLookback_(payLookback), payLockoutDays_(payLockoutDays), 
-      payIsAveraged_(payIsAveraged), recIncludeSpread_(recIncludeSpread), recLookback_(recLookback), 
-      recLockoutDays_(recLockoutDays), recIsAveraged_(recIsAveraged), telescopicValueDates_(telescopicValueDates) {
+      payCompoundSpread_(payCompoundSpread), payLookbackDays_(payLookbackDays),
+      payObservationShift_(payObservationShift), payLockoutDays_(payLockoutDays),
+      payAveragingMethod_(payAveragingMethod), recCompoundSpread_(recCompoundSpread),
+      recLookbackDays_(recLookbackDays), recObservationShift_(recObservationShift),
+      recLockoutDays_(recLockoutDays), recAveragingMethod_(recAveragingMethod), telescopicValueDates_(telescopicValueDates) {
     registerWith(payIndex_);
     registerWith(recIndex_);
     initialize();
@@ -56,11 +60,11 @@ void ConstNotionalCrossCurrencyBasisSwap::initialize() {
                         .withSpreads(paySpread_)
                         .withGearings(payGearing_)
                         .withPaymentLag(payPaymentLag_)
-                        .withSpreads(payIncludeSpread_ ? *payIncludeSpread_ : false)
-                        .withLookbackDays(payLookback_ ? *payLookback_ : 0)
-                        .withLockoutDays(payLockoutDays_ ? *payLockoutDays_ : 0)
-                        .withAveragingMethod(payIsAveraged_ ? 
-                            (*payIsAveraged_ ? RateAveraging::Simple : RateAveraging::Compound) : RateAveraging::Compound)
+                        .compoundingSpreadDaily(payCompoundSpread_)
+                        .withLookbackDays(payLookbackDays_)
+                        .withObservationShift(payObservationShift_)
+                        .withLockoutDays(payLockoutDays_)
+                        .withAveragingMethod(payAveragingMethod_)
                         .withTelescopicValueDates(telescopicValueDates_);
     } else {
         // Ibor leg
@@ -81,11 +85,11 @@ void ConstNotionalCrossCurrencyBasisSwap::initialize() {
                         .withSpreads(recSpread_)
                         .withGearings(recGearing_)
                         .withPaymentLag(recPaymentLag_)
-                        .withSpreads(recIncludeSpread_ ? *recIncludeSpread_ : false)
-                        .withLookbackDays(recLookback_ ? *recLookback_ : 0)
-                        .withLockoutDays(recLockoutDays_ ? *recLockoutDays_ : 0)
-                        .withAveragingMethod(recIsAveraged_ ? 
-                            (*recIsAveraged_ ? RateAveraging::Simple : RateAveraging::Compound) : RateAveraging::Compound)
+                        .compoundingSpreadDaily(recCompoundSpread_)
+                        .withLookbackDays(recLookbackDays_)
+                        .withObservationShift(recObservationShift_)
+                        .withLockoutDays(recLockoutDays_)
+                        .withAveragingMethod(recAveragingMethod_)
                         .withTelescopicValueDates(telescopicValueDates_);
     } else {
         // Ibor leg

--- a/ql/instruments/constnotionalcrosscurrencybasisswap.hpp
+++ b/ql/instruments/constnotionalcrosscurrencybasisswap.hpp
@@ -26,6 +26,7 @@
 #define quantlib_cross_currency_basis_swap_hpp
 
 #include <ql/indexes/iborindex.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/time/schedule.hpp>
 #include <ql/instruments/constnotionalcrosscurrencyswap.hpp>
 
@@ -61,27 +62,29 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
         \param recIndex           Floating rate index for the receive leg.
         \param recSpread          Spread over the floating rate for the receive leg.
         \param recGearing         Gearing factor for the receive leg.
-        \param payPaymentLag      Payment lag for the pay leg (default: 0).
-        \param recPaymentLag      Payment lag for the receive leg (default: 0).
-        \param payIncludeSpread   Optional flag to include the spread in the pay leg calculation (default: null).
-        \param payLookback        Optional lookback days for the pay leg (default: null).
-        \param payLockoutDays     Optional lockout period (in business days) before payment during which rate observations are frozen for the pay leg (defaul: 0).
-        \param payIsAveraged      If true, use arithmetic averaging of overnight rates instead of compounding when building the pay leg (defaul: 0).
-        \param recIncludeSpread   Optional flag to include the spread in the receive leg calculation (default: null).
-        \param recLookback        Optional lookback days for the receive leg (default: null).
-        \param recLockoutDays     Optional lockout period (in business days) before payment during which rate observations are frozen for the rec leg (defaul: 0).
-        \param recIsAveraged      If true, use arithmetic averaging of overnight rates instead of compounding when building the rec leg (defaul: 0).
-        \param telescopicValueDates Flag indicating whether telescopic value dates are used (default: false).
+        \param payPaymentLag      Payment lag in days for the pay leg if overnight (default: 0).
+        \param recPaymentLag      Payment lag in days for the receive leg if overnight (default: 0).
+        \param payCompoundSpread  Whether to compound the spread daily for the pay leg if overnight (default: false).
+        \param payLookbackDays    Lookback days for the pay leg if overnight (default: null).
+        \param payObservationShift  Whether the observation shift is applied for the pay leg if overnight (default: false).
+        \param payLockoutDays     Lockout period (in business days) for the pay leg if overnight (default: 0).
+        \param payAveragingMethod   Averaging method for the pay leg if overnight (default: compounding).
+        \param recCompoundSpread  Whether to compound the spread daily for the receive leg if overnight (default: false).
+        \param recLookbackDays    Lookback days for the receive leg if overnight (default: null).
+        \param recObservationShift  Whether the observation shift is applied for the receive leg if overnight (default: false).
+        \param recLockoutDays     Lockout period (in business days) for the receive leg if overnight (default: 0).
+        \param recAveragingMethod   Averaging method for the receive leg if overnight (default: compounding).
+        \param telescopicValueDates Flag indicating whether telescopic value dates are used if overnight (default: false).
     */
     ConstNotionalCrossCurrencyBasisSwap(
         Real payNominal, const Currency& payCurrency, const Schedule& paySchedule,
         const ext::shared_ptr<IborIndex>& payIndex, Spread paySpread, Real payGearing, Real recNominal,
         const Currency& recCurrency, const Schedule& recSchedule, const ext::shared_ptr<IborIndex>& recIndex,
-        Spread recSpread, Real recGearing, Size payPaymentLag = 0, Size recPaymentLag = 0,
-        ext::optional<bool> payIncludeSpread = ext::nullopt, ext::optional<Natural> payLookback = ext::nullopt,
-        ext::optional<Size> payLockoutDays = ext::nullopt, ext::optional<bool> payIsAveraged = ext::nullopt,
-        ext::optional<bool> recIncludeSpread = ext::nullopt, ext::optional<Natural> recLookback = ext::nullopt, 
-        ext::optional<Size> recLockoutDays = ext::nullopt, ext::optional<bool> recIsAveraged = ext::nullopt,
+        Spread recSpread, Real recGearing, Integer payPaymentLag = 0, Integer recPaymentLag = 0,
+        bool payCompoundSpread = false, Natural payLookbackDays = Null<Natural>(), bool payObservationShift = false,
+        Natural payLockoutDays = 0, RateAveraging::Type payAveragingMethod = RateAveraging::Compound,
+        bool recCompoundSpread = false, Natural recLookbackDays = Null<Natural>(), bool recObservationShift = false,
+        Natural recLockoutDays = 0, RateAveraging::Type recAveragingMethod = RateAveraging::Compound,
         const bool telescopicValueDates = false);
     //@}
     //! \name Instrument interface
@@ -143,17 +146,20 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
     Spread recSpread_;
     Real recGearing_;
 
-    Size payPaymentLag_;
-    Size recPaymentLag_;
+    Integer payPaymentLag_;
+    Integer recPaymentLag_;
+
     // OIS only
-    ext::optional<bool> payIncludeSpread_;
-    ext::optional<QuantLib::Natural> payLookback_;
-    ext::optional<Size> payLockoutDays_;
-    ext::optional<bool> payIsAveraged_;
-    ext::optional<bool> recIncludeSpread_;
-    ext::optional<QuantLib::Natural> recLookback_;
-    ext::optional<Size> recLockoutDays_;
-    ext::optional<bool> recIsAveraged_;
+    bool payCompoundSpread_;
+    Natural payLookbackDays_;
+    bool payObservationShift_;
+    Natural payLockoutDays_;
+    RateAveraging::Type payAveragingMethod_;
+    bool recCompoundSpread_;
+    Natural recLookbackDays_;
+    bool recObservationShift_;
+    Natural recLockoutDays_;
+    RateAveraging::Type recAveragingMethod_;
     bool telescopicValueDates_;
 
     mutable Spread fairPaySpread_;

--- a/ql/instruments/constnotionalcrosscurrencyfixedvsfloatingswap.cpp
+++ b/ql/instruments/constnotionalcrosscurrencyfixedvsfloatingswap.cpp
@@ -33,8 +33,8 @@ ConstNotionalCrossCurrencyFixedVsFloatingSwap::ConstNotionalCrossCurrencyFixedVs
     const Calendar& fixedPaymentCalendar, Real floatNominal, const Currency& floatCurrency,
     const Schedule& floatSchedule, const ext::shared_ptr<IborIndex>& floatIndex, Spread floatSpread,
     BusinessDayConvention floatPaymentBdc, Natural floatPaymentLag, const Calendar& floatPaymentCalendar,
-    const bool telescopicValueDates, ext::optional<bool> floatIncludeSpread, ext::optional<Natural> floatLookbackDays,
-    ext::optional<Size> floatLockoutDays, ext::optional<bool> floatIsAveraged)
+    const bool telescopicValueDates, bool floatCompoundSpread, Natural floatLookbackDays,
+    bool floatObservationShift, Natural floatLockoutDays, RateAveraging::Type floatAveragingMethod)
     : ConstNotionalCrossCurrencySwap(2), type_(type), fixedNominal_(fixedNominal), fixedCurrency_(fixedCurrency),
       fixedSchedule_(fixedSchedule), fixedRate_(fixedRate), fixedDayCount_(fixedDayCount),
       fixedPaymentBdc_(fixedPaymentBdc), fixedPaymentLag_(fixedPaymentLag), fixedPaymentCalendar_(fixedPaymentCalendar),
@@ -42,8 +42,9 @@ ConstNotionalCrossCurrencyFixedVsFloatingSwap::ConstNotionalCrossCurrencyFixedVs
       floatIndex_(floatIndex), floatSpread_(floatSpread), floatPaymentBdc_(floatPaymentBdc),
       floatPaymentLag_(floatPaymentLag), floatPaymentCalendar_(floatPaymentCalendar),
       telescopicValueDates_(telescopicValueDates),
-      floatIncludeSpread_(floatIncludeSpread), floatLookbackDays_(floatLookbackDays),
-      floatLockoutDays_(floatLockoutDays), floatIsAveraged_(floatIsAveraged) {
+      floatCompoundSpread_(floatCompoundSpread), floatLookbackDays_(floatLookbackDays),
+      floatObservationShift_(floatObservationShift),
+      floatLockoutDays_(floatLockoutDays), floatAveragingMethod_(floatAveragingMethod) {
 
     // Build the float leg
     Leg floatLeg;
@@ -53,11 +54,12 @@ ConstNotionalCrossCurrencyFixedVsFloatingSwap::ConstNotionalCrossCurrencyFixedVs
                     .withSpreads(floatSpread_)
                     .withPaymentAdjustment(floatPaymentBdc_)
                     .withPaymentLag(floatPaymentLag_)
-                    .withLookbackDays(floatLookbackDays ? *floatLookbackDays : 0)
+                    .withLookbackDays(floatLookbackDays_)
+                    .compoundingSpreadDaily(floatCompoundSpread_)
+                    .withObservationShift(floatObservationShift_)
                     .withPaymentCalendar(floatPaymentCalendar_)
-                    .withLockoutDays(floatLockoutDays_ ? *floatLockoutDays_ : 0)
-                    .withAveragingMethod(floatIsAveraged_ ? 
-                        (*floatIsAveraged_ ? RateAveraging::Simple : RateAveraging::Compound) : RateAveraging::Compound)
+                    .withLockoutDays(floatLockoutDays_)
+                    .withAveragingMethod(floatAveragingMethod_)
                     .withTelescopicValueDates(telescopicValueDates_);
     } else {
         floatLeg = IborLeg(floatSchedule_, floatIndex_)

--- a/ql/instruments/constnotionalcrosscurrencyfixedvsfloatingswap.hpp
+++ b/ql/instruments/constnotionalcrosscurrencyfixedvsfloatingswap.hpp
@@ -26,6 +26,7 @@
 #define quantlib_cross_currency_fix_vs_floating_swap_hpp
 
 #include <ql/indexes/iborindex.hpp>
+#include <ql/cashflows/rateaveraging.hpp>
 #include <ql/time/schedule.hpp>
 #include <ql/instruments/constnotionalcrosscurrencyswap.hpp>
 
@@ -64,13 +65,15 @@ class ConstNotionalCrossCurrencyFixedVsFloatingSwap : public ConstNotionalCrossC
         \param floatPaymentBdc       Business day convention for floating leg payments.
         \param floatPaymentLag       Payment lag for the floating leg (default: 0).
         \param floatPaymentCalendar  Calendar for floating leg payments.
-        \param telescopicValueDates  Set to true if the floatIndex is an OvernightIndex and you want to use telescopic values when calculating the rate.
-        \param floatIncludeSpread    If true, include the `floatSpread` when computing compounded or averaged overnight rates; if not provided, the index default behaviour is used.
-        \param floatLookbackDays     Optional lookback period (in calendar days) applied to the floating-rate observation window for the floating leg.
-        \param floatLockoutDays      Optional lockout period (in business days) before payment during which rate observations are frozen.
-        \param floatIsAveraged       If true, use arithmetic averaging of overnight rates instead of compounding when building the floating leg.
+        \param telescopicValueDates  For overnight legs, whether to use telescopic value dates (default: false).
+        \param floatCompoundSpread   For overnight legs, whether to compound the spread daily (default: false).
+        \param floatLookbackDays     For overnight legs, optional lookback days (default: null).
+        \param floatObservationShift For overnight legs, whether the observation shift is applied (default: false).
+        \param floatLockoutDays      For overnight legs, optional lockout period in business days (default: 0).
+        \param floatAveragingMethod  For overnight legs, averaging method (default: compounding).
     */
-    ConstNotionalCrossCurrencyFixedVsFloatingSwap(Type type, Real fixedNominal, const Currency& fixedCurrency,
+    ConstNotionalCrossCurrencyFixedVsFloatingSwap(
+                         Type type, Real fixedNominal, const Currency& fixedCurrency,
                          const Schedule& fixedSchedule, Rate fixedRate,
                          const DayCounter& fixedDayCount, BusinessDayConvention fixedPaymentBdc,
                          Natural fixedPaymentLag, const Calendar& fixedPaymentCalendar,
@@ -80,10 +83,11 @@ class ConstNotionalCrossCurrencyFixedVsFloatingSwap : public ConstNotionalCrossC
                          BusinessDayConvention floatPaymentBdc, Natural floatPaymentLag,
                          const Calendar& floatPaymentCalendar, 
                          const bool telescopicValueDates = false,
-                         ext::optional<bool> floatIncludeSpread = ext::nullopt,
-                         ext::optional<Natural> floatLookbackDays = ext::nullopt,
-                         ext::optional<Size> floatLockoutDays = ext::nullopt,
-                         ext::optional<bool> floatIsAveraged = ext::nullopt);
+                         bool floatCompoundSpread = false,
+                         Natural floatLookbackDays = Null<Natural>(),
+                         bool floatObservationShift = false,
+                         Natural floatLockoutDays = 0,
+                         RateAveraging::Type floatAveragingMethod = RateAveraging::Compound);
     //@}
 
     //! \name Instrument interface
@@ -113,10 +117,10 @@ class ConstNotionalCrossCurrencyFixedVsFloatingSwap : public ConstNotionalCrossC
     BusinessDayConvention floatPaymentBdc() const { return floatPaymentBdc_; }
     Natural floatPaymentLag() const { return floatPaymentLag_; }
     const Calendar& floatPaymentCalendar() const { return floatPaymentCalendar_; }
-    ext::optional<bool> floatIncludeSpread() const { return floatIncludeSpread_; }
-    ext::optional<Natural> floatLookbackDays() const { return floatLookbackDays_; }
-    ext::optional<Size> floatLockoutDays() const { return floatLockoutDays_; }
-    ext::optional<bool> floatIsAveraged() const { return floatIsAveraged_; }
+    bool floatCompoundSpread() const { return floatCompoundSpread_; }
+    Natural floatLookbackDays() const { return floatLookbackDays_; }
+    Natural floatLockoutDays() const { return floatLockoutDays_; }
+    RateAveraging::Type floatAveragingMethod() const { return floatAveragingMethod_; }
     //@}
 
     //! \name Additional interface
@@ -161,10 +165,11 @@ class ConstNotionalCrossCurrencyFixedVsFloatingSwap : public ConstNotionalCrossC
     Natural floatPaymentLag_;
     Calendar floatPaymentCalendar_;
     bool telescopicValueDates_;
-    ext::optional<bool> floatIncludeSpread_;
-    ext::optional<Natural> floatLookbackDays_;
-    ext::optional<Size> floatLockoutDays_;
-    ext::optional<bool> floatIsAveraged_;
+    bool floatCompoundSpread_;
+    Natural floatLookbackDays_;
+    bool floatObservationShift_;
+    Natural floatLockoutDays_;
+    RateAveraging::Type floatAveragingMethod_;
 
     mutable Rate fairFixedRate_;
     mutable Spread fairSpread_;

--- a/test-suite/constnotionalcrosscurrencybasisswap.cpp
+++ b/test-suite/constnotionalcrosscurrencybasisswap.cpp
@@ -346,15 +346,17 @@ ext::shared_ptr<ConstNotionalCrossCurrencyBasisSwap> makeONBasisXCCY(Rate spotFx
         GBPNominal, GBPCurrency(), schedule, soniaIndex, GBPSpread, 1.0, 
 		GBPNominal * spotFx, USDCurrency(), schedule, sofrIndex, 0.0, 1.0, 
         0, // payPaymentLag
-        0, // recPaymentLaf
-        false, // payIncludeSpread
-        0, // payLookback
+        0, // recPaymentLag
+        false, // payCompoundSpread
+        0, // payLookbackDays
+        false, // payObservationShift
         3, // payLockoutDays
-        false, // payIsAveraged
-        false, // recIncludeSpread
-        0, // recLookback
+        RateAveraging::Compound, // payAveragingMethod
+        false, // recCompoundSpread
+        0, // recLookbackDays
+        false, // recObservationShift
         2, // recLockoutDays
-        false, // recIsAveraged
+        RateAveraging::Compound, // recAveragingMethod
         false // telescopicValueDates
     );
 }

--- a/test-suite/constnotionalcrosscurrencyfixedvsfloatingswap.cpp
+++ b/test-suite/constnotionalcrosscurrencyfixedvsfloatingswap.cpp
@@ -243,7 +243,7 @@ ext::shared_ptr<ConstNotionalCrossCurrencyFixedVsFloatingSwap> makeFixFloatXCCYS
 
     // Create swap
     return ext::make_shared<ConstNotionalCrossCurrencyFixedVsFloatingSwap>(
-                                 ConstNotionalCrossCurrencyFixedVsFloatingSwap::Payer, usdNominal * spotFx, TRYCurrency(), fixedSchedule, rate,
+                                 Swap::Payer, usdNominal * spotFx, TRYCurrency(), fixedSchedule, rate,
                                  Actual360(), payConvention, payLag, payCalendar, usdNominal, USDCurrency(),
                                  floatSchedule, index, spread, payConvention, payLag, payCalendar);
 }


### PR DESCRIPTION
- No need for optionals; nulls are immediately converted into defaults in the constructors and passed to the leg builders.
- Observation shift was missing.
- `withSpread` had been used instead of `compoundingSpreadDaily`.