### PR TITLE
Allow passing a coupon pricer to `SwapRateHelper`

### DIFF
--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -37,6 +37,7 @@
 #include <ql/time/imm.hpp>
 #include <ql/utilities/null_deleter.hpp>
 #include <utility>
+#include <ql/cashflows/couponpricer.hpp>
 
 namespace QuantLib {
 
@@ -466,12 +467,13 @@ namespace QuantLib {
                                    Pillar::Choice pillarChoice,
                                    Date customPillarDate,
                                    bool endOfMonth,
-                                   const ext::optional<bool>& useIndexedCoupons)
+                                   const ext::optional<bool>& useIndexedCoupons,
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
     : SwapRateHelper(rate, swapIndex->tenor(), swapIndex->fixingCalendar(),
         swapIndex->fixedLegTenor().frequency(), swapIndex->fixedLegConvention(),
         swapIndex->dayCounter(), swapIndex->iborIndex(), std::move(spread), fwdStart,
         std::move(discount), Null<Natural>(), pillarChoice, customPillarDate, endOfMonth,
-        useIndexedCoupons) {}
+        useIndexedCoupons, ext::nullopt, couponPricer) {}
 
     SwapRateHelper::SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                                    const Period& tenor,
@@ -488,13 +490,15 @@ namespace QuantLib {
                                    Date customPillarDate,
                                    bool endOfMonth,
                                    const ext::optional<bool>& useIndexedCoupons,
-                                   const ext::optional<BusinessDayConvention>& floatConvention)
+                                   const ext::optional<BusinessDayConvention>& floatConvention,
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
     : RelativeDateRateHelper(rate), settlementDays_(settlementDays), tenor_(tenor),
       pillarChoice_(pillarChoice), calendar_(std::move(calendar)),
       fixedConvention_(fixedConvention), fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)), spread_(std::move(spread)), endOfMonth_(endOfMonth),
       fwdStart_(fwdStart), discountHandle_(std::move(discount)),
-      useIndexedCoupons_(useIndexedCoupons), floatConvention_(floatConvention) {
+      useIndexedCoupons_(useIndexedCoupons), floatConvention_(floatConvention),
+      couponPricer_(couponPricer) {
         initialize(iborIndex, customPillarDate);
     }
 
@@ -512,13 +516,14 @@ namespace QuantLib {
                                    Date customPillarDate,
                                    bool endOfMonth,
                                    const ext::optional<bool>& useIndexedCoupons,
-                                   const ext::optional<BusinessDayConvention>& floatConvention)
+                                   const ext::optional<BusinessDayConvention>& floatConvention,
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
     : RelativeDateRateHelper(rate, false), startDate_(startDate), endDate_(endDate),
       pillarChoice_(pillarChoice), calendar_(std::move(calendar)),
       fixedConvention_(fixedConvention), fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)), spread_(std::move(spread)), endOfMonth_(endOfMonth),
       discountHandle_(std::move(discount)), useIndexedCoupons_(useIndexedCoupons),
-      floatConvention_(floatConvention) {
+      floatConvention_(floatConvention), couponPricer_(couponPricer) {
         QL_REQUIRE(fixedFrequency != Once,
             "fixedFrequency == Once is not supported when passing explicit "
             "startDate and endDate");
@@ -537,6 +542,7 @@ namespace QuantLib {
         registerWith(iborIndex_);
         registerWith(spread_);
         registerWith(discountHandle_);
+        registerWith(couponPricer_);
 
         pillarDate_ = customPillarDate;
         SwapRateHelper::initializeDates();
@@ -569,6 +575,9 @@ namespace QuantLib {
         if (startDate_ == Date() && settlementDays_ != Null<Natural>())
             tmp.withSettlementDays(settlementDays_);
         swap_ = tmp;
+
+        if (couponPricer_)
+            setCouponPricer(swap_->floatingLeg(), couponPricer_);
 
         simplifyNotificationGraph(*swap_, true);
 

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -42,6 +42,7 @@ namespace QuantLib {
 
     class SwapIndex;
     class Quote;
+    class FloatingRateCouponPricer;
 
     typedef BootstrapHelper<YieldTermStructure> RateHelper;
     typedef RelativeDateBootstrapHelper<YieldTermStructure>
@@ -206,7 +207,8 @@ namespace QuantLib {
                        Pillar::Choice pillar = Pillar::LastRelevantDate,
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
-                       const ext::optional<bool>& useIndexedCoupons = ext::nullopt);
+                       const ext::optional<bool>& useIndexedCoupons = ext::nullopt,
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
         SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                        const Period& tenor,
                        Calendar calendar,
@@ -225,7 +227,8 @@ namespace QuantLib {
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
                        const ext::optional<bool>& useIndexedCoupons = ext::nullopt,
-                       const ext::optional<BusinessDayConvention>& floatConvention = ext::nullopt);
+                       const ext::optional<BusinessDayConvention>& floatConvention = ext::nullopt,
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
         SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                        const Date& startDate,
                        const Date& endDate,
@@ -243,7 +246,8 @@ namespace QuantLib {
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
                        const ext::optional<bool>& useIndexedCoupons = ext::nullopt,
-                       const ext::optional<BusinessDayConvention>& floatConvention = ext::nullopt);
+                       const ext::optional<BusinessDayConvention>& floatConvention = ext::nullopt,
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -282,6 +286,7 @@ namespace QuantLib {
         RelinkableHandle<YieldTermStructure> discountRelinkableHandle_;
         ext::optional<bool> useIndexedCoupons_;
         ext::optional<BusinessDayConvention> floatConvention_;
+        ext::shared_ptr<FloatingRateCouponPricer> couponPricer_;
     };
 
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -21,6 +21,7 @@
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
 #include <ql/cashflows/iborcoupon.hpp>
+#include <ql/cashflows/couponpricer.hpp>
 #include <ql/experimental/termstructures/basisswapratehelpers.hpp>
 #include <ql/indexes/bmaindex.hpp>
 #include <ql/indexes/ibor/estr.hpp>
@@ -51,6 +52,7 @@
 #include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
 #include <ql/termstructures/yield/ratehelpers.hpp>
 #include <ql/termstructures/yield/zerospreadedtermstructure.hpp>
+#include <ql/termstructures/volatility/optionlet/constantoptionletvol.hpp>
 #include <ql/time/asx.hpp>
 #include <ql/time/calendars/canada.hpp>
 #include <ql/time/calendars/japan.hpp>
@@ -67,7 +69,7 @@
 #include <map>
 #include <string>
 #include <utility>
-#include <vector>
+#include <vector>  
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -2258,6 +2260,80 @@ BOOST_AUTO_TEST_CASE(testDatedSwapHelpers) {
                         << "\n    error:          " << io::rate(error)
                         << "\n    tolerance:      " << io::rate(tolerance));
         }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testSwapRateHelperWithCouponPricer) {
+    BOOST_TEST_MESSAGE("Testing SwapRateHelper with a custom coupon pricer...");
+
+    // Test for issue #1817: a coupon pricer (e.g. a BlackIborCouponPricer
+    // carrying a volatility surface for timing/convexity adjustments) can be
+    // attached to the floating leg of the swap built internally by
+    // SwapRateHelper, so that the curve is bootstrapped with the same pricing
+    // methodology that is later used to value swaps.
+
+    Date today(15, June, 2020);
+    Settings::instance().evaluationDate() = today;
+
+    Datum swapData[] = {
+        {2, Years, 0.015}, {5, Years, 0.020}, {10, Years, 0.025}, {20, Years, 0.030}};
+
+    Handle<OptionletVolatilityStructure> vol(ext::make_shared<ConstantOptionletVolatility>(
+        today, TARGET(), Following, 0.20, Actual365Fixed()));
+    auto pricer = ext::make_shared<BlackIborCouponPricer>(vol);
+
+    RelinkableHandle<YieldTermStructure> curveHandle;
+    auto index = ext::make_shared<Euribor6M>(curveHandle);
+
+    std::vector<ext::shared_ptr<SwapRateHelper>> helpers;
+    for (auto& d : swapData) {
+        helpers.push_back(ext::make_shared<SwapRateHelper>(
+            d.rate, Period(d.n, d.units), TARGET(), Annual, ModifiedFollowing,
+            Thirty360(Thirty360::BondBasis), index, Handle<Quote>(), 0 * Days,
+            Handle<YieldTermStructure>(), Null<Natural>(), Pillar::LastRelevantDate, Date(), false,
+            ext::nullopt, ext::nullopt, pricer));
+    }
+
+    // the supplied pricer must be attached to every coupon of the floating leg
+    // of the swap the helper builds internally
+    for (const auto& helper : helpers) {
+        for (const auto& cf : helper->swap()->floatingLeg()) {
+            auto coupon = ext::dynamic_pointer_cast<FloatingRateCoupon>(cf);
+            BOOST_REQUIRE(coupon);
+            BOOST_CHECK_MESSAGE(coupon->pricer() == pricer,
+                                "the coupon pricer was not attached to the floating leg of the "
+                                "rate helper's internal swap");
+        }
+    }
+
+    // bootstrap and check self-consistency: a swap priced at its market rate
+    // with the same coupon pricer must be at par on the resulting curve
+    std::vector<ext::shared_ptr<RateHelper>> rateHelpers(helpers.begin(), helpers.end());
+    curveHandle.linkTo(ext::make_shared<PiecewiseYieldCurve<Discount, LogLinear>>(
+        today, rateHelpers, Actual365Fixed()));
+
+    Real tolerance = 1.0e-6;
+    for (auto& d : swapData) {
+        // built to match the helper's internal swap, priced with the same pricer
+        ext::shared_ptr<VanillaSwap> swap =
+            MakeVanillaSwap(Period(d.n, d.units), index, d.rate, 0 * Days)
+                .withDiscountingTermStructure(curveHandle)
+                .withFixedLegDayCount(Thirty360(Thirty360::BondBasis))
+                .withFixedLegTenor(Period(Annual))
+                .withFixedLegConvention(ModifiedFollowing)
+                .withFixedLegTerminationDateConvention(ModifiedFollowing)
+                .withFixedLegCalendar(TARGET())
+                .withFixedLegEndOfMonth(false)
+                .withFloatingLegCalendar(TARGET())
+                .withFloatingLegEndOfMonth(false);
+        setCouponPricer(swap->floatingLeg(), pricer);
+
+        Real npv = swap->NPV();
+        if (std::fabs(npv) > tolerance)
+            BOOST_ERROR("swap priced with the bootstrapping coupon pricer is not "
+                        "at par:"
+                        << std::setprecision(12) << "\n    tenor:     " << Period(d.n, d.units)
+                        << "\n    NPV:       " << npv << "\n    tolerance: " << tolerance);
     }
 }
 


### PR DESCRIPTION
This PR addresses issue #1817.

It adds an optional coupon pricer parameter to SwapRateHelper and propagates it to the floating leg of the internal swap used during bootstrapping.

A regression test has been added to test-suite/piecewiseyieldcurve.cpp. The test verifies that: the supplied coupon pricer is attached to the floating coupons of the helper's internal swap; a curve bootstrapped with these helpers remains self-consistent;
swaps priced with the same coupon pricer reprice to par.

Fixes #1817.