### PR TITLE
Add 2025 South Korea temporary holiday

### DIFF
--- a/ql/time/calendars/southkorea.cpp
+++ b/ql/time/calendars/southkorea.cpp
@@ -207,6 +207,7 @@ namespace QuantLib {
             || (d == 17 && m == August && y == 2020)
             || (d == 2 && m == October && y == 2023)
             || (d == 1 && m == October && y == 2024)
+            || (d == 27 && m == January && y == 2025)
 
             // Harvest Moon Day
             || ((d == 27 || d == 28 || d == 29) && m == September && y == 2004)

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -1698,6 +1698,7 @@ BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
     expectedHol.emplace_back(9, October, 2024);
     expectedHol.emplace_back(25, December, 2024);
     expectedHol.emplace_back(1, January, 2025);
+    expectedHol.emplace_back(27, January, 2025);
     expectedHol.emplace_back(28, January, 2025);
     expectedHol.emplace_back(29, January, 2025);
     expectedHol.emplace_back(30, January, 2025);
@@ -2441,6 +2442,7 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(25, December, 2024);
     expectedHol.emplace_back(31, December, 2024);
     expectedHol.emplace_back(1, January, 2025);
+    expectedHol.emplace_back(27, January, 2025);
     expectedHol.emplace_back(28, January, 2025);
     expectedHol.emplace_back(29, January, 2025);
     expectedHol.emplace_back(30, January, 2025);


### PR DESCRIPTION
This adds January 27, 2025 as a South Korean temporary holiday.

The date was designated as a temporary public holiday ahead of the 2025 Lunar New Year holiday, and Korean stock and FX markets were closed on that day.  The change updates both the Settlement and KRX calendars and adds the date to the corresponding calendar tests.

source : https://www.korea.net/NewsFocus/Society/view?articleId=265023&koreanId=265018