### PR TITLE
Fix out-of-bounds write in `FastFourierTransform` constructor for order=0

### DIFF
--- a/ql/math/fastfouriertransform.hpp
+++ b/ql/math/fastfouriertransform.hpp
@@ -46,6 +46,12 @@ namespace QuantLib {
 
         FastFourierTransform(std::size_t order)
         : cs_(order), sn_(order) {
+            // For order == 0 the transform is over a single element and
+            // reduces to a copy; no twiddle factors need to be computed.
+            // Skipping the setup avoids writing to cs_[size_t(-1)] /
+            // sn_[size_t(-1)] when the vectors are empty.
+            if (order == 0)
+                return;
             std::size_t m = static_cast<std::size_t>(1) << order;
             cs_[order - 1] = std::cos (2 * M_PI / m);
             sn_[order - 1] = std::sin (2 * M_PI / m);

--- a/test-suite/fastfouriertransform.cpp
+++ b/test-suite/fastfouriertransform.cpp
@@ -105,6 +105,28 @@ BOOST_AUTO_TEST_CASE(testInverse) {
 
 }
 
+BOOST_AUTO_TEST_CASE(testTrivialOrder) {
+    BOOST_TEST_MESSAGE("Testing FFT of size 1 (order 0)...");
+    // min_order(1) is 0; constructing an FFT of order 0 used to write
+    // out of bounds in the constructor.  A size-1 transform reduces to
+    // a copy of the single input element.
+    BOOST_CHECK_EQUAL(FastFourierTransform::min_order(1), 0u);
+
+    typedef std::complex<Real> cx;
+    FastFourierTransform fft(0);
+    BOOST_CHECK_EQUAL(fft.output_size(), 1u);
+
+    cx a[] = { cx(2.5, -1.5) };
+    cx b[1];
+    fft.transform(a, a+1, b);
+    if (std::fabs(b[0].real() - a[0].real()) > 1.0e-12 ||
+        std::fabs(b[0].imag() - a[0].imag()) > 1.0e-12)
+        BOOST_ERROR("Size-1 FFT\n"
+                    << std::setprecision(16) << std::scientific
+                    << "    calculated: " << b[0] << "\n"
+                    << "    expected:   " << a[0]);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

The `FastFourierTransform(std::size_t order)` constructor in
`ql/math/fastfouriertransform.hpp` allocates `cs_` and `sn_` with size
`order` and then unconditionally writes to `cs_[order - 1]` and
`sn_[order - 1]`. When `order == 0` both vectors are empty and the
indexing wraps to `size_t(-1)`, producing an out-of-bounds heap write.

## How to reproduce

`FastFourierTransform::min_order(1)` returns `0`, so a caller that
chains it straight into the constructor for a single-element transform
hits the bug:

```c++
#include <ql/math/fastfouriertransform.hpp>
int main() { QuantLib::FastFourierTransform fft(0); }
```

With a debug-checked standard library (`-D_LIBCPP_DEBUG=1` /
`-D_GLIBCXX_DEBUG`) this segfaults (exit 139). Under release builds it
silently scribbles past the end of the allocator's bookkeeping for the
empty `std::vector` storage.

Affected lines (pre-patch):

```
ql/math/fastfouriertransform.hpp:47
        FastFourierTransform(std::size_t order)
        : cs_(order), sn_(order) {
            std::size_t m = static_cast<std::size_t>(1) << order;
            cs_[order - 1] = std::cos (2 * M_PI / m);   // OOB when order==0
            sn_[order - 1] = std::sin (2 * M_PI / m);   // OOB when order==0
            for (std::size_t i = order - 1; i > 0; --i) {
                ...
```

## The fix

A transform of length `1 == (1 << 0)` reduces to a copy and needs no
twiddle factors. The existing transform loop body
`for (s = 1; s <= order; ++s) { ... }` already does the right thing
for `order == 0` (it iterates zero times). The only piece that misbehaves
is the precomputation in the constructor, so early-return there when
`order == 0`. The change is local to the callee and does not affect any
other code path.

## Test / build evidence

Built and ran a small program that exercises both the previously-crashing
`order == 0` path and a regression case for `order == 3`:

```
ok: order=0
ok: order=0 transform
ok: order=3 transform
```

Compiled with `-D_LIBCPP_DEBUG=1` to catch the OOB write; the unpatched
header exits 139, the patched header exits 0 and produces the expected
DFT bin values (first bin == sum of inputs).