### PR TITLE
Use `make_shared` in cap/floor volatilities and null calendar

### DIFF
--- a/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolcurve.cpp
@@ -91,8 +91,7 @@ namespace QuantLib {
         initializeOptionDatesAndTimes();
         // fill dummy handles to allow generic handle-based computations later
         for (Size i=0; i<nOptionTenors_; ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(vols_[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i]));
         interpolate();
     }
 
@@ -116,8 +115,7 @@ namespace QuantLib {
         initializeOptionDatesAndTimes();
         // fill dummy handles to allow generic handle-based computations later
         for (Size i=0; i<nOptionTenors_; ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(vols_[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i]));
         interpolate();
     }
 

--- a/ql/termstructures/volatility/capfloor/capfloortermvolsurface.cpp
+++ b/ql/termstructures/volatility/capfloor/capfloortermvolsurface.cpp
@@ -114,8 +114,8 @@ namespace QuantLib {
         for (Size i=0; i<nOptionTenors_; ++i) {
             volHandles_[i].resize(nStrikes_);
             for (Size j=0; j<nStrikes_; ++j)
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols_[i][j])));
+                volHandles_[i][j] =
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i][j]));
         }
         interpolate();
     }
@@ -145,8 +145,8 @@ namespace QuantLib {
         for (Size i=0; i<nOptionTenors_; ++i) {
             volHandles_[i].resize(nStrikes_);
             for (Size j=0; j<nStrikes_; ++j)
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols_[i][j])));
+                volHandles_[i][j] =
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(vols_[i][j]));
         }
         interpolate();
     }

--- a/ql/termstructures/volatility/capfloor/constantcapfloortermvol.cpp
+++ b/ql/termstructures/volatility/capfloor/constantcapfloortermvol.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
                                                     Volatility vol,
                                                     const DayCounter& dc)
     : CapFloorTermVolatilityStructure(settlementDays, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))) {}
+      volatility_(ext::make_shared<SimpleQuote>(vol)) {}
 
     // fixed reference date, fixed market data
     ConstantCapFloorTermVolatility::ConstantCapFloorTermVolatility(
@@ -61,7 +61,7 @@ namespace QuantLib {
                                                     Volatility vol,
                                                     const DayCounter& dc)
     : CapFloorTermVolatilityStructure(referenceDate, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))) {}
+      volatility_(ext::make_shared<SimpleQuote>(vol)) {}
 
     Volatility ConstantCapFloorTermVolatility::volatilityImpl(Time,
                                                               Rate) const {

--- a/ql/time/calendars/nullcalendar.hpp
+++ b/ql/time/calendars/nullcalendar.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         };
       public:
         NullCalendar() {
-            impl_ = ext::shared_ptr<Calendar::Impl>(new NullCalendar::Impl);
+            impl_ = ext::make_shared<NullCalendar::Impl>();
         }
     };
 


### PR DESCRIPTION
mechanical change from shared_ptr<T>(new ... ) to make_shared<T>(...) from termstructures/volatility/ with omitted NullCalendar part