### PR TITLE
Update Hull/White's r0 when the underlying term structure is relinked

### DIFF
--- a/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -83,6 +83,7 @@ namespace QuantLib {
     }
 
     void HullWhite::generateArguments() {
+        r0_ = termStructure()->forwardRate(0.0, 0.0, Continuous, NoFrequency);
         phi_ = FittingParameter(termStructure(), a(), sigma());
     }
 
@@ -168,4 +169,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/models/shortrate/onefactormodels/hullwhite.cpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.cpp
@@ -83,7 +83,7 @@ namespace QuantLib {
     }
 
     void HullWhite::generateArguments() {
-        r0_ = termStructure()->forwardRate(0.0, 0.0, Continuous, NoFrequency);
+        r0_ = termStructure()->zeroRate(0.0, Continuous, NoFrequency);
         phi_ = FittingParameter(termStructure(), a(), sigma());
     }
 

--- a/ql/models/shortrate/onefactormodels/hullwhite.hpp
+++ b/ql/models/shortrate/onefactormodels/hullwhite.hpp
@@ -41,9 +41,6 @@ namespace QuantLib {
 
         \test calibration results are tested against cached values
 
-        \bug When the term structure is relinked, the r0 parameter of
-             the underlying Vasicek model is not updated.
-
         \ingroup shortrate
     */
     class HullWhite : public Vasicek, public TermStructureConsistentModel {
@@ -169,4 +166,3 @@ namespace QuantLib {
 
 
 #endif
-

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -54,6 +54,30 @@ struct CalibrationData {
     Volatility volatility;
 };
 
+BOOST_AUTO_TEST_CASE(testHullWhiteUpdatesR0WhenTermStructureRelinks) {
+    BOOST_TEST_MESSAGE("Testing Hull-White r0 update when the term structure is relinked...");
+
+    Date today(19, May, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    RelinkableHandle<YieldTermStructure> termStructure;
+    termStructure.linkTo(flatRate(today, 0.02, Actual365Fixed()));
+
+    HullWhite model(termStructure);
+
+    termStructure.linkTo(flatRate(today, 0.05, Actual365Fixed()));
+
+    const Rate expected =
+        termStructure->forwardRate(0.0, 0.0, Continuous, NoFrequency);
+    const Real tolerance = 1.0e-12;
+
+    if (std::fabs(model.r0() - expected) > tolerance) {
+        BOOST_ERROR("failed to update r0 after relinking the term structure:\n"
+                    << "expected:   " << expected << "\n"
+                    << "calculated: " << model.r0());
+    }
+}
+
 
 BOOST_AUTO_TEST_CASE(testCachedHullWhite) {
     BOOST_TEST_MESSAGE("Testing Hull-White calibration against cached values using swaptions with start delay...");


### PR DESCRIPTION
This fixes the documented `HullWhite` issue where the inherited `Vasicek::r0_` value was not updated after the underlying term-structure handle was relinked.

`HullWhite` observes the term-structure handle and rebuilds its fitting parameter in `generateArguments()`, but `r0_` was only initialized in the constructor. As a result, after relinking the handle to a new curve, `model.r0()` could still return the initial curve's short rate.

This change updates `r0_` in `HullWhite::generateArguments()` from the current term structure's instantaneous forward rate, keeping it consistent with the relinked curve.

A regression test was added to check that `HullWhite::r0()` changes after relinking a `RelinkableHandle<YieldTermStructure>`.

Add a test for this :
run_test=QuantLibTests/ShortRateModelTests/testHullWhiteUpdatesR0WhenTermStructureRelinks