### PR TITLE
Fix out-of-bounds read in discrete integrals on degenerate grids

### DIFF
--- a/ql/math/integrals/discreteintegrals.cpp
+++ b/ql/math/integrals/discreteintegrals.cpp
@@ -27,6 +27,9 @@ namespace QuantLib {
         const Size n = f.size();
         QL_REQUIRE(n == x.size(), "inconsistent size");
 
+        if (n < 2)
+            return 0.0;
+
         Real sum = 0.0;
 
         for (Size i=0; i < n-1; ++i) {
@@ -41,6 +44,9 @@ namespace QuantLib {
 
         const Size n = f.size();
         QL_REQUIRE(n == x.size(), "inconsistent size");
+
+        if (n < 2)
+            return 0.0;
 
         Real sum = 0.0;
 

--- a/test-suite/integrals.cpp
+++ b/test-suite/integrals.cpp
@@ -340,6 +340,23 @@ BOOST_AUTO_TEST_CASE(testDiscreteIntegrals) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testDiscreteIntegralsWithFewPoints) {
+    BOOST_TEST_MESSAGE("Testing discrete integrals on degenerate grids...");
+
+    // With fewer than two nodes there is no interval to integrate, but the
+    // unsigned loop bounds (n-1, n-2) used to wrap around to SIZE_MAX and
+    // read past the arrays (e.g. a single-point Simpson rule indexing x[2]).
+    for (Size n=0; n < 2; ++n) {
+        Array x(n), f(n);
+        for (Size i=0; i < n; ++i) {
+            x[i] = Real(i);
+            f[i] = 1.0;
+        }
+        BOOST_CHECK_EQUAL(DiscreteTrapezoidIntegral()(x, f), 0.0);
+        BOOST_CHECK_EQUAL(DiscreteSimpsonIntegral()(x, f), 0.0);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testDiscreteIntegrator) {
     BOOST_TEST_MESSAGE("Testing discrete integrator formulae...");
 


### PR DESCRIPTION
DiscreteSimpsonIntegral and DiscreteTrapezoidIntegral loop on the unsigned bounds n-2 and n-1, so a one- or zero-element grid wraps the bound to SIZE_MAX and runs the body, reading past the arrays (a single-point Simpson rule already indexes x[2]). Return early when there are fewer than two nodes, where there is no interval and the integral is zero.