### PR TITLE
Fix out-of-bounds read in Akima cubic interpolation with 3 points

### DIFF
--- a/ql/math/interpolations/cubicinterpolation.hpp
+++ b/ql/math/interpolations/cubicinterpolation.hpp
@@ -398,7 +398,12 @@ namespace QuantLib {
                     || rightType_ == CubicInterpolation::Lagrange) {
                     QL_REQUIRE((xEnd-xBegin) >= 4,
                                "Lagrange boundary condition requires at least "
-                               "4 points (" << (xEnd-xBegin) << " are given)"); 
+                               "4 points (" << (xEnd-xBegin) << " are given)");
+                }
+                if (da_ == CubicInterpolation::Akima) {
+                    QL_REQUIRE((xEnd-xBegin) >= 4,
+                               "Akima approximation requires at least "
+                               "4 points (" << (xEnd-xBegin) << " are given)");
                 }
             }
 

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1063,9 +1063,11 @@ BOOST_AUTO_TEST_CASE(testAkimaWithFewPoints) {
     // rather than read past the end of the vector.
     const Real x3[3] = { 0.0, 1.0, 2.0 };
     const Real y3[3] = { 1.0, 2.0, 0.5 };
-    BOOST_CHECK_THROW(AkimaCubicInterpolation(std::begin(x3), std::end(x3),
-                                              std::begin(y3)),
-                      QuantLib::Error);
+    BOOST_CHECK_EXCEPTION(AkimaCubicInterpolation(std::begin(x3), std::end(x3),
+                                                  std::begin(y3)),
+                          QuantLib::Error,
+                          ExpectedErrorMessage(
+                              "Akima approximation requires at least 4 points"));
 
     // Four points are enough; the interpolation must reproduce the knots.
     const Real x4[4] = { 0.0, 1.0, 2.0, 3.0 };

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1053,6 +1053,28 @@ BOOST_AUTO_TEST_CASE(testFritschButland) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testAkimaWithFewPoints) {
+
+    BOOST_TEST_MESSAGE("Testing Akima interpolation with few points...");
+
+    // The Akima scheme reads S_[2] and S_[n-4] while computing the
+    // first-derivative estimates; with three points S_ has size two and
+    // both indices are out of bounds. Construction must fail cleanly
+    // rather than read past the end of the vector.
+    const Real x3[3] = { 0.0, 1.0, 2.0 };
+    const Real y3[3] = { 1.0, 2.0, 0.5 };
+    BOOST_CHECK_THROW(AkimaCubicInterpolation(std::begin(x3), std::end(x3),
+                                              std::begin(y3)),
+                      QuantLib::Error);
+
+    // Four points are enough; the interpolation must reproduce the knots.
+    const Real x4[4] = { 0.0, 1.0, 2.0, 3.0 };
+    const Real y4[4] = { 1.0, 2.0, 0.5, 1.5 };
+    AkimaCubicInterpolation f(std::begin(x4), std::end(x4), std::begin(y4));
+    for (Size i=0; i<4; ++i)
+        BOOST_CHECK_CLOSE(f(x4[i]), y4[i], 1.0e-12);
+}
+
 BOOST_AUTO_TEST_CASE(testBackwardFlat) {
 
     BOOST_TEST_MESSAGE("Testing backward-flat interpolation...");


### PR DESCRIPTION
libc++ hardened mode aborts when AkimaCubicInterpolation is built from 3 points:

    vector.h:403: assertion __n < size() failed: vector[] index out of bounds

The Akima branch in `CubicInterpolationImpl::update()` reads `S_[2]` and `S_[n_-4]` while estimating the end-point derivatives, but `S_` has size `n_-1` (2 here), so three nodes index past the ends. Require at least 4 points, matching the existing Lagrange-boundary check in the same constructor.
