### PR TITLE
Fix excessive branching in trinomial tree

### DIFF
--- a/ql/methods/lattices/trinomialtree.cpp
+++ b/ql/methods/lattices/trinomialtree.cpp
@@ -23,6 +23,15 @@
 
 namespace QuantLib {
 
+    namespace {
+        // Floor activation threshold: the dx floor (Clewlow-Strickland 1998)
+        // is applied only on grid steps shorter than `kFloorThreshold * dtMax`.
+        // Two orders of magnitude leaves uniform and typical non-uniform
+        // grids (weekend rolls, 1-day mismatches) untouched; the floor
+        // intervenes only on the pathological small-mandatory-gap case.
+        constexpr Real kFloorThreshold = 0.01;
+    }
+
     TrinomialTree::TrinomialTree(
                         const ext::shared_ptr<StochasticProcess1D>& process,
                         const TimeGrid& timeGrid,
@@ -33,6 +42,30 @@ namespace QuantLib {
         Size nTimeSteps = timeGrid.size() - 1;
         QL_REQUIRE(nTimeSteps > 0, "null time steps for trinomial tree");
 
+        // Preflight: capture per-step variances and dtMax in one pass.
+        // dxFloor is the largest natural dx in the grid: when applied
+        // on a tiny step it produces a dx no larger than what some
+        // other step is already using, preventing node explosion.
+        // Iterating over actual step durations (rather than a
+        // hypothetical dtMax window anchored at each step start) keeps
+        // the variance integration strictly within the declared grid
+        // horizon and avoids floating-point fragility from any
+        // `terminal - t_i` subtraction.  The per-step v2 values are
+        // cached so the main loop below does not re-invoke
+        // process->variance(); for processes with non-trivial variance
+        // evaluation cost this halves the call count.
+        Time dtMax = 0.0;
+        std::vector<Real> v2Cache(nTimeSteps);
+        Real dxFloorVar = 0.0;
+        for (Size i = 0; i < nTimeSteps; i++) {
+            Time dt_i = timeGrid.dt(i);
+            dtMax = std::max(dtMax, dt_i);
+            Real v2_i = process->variance(timeGrid[i], 0.0, dt_i);
+            v2Cache[i] = v2_i;
+            dxFloorVar = std::max(dxFloorVar, v2_i);
+        }
+        Real dxFloor = std::sqrt(3.0 * dxFloorVar);
+
         Integer jMin = 0;
         Integer jMax = 0;
 
@@ -41,9 +74,23 @@ namespace QuantLib {
             Time dt = timeGrid.dt(i);
 
             //Variance must be independent of x
-            Real v2 = process->variance(t, 0.0, dt);
+            Real v2 = v2Cache[i];
             Volatility v = std::sqrt(v2);
-            dx_.push_back(v*std::sqrt(3.0));
+            Real dxNatural = v*std::sqrt(3.0);
+            Real dxNext = (dt < kFloorThreshold * dtMax)
+                          ? std::max(dxNatural, dxFloor)
+                          : dxNatural;
+            dx_.push_back(dxNext);
+
+            // dxIsFloored captures whether the floor was *effective*
+            // at this step (dx widened beyond its natural value),
+            // not just whether the gate condition fired.  Time-
+            // dependent diffusions can have a small dt whose
+            // natural dx already equals or exceeds dxFloor; in
+            // that case the gate fires but dx is unchanged, and
+            // the classical-formula branch below still applies.
+            bool dxIsFloored = (dxNext > dxNatural);
+            Real dx2 = dxNext*dxNext;
 
             Branching branching;
             for (Integer j=jMin; j<=jMax; j++) {
@@ -51,19 +98,71 @@ namespace QuantLib {
                 Real m = process->expectation(t, x, dt);
                 auto temp = Integer(std::floor((m - x0_) / dx_[i + 1] + 0.5));
 
+                bool tempBumped = false;
                 if (isPositive) {
                     while (x0_+(temp-1)*dx_[i+1]<=0) {
                         temp++;
+                        tempBumped = true;
                     }
                 }
 
                 Real e = m - (x0_ + temp*dx_[i+1]);
                 Real e2 = e*e;
-                Real e3 = e*std::sqrt(3.0);
 
-                Real p1 = (1.0 + e2/v2 - e3/v)/6.0;
-                Real p2 = (2.0 - e2/v2)/3.0;
-                Real p3 = (1.0 + e2/v2 + e3/v)/6.0;
+                Real p1, p2, p3;
+                if (dxIsFloored) {
+                    // General moment-matching probabilities valid for
+                    // any grid spacing dx, used only when the floor
+                    // widened dx beyond v*sqrt(3).  They redistribute
+                    // probability toward the middle node to reflect
+                    // the smaller variance of the short step.
+                    //
+                    // Non-negativity requires v^2 >= |e|*(dx - |e|),
+                    // which can fail in the floored regime when
+                    // v << v_max.  We accept slightly negative weights
+                    // as the cost of the pathology fix; first two
+                    // moments are still matched exactly so signed
+                    // weights remain arithmetically consistent.
+                    // Hull-White-style alternative branching does not
+                    // help (it solves boundary drift, not the small-
+                    // variance regime).
+                    p1 = (v2 + e2 - e*dxNext) / (2.0*dx2);
+                    p2 = 1.0 - (v2 + e2) / dx2;
+                    p3 = (v2 + e2 + e*dxNext) / (2.0*dx2);
+                } else {
+                    // Classical Hull-White / Clewlow trinomial
+                    // probabilities for dx = v*sqrt(3).  Kept in this
+                    // exact form (not the algebraically-equivalent
+                    // dx-based form) so cached pricing values in
+                    // bermudanswaption.cpp / callablebonds.cpp remain
+                    // bit-for-bit identical to upstream master by
+                    // construction rather than by FP coincidence.
+                    Real e3 = e*std::sqrt(3.0);
+                    p1 = (1.0 + e2/v2 - e3/v)/6.0;
+                    p2 = (2.0 - e2/v2)/3.0;
+                    p3 = (1.0 + e2/v2 + e3/v)/6.0;
+                }
+
+                // In the unfloored regime with naturally-rounded temp
+                // the formulas above are non-negative by construction
+                // (|e| <= dx/2 implies v^2 >= |e|*(dx - |e|)); guard
+                // against future drift in this safe path.  When
+                // isPositive bumps temp upward to keep the underlying
+                // positive, |e| can exceed dx/2 -- the resulting signed
+                // weights were accepted by upstream before this change
+                // (CIR family models rely on this), so we skip the
+                // assertion in that case.  In the floored regime the
+                // limitation is documented and accepted uniformly.
+                if (!dxIsFloored && !tempBumped) {
+                    QL_ENSURE(p1 >= 0.0 && p2 >= 0.0 && p3 >= 0.0,
+                              "negative probability in trinomial tree "
+                              "(unfloored regime) at step " << i
+                              << ", node " << j
+                              << ": p1=" << p1 << ", p2=" << p2
+                              << ", p3=" << p3
+                              << " (v=" << v << ", dx=" << dxNext
+                              << ", e=" << e << ")");
+                }
 
                 branching.add(temp, p1, p2, p3);
             }

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -166,6 +166,7 @@ set(QL_TEST_SOURCES
     timeseries.cpp
     tqreigendecomposition.cpp
     tracing.cpp
+    trinomialtree.cpp
     twoassetbarrieroption.cpp
     twoassetcorrelationoption.cpp
     ultimateforwardtermstructure.cpp

--- a/test-suite/Makefile.am
+++ b/test-suite/Makefile.am
@@ -167,6 +167,7 @@ QL_TEST_SRCS = \
 	timeseries.cpp \
 	tqreigendecomposition.cpp \
 	tracing.cpp \
+	trinomialtree.cpp \
 	twoassetbarrieroption.cpp \
 	twoassetcorrelationoption.cpp \
 	ultimateforwardtermstructure.cpp \

--- a/test-suite/testsuite.vcxproj
+++ b/test-suite/testsuite.vcxproj
@@ -811,6 +811,7 @@
     <ClCompile Include="timeseries.cpp" />
     <ClCompile Include="tqreigendecomposition.cpp" />
     <ClCompile Include="tracing.cpp" />
+    <ClCompile Include="trinomialtree.cpp" />
     <ClCompile Include="twoassetbarrieroption.cpp" />
     <ClCompile Include="twoassetcorrelationoption.cpp" />
     <ClCompile Include="ultimateforwardtermstructure.cpp" />

--- a/test-suite/testsuite.vcxproj.filters
+++ b/test-suite/testsuite.vcxproj.filters
@@ -425,6 +425,9 @@
     <ClCompile Include="tracing.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="trinomialtree.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="twoassetbarrieroption.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/test-suite/trinomialtree.cpp
+++ b/test-suite/trinomialtree.cpp
@@ -1,0 +1,185 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Richard Amaya
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include "toplevelfixture.hpp"
+#include "utilities.hpp"
+#include <ql/methods/lattices/trinomialtree.hpp>
+#include <ql/models/shortrate/onefactormodels/hullwhite.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+#include <ql/timegrid.hpp>
+
+using namespace QuantLib;
+using namespace boost::unit_test_framework;
+
+BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
+
+BOOST_AUTO_TEST_SUITE(TrinomialTreeTests)
+
+BOOST_AUTO_TEST_CASE(testSmallMandatoryGapDoesNotExplode) {
+    BOOST_TEST_MESSAGE(
+        "Testing trinomial tree node count stays bounded with a "
+        "small mandatory time gap...");
+
+    Date today(15, January, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    // Flat yield curve at 5%
+    Handle<YieldTermStructure> termStructure(
+        flatRate(today, 0.05, Actual365Fixed()));
+
+    // Hull-White process: a=0.1, sigma=0.01
+    auto model = ext::make_shared<HullWhite>(termStructure, 0.1, 0.01);
+    ext::shared_ptr<StochasticProcess1D> process =
+        model->dynamics()->process();
+
+    // TimeGrid with one very short mandatory-time gap (1ms after t=1.0).
+    // Without the global dx floor this causes node count to explode to
+    // several hundred at the tiny-dt step; with the floor it stays bounded.
+    std::vector<Time> mandatoryTimes = {1.0, 1.0 + 1.0e-3, 2.0, 3.0};
+    TimeGrid grid(mandatoryTimes.begin(), mandatoryTimes.end());
+
+    TrinomialTree tree(process, grid);
+
+    Size maxNodes = 0;
+    for (Size i = 0; i < grid.size(); ++i)
+        maxNodes = std::max(maxNodes, tree.size(i));
+
+    // The trinomial tree node count grows by at most one j-index per
+    // side per step, so after nSteps steps maxNodes <= 2*nSteps + 1.
+    // Without the floor, the tiny-dt step would force dx down enough
+    // that the surrounding steps' integer offsets land far from j=0,
+    // producing hundreds of nodes.  With the floor, this bound holds.
+    Size nSteps = grid.size() - 1;
+    Size expectedBound = 2*nSteps + 1;
+    BOOST_CHECK_MESSAGE(maxNodes <= expectedBound,
+        "trinomial tree exceeded derived bound: max node count "
+        << maxNodes << " > 2*nSteps+1 = " << expectedBound
+        << " (dx-floor fix may be broken)");
+
+    // The grid contains a step short enough to activate the dx floor.
+    // Per trinomialtree.cpp, the floored regime accepts slightly
+    // negative probabilities as the documented cost of the pathology
+    // fix (first two moments still match exactly).  Asserting `p in
+    // [0, 1]` here would couple this regression test to the specific
+    // HW parameters where |e| happens to stay small; bounded node
+    // count is the actual invariant being validated.
+}
+
+BOOST_AUTO_TEST_CASE(testFloorThresholdBoundary) {
+    BOOST_TEST_MESSAGE(
+        "Testing trinomial tree behaviour at the floor activation "
+        "threshold (dt_i / dt_max = 0.01)...");
+
+    Date today(15, January, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Handle<YieldTermStructure> termStructure(
+        flatRate(today, 0.05, Actual365Fixed()));
+    auto model = ext::make_shared<HullWhite>(termStructure, 0.1, 0.01);
+    ext::shared_ptr<StochasticProcess1D> process =
+        model->dynamics()->process();
+
+    // Helper: build a tree on a grid with one custom-ratio short step
+    // and report:
+    //  - maxNodes (peak j-range across the grid)
+    //  - nSteps (so the bounded-node test can derive its own bound)
+    //  - shortStepDx (the dx assigned to the short step, possibly floored)
+    //  - shortStepNaturalDx (v*sqrt(3) for the short step, the unfloored
+    //    value).
+    // The two dx values let the boundary test positively assert the
+    // floor's on/off state on each side of the threshold, catching
+    // drift in either direction.
+    struct Probe {
+        Size maxNodes; Size nSteps;
+        Real shortStepDx; Real shortStepNaturalDx;
+    };
+    auto runProbe = [&](Time gapRatio) -> Probe {
+        Time dtMax = 1.0;
+        std::vector<Time> times = {1.0, 1.0 + gapRatio*dtMax, 2.0, 3.0};
+        TimeGrid grid(times.begin(), times.end());
+
+        TrinomialTree tree(process, grid);
+
+        // Locate the short step by scanning for the smallest dt: the
+        // TimeGrid constructor prepends t=0 to the mandatory-time list
+        // we pass, so the index of the short step is one greater than
+        // its position in `times` above.  Scanning instead of
+        // hard-coding the index keeps this test independent of that
+        // detail and of any future reordering of `times`.  In the
+        // constructor, dx_ starts at length 1 and step i's dx is
+        // pushed into dx_[i+1], so the short step's dx lives at
+        // tree.dx(shortIdx + 1).  Compute the reference natural dx in
+        // the same operation order as production (sqrt(v2) * sqrt(3.0),
+        // not sqrt(3.0 * v2)) so BOOST_CHECK_EQUAL below holds
+        // bit-for-bit across compilers and optimisation levels rather
+        // than relying on the two forms happening to agree in the
+        // last bit.
+        Size shortIdx = 0;
+        for (Size i = 1; i < grid.size() - 1; ++i)
+            if (grid.dt(i) < grid.dt(shortIdx))
+                shortIdx = i;
+        Time shortDt = grid.dt(shortIdx);
+        Real shortV2 = process->variance(grid[shortIdx], 0.0, shortDt);
+        Real shortNatural = std::sqrt(shortV2) * std::sqrt(3.0);
+
+        Size maxNodes = 0;
+        for (Size i = 0; i < grid.size(); ++i)
+            maxNodes = std::max(maxNodes, tree.size(i));
+        return {maxNodes, grid.size() - 1,
+                tree.dx(shortIdx + 1), shortNatural};
+    };
+
+    // Probes are placed immediately on either side of the activation
+    // threshold (0.01) so the test exercises the gating boundary
+    // itself; loose multipliers (e.g. 0.005 / 0.02) would still pass
+    // for any threshold in a wide range.
+    constexpr Time kBelow = 0.0099;
+    constexpr Time kAbove = 0.0101;
+
+    // Just below threshold: floor active.  Node count must stay
+    // bounded (each step extends the j-range by at most 1 on each
+    // side) AND the short step's dx must be strictly larger than its
+    // natural value, positively confirming the floor activated here.
+    // Without the dx check, a `kFloorThreshold` that drifted *down*
+    // could leave kBelow unfloored without this test noticing.
+    auto belowResult = runProbe(kBelow);
+    Size belowBound = 2*belowResult.nSteps + 1;
+    BOOST_CHECK_MESSAGE(belowResult.maxNodes <= belowBound,
+        "below-threshold node count " << belowResult.maxNodes
+        << " exceeded derived bound 2*nSteps+1 = " << belowBound);
+    BOOST_CHECK_MESSAGE(belowResult.shortStepDx > belowResult.shortStepNaturalDx,
+        "below-threshold floor did not activate: dx="
+        << belowResult.shortStepDx
+        << " natural=" << belowResult.shortStepNaturalDx
+        << " (kFloorThreshold may have drifted down)");
+
+    // Just above threshold: floor inactive.  The constructor assigns
+    // dx exactly equal to v*sqrt(3) in this regime, so strict equality
+    // holds.  The check positively confirms the floor is OFF, catching
+    // a `kFloorThreshold` that drifted *up*.  Any regression in the
+    // unfloored-regime QL_ENSURE would also throw out of runProbe and
+    // fail the test as an unhandled exception.
+    auto aboveResult = runProbe(kAbove);
+    BOOST_CHECK_EQUAL(aboveResult.shortStepDx, aboveResult.shortStepNaturalDx);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes #364.

## Problem

When a TimeGrid contains mandatory time points separated by very
short intervals (e.g. millisecond gaps inside a multi-year schedule),
the trinomial tree's per-step `dx = v*sqrt(3)` shrinks to a tiny
value at the short step. Subsequent steps still need to cover the
full state range, so the integer-rounded `temp` index for each parent
node lands far from j=0 and the j-range expands at each step,
producing node counts in the hundreds on grids that should stay
bounded.

## Fix

A Clewlow-Strickland (1998) global dx floor based on the largest
natural dx in the grid, gated on `dt < kFloorThreshold * dtMax` with
`kFloorThreshold = 0.01`. The gate keeps the floor inactive on
uniform and typical non-uniform grids (weekend rolls, 1-day
mismatches) and activates only when one step is at least two orders
of magnitude shorter than the longest step in the grid.

Probability formulas use a dual branch on `dxIsFloored`:

- Unfloored regime: the classical Hull-White / Clewlow form is kept
  character-identical to current master. This is the hot path
  covering every existing cached-value pricing test
  (`BermudanSwaptionTests/testCachedValues`,
  `BermudanSwaptionTests/testCachedG2Values`, callable bonds), so
  cached values are bit-for-bit identical by code structure rather
  than by IEEE-754 coincidence.
- Floored regime: the general dx-based moment-matching form, which
  reduces to (1/6, 2/3, 1/6) when `dx = v*sqrt(3)`. Non-negativity
  requires `v^2 >= |e|*(dx - |e|)`, which can fail when `v << v_max`.
  Documented in code as the accepted cost of the pathology fix;
  first two moments are matched exactly, so signed weights remain
  arithmetically consistent for linear payoff propagation.

A defensive `QL_ENSURE` on probability non-negativity guards the
unfloored, non-`tempBumped` path against future drift. The
`tempBumped` flag tracks the `isPositive` while-loop where `|e|` can
legitimately exceed `dx/2` (CIR-family models); upstream allowed
signed weights there before this change and that behaviour is
preserved.

The preflight pass that derives `dtMax` and `dxFloor` caches per-step
variances, halving the `process->variance()` call count in the main
loop.

## On the gate form

An alternative gate of the form `dxNext < dx_prev * fraction` was
also considered. Empirically, fractions calibrated to leave realistic
holiday-adjustment cases unfloored still fire on the notice-period
steps in `BermudanSwaptionTests/testCachedValues` when exercise dates
are shifted by ~10 calendar days, causing cached ITM/ATM/OTM values
to drift by 4e-4 to 2e-3. The dx-ratio range for the pathological
small-mandatory-gap case (~0.03) and for ordinary short notice steps
(~0.15-0.50) overlaps too closely to admit a single fixed fraction.

The `dt`-against-`dtMax` form separates the two regimes cleanly:
small-mandatory-gap pathologies have `dt/dtMax` on the order of 1e-3,
while the shortest steps that appear in the existing pricing tests
sit at `dt/dtMax >= 2e-2`, well clear of the 1e-2 threshold.

## Tests

`test-suite/trinomialtree.cpp` (new file):

- `testSmallMandatoryGapDoesNotExplode` exercises the small-
  mandatory-gap pathology (1ms gap inside an annual grid) and
  asserts node count stays within the derived `2*nSteps + 1` bound.
- `testFloorThresholdBoundary` probes immediately on either side of
  `kFloorThreshold` (gapRatio = 0.0099 floored, 0.0101 unfloored).
  Both sides positively assert the floor's on/off state, catching
  drift of `kFloorThreshold` in either direction. The probe scans
  for the minimum-dt step rather than hard-coding an index, and
  computes the reference natural dx in the same operation order as
  production (`sqrt(v2)*sqrt(3.0)`, not `sqrt(3.0*v2)`) so
  `BOOST_CHECK_EQUAL` is bit-stable across compilers.

A pricing-level regression test for the floored regime (Bermudan
swaption or callable bond on a small-mandatory-gap grid) is
deferred: it would require modifying the engine's internal TimeGrid
construction to inject a mandatory time outside any exercise date,
which is outside the scope of this trinomial-tree fix. The unfloored
hot path covering every current cached-value pricing test is
bit-for-bit identical to upstream by construction.

Full test suite: 1293/1293 pass (11781/11781 assertions).
