### PR TITLE
Discount FX-forward NPV to reference date

### DIFF
--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -61,17 +61,21 @@ namespace QuantLib {
         Real spotFxRate = spotFx_->value();
         QL_REQUIRE(spotFxRate > 0.0, "spot FX rate must be positive");
 
-        // Get discount factors to maturity
+        // Get discount factors from settlement to maturity
         DiscountFactor dfSource = sourceCurrencyDiscountCurve_->discount(maturityDate) /
                                   sourceCurrencyDiscountCurve_->discount(settlementDate);
         DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
                                   targetCurrencyDiscountCurve_->discount(settlementDate);
+        DiscountFactor dfSourceSettlement =
+            sourceCurrencyDiscountCurve_->discount(settlementDate);
+        DiscountFactor dfTargetSettlement =
+            targetCurrencyDiscountCurve_->discount(settlementDate);
 
         // Calculate fair forward rate: F = S * dfSource / dfTarget
         // This is the forward rate targetCurrency/sourceCurrency
         results_.fairForwardRate = spotFxRate * dfSource / dfTarget;
 
-        // Calculate present values of each leg
+        // Calculate settlement-date present values of each leg
         // PV of source currency leg (in source currency)
         Real pvSource = arguments_.sourceNominal * dfSource;
 
@@ -86,22 +90,31 @@ namespace QuantLib {
         //   NPV = -PVSource + PVTarget (in source currency terms)
         // If paySourceCurrency is false: receive source currency, pay target currency
         //   NPV = +PVSource - PVTarget (in source currency terms)
-        Real npvInSourceCurrency;
+        Real npvAtSettlementInSourceCurrency;
         if (arguments_.paySourceCurrency) {
-            npvInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
+            npvAtSettlementInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
         } else {
-            npvInSourceCurrency = pvSource - pvTargetInSourceCurrency;
+            npvAtSettlementInSourceCurrency = pvSource - pvTargetInSourceCurrency;
         }
+
+        Real npvInSourceCurrency =
+            npvAtSettlementInSourceCurrency * dfSourceSettlement;
+        Real npvInTargetCurrency =
+            npvAtSettlementInSourceCurrency * spotFxRate * dfTargetSettlement;
 
         // Store results - NPV is as of the curve reference date
         results_.value = npvInSourceCurrency;
         results_.npvSourceCurrency = npvInSourceCurrency;
-        results_.npvTargetCurrency = npvInSourceCurrency * spotFxRate;
+        results_.npvTargetCurrency = npvInTargetCurrency;
 
         // Store additional results for inspection
         results_.additionalResults["spotFx"] = spotFxRate;
         results_.additionalResults["sourceCurrencyDiscountFactor"] = dfSource;
         results_.additionalResults["targetCurrencyDiscountFactor"] = dfTarget;
+        results_.additionalResults["sourceCurrencySettlementDiscountFactor"] =
+            dfSourceSettlement;
+        results_.additionalResults["targetCurrencySettlementDiscountFactor"] =
+            dfTargetSettlement;
         results_.additionalResults["sourceCurrencyPV"] = pvSource;
         results_.additionalResults["targetCurrencyPV"] = pvTarget;
     }

--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -48,8 +48,8 @@ namespace QuantLib {
         const Date& settlementDate = arguments_.settlementDate;
 
         // Validate that curve reference dates are on or before settlement date
-        Date sourceRefDate = sourceCurrencyDiscountCurve_->referenceDate();
-        Date targetRefDate = targetCurrencyDiscountCurve_->referenceDate();
+        const Date sourceRefDate = sourceCurrencyDiscountCurve_->referenceDate();
+        const Date targetRefDate = targetCurrencyDiscountCurve_->referenceDate();
         QL_REQUIRE(sourceRefDate <= settlementDate,
                    "source currency discount curve reference date (" << sourceRefDate
                    << ") must be on or before settlement date (" << settlementDate << ")");
@@ -58,17 +58,19 @@ namespace QuantLib {
                    << ") must be on or before settlement date (" << settlementDate << ")");
 
         // Get the spot FX rate (targetCurrency/sourceCurrency)
-        Real spotFxRate = spotFx_->value();
+        const Real spotFxRate = spotFx_->value();
         QL_REQUIRE(spotFxRate > 0.0, "spot FX rate must be positive");
 
         // Get discount factors from settlement to maturity
-        DiscountFactor dfSource = sourceCurrencyDiscountCurve_->discount(maturityDate) /
-                                  sourceCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfTarget = targetCurrencyDiscountCurve_->discount(maturityDate) /
-                                  targetCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfSourceSettlement =
+        const DiscountFactor dfSource =
+            sourceCurrencyDiscountCurve_->discount(maturityDate) /
             sourceCurrencyDiscountCurve_->discount(settlementDate);
-        DiscountFactor dfTargetSettlement =
+        const DiscountFactor dfTarget =
+            targetCurrencyDiscountCurve_->discount(maturityDate) /
+            targetCurrencyDiscountCurve_->discount(settlementDate);
+        const DiscountFactor dfSourceSettlement =
+            sourceCurrencyDiscountCurve_->discount(settlementDate);
+        const DiscountFactor dfTargetSettlement =
             targetCurrencyDiscountCurve_->discount(settlementDate);
 
         // Calculate fair forward rate: F = S * dfSource / dfTarget
@@ -77,29 +79,27 @@ namespace QuantLib {
 
         // Calculate settlement-date present values of each leg
         // PV of source currency leg (in source currency)
-        Real pvSource = arguments_.sourceNominal * dfSource;
+        const Real pvSource = arguments_.sourceNominal * dfSource;
 
         // PV of target currency leg (in target currency)
-        Real pvTarget = arguments_.targetNominal * dfTarget;
+        const Real pvTarget = arguments_.targetNominal * dfTarget;
 
         // Convert target currency PV to source currency using spot FX rate
-        Real pvTargetInSourceCurrency = pvTarget / spotFxRate;
+        const Real pvTargetInSourceCurrency = pvTarget / spotFxRate;
 
         // Calculate NPV based on direction of trade
         // If paySourceCurrency is true: pay source currency, receive target currency
         //   NPV = -PVSource + PVTarget (in source currency terms)
         // If paySourceCurrency is false: receive source currency, pay target currency
         //   NPV = +PVSource - PVTarget (in source currency terms)
-        Real npvAtSettlementInSourceCurrency;
-        if (arguments_.paySourceCurrency) {
-            npvAtSettlementInSourceCurrency = -pvSource + pvTargetInSourceCurrency;
-        } else {
-            npvAtSettlementInSourceCurrency = pvSource - pvTargetInSourceCurrency;
-        }
+        const Real npvAtSettlementInSourceCurrency =
+            arguments_.paySourceCurrency ?
+                -pvSource + pvTargetInSourceCurrency :
+                pvSource - pvTargetInSourceCurrency;
 
-        Real npvInSourceCurrency =
+        const Real npvInSourceCurrency =
             npvAtSettlementInSourceCurrency * dfSourceSettlement;
-        Real npvInTargetCurrency =
+        const Real npvInTargetCurrency =
             npvAtSettlementInSourceCurrency * spotFxRate * dfTargetSettlement;
 
         // Store results - NPV is as of the curve reference date

--- a/ql/pricingengines/forward/discountingfxforwardengine.hpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.hpp
@@ -34,21 +34,29 @@ namespace QuantLib {
     /*! This engine discounts the two legs of an FX forward using their
         respective currency discount curves.
 
-        The NPV is computed as:
+        The source-currency NPV is computed as:
         \f[
-        \text{NPV} = \pm N_{source} \times D_{source}(T) \mp N_{target} \times D_{target}(T) / S
+        \text{NPV}_{source} =
+            \left(\pm N_{source} \times D_{source}(\tau,T)
+            \mp N_{target} \times D_{target}(\tau,T) / S\right)
+            \times D_{source}(\tau)
         \f]
         where:
         - \f$ N_{source} \f$ is the source currency nominal
         - \f$ N_{target} \f$ is the target currency nominal
-        - \f$ D_{source}(T) \f$ is the source currency discount factor to maturity
-        - \f$ D_{target}(T) \f$ is the target currency discount factor to maturity
+        - \f$ D_{source}(\tau,T) \f$ is the source currency discount factor
+          from settlement to maturity
+        - \f$ D_{target}(\tau,T) \f$ is the target currency discount factor
+          from settlement to maturity
+        - \f$ D_{source}(\tau) \f$ is the source currency discount factor to
+          settlement
         - \f$ S \f$ is the spot FX rate (target/source)
+        - \f$ \tau \f$ is the settlement date
         - \f$ T \f$ is the maturity date
 
         The fair forward rate is computed as:
         \f[
-        F = S \times \frac{D_{source}(T)}{D_{target}(T)}
+        F = S \times \frac{D_{source}(\tau,T)}{D_{target}(\tau,T)}
         \f]
 
         \ingroup forwardengines


### PR DESCRIPTION
DiscountingFxForwardEngine::calculate() currently returns the NPV as of the FX forward settlement date instead of the discount curve reference date. Discount the settlement-date NPV back to the curve reference date.