### PR TITLE
Add Shir overnight index for ILS

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -839,6 +839,7 @@
     <ClInclude Include="ql\indexes\ibor\saron.hpp" />
     <ClInclude Include="ql\indexes\ibor\seklibor.hpp" />
     <ClInclude Include="ql\indexes\ibor\shibor.hpp" />
+    <ClInclude Include="ql\indexes\ibor\shir.hpp" />
     <ClInclude Include="ql\indexes\ibor\sofr.hpp" />
     <ClInclude Include="ql\indexes\ibor\sonia.hpp" />
     <ClInclude Include="ql\indexes\ibor\swestr.hpp" />
@@ -2162,6 +2163,7 @@
     <ClCompile Include="ql\indexes\ibor\libor.cpp" />
     <ClCompile Include="ql\indexes\ibor\saron.cpp" />
     <ClCompile Include="ql\indexes\ibor\shibor.cpp" />
+    <ClCompile Include="ql\indexes\ibor\shir.cpp" />
     <ClCompile Include="ql\indexes\ibor\sofr.cpp" />
     <ClCompile Include="ql\indexes\ibor\sonia.cpp" />
     <ClCompile Include="ql\indexes\iborindex.cpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -699,6 +699,9 @@
     <ClInclude Include="ql\indexes\ibor\shibor.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
+    <ClInclude Include="ql\indexes\ibor\shir.hpp">
+      <Filter>indexes\ibor</Filter>
+    </ClInclude>
     <ClInclude Include="ql\indexes\ibor\sofr.hpp">
       <Filter>indexes\ibor</Filter>
     </ClInclude>
@@ -4749,6 +4752,9 @@
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\shibor.cpp">
+      <Filter>indexes\ibor</Filter>
+    </ClCompile>
+    <ClCompile Include="ql\indexes\ibor\shir.cpp">
       <Filter>indexes\ibor</Filter>
     </ClCompile>
     <ClCompile Include="ql\indexes\ibor\sofr.cpp">

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -221,6 +221,7 @@ set(QL_SOURCES
     indexes/ibor/libor.cpp
     indexes/ibor/saron.cpp
     indexes/ibor/shibor.cpp
+    indexes/ibor/shir.cpp
     indexes/ibor/sofr.cpp
     indexes/ibor/sonia.cpp
     indexes/ibor/zaronia.cpp
@@ -1293,6 +1294,7 @@ set(QL_HEADERS
     indexes/ibor/saron.hpp
     indexes/ibor/seklibor.hpp
     indexes/ibor/shibor.hpp
+    indexes/ibor/shir.hpp
     indexes/ibor/sofr.hpp
     indexes/ibor/sonia.hpp
     indexes/ibor/swestr.hpp

--- a/ql/indexes/ibor/Makefile.am
+++ b/ql/indexes/ibor/Makefile.am
@@ -36,6 +36,7 @@ this_include_HEADERS = \
     saron.hpp \
     seklibor.hpp \
     shibor.hpp \
+    shir.hpp \
     sofr.hpp \
     sonia.hpp \
     swestr.hpp \
@@ -62,6 +63,7 @@ cpp_files = \
     libor.cpp \
     saron.cpp \
     shibor.cpp \
+    shir.cpp \
     sofr.cpp \
     sonia.cpp \
     zaronia.cpp

--- a/ql/indexes/ibor/all.hpp
+++ b/ql/indexes/ibor/all.hpp
@@ -33,6 +33,7 @@
 #include <ql/indexes/ibor/saron.hpp>
 #include <ql/indexes/ibor/seklibor.hpp>
 #include <ql/indexes/ibor/shibor.hpp>
+#include <ql/indexes/ibor/shir.hpp>
 #include <ql/indexes/ibor/sofr.hpp>
 #include <ql/indexes/ibor/sonia.hpp>
 #include <ql/indexes/ibor/swestr.hpp>

--- a/ql/indexes/ibor/shir.cpp
+++ b/ql/indexes/ibor/shir.cpp
@@ -1,0 +1,30 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Pratyush Patel
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <ql/currencies/asia.hpp>
+#include <ql/indexes/ibor/shir.hpp>
+#include <ql/indexes/iborindex.hpp>
+#include <ql/time/calendars/israel.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
+
+namespace QuantLib {
+    Shir::Shir(const Handle<YieldTermStructure>& h)
+    : OvernightIndex("Shir", 0, ILSCurrency(), Israel(Israel::SHIR), Actual365Fixed(), h) {}
+
+}

--- a/ql/indexes/ibor/shir.hpp
+++ b/ql/indexes/ibor/shir.hpp
@@ -1,0 +1,45 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2026 Pratyush Patel 
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <https://www.quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file shir.hpp
+    \brief %SHIR index
+*/
+
+#ifndef quantlib_shir_hpp
+#define quantlib_shir_hpp
+
+#include <ql/indexes/iborindex.hpp>
+
+namespace QuantLib {
+
+    //! %SHIR index.
+    /*! Shekel Overnight Interest Rate (SHIR), published by the Bank of
+        Israel, replacing the Telbor rate in interest rate derivative
+        transactions. SHIR serves as the overnight interest rate for
+        that day (same-day fixing).
+        See <https://www.boi.org.il/en/economic-roles/financial-markets/shir/>.
+    */
+    class Shir : public OvernightIndex {
+      public:
+        explicit Shir(const Handle<YieldTermStructure>& h = {});
+    };
+
+}
+
+#endif

--- a/test-suite/indexes.cpp
+++ b/test-suite/indexes.cpp
@@ -19,17 +19,21 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include <ql/currencies/asia.hpp>
 #include <ql/indexes/bmaindex.hpp>
-#include <ql/indexes/ibor/custom.hpp>
 #include <ql/indexes/ibor/cdi.hpp>
+#include <ql/indexes/ibor/custom.hpp>
 #include <ql/indexes/ibor/euribor.hpp>
+#include <ql/indexes/ibor/shir.hpp>
+#include <ql/quotes/simplequote.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/calendars/bespokecalendar.hpp>
 #include <ql/time/calendars/brazil.hpp>
+#include <ql/time/calendars/israel.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/daycounters/actual360.hpp>
+#include <ql/time/daycounters/actual365fixed.hpp>
 #include <ql/utilities/dataformatters.hpp>
-#include <ql/quotes/simplequote.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
 using namespace QuantLib;
@@ -218,6 +222,18 @@ BOOST_AUTO_TEST_CASE(testCdiIndex) {
     auto approx = pow(discountStart / discountEnd, 252.0) - 1.0;
     QL_ASSERT(std::fabs(0.05127 - forecast) < 1e-5, "discrepancy in fixing forecast computation\n");
     QL_ASSERT(std::fabs(approx - forecast) < 1e-6, "discrepancy in fixing forecast computation with approximation\n");
+}
+
+BOOST_AUTO_TEST_CASE(testShirIndex) {
+    BOOST_TEST_MESSAGE("Testing Shir index...");
+
+    auto shir = ext::make_shared<Shir>();
+
+    BOOST_CHECK_EQUAL(shir->familyName(), "Shir");
+    BOOST_CHECK_EQUAL(shir->fixingDays(), 0);
+    BOOST_CHECK(shir->currency() == ILSCurrency());
+    BOOST_CHECK(shir->fixingCalendar() == Israel(Israel::SHIR));
+    BOOST_CHECK(shir->dayCounter() == Actual365Fixed());
 }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Adds support for SHIR (Shekel Overnight Interest Rate), the Bank of
Israel's overnight rate that replaced Telbor.

`Shir` is implemented as a thin `OvernightIndex` subclass
(ql/indexes/ibor/shir.hpp/.cpp), following the same pattern used for
SOFR, SONIA, KOFR, etc.:

- 0 fixing days (same-day fixing)
- fixing calendar: Israel(Israel::SHIR)
- day counter: Actual/365 (Fixed), per ISDA convention
- currency: ILS

Registered in all.hpp, Makefile.am, ql/CMakeLists.txt,
QuantLib.vcxproj and QuantLib.vcxproj.filters following the existing
ibor index entries.

Added testShirIndex to test-suite/indexes.cpp, checking family name,
fixing days, currency, fixing calendar, and day counter.

Resolves #2222.