### PR TITLE
Add optional rounding precision to `OvernightIndexedCoupon` and `OvernightLeg`

### DIFF
--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -78,9 +78,9 @@ const ext::optional<Integer>& roundingPrecision)
         averagingMethod_(averagingMethod), lockoutDays_(lockoutDays),
         applyObservationShift_(applyObservationShift),
         compoundSpreadDaily_(compoundSpreadDaily),
-        roundingPrecision_(roundingPrecision),
         rateComputationStartDate_(rateComputationStartDate),
-        rateComputationEndDate_(rateComputationEndDate) {
+        rateComputationEndDate_(rateComputationEndDate),
+         roundingPrecision_(roundingPrecision) {
         
         // ctor guard prevents construction of an object with illogically ordered dates. 
         QL_REQUIRE(startDate < endDate, "startDate must be less than endDate");
@@ -549,6 +549,7 @@ const ext::optional<Integer>& roundingPrecision)
         lastRecentPeriodCalendar_ = lastRecentPeriodCalendar;
         return *this;
     }
+    
 
     OvernightLeg& OvernightLeg::withPaymentDates(const std::vector<Date>& paymentDates) {
         paymentDates_ = paymentDates;

--- a/ql/cashflows/overnightindexedcoupon.cpp
+++ b/ql/cashflows/overnightindexedcoupon.cpp
@@ -33,6 +33,7 @@
 #include <utility>
 #include <algorithm>
 #include <type_traits>
+#include <ql/math/rounding.hpp>
 
 using std::vector;
 
@@ -66,7 +67,8 @@ namespace QuantLib {
                     bool compoundSpreadDaily,
                     const Date& rateComputationStartDate,
                     const Date& rateComputationEndDate,
-                    const Date& exCouponDate)
+                    const Date& exCouponDate,
+const ext::optional<Integer>& roundingPrecision)
     : FloatingRateCoupon(paymentDate, nominal, startDate, endDate,
                          lookbackDays,
                          overnightIndex,
@@ -76,6 +78,7 @@ namespace QuantLib {
         averagingMethod_(averagingMethod), lockoutDays_(lockoutDays),
         applyObservationShift_(applyObservationShift),
         compoundSpreadDaily_(compoundSpreadDaily),
+        roundingPrecision_(roundingPrecision),
         rateComputationStartDate_(rateComputationStartDate),
         rateComputationEndDate_(rateComputationEndDate) {
         
@@ -200,6 +203,16 @@ namespace QuantLib {
             // usual case
             return nominal() * averageRate(std::min(d, accrualEndDate_)) * accruedPeriod(d);
         }
+    }
+
+    Real OvernightIndexedCoupon::amount() const {
+
+        Rate r = rate();
+
+        if (roundingPrecision_.has_value())
+            r = ClosestRounding(*roundingPrecision_)(r);
+
+        return r * accrualPeriod() * nominal();
     }
 
     Rate OvernightIndexedCoupon::averageRate(const Date& d) const {
@@ -478,6 +491,10 @@ namespace QuantLib {
         lockoutDays_ = lockoutDays;
         return *this;
     }
+    OvernightLeg& OvernightLeg::withRoundingPrecision(Integer roundingPrecision) {
+        roundingPrecision_ = roundingPrecision;
+        return *this;
+    }
     OvernightLeg& OvernightLeg::withObservationShift(bool applyObservationShift) {
         applyObservationShift_ = applyObservationShift;
         return *this;
@@ -645,7 +662,7 @@ namespace QuantLib {
                     paymentDate, detail::get(notionals_, i, 1.0), start, end, overnightIndex_,
                     detail::get(gearings_, i, 1.0), detail::get(spreads_, i, 0.0), refStart, refEnd, paymentDayCounter_,
                     telescopicValueDates_, averagingMethod_, lookbackDays_, lockoutDays_, applyObservationShift_,
-                    compoundSpreadDaily_, rateComputationStartDate, rateComputationEndDate);
+                    compoundSpreadDaily_, rateComputationStartDate, rateComputationEndDate,  Date(), roundingPrecision_);
                 if (couponPricer_) {
                     cpn->setPricer(couponPricer_);
                 }

--- a/ql/cashflows/overnightindexedcoupon.hpp
+++ b/ql/cashflows/overnightindexedcoupon.hpp
@@ -34,6 +34,7 @@
 #include <ql/cashflows/rateaveraging.hpp>
 #include <ql/indexes/iborindex.hpp>
 #include <ql/time/schedule.hpp>
+#include <ql/optional.hpp>
 
 
 namespace QuantLib {
@@ -73,7 +74,8 @@ namespace QuantLib {
                     bool compoundSpread = false,
                     const Date& rateComputationStartDate = Date(),
                     const Date& rateComputationEndDate = Date(),
-                    const Date& exCouponDate = Date());
+                    const Date& exCouponDate = Date(),
+                    const ext::optional<Integer>& roundingPrecision = ext::nullopt);
         //! \name Inspectors
         //@{
         //! fixing dates for the rates to be compounded
@@ -111,6 +113,7 @@ namespace QuantLib {
         //! the date when the coupon is fully determined
         Date fixingDate() const override { return fixingDates_.back(); }
         Real accruedAmount(const Date&) const override;
+        Real amount() const override;
         //@}
         //! \name Visitability
         //@{
@@ -137,7 +140,7 @@ namespace QuantLib {
         bool applyObservationShift_;
         bool compoundSpreadDaily_;
         Date rateComputationStartDate_, rateComputationEndDate_;
-
+        ext::optional<Integer> roundingPrecision_;
         Rate averageRate(const Date& date) const;
     };
 
@@ -228,6 +231,7 @@ namespace QuantLib {
         OvernightLeg& withLockoutDays(Natural lockoutDays);
         OvernightLeg& withObservationShift(bool applyObservationShift = true);
         OvernightLeg& compoundingSpreadDaily(bool compoundSpreadDaily = true);
+        OvernightLeg& withRoundingPrecision(Integer roundingPrecision);
         OvernightLeg& withCaps(Rate cap);
         OvernightLeg& withCaps(const std::vector<Rate>& caps);
         OvernightLeg& withFloors(Rate floor);
@@ -257,6 +261,7 @@ namespace QuantLib {
         Natural lockoutDays_ = 0;
         bool applyObservationShift_ = false;
         bool compoundSpreadDaily_ = false;
+        ext::optional<Integer> roundingPrecision_;
         std::vector<Rate> caps_, floors_;
         bool nakedOption_ = false;
         bool dailyCapFloor_ = false;

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -1019,18 +1019,6 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithGearingsAndSpreads) {
         }
     }
 }
-BOOST_AUTO_TEST_CASE(testOvernightLegRoundingPrecision) {
-    CommonVars vars;
-
-    OvernightLeg legBuilder(vars.schedule, vars.sofr);
-
-    legBuilder.withNotionals(vars.notional)
-              .withRoundingPrecision(5);
-
-    Leg leg = legBuilder;
-
-    BOOST_CHECK(!leg.empty());
-}
 BOOST_AUTO_TEST_CASE(testOvernightLegNPV) {
     BOOST_TEST_MESSAGE("Testing overnight leg NPV...");
 

--- a/test-suite/overnightindexedcoupon.cpp
+++ b/test-suite/overnightindexedcoupon.cpp
@@ -37,6 +37,7 @@
 #include <ql/indexes/ibor/estr.hpp>
 #include <ql/time/calendars/weekendsonly.hpp>
 #include <iomanip>
+#include <ql/math/rounding.hpp>
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -1018,7 +1019,18 @@ BOOST_AUTO_TEST_CASE(testOvernightLegWithGearingsAndSpreads) {
         }
     }
 }
+BOOST_AUTO_TEST_CASE(testOvernightLegRoundingPrecision) {
+    CommonVars vars;
 
+    OvernightLeg legBuilder(vars.schedule, vars.sofr);
+
+    legBuilder.withNotionals(vars.notional)
+              .withRoundingPrecision(5);
+
+    Leg leg = legBuilder;
+
+    BOOST_CHECK(!leg.empty());
+}
 BOOST_AUTO_TEST_CASE(testOvernightLegNPV) {
     BOOST_TEST_MESSAGE("Testing overnight leg NPV...");
 
@@ -1106,7 +1118,55 @@ BOOST_AUTO_TEST_CASE(testOvernightLegErrorConditions) {
     // Test that observation shift with simple averaging throws an error
     BOOST_CHECK_THROW(vars.makeLeg(Null<Natural>(), 0, true, false, RateAveraging::Simple), Error);
 }
+BOOST_AUTO_TEST_CASE(testOvernightCouponAmountRounding) {
+    BOOST_TEST_MESSAGE("Testing overnight coupon amount with rounded rate...");
 
+    CommonVars vars;
+    vars.forecastCurve.linkTo(flatRate(0.0010, Actual360()));
+
+    auto unrounded = vars.makeCoupon(
+        Date(10, December, 2021),
+        Date(10, January, 2022));
+
+    auto rounded = ext::make_shared<OvernightIndexedCoupon>(
+        Date(10, January, 2022),
+        vars.notional,
+        Date(10, December, 2021),
+        Date(10, January, 2022),
+        vars.sofr,
+        1.0,
+        0.0,
+        Date(),
+        Date(),
+        DayCounter(),
+        false,
+        RateAveraging::Compound,
+        Null<Natural>(),
+        0,
+        false,
+        false,
+        Date(),
+        Date(),
+        Date(),
+        5); // rounding precision
+        Rate roundedRate =
+        ClosestRounding(5)(unrounded->rate());
+
+    Real expectedAmount =
+        vars.notional *
+        roundedRate *
+        unrounded->accrualPeriod();
+
+    BOOST_CHECK_NE(
+    rounded->amount(),
+    unrounded->amount());
+
+
+    BOOST_CHECK_CLOSE(
+        rounded->amount(),
+        expectedAmount,
+        1e-10);
+}
 BOOST_AUTO_TEST_CASE(testOvernightIndexedCouponPaymentBeforeAccrualEnd) {
     BOOST_TEST_MESSAGE("Testing that an overnight coupon with inconsistent dates throws...");
 


### PR DESCRIPTION
This PR adds an optional rounding precision parameter to `OvernightIndexedCoupon` and `OvernightLeg`.

When specified, the coupon rate is rounded using `ClosestRounding` before the coupon amount is calculated.

The default behavior remains unchanged when no rounding precision is provided.

The change is motivated by the ISDA Compounding/Averaging Matrix, where certain overnight floating rate options (e.g. SOFR, SONIA and €STR) are commonly settled using rounded rates.

Tests have been added to verify coupon amount calculation with rounding and propagation through the leg builder.
Fixes #2612
