### PR TITLE
fix fxforward to have npv of reference date

### DIFF
--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -67,9 +67,9 @@ namespace QuantLib {
         DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
                                   targetCurrencyDiscountCurve_->discount(settlementDate);
 
-        // Calculate fair forward rate: F = S * dfTarget / dfSource
+        // Calculate fair forward rate: F = S * dfSource / dfTarget
         // This is the forward rate targetCurrency/sourceCurrency
-        results_.fairForwardRate = spotFxRate * dfTarget / dfSource;
+        results_.fairForwardRate = spotFxRate * dfSource / dfTarget;
 
         // Calculate present values of each leg
         // PV of source currency leg (in source currency)

--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -61,17 +61,21 @@ namespace QuantLib {
         Real spotFxRate = spotFx_->value();
         QL_REQUIRE(spotFxRate > 0.0, "spot FX rate must be positive");
 
-        // Get discount factors to maturity
+        // Get discount factors from settlement to maturity
         DiscountFactor dfSource = sourceCurrencyDiscountCurve_->discount(maturityDate) /
                                   sourceCurrencyDiscountCurve_->discount(settlementDate);
         DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
                                   targetCurrencyDiscountCurve_->discount(settlementDate);
+        DiscountFactor dfSourceSettlement =
+            sourceCurrencyDiscountCurve_->discount(settlementDate);
+        DiscountFactor dfTargetSettlement =
+            targetCurrencyDiscountCurve_->discount(settlementDate);
 
         // Calculate fair forward rate: F = S * dfSource / dfTarget
         // This is the forward rate targetCurrency/sourceCurrency
         results_.fairForwardRate = spotFxRate * dfSource / dfTarget;
 
-        // Calculate present values of each leg
+        // Calculate settlement-date present values of each leg
         // PV of source currency leg (in source currency)
         Real pvSource = arguments_.sourceNominal * dfSource;
 
@@ -86,22 +90,31 @@ namespace QuantLib {
         //   NPV = -PVSource + PVTarget (in source currency terms)
         // If paySourceCurrency is false: receive source currency, pay target currency
         //   NPV = +PVSource - PVTarget (in source currency terms)
-        Real npvInSourceCurrency;
+        Real npvAtSettlementInSourceCurrency;
         if (arguments_.paySourceCurrency) {
-            npvInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
+            npvAtSettlementInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
         } else {
-            npvInSourceCurrency = pvSource - pvTargetInSourceCurrency;
+            npvAtSettlementInSourceCurrency = pvSource - pvTargetInSourceCurrency;
         }
+
+        Real npvInSourceCurrency =
+            npvAtSettlementInSourceCurrency * dfSourceSettlement;
+        Real npvInTargetCurrency =
+            npvAtSettlementInSourceCurrency * spotFxRate * dfTargetSettlement;
 
         // Store results - NPV is as of the curve reference date
         results_.value = npvInSourceCurrency;
         results_.npvSourceCurrency = npvInSourceCurrency;
-        results_.npvTargetCurrency = npvInSourceCurrency * spotFxRate;
+        results_.npvTargetCurrency = npvInTargetCurrency;
 
         // Store additional results for inspection
         results_.additionalResults["spotFx"] = spotFxRate;
         results_.additionalResults["sourceCurrencyDiscountFactor"] = dfSource;
         results_.additionalResults["targetCurrencyDiscountFactor"] = dfTarget;
+        results_.additionalResults["sourceCurrencySettlementDiscountFactor"] =
+            dfSourceSettlement;
+        results_.additionalResults["targetCurrencySettlementDiscountFactor"] =
+            dfTargetSettlement;
         results_.additionalResults["sourceCurrencyPV"] = pvSource;
         results_.additionalResults["targetCurrencyPV"] = pvTarget;
     }

--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -48,8 +48,8 @@ namespace QuantLib {
         const Date& settlementDate = arguments_.settlementDate;
 
         // Validate that curve reference dates are on or before settlement date
-        Date sourceRefDate = sourceCurrencyDiscountCurve_->referenceDate();
-        Date targetRefDate = targetCurrencyDiscountCurve_->referenceDate();
+        const Date sourceRefDate = sourceCurrencyDiscountCurve_->referenceDate();
+        const Date targetRefDate = targetCurrencyDiscountCurve_->referenceDate();
         QL_REQUIRE(sourceRefDate <= settlementDate,
                    "source currency discount curve reference date (" << sourceRefDate
                    << ") must be on or before settlement date (" << settlementDate << ")");
@@ -58,17 +58,17 @@ namespace QuantLib {
                    << ") must be on or before settlement date (" << settlementDate << ")");
 
         // Get the spot FX rate (targetCurrency/sourceCurrency)
-        Real spotFxRate = spotFx_->value();
+        const Real spotFxRate = spotFx_->value();
         QL_REQUIRE(spotFxRate > 0.0, "spot FX rate must be positive");
 
         // Get discount factors from settlement to maturity
-        DiscountFactor dfSource = sourceCurrencyDiscountCurve_->discount(maturityDate) /
-                                  sourceCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
-                                  targetCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfSourceSettlement =
+        const DiscountFactor dfSource = sourceCurrencyDiscountCurve_->discount(maturityDate) /
+                                        sourceCurrencyDiscountCurve_->discount(settlementDate);
+        const DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
+                                        targetCurrencyDiscountCurve_->discount(settlementDate);
+        const DiscountFactor dfSourceSettlement =
             sourceCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfTargetSettlement =
+        const DiscountFactor dfTargetSettlement =
             targetCurrencyDiscountCurve_->discount(settlementDate);
 
         // Calculate fair forward rate: F = S * dfSource / dfTarget
@@ -77,29 +77,27 @@ namespace QuantLib {
 
         // Calculate settlement-date present values of each leg
         // PV of source currency leg (in source currency)
-        Real pvSource = arguments_.sourceNominal * dfSource;
+        const Real pvSource = arguments_.sourceNominal * dfSource;
 
         // PV of target currency leg (in target currency)
-        Real pvTarget = arguments_.targetNominal * dfTarget;
+        const Real pvTarget = arguments_.targetNominal * dfTarget;
 
         // Convert target currency PV to source currency using spot FX rate
-        Real pvTargetInSourceCurrency = pvTarget / spotFxRate;
+        const Real pvTargetInSourceCurrency = pvTarget / spotFxRate;
 
         // Calculate NPV based on direction of trade
         // If paySourceCurrency is true: pay source currency, receive target currency
         //   NPV = -PVSource + PVTarget (in source currency terms)
         // If paySourceCurrency is false: receive source currency, pay target currency
         //   NPV = +PVSource - PVTarget (in source currency terms)
-        Real npvAtSettlementInSourceCurrency;
-        if (arguments_.paySourceCurrency) {
-            npvAtSettlementInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
-        } else {
-            npvAtSettlementInSourceCurrency = pvSource - pvTargetInSourceCurrency;
-        }
+        const Real npvAtSettlementInSourceCurrency =
+            arguments_.paySourceCurrency ?
+                -pvSource + pvTargetInSourceCurrency :
+                pvSource - pvTargetInSourceCurrency;
 
-        Real npvInSourceCurrency =
+        const Real npvInSourceCurrency =
             npvAtSettlementInSourceCurrency * dfSourceSettlement;
-        Real npvInTargetCurrency =
+        const Real npvInTargetCurrency =
             npvAtSettlementInSourceCurrency * spotFxRate * dfTargetSettlement;
 
         // Store results - NPV is as of the curve reference date

--- a/ql/pricingengines/forward/discountingfxforwardengine.hpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
 
         The fair forward rate is computed as:
         \f[
-        F = S \times \frac{D_{target}(T)}{D_{source}(T)}
+        F = S \times \frac{D_{source}(T)}{D_{target}(T)}
         \f]
 
         \ingroup forwardengines

--- a/ql/pricingengines/forward/discountingfxforwardengine.hpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.hpp
@@ -34,21 +34,29 @@ namespace QuantLib {
     /*! This engine discounts the two legs of an FX forward using their
         respective currency discount curves.
 
-        The NPV is computed as:
+        The source-currency NPV is computed as:
         \f[
-        \text{NPV} = \pm N_{source} \times D_{source}(T) \mp N_{target} \times D_{target}(T) / S
+        \text{NPV}_{source} =
+            \left(\pm N_{source} \times D_{source}(\tau,T)
+            \mp N_{target} \times D_{target}(\tau,T) / S\right)
+            \times D_{source}(\tau)
         \f]
         where:
         - \f$ N_{source} \f$ is the source currency nominal
         - \f$ N_{target} \f$ is the target currency nominal
-        - \f$ D_{source}(T) \f$ is the source currency discount factor to maturity
-        - \f$ D_{target}(T) \f$ is the target currency discount factor to maturity
+        - \f$ D_{source}(\tau,T) \f$ is the source currency discount factor
+          from settlement to maturity
+        - \f$ D_{target}(\tau,T) \f$ is the target currency discount factor
+          from settlement to maturity
+        - \f$ D_{source}(\tau) \f$ is the source currency discount factor to
+          settlement
         - \f$ S \f$ is the spot FX rate (target/source)
+        - \f$ \tau \f$ is the settlement date
         - \f$ T \f$ is the maturity date
 
         The fair forward rate is computed as:
         \f[
-        F = S \times \frac{D_{source}(T)}{D_{target}(T)}
+        F = S \times \frac{D_{source}(\tau,T)}{D_{target}(\tau,T)}
         \f]
 
         \ingroup forwardengines

--- a/test-suite/fxforward.cpp
+++ b/test-suite/fxforward.cpp
@@ -196,17 +196,17 @@ BOOST_AUTO_TEST_CASE(testNPVDiscountedToReferenceDate) {
 
     fwd.setPricingEngine(engine);
 
-    Date settlementDate = fwd.settlementDate();
-    Real spotFx = vars.spotFxHandle->value();
-    DiscountFactor dfUsd = vars.usdCurveHandle->discount(vars.maturityDate) /
-                           vars.usdCurveHandle->discount(settlementDate);
-    DiscountFactor dfSgd = vars.sgdCurveHandle->discount(vars.maturityDate) /
-                           vars.sgdCurveHandle->discount(settlementDate);
+    const Date settlementDate = fwd.settlementDate();
+    const Real spotFx = vars.spotFxHandle->value();
+    const DiscountFactor dfUsd = vars.usdCurveHandle->discount(vars.maturityDate) /
+                                 vars.usdCurveHandle->discount(settlementDate);
+    const DiscountFactor dfSgd = vars.sgdCurveHandle->discount(vars.maturityDate) /
+                                 vars.sgdCurveHandle->discount(settlementDate);
 
-    Real npvAtSettlement = -usdNominal * dfUsd + sgdNominal * dfSgd / spotFx;
-    Real expectedSourceNpv =
+    const Real npvAtSettlement = -usdNominal * dfUsd + sgdNominal * dfSgd / spotFx;
+    const Real expectedSourceNpv =
         npvAtSettlement * vars.usdCurveHandle->discount(settlementDate);
-    Real expectedTargetNpv =
+    const Real expectedTargetNpv =
         npvAtSettlement * spotFx * vars.sgdCurveHandle->discount(settlementDate);
 
     QL_CHECK_CLOSE(fwd.NPV(), expectedSourceNpv, 1.0e-8);

--- a/test-suite/fxforward.cpp
+++ b/test-suite/fxforward.cpp
@@ -195,21 +195,27 @@ BOOST_AUTO_TEST_CASE(testFairForwardRate) {
 
     fwd.setPricingEngine(engine);
 
-    // Fair forward rate = Spot * (DFforeign / DFdomestic)
+    // Fair forward rate = Spot * (DFsource / DFtarget)
     // The engine calculates discount factors from settlement date to maturity
     // With USD as source currency (domestic) and SGD as target currency (foreign):
-    // F = S * (DF_SGD / DF_USD)
+    // F = S * (DF_USD / DF_SGD)
     Date settlementDate = fwd.settlementDate();
     Real spotFx = vars.spotFxHandle->value();
     Real dfUsd = vars.usdCurveHandle->discount(vars.maturityDate) /
                  vars.usdCurveHandle->discount(settlementDate);
     Real dfSgd = vars.sgdCurveHandle->discount(vars.maturityDate) /
                  vars.sgdCurveHandle->discount(settlementDate);
-    Real expectedFairRate = spotFx * dfSgd / dfUsd;
+    Real expectedFairRate = spotFx * dfUsd / dfSgd;
 
     Real calculatedFairRate = fwd.fairForwardRate();
 
     QL_CHECK_CLOSE(calculatedFairRate, expectedFairRate, 1.0e-4); // 0.0001% tolerance
+
+    FxForward atmFwd(usdNominal, vars.usd, vars.sgd, calculatedFairRate,
+                     vars.maturityDate, true);
+    atmFwd.setPricingEngine(engine);
+
+    QL_CHECK_SMALL(atmFwd.NPV(), 1.0e-4);
 }
 
 

--- a/test-suite/fxforward.cpp
+++ b/test-suite/fxforward.cpp
@@ -180,41 +180,6 @@ BOOST_AUTO_TEST_CASE(testDiscountingFxForwardEngine) {
 }
 
 
-BOOST_AUTO_TEST_CASE(testNPVDiscountedToReferenceDate) {
-    BOOST_TEST_MESSAGE("Testing FX-forward NPV is discounted to the reference date...");
-
-    CommonVars vars;
-
-    Real usdNominal = 1000000.0;
-    Real sgdNominal = 1350000.0;
-
-    FxForward fwd(usdNominal, vars.usd, sgdNominal, vars.sgd, vars.maturityDate,
-                  true);
-
-    auto engine = ext::make_shared<DiscountingFxForwardEngine>(
-        vars.usdCurveHandle, vars.sgdCurveHandle, vars.spotFxHandle);
-
-    fwd.setPricingEngine(engine);
-
-    const Date settlementDate = fwd.settlementDate();
-    const Real spotFx = vars.spotFxHandle->value();
-    const DiscountFactor dfUsd = vars.usdCurveHandle->discount(vars.maturityDate) /
-                                 vars.usdCurveHandle->discount(settlementDate);
-    const DiscountFactor dfSgd = vars.sgdCurveHandle->discount(vars.maturityDate) /
-                                 vars.sgdCurveHandle->discount(settlementDate);
-
-    const Real npvAtSettlement = -usdNominal * dfUsd + sgdNominal * dfSgd / spotFx;
-    const Real expectedSourceNpv =
-        npvAtSettlement * vars.usdCurveHandle->discount(settlementDate);
-    const Real expectedTargetNpv =
-        npvAtSettlement * spotFx * vars.sgdCurveHandle->discount(settlementDate);
-
-    QL_CHECK_CLOSE(fwd.NPV(), expectedSourceNpv, 1.0e-8);
-    QL_CHECK_CLOSE(fwd.npvSourceCurrency(), expectedSourceNpv, 1.0e-8);
-    QL_CHECK_CLOSE(fwd.npvTargetCurrency(), expectedTargetNpv, 1.0e-8);
-}
-
-
 BOOST_AUTO_TEST_CASE(testFairForwardRate) {
     BOOST_TEST_MESSAGE("Testing fair forward rate calculation...");
 

--- a/test-suite/fxforward.cpp
+++ b/test-suite/fxforward.cpp
@@ -180,6 +180,41 @@ BOOST_AUTO_TEST_CASE(testDiscountingFxForwardEngine) {
 }
 
 
+BOOST_AUTO_TEST_CASE(testNPVDiscountedToReferenceDate) {
+    BOOST_TEST_MESSAGE("Testing FX-forward NPV is discounted to the reference date...");
+
+    CommonVars vars;
+
+    Real usdNominal = 1000000.0;
+    Real sgdNominal = 1350000.0;
+
+    FxForward fwd(usdNominal, vars.usd, sgdNominal, vars.sgd, vars.maturityDate,
+                  true);
+
+    auto engine = ext::make_shared<DiscountingFxForwardEngine>(
+        vars.usdCurveHandle, vars.sgdCurveHandle, vars.spotFxHandle);
+
+    fwd.setPricingEngine(engine);
+
+    Date settlementDate = fwd.settlementDate();
+    Real spotFx = vars.spotFxHandle->value();
+    DiscountFactor dfUsd = vars.usdCurveHandle->discount(vars.maturityDate) /
+                           vars.usdCurveHandle->discount(settlementDate);
+    DiscountFactor dfSgd = vars.sgdCurveHandle->discount(vars.maturityDate) /
+                           vars.sgdCurveHandle->discount(settlementDate);
+
+    Real npvAtSettlement = -usdNominal * dfUsd + sgdNominal * dfSgd / spotFx;
+    Real expectedSourceNpv =
+        npvAtSettlement * vars.usdCurveHandle->discount(settlementDate);
+    Real expectedTargetNpv =
+        npvAtSettlement * spotFx * vars.sgdCurveHandle->discount(settlementDate);
+
+    QL_CHECK_CLOSE(fwd.NPV(), expectedSourceNpv, 1.0e-8);
+    QL_CHECK_CLOSE(fwd.npvSourceCurrency(), expectedSourceNpv, 1.0e-8);
+    QL_CHECK_CLOSE(fwd.npvTargetCurrency(), expectedTargetNpv, 1.0e-8);
+}
+
+
 BOOST_AUTO_TEST_CASE(testFairForwardRate) {
     BOOST_TEST_MESSAGE("Testing fair forward rate calculation...");
 


### PR DESCRIPTION
DiscountingFxForwardEngine currently returns a settlement-date value. When settlementDays > 0, this differs from the NPV as of the curve reference date.

This patch discounts the FX forward value back to the reference date so that the result matches the expected Instrument::NPV() convention.