### PR TITLE
Use Real-compatible types so AAD builds compile (FX forward engine, variance surface test)

### DIFF
--- a/ql/pricingengines/forward/discountingfxforwardengine.cpp
+++ b/ql/pricingengines/forward/discountingfxforwardengine.cpp
@@ -94,8 +94,8 @@ namespace QuantLib {
         //   NPV = +PVSource - PVTarget (in source currency terms)
         const Real npvAtSettlementInSourceCurrency =
             arguments_.paySourceCurrency ?
-                -pvSource + pvTargetInSourceCurrency :
-                pvSource - pvTargetInSourceCurrency;
+                Real(-pvSource + pvTargetInSourceCurrency) :
+                Real(pvSource - pvTargetInSourceCurrency);
 
         const Real npvInSourceCurrency =
             npvAtSettlementInSourceCurrency * dfSourceSettlement;

--- a/test-suite/piecewiseblackvariancesurface.cpp
+++ b/test-suite/piecewiseblackvariancesurface.cpp
@@ -1175,7 +1175,7 @@ BOOST_AUTO_TEST_CASE(testSmileSectionFromBlackVolSurface) {
                    "the stored SmileSection (pointer mismatch)");
 
     // At a stored tenor: volatilities should match exactly
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         Volatility surfaceVol = surface->blackVol(d1, strike);
         Volatility sectionVol = smile1->volatility(strike);
         if (std::fabs(surfaceVol - sectionVol) > tolerance)
@@ -1198,7 +1198,7 @@ BOOST_AUTO_TEST_CASE(testSmileSectionFromBlackVolSurface) {
                    "return a stored SmileSection");
 
     // Between tenors: adapter should reproduce blackVol() at each strike
-    for (double strike : strikes) {
+    for (Real strike : strikes) {
         Volatility surfaceVol = surface->blackVol(dMid, strike);
         Volatility sectionVol = smileMid->volatility(strike);
         if (std::fabs(surfaceVol - sectionVol) > tolerance)


### PR DESCRIPTION
Use Real-compatible types for AAD in FX forward engine and variance surface test