### PR TITLE
Add `GaussianCopulaSpreadEngine` for spread option pricing

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1510,6 +1510,7 @@
     <ClInclude Include="ql\pricingengines\basket\denglizhoubasketengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\fd2dblackscholesvanillaengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\fdndimblackscholesvanillaengine.hpp" />
+    <ClInclude Include="ql\pricingengines\basket\gaussiancopulaspreadengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\kirkengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\mcamericanbasketengine.hpp" />
     <ClInclude Include="ql\pricingengines\basket\mceuropeanbasketengine.hpp" />
@@ -2617,6 +2618,7 @@
     <ClCompile Include="ql\pricingengines\basket\denglizhoubasketengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\fd2dblackscholesvanillaengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\fdndimblackscholesvanillaengine.cpp" />
+    <ClCompile Include="ql\pricingengines\basket\gaussiancopulaspreadengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\kirkengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\mcamericanbasketengine.cpp" />
     <ClCompile Include="ql\pricingengines\basket\mceuropeanbasketengine.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2520,6 +2520,9 @@
     <ClInclude Include="ql\pricingengines\basket\mceuropeanbasketengine.hpp">
       <Filter>pricingengines\basket</Filter>
     </ClInclude>
+    <ClInclude Include="ql\pricingengines\basket\gaussiancopulaspreadengine.hpp">
+      <Filter>pricingengines\basket</Filter>
+    </ClInclude>
     <ClInclude Include="ql\pricingengines\basket\kirkengine.hpp">
       <Filter>pricingengines\basket</Filter>
     </ClInclude>
@@ -5940,6 +5943,9 @@
       <Filter>pricingengines\basket</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\basket\mceuropeanbasketengine.cpp">
+      <Filter>pricingengines\basket</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\pricingengines\basket\gaussiancopulaspreadengine.cpp">
       <Filter>pricingengines\basket</Filter>
     </ClCompile>
     <ClCompile Include="ql\pricingengines\basket\kirkengine.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -682,6 +682,7 @@ set(QL_SOURCES
     pricingengines/basket/denglizhoubasketengine.cpp
     pricingengines/basket/fd2dblackscholesvanillaengine.cpp
     pricingengines/basket/fdndimblackscholesvanillaengine.cpp
+    pricingengines/basket/gaussiancopulaspreadengine.cpp
     pricingengines/basket/kirkengine.cpp
     pricingengines/basket/mcamericanbasketengine.cpp
     pricingengines/basket/mceuropeanbasketengine.cpp
@@ -1921,6 +1922,7 @@ set(QL_HEADERS
     pricingengines/basket/denglizhoubasketengine.hpp
     pricingengines/basket/fd2dblackscholesvanillaengine.hpp
     pricingengines/basket/fdndimblackscholesvanillaengine.hpp    
+    pricingengines/basket/gaussiancopulaspreadengine.hpp
     pricingengines/basket/kirkengine.hpp
     pricingengines/basket/mcamericanbasketengine.hpp
     pricingengines/basket/mceuropeanbasketengine.hpp

--- a/ql/pricingengines/basket/Makefile.am
+++ b/ql/pricingengines/basket/Makefile.am
@@ -9,6 +9,7 @@ this_include_HEADERS = \
 	denglizhoubasketengine.hpp \
 	fd2dblackscholesvanillaengine.hpp \
 	fdndimblackscholesvanillaengine.hpp \
+	gaussiancopulaspreadengine.hpp \
 	kirkengine.hpp \
 	mcamericanbasketengine.hpp \
 	mceuropeanbasketengine.hpp \
@@ -25,6 +26,7 @@ cpp_files = \
 	denglizhoubasketengine.cpp \
 	fd2dblackscholesvanillaengine.cpp \
 	fdndimblackscholesvanillaengine.cpp \
+	gaussiancopulaspreadengine.cpp \
 	kirkengine.cpp \
 	mcamericanbasketengine.cpp \
 	mceuropeanbasketengine.cpp \

--- a/ql/pricingengines/basket/all.hpp
+++ b/ql/pricingengines/basket/all.hpp
@@ -6,6 +6,7 @@
 #include <ql/pricingengines/basket/denglizhoubasketengine.hpp>
 #include <ql/pricingengines/basket/fd2dblackscholesvanillaengine.hpp>
 #include <ql/pricingengines/basket/fdndimblackscholesvanillaengine.hpp>
+#include <ql/pricingengines/basket/gaussiancopulaspreadengine.hpp>
 #include <ql/pricingengines/basket/kirkengine.hpp>
 #include <ql/pricingengines/basket/mcamericanbasketengine.hpp>
 #include <ql/pricingengines/basket/mceuropeanbasketengine.hpp>

--- a/ql/pricingengines/basket/gaussiancopulaspreadengine.cpp
+++ b/ql/pricingengines/basket/gaussiancopulaspreadengine.cpp
@@ -1,0 +1,129 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/pricingengines/basket/gaussiancopulaspreadengine.hpp>
+#include <ql/exercise.hpp>
+#include <ql/math/distributions/normaldistribution.hpp>
+#include <ql/math/integrals/gaussianquadratures.hpp>
+#include <ql/methods/finitedifferences/utilities/smilesectionrndcalculator.hpp>
+#include <ql/termstructures/volatility/atmsmilesection.hpp>
+#include <utility>
+#include <algorithm>
+#include <cmath>
+
+namespace QuantLib {
+
+    GaussianCopulaSpreadEngine::GaussianCopulaSpreadEngine(
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process1,
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process2,
+        Real correlation,
+        Size nPoints)
+    : process1_(std::move(process1)),
+      process2_(std::move(process2)),
+      rho_(correlation),
+      nPoints_(nPoints) {
+        QL_REQUIRE(correlation >= -1.0 && correlation <= 1.0,
+                   "correlation must be in [-1, 1], got " << correlation);
+        QL_REQUIRE(process1_->riskFreeRate().currentLink() ==
+                   process2_->riskFreeRate().currentLink(),
+                   "process1 and process2 must share the risk-free term "
+                   "structure (used for discounting the spread payoff)");
+        registerWith(process1_);
+        registerWith(process2_);
+    }
+
+    void GaussianCopulaSpreadEngine::calculate() const {
+        const ext::shared_ptr<EuropeanExercise> exercise =
+            ext::dynamic_pointer_cast<EuropeanExercise>(arguments_.exercise);
+        QL_REQUIRE(exercise, "not a European exercise");
+
+        const ext::shared_ptr<SpreadBasketPayoff> spreadPayoff =
+            ext::dynamic_pointer_cast<SpreadBasketPayoff>(arguments_.payoff);
+        QL_REQUIRE(spreadPayoff, "spread payoff expected");
+
+        const ext::shared_ptr<PlainVanillaPayoff> payoff =
+            ext::dynamic_pointer_cast<PlainVanillaPayoff>(spreadPayoff->basePayoff());
+        QL_REQUIRE(payoff, "non-plain payoff given");
+
+        // 1. Forwards, discount, and smile sections.
+        const Date maturityDate = exercise->lastDate();
+
+        const Real fwd1 = process1_->stateVariable()->value()
+            * process1_->dividendYield()->discount(maturityDate)
+            / process1_->riskFreeRate()->discount(maturityDate);
+
+        const Real fwd2 = process2_->stateVariable()->value()
+            * process2_->dividendYield()->discount(maturityDate)
+            / process2_->riskFreeRate()->discount(maturityDate);
+
+        const DiscountFactor df = process1_->riskFreeRate()->discount(maturityDate);
+
+        const Time T1 = process1_->blackVolatility()->timeFromReference(maturityDate);
+        const Time T2 = process2_->blackVolatility()->timeFromReference(maturityDate);
+
+        const auto smile1 = ext::make_shared<AtmSmileSection>(
+            process1_->blackVolatility()->smileSection(T1), fwd1);
+        const auto smile2 = ext::make_shared<AtmSmileSection>(
+            process2_->blackVolatility()->smileSection(T2), fwd2);
+
+        // 2. Risk-neutral marginals.
+        SmileSectionRNDCalculator rnd1(smile1);
+        SmileSectionRNDCalculator rnd2(smile2);
+
+        // 3. Nested Gauss-Hermite quadrature.  GaussHermiteIntegration
+        // approximates int f(x) dx, so to integrate against phi(z) we
+        // substitute z = sqrt(2)*x and weight by (1/pi) exp(-x_i^2 - x_j^2).
+
+        GaussHermiteIntegration gh(nPoints_);
+
+        const Array& x = gh.x();
+        const Array& w = gh.weights();
+
+        const CumulativeNormalDistribution Phi;
+        const Real rhoComp = std::sqrt(std::max(1.0 - rho_ * rho_, 0.0));
+        const Real normFactor = 1.0 / M_PI;
+
+        Real sum = 0.0;
+        for (Size i = 0; i < gh.order(); ++i) {
+            const Real z1 = M_SQRT2 * x[i];
+            // At extreme GH nodes Phi(z) saturates to exactly 0 or 1;
+            // nudge it inside the open interval that invcdf requires.
+            const Real u1 = std::clamp(Phi(z1), QL_EPSILON, 1.0 - QL_EPSILON);
+            const Real S1 = std::exp(rnd1.invcdf(u1));
+            const Real expX1sq = std::exp(-x[i] * x[i]);
+
+            Real innerSum = 0.0;
+            for (Size j = 0; j < gh.order(); ++j) {
+                const Real z2perp = M_SQRT2 * x[j];
+                const Real z2 = rho_ * z1 + rhoComp * z2perp;
+                const Real u2 = std::clamp(Phi(z2), QL_EPSILON, 1.0 - QL_EPSILON);
+                const Real S2 = std::exp(rnd2.invcdf(u2));
+
+                const Real payoffVal = (*payoff)(S1 - S2);
+
+                const Real kernel = expX1sq * std::exp(-x[j] * x[j]);
+                innerSum += w[j] * kernel * payoffVal;
+            }
+            sum += w[i] * innerSum;
+        }
+
+        results_.value = df * normFactor * sum;
+    }
+
+}

--- a/ql/pricingengines/basket/gaussiancopulaspreadengine.hpp
+++ b/ql/pricingengines/basket/gaussiancopulaspreadengine.hpp
@@ -1,0 +1,59 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Yassine Idyiahia
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file gaussiancopulaspreadengine.hpp
+    \brief Spread option pricing via nested Gauss-Hermite quadrature on a Gaussian copula
+*/
+
+#ifndef quantlib_gaussian_copula_spread_engine_hpp
+#define quantlib_gaussian_copula_spread_engine_hpp
+
+#include <ql/instruments/basketoption.hpp>
+#include <ql/processes/blackscholesprocess.hpp>
+
+namespace QuantLib {
+
+    //! Gaussian copula engine for spread options with smile-implied marginals
+    /*! Prices \f$ \max(S_1 - S_2 - K, 0) \f$ via nested Gauss-Hermite
+        quadrature over a Gaussian copula with smile-implied marginals.
+
+        \ingroup basketengines
+
+        \test the correctness of the returned value is tested by
+              benchmarking against 2D Dupire local-vol PDE.
+    */
+    class GaussianCopulaSpreadEngine : public BasketOption::engine {
+      public:
+        GaussianCopulaSpreadEngine(
+            ext::shared_ptr<GeneralizedBlackScholesProcess> process1,
+            ext::shared_ptr<GeneralizedBlackScholesProcess> process2,
+            Real correlation,
+            Size nPoints = 64);
+
+        void calculate() const override;
+
+      private:
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process1_;
+        ext::shared_ptr<GeneralizedBlackScholesProcess> process2_;
+        Real rho_;
+        Size nPoints_;
+    };
+}
+
+#endif

--- a/test-suite/basketoption.cpp
+++ b/test-suite/basketoption.cpp
@@ -36,6 +36,9 @@
 #include <ql/pricingengines/basket/operatorsplittingspreadengine.hpp>
 #include <ql/pricingengines/basket/singlefactorbsmbasketengine.hpp>
 #include <ql/pricingengines/basket/denglizhoubasketengine.hpp>
+#include <ql/pricingengines/basket/gaussiancopulaspreadengine.hpp>
+#include <ql/experimental/volatility/svismilesection.hpp>
+#include <ql/termstructures/volatility/equityfx/piecewiseblackvariancesurface.hpp>
 #include <ql/pricingengines/basket/stulzengine.hpp>
 #include <ql/pricingengines/vanilla/fdblackscholesvanillaengine.hpp>
 #include <ql/processes/stochasticprocessarray.hpp>
@@ -1368,22 +1371,24 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
     const ext::shared_ptr<SimpleQuote> v1 = ext::make_shared<SimpleQuote>(0.25);
     const ext::shared_ptr<SimpleQuote> v2 = ext::make_shared<SimpleQuote>(0.4);
 
+    // The spread option has a single discount.
+    const Handle<YieldTermStructure> rTS(flatRate(today, r, dc));
+
     const ext::shared_ptr<BlackProcess> p1 =
         ext::make_shared<BlackProcess>(
-            Handle<Quote>(s1),
-            Handle<YieldTermStructure>(flatRate(today, r, dc)),
+            Handle<Quote>(s1), rTS,
             Handle<BlackVolTermStructure>(flatVol(today, v1, dc))
     );
     const ext::shared_ptr<BlackProcess> p2 =
         ext::make_shared<BlackProcess>(
-            Handle<Quote>(s2),
-            Handle<YieldTermStructure>(flatRate(today, r, dc)),
+            Handle<Quote>(s2), rTS,
             Handle<BlackVolTermStructure>(flatVol(today, v2, dc))
     );
 
     const Real strike = 5;
 
-    IncrementalStatistics statKirk, statBS2014, statOs1, statOs2, statPearson;
+    IncrementalStatistics statKirk, statBS2014, statOs1, statOs2,
+                          statPearson, statGaussianCopula;
 
     for (Option::Type type: {Option::Call, Option::Put}) {
         BasketOption option(
@@ -1408,6 +1413,9 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
 
             const ext::shared_ptr<PricingEngine> pearsonEngine
                 = ext::make_shared<PearsonSpreadEngine>(p1, p2, rho);
+
+            const ext::shared_ptr<PricingEngine> gaussianCopulaEngine
+                = ext::make_shared<GaussianCopulaSpreadEngine>(p1, p2, rho);
 
             const ext::shared_ptr<PricingEngine> fdEngine
                 = ext::make_shared<Fd2dBlackScholesVanillaEngine>(
@@ -1435,6 +1443,9 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
 
                     option.setPricingEngine(pearsonEngine);
                     statPearson.add(option.NPV() - fdNPV);
+
+                    option.setPricingEngine(gaussianCopulaEngine);
+                    statGaussianCopula.add(option.NPV() - fdNPV);
                 }
             }
         }
@@ -1475,6 +1486,14 @@ BOOST_AUTO_TEST_CASE(testPDEvsApproximations) {
                 " with Pearson engine."
                    << std::fixed << std::setprecision(5)
                    << "\n    stdev     : " << statPearson.standardDeviation()
+                   << "\n    tolerance : " << 0.02);
+    }
+
+    if (statGaussianCopula.standardDeviation() > 0.02) {
+        BOOST_FAIL("failed to reproduce PDE spread option prices"
+                " with Gaussian Copula spread engine."
+                   << std::fixed << std::setprecision(5)
+                   << "\n    stdev     : " << statGaussianCopula.standardDeviation()
                    << "\n    tolerance : " << 0.02);
     }
 }
@@ -2677,6 +2696,178 @@ BOOST_AUTO_TEST_CASE(testPearsonSpreadEngine) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testGaussianCopulaSpreadEngineFlatVol) {
+    BOOST_TEST_MESSAGE("Testing Gaussian Copula spread engine "
+                       "with flat volatility...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(1, March, 2025);
+    const Date maturity = today + Period(12, Months);
+
+    const ext::shared_ptr<EuropeanExercise> exercise
+        = ext::make_shared<EuropeanExercise>(maturity);
+
+    const Real rho = 0.5;
+    const Real f1 = 100, f2 = 96;
+    const Handle<YieldTermStructure> r
+        = Handle<YieldTermStructure>(flatRate(today, 0.05, dc));
+    const ext::shared_ptr<BlackProcess> p1 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(f1)), r,
+            Handle<BlackVolTermStructure>(flatVol(today, 0.20, dc))
+    );
+    const ext::shared_ptr<BlackProcess> p2 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(f2)), r,
+            Handle<BlackVolTermStructure>(flatVol(today, 0.25, dc))
+    );
+
+    const ext::shared_ptr<PricingEngine> copulaEngine
+        = ext::make_shared<GaussianCopulaSpreadEngine>(p1, p2, rho);
+
+    // 1. Put-call parity: (C - P) / df = F1 - F2 - K
+    const Real strike = 3;
+    BasketOption callOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, strike)),
+        exercise);
+    callOption.setPricingEngine(copulaEngine);
+    const Real callNPV = callOption.NPV();
+
+    BasketOption putOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(Option::Put, strike)),
+        exercise);
+    putOption.setPricingEngine(copulaEngine);
+    const Real putNPV = putOption.NPV();
+
+    const DiscountFactor df = r->discount(maturity);
+    const Real fwd = (callNPV - putNPV) / df;
+    const Real expectedFwd = f1 - f2 - strike;
+    Real relError = relativeError(fwd, expectedFwd, f1);
+    constexpr double parityRelTol = 1e-3;
+
+    if (relError > parityRelTol) {
+        BOOST_FAIL("failed to reproduce call-put parity "
+                "using the Gaussian Copula spread engine."
+                   << std::fixed << std::setprecision(8)
+                   << "\n    calculated fwd: " << fwd
+                   << "\n    expected fwd : " << expectedFwd
+                   << "\n    rel error    : " << relError
+                   << "\n    tolerance    : " << parityRelTol);
+    }
+
+    // 2. Exchange option (K=0): should match Margrabe via Bjerksund-Stensland
+    const Real exchangeStrike = 0.0;
+    BasketOption exchangeOption(ext::make_shared<SpreadBasketPayoff>(
+            ext::make_shared<PlainVanillaPayoff>(
+                Option::Call, exchangeStrike)),
+        exercise);
+
+    exchangeOption.setPricingEngine(copulaEngine);
+    const Real copulaExchange = exchangeOption.NPV();
+
+    const ext::shared_ptr<PricingEngine> bsEngine
+        = ext::make_shared<BjerksundStenslandSpreadEngine>(p1, p2, rho);
+    exchangeOption.setPricingEngine(bsEngine);
+    const Real bsExchange = exchangeOption.NPV();
+
+    relError = relativeError(copulaExchange, bsExchange, f1);
+    constexpr double exchangeRelTol = 1e-3;
+    if (relError > exchangeRelTol) {
+        BOOST_FAIL("failed to reproduce exchange option price "
+                "using the Gaussian Copula spread engine."
+                   << std::fixed << std::setprecision(8)
+                   << "\n    Copula    : " << copulaExchange
+                   << "\n    BS2014    : " << bsExchange
+                   << "\n    rel error : " << relError
+                   << "\n    tolerance : " << exchangeRelTol);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testGaussianCopulaSpreadEngineSVI) {
+    BOOST_TEST_MESSAGE("Testing Gaussian Copula spread engine "
+                       "with SVI smile vs 2D Dupire PDE...");
+
+    const DayCounter dc = Actual365Fixed();
+    const Date today = Date(1, March, 2025);
+    const Date maturity = today + Period(12, Months);
+
+    const ext::shared_ptr<EuropeanExercise> exercise
+        = ext::make_shared<EuropeanExercise>(maturity);
+
+    const Real rho = 0.5;
+    const Real spot1 = 100, spot2 = 96;
+
+    // SVI parameters: { a, b, sigma, rho_svi, m }
+    const std::vector<Real> sviParams1 = { 0.04, 0.10, 0.30, -0.40, 0.0 };
+    const std::vector<Real> sviParams2 = { 0.02, 0.08, 0.25, -0.30, 0.0 };
+
+    const Handle<YieldTermStructure> rTS(flatRate(today, 0.05, dc));
+    const DiscountFactor df = rTS->discount(maturity);
+    const Real fwd1 = spot1 / df;
+    const Real fwd2 = spot2 / df;
+
+    const Time T = dc.yearFraction(today, maturity);
+
+    const auto sviSmile1 =
+        ext::make_shared<SviSmileSection>(T, fwd1, sviParams1);
+    const auto sviSmile2 =
+        ext::make_shared<SviSmileSection>(T, fwd2, sviParams2);
+
+    const Handle<BlackVolTermStructure> sviVolTS1(
+        ext::make_shared<PiecewiseBlackVarianceSurface>(
+            today, maturity, sviSmile1, dc));
+    const Handle<BlackVolTermStructure> sviVolTS2(
+        ext::make_shared<PiecewiseBlackVarianceSurface>(
+            today, maturity, sviSmile2, dc));
+
+    const ext::shared_ptr<BlackProcess> p1 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(spot1)),
+            rTS, sviVolTS1);
+    const ext::shared_ptr<BlackProcess> p2 =
+        ext::make_shared<BlackProcess>(
+            Handle<Quote>(ext::make_shared<SimpleQuote>(spot2)),
+            rTS, sviVolTS2);
+
+    const ext::shared_ptr<PricingEngine> copulaEngine
+        = ext::make_shared<GaussianCopulaSpreadEngine>(p1, p2, rho);
+
+    // 2D PDE with Dupire local vol
+    const ext::shared_ptr<PricingEngine> pdeEngine
+        = ext::make_shared<Fd2dBlackScholesVanillaEngine>(
+            p1, p2, rho, 100, 100, 50, 0,
+            FdmSchemeDesc::Hundsdorfer(), true);
+
+    constexpr double tol = 5e-3;
+    const Real f1 = fwd1;
+
+    for (Real strike : { -2.0, 0.0, 4.0, 8.0 }) {
+
+        BasketOption option(
+            ext::make_shared<SpreadBasketPayoff>(
+                ext::make_shared<PlainVanillaPayoff>(Option::Call, strike)),
+            exercise);
+
+        option.setPricingEngine(copulaEngine);
+        const Real copulaNPV = option.NPV();
+
+        option.setPricingEngine(pdeEngine);
+        const Real pdeNPV = option.NPV();
+
+        const Real relError = relativeError(copulaNPV, pdeNPV, f1);
+
+        if (relError > tol) {
+            BOOST_FAIL("failed to reproduce SVI-smile spread option price "
+                       "using the Gaussian Copula spread engine vs 2D PDE."
+                       << std::fixed << std::setprecision(8)
+                       << "\n    strike     : " << strike
+                       << "\n    Copula     : " << copulaNPV
+                       << "\n    2D PDE     : " << pdeNPV
+                       << "\n    rel error  : " << relError
+                       << "\n    tolerance  : " << tol);
+        }
+    }
+}
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Prices via nested Gauss-Hermite quadrature over a Gaussian copula.

Tested in: 
- `testPDEvsApproximations` 
- `testGaussianCopulaSpreadEngineFlatVol`
- `testGaussianCopulaSpreadEngineSVI`