### PR TITLE
Fix Vasicek zero-reversion limit

### DIFF
--- a/ql/models/shortrate/onefactormodels/vasicek.cpp
+++ b/ql/models/shortrate/onefactormodels/vasicek.cpp
@@ -36,7 +36,10 @@ namespace QuantLib {
     Real Vasicek::A(Time t, Time T) const {
         Real _a = a();
         if (_a < std::sqrt(QL_EPSILON)) {
-            return 0.0;
+            const Real sigma2 = sigma()*sigma();
+            const Real tau = T - t;
+            return std::exp(-0.5*lambda()*sigma()*tau*tau +
+                            sigma2*tau*tau*tau/6.0);
         } else {
             Real sigma2 = sigma()*sigma();
             Real bt = B(t, T);
@@ -75,4 +78,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/test-suite/shortratemodels.cpp
+++ b/test-suite/shortratemodels.cpp
@@ -25,6 +25,7 @@
 #include "utilities.hpp"
 #include <ql/cashflows/iborcoupon.hpp>
 #include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
+#include <ql/models/shortrate/onefactormodels/vasicek.hpp>
 #include <ql/models/shortrate/onefactormodels/extendedcoxingersollross.hpp>
 #include <ql/models/shortrate/calibrationhelpers/swaptionhelper.hpp>
 #include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
@@ -438,6 +439,34 @@ BOOST_AUTO_TEST_CASE(testExtendedCoxIngersollRossDiscountFactor) {
                     << std::scientific
                     << "\n  difference: " << diff
                     << "\n  tolerance : " << tol);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testVasicekDiscountFactorForSmallMeanReversion) {
+    BOOST_TEST_MESSAGE("Testing zero-bond pricing for Vasicek model with small mean reversion...");
+
+    const Rate r0 = 0.05;
+    const Real a = 1e-12;
+    const Real b = 0.05;
+    const Volatility sigma = 0.01;
+    const Real lambda = 0.0;
+    const Time now = 0.0;
+    const Time maturity = 1.0;
+
+    const Vasicek model(r0, a, b, sigma, lambda);
+
+    const Real expected = std::exp(-r0*maturity + sigma*sigma*maturity*maturity*maturity/6.0);
+    const Real calculated = model.discountBond(now, maturity, r0);
+
+    const Real tolerance = 1e-12;
+    const Real error = std::fabs(expected-calculated);
+    if (error > tolerance) {
+        BOOST_ERROR("Failed to reproduce small-mean-reversion zero-bond price:"
+                    << "\n  calculated: " << calculated
+                    << "\n  expected  : " << expected
+                    << std::scientific
+                    << "\n  error     : " << error
+                    << "\n  tolerance : " << tolerance);
     }
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The small-a branch is still needed for numerical stability, but returning `0.0` is not the correct limit.

Let `tau = T - t`. In the Vasicek model,

$$
P(t,T,r) = A(t,T)\exp(-B(t,T)r),
$$

with

$$
B(t,T) = \frac{1-\exp(-a\tau)}{a}.
$$

Using the Taylor expansion of `exp(-a*tau)` around `a = 0`,

$$
B(t,T)= \tau - \frac{a\tau^2}{2} + \frac{a^2\tau^3}{6} + O(a^3),
$$

so \(B(t,T) \to \tau\).

For the `A(t,T)` term, QuantLib uses

$$
\log A(t,T)=\left(b + \frac{\lambda\sigma}{a} - \frac{\sigma^2}{2a^2}\right) (B(t,T)-\tau) -\frac{\sigma^2 B(t,T)^2}{4a}.
$$

Substituting the expansion of \(B(t,T)\),

$$
B(t,T)-\tau= -\frac{a\tau^2}{2} +\frac{a^2\tau^3}{6} +O(a^3),
$$

and

$$
B(t,T)^2 =\tau^2-a\tau^3+O(a^2).
$$

Therefore,

$$
\log A(t,T)
\to -\frac{1}{2}\lambda\sigma\tau^2 +\frac{\sigma^2\tau^3}{6}.
$$

Hence,

$$
A(t,T)
\to \exp\left( -\frac{1}{2}\lambda\sigma\tau^2 +\frac{\sigma^2\tau^3}{6}\right).
$$

Therefore, the small-a branch should return this finite limit instead of `0.0`.