### PR TITLE
Use `make_shared` in indexes

### DIFF
--- a/ql/indexes/ibor/shibor.cpp
+++ b/ql/indexes/ibor/shibor.cpp
@@ -49,6 +49,6 @@ namespace QuantLib {
     
     ext::shared_ptr<IborIndex> Shibor::clone(
                                   const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(new Shibor(tenor(), h));
+        return ext::make_shared<Shibor>(tenor(), h);
     }
 }

--- a/ql/indexes/iborindex.cpp
+++ b/ql/indexes/iborindex.cpp
@@ -84,13 +84,12 @@ namespace QuantLib {
 
     ext::shared_ptr<IborIndex> OvernightIndex::clone(
                                const Handle<YieldTermStructure>& h) const {
-        return ext::shared_ptr<IborIndex>(
-                                        new OvernightIndex(familyName(),
-                                                           fixingDays(),
-                                                           currency(),
-                                                           fixingCalendar(),
-                                                           dayCounter(),
-                                                           h));
+        return ext::make_shared<OvernightIndex>(familyName(),
+                                                fixingDays(),
+                                                currency(),
+                                                fixingCalendar(),
+                                                dayCounter(),
+                                                h);
     }
 
 }

--- a/ql/indexes/region.cpp
+++ b/ql/indexes/region.cpp
@@ -29,35 +29,34 @@ namespace QuantLib {
 
 
     AustraliaRegion::AustraliaRegion() {
-        static ext::shared_ptr<Data> AUdata(new Data("Australia","AU"));
+        static auto AUdata = ext::make_shared<Data>("Australia","AU");
         data_ = AUdata;
     }
 
     EURegion::EURegion() {
-        static ext::shared_ptr<Data> EUdata(new Data("EU","EU"));
+        static auto EUdata = ext::make_shared<Data>("EU","EU");
         data_ = EUdata;
     }
 
     FranceRegion::FranceRegion() {
-        static ext::shared_ptr<Data> FRdata(new Data("France","FR"));
+        static auto FRdata = ext::make_shared<Data>("France","FR");
         data_ = FRdata;
     }
 
     UKRegion::UKRegion() {
-        static ext::shared_ptr<Data> UKdata(new Data("UK","UK"));
+        static auto UKdata = ext::make_shared<Data>("UK","UK");
         data_ = UKdata;
     }
 
     USRegion::USRegion() {
-        static ext::shared_ptr<Data> USdata(new Data("USA","US"));
+        static auto USdata = ext::make_shared<Data>("USA","US");
         data_ = USdata;
     }
 
     ZARegion::ZARegion() {
-        static ext::shared_ptr<Data> ZAdata(new Data("South Africa","ZA"));
+        static auto ZAdata = ext::make_shared<Data>("South Africa","ZA");
         data_ = ZAdata;
     }
 
 
 }
-

--- a/ql/indexes/swap/chfliborswap.cpp
+++ b/ql/indexes/swap/chfliborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, h))) {}
+                    ext::make_shared<CHFLibor>(6*Months, h) :
+                    ext::make_shared<CHFLibor>(3*Months, h)) {}
 
     ChfLiborSwapIsdaFix::ChfLiborSwapIsdaFix(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new CHFLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new CHFLibor(3*Months, forwarding)),
+                    ext::make_shared<CHFLibor>(6*Months, forwarding) :
+                    ext::make_shared<CHFLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/euriborswap.cpp
+++ b/ql/indexes/swap/euriborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIsdaFixA::EuriborSwapIsdaFixA(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
@@ -70,8 +70,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIsdaFixB::EuriborSwapIsdaFixB(
                                 const Period& tenor,
@@ -86,8 +86,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
 
@@ -102,8 +102,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, h))) {}
+                    ext::make_shared<Euribor>(6*Months, h) :
+                    ext::make_shared<Euribor>(3*Months, h)) {}
 
     EuriborSwapIfrFix::EuriborSwapIfrFix(
                                 const Period& tenor,
@@ -118,8 +118,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new Euribor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new Euribor(3*Months, forwarding)),
+                    ext::make_shared<Euribor>(6*Months, forwarding) :
+                    ext::make_shared<Euribor>(3*Months, forwarding),
                 discounting) {}
 
 

--- a/ql/indexes/swap/eurliborswap.cpp
+++ b/ql/indexes/swap/eurliborswap.cpp
@@ -38,8 +38,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIsdaFixA::EurLiborSwapIsdaFixA(
                                 const Period& tenor,
@@ -54,8 +54,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
@@ -70,8 +70,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIsdaFixB::EurLiborSwapIsdaFixB(
                                 const Period& tenor,
@@ -86,8 +86,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
@@ -102,8 +102,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, h))) {}
+                    ext::make_shared<EURLibor>(6*Months, h) :
+                    ext::make_shared<EURLibor>(3*Months, h)) {}
 
     EurLiborSwapIfrFix::EurLiborSwapIfrFix(
                                 const Period& tenor,
@@ -118,8 +118,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new EURLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new EURLibor(3*Months, forwarding)),
+                    ext::make_shared<EURLibor>(6*Months, forwarding) :
+                    ext::make_shared<EURLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/gbpliborswap.cpp
+++ b/ql/indexes/swap/gbpliborswap.cpp
@@ -39,8 +39,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, h)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, h))) {}
+                    ext::make_shared<GBPLibor>(6*Months, h) :
+                    ext::make_shared<GBPLibor>(3*Months, h)) {}
 
     GbpLiborSwapIsdaFix::GbpLiborSwapIsdaFix(
                             const Period& tenor,
@@ -56,8 +56,8 @@ namespace QuantLib {
                 ModifiedFollowing, // fixedLegConvention
                 Actual365Fixed(), // fixedLegDaycounter
                 tenor > 1*Years ?
-                    ext::shared_ptr<IborIndex>(new GBPLibor(6*Months, forwarding)) :
-                    ext::shared_ptr<IborIndex>(new GBPLibor(3*Months, forwarding)),
+                    ext::make_shared<GBPLibor>(6*Months, forwarding) :
+                    ext::make_shared<GBPLibor>(3*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/jpyliborswap.cpp
+++ b/ql/indexes/swap/jpyliborswap.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::make_shared<JPYLibor>(6*Months, h)) {}
 
     JpyLiborSwapIsdaFixAm::JpyLiborSwapIsdaFixAm(
                                 const Period& tenor,
@@ -50,7 +50,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
+                ext::make_shared<JPYLibor>(6*Months, forwarding),
                 discounting) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
@@ -64,7 +64,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, h))) {}
+                ext::make_shared<JPYLibor>(6*Months, h)) {}
 
     JpyLiborSwapIsdaFixPm::JpyLiborSwapIsdaFixPm(
                                 const Period& tenor,
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 ActualActual(ActualActual::ISDA), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new JPYLibor(6*Months, forwarding)),
+                ext::make_shared<JPYLibor>(6*Months, forwarding),
                 discounting) {}
 
 }

--- a/ql/indexes/swap/usdliborswap.cpp
+++ b/ql/indexes/swap/usdliborswap.cpp
@@ -36,7 +36,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::make_shared<USDLibor>(3*Months, h)) {}
 
     UsdLiborSwapIsdaFixAm::UsdLiborSwapIsdaFixAm(
                                 const Period& tenor,
@@ -50,7 +50,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
+                ext::make_shared<USDLibor>(3*Months, forwarding),
                 discounting) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
@@ -64,7 +64,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, h))) {}
+                ext::make_shared<USDLibor>(3*Months, h)) {}
 
     UsdLiborSwapIsdaFixPm::UsdLiborSwapIsdaFixPm(
                                 const Period& tenor,
@@ -78,7 +78,7 @@ namespace QuantLib {
                 6*Months, // fixedLegTenor
                 ModifiedFollowing, // fixedLegConvention
                 Thirty360(Thirty360::BondBasis), // fixedLegDaycounter
-                ext::shared_ptr<IborIndex>(new USDLibor(3*Months, forwarding)),
+                ext::make_shared<USDLibor>(3*Months, forwarding),
                 discounting) {}
 
 }


### PR DESCRIPTION
use make_shared<T> instead of shared<T>(new ...)

also add auto when RHS type is explicit