### PR TITLE
Fix out-of-bounds read in mixed interpolation switch point

### DIFF
--- a/ql/math/interpolations/mixedinterpolation.hpp
+++ b/ql/math/interpolations/mixedinterpolation.hpp
@@ -233,11 +233,10 @@ namespace QuantLib {
                                    SwitchFn switchFn)
             : Interpolation::templateImpl<I1, I2>(xBegin, xEnd, yBegin, 1),
               switchFn_(std::move(switchFn)) {
-                Size maxN = static_cast<Size>(xEnd - xBegin);
-                // SplitRanges needs xBegin2_+1 to be valid
-                if (behavior == MixedInterpolation::SplitRanges) {
-                    --maxN;
-                }
+                // the switch point xBegin_ + n is dereferenced in update() and
+                // value(), so it must be a valid element; for SplitRanges the
+                // first segment additionally reads xBegin_ + n + 1
+                Size maxN = static_cast<Size>(xEnd - xBegin) - 1;
                 // This only checks that we pass valid iterators into interpolate()
                 // calls below. The calls themselves check requiredPoints for each
                 // of the segments.

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1317,6 +1317,31 @@ BOOST_AUTO_TEST_CASE(testMixedLinearCubicMatchDerivatives) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testMixedLinearCubicSwitchPoint) {
+    BOOST_TEST_MESSAGE("Testing switch point bounds of mixed linear/cubic interpolation...");
+
+    Size n = 5;
+    std::vector<Real> x = xRange(-2.0, 2.0, n);
+    std::vector<Real> y = parabolic(x);
+
+    // a switch index equal to the number of points puts the switch
+    // iterator one past the end of the x range, which used to be
+    // dereferenced; it must be rejected instead
+    BOOST_CHECK_THROW(MixedLinearCubicNaturalSpline(x.begin(), x.end(), y.begin(), n),
+                      Error);
+
+    // the largest valid switch index still reproduces the knots
+    MixedLinearCubicNaturalSpline f(x.begin(), x.end(), y.begin(), n - 1);
+    for (Size i = 0; i < n; ++i) {
+        Real interpolated = f(x[i]);
+        if (std::fabs(interpolated - y[i]) > 1e-12)
+            BOOST_ERROR("failed to reproduce knot " << i
+                        << std::scientific
+                        << "\n    expected:     " << y[i]
+                        << "\n    interpolated: " << interpolated);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testSabrInterpolation){
 
     BOOST_TEST_MESSAGE("Testing Sabr interpolation...");

--- a/test-suite/interpolations.cpp
+++ b/test-suite/interpolations.cpp
@@ -1327,8 +1327,10 @@ BOOST_AUTO_TEST_CASE(testMixedLinearCubicSwitchPoint) {
     // a switch index equal to the number of points puts the switch
     // iterator one past the end of the x range, which used to be
     // dereferenced; it must be rejected instead
-    BOOST_CHECK_THROW(MixedLinearCubicNaturalSpline(x.begin(), x.end(), y.begin(), n),
-                      Error);
+    BOOST_CHECK_EXCEPTION(
+        MixedLinearCubicNaturalSpline(x.begin(), x.end(), y.begin(), n),
+        Error,
+        ExpectedErrorMessage("n is too large"));
 
     // the largest valid switch index still reproduces the knots
     MixedLinearCubicNaturalSpline f(x.begin(), x.end(), y.begin(), n - 1);


### PR DESCRIPTION
MixedInterpolationImpl sets the switch iterator to xBegin_ + n and dereferences it in update() and value(), but for ShareRanges the bound only required n <= xEnd_ - xBegin_. Passing n equal to the number of points (e.g. MixedLinearCubicNaturalSpline, which defaults to ShareRanges) leaves the switch point at xEnd_ and reads one past the array. Cap n at one below the point count, matching the SplitRanges case.