### PR TITLE
Use `make_shared` in day counters

### DIFF
--- a/ql/time/daycounters/actual360.hpp
+++ b/ql/time/daycounters/actual360.hpp
@@ -58,8 +58,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual360(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual360::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual360::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actual364.hpp
+++ b/ql/time/daycounters/actual364.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         };
       public:
         Actual364()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Actual364::Impl)) {}
+        : DayCounter(ext::make_shared<Actual364::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/actual36525.hpp
+++ b/ql/time/daycounters/actual36525.hpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual36525(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual36525::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual36525::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actual365fixed.cpp
+++ b/ql/time/daycounters/actual365fixed.cpp
@@ -27,11 +27,11 @@ namespace QuantLib {
     Actual365Fixed::implementation(Actual365Fixed::Convention c) {
         switch (c) {
           case Standard:
-            return ext::shared_ptr<DayCounter::Impl>(new Impl);
+            return ext::make_shared<Impl>();
           case Canadian:
-            return ext::shared_ptr<DayCounter::Impl>(new CA_Impl);
+            return ext::make_shared<CA_Impl>();
           case NoLeap:
-            return ext::shared_ptr<DayCounter::Impl>(new NL_Impl);
+            return ext::make_shared<NL_Impl>();
           default:
             QL_FAIL("unknown Actual/365 (Fixed) convention");
         }

--- a/ql/time/daycounters/actual366.hpp
+++ b/ql/time/daycounters/actual366.hpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         };
       public:
         explicit Actual366(const bool includeLastDay = false)
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-            new Actual366::Impl(includeLastDay))) {}
+        : DayCounter(ext::make_shared<Actual366::Impl>(includeLastDay)) {}
     };
 
 }

--- a/ql/time/daycounters/actualactual.cpp
+++ b/ql/time/daycounters/actualactual.cpp
@@ -118,16 +118,16 @@ namespace QuantLib {
           case ISMA:
           case Bond:
             if (!schedule.empty())
-                return ext::shared_ptr<DayCounter::Impl>(new ISMA_Impl(std::move(schedule)));
+                return ext::make_shared<ISMA_Impl>(std::move(schedule));
             else
-                return ext::shared_ptr<DayCounter::Impl>(new Old_ISMA_Impl);
+                return ext::make_shared<Old_ISMA_Impl>();
           case ISDA:
           case Historical:
           case Actual365:
-            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl);
+            return ext::make_shared<ISDA_Impl>();
           case AFB:
           case Euro:
-            return ext::shared_ptr<DayCounter::Impl>(new AFB_Impl);
+            return ext::make_shared<AFB_Impl>();
           default:
             QL_FAIL("unknown act/act convention");
         }

--- a/ql/time/daycounters/business252.hpp
+++ b/ql/time/daycounters/business252.hpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         };
       public:
         Business252(const Calendar& c = Brazil())
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Business252::Impl(c))) {}
+        : DayCounter(ext::make_shared<Business252::Impl>(c)) {}
     };
 
 }

--- a/ql/time/daycounters/one.hpp
+++ b/ql/time/daycounters/one.hpp
@@ -46,8 +46,7 @@ namespace QuantLib {
         };
       public:
         OneDayCounter()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-                                        new OneDayCounter::Impl)) {}
+        : DayCounter(ext::make_shared<OneDayCounter::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/simpledaycounter.hpp
+++ b/ql/time/daycounters/simpledaycounter.hpp
@@ -54,8 +54,7 @@ namespace QuantLib {
         };
       public:
         SimpleDayCounter()
-        : DayCounter(ext::shared_ptr<DayCounter::Impl>(
-                                             new SimpleDayCounter::Impl())) {}
+        : DayCounter(ext::make_shared<SimpleDayCounter::Impl>()) {}
     };
 
 }

--- a/ql/time/daycounters/thirty360.cpp
+++ b/ql/time/daycounters/thirty360.cpp
@@ -35,20 +35,20 @@ namespace QuantLib {
     Thirty360::implementation(Thirty360::Convention c, const Date& terminationDate) {
         switch (c) {
           case USA:
-            return ext::shared_ptr<DayCounter::Impl>(new US_Impl);
+            return ext::make_shared<US_Impl>();
           case European:
           case EurobondBasis:
-            return ext::shared_ptr<DayCounter::Impl>(new EU_Impl);
+            return ext::make_shared<EU_Impl>();
           case Italian:
-            return ext::shared_ptr<DayCounter::Impl>(new IT_Impl);
+            return ext::make_shared<IT_Impl>();
           case ISMA:
           case BondBasis:
-            return ext::shared_ptr<DayCounter::Impl>(new ISMA_Impl);
+            return ext::make_shared<ISMA_Impl>();
           case ISDA:
           case German:
-            return ext::shared_ptr<DayCounter::Impl>(new ISDA_Impl(terminationDate));
+            return ext::make_shared<ISDA_Impl>(terminationDate);
           case NASD:
-            return ext::shared_ptr<DayCounter::Impl>(new NASD_Impl);
+            return ext::make_shared<NASD_Impl>();
           default:
             QL_FAIL("unknown 30/360 convention");
         }

--- a/ql/time/daycounters/thirty365.cpp
+++ b/ql/time/daycounters/thirty365.cpp
@@ -36,6 +36,6 @@ namespace QuantLib {
     }
 
     Thirty365::Thirty365()
-    : DayCounter(ext::shared_ptr<DayCounter::Impl>(new Thirty365::Impl)) {}
+    : DayCounter(ext::make_shared<Thirty365::Impl>()) {}
 
 }


### PR DESCRIPTION
Replace explicit shared_ptr construction with ext::make_shared in day-counter implementations.