### PR TITLE
New TELBOR case for Israel calendar; update weekdays for TASE

### DIFF
--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -393,13 +393,6 @@ namespace QuantLib {
         bool isBusinessDay(const Date&) const override;
     };
 
-    class Israel::TelAvivNationalImpl final : public Calendar::Impl {
-      public:
-        std::string name() const override { return "Tel Aviv stock exchange (national days)"; }
-        bool isWeekend(Weekday) const override;
-        bool isBusinessDay(const Date&) const override;
-    };
-
     class Israel::TelborImpl final : public Calendar::Impl {
       public:
         std::string name() const override { return "Israel Telbor Implementation"; }
@@ -417,15 +410,11 @@ namespace QuantLib {
         // all calendar instances share the same implementation instance
         static auto telAvivImpl = ext::make_shared<Israel::TelAvivImpl>();
         static auto shirImpl = ext::make_shared<Israel::ShirImpl>();
-        static auto telAvivNationalImpl = ext::make_shared<Israel::TelAvivNationalImpl>();
         static auto telborImpl = ext::make_shared<Israel::TelborImpl>();
         switch (market) {
         case Settlement:
         case TASE:
             impl_ = telAvivImpl;
-            break;
-        case TASE_National:
-            impl_ = telAvivNationalImpl;
             break;
         case Telbor:
             impl_ = telborImpl;
@@ -445,8 +434,12 @@ namespace QuantLib {
     bool Israel::TelAvivImpl::isBusinessDay(const Date& date) const {
         Weekday w = date.weekday();
         Year y = date.year();
+        const Date switchDate(5, January, 2026);
+        bool weekend = isWeekend(w);
+        if (date >= switchDate)
+            weekend = (w == Saturday || w == Sunday);
 
-        if (isWeekend(w)
+        if (weekend
             || isPurim(date)
             || (y <= 2020 && isPassover1st(date+1)) // Eve of Passover, until 2020
             || isPassover1st(date)
@@ -471,38 +464,6 @@ namespace QuantLib {
         return true;
     }
 
-    bool Israel::TelAvivNationalImpl::isWeekend(Weekday w) const {
-        return w == Saturday || w == Sunday;
-    }
-
-    bool Israel::TelAvivNationalImpl::isBusinessDay(const Date& date) const {
-        Weekday w = date.weekday();
-        Year y = date.year();
-
-        if (isWeekend(w)
-            || isPurim(date)
-            || (y <= 2020 && isPassover1st(date+1)) // Eve of Passover, until 2020
-            || isPassover1st(date)
-            || isPassover1st(date-5) // Eve of Passover VII, until 2020
-            || isPassover1st(date-6) // Passover VII
-            || isMemorialDay(date)
-            || isIndependenceDay(date)
-            || (y <= 2020 && isShavuot(date+1)) // Eve of Shavuot, until 2020
-            || isShavuot(date)
-            || isFastDay(date)
-            || (y <= 2019 && isNewYearsDay(date+1))  // Eve of new year, until 2019
-            || isNewYearsDay(date)
-            || isNewYearsDay(date-1)  // 2nd day of new year
-            || isYomKippur(date+1) // Eve of Yom Kippur
-            || isYomKippur(date)
-            || isSukkot(date+1)  // Eve of Sukkot
-            || isSukkot(date)
-            || isSimchatTorah(date+1)  // Eve of Simchat Torah
-            || isSimchatTorah(date))
-            return false; // NOLINT(readability-simplify-boolean-expr)
-
-        return true;
-    }
 
     bool Israel::TelborImpl::isWeekend(Weekday w) const {
         return w == Saturday || w == Sunday;

--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -412,7 +412,9 @@ namespace QuantLib {
         static auto shirImpl = ext::make_shared<Israel::ShirImpl>();
         static auto telborImpl = ext::make_shared<Israel::TelborImpl>();
         switch (market) {
+        QL_DEPRECATED_DISABLE_WARNING
         case Settlement:
+        QL_DEPRECATED_ENABLE_WARNING
         case TASE:
             impl_ = telAvivImpl;
             break;

--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -393,6 +393,20 @@ namespace QuantLib {
         bool isBusinessDay(const Date&) const override;
     };
 
+    class Israel::TelAvivNationalImpl final : public Calendar::Impl {
+      public:
+        std::string name() const override { return "Tel Aviv stock exchange (national days)"; }
+        bool isWeekend(Weekday) const override;
+        bool isBusinessDay(const Date&) const override;
+    };
+
+    class Israel::TelborImpl final : public Calendar::Impl {
+      public:
+        std::string name() const override { return "Israel Telbor Implementation"; }
+        bool isWeekend(Weekday) const override;
+        bool isBusinessDay(const Date&) const override;
+    };
+
     class Israel::ShirImpl final : public Calendar::WesternImpl {
       public:
         std::string name() const override { return "SHIR fixing calendar"; }
@@ -403,11 +417,19 @@ namespace QuantLib {
         // all calendar instances share the same implementation instance
         static auto telAvivImpl = ext::make_shared<Israel::TelAvivImpl>();
         static auto shirImpl = ext::make_shared<Israel::ShirImpl>();
+        static auto telAvivNationalImpl = ext::make_shared<Israel::TelAvivNationalImpl>();
+        static auto telborImpl = ext::make_shared<Israel::TelborImpl>();
         switch (market) {
         case Settlement:
         case TASE:
             impl_ = telAvivImpl;
             break;
+        case TASE_National:
+            impl_ = telAvivNationalImpl;
+            break;
+        case Telbor:
+            impl_ = telborImpl;
+            break; 
         case SHIR:
             impl_ = shirImpl;
             break;
@@ -444,6 +466,91 @@ namespace QuantLib {
             || isSukkot(date)
             || isSimchatTorah(date+1)  // Eve of Simchat Torah
             || isSimchatTorah(date))
+            return false; // NOLINT(readability-simplify-boolean-expr)
+
+        return true;
+    }
+
+    bool Israel::TelAvivNationalImpl::isWeekend(Weekday w) const {
+        return w == Saturday || w == Sunday;
+    }
+
+    bool Israel::TelAvivNationalImpl::isBusinessDay(const Date& date) const {
+        Weekday w = date.weekday();
+        Year y = date.year();
+
+        if (isWeekend(w)
+            || isPurim(date)
+            || (y <= 2020 && isPassover1st(date+1)) // Eve of Passover, until 2020
+            || isPassover1st(date)
+            || isPassover1st(date-5) // Eve of Passover VII, until 2020
+            || isPassover1st(date-6) // Passover VII
+            || isMemorialDay(date)
+            || isIndependenceDay(date)
+            || (y <= 2020 && isShavuot(date+1)) // Eve of Shavuot, until 2020
+            || isShavuot(date)
+            || isFastDay(date)
+            || (y <= 2019 && isNewYearsDay(date+1))  // Eve of new year, until 2019
+            || isNewYearsDay(date)
+            || isNewYearsDay(date-1)  // 2nd day of new year
+            || isYomKippur(date+1) // Eve of Yom Kippur
+            || isYomKippur(date)
+            || isSukkot(date+1)  // Eve of Sukkot
+            || isSukkot(date)
+            || isSimchatTorah(date+1)  // Eve of Simchat Torah
+            || isSimchatTorah(date))
+            return false; // NOLINT(readability-simplify-boolean-expr)
+
+        return true;
+    }
+
+    bool Israel::TelborImpl::isWeekend(Weekday w) const {
+        return w == Saturday || w == Sunday;
+    }
+
+    bool Israel::TelborImpl::isBusinessDay(const Date& date) const {
+        Weekday w = date.weekday();
+        Day d = date.dayOfMonth();
+        Month m = date.month();
+        Year y = date.year();
+
+        if (isWeekend(w)
+            // New Year's Day
+            || (d == 1 && m == January)
+            // General Elections
+            || (((d == 9 && m == April) || (d == 17 && m == September)) && y == 2019)
+            || (d == 2 && m == March && y == 2020)
+            // Holiday abroad
+            || (((d == 22 && m == April) || (d == 27 && m == May)) && y == 2019)
+            || ((((d == 10 || d == 13) && m == April) || ((d == 8 || d == 25) && m == May)) && y == 2020)
+            // Purim
+            || isPurim(date)
+            || isPurim(date-1) // Shushan Purim
+            // Passover I and Passover VII
+            || isPassover1st(date+1) // Eve of Passover
+            || isPassover1st(date)
+            || isPassover1st(date-6) // Passover VII
+            // Israel Independence Day
+            || isIndependenceDay(date)
+            // Feast of Shavuot (Pentecost)
+            || isShavuot(date)
+            // Fast of Ninth of Av
+            || isFastDay(date)
+            // Jewish New Year (Rosh Hashanah)
+            || isNewYearsDay(date)
+            || isNewYearsDay(date-1) // 2nd day of new year
+            // Day of Atonement (Yom Kippur)
+            || isYomKippur(date)
+            // First Day of Sukkot (Tabernacles)
+            || isSukkot(date)
+            // Rejoicing of the Law Festival (Simchat Torah)
+            || isSimchatTorah(date)
+            // last Monday of May (Spring Bank Holiday)
+            || (d >= 25 && w == Monday && m == May && y != 2002 && y != 2012)
+            // Christmas
+            || (d == 25 && m == December)
+            // Day of Goodwill (Boxing Day)
+            || (d == 26 && m == December && y >= 2000 && y != 2020))
             return false; // NOLINT(readability-simplify-boolean-expr)
 
         return true;

--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -428,7 +428,7 @@ namespace QuantLib {
     }
 
     bool Israel::TelAvivImpl::isWeekend(Weekday w) const {
-        return w == Friday || w == Saturday;
+        return w == Saturday || w == Sunday;
     }
 
     bool Israel::TelAvivImpl::isBusinessDay(const Date& date) const {

--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -435,9 +435,12 @@ namespace QuantLib {
         Weekday w = date.weekday();
         Year y = date.year();
         const Date switchDate(5, January, 2026);
-        bool weekend = isWeekend(w);
+        
+        bool weekend;
         if (date >= switchDate)
             weekend = (w == Saturday || w == Sunday);
+        else
+            weekend = (w == Friday || w == Saturday);
 
         if (weekend
             || isPurim(date)

--- a/ql/time/calendars/israel.cpp
+++ b/ql/time/calendars/israel.cpp
@@ -395,7 +395,7 @@ namespace QuantLib {
 
     class Israel::TelborImpl final : public Calendar::Impl {
       public:
-        std::string name() const override { return "Israel Telbor Implementation"; }
+        std::string name() const override { return "Telbor fixing calendar"; }
         bool isWeekend(Weekday) const override;
         bool isBusinessDay(const Date&) const override;
     };
@@ -407,7 +407,7 @@ namespace QuantLib {
     };
 
     Israel::Israel(Israel::Market market) {
-        // all calendar instances share the same implementation instance
+        // all calendar instances for the same market share the same implementation instance
         static auto telAvivImpl = ext::make_shared<Israel::TelAvivImpl>();
         static auto shirImpl = ext::make_shared<Israel::ShirImpl>();
         static auto telborImpl = ext::make_shared<Israel::TelborImpl>();

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -61,11 +61,11 @@ namespace QuantLib {
     class Israel : public Calendar {
       private:
         class TelAvivImpl;
+        class TelborImpl;
         class ShirImpl;
       public:
           enum Market { Settlement,     //!< generic settlement calendar
                         TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026)
-                        TASE_National,  //!< Tel-Aviv stock exchange calendar (Sat/Sun weekends, from Jan 5 2026)
                         Telbor,         //!< TELBOR fixing calendar (Sat/Sun weekends)
                         SHIR            //!< SHIR fixing calendar
           };

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -65,9 +65,9 @@ namespace QuantLib {
         class ShirImpl;
       public:
           enum Market { Settlement,     //!< generic settlement calendar
-                        TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026)
+                        TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026; Sat/Sun afterwards)
                         Telbor,         //!< TELBOR fixing calendar (Sat/Sun weekends)
-                        SHIR            //!< SHIR fixing calendar
+                        SHIR            //!< SHIR fixing calendar (Sat/Sun weekends)
           };
           Israel(Market market = Settlement);
     };

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -64,7 +64,9 @@ namespace QuantLib {
         class ShirImpl;
       public:
           enum Market { Settlement,     //!< generic settlement calendar
-                        TASE,           //!< Tel-Aviv stock exchange calendar
+                        TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026)
+                        TASE_National,  //!< Tel-Aviv stock exchange calendar (Sat/Sun weekends, from Jan 5 2026)
+                        Telbor,         //!< TELBOR fixing calendar (Sat/Sun weekends)
                         SHIR            //!< SHIR fixing calendar
           };
           Israel(Market market = Settlement);

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -102,12 +102,13 @@ namespace QuantLib {
         class ShirImpl;
       public:
           enum Market {
-              Settlement,     //!< generic settlement calendar
-              TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026; Sat/Sun afterwards)
-              Telbor,         //!< Telbor fixing calendar (Sat/Sun weekends)
-              SHIR            //!< SHIR fixing calendar (Sat/Sun weekends)
+              Settlement [[deprecated("Use an explicit market")]] = 0,     /*!< generic settlement calendar.
+                                                                                \deprecated Use an explicit market. Deprecated in version 1.43. */
+              TASE = 1,    //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026; Sat/Sun afterwards)
+              Telbor = 2,  //!< Telbor fixing calendar (Sat/Sun weekends)
+              SHIR = 3     //!< SHIR fixing calendar (Sat/Sun weekends)
           };
-          Israel(Market market = Settlement);
+          Israel(Market market = TASE);
     };
 
 }

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -33,11 +33,10 @@ namespace QuantLib {
     /*! Due to the lack of reliable sources, the settlement calendar
         has the same holidays as the Tel Aviv stock-exchange.
 
-        Holidays for the Tel-Aviv Stock Exchange
+        Holidays for the Tel-Aviv Stock Exchange (TASE)
         (data from <http://www.tase.co.il>):
         <ul>
-        <li>Friday</li>
-        <li>Saturday</li>
+        <li>Weekdays: Friday and Saturday until 2025, Saturday and Sunday since 2026</li>
         </ul>
         Other holidays for wich no rule is given
         (data available for 2013-2044 only:)
@@ -55,6 +54,44 @@ namespace QuantLib {
         <li>Simchat Tora, Tishrei 22nd (between Sep 26th & Oct 26th)</li>
         </ul>
 
+        Holidays for the Telbor fixing calendar:
+        <ul>
+        <li>Weekdays: Saturday and Sunday</li>
+        <li>Purim I and II</li>
+        <li>Passover Eve, I and VII</li>
+        <li>Indipendence Day</li>
+        <li>Pentecost (Shavuot)</li>
+        <li>Fast Day</li>
+        <li>Jewish New Year I and II</li>
+        <li>Yom Kippur</li>
+        <li>Sukkoth</li>
+        <li>Simchat Torah</li>
+        <li>Western New Year, January 1st</li>
+        <li>Spring Bank Holiday, last Monday of May</li>
+        <li>Christmas, December 25th</li>
+        <li>Boxing Day, December 26th</li>
+        <li>One-off days for elections</li>
+        </ul>
+
+        Holidays for the SHIR fixing calendar:
+        <ul>
+        <li>Weekdays: Saturday and Sunday</li>
+        <li>Purim I and II</li>
+        <li>Passover Eve, I and VII</li>
+        <li>Indipendence Day</li>
+        <li>Pentecost (Shavuot)</li>
+        <li>Fast Day</li>
+        <li>Jewish New Year Eve, I and II</li>
+        <li>Yom Kippur and its Eve</li>
+        <li>Sukkoth</li>
+        <li>Simchat Torah</li>
+        <li>Western New Year, January 1st</li>
+        <li>Good Friday</li>
+        <li>Spring Bank Holiday, last Monday of May</li>
+        <li>Christmas, December 25th</li>
+        <li>Boxing Day, December 26th</li>
+        <li>One-off days for elections</li>
+        </ul>
 
         \ingroup calendars
     */
@@ -64,10 +101,11 @@ namespace QuantLib {
         class TelborImpl;
         class ShirImpl;
       public:
-          enum Market { Settlement,     //!< generic settlement calendar
-                        TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026; Sat/Sun afterwards)
-                        Telbor,         //!< TELBOR fixing calendar (Sat/Sun weekends)
-                        SHIR            //!< SHIR fixing calendar (Sat/Sun weekends)
+          enum Market {
+              Settlement,     //!< generic settlement calendar
+              TASE,           //!< Tel-Aviv stock exchange calendar (Fri/Sat weekends, pre-2026; Sat/Sun afterwards)
+              Telbor,         //!< Telbor fixing calendar (Sat/Sun weekends)
+              SHIR            //!< SHIR fixing calendar (Sat/Sun weekends)
           };
           Israel(Market market = Settlement);
     };

--- a/ql/time/calendars/israel.hpp
+++ b/ql/time/calendars/israel.hpp
@@ -61,6 +61,8 @@ namespace QuantLib {
     class Israel : public Calendar {
       private:
         class TelAvivImpl;
+        class TelAvivNationalImpl;
+        class TelborImpl;
         class ShirImpl;
       public:
           enum Market { Settlement,     //!< generic settlement calendar

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3449,6 +3449,32 @@ BOOST_AUTO_TEST_CASE(testSHIRCalendar) {
     checkHolidays(c.holidayList(Date(5, May, 2022), Date(31, December, 2025)), expected);
 }
 
+BOOST_AUTO_TEST_CASE(testTelborCalendar) {
+    BOOST_TEST_MESSAGE("Testing Telbor calendar...");
+
+    std::vector<Date> expected = {
+        {5, May, 2022},        {30, May, 2022},       {26, September, 2022},
+        {27, September, 2022}, {5, October, 2022},    {10, October, 2022},
+        {17, October, 2022},   {26, December, 2022},  {7, March, 2023},
+        {8, March, 2023},      {5, April, 2023},      {6, April, 2023},
+        {12, April, 2023},     {26, April, 2023},     {26, May, 2023},
+        {29, May, 2023},       {27, July, 2023},      {25, September, 2023},
+        {25, December, 2023},  {26, December, 2023},  {1, January, 2024},
+        {25, March, 2024},     {22, April, 2024},     {23, April, 2024},
+        {29, April, 2024},     {14, May, 2024},       {27, May, 2024},
+        {12, June, 2024},      {13, August, 2024},    {3, October, 2024},
+        {4, October, 2024},    {17, October, 2024},   {24, October, 2024},
+        {25, December, 2024},  {26, December, 2024},  {1, January, 2025},
+        {14, March, 2025},     {1, May, 2025},        {26, May, 2025},
+        {2, June, 2025},       {23, September, 2025}, {24, September, 2025},
+        {2, October, 2025},    {7, October, 2025},    {14, October, 2025},
+        {25, December, 2025},  {26, December, 2025},
+    };
+
+    auto c = Israel(Israel::Telbor);
+    checkHolidays(c.holidayList(Date(5, May, 2022), Date(31, December, 2025)), expected);
+}
+
 BOOST_AUTO_TEST_CASE(testStartOfMonth) {
     BOOST_TEST_MESSAGE("Testing start-of-month calculation...");
 

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -3384,6 +3384,18 @@ BOOST_AUTO_TEST_CASE(testNewZealand) {
 BOOST_AUTO_TEST_CASE(testTASECalendar) {
     BOOST_TEST_MESSAGE("Testing TASE calendar...");
 
+    auto c = Israel(Israel::TASE);
+
+    auto is_weekend = [](Date d) {
+        if (d >= Date {5, January, 2026})
+            return d.weekday() == Saturday || d.weekday() == Sunday;
+        else
+            return d.weekday() == Friday || d.weekday() == Saturday;
+    };
+
+    // using checkHolidays with includeWeekEnds = false doesn't work in this case;
+    // weekdays changed in 2026.
+
     std::vector<Date> expected2013 = {
         {24, February, 2013},  {25, March, 2013},     {26, March, 2013},     {31, March, 2013},
         {1, April, 2013},      {15, April, 2013},     {16, April, 2013},     {14, May, 2013},
@@ -3391,8 +3403,9 @@ BOOST_AUTO_TEST_CASE(testTASECalendar) {
         {18, September, 2013}, {19, September, 2013}, {25, September, 2013}, {26, September, 2013},
     };
 
-    auto c = Israel();
-    checkHolidays(c.holidayList(Date(1, January, 2013), Date(31, December, 2013)), expected2013);
+    auto holidays = c.holidayList(Date(1, January, 2013), Date(31, December, 2013), true);
+    holidays.erase(std::remove_if(holidays.begin(), holidays.end(), is_weekend), holidays.end());
+    checkHolidays(holidays, expected2013);
 
     std::vector<Date> expected2025 = {
         {13, April, 2025},   {30, April, 2025},     {1, May, 2025},        {2, June, 2025},
@@ -3401,7 +3414,9 @@ BOOST_AUTO_TEST_CASE(testTASECalendar) {
         {14, October, 2025},
     };
 
-    checkHolidays(c.holidayList(Date(1, January, 2025), Date(31, December, 2025)), expected2025);
+    holidays = c.holidayList(Date(1, January, 2025), Date(31, December, 2025), true);
+    holidays.erase(std::remove_if(holidays.begin(), holidays.end(), is_weekend), holidays.end());
+    checkHolidays(holidays, expected2025);
 }
 
 BOOST_AUTO_TEST_CASE(testSHIRCalendar) {


### PR DESCRIPTION
Per TASE website (https://www.tase.co.il/en/content/about/tradingdays_change), on the 5th January 2026 we have seen the transition from Friday-Saturday week-end to Saturday-Sunday. This MR add a new calendar.

In addition, within ORE we had the TELBOR calendar which has distinct holiday rules (Sat/Sun weekends + Israeli holidays + international holidays like Christmas, Good Friday, Boxing Day, Spring Bank Holiday). We would like to reconcile our external calendar to integrate it within QuantLib.