### PR TITLE
Use `make_shared` in volatility-related code

### DIFF
--- a/ql/experimental/callablebonds/callablebondconstantvol.cpp
+++ b/ql/experimental/callablebonds/callablebondconstantvol.cpp
@@ -28,7 +28,7 @@ namespace QuantLib {
                                                                    Volatility volatility,
                                                                    DayCounter dayCounter)
     : CallableBondVolatilityStructure(referenceDate),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)), maxBondTenor_(100 * Years) {}
 
     CallableBondConstantVolatility::CallableBondConstantVolatility(const Date& referenceDate,
@@ -44,7 +44,7 @@ namespace QuantLib {
                                                                    Volatility volatility,
                                                                    DayCounter dayCounter)
     : CallableBondVolatilityStructure(settlementDays, calendar),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)), maxBondTenor_(100 * Years) {}
 
     CallableBondConstantVolatility::CallableBondConstantVolatility(Natural settlementDays,
@@ -72,11 +72,7 @@ namespace QuantLib {
     CallableBondConstantVolatility::smileSectionImpl(Time optionTime,
                                                      Time) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-                                    new FlatSmileSection(optionTime,
-                                                         atmVol,
-                                                         dayCounter_));
+        return ext::make_shared<FlatSmileSection>(optionTime, atmVol, dayCounter_);
     }
 
 }
-

--- a/ql/experimental/variancegamma/fftengine.cpp
+++ b/ql/experimental/variancegamma/fftengine.cpp
@@ -66,8 +66,7 @@ namespace QuantLib {
 
     void FFTEngine::calculateUncached(const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                       const ext::shared_ptr<Exercise>& exercise) const {
-        ext::shared_ptr<VanillaOption> option =
-            ext::make_shared<VanillaOption>(payoff, exercise);
+        auto option = ext::make_shared<VanillaOption>(payoff, exercise);
         std::vector<ext::shared_ptr<Instrument> > optionList;
         optionList.push_back(option);
 

--- a/ql/experimental/variancegamma/fftengine.cpp
+++ b/ql/experimental/variancegamma/fftengine.cpp
@@ -66,7 +66,8 @@ namespace QuantLib {
 
     void FFTEngine::calculateUncached(const ext::shared_ptr<StrikedTypePayoff>& payoff,
                                       const ext::shared_ptr<Exercise>& exercise) const {
-        ext::shared_ptr<VanillaOption> option(new VanillaOption(payoff, exercise));
+        ext::shared_ptr<VanillaOption> option =
+            ext::make_shared<VanillaOption>(payoff, exercise);
         std::vector<ext::shared_ptr<Instrument> > optionList;
         optionList.push_back(option);
 
@@ -178,4 +179,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/experimental/variancegamma/fftvanillaengine.cpp
+++ b/ql/experimental/variancegamma/fftvanillaengine.cpp
@@ -34,7 +34,7 @@ namespace QuantLib {
     {
         ext::shared_ptr<GeneralizedBlackScholesProcess> process =
             ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(process_);
-        return std::unique_ptr<FFTEngine>(new FFTVanillaEngine(process, lambda_));
+        return std::make_unique<FFTVanillaEngine>(process, lambda_);
     }
 
     void FFTVanillaEngine::precalculateExpiry(Date d)

--- a/ql/experimental/variancegamma/fftvariancegammaengine.cpp
+++ b/ql/experimental/variancegamma/fftvariancegammaengine.cpp
@@ -32,7 +32,7 @@ namespace QuantLib {
     {
         ext::shared_ptr<VarianceGammaProcess> process =
             ext::dynamic_pointer_cast<VarianceGammaProcess>(process_);
-        return std::unique_ptr<FFTEngine>(new FFTVarianceGammaEngine(process, lambda_));
+        return std::make_unique<FFTVarianceGammaEngine>(process, lambda_);
     }
 
     void FFTVarianceGammaEngine::precalculateExpiry(Date d)

--- a/ql/experimental/variancegamma/variancegammaprocess.cpp
+++ b/ql/experimental/variancegamma/variancegammaprocess.cpp
@@ -31,7 +31,7 @@ namespace QuantLib {
                                                Real sigma,
                                                Real nu,
                                                Real theta)
-    : StochasticProcess1D(ext::shared_ptr<discretization>(new EulerDiscretization)),
+    : StochasticProcess1D(ext::make_shared<EulerDiscretization>()),
       s0_(std::move(s0)), dividendYield_(std::move(dividendYield)),
       riskFreeRate_(std::move(riskFreeRate)), sigma_(sigma), nu_(nu), theta_(theta) {
         registerWith(riskFreeRate_);

--- a/ql/termstructures/volatility/abcdcalibration.cpp
+++ b/ql/termstructures/volatility/abcdcalibration.cpp
@@ -84,8 +84,8 @@ namespace QuantLib {
             Real xtol = 1.0e-8;
             Real gtol = 1.0e-8;
             bool useCostFunctionsJacobian = false;
-            optMethod_ = ext::shared_ptr<OptimizationMethod>(new
-                LevenbergMarquardt(epsfcn, xtol, gtol, useCostFunctionsJacobian));
+            optMethod_ = ext::make_shared<LevenbergMarquardt>(
+                epsfcn, xtol, gtol, useCostFunctionsJacobian);
         }
         if (!endCriteria_) {
             Size maxIterations = 10000;
@@ -122,8 +122,7 @@ namespace QuantLib {
         } else {
 
             AbcdError costFunction(this);
-            transformation_ = ext::shared_ptr<ParametersTransformation>(new
-                AbcdParametersTransformation);
+            transformation_ = ext::make_shared<AbcdParametersTransformation>();
 
             Array guess(4);
             guess[0] = a_;

--- a/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
+++ b/ql/termstructures/volatility/equityfx/andreasenhugevolatilityinterpl.hpp
@@ -72,7 +72,7 @@ namespace QuantLib {
             Real minStrike = Null<Real>(),
             Real maxStrike = Null<Real>(),
             ext::shared_ptr<OptimizationMethod> optimizationMethod =
-                ext::shared_ptr<OptimizationMethod>(new LevenbergMarquardt),
+                ext::make_shared<LevenbergMarquardt>(),
             const EndCriteria& endCriteria = EndCriteria(500, 100, 1e-12, 1e-10, 1e-10));
 
         Date maxDate() const;

--- a/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/blackconstantvol.hpp
@@ -83,7 +83,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               const DayCounter& dc)
     : BlackVolatilityTermStructure(referenceDate, cal, Following, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))) {}
+      volatility_(ext::make_shared<SimpleQuote>(volatility)) {}
 
     inline BlackConstantVol::BlackConstantVol(const Date& referenceDate,
                                               const Calendar& cal,
@@ -99,7 +99,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               const DayCounter& dc)
     : BlackVolatilityTermStructure(settlementDays, cal, Following, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))) {}
+      volatility_(ext::make_shared<SimpleQuote>(volatility)) {}
 
     inline BlackConstantVol::BlackConstantVol(Natural settlementDays,
                                               const Calendar& cal,

--- a/ql/termstructures/volatility/equityfx/localconstantvol.hpp
+++ b/ql/termstructures/volatility/equityfx/localconstantvol.hpp
@@ -77,7 +77,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               DayCounter dayCounter)
     : LocalVolTermStructure(referenceDate),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)) {}
 
     inline LocalConstantVol::LocalConstantVol(const Date& referenceDate,
@@ -93,7 +93,7 @@ namespace QuantLib {
                                               Volatility volatility,
                                               DayCounter dayCounter)
     : LocalVolTermStructure(settlementDays, calendar),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(volatility))),
+      volatility_(ext::make_shared<SimpleQuote>(volatility)),
       dayCounter_(std::move(dayCounter)) {}
 
     inline LocalConstantVol::LocalConstantVol(Natural settlementDays,

--- a/ql/termstructures/volatility/equityfx/localvolsurface.cpp
+++ b/ql/termstructures/volatility/equityfx/localvolsurface.cpp
@@ -65,7 +65,7 @@ namespace QuantLib {
                                      Real underlying)
     : LocalVolTermStructure(blackTS->businessDayConvention(), blackTS->dayCounter()),
       blackTS_(blackTS), riskFreeTS_(std::move(riskFreeTS)), dividendTS_(std::move(dividendTS)),
-      underlying_(ext::shared_ptr<Quote>(new SimpleQuote(underlying))) {
+      underlying_(ext::make_shared<SimpleQuote>(underlying)) {
         registerWith(blackTS_);
         registerWith(riskFreeTS_);
         registerWith(dividendTS_);
@@ -155,4 +155,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/termstructures/volatility/interpolatedsmilesection.hpp
+++ b/ql/termstructures/volatility/interpolatedsmilesection.hpp
@@ -145,10 +145,8 @@ namespace QuantLib {
         // fill dummy handles to allow generic handle-based
         // computations later on
         for (Size i=0; i<stdDevs.size(); ++i)
-            stdDevHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(stdDevs[i])));
-        atmLevel_ = Handle<Quote>
-           (ext::shared_ptr<Quote>(new SimpleQuote(atmLevel)));
+            stdDevHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(stdDevs[i]));
+        atmLevel_ = Handle<Quote>(ext::make_shared<SimpleQuote>(atmLevel));
         
         checkStrikes();
         interpolation_ = interpolator.interpolate(strikes_.begin(),
@@ -203,10 +201,8 @@ namespace QuantLib {
         //fill dummy handles to allow generic handle-based
         // computations later on
         for (Size i=0; i<stdDevs.size(); ++i)
-            stdDevHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                SimpleQuote(stdDevs[i])));
-        atmLevel_ = Handle<Quote>
-           (ext::shared_ptr<Quote>(new SimpleQuote(atmLevel)));
+            stdDevHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(stdDevs[i]));
+        atmLevel_ = Handle<Quote>(ext::make_shared<SimpleQuote>(atmLevel));
         
         checkStrikes();
         interpolation_ = interpolator.interpolate(strikes_.begin(),

--- a/ql/termstructures/volatility/optionlet/constantoptionletvol.cpp
+++ b/ql/termstructures/volatility/optionlet/constantoptionletvol.cpp
@@ -58,7 +58,7 @@ namespace QuantLib {
         Volatility vol, const DayCounter &dc, VolatilityType type,
         Real displacement)
         : OptionletVolatilityStructure(settlementDays, cal, bdc, dc),
-          volatility_(ext::shared_ptr< Quote >(new SimpleQuote(vol))),
+          volatility_(ext::make_shared<SimpleQuote>(vol)),
           type_(type), displacement_(displacement) {}
 
     // fixed reference date, fixed market data
@@ -67,21 +67,20 @@ namespace QuantLib {
         BusinessDayConvention bdc, Volatility vol, const DayCounter &dc,
         VolatilityType type, Real displacement)
         : OptionletVolatilityStructure(referenceDate, cal, bdc, dc),
-          volatility_(ext::shared_ptr< Quote >(new SimpleQuote(vol))),
+          volatility_(ext::make_shared<SimpleQuote>(vol)),
           type_(type), displacement_(displacement) {}
 
     ext::shared_ptr<SmileSection>
     ConstantOptionletVolatility::smileSectionImpl(const Date& d) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(new
-            FlatSmileSection(d, atmVol, dayCounter(), referenceDate()));
+        return ext::make_shared<FlatSmileSection>(
+            d, atmVol, dayCounter(), referenceDate());
     }
 
     ext::shared_ptr<SmileSection>
     ConstantOptionletVolatility::smileSectionImpl(Time optionTime) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(new
-            FlatSmileSection(optionTime, atmVol, dayCounter()));
+        return ext::make_shared<FlatSmileSection>(optionTime, atmVol, dayCounter());
     }
 
     Volatility ConstantOptionletVolatility::volatilityImpl(Time,

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -63,10 +63,9 @@ namespace QuantLib {
         // update dates
         const Date& referenceDate = termVolSurface_->referenceDate();
         const DayCounter& dc = termVolSurface_->dayCounter();
-        ext::shared_ptr<BlackCapFloorEngine> dummy(new
-                    BlackCapFloorEngine(// discounting does not matter here
-                                        iborIndex_->forwardingTermStructure(),
-                                        0.20, dc));
+        ext::shared_ptr<BlackCapFloorEngine> dummy =
+            ext::make_shared<BlackCapFloorEngine>( // discounting does not matter here
+                iborIndex_->forwardingTermStructure(), 0.20, dc);
         for (Size i=0; i<nOptionletTenors_; ++i) {
             CapFloor temp = MakeCapFloor(CapFloor::Cap,
                                          capFloorLengths_[i],
@@ -100,7 +99,7 @@ namespace QuantLib {
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
 
         ext::shared_ptr<PricingEngine> capFloorEngine;
-        ext::shared_ptr<SimpleQuote> volQuote(new SimpleQuote);
+        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
 
         if (volatilityType_ == ShiftedLognormal) {
             capFloorEngine = ext::make_shared<BlackCapFloorEngine>(

--- a/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper1.cpp
@@ -63,7 +63,7 @@ namespace QuantLib {
         // update dates
         const Date& referenceDate = termVolSurface_->referenceDate();
         const DayCounter& dc = termVolSurface_->dayCounter();
-        ext::shared_ptr<BlackCapFloorEngine> dummy =
+        auto dummy =
             ext::make_shared<BlackCapFloorEngine>( // discounting does not matter here
                 iborIndex_->forwardingTermStructure(), 0.20, dc);
         for (Size i=0; i<nOptionletTenors_; ++i) {
@@ -99,7 +99,7 @@ namespace QuantLib {
         const std::vector<Rate>& strikes = termVolSurface_->strikes();
 
         ext::shared_ptr<PricingEngine> capFloorEngine;
-        ext::shared_ptr<SimpleQuote> volQuote = ext::make_shared<SimpleQuote>();
+        auto volQuote = ext::make_shared<SimpleQuote>();
 
         if (volatilityType_ == ShiftedLognormal) {
             capFloorEngine = ext::make_shared<BlackCapFloorEngine>(

--- a/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
@@ -76,9 +76,9 @@ namespace QuantLib {
         for (Size j=0; j<nOptionExpiries_; ++j) {
             Volatility atmOptionVol = atmCapFloorTermVolCurve_->volatility(
                 optionExpiriesTimes[j], 33.3333); // dummy strike
-            ext::shared_ptr<BlackCapFloorEngine> engine(new
-                    BlackCapFloorEngine(iborIndex_->forwardingTermStructure(),
-                                        atmOptionVol, dc_));
+            ext::shared_ptr<BlackCapFloorEngine> engine =
+                ext::make_shared<BlackCapFloorEngine>(
+                    iborIndex_->forwardingTermStructure(), atmOptionVol, dc_);
             caps_[j] = MakeCapFloor(CapFloor::Cap,
                                     optionExpiriesTenors[j],
                                     iborIndex_,
@@ -159,22 +159,22 @@ namespace QuantLib {
         ext::shared_ptr<CapFloor> cap,
         Real targetValue)
     : cap_(std::move(cap)), targetValue_(targetValue) {
-        ext::shared_ptr<OptionletVolatilityStructure> adapter(new
-            StrippedOptionletAdapter(optionletStripper1));
+        ext::shared_ptr<OptionletVolatilityStructure> adapter =
+            ext::make_shared<StrippedOptionletAdapter>(optionletStripper1);
         adapter->enableExtrapolation();
 
         // set an implausible value, so that calculation is forced
         // at first operator()(Volatility x) call
         spreadQuote_ = ext::make_shared<SimpleQuote>(-1.0);
 
-        ext::shared_ptr<OptionletVolatilityStructure> spreadedAdapter(new
-            SpreadedOptionletVolatility(Handle<OptionletVolatilityStructure>(
-                adapter), Handle<Quote>(spreadQuote_)));
+        ext::shared_ptr<OptionletVolatilityStructure> spreadedAdapter =
+            ext::make_shared<SpreadedOptionletVolatility>(
+                Handle<OptionletVolatilityStructure>(adapter), Handle<Quote>(spreadQuote_));
 
-        ext::shared_ptr<BlackCapFloorEngine> engine(new
-            BlackCapFloorEngine(
+        ext::shared_ptr<BlackCapFloorEngine> engine =
+            ext::make_shared<BlackCapFloorEngine>(
                 optionletStripper1->iborIndex()->forwardingTermStructure(),
-                Handle<OptionletVolatilityStructure>(spreadedAdapter)));
+                Handle<OptionletVolatilityStructure>(spreadedAdapter));
 
         cap_->setPricingEngine(engine);
     }

--- a/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
+++ b/ql/termstructures/volatility/optionlet/optionletstripper2.cpp
@@ -76,7 +76,7 @@ namespace QuantLib {
         for (Size j=0; j<nOptionExpiries_; ++j) {
             Volatility atmOptionVol = atmCapFloorTermVolCurve_->volatility(
                 optionExpiriesTimes[j], 33.3333); // dummy strike
-            ext::shared_ptr<BlackCapFloorEngine> engine =
+            auto engine =
                 ext::make_shared<BlackCapFloorEngine>(
                     iborIndex_->forwardingTermStructure(), atmOptionVol, dc_);
             caps_[j] = MakeCapFloor(CapFloor::Cap,
@@ -171,7 +171,7 @@ namespace QuantLib {
             ext::make_shared<SpreadedOptionletVolatility>(
                 Handle<OptionletVolatilityStructure>(adapter), Handle<Quote>(spreadQuote_));
 
-        ext::shared_ptr<BlackCapFloorEngine> engine =
+        auto engine =
             ext::make_shared<BlackCapFloorEngine>(
                 optionletStripper1->iborIndex()->forwardingTermStructure(),
                 Handle<OptionletVolatilityStructure>(spreadedAdapter));

--- a/ql/termstructures/volatility/optionlet/spreadedoptionletvol.cpp
+++ b/ql/termstructures/volatility/optionlet/spreadedoptionletvol.cpp
@@ -37,16 +37,14 @@ namespace QuantLib {
     SpreadedOptionletVolatility::smileSectionImpl(const Date& d) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(d, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     ext::shared_ptr<SmileSection>
     SpreadedOptionletVolatility::smileSectionImpl(Time optionTime) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(optionTime, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     Volatility SpreadedOptionletVolatility::volatilityImpl(Time t,

--- a/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
+++ b/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
@@ -73,9 +73,9 @@ namespace QuantLib {
 
         const std::vector<Time>& optionletTimes =
                                     optionletStripper_->optionletFixingTimes();
-        ext::shared_ptr<LinearInterpolation> timeInterpolator(new
-            LinearInterpolation(optionletTimes.begin(), optionletTimes.end(),
-                                vol.begin()));
+        ext::shared_ptr<LinearInterpolation> timeInterpolator =
+            ext::make_shared<LinearInterpolation>(
+                optionletTimes.begin(), optionletTimes.end(), vol.begin());
         return (*timeInterpolator)(length, true);
     }
 
@@ -89,8 +89,8 @@ namespace QuantLib {
                 optionletStripper_->optionletStrikes(i);
             const std::vector<Volatility>& optionletVolatilities =
                 optionletStripper_->optionletVolatilities(i);
-            //strikeInterpolations_[i] = ext::shared_ptr<SABRInterpolation>(new
-            //            SABRInterpolation(optionletStrikes.begin(), optionletStrikes.end(),
+            //strikeInterpolations_[i] = ext::make_shared<SABRInterpolation>(
+            //            optionletStrikes.begin(), optionletStrikes.end(),
             //                              optionletVolatilities.begin(),
             //                              optionletTimes[i], atmForward[i],
             //                              0.02,0.5,0.2,0.,

--- a/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
+++ b/ql/termstructures/volatility/optionlet/strippedoptionletadapter.cpp
@@ -73,7 +73,7 @@ namespace QuantLib {
 
         const std::vector<Time>& optionletTimes =
                                     optionletStripper_->optionletFixingTimes();
-        ext::shared_ptr<LinearInterpolation> timeInterpolator =
+        auto timeInterpolator =
             ext::make_shared<LinearInterpolation>(
                 optionletTimes.begin(), optionletTimes.end(), vol.begin());
         return (*timeInterpolator)(length, true);

--- a/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
+++ b/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
@@ -95,7 +95,7 @@ namespace QuantLib {
     }
 
     void SabrInterpolatedSmileSection::createInterpolation() const {
-         ext::shared_ptr<SABRInterpolation> tmp = ext::make_shared<SABRInterpolation>(
+         auto tmp = ext::make_shared<SABRInterpolation>(
              actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
              exerciseTime(), forwardValue_, alpha_, beta_, nu_, rho_,
              isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, vegaWeighted_,

--- a/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
+++ b/ql/termstructures/volatility/sabrinterpolatedsmilesection.cpp
@@ -81,8 +81,8 @@ namespace QuantLib {
         const DayCounter& dc,
         const Real shift)
     : SmileSection(optionDate, dc, Date(), ShiftedLognormal, shift),
-      forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-      atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+      forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+      atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
       volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
       hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), alpha_(alpha), beta_(beta),
       nu_(nu), rho_(rho), isAlphaFixed_(isAlphaFixed), isBetaFixed_(isBetaFixed),
@@ -91,16 +91,15 @@ namespace QuantLib {
       evaluationDate_(Settings::instance().evaluationDate()) {
 
         for (Size i = 0; i < volHandles_.size(); ++i)
-            volHandles_[i] = Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+            volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(volHandles[i]));
     }
 
     void SabrInterpolatedSmileSection::createInterpolation() const {
-         ext::shared_ptr<SABRInterpolation> tmp(new SABRInterpolation(
-                     actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
-                     exerciseTime(), forwardValue_,
-                     alpha_, beta_, nu_, rho_,
-                     isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, vegaWeighted_,
-                     endCriteria_, method_, 0.0020, false, 50, shift()));
+         ext::shared_ptr<SABRInterpolation> tmp = ext::make_shared<SABRInterpolation>(
+             actualStrikes_.begin(), actualStrikes_.end(), vols_.begin(),
+             exerciseTime(), forwardValue_, alpha_, beta_, nu_, rho_,
+             isAlphaFixed_, isBetaFixed_, isNuFixed_, isRhoFixed_, vegaWeighted_,
+             endCriteria_, method_, 0.0020, false, 50, shift());
          swap(tmp, sabrInterpolation_);
     }
 
@@ -133,4 +132,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/termstructures/volatility/swaption/interpolatedswaptionvolatilitycube.cpp
+++ b/ql/termstructures/volatility/swaption/interpolatedswaptionvolatilitycube.cpp
@@ -102,14 +102,8 @@ namespace QuantLib {
                 atmVol + volSpreadsInterpolator_[i](length, optionTime)));
         }
         Real shift = atmVol_->shift(optionTime,length);
-        return ext::shared_ptr<SmileSection>(new
-            InterpolatedSmileSection<Linear>(optionTime,
-                                             strikes,
-                                             stdDevs,
-                                             atmForward,
-                                             Linear(),
-                                             Actual365Fixed(),
-                                             volatilityType(),
-                                             shift));
+        return ext::make_shared<InterpolatedSmileSection<Linear>>(
+            optionTime, strikes, stdDevs, atmForward, Linear(), Actual365Fixed(),
+            volatilityType(), shift);
     }
 }

--- a/ql/termstructures/volatility/swaption/spreadedswaptionvol.cpp
+++ b/ql/termstructures/volatility/swaption/spreadedswaptionvol.cpp
@@ -39,8 +39,7 @@ namespace QuantLib {
                                                  const Period& swapT) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(d, swapT, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     ext::shared_ptr<SmileSection>
@@ -48,8 +47,7 @@ namespace QuantLib {
                                                  Time swapLength) const {
         ext::shared_ptr<SmileSection> baseSmile =
             baseVol_->smileSection(optionTime, swapLength, true);
-        return ext::shared_ptr<SmileSection>(new
-            SpreadedSmileSection(baseSmile, spread_));
+        return ext::make_shared<SpreadedSmileSection>(baseSmile, spread_);
     }
 
     Volatility SpreadedSwaptionVolatility::volatilityImpl(const Date& d,

--- a/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionconstantvol.cpp
@@ -62,7 +62,7 @@ namespace QuantLib {
                                                     const VolatilityType type,
                                                     const Real shift)
     : SwaptionVolatilityStructure(settlementDays, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))),
+      volatility_(ext::make_shared<SimpleQuote>(vol)),
       maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     // fixed reference date, fixed market data
@@ -75,25 +75,24 @@ namespace QuantLib {
                                                     const VolatilityType type,
                                                     const Real shift)
     : SwaptionVolatilityStructure(referenceDate, cal, bdc, dc),
-      volatility_(ext::shared_ptr<Quote>(new SimpleQuote(vol))),
+      volatility_(ext::make_shared<SimpleQuote>(vol)),
       maxSwapTenor_(100*Years), volatilityType_(type), shift_(shift) {}
 
     ext::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(const Date& d,
                                                  const Period&) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-            new FlatSmileSection(d, atmVol, dayCounter(), referenceDate(),
-                                 Null<Rate>(), volatilityType_, shift_));
+        return ext::make_shared<FlatSmileSection>(
+            d, atmVol, dayCounter(), referenceDate(), Null<Rate>(),
+            volatilityType_, shift_);
     }
 
     ext::shared_ptr<SmileSection>
     ConstantSwaptionVolatility::smileSectionImpl(Time optionTime,
                                                  Time) const {
         Volatility atmVol = volatility_->value();
-        return ext::shared_ptr<SmileSection>(
-            new FlatSmileSection(optionTime, atmVol, dayCounter(), Null<Rate>(),
-                                 volatilityType_, shift_));
+        return ext::make_shared<FlatSmileSection>(
+            optionTime, atmVol, dayCounter(), Null<Rate>(), volatilityType_, shift_);
     }
 
     Volatility ConstantSwaptionVolatility::volatilityImpl(const Date&,

--- a/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
+++ b/ql/termstructures/volatility/swaption/swaptionvolmatrix.cpp
@@ -131,8 +131,8 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] =
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -180,8 +180,8 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] =
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -229,8 +229,8 @@ namespace QuantLib {
             volHandles_[i].resize(vols.columns());
             shiftValues_[i].resize(vols.columns());
             for (Size j=0; j<vols.columns(); ++j) {
-                volHandles_[i][j] = Handle<Quote>(ext::shared_ptr<Quote>(new
-                    SimpleQuote(vols[i][j])));
+                volHandles_[i][j] =
+                    Handle<Quote>(ext::make_shared<SimpleQuote>(vols[i][j]));
                 shiftValues_[i][j] = shifts.rows() > 0 ? shifts[i][j] : 0.0;
             }
         }
@@ -312,8 +312,8 @@ namespace QuantLib {
     //    Time swapLength = convertSwapTenor(swapTenor);
     //    // dummy strike
     //    Volatility atmVol = volatilityImpl(optionTime, swapLength, 0.05);
-    //    return ext::shared_ptr<SmileSection>(new
-    //        FlatSmileSection(d, atmVol, dayCounter(), referenceDate()));
+    //    return ext::make_shared<FlatSmileSection>(
+    //        d, atmVol, dayCounter(), referenceDate());
     //}
 
     ext::shared_ptr<SmileSection>
@@ -321,9 +321,9 @@ namespace QuantLib {
                                                Time swapLength) const {
         // dummy strike
         Volatility atmVol = volatilityImpl(optionTime, swapLength, 0.05);
-        return ext::shared_ptr<SmileSection>(new FlatSmileSection(
+        return ext::make_shared<FlatSmileSection>(
             optionTime, atmVol, dayCounter(), Null<Real>(), volatilityType(),
-            shift(optionTime, swapLength, true)));
+            shift(optionTime, swapLength, true));
     }
 
 }

--- a/ql/termstructures/volatility/zabr.cpp
+++ b/ql/termstructures/volatility/zabr.cpp
@@ -146,18 +146,20 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
 #endif
 
     // Mesher
-    const ext::shared_ptr<Fdm1dMesher> m1(new Concentrating1dMesher(
-        start, end, size, std::pair<Real, Real>(forward_, density), true));
-    // const ext::shared_ptr<Fdm1dMesher> m1(new
-    // Uniform1dMesher(start,end,size));
-    // const ext::shared_ptr<Fdm1dMesher> m1a(new
-    // Uniform1dMesher(start,0.03,101));
-    // const ext::shared_ptr<Fdm1dMesher> m1b(new
-    // Uniform1dMesher(0.03,end,100));
-    // const ext::shared_ptr<Fdm1dMesher> m1(new Glued1dMesher(*m1a,*m1b));
+    const ext::shared_ptr<Fdm1dMesher> m1 =
+        ext::make_shared<Concentrating1dMesher>(
+            start, end, size, std::pair<Real, Real>(forward_, density), true);
+    // const ext::shared_ptr<Fdm1dMesher> m1 =
+    //     ext::make_shared<Uniform1dMesher>(start,end,size);
+    // const ext::shared_ptr<Fdm1dMesher> m1a =
+    //     ext::make_shared<Uniform1dMesher>(start,0.03,101);
+    // const ext::shared_ptr<Fdm1dMesher> m1b =
+    //     ext::make_shared<Uniform1dMesher>(0.03,end,100);
+    // const ext::shared_ptr<Fdm1dMesher> m1 =
+    //     ext::make_shared<Glued1dMesher>(*m1a,*m1b);
     const std::vector<ext::shared_ptr<Fdm1dMesher> > meshers(1, m1);
-    const ext::shared_ptr<FdmMesher> mesher(
-        new FdmMesherComposite(layout, meshers));
+    const ext::shared_ptr<FdmMesher> mesher =
+        ext::make_shared<FdmMesherComposite>(layout, meshers);
 
     // Boundary conditions
     FdmBoundaryConditionSet boundaries;
@@ -178,19 +180,20 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
     std::copy(locVolv.begin(), locVolv.end(), locVol.begin());
 
     // solver
-    ext::shared_ptr<FdmDupire1dOp> map(new FdmDupire1dOp(mesher, locVol));
+    ext::shared_ptr<FdmDupire1dOp> map =
+        ext::make_shared<FdmDupire1dOp>(mesher, locVol);
     FdmBackwardSolver solver(map, boundaries,
                              ext::shared_ptr<FdmStepConditionComposite>(),
                              FdmSchemeDesc::Douglas());
     solver.rollback(rhs, expiryTime_, 0.0, steps, dampingSteps);
 
     // interpolate solution
-    ext::shared_ptr<Interpolation> solution(new CubicInterpolation(
+    ext::shared_ptr<Interpolation> solution = ext::make_shared<CubicInterpolation>(
         k.begin(), k.end(), rhs.begin(), CubicInterpolation::Spline, true,
         CubicInterpolation::SecondDerivative, 0.0,
-        CubicInterpolation::SecondDerivative, 0.0));
-    // ext::shared_ptr<Interpolation> solution(new
-    // LinearInterpolation(k.begin(),k.end(),rhs.begin()));
+        CubicInterpolation::SecondDerivative, 0.0);
+    // ext::shared_ptr<Interpolation> solution =
+    //     ext::make_shared<LinearInterpolation>(k.begin(),k.end(),rhs.begin());
     solution->disableExtrapolation();
     std::vector<Real> result(strikes.size());
     std::transform(strikes.begin(), strikes.end(), result.begin(), *solution);
@@ -243,27 +246,29 @@ Real ZabrModel::fullFdPrice(const Real strike) const {
         4, (Size)std::ceil(((x0 + x1) / 2.0 - f0) / (f1 - f0) * (Real)sizef));
     const Size sizefb = sizef - sizefa + 1; // common point, so we can spend
     // one more here
-    const ext::shared_ptr<Fdm1dMesher> mfa(
-        new Concentrating1dMesher(f0, (x0 + x1) / 2.0, sizefa,
-                                  std::pair<Real, Real>(x0, densityf), true));
-    const ext::shared_ptr<Fdm1dMesher> mfb(
-        new Concentrating1dMesher((x0 + x1) / 2.0, f1, sizefb,
-                                  std::pair<Real, Real>(x1, densityf), true));
-    const ext::shared_ptr<Fdm1dMesher> mf(new Glued1dMesher(*mfa, *mfb));
+    const ext::shared_ptr<Fdm1dMesher> mfa =
+        ext::make_shared<Concentrating1dMesher>(
+            f0, (x0 + x1) / 2.0, sizefa, std::pair<Real, Real>(x0, densityf), true);
+    const ext::shared_ptr<Fdm1dMesher> mfb =
+        ext::make_shared<Concentrating1dMesher>(
+            (x0 + x1) / 2.0, f1, sizefb, std::pair<Real, Real>(x1, densityf), true);
+    const ext::shared_ptr<Fdm1dMesher> mf = ext::make_shared<Glued1dMesher>(*mfa, *mfb);
 
     // concentraing mesher around f to get the forward mesher
-    // const ext::shared_ptr<Fdm1dMesher> mf(new Concentrating1dMesher(
-    //     f0, f1, sizef, std::pair<Real, Real>(forward_, densityf), true));
+    // const ext::shared_ptr<Fdm1dMesher> mf =
+    //     ext::make_shared<Concentrating1dMesher>(
+    //         f0, f1, sizef, std::pair<Real, Real>(forward_, densityf), true);
 
     // Volatility mesher
-    const ext::shared_ptr<Fdm1dMesher> mv(new Concentrating1dMesher(
-        v0, v1, sizev, std::pair<Real, Real>(alpha_, densityv), true));
+    const ext::shared_ptr<Fdm1dMesher> mv =
+        ext::make_shared<Concentrating1dMesher>(
+            v0, v1, sizev, std::pair<Real, Real>(alpha_, densityv), true);
 
     // uniform meshers
-    // const ext::shared_ptr<Fdm1dMesher> mf(new
-    // Uniform1dMesher(f0,f1,sizef));
-    // const ext::shared_ptr<Fdm1dMesher> mv(new
-    // Uniform1dMesher(v0,v1,sizev));
+    // const ext::shared_ptr<Fdm1dMesher> mf =
+    //     ext::make_shared<Uniform1dMesher>(f0,f1,sizef);
+    // const ext::shared_ptr<Fdm1dMesher> mv =
+    //     ext::make_shared<Uniform1dMesher>(v0,v1,sizev);
 
     std::vector<ext::shared_ptr<Fdm1dMesher> > meshers;
     meshers.push_back(mf);

--- a/ql/termstructures/volatility/zabr.cpp
+++ b/ql/termstructures/volatility/zabr.cpp
@@ -180,7 +180,7 @@ std::vector<Real> ZabrModel::fdPrice(const std::vector<Real> &strikes) const {
     std::copy(locVolv.begin(), locVolv.end(), locVol.begin());
 
     // solver
-    ext::shared_ptr<FdmDupire1dOp> map =
+    auto map =
         ext::make_shared<FdmDupire1dOp>(mesher, locVol);
     FdmBackwardSolver solver(map, boundaries,
                              ext::shared_ptr<FdmStepConditionComposite>(),

--- a/ql/termstructures/volatility/zabrinterpolatedsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrinterpolatedsmilesection.hpp
@@ -274,8 +274,8 @@ ZabrInterpolatedSmileSection<Evaluation>::ZabrInterpolatedSmileSection(
     ext::shared_ptr<OptimizationMethod> method,
     const DayCounter& dc)
 : SmileSection(optionDate, dc),
-  forward_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(forward)))),
-  atmVolatility_(Handle<Quote>(ext::shared_ptr<Quote>(new SimpleQuote(atmVolatility)))),
+  forward_(Handle<Quote>(ext::make_shared<SimpleQuote>(forward))),
+  atmVolatility_(Handle<Quote>(ext::make_shared<SimpleQuote>(atmVolatility))),
   volHandles_(volHandles.size()), strikes_(strikes), actualStrikes_(strikes),
   hasFloatingStrikes_(hasFloatingStrikes), vols_(volHandles.size()), alpha_(alpha), beta_(beta),
   nu_(nu), rho_(rho), gamma_(gamma), isAlphaFixed_(isAlphaFixed), isBetaFixed_(isBetaFixed),
@@ -283,8 +283,7 @@ ZabrInterpolatedSmileSection<Evaluation>::ZabrInterpolatedSmileSection(
   vegaWeighted_(vegaWeighted), endCriteria_(std::move(endCriteria)), method_(std::move(method)) {
 
     for (Size i = 0; i < volHandles_.size(); ++i)
-        volHandles_[i] = Handle<Quote>(
-            ext::shared_ptr<Quote>(new SimpleQuote(volHandles[i])));
+        volHandles_[i] = Handle<Quote>(ext::make_shared<SimpleQuote>(volHandles[i]));
 }
 
 template <typename Evaluation>

--- a/ql/termstructures/volatility/zabrsmilesection.hpp
+++ b/ql/termstructures/volatility/zabrsmilesection.hpp
@@ -231,13 +231,13 @@ void ZabrSmileSection<Evaluation>::init3(ZabrLocalVolatility) {
     strikes_.insert(strikes_.begin(), 0.0);
     callPrices_.insert(callPrices_.begin(), forward_);
 
-    callPriceFct_ = ext::shared_ptr<Interpolation>(new CubicInterpolation(
+    callPriceFct_ = ext::make_shared<CubicInterpolation>(
         strikes_.begin(), strikes_.end(), callPrices_.begin(),
         CubicInterpolation::Spline, true, CubicInterpolation::SecondDerivative,
-        0.0, CubicInterpolation::SecondDerivative, 0.0));
+        0.0, CubicInterpolation::SecondDerivative, 0.0);
     // callPriceFct_ =
-    //     ext::shared_ptr<Interpolation>(new LinearInterpolation(
-    //         strikes_.begin(), strikes_.end(), callPrices_.begin()));
+    //     ext::make_shared<LinearInterpolation>(
+    //         strikes_.begin(), strikes_.end(), callPrices_.begin());
 
     callPriceFct_->enableExtrapolation();
 


### PR DESCRIPTION
update to use make_shared and make_unique.

There is no unique_ptr<T>(new ... ) in the source code from this mr 