### PR TITLE
Avoid `constexpr Real` so AAD builds compile

### DIFF
--- a/ql/methods/lattices/trinomialtree.cpp
+++ b/ql/methods/lattices/trinomialtree.cpp
@@ -29,7 +29,7 @@ namespace QuantLib {
         // Two orders of magnitude leaves uniform and typical non-uniform
         // grids (weekend rolls, 1-day mismatches) untouched; the floor
         // intervenes only on the pathological small-mandatory-gap case.
-        constexpr Real kFloorThreshold = 0.01;
+        constexpr double kFloorThreshold = 0.01;
     }
 
     TrinomialTree::TrinomialTree(

--- a/test-suite/trinomialtree.cpp
+++ b/test-suite/trinomialtree.cpp
@@ -150,8 +150,8 @@ BOOST_AUTO_TEST_CASE(testFloorThresholdBoundary) {
     // threshold (0.01) so the test exercises the gating boundary
     // itself; loose multipliers (e.g. 0.005 / 0.02) would still pass
     // for any threshold in a wide range.
-    constexpr Time kBelow = 0.0099;
-    constexpr Time kAbove = 0.0101;
+    constexpr double kBelow = 0.0099;
+    constexpr double kAbove = 0.0101;
 
     // Just below threshold: floor active.  Node count must stay
     // bounded (each step extends the j-range by at most 1 on each


### PR DESCRIPTION
Use double instead of constexpr Real in TrinomialTree for AAD builds