### PR TITLE
Use make_shared in pricing engines

### DIFF
--- a/ql/pricingengines/asian/fdblackscholesasianengine.cpp
+++ b/ql/pricingengines/asian/fdblackscholesasianengine.cpp
@@ -57,8 +57,8 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_, maturity,
-                                      payoff->strike()));
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_, maturity,
+                                      payoff->strike());
 
         const Real spot = process_->x0();
         QL_REQUIRE(spot > 0.0, "negative or null underlying given");
@@ -75,13 +75,13 @@ namespace QuantLib {
         Real xMin = std::min(std::log(avg)  - 0.25*r, std::log(spot) - 1.5*r);
         Real xMax = std::max(std::log(avg)  + 0.25*r, std::log(spot) + 1.5*r);
 
-        const ext::shared_ptr<Fdm1dMesher> averageMesher(ext::make_shared<FdmBlackScholesMesher>(aGrid_, process_, maturity,
-                                      payoff->strike(), xMin, xMax));
+        const auto averageMesher = ext::make_shared<FdmBlackScholesMesher>(aGrid_, process_, maturity,
+                                      payoff->strike(), xMin, xMax);
 
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, averageMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, averageMesher);
 
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 1));
+        auto calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 1);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;

--- a/ql/pricingengines/asian/fdblackscholesasianengine.cpp
+++ b/ql/pricingengines/asian/fdblackscholesasianengine.cpp
@@ -57,8 +57,7 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(xGrid_, process_, maturity,
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_, maturity,
                                       payoff->strike()));
 
         const Real spot = process_->x0();
@@ -76,16 +75,13 @@ namespace QuantLib {
         Real xMin = std::min(std::log(avg)  - 0.25*r, std::log(spot) - 1.5*r);
         Real xMax = std::max(std::log(avg)  + 0.25*r, std::log(spot) + 1.5*r);
 
-        const ext::shared_ptr<Fdm1dMesher> averageMesher(
-            new FdmBlackScholesMesher(aGrid_, process_, maturity,
+        const ext::shared_ptr<Fdm1dMesher> averageMesher(ext::make_shared<FdmBlackScholesMesher>(aGrid_, process_, maturity,
                                       payoff->strike(), xMin, xMax));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, averageMesher));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, averageMesher));
 
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 1));
+        ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 1));
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -99,13 +95,11 @@ namespace QuantLib {
             averageTimes.push_back(t);
         }
         stoppingTimes.emplace_back(averageTimes);
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-                new FdmArithmeticAverageCondition(
+        stepConditions.push_back(ext::make_shared<FdmArithmeticAverageCondition>(
                         averageTimes, arguments_.runningAccumulator,
-                        arguments_.pastFixings, mesher, 0)));
+                        arguments_.pastFixings, mesher, 0));
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        auto conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -113,10 +107,9 @@ namespace QuantLib {
         // 5. Solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
-        ext::shared_ptr<FdmSimple2dBSSolver> solver(
-              new FdmSimple2dBSSolver(
+        auto solver = ext::make_shared<FdmSimple2dBSSolver>(
                               Handle<GeneralizedBlackScholesProcess>(process_),
-                              payoff->strike(), solverDesc, schemeDesc_));
+                              payoff->strike(), solverDesc, schemeDesc_);
 
         results_.value = solver->valueAt(spot, avg);
         results_.delta = solver->deltaAt(spot, avg, spot*0.01);

--- a/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price.hpp
@@ -75,8 +75,7 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<GeneralizedBlackScholesProcess>(
                     this->process_);
             QL_REQUIRE(process, "Black-Scholes process required");
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticDiscreteGeometricAveragePriceAsianEngine(process));
+            return ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianEngine>(process);
         }
     };
 
@@ -141,14 +140,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPEngine<RNG,S>::path_pricer_type>(
-                new ArithmeticAPOPathPricer(
+        return ext::make_shared<ArithmeticAPOPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S>
@@ -175,12 +172,10 @@ namespace QuantLib {
         // for seasoned option the geometric strike might be rescaled
         // to obtain an equivalent arithmetic strike.
         // Any change applied here MUST be applied to the analytic engine too
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPEngine<RNG,S>::path_pricer_type>(
-            new GeometricAPOPathPricer(
+        return ext::make_shared<GeometricAPOPathPricer>(
               payoff->optionType(),
               payoff->strike(),
-              process->riskFreeRate()->discount(this->timeGrid().back())));
+              process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
     template <class RNG = PseudoRandom, class S = Statistics>
@@ -274,13 +269,12 @@ namespace QuantLib {
     inline
     MakeMCDiscreteArithmeticAPEngine<RNG,S>::operator ext::shared_ptr<PricingEngine>()
                                                                       const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCDiscreteArithmeticAPEngine<RNG,S>(process_,
+        return ext::make_shared<MCDiscreteArithmeticAPEngine<RNG,S>>(process_,
                                                 brownianBridge_,
                                                 antithetic_, controlVariate_,
                                                 samples_, tolerance_,
                                                 maxSamples_,
-                                                seed_));
+                                                seed_);
     }
 
 

--- a/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_price_heston.hpp
@@ -74,8 +74,7 @@ namespace QuantLib {
             ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
             QL_REQUIRE(process, "Heston-like process required");
 
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticDiscreteGeometricAveragePriceAsianHestonEngine(process));
+            return ext::make_shared<AnalyticDiscreteGeometricAveragePriceAsianHestonEngine>(process);
         }
     };
 
@@ -180,15 +179,13 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ArithmeticAPOHestonPathPricer(
+        return ext::make_shared<ArithmeticAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     fixingIndexes,
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S, class P>
@@ -224,13 +221,11 @@ namespace QuantLib {
         // pass seasoning details to the path pricer (NB. NEED to pass them to
         // the analytic pricer as well in that case).
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new GeometricAPOHestonPathPricer(
+        return ext::make_shared<GeometricAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
-                    fixingIndexes));
+                    fixingIndexes);
     }
 
     template <class RNG, class S, class P>
@@ -309,8 +304,7 @@ namespace QuantLib {
 
     template <class RNG, class S, class P>
     inline MakeMCDiscreteArithmeticAPHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>() const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCDiscreteArithmeticAPHestonEngine<RNG,S,P>(process_,
+        return ext::make_shared<MCDiscreteArithmeticAPHestonEngine<RNG,S,P>>(process_,
                                                         antithetic_,
                                                         samples_,
                                                         tolerance_,
@@ -318,7 +312,7 @@ namespace QuantLib {
                                                         seed_,
                                                         steps_,
                                                         stepsPerYear_,
-                                                        controlVariate_));
+                                                        controlVariate_);
     }
 }
 

--- a/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
+++ b/ql/pricingengines/asian/mc_discr_arith_av_strike.hpp
@@ -143,14 +143,12 @@ namespace QuantLib {
             }
         }
 
-        return ext::shared_ptr<typename
-            MCDiscreteArithmeticASEngine<RNG,S>::path_pricer_type>(
-                new ArithmeticASOPathPricer(
+        return ext::make_shared<ArithmeticASOPathPricer>(
                     payoff->optionType(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
                     this->arguments_.pastFixings,
-                    fixingCount));
+                    fixingCount);
     }
 
 
@@ -238,13 +236,12 @@ namespace QuantLib {
     inline
     MakeMCDiscreteArithmeticASEngine<RNG,S>::
     operator ext::shared_ptr<PricingEngine>() const {
-        return ext::shared_ptr<PricingEngine>(
-            new MCDiscreteArithmeticASEngine<RNG,S>(process_,
+        return ext::make_shared<MCDiscreteArithmeticASEngine<RNG,S>>(process_,
                                                     brownianBridge_,
                                                     antithetic_,
                                                     samples_, tolerance_,
                                                     maxSamples_,
-                                                    seed_));
+                                                    seed_);
     }
 
 }

--- a/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price.hpp
@@ -128,14 +128,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteGeometricAPEngine<RNG,S>::path_pricer_type>(
-                new GeometricAPOPathPricer(
+        return ext::make_shared<GeometricAPOPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
 
@@ -222,13 +220,12 @@ namespace QuantLib {
     inline
     MakeMCDiscreteGeometricAPEngine<RNG,S>::operator ext::shared_ptr<PricingEngine>()
                                                                       const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCDiscreteGeometricAPEngine<RNG,S>(process_,
+        return ext::make_shared<MCDiscreteGeometricAPEngine<RNG,S>>(process_,
                                                brownianBridge_,
                                                antithetic_,
                                                samples_, tolerance_,
                                                maxSamples_,
-                                               seed_));
+                                               seed_);
     }
 
 }

--- a/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
+++ b/ql/pricingengines/asian/mc_discr_geom_av_price_heston.hpp
@@ -162,15 +162,13 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCDiscreteGeometricAPHestonEngine<RNG,S,P>::path_pricer_type>(
-                new GeometricAPOHestonPathPricer(
+        return ext::make_shared<GeometricAPOHestonPathPricer>(
                     payoff->optionType(),
                     payoff->strike(),
                     process->riskFreeRate()->discount(exercise->lastDate()),
                     fixingIndexes,
                     this->arguments_.runningAccumulator,
-                    this->arguments_.pastFixings));
+                    this->arguments_.pastFixings);
     }
 
     template <class RNG, class S, class P>
@@ -242,15 +240,14 @@ namespace QuantLib {
 
     template <class RNG, class S, class P>
     inline MakeMCDiscreteGeometricAPHestonEngine<RNG,S,P>::operator ext::shared_ptr<PricingEngine>() const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCDiscreteGeometricAPHestonEngine<RNG,S,P>(process_,
+        return ext::make_shared<MCDiscreteGeometricAPHestonEngine<RNG,S,P>>(process_,
                                                        antithetic_,
                                                        samples_,
                                                        tolerance_,
                                                        maxSamples_,
                                                        seed_,
                                                        steps_,
-                                                       stepsPerYear_));
+                                                       stepsPerYear_);
     }
 }
 

--- a/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
+++ b/ql/pricingengines/asian/mcdiscreteasianenginebase.hpp
@@ -113,9 +113,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         Real controlVariateValue() const override;
         // data members

--- a/ql/pricingengines/bacheliercalculator.cpp
+++ b/ql/pricingengines/bacheliercalculator.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         Option::Type optionType, Real strike, Real forward, Real stdDev, Real discount)
     : strike_(strike), forward_(forward), stdDev_(stdDev),
       discount_(discount), variance_(stdDev*stdDev) {
-        initialize(ext::shared_ptr<StrikedTypePayoff>(new PlainVanillaPayoff(optionType, strike)));
+        initialize(ext::make_shared<PlainVanillaPayoff>(optionType, strike));
     }
 
     void BachelierCalculator::initialize(const ext::shared_ptr<StrikedTypePayoff>& p) {

--- a/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
+++ b/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
@@ -102,10 +102,10 @@ namespace QuantLib {
         if ((barrierType == Barrier::DownIn && spot <= barrier) ||
            (barrierType == Barrier::UpIn && spot >= barrier)) {
             // knocked in - is a digital european
-            ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(
-                                             arguments_.exercise->lastDate()));
+            auto exercise = ext::make_shared<EuropeanExercise>(
+                                             arguments_.exercise->lastDate());
 
-            ext::shared_ptr<PricingEngine> engine(ext::make_shared<AnalyticEuropeanEngine>(process_));
+            auto engine = ext::make_shared<AnalyticEuropeanEngine>(process_);
 
             VanillaOption opt(payoff, exercise);
             opt.setPricingEngine(engine);
@@ -320,4 +320,3 @@ namespace QuantLib {
 
 
 }
-

--- a/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
+++ b/ql/pricingengines/barrier/analyticbinarybarrierengine.cpp
@@ -102,11 +102,10 @@ namespace QuantLib {
         if ((barrierType == Barrier::DownIn && spot <= barrier) ||
            (barrierType == Barrier::UpIn && spot >= barrier)) {
             // knocked in - is a digital european
-            ext::shared_ptr<Exercise> exercise(new EuropeanExercise(
+            ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(
                                              arguments_.exercise->lastDate()));
 
-            ext::shared_ptr<PricingEngine> engine(
-                                       new AnalyticEuropeanEngine(process_));
+            ext::shared_ptr<PricingEngine> engine(ext::make_shared<AnalyticEuropeanEngine>(process_));
 
             VanillaOption opt(payoff, exercise);
             opt.setPricingEngine(engine);

--- a/ql/pricingengines/barrier/binomialbarrierengine.hpp
+++ b/ql/pricingengines/barrier/binomialbarrierengine.hpp
@@ -112,19 +112,15 @@ namespace QuantLib {
 
         // binomial trees with constant coefficient
         Handle<YieldTermStructure> flatRiskFree(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, r, rfdc)));
+            ext::make_shared<FlatForward>(referenceDate, r, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, q, divdc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
         Handle<BlackVolTermStructure> flatVol(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(
-                         new GeneralizedBlackScholesProcess(
+        ext::shared_ptr<StochasticProcess1D> bs(ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
                                       flatDividends, flatRiskFree, flatVol));
 
@@ -157,11 +153,10 @@ namespace QuantLib {
 
         TimeGrid grid(maturity, optimum_steps);
 
-        ext::shared_ptr<T> tree(new T(bs, maturity, optimum_steps,
-                                        payoff->strike()));
+        auto tree = ext::make_shared<T>(bs, maturity, optimum_steps,
+                                        payoff->strike());
 
-        ext::shared_ptr<BlackScholesLattice<T> > lattice(
-            new BlackScholesLattice<T>(tree, r, maturity, optimum_steps));
+        auto lattice = ext::make_shared<BlackScholesLattice<T>>(tree, r, maturity, optimum_steps);
 
         D option(arguments_, *process_, grid);
         option.initialize(lattice, maturity);

--- a/ql/pricingengines/barrier/binomialbarrierengine.hpp
+++ b/ql/pricingengines/barrier/binomialbarrierengine.hpp
@@ -120,9 +120,9 @@ namespace QuantLib {
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(ext::make_shared<GeneralizedBlackScholesProcess>(
+        auto bs = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
-                                      flatDividends, flatRiskFree, flatVol));
+                                      flatDividends, flatRiskFree, flatVol);
 
         // correct timesteps to ensure a (local) minimum, using Boyle and Lau
         // approach. See Journal of Derivatives, 1/1994,

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -99,8 +99,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),

--- a/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesbarrierengine.cpp
@@ -99,28 +99,25 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
         
-        const ext::shared_ptr<FdmMesher> mesher (
-            ext::make_shared<FdmMesherComposite>(equityMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher);
 
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-            ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
+        auto calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
         std::list<std::vector<Time> > stoppingTimes;
 
         // 3.1 Step condition if discrete dividends
-        ext::shared_ptr<FdmDividendHandler> dividendCondition(
-            ext::make_shared<FdmDividendHandler>(dividends_, mesher,
+        auto dividendCondition = ext::make_shared<FdmDividendHandler>(dividends_, mesher,
                                    process_->riskFreeRate()->referenceDate(),
-                                   process_->riskFreeRate()->dayCounter(), 0));
+                                   process_->riskFreeRate()->dayCounter(), 0);
 
         if (!dividends_.empty()) {
             stepConditions.push_back(dividendCondition);
@@ -131,8 +128,7 @@ namespace QuantLib {
             stoppingTimes.push_back(dividendTimes);
         }
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-            ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions));
+        auto conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
@@ -155,11 +151,10 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions, calculator,
                                      maturity, tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmBlackScholesSolver> solver(
-            ext::make_shared<FdmBlackScholesSolver>(
+        auto solver = ext::make_shared<FdmBlackScholesSolver>(
                                Handle<GeneralizedBlackScholesProcess>(process_),
                                payoff->strike(), solverDesc, schemeDesc_,
-                               localVol_, illegalLocalVolOverwrite_));
+                               localVol_, illegalLocalVolOverwrite_);
 
         results_.value = solver->valueAt(spot);
         results_.delta = solver->deltaAt(spot);

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -83,17 +83,17 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
         
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher);
         
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0));
+        const auto rebatePayoff = ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate);
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0);
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -83,21 +83,17 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, process_, maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
                 dividends_));
         
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher));
         
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(
-                new CashOrNothingPayoff(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(rebatePayoff, mesher, 0));
+        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0));
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
@@ -130,11 +126,10 @@ namespace QuantLib {
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions, calculator,
                                      maturity, tGrid_, dampingSteps_ };
 
-        const ext::shared_ptr<FdmBlackScholesSolver> solver(
-                new FdmBlackScholesSolver(
+        const auto solver = ext::make_shared<FdmBlackScholesSolver>(
                                 Handle<GeneralizedBlackScholesProcess>(process_),
                                 payoff->strike(), solverDesc, schemeDesc_,
-                                localVol_, illegalLocalVolOverwrite_));
+                                localVol_, illegalLocalVolOverwrite_);
 
         const Real spot = process_->x0();
         results_.value = solver->valueAt(spot);

--- a/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdblackscholesrebateengine.cpp
@@ -110,16 +110,14 @@ namespace QuantLib {
         FdmBoundaryConditionSet  boundaries;
         if (   arguments_.barrierType == Barrier::DownIn
             || arguments_.barrierType == Barrier::DownOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Lower)));
+            boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+                mesher, arguments_.rebate, 0, FdmDirichletBoundary::Lower));
 
         }
         if (   arguments_.barrierType == Barrier::UpIn
             || arguments_.barrierType == Barrier::UpOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Upper)));
+            boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+                mesher, arguments_.rebate, 0, FdmDirichletBoundary::Upper));
         }
 
         // 5. Solver

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -94,8 +94,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),

--- a/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonbarrierengine.cpp
@@ -75,8 +75,7 @@ namespace QuantLib {
         const Size tGridMin = 5;
         const Size tGridAvgSteps = std::max(tGridMin, tGrid_/50);
 
-        const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
-            = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
+        const auto vMesher = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
                   vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
@@ -94,7 +93,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
@@ -102,24 +101,21 @@ namespace QuantLib {
                 maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
 
-        const ext::shared_ptr<FdmMesher> mesher (
-			ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-			ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
+        auto calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
         std::list<std::vector<Time> > stoppingTimes;
 
         // 3.1 Step condition if discrete dividends
-        ext::shared_ptr<FdmDividendHandler> dividendCondition(
-			ext::make_shared<FdmDividendHandler>(dividends_, mesher,
+        auto dividendCondition = ext::make_shared<FdmDividendHandler>(dividends_, mesher,
                                    process->riskFreeRate()->referenceDate(),
-                                   process->riskFreeRate()->dayCounter(), 0));
+                                   process->riskFreeRate()->dayCounter(), 0);
 
         if (!dividends_.empty()) {
             stepConditions.push_back(dividendCondition);
@@ -133,8 +129,7 @@ namespace QuantLib {
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "only european style option are supported");
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-			ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions));
+        auto conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
@@ -157,9 +152,9 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmHestonSolver> solver(ext::make_shared<FdmHestonSolver>(
+        auto solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_);
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
@@ -92,13 +92,11 @@ namespace QuantLib {
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
-        boundaries.push_back(FdmBoundaryConditionSet::value_type(
-            new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                     FdmDirichletBoundary::Lower)));
+        boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+            mesher, arguments_.rebate, 0, FdmDirichletBoundary::Lower));
 
-        boundaries.push_back(FdmBoundaryConditionSet::value_type(
-            new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                     FdmDirichletBoundary::Upper)));
+        boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+            mesher, arguments_.rebate, 0, FdmDirichletBoundary::Upper));
 
         // 5. Solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,

--- a/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
@@ -59,8 +59,7 @@ namespace QuantLib {
         const Size tGridMin = 5;
         const Size tGridAvgSteps = std::max(tGridMin, tGrid_/50);
 
-        const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
-            = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
+        const auto vMesher = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
                   vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
@@ -70,17 +69,17 @@ namespace QuantLib {
         Real xMin = std::log(arguments_.barrier_lo);
         Real xMax = std::log(arguments_.barrier_hi);
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
                     process->riskFreeRate(), vMesher->volaEstimate()),
-                maturity, payoff->strike(), xMin, xMax));
+                maturity, payoff->strike(), xMin, xMax);
 
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;

--- a/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
+++ b/ql/pricingengines/barrier/fdhestondoublebarrierengine.cpp
@@ -70,20 +70,17 @@ namespace QuantLib {
         Real xMin = std::log(arguments_.barrier_lo);
         Real xMax = std::log(arguments_.barrier_hi);
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
                     process->riskFreeRate(), vMesher->volaEstimate()),
                 maturity, payoff->strike(), xMin, xMax));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
 
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -92,8 +89,7 @@ namespace QuantLib {
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
                    "only european style option are supported");
 
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        auto conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
 
         // 4. Boundary conditions
         FdmBoundaryConditionSet boundaries;
@@ -110,9 +106,9 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        auto solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_);
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -95,8 +95,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
@@ -106,14 +105,11 @@ namespace QuantLib {
                 std::make_pair(Null<Real>(), Null<Real>()),
                 dividends_));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
 
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(
-                new CashOrNothingPayoff(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogInnerValue(rebatePayoff, mesher, 0));
+        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0));
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,
@@ -147,9 +143,9 @@ namespace QuantLib {
                                      calculator, maturity,
                                      tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        auto solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process), solverDesc, schemeDesc_,
-                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_));
+                    Handle<FdmQuantoHelper>(), leverageFct_, mixingFactor_);
 
         const Real spot = process->s0()->value();
         results_.value = solver->valueAt(spot, process->v0());

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -125,16 +125,14 @@ namespace QuantLib {
         FdmBoundaryConditionSet boundaries;
         if (   arguments_.barrierType == Barrier::DownIn
             || arguments_.barrierType == Barrier::DownOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Lower)));
+            boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+                mesher, arguments_.rebate, 0, FdmDirichletBoundary::Lower));
 
         }
         if (   arguments_.barrierType == Barrier::UpIn
             || arguments_.barrierType == Barrier::UpOut) {
-            boundaries.push_back(FdmBoundaryConditionSet::value_type(
-                new FdmDirichletBoundary(mesher, arguments_.rebate, 0,
-                                         FdmDirichletBoundary::Upper)));
+            boundaries.push_back(ext::make_shared<FdmDirichletBoundary>(
+                mesher, arguments_.rebate, 0, FdmDirichletBoundary::Upper));
         }
 
         // 5. Solver

--- a/ql/pricingengines/barrier/fdhestonrebateengine.cpp
+++ b/ql/pricingengines/barrier/fdhestonrebateengine.cpp
@@ -76,8 +76,7 @@ namespace QuantLib {
         const Size tGridMin = 5;
         const Size tGridAvgSteps = std::max(tGridMin, tGrid_/50);
 
-        const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
-            = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
+        const auto vMesher = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
                   vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         // 1.2 The equity mesher
@@ -95,7 +94,7 @@ namespace QuantLib {
             xMax = std::log(arguments_.barrier);
         }
 
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_,
                 FdmBlackScholesMesher::processHelper(
                     process->s0(), process->dividendYield(),
@@ -103,13 +102,13 @@ namespace QuantLib {
                 maturity, payoff->strike(),
                 xMin, xMax, 0.0001, 1.5,
                 std::make_pair(Null<Real>(), Null<Real>()),
-                dividends_));
+                dividends_);
 
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<StrikedTypePayoff> rebatePayoff(ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate));
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0));
+        const auto rebatePayoff = ext::make_shared<CashOrNothingPayoff>(Option::Call, 0.0, arguments_.rebate);
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(rebatePayoff, mesher, 0);
 
         // 3. Step conditions
         QL_REQUIRE(arguments_.exercise->type() == Exercise::European,

--- a/ql/pricingengines/barrier/mcbarrierengine.hpp
+++ b/ql/pricingengines/barrier/mcbarrierengine.hpp
@@ -95,9 +95,8 @@ namespace QuantLib {
             TimeGrid grid = timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -243,21 +242,17 @@ namespace QuantLib {
 
         // do this with template parameters?
         if (isBiased_) {
-            return ext::shared_ptr<
-                        typename MCBarrierEngine<RNG,S>::path_pricer_type>(
-                new BiasedBarrierPathPricer(
+            return ext::make_shared<BiasedBarrierPathPricer>(
                        arguments_.barrierType,
                        arguments_.barrier,
                        arguments_.rebate,
                        payoff->optionType(),
                        payoff->strike(),
-                       discounts));
+                       discounts);
         } else {
             PseudoRandom::ursg_type sequenceGen(grid.size()-1,
                                                 PseudoRandom::urng_type(5));
-            return ext::shared_ptr<
-                        typename MCBarrierEngine<RNG,S>::path_pricer_type>(
-                new BarrierPathPricer(
+            return ext::make_shared<BarrierPathPricer>(
                     arguments_.barrierType,
                     arguments_.barrier,
                     arguments_.rebate,
@@ -265,7 +260,7 @@ namespace QuantLib {
                     payoff->strike(),
                     discounts,
                     process_,
-                    sequenceGen));
+                    sequenceGen);
         }
     }
 
@@ -354,8 +349,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCBarrierEngine<RNG,S>(process_,
+        return ext::make_shared<MCBarrierEngine<RNG,S>>(process_,
                                    steps_,
                                    stepsPerYear_,
                                    brownianBridge_,
@@ -363,7 +357,7 @@ namespace QuantLib {
                                    samples_, tolerance_,
                                    maxSamples_,
                                    biased_,
-                                   seed_));
+                                   seed_);
     }
 
 }

--- a/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
+++ b/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
@@ -56,24 +56,20 @@ namespace QuantLib {
 
         // 2. Mesher
         const Time maturity = p1_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> em1(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> em1(ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_, p1_, maturity, p1_->x0(), 
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
                     std::pair<Real, Real>(p1_->x0(), 0.1)));
 
-        const ext::shared_ptr<Fdm1dMesher> em2(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> em2(ext::make_shared<FdmBlackScholesMesher>(
                     yGrid_, p2_, maturity, p2_->x0(),
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
                     std::pair<Real, Real>(p2_->x0(), 0.1)));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(em1, em2));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(em1, em2));
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                new FdmLogBasketInnerValue(payoff, mesher));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogBasketInnerValue>(payoff, mesher));
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -91,12 +87,11 @@ namespace QuantLib {
                                            conditions, calculator,
                                            maturity, tGrid_, dampingSteps_ };
 
-        ext::shared_ptr<Fdm2dBlackScholesSolver> solver(
-                new Fdm2dBlackScholesSolver(
+        auto solver = ext::make_shared<Fdm2dBlackScholesSolver>(
                              Handle<GeneralizedBlackScholesProcess>(p1_),
                              Handle<GeneralizedBlackScholesProcess>(p2_),
                              correlation_, solverDesc, schemeDesc_,
-                             localVol_, illegalLocalVolOverwrite_));
+                             localVol_, illegalLocalVolOverwrite_);
 
         const Real x = p1_->x0();
         const Real y = p2_->x0();

--- a/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
+++ b/ql/pricingengines/basket/fd2dblackscholesvanillaengine.cpp
@@ -56,20 +56,20 @@ namespace QuantLib {
 
         // 2. Mesher
         const Time maturity = p1_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> em1(ext::make_shared<FdmBlackScholesMesher>(
+        const auto em1 = ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_, p1_, maturity, p1_->x0(), 
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
-                    std::pair<Real, Real>(p1_->x0(), 0.1)));
+                    std::pair<Real, Real>(p1_->x0(), 0.1));
 
-        const ext::shared_ptr<Fdm1dMesher> em2(ext::make_shared<FdmBlackScholesMesher>(
+        const auto em2 = ext::make_shared<FdmBlackScholesMesher>(
                     yGrid_, p2_, maturity, p2_->x0(),
                     Null<Real>(), Null<Real>(), 0.0001, 1.5, 
-                    std::pair<Real, Real>(p2_->x0(), 0.1)));
+                    std::pair<Real, Real>(p2_->x0(), 0.1));
 
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(em1, em2));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(em1, em2);
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogBasketInnerValue>(payoff, mesher));
+        const auto calculator = ext::make_shared<FdmLogBasketInnerValue>(payoff, mesher);
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =

--- a/ql/pricingengines/basket/mcamericanbasketengine.hpp
+++ b/ql/pricingengines/basket/mcamericanbasketengine.hpp
@@ -174,11 +174,10 @@ namespace QuantLib {
         QL_REQUIRE(!exercise->payoffAtExpiry(),
                    "payoff at expiry not handled");
 
-        ext::shared_ptr<AmericanBasketPathPricer> earlyExercisePathPricer(
-            new AmericanBasketPathPricer(processArray->size(),
+        auto earlyExercisePathPricer = ext::make_shared<AmericanBasketPathPricer>(processArray->size(),
                                          this->arguments_.payoff,
                                          polynomialOrder_,
-                                         polynomialType_));
+                                         polynomialType_);
 
         return ext::make_shared<LongstaffSchwartzPathPricer<MultiPath> > (
              
@@ -287,8 +286,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCAmericanBasketEngine<RNG>(process_,
+        return ext::make_shared<MCAmericanBasketEngine<RNG>>(process_,
                                         steps_,
                                         stepsPerYear_,
                                         brownianBridge_,
@@ -299,7 +297,7 @@ namespace QuantLib {
                                         seed_,
                                         calibrationSamples_,
                                         polynomialOrder_,
-                                        polynomialType_));
+                                        polynomialType_);
     }
 
 }

--- a/ql/pricingengines/basket/mceuropeanbasketengine.hpp
+++ b/ql/pricingengines/basket/mceuropeanbasketengine.hpp
@@ -80,9 +80,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(numAssets*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(processes_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(processes_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -193,11 +192,9 @@ namespace QuantLib {
                                                       processes_->process(0));
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                    typename MCEuropeanBasketEngine<RNG,S>::path_pricer_type>(
-            new EuropeanMultiPathPricer(payoff,
+        return ext::make_shared<EuropeanMultiPathPricer>(payoff,
                                         process->riskFreeRate()->discount(
-                                           arguments_.exercise->lastDate())));
+                                           arguments_.exercise->lastDate()));
     }
 
 
@@ -278,15 +275,14 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCEuropeanBasketEngine<RNG,S>(process_,
+        return ext::make_shared<MCEuropeanBasketEngine<RNG,S>>(process_,
                                           steps_,
                                           stepsPerYear_,
                                           brownianBridge_,
                                           antithetic_,
                                           samples_, tolerance_,
                                           maxSamples_,
-                                          seed_));
+                                          seed_);
     }
 
 }

--- a/ql/pricingengines/basket/stulzengine.cpp
+++ b/ql/pricingengines/basket/stulzengine.cpp
@@ -84,8 +84,7 @@ namespace QuantLib {
                                        Real variance1, Real variance2,
                                        Real rho) {
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(new
-                PlainVanillaPayoff(Option::Call, strike));
+            ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(Option::Call, strike));
 
             Real black1 = blackFormula(payoff->optionType(), payoff->strike(),
                 forward1, std::sqrt(variance1)) * riskFreeDiscount;

--- a/ql/pricingengines/basket/stulzengine.cpp
+++ b/ql/pricingengines/basket/stulzengine.cpp
@@ -84,7 +84,7 @@ namespace QuantLib {
                                        Real variance1, Real variance2,
                                        Real rho) {
 
-            ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(Option::Call, strike));
+            auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, strike);
 
             Real black1 = blackFormula(payoff->optionType(), payoff->strike(),
                 forward1, std::sqrt(variance1)) * riskFreeDiscount;
@@ -204,4 +204,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/pricingengines/blackcalculator.cpp
+++ b/ql/pricingengines/blackcalculator.cpp
@@ -58,8 +58,7 @@ namespace QuantLib {
                                      Real discount)
     : strike_(strike), forward_(forward), stdDev_(stdDev),
       discount_(discount), variance_(stdDev*stdDev) {
-        initialize(ext::shared_ptr<StrikedTypePayoff>(new
-            PlainVanillaPayoff(optionType, strike)));
+        initialize(ext::make_shared<PlainVanillaPayoff>(optionType, strike));
     }
 
     void BlackCalculator::initialize(const ext::shared_ptr<StrikedTypePayoff>& p) {

--- a/ql/pricingengines/bond/binomialconvertibleengine.hpp
+++ b/ql/pricingengines/bond/binomialconvertibleengine.hpp
@@ -115,8 +115,8 @@ namespace QuantLib {
 
         Real creditSpread = creditSpread_->value();
 
-        ext::shared_ptr<Lattice> lattice(ext::make_shared<TsiveriotisFernandesLattice<T>>(
-            tree, riskFreeRate, maturity, timeSteps_, creditSpread, v, q));
+        auto lattice = ext::make_shared<TsiveriotisFernandesLattice<T>>(
+            tree, riskFreeRate, maturity, timeSteps_, creditSpread, v, q);
 
         DiscretizedConvertible convertible(arguments_, bs, dividends_, creditSpread_, TimeGrid(maturity, timeSteps_));
 

--- a/ql/pricingengines/bond/binomialconvertibleengine.hpp
+++ b/ql/pricingengines/bond/binomialconvertibleengine.hpp
@@ -101,24 +101,21 @@ namespace QuantLib {
             "negative value after subtracting dividends");
 
         // binomial trees with constant coefficient
-        Handle<Quote> underlying(ext::shared_ptr<Quote>(new SimpleQuote(s0)));
-        Handle<YieldTermStructure> flatRiskFree(ext::shared_ptr<YieldTermStructure>(
-            new FlatForward(referenceDate, riskFreeRate, rfdc)));
+        Handle<Quote> underlying(ext::make_shared<SimpleQuote>(s0));
+        Handle<YieldTermStructure> flatRiskFree(ext::make_shared<FlatForward>(referenceDate, riskFreeRate, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(new FlatForward(referenceDate, q, divdc)));
-        Handle<BlackVolTermStructure> flatVol(ext::shared_ptr<BlackVolTermStructure>(
-            new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
+        Handle<BlackVolTermStructure> flatVol(ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         Time maturity = rfdc.yearFraction(arguments_.settlementDate, maturityDate);
         Real strike = arguments_.redemption / arguments_.conversionRatio ;
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bs(
-            new GeneralizedBlackScholesProcess(underlying, flatDividends, flatRiskFree, flatVol));
-        ext::shared_ptr<T> tree(new T(bs, maturity, timeSteps_, strike));
+        auto bs = ext::make_shared<GeneralizedBlackScholesProcess>(underlying, flatDividends, flatRiskFree, flatVol);
+        auto tree = ext::make_shared<T>(bs, maturity, timeSteps_, strike);
 
         Real creditSpread = creditSpread_->value();
 
-        ext::shared_ptr<Lattice> lattice(new TsiveriotisFernandesLattice<T>(
+        ext::shared_ptr<Lattice> lattice(ext::make_shared<TsiveriotisFernandesLattice<T>>(
             tree, riskFreeRate, maturity, timeSteps_, creditSpread, v, q));
 
         DiscretizedConvertible convertible(arguments_, bs, dividends_, creditSpread_, TimeGrid(maturity, timeSteps_));

--- a/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/bacheliercapfloorengine.cpp
@@ -32,8 +32,7 @@ namespace QuantLib {
                                                      Volatility v,
                                                      const DayCounter& dc)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))) {
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)) {
         registerWith(discountCurve_);
     }
 
@@ -41,8 +40,7 @@ namespace QuantLib {
                                                      const Handle<Quote>& v,
                                                      const DayCounter& dc)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))) {
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)) {
         registerWith(discountCurve_);
         registerWith(vol_);
     }

--- a/ql/pricingengines/capfloor/blackcapfloorengine.cpp
+++ b/ql/pricingengines/capfloor/blackcapfloorengine.cpp
@@ -35,8 +35,7 @@ namespace QuantLib {
                                              const DayCounter& dc,
                                              Real displacement)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))),
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)),
       displacement_(displacement) {
         registerWith(discountCurve_);
     }
@@ -46,8 +45,7 @@ namespace QuantLib {
                                              const DayCounter& dc,
                                              Real displacement)
     : discountCurve_(std::move(discountCurve)),
-      vol_(ext::shared_ptr<OptionletVolatilityStructure>(
-          new ConstantOptionletVolatility(0, NullCalendar(), Following, v, dc))),
+      vol_(ext::make_shared<ConstantOptionletVolatility>(0, NullCalendar(), Following, v, dc)),
       displacement_(displacement) {
         registerWith(discountCurve_);
         registerWith(vol_);

--- a/ql/pricingengines/capfloor/mchullwhiteengine.hpp
+++ b/ql/pricingengines/capfloor/mchullwhiteengine.hpp
@@ -101,9 +101,8 @@ namespace QuantLib {
             Time forwardMeasureTime =
                 dayCounter.yearFraction(referenceDate,
                                         arguments_.endDates.back());
-            return ext::shared_ptr<path_pricer_type>(
-                     new detail::HullWhiteCapFloorPricer(arguments_, model_,
-                                                         forwardMeasureTime));
+            return ext::make_shared<detail::HullWhiteCapFloorPricer>(arguments_, model_,
+                                                         forwardMeasureTime);
         }
 
         TimeGrid timeGrid() const {
@@ -137,16 +136,14 @@ namespace QuantLib {
                                         arguments_.endDates.back());
             Array parameters = model_->params();
             Real a = parameters[0], sigma = parameters[1];
-            ext::shared_ptr<HullWhiteForwardProcess> process(
-                                new HullWhiteForwardProcess(curve, a, sigma));
+            auto process = ext::make_shared<HullWhiteForwardProcess>(curve, a, sigma);
             process->setForwardMeasureTime(forwardMeasureTime);
 
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type generator =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                             new path_generator_type(process, grid, generator,
-                                                     brownianBridge_));
+            return ext::make_shared<path_generator_type>(process, grid, generator,
+                                                     brownianBridge_);
         }
     };
 
@@ -237,11 +234,10 @@ namespace QuantLib {
     template <class RNG, class S>
     inline MakeMCHullWhiteCapFloorEngine<RNG,S>::
     operator ext::shared_ptr<PricingEngine>() const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCHullWhiteCapFloorEngine<RNG,S>(model_,
+        return ext::make_shared<MCHullWhiteCapFloorEngine<RNG,S>>(model_,
                                              brownianBridge_, antithetic_,
                                              samples_, tolerance_,
-                                             maxSamples_, seed_));
+                                             maxSamples_, seed_);
     }
 
 }

--- a/ql/pricingengines/cliquet/analyticcliquetengine.cpp
+++ b/ql/pricingengines/cliquet/analyticcliquetengine.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
         Real strike = underlying * moneyness->strike();
-        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(),strike));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(),strike);
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;
@@ -110,4 +110,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/pricingengines/cliquet/analyticcliquetengine.cpp
+++ b/ql/pricingengines/cliquet/analyticcliquetengine.cpp
@@ -55,8 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
         Real strike = underlying * moneyness->strike();
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                      new PlainVanillaPayoff(moneyness->optionType(),strike));
+        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(),strike));
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;

--- a/ql/pricingengines/cliquet/analyticperformanceengine.cpp
+++ b/ql/pricingengines/cliquet/analyticperformanceengine.cpp
@@ -55,8 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                        new PlainVanillaPayoff(moneyness->optionType(), 1.0));
+        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(), 1.0));
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;

--- a/ql/pricingengines/cliquet/analyticperformanceengine.cpp
+++ b/ql/pricingengines/cliquet/analyticperformanceengine.cpp
@@ -55,7 +55,7 @@ namespace QuantLib {
         Real underlying = process_->stateVariable()->value();
         QL_REQUIRE(underlying > 0.0, "negative or null underlying");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(), 1.0));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(moneyness->optionType(), 1.0);
 
         results_.value = 0.0;
         results_.delta = results_.gamma = 0.0;
@@ -110,4 +110,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/pricingengines/cliquet/mcperformanceengine.hpp
+++ b/ql/pricingengines/cliquet/mcperformanceengine.hpp
@@ -66,9 +66,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -174,11 +173,9 @@ namespace QuantLib {
         discounts.push_back(this->process_->riskFreeRate()->discount(
                                             arguments_.exercise->lastDate()));
 
-        return ext::shared_ptr<
-            typename MCPerformanceEngine<RNG,S>::path_pricer_type>(
-                         new PerformanceOptionPathPricer(payoff->optionType(),
+        return ext::make_shared<PerformanceOptionPathPricer>(payoff->optionType(),
                                                          payoff->strike(),
-                                                         discounts));
+                                                         discounts);
     }
 
 
@@ -241,14 +238,13 @@ namespace QuantLib {
     inline
     MakeMCPerformanceEngine<RNG,S>::operator ext::shared_ptr<PricingEngine>()
                                                                       const {
-        return ext::shared_ptr<PricingEngine>(new
-            MCPerformanceEngine<RNG,S>(process_,
+        return ext::make_shared<MCPerformanceEngine<RNG,S>>(process_,
                                        brownianBridge_,
                                        antithetic_,
                                        samples_,
                                        tolerance_,
                                        maxSamples_,
-                                       seed_));
+                                       seed_);
     }
 
 }

--- a/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
+++ b/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
@@ -64,7 +64,7 @@ namespace QuantLib {
 
         auto spot = ext::make_shared<SimpleQuote>(arguments_.Q1*s1);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(Option::Call, arguments_.Q2*s2));
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, arguments_.Q2*s2);
 
         DiscountFactor dividendDiscount1 =
             process1_->dividendYield()->discount(exercise->lastDate());
@@ -74,9 +74,9 @@ namespace QuantLib {
             process2_->dividendYield()->discount(exercise->lastDate());
         Rate q2 = -std::log(dividendDiscount2)/t;
 
-        ext::shared_ptr<YieldTermStructure> qTS(ext::make_shared<FlatForward>(today, q1, rfdc));
+        auto qTS = ext::make_shared<FlatForward>(today, q1, rfdc);
 
-        ext::shared_ptr<YieldTermStructure> rTS(ext::make_shared<FlatForward>(today, q2, rfdc));
+        auto rTS = ext::make_shared<FlatForward>(today, q2, rfdc);
 
         Real variance1 = process1_->blackVolatility()->blackVariance(
                                                 exercise->lastDate(), s1);
@@ -86,14 +86,14 @@ namespace QuantLib {
                       - 2*rho_*std::sqrt(variance1)*std::sqrt(variance2);
         Volatility volatility = std::sqrt(variance/t);
 
-        ext::shared_ptr<BlackVolTermStructure> volTS(ext::make_shared<BlackConstantVol>(today, NullCalendar(), volatility, rfdc));
+        auto volTS = ext::make_shared<BlackConstantVol>(today, NullCalendar(), volatility, rfdc);
 
         auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
                                       Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess));
+        auto engine = ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess);
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);

--- a/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
+++ b/ql/pricingengines/exotic/analyticamericanmargrabeengine.cpp
@@ -62,10 +62,9 @@ namespace QuantLib {
         Real s1 = process1_->stateVariable()->value();
         Real s2 = process2_->stateVariable()->value();
 
-        ext::shared_ptr<SimpleQuote> spot(new SimpleQuote(arguments_.Q1*s1));
+        auto spot = ext::make_shared<SimpleQuote>(arguments_.Q1*s1);
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                      new PlainVanillaPayoff(Option::Call, arguments_.Q2*s2));
+        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(Option::Call, arguments_.Q2*s2));
 
         DiscountFactor dividendDiscount1 =
             process1_->dividendYield()->discount(exercise->lastDate());
@@ -75,11 +74,9 @@ namespace QuantLib {
             process2_->dividendYield()->discount(exercise->lastDate());
         Rate q2 = -std::log(dividendDiscount2)/t;
 
-        ext::shared_ptr<YieldTermStructure> qTS(
-                                            new FlatForward(today, q1, rfdc));
+        ext::shared_ptr<YieldTermStructure> qTS(ext::make_shared<FlatForward>(today, q1, rfdc));
 
-        ext::shared_ptr<YieldTermStructure> rTS(
-                                            new FlatForward(today, q2, rfdc));
+        ext::shared_ptr<YieldTermStructure> rTS(ext::make_shared<FlatForward>(today, q2, rfdc));
 
         Real variance1 = process1_->blackVolatility()->blackVariance(
                                                 exercise->lastDate(), s1);
@@ -89,17 +86,14 @@ namespace QuantLib {
                       - 2*rho_*std::sqrt(variance1)*std::sqrt(variance2);
         Volatility volatility = std::sqrt(variance/t);
 
-        ext::shared_ptr<BlackVolTermStructure> volTS(
-               new BlackConstantVol(today, NullCalendar(), volatility, rfdc));
+        ext::shared_ptr<BlackVolTermStructure> volTS(ext::make_shared<BlackConstantVol>(today, NullCalendar(), volatility, rfdc));
 
-        ext::shared_ptr<BlackScholesMertonProcess> stochProcess(new
-            BlackScholesMertonProcess(Handle<Quote>(spot),
+        auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(Handle<Quote>(spot),
                                       Handle<YieldTermStructure>(qTS),
                                       Handle<YieldTermStructure>(rTS),
-                                      Handle<BlackVolTermStructure>(volTS)));
+                                      Handle<BlackVolTermStructure>(volTS));
 
-        ext::shared_ptr<PricingEngine> engine(
-                     new BjerksundStenslandApproximationEngine(stochProcess));
+        ext::shared_ptr<PricingEngine> engine(ext::make_shared<BjerksundStenslandApproximationEngine>(stochProcess));
 
         VanillaOption option(payoff, exercise);
         option.setPricingEngine(engine);

--- a/ql/pricingengines/exotic/analyticcompoundoptionengine.cpp
+++ b/ql/pricingengines/exotic/analyticcompoundoptionengine.cpp
@@ -85,9 +85,8 @@ namespace QuantLib {
             process_->riskFreeRate()->discount(helpMaturity);
 
 
-        ext::shared_ptr<ImpliedSpotHelper> f(
-                new ImpliedSpotHelper(dividendDiscount, riskFreeDiscount,
-                                      vol, payoffDaughter(), strikeMother()));
+        auto f = ext::make_shared<ImpliedSpotHelper>(dividendDiscount, riskFreeDiscount,
+                                      vol, payoffDaughter(), strikeMother());
 
         Brent solver;
         solver.setMaxEvaluations(1000);

--- a/ql/pricingengines/forward/forwardengine.hpp
+++ b/ql/pricingengines/forward/forwardengine.hpp
@@ -81,8 +81,7 @@ namespace QuantLib {
                 this->arguments_.payoff);
         QL_REQUIRE(argumentsPayoff, "wrong payoff given");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(
-                   new PlainVanillaPayoff(argumentsPayoff->optionType(),
+        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(argumentsPayoff->optionType(),
                                           this->arguments_.moneyness *
                                           process_->x0()));
 
@@ -92,29 +91,25 @@ namespace QuantLib {
         Handle<Quote> spot = process_->stateVariable();
         QL_REQUIRE(spot->value() > 0.0, "negative or null underlying given");
         Handle<YieldTermStructure> dividendYield(
-            ext::shared_ptr<YieldTermStructure>(
-               new ImpliedTermStructure(process_->dividendYield(),
-                                        this->arguments_.resetDate)));
+            ext::make_shared<ImpliedTermStructure>(process_->dividendYield(),
+                                        this->arguments_.resetDate));
         Handle<YieldTermStructure> riskFreeRate(
-            ext::shared_ptr<YieldTermStructure>(
-               new ImpliedTermStructure(process_->riskFreeRate(),
-                                        this->arguments_.resetDate)));
+            ext::make_shared<ImpliedTermStructure>(process_->riskFreeRate(),
+                                        this->arguments_.resetDate));
         // The following approach is ok if the vol is at most
         // time-dependent. It is plain wrong if it is asset-dependent.
         // In the latter case the right solution would be stochastic
         // volatility or at least local volatility (which unfortunately
         // implies an unrealistic time-decreasing smile)
         Handle<BlackVolTermStructure> blackVolatility(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new ImpliedVolTermStructure(process_->blackVolatility(),
-                                            this->arguments_.resetDate)));
+            ext::make_shared<ImpliedVolTermStructure>(process_->blackVolatility(),
+                                            this->arguments_.resetDate));
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> fwdProcess(
-                       new GeneralizedBlackScholesProcess(spot, dividendYield,
+        auto fwdProcess = ext::make_shared<GeneralizedBlackScholesProcess>(spot, dividendYield,
                                                           riskFreeRate,
-                                                          blackVolatility));
+                                                          blackVolatility);
 
-        originalEngine_ = ext::shared_ptr<Engine>(new Engine(fwdProcess));
+        originalEngine_ = ext::make_shared<Engine>(fwdProcess);
         originalEngine_->reset();
 
         originalArguments_ =

--- a/ql/pricingengines/forward/forwardengine.hpp
+++ b/ql/pricingengines/forward/forwardengine.hpp
@@ -81,9 +81,9 @@ namespace QuantLib {
                 this->arguments_.payoff);
         QL_REQUIRE(argumentsPayoff, "wrong payoff given");
 
-        ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(argumentsPayoff->optionType(),
+        auto payoff = ext::make_shared<PlainVanillaPayoff>(argumentsPayoff->optionType(),
                                           this->arguments_.moneyness *
-                                          process_->x0()));
+                                          process_->x0());
 
         // maybe the forward value is "better", in some fashion
         // the right level is needed in order to interpolate

--- a/ql/pricingengines/forward/mcforwardeuropeanbsengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanbsengine.hpp
@@ -152,14 +152,12 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanBSEngine<RNG,S>::path_pricer_type>(
-                new ForwardEuropeanBSPathPricer(
+        return ext::make_shared<ForwardEuropeanBSPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
 
@@ -241,15 +239,14 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified - set EITHER steps OR stepsPerYear");
-        return ext::shared_ptr<PricingEngine>(new
-            MCForwardEuropeanBSEngine<RNG,S>(process_,
+        return ext::make_shared<MCForwardEuropeanBSEngine<RNG,S>>(process_,
                                              steps_,
                                              stepsPerYear_,
                                              brownianBridge_,
                                              antithetic_,
                                              samples_, tolerance_,
                                              maxSamples_,
-                                             seed_));
+                                             seed_);
     }
 
 }

--- a/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
+++ b/ql/pricingengines/forward/mcforwardeuropeanhestonengine.hpp
@@ -77,9 +77,8 @@ namespace QuantLib {
             ext::shared_ptr<P> process = ext::dynamic_pointer_cast<P>(this->process_);
             QL_REQUIRE(process, "Heston-like process required");
 
-            ext::shared_ptr<HestonModel> hestonModel(new HestonModel(process));
-            return ext::shared_ptr<PricingEngine>(new
-                AnalyticHestonEngine(hestonModel));
+            auto hestonModel = ext::make_shared<HestonModel>(process);
+            return ext::make_shared<AnalyticHestonEngine>(hestonModel);
         }
     };
 
@@ -173,14 +172,12 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ForwardEuropeanHestonPathPricer(
+        return ext::make_shared<ForwardEuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
     template <class RNG, class S, class P>
@@ -206,14 +203,12 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<typename
-            MCForwardEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                new ForwardEuropeanHestonPathPricer(
+        return ext::make_shared<ForwardEuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         this->arguments_.moneyness,
                                         resetIndex,
                                         process->riskFreeRate()->discount(
-                                                   timeGrid.back())));
+                                                   timeGrid.back()));
     }
 
     template <class RNG, class S, class P>
@@ -293,8 +288,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified - set EITHER steps OR stepsPerYear");
-        return ext::shared_ptr<PricingEngine>(new
-            MCForwardEuropeanHestonEngine<RNG,S,P>(process_,
+        return ext::make_shared<MCForwardEuropeanHestonEngine<RNG,S,P>>(process_,
                                                    steps_,
                                                    stepsPerYear_,
                                                    antithetic_,
@@ -302,7 +296,7 @@ namespace QuantLib {
                                                    tolerance_,
                                                    maxSamples_,
                                                    seed_,
-                                                   controlVariate_));
+                                                   controlVariate_);
     }
 }
 

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -158,7 +158,7 @@ namespace QuantLib {
         Real moneyness = this->arguments_.moneyness;
         Real strike = moneyness * spot;
 
-        ext::shared_ptr<StrikedTypePayoff> newPayoff(ext::make_shared<PlainVanillaPayoff>(payoff->optionType(), strike));
+        auto newPayoff = ext::make_shared<PlainVanillaPayoff>(payoff->optionType(), strike);
 
         auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
 

--- a/ql/pricingengines/forward/mcforwardvanillaengine.hpp
+++ b/ql/pricingengines/forward/mcforwardvanillaengine.hpp
@@ -74,9 +74,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid,
-                                                 gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                                 gen, brownianBridge_);
         }
         // data members
         ext::shared_ptr<StochasticProcess> process_;
@@ -159,8 +158,7 @@ namespace QuantLib {
         Real moneyness = this->arguments_.moneyness;
         Real strike = moneyness * spot;
 
-        ext::shared_ptr<StrikedTypePayoff> newPayoff(new
-            PlainVanillaPayoff(payoff->optionType(), strike));
+        ext::shared_ptr<StrikedTypePayoff> newPayoff(ext::make_shared<PlainVanillaPayoff>(payoff->optionType(), strike));
 
         auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
 

--- a/ql/pricingengines/forward/mcvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/mcvarianceswapengine.hpp
@@ -112,9 +112,8 @@ namespace QuantLib {
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
 
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_, grid, gen,
-                                                 brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid, gen,
+                                                 brownianBridge_);
         }
         // data members
         ext::shared_ptr<GeneralizedBlackScholesProcess> process_;
@@ -215,9 +214,7 @@ namespace QuantLib {
         typename MCVarianceSwapEngine<RNG,S>::path_pricer_type>
     MCVarianceSwapEngine<RNG,S>::pathPricer() const {
 
-        return ext::shared_ptr<
-            typename MCVarianceSwapEngine<RNG,S>::path_pricer_type>(
-                                            new VariancePathPricer(process_));
+        return ext::make_shared<VariancePathPricer>(process_);
     }
 
 
@@ -297,15 +294,14 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(
-                         new MCVarianceSwapEngine<RNG,S>(process_,
+        return ext::make_shared<MCVarianceSwapEngine<RNG,S>>(process_,
                                                          steps_,
                                                          stepsPerYear_,
                                                          brownianBridge_,
                                                          antithetic_,
                                                          samples_, tolerance_,
                                                          maxSamples_,
-                                                         seed_));
+                                                         seed_);
     }
 
 

--- a/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
@@ -132,8 +132,7 @@ namespace QuantLib {
             slope = std::fabs((computeLogPayoff(*(k+1), f) -
                                computeLogPayoff(*k, f))/
                               (*(k+1) - *k));
-            ext::shared_ptr<StrikedTypePayoff> payoff(
-                                            new PlainVanillaPayoff(type, *k));
+            ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(type, *k));
             if ( k == strikes.begin() )
                 optionWeights.emplace_back(payoff,slope);
             else
@@ -155,10 +154,8 @@ namespace QuantLib {
     Real ReplicatingVarianceSwapEngine::computeReplicatingPortfolio(
                                     const weights_type& optionWeights) const {
 
-        ext::shared_ptr<Exercise> exercise(
-                               new EuropeanExercise(arguments_.maturityDate));
-        ext::shared_ptr<PricingEngine> optionEngine(
-                                        new AnalyticEuropeanEngine(process_));
+        ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(arguments_.maturityDate));
+        ext::shared_ptr<PricingEngine> optionEngine(ext::make_shared<AnalyticEuropeanEngine>(process_));
         Real optionsValue = 0.0;
 
         for (auto i = optionWeights.begin(); i < optionWeights.end(); ++i) {

--- a/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
+++ b/ql/pricingengines/forward/replicatingvarianceswapengine.hpp
@@ -132,7 +132,7 @@ namespace QuantLib {
             slope = std::fabs((computeLogPayoff(*(k+1), f) -
                                computeLogPayoff(*k, f))/
                               (*(k+1) - *k));
-            ext::shared_ptr<StrikedTypePayoff> payoff(ext::make_shared<PlainVanillaPayoff>(type, *k));
+            auto payoff = ext::make_shared<PlainVanillaPayoff>(type, *k);
             if ( k == strikes.begin() )
                 optionWeights.emplace_back(payoff,slope);
             else
@@ -154,8 +154,8 @@ namespace QuantLib {
     Real ReplicatingVarianceSwapEngine::computeReplicatingPortfolio(
                                     const weights_type& optionWeights) const {
 
-        ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(arguments_.maturityDate));
-        ext::shared_ptr<PricingEngine> optionEngine(ext::make_shared<AnalyticEuropeanEngine>(process_));
+        auto exercise = ext::make_shared<EuropeanExercise>(arguments_.maturityDate);
+        auto optionEngine = ext::make_shared<AnalyticEuropeanEngine>(process_);
         Real optionsValue = 0.0;
 
         for (auto i = optionWeights.begin(); i < optionWeights.end(); ++i) {

--- a/ql/pricingengines/lookback/mclookbackengine.cpp
+++ b/ql/pricingengines/lookback/mclookbackengine.cpp
@@ -83,10 +83,9 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<PlainVanillaPayoff>(args.payoff);
             QL_REQUIRE(payoff, "non-plain payoff given");
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackFixedPathPricer(payoff->optionType(),
+            return ext::make_shared<LookbackFixedPathPricer>(payoff->optionType(),
                                             payoff->strike(),
-                                            discount));
+                                            discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -100,11 +99,10 @@ namespace QuantLib {
 
             Time lookbackStart = process.time(args.lookbackPeriodStart);
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackPartialFixedPathPricer(lookbackStart,
+            return ext::make_shared<LookbackPartialFixedPathPricer>(lookbackStart,
                                                    payoff->optionType(),
                                                    payoff->strike(),
-                                                   discount));
+                                                   discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -116,9 +114,8 @@ namespace QuantLib {
                 ext::dynamic_pointer_cast<FloatingTypePayoff>(args.payoff);
             QL_REQUIRE(payoff, "non-floating payoff given");
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackFloatingPathPricer(payoff->optionType(),
-                                               discount));
+            return ext::make_shared<LookbackFloatingPathPricer>(payoff->optionType(),
+                                               discount);
         }
 
         ext::shared_ptr<PathPricer<Path> >
@@ -132,10 +129,9 @@ namespace QuantLib {
 
             Time lookbackEnd = process.time(args.lookbackPeriodEnd);
 
-            return ext::shared_ptr<PathPricer<Path> >(
-                new LookbackPartialFloatingPathPricer(lookbackEnd,
+            return ext::make_shared<LookbackPartialFloatingPathPricer>(lookbackEnd,
                                                       payoff->optionType(),
-                                                      discount));
+                                                      discount);
         }
 
     }

--- a/ql/pricingengines/lookback/mclookbackengine.hpp
+++ b/ql/pricingengines/lookback/mclookbackengine.hpp
@@ -70,9 +70,8 @@ namespace QuantLib {
             TimeGrid grid = timeGrid();
             typename RNG::rsg_type gen =
                 RNG::make_sequence_generator(grid.size()-1,seed_);
-            return ext::shared_ptr<path_generator_type>(
-                         new path_generator_type(process_,
-                                                 grid, gen, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_,
+                                                 grid, gen, brownianBridge_);
         }
         ext::shared_ptr<path_pricer_type> pathPricer() const override;
         // data members
@@ -278,8 +277,7 @@ namespace QuantLib {
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
 
-        return ext::shared_ptr<PricingEngine>(
-            new MCLookbackEngine<I,RNG,S>(process_,
+        return ext::make_shared<MCLookbackEngine<I,RNG,S>>(process_,
                                           steps_,
                                           stepsPerYear_,
                                           brownianBridge_,
@@ -287,7 +285,7 @@ namespace QuantLib {
                                           samples_,
                                           tolerance_,
                                           maxSamples_,
-                                          seed_));
+                                          seed_);
     }
 
 }

--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -184,9 +184,7 @@ namespace QuantLib {
         typename RNG_Calibration::rsg_type generator =
             RNG_Calibration::make_sequence_generator(
                 dimensions * (grid.size() - 1), seedCalibration_);
-        ext::shared_ptr<path_generator_type_calibration>
-            pathGeneratorCalibration =
-                ext::make_shared<path_generator_type_calibration>(
+        auto pathGeneratorCalibration = ext::make_shared<path_generator_type_calibration>(
                     process_, grid, generator, brownianBridgeCalibration_);
         mcModelCalibration_ =
             ext::make_shared<MonteCarloModel<MC, RNG_Calibration, S>>(

--- a/ql/pricingengines/mclongstaffschwartzengine.hpp
+++ b/ql/pricingengines/mclongstaffschwartzengine.hpp
@@ -189,10 +189,9 @@ namespace QuantLib {
                 ext::make_shared<path_generator_type_calibration>(
                     process_, grid, generator, brownianBridgeCalibration_);
         mcModelCalibration_ =
-            ext::shared_ptr<MonteCarloModel<MC, RNG_Calibration, S> >(
-                new MonteCarloModel<MC, RNG_Calibration, S>(
+            ext::make_shared<MonteCarloModel<MC, RNG_Calibration, S>>(
                     pathGeneratorCalibration, pathPricer_, stats_type(),
-                    this->antitheticVariateCalibration_));
+                    this->antitheticVariateCalibration_);
 
         mcModelCalibration_->addSamples(nCalibrationSamples_);
         pathPricer_->calibrate();
@@ -250,9 +249,8 @@ namespace QuantLib {
         TimeGrid grid = this->timeGrid();
         typename RNG::rsg_type generator =
             RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-        return ext::shared_ptr<path_generator_type>(
-                   new path_generator_type(process_,
-                                           grid, generator, brownianBridge_));
+        return ext::make_shared<path_generator_type>(process_,
+                                           grid, generator, brownianBridge_);
     }
 
 }

--- a/ql/pricingengines/mcsimulation.hpp
+++ b/ql/pricingengines/mcsimulation.hpp
@@ -181,17 +181,15 @@ namespace QuantLib {
                 this->controlPathGenerator();
 
             this->mcModel_ =
-                ext::shared_ptr<MonteCarloModel<MC,RNG,S> >(
-                    new MonteCarloModel<MC,RNG,S>(
+                ext::make_shared<MonteCarloModel<MC,RNG,S>>(
                            pathGenerator(), this->pathPricer(), stats_type(),
                            this->antitheticVariate_, controlPP,
-                           controlVariateValue, controlPG));
+                           controlVariateValue, controlPG);
         } else {
             this->mcModel_ =
-                ext::shared_ptr<MonteCarloModel<MC,RNG,S> >(
-                    new MonteCarloModel<MC,RNG,S>(
+                ext::make_shared<MonteCarloModel<MC,RNG,S>>(
                            pathGenerator(), this->pathPricer(), S(),
-                           this->antitheticVariate_));
+                           this->antitheticVariate_);
         }
 
         if (requiredTolerance != Null<Real>()) {

--- a/ql/pricingengines/quanto/quantoengine.hpp
+++ b/ql/pricingengines/quanto/quantoengine.hpp
@@ -99,22 +99,20 @@ namespace QuantLib {
         Handle<YieldTermStructure> riskFreeRate = process_->riskFreeRate();
         // dividendTS needs modification
         Handle<YieldTermStructure> dividendYield(
-            ext::shared_ptr<YieldTermStructure>(
-                new QuantoTermStructure(process_->dividendYield(),
+            ext::make_shared<QuantoTermStructure>(process_->dividendYield(),
                                         process_->riskFreeRate(),
                                         foreignRiskFreeRate_,
                                         process_->blackVolatility(),
                                         strike,
                                         exchangeRateVolatility_,
                                         exchangeRateATMlevel,
-                                        correlation_->value())));
+                                        correlation_->value()));
         Handle<BlackVolTermStructure> blackVol = process_->blackVolatility();
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> quantoProcess(
-                  new GeneralizedBlackScholesProcess(spot, dividendYield,
-                                                     riskFreeRate, blackVol));
+        auto quantoProcess = ext::make_shared<GeneralizedBlackScholesProcess>(spot, dividendYield,
+                                                     riskFreeRate, blackVol);
 
-        ext::shared_ptr<Engine> originalEngine(new Engine(quantoProcess));
+        auto originalEngine = ext::make_shared<Engine>(quantoProcess);
         originalEngine->reset();
         auto* originalArguments =
             dynamic_cast<typename Instr::arguments*>(originalEngine->getArguments());

--- a/ql/pricingengines/swaption/blackswaptionengine.hpp
+++ b/ql/pricingengines/swaption/blackswaptionengine.hpp
@@ -186,8 +186,8 @@ namespace QuantLib {
             Real displacement,
             CashAnnuityModel model)
         : discountCurve_(std::move(discountCurve)),
-          vol_(ext::shared_ptr<SwaptionVolatilityStructure>(new ConstantSwaptionVolatility(
-              0, NullCalendar(), Following, vol, dc, Spec().type, displacement))),
+          vol_(ext::make_shared<ConstantSwaptionVolatility>(
+              0, NullCalendar(), Following, vol, dc, Spec().type, displacement)),
           model_(model) {
             registerWith(discountCurve_);
         }
@@ -200,8 +200,8 @@ namespace QuantLib {
             Real displacement,
             CashAnnuityModel model)
         : discountCurve_(std::move(discountCurve)),
-          vol_(ext::shared_ptr<SwaptionVolatilityStructure>(new ConstantSwaptionVolatility(
-              0, NullCalendar(), Following, vol, dc, Spec().type, displacement))),
+          vol_(ext::make_shared<ConstantSwaptionVolatility>(
+              0, NullCalendar(), Following, vol, dc, Spec().type, displacement)),
           model_(model) {
             registerWith(discountCurve_);
             registerWith(vol_);

--- a/ql/pricingengines/swaption/fdg2swaptionengine.cpp
+++ b/ql/pricingengines/swaption/fdg2swaptionengine.cpp
@@ -61,11 +61,11 @@ namespace QuantLib {
 
         const auto process2 = ext::make_shared<OrnsteinUhlenbeckProcess>(model_->b(), model_->eta());
 
-        const ext::shared_ptr<Fdm1dMesher> xMesher(ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_,process1,maturity,1,invEps_));
+        const auto xMesher = ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_,process1,maturity,1,invEps_);
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(ext::make_shared<FdmSimpleProcess1dMesher>(yGrid_,process2,maturity,1,invEps_));
+        const auto yMesher = ext::make_shared<FdmSimpleProcess1dMesher>(yGrid_,process2,maturity,1,invEps_);
 
-        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(xMesher, yMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(xMesher, yMesher);
 
         // 3. Inner Value Calculator
         const std::vector<Date>& exerciseDates = arguments_.exercise->dates();
@@ -90,9 +90,9 @@ namespace QuantLib {
         const auto fwdModel = ext::make_shared<G2>(fwdTs, model_->a(), model_->sigma(),
                    model_->b(), model_->eta(), model_->rho());
 
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmAffineModelSwapInnerValue<G2>>(
+        const auto calculator = ext::make_shared<FdmAffineModelSwapInnerValue<G2>>(
                  model_.currentLink(), fwdModel,
-                 arguments_.swap, t2d, mesher, 0));
+                 arguments_.swap, t2d, mesher, 0);
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =

--- a/ql/pricingengines/swaption/fdg2swaptionengine.cpp
+++ b/ql/pricingengines/swaption/fdg2swaptionengine.cpp
@@ -57,20 +57,15 @@ namespace QuantLib {
         const Time maturity = dc.yearFraction(referenceDate,
                                               arguments_.exercise->lastDate());
 
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process1(
-            new OrnsteinUhlenbeckProcess(model_->a(), model_->sigma()));
+        const auto process1 = ext::make_shared<OrnsteinUhlenbeckProcess>(model_->a(), model_->sigma());
 
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> process2(
-            new OrnsteinUhlenbeckProcess(model_->b(), model_->eta()));
+        const auto process2 = ext::make_shared<OrnsteinUhlenbeckProcess>(model_->b(), model_->eta());
 
-        const ext::shared_ptr<Fdm1dMesher> xMesher(
-            new FdmSimpleProcess1dMesher(xGrid_,process1,maturity,1,invEps_));
+        const ext::shared_ptr<Fdm1dMesher> xMesher(ext::make_shared<FdmSimpleProcess1dMesher>(xGrid_,process1,maturity,1,invEps_));
 
-        const ext::shared_ptr<Fdm1dMesher> yMesher(
-            new FdmSimpleProcess1dMesher(yGrid_,process2,maturity,1,invEps_));
+        const ext::shared_ptr<Fdm1dMesher> yMesher(ext::make_shared<FdmSimpleProcess1dMesher>(yGrid_,process2,maturity,1,invEps_));
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(xMesher, yMesher));
+        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(xMesher, yMesher));
 
         // 3. Inner Value Calculator
         const std::vector<Date>& exerciseDates = arguments_.exercise->dates();
@@ -92,12 +87,10 @@ namespace QuantLib {
         QL_REQUIRE(fwdTs->referenceDate() == disTs->referenceDate(),
                 "reference date of forward and discount curve must match");
 
-        const ext::shared_ptr<G2> fwdModel(
-            new G2(fwdTs, model_->a(), model_->sigma(),
-                   model_->b(), model_->eta(), model_->rho()));
+        const auto fwdModel = ext::make_shared<G2>(fwdTs, model_->a(), model_->sigma(),
+                   model_->b(), model_->eta(), model_->rho());
 
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-             new FdmAffineModelSwapInnerValue<G2>(
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmAffineModelSwapInnerValue<G2>>(
                  model_.currentLink(), fwdModel,
                  arguments_.swap, t2d, mesher, 0));
 

--- a/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
+++ b/ql/pricingengines/vanilla/analyticbsmhullwhiteengine.cpp
@@ -110,18 +110,15 @@ namespace QuantLib {
         }
 
         Handle<BlackVolTermStructure> volTS(
-             ext::shared_ptr<BlackVolTermStructure>(
-              new ShiftedBlackVolTermStructure(varianceOffset,
-                                               process_->blackVolatility())));
+             ext::make_shared<ShiftedBlackVolTermStructure>(varianceOffset,
+                                               process_->blackVolatility()));
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> adjProcess(
-                new GeneralizedBlackScholesProcess(process_->stateVariable(),
+        auto adjProcess = ext::make_shared<GeneralizedBlackScholesProcess>(process_->stateVariable(),
                                                    process_->dividendYield(),
                                                    process_->riskFreeRate(),
-                                                   volTS));
+                                                   volTS);
 
-        ext::shared_ptr<AnalyticEuropeanEngine> bsmEngine(
-                                      new AnalyticEuropeanEngine(adjProcess));
+        auto bsmEngine = ext::make_shared<AnalyticEuropeanEngine>(adjProcess);
 
         VanillaOption(payoff, exercise).setupArguments(
                                                    bsmEngine->getArguments());

--- a/ql/pricingengines/vanilla/analytichestonengine.cpp
+++ b/ql/pricingengines/vanilla/analytichestonengine.cpp
@@ -887,88 +887,77 @@ namespace QuantLib {
     AnalyticHestonEngine::Integration::gaussLobatto(
        Real relTolerance, Real absTolerance, Size maxEvaluations, bool useConvergenceEstimate) {
        return Integration(GaussLobatto,
-                           ext::shared_ptr<Integrator>(
-                               new GaussLobattoIntegral(maxEvaluations,
+                           ext::make_shared<GaussLobattoIntegral>(maxEvaluations,
                                                         absTolerance,
                                                         relTolerance,
-                                                        useConvergenceEstimate)));
+                                                        useConvergenceEstimate));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussKronrod(Real absTolerance,
                                                    Size maxEvaluations) {
         return Integration(GaussKronrod,
-                           ext::shared_ptr<Integrator>(
-                               new GaussKronrodAdaptive(absTolerance,
-                                                        maxEvaluations)));
+                           ext::make_shared<GaussKronrodAdaptive>(absTolerance,
+                                                        maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::simpson(Real absTolerance,
                                                Size maxEvaluations) {
         return Integration(Simpson,
-                           ext::shared_ptr<Integrator>(
-                               new SimpsonIntegral(absTolerance,
-                                                   maxEvaluations)));
+                           ext::make_shared<SimpsonIntegral>(absTolerance,
+                                                   maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::trapezoid(Real absTolerance,
                                         Size maxEvaluations) {
         return Integration(Trapezoid,
-                           ext::shared_ptr<Integrator>(
-                              new TrapezoidIntegral<Default>(absTolerance,
-                                                             maxEvaluations)));
+                           ext::make_shared<TrapezoidIntegral<Default>>(absTolerance,
+                                                             maxEvaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussLaguerre(Size intOrder) {
         QL_REQUIRE(intOrder <= 192, "maximum integraton order (192) exceeded");
         return Integration(GaussLaguerre,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussLaguerreIntegration(intOrder)));
+                           ext::make_shared<GaussLaguerreIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussLegendre(Size intOrder) {
         return Integration(GaussLegendre,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussLegendreIntegration(intOrder)));
+                           ext::make_shared<GaussLegendreIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussChebyshev(Size intOrder) {
         return Integration(GaussChebyshev,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussChebyshevIntegration(intOrder)));
+                           ext::make_shared<GaussChebyshevIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::gaussChebyshev2nd(Size intOrder) {
         return Integration(GaussChebyshev2nd,
-                           ext::shared_ptr<GaussianQuadrature>(
-                               new GaussChebyshev2ndIntegration(intOrder)));
+                           ext::make_shared<GaussChebyshev2ndIntegration>(intOrder));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::discreteSimpson(Size evaluations) {
         return Integration(
-            DiscreteSimpson, ext::shared_ptr<Integrator>(
-                new DiscreteSimpsonIntegrator(evaluations)));
+            DiscreteSimpson, ext::make_shared<DiscreteSimpsonIntegrator>(evaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::discreteTrapezoid(Size evaluations) {
         return Integration(
-            DiscreteTrapezoid, ext::shared_ptr<Integrator>(
-                new DiscreteTrapezoidIntegrator(evaluations)));
+            DiscreteTrapezoid, ext::make_shared<DiscreteTrapezoidIntegrator>(evaluations));
     }
 
     AnalyticHestonEngine::Integration
     AnalyticHestonEngine::Integration::expSinh(Real relTolerance) {
         return Integration(
-            ExpSinh, ext::shared_ptr<Integrator>(
-                new ExpSinhIntegral(relTolerance)));
+            ExpSinh, ext::make_shared<ExpSinhIntegral>(relTolerance));
     }
 
     Size AnalyticHestonEngine::Integration::numberOfEvaluations() const {

--- a/ql/pricingengines/vanilla/binomialengine.hpp
+++ b/ql/pricingengines/vanilla/binomialengine.hpp
@@ -104,9 +104,9 @@ namespace QuantLib {
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(ext::make_shared<GeneralizedBlackScholesProcess>(
+        auto bs = ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
-                                      flatDividends, flatRiskFree, flatVol));
+                                      flatDividends, flatRiskFree, flatVol);
 
         TimeGrid grid(maturity, timeSteps_);
 

--- a/ql/pricingengines/vanilla/binomialengine.hpp
+++ b/ql/pricingengines/vanilla/binomialengine.hpp
@@ -92,14 +92,11 @@ namespace QuantLib {
 
         // binomial trees with constant coefficient
         Handle<YieldTermStructure> flatRiskFree(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, r, rfdc)));
+            ext::make_shared<FlatForward>(referenceDate, r, rfdc));
         Handle<YieldTermStructure> flatDividends(
-            ext::shared_ptr<YieldTermStructure>(
-                new FlatForward(referenceDate, q, divdc)));
+            ext::make_shared<FlatForward>(referenceDate, q, divdc));
         Handle<BlackVolTermStructure> flatVol(
-            ext::shared_ptr<BlackVolTermStructure>(
-                new BlackConstantVol(referenceDate, volcal, v, voldc)));
+            ext::make_shared<BlackConstantVol>(referenceDate, volcal, v, voldc));
 
         ext::shared_ptr<PlainVanillaPayoff> payoff =
             ext::dynamic_pointer_cast<PlainVanillaPayoff>(arguments_.payoff);
@@ -107,18 +104,16 @@ namespace QuantLib {
 
         Time maturity = rfdc.yearFraction(referenceDate, maturityDate);
 
-        ext::shared_ptr<StochasticProcess1D> bs(
-                         new GeneralizedBlackScholesProcess(
+        ext::shared_ptr<StochasticProcess1D> bs(ext::make_shared<GeneralizedBlackScholesProcess>(
                                       process_->stateVariable(),
                                       flatDividends, flatRiskFree, flatVol));
 
         TimeGrid grid(maturity, timeSteps_);
 
-        ext::shared_ptr<T> tree(new T(bs, maturity, timeSteps_,
-                                        payoff->strike()));
+        auto tree = ext::make_shared<T>(bs, maturity, timeSteps_,
+                                        payoff->strike());
 
-        ext::shared_ptr<BlackScholesLattice<T> > lattice(
-            new BlackScholesLattice<T>(tree, r, maturity, timeSteps_));
+        auto lattice = ext::make_shared<BlackScholesLattice<T>>(tree, r, maturity, timeSteps_);
 
         DiscretizedVanillaOption option(arguments_, *process_, grid);
 

--- a/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdbatesvanillaengine.cpp
@@ -69,9 +69,8 @@ namespace QuantLib {
         const ext::shared_ptr<BatesProcess> process =
                 ext::dynamic_pointer_cast<BatesProcess>(model_->process());
 
-        ext::shared_ptr<FdmBatesSolver> solver(
-            new FdmBatesSolver(Handle<BatesProcess>(process),
-                               solverDesc, schemeDesc_));
+        auto solver = ext::make_shared<FdmBatesSolver>(Handle<BatesProcess>(process),
+                               solverDesc, schemeDesc_);
 
         const Real v0   = process->v0();
         const Real spot = process->s0()->value();

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -70,24 +70,20 @@ namespace QuantLib {
         const Time maturity = bsProcess_->time(arguments_.exercise->lastDate());
 
         // The short rate mesher
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
-            new FdmSimpleProcess1dMesher(rGrid_, cirProcess_, maturity, tGrid_));
+        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, cirProcess_, maturity, tGrid_));
 
         // The equity mesher
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, bsProcess_, maturity, payoff->strike(),
                 Null<Real>(), Null<Real>(), 0.0001, 1.5,
                 std::pair<Real, Real>(payoff->strike(), 0.1),
                 dividends_, quantoHelper_,
                 0.0));
         
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, shortRateMesher));
+        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, shortRateMesher));
 
         // Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                          new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
 
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -112,11 +108,11 @@ namespace QuantLib {
         const ext::shared_ptr<StrikedTypePayoff> payoff =
             ext::dynamic_pointer_cast<StrikedTypePayoff>(arguments_.payoff);
 
-        ext::shared_ptr<FdmCIRSolver> solver(new FdmCIRSolver(
+        auto solver = ext::make_shared<FdmCIRSolver>(
                     Handle<CoxIngersollRossProcess>(cirProcess_),
                     Handle<GeneralizedBlackScholesProcess>(bsProcess_),
                     getSolverDesc(1.5), schemeDesc_,
-                    rho_, payoff->strike()));
+                    rho_, payoff->strike());
 
         const Real r0   = cirProcess_->x0();
         const Real spot = bsProcess_->x0();

--- a/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdcirvanillaengine.cpp
@@ -70,20 +70,20 @@ namespace QuantLib {
         const Time maturity = bsProcess_->time(arguments_.exercise->lastDate());
 
         // The short rate mesher
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, cirProcess_, maturity, tGrid_));
+        const auto shortRateMesher = ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, cirProcess_, maturity, tGrid_);
 
         // The equity mesher
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                 xGrid_, bsProcess_, maturity, payoff->strike(),
                 Null<Real>(), Null<Real>(), 0.0001, 1.5,
                 std::pair<Real, Real>(payoff->strike(), 0.1),
                 dividends_, quantoHelper_,
-                0.0));
+                0.0);
         
-        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, shortRateMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, shortRateMesher);
 
         // Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
@@ -136,13 +136,13 @@ namespace QuantLib {
        
         //2.3 The short rate mesher        
         const auto ouProcess = ext::make_shared<OrnsteinUhlenbeckProcess>(hwProcess_->a(),hwProcess_->sigma());
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, ouProcess, maturity));
+        const auto shortRateMesher = ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, ouProcess, maturity);
         
-        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, varianceMesher,
-                                   shortRateMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, varianceMesher,
+                                   shortRateMesher);
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -188,8 +188,8 @@ namespace QuantLib {
         }
      
         if (controlVariate_) {
-            ext::shared_ptr<PricingEngine> analyticEngine(ext::make_shared<AnalyticHestonEngine>(*model_, 164));
-            ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(arguments_.exercise->lastDate()));
+            auto analyticEngine = ext::make_shared<AnalyticHestonEngine>(*model_, 164);
+            auto exercise = ext::make_shared<EuropeanExercise>(arguments_.exercise->lastDate());
             
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(analyticEngine);

--- a/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonhullwhitevanillaengine.cpp
@@ -100,9 +100,8 @@ namespace QuantLib {
 
         // 2.1 The variance mesher
         const Size tGridMin = 5;
-        const ext::shared_ptr<FdmHestonVarianceMesher> varianceMesher(
-            new FdmHestonVarianceMesher(vGrid_, hestonProcess,
-                                        maturity,std::max(tGridMin,tGrid_/50)));
+        const auto varianceMesher = ext::make_shared<FdmHestonVarianceMesher>(vGrid_, hestonProcess,
+                                        maturity,std::max(tGridMin,tGrid_/50));
 
         // 2.2 The equity mesher
         const ext::shared_ptr<StrikedTypePayoff> payoff =
@@ -111,8 +110,7 @@ namespace QuantLib {
 
         ext::shared_ptr<Fdm1dMesher> equityMesher;
         if (strikes_.empty()) {
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_, 
                     FdmBlackScholesMesher::processHelper(
                       hestonProcess->s0(), hestonProcess->dividendYield(), 
@@ -121,35 +119,30 @@ namespace QuantLib {
                       maturity, payoff->strike(),
                       Null<Real>(), Null<Real>(), 0.0001, 1.5, 
                       std::pair<Real, Real>(payoff->strike(), 0.1),
-                      dividends_));
+                      dividends_);
         }
         else {
             QL_REQUIRE(dividends_.empty(),
                        "multiple strikes engine does not work with discrete dividends");
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMultiStrikeMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMultiStrikeMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
                       hestonProcess->s0(), hestonProcess->dividendYield(), 
                       hestonProcess->riskFreeRate(), 
                       varianceMesher->volaEstimate()),
                     maturity, strikes_, 0.0001, 1.5,
-                    std::pair<Real, Real>(payoff->strike(), 0.075)));            
+                    std::pair<Real, Real>(payoff->strike(), 0.075));
         }
        
         //2.3 The short rate mesher        
-        const ext::shared_ptr<OrnsteinUhlenbeckProcess> ouProcess(
-            new OrnsteinUhlenbeckProcess(hwProcess_->a(),hwProcess_->sigma()));
-        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(
-                   new FdmSimpleProcess1dMesher(rGrid_, ouProcess, maturity));
+        const auto ouProcess = ext::make_shared<OrnsteinUhlenbeckProcess>(hwProcess_->a(),hwProcess_->sigma());
+        const ext::shared_ptr<Fdm1dMesher> shortRateMesher(ext::make_shared<FdmSimpleProcess1dMesher>(rGrid_, ouProcess, maturity));
         
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, varianceMesher,
+        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, varianceMesher,
                                    shortRateMesher));
 
         // 3. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                            new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
 
         // 4. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions = 
@@ -167,11 +160,10 @@ namespace QuantLib {
                                            calculator, maturity,
                                            tGrid_, dampingSteps_ };
 
-        const ext::shared_ptr<FdmHestonHullWhiteSolver> solver(
-            new FdmHestonHullWhiteSolver(Handle<HestonProcess>(hestonProcess),
+        const auto solver = ext::make_shared<FdmHestonHullWhiteSolver>(Handle<HestonProcess>(hestonProcess),
                                          Handle<HullWhiteProcess>(hwProcess_),
                                          corrEquityShortRate_,
-                                         solverDesc, schemeDesc_));
+                                         solverDesc, schemeDesc_);
 
         const Real spot = hestonProcess->s0()->value();
         const Real v0   = hestonProcess->v0();
@@ -196,19 +188,16 @@ namespace QuantLib {
         }
      
         if (controlVariate_) {
-            ext::shared_ptr<PricingEngine> analyticEngine(
-                                       new AnalyticHestonEngine(*model_, 164));
-            ext::shared_ptr<Exercise> exercise(
-                        new EuropeanExercise(arguments_.exercise->lastDate()));
+            ext::shared_ptr<PricingEngine> analyticEngine(ext::make_shared<AnalyticHestonEngine>(*model_, 164));
+            ext::shared_ptr<Exercise> exercise(ext::make_shared<EuropeanExercise>(arguments_.exercise->lastDate()));
             
             VanillaOption option(payoff, exercise);
             option.setPricingEngine(analyticEngine);
             Real analyticNPV = option.NPV();
 
-            ext::shared_ptr<FdHestonVanillaEngine> fdEngine(
-                    new FdHestonVanillaEngine(*model_, tGrid_, xGrid_,
+            auto fdEngine = ext::make_shared<FdHestonVanillaEngine>(*model_, tGrid_, xGrid_,
                                               vGrid_, dampingSteps_, 
-                                              schemeDesc_));
+                                              schemeDesc_);
             fdEngine->enableMultipleStrikesCaching(strikes_);
             option.setPricingEngine(fdEngine);
             
@@ -216,9 +205,8 @@ namespace QuantLib {
             results_.value += analyticNPV - fdNPV;
             for (Size i=0; i < strikes_.size(); ++i) {
                 VanillaOption controlVariateOption(
-                    ext::shared_ptr<StrikedTypePayoff>(
-                        new PlainVanillaPayoff(payoff->optionType(), 
-                                               strikes_[i])), exercise);
+                    ext::make_shared<PlainVanillaPayoff>(payoff->optionType(),
+                                               strikes_[i]), exercise);
                 controlVariateOption.setPricingEngine(analyticEngine);
                 analyticNPV = controlVariateOption.NPV();
                 

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -109,8 +109,7 @@ namespace QuantLib {
         // 1.1 The variance mesher
         const Size tGridMin = 5;
         const Size tGridAvgSteps = std::max(tGridMin, tGrid_/50);
-        const ext::shared_ptr<FdmHestonLocalVolatilityVarianceMesher> vMesher
-            = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
+        const auto vMesher = ext::make_shared<FdmHestonLocalVolatilityVarianceMesher>(
                   vGrid_, process, leverageFct_, maturity, tGridAvgSteps, 0.0001, mixingFactor_);
 
         const Volatility avgVolaEstimate = vMesher->volaEstimate();
@@ -144,10 +143,10 @@ namespace QuantLib {
                     std::pair<Real, Real>(payoff->strike(), 0.075));
         }
 
-        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, vMesher);
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
+        const auto calculator = ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0);
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =

--- a/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
+++ b/ql/pricingengines/vanilla/fdhestonvanillaengine.cpp
@@ -121,8 +121,7 @@ namespace QuantLib {
 
         ext::shared_ptr<Fdm1dMesher> equityMesher;
         if (strikes_.empty()) {
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
                         process->s0(), process->dividendYield(),
@@ -131,27 +130,24 @@ namespace QuantLib {
                     Null<Real>(), Null<Real>(), 0.0001, 2.0,
                     std::pair<Real, Real>(payoff->strike(), 0.1),
                     dividends_,
-                    quantoHelper_));
+                    quantoHelper_);
         }
         else {
             QL_REQUIRE(dividends_.empty(),
                        "multiple strikes engine does not work with discrete dividends");
-            equityMesher = ext::shared_ptr<Fdm1dMesher>(
-                new FdmBlackScholesMultiStrikeMesher(
+            equityMesher = ext::make_shared<FdmBlackScholesMultiStrikeMesher>(
                     xGrid_,
                     FdmBlackScholesMesher::processHelper(
                       process->s0(), process->dividendYield(),
                       process->riskFreeRate(), avgVolaEstimate),
                     maturity, strikes_, 0.0001, 1.5,
-                    std::pair<Real, Real>(payoff->strike(), 0.075)));
+                    std::pair<Real, Real>(payoff->strike(), 0.075));
         }
 
-        const ext::shared_ptr<FdmMesher> mesher(
-            new FdmMesherComposite(equityMesher, vMesher));
+        const ext::shared_ptr<FdmMesher> mesher(ext::make_shared<FdmMesherComposite>(equityMesher, vMesher));
 
         // 2. Calculator
-        const ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                          new FdmLogInnerValue(arguments_.payoff, mesher, 0));
+        const ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmLogInnerValue>(arguments_.payoff, mesher, 0));
 
         // 3. Step conditions
         const ext::shared_ptr<FdmStepConditionComposite> conditions =
@@ -196,11 +192,11 @@ namespace QuantLib {
 
         const ext::shared_ptr<HestonProcess> process = model_->process();
 
-        ext::shared_ptr<FdmHestonSolver> solver(new FdmHestonSolver(
+        auto solver = ext::make_shared<FdmHestonSolver>(
                     Handle<HestonProcess>(process),
                     getSolverDesc(1.5), schemeDesc_,
                     Handle<FdmQuantoHelper>(quantoHelper_), leverageFct_,
-                    mixingFactor_));
+                    mixingFactor_);
 
         const Real v0   = process->v0();
         const Real spot = process->s0()->value();

--- a/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
+++ b/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
@@ -52,21 +52,17 @@ namespace QuantLib {
         QL_REQUIRE(payoff, "Strike type payoff expected");
             
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(
-            new FdmBlackScholesMesher(xGrid_, process_,
+        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_,
                                       maturity, payoff->strike()));
         
-        const ext::shared_ptr<Fdm1dMesher> exerciseMesher(
-                 new Uniform1dMesher(
+        const ext::shared_ptr<Fdm1dMesher> exerciseMesher(ext::make_shared<Uniform1dMesher>(
                            0, static_cast<Real>(arguments_.maxExerciseRights),
                            arguments_.maxExerciseRights+1));
 
-        const ext::shared_ptr<FdmMesher> mesher (
-            new FdmMesherComposite(equityMesher, exerciseMesher));
+        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, exerciseMesher));
         
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(
-                                                    new FdmZeroInnerValue());
+        ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmZeroInnerValue>());
         
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -81,16 +77,13 @@ namespace QuantLib {
         }
         stoppingTimes.push_back(exerciseTimes);
         
-        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator(
-                                    new FdmLogInnerValue(payoff, mesher, 0));
+        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
 
-        stepConditions.push_back(ext::shared_ptr<StepCondition<Array> >(
-            new FdmSimpleSwingCondition(
+        stepConditions.push_back(ext::make_shared<FdmSimpleSwingCondition>(
                 exerciseTimes, mesher, exerciseCalculator,
-                1, arguments_.minExerciseRights)));
+                1, arguments_.minExerciseRights));
         
-        ext::shared_ptr<FdmStepConditionComposite> conditions(
-                new FdmStepConditionComposite(stoppingTimes, stepConditions));
+        auto conditions = ext::make_shared<FdmStepConditionComposite>(stoppingTimes, stepConditions);
         
         // 4. Boundary conditions
         const FdmBoundaryConditionSet boundaries;
@@ -98,10 +91,9 @@ namespace QuantLib {
         // 5. Solver
         FdmSolverDesc solverDesc = { mesher, boundaries, conditions,
                                      calculator, maturity, tGrid_, 0 };
-        ext::shared_ptr<FdmSimple2dBSSolver> solver(
-                new FdmSimple2dBSSolver(
+        auto solver = ext::make_shared<FdmSimple2dBSSolver>(
                                Handle<GeneralizedBlackScholesProcess>(process_),
-                               payoff->strike(), solverDesc, schemeDesc_));
+                               payoff->strike(), solverDesc, schemeDesc_);
     
         const Real spot = process_->x0();
 

--- a/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
+++ b/ql/pricingengines/vanilla/fdsimplebsswingengine.cpp
@@ -52,17 +52,17 @@ namespace QuantLib {
         QL_REQUIRE(payoff, "Strike type payoff expected");
             
         const Time maturity = process_->time(arguments_.exercise->lastDate());
-        const ext::shared_ptr<Fdm1dMesher> equityMesher(ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_,
-                                      maturity, payoff->strike()));
+        const auto equityMesher = ext::make_shared<FdmBlackScholesMesher>(xGrid_, process_,
+                                      maturity, payoff->strike());
         
-        const ext::shared_ptr<Fdm1dMesher> exerciseMesher(ext::make_shared<Uniform1dMesher>(
+        const auto exerciseMesher = ext::make_shared<Uniform1dMesher>(
                            0, static_cast<Real>(arguments_.maxExerciseRights),
-                           arguments_.maxExerciseRights+1));
+                           arguments_.maxExerciseRights+1);
 
-        const ext::shared_ptr<FdmMesher> mesher (ext::make_shared<FdmMesherComposite>(equityMesher, exerciseMesher));
+        const auto mesher = ext::make_shared<FdmMesherComposite>(equityMesher, exerciseMesher);
         
         // 2. Calculator
-        ext::shared_ptr<FdmInnerValueCalculator> calculator(ext::make_shared<FdmZeroInnerValue>());
+        auto calculator = ext::make_shared<FdmZeroInnerValue>();
         
         // 3. Step conditions
         std::list<ext::shared_ptr<StepCondition<Array> > > stepConditions;
@@ -77,7 +77,7 @@ namespace QuantLib {
         }
         stoppingTimes.push_back(exerciseTimes);
         
-        ext::shared_ptr<FdmInnerValueCalculator> exerciseCalculator(ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0));
+        auto exerciseCalculator = ext::make_shared<FdmLogInnerValue>(payoff, mesher, 0);
 
         stepConditions.push_back(ext::make_shared<FdmSimpleSwingCondition>(
                 exerciseTimes, mesher, exerciseCalculator,

--- a/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
+++ b/ql/pricingengines/vanilla/jumpdiffusionengine.cpp
@@ -75,9 +75,8 @@ namespace QuantLib {
         RelinkableHandle<BlackVolTermStructure> volTS(
                                                 *process_->blackVolatility());
 
-        ext::shared_ptr<GeneralizedBlackScholesProcess> bsProcess(
-                 new GeneralizedBlackScholesProcess(stateVariable, dividendTS,
-                                                    riskFreeTS, volTS));
+        auto bsProcess = ext::make_shared<GeneralizedBlackScholesProcess>(stateVariable, dividendTS,
+                                                    riskFreeTS, volTS);
 
         AnalyticEuropeanEngine baseEngine(bsProcess);
 
@@ -111,10 +110,8 @@ namespace QuantLib {
             v = std::sqrt((variance + i*jumpSquareVol)/t);
             r = riskFreeRate - process_->jumpIntensity()->value()*k
                 + i*muPlusHalfSquareVol/t;
-            riskFreeTS.linkTo(ext::shared_ptr<YieldTermStructure>(new
-                FlatForward(rateRefDate, r, voldc)));
-            volTS.linkTo(ext::shared_ptr<BlackVolTermStructure>(new
-                BlackConstantVol(rateRefDate, volcal, v, voldc)));
+            riskFreeTS.linkTo(ext::make_shared<FlatForward>(rateRefDate, r, voldc));
+            volTS.linkTo(ext::make_shared<BlackConstantVol>(rateRefDate, volcal, v, voldc));
 
             baseArguments->validate();
             baseEngine.calculate();

--- a/ql/pricingengines/vanilla/mcamericanengine.hpp
+++ b/ql/pricingengines/vanilla/mcamericanengine.hpp
@@ -197,9 +197,8 @@ namespace QuantLib {
         QL_REQUIRE(!exercise->payoffAtExpiry(),
                    "payoff at expiry not handled");
 
-        ext::shared_ptr<AmericanPathPricer> earlyExercisePathPricer(
-            new AmericanPathPricer(this->arguments_.payoff,
-                                   polynomialOrder_, polynomialType_));
+        auto earlyExercisePathPricer = ext::make_shared<AmericanPathPricer>(this->arguments_.payoff,
+                                   polynomialOrder_, polynomialType_);
 
         return ext::make_shared<LongstaffSchwartzPathPricer<Path> > (
              
@@ -221,12 +220,10 @@ namespace QuantLib {
                                                               this->process_);
         QL_REQUIRE(process, "generalized Black-Scholes process required");
 
-        return ext::shared_ptr<PathPricer<Path> >(
-            new EuropeanPathPricer(
+        return ext::make_shared<EuropeanPathPricer>(
                 payoff->optionType(),
                 payoff->strike(),
-                process->riskFreeRate()->discount(this->timeGrid().back()))
-            );
+                process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
     template <class RNG, class S, class RNG_Calibration>
@@ -237,8 +234,7 @@ namespace QuantLib {
                                                               this->process_);
         QL_REQUIRE(process, "generalized Black-Scholes process required");
 
-        return ext::shared_ptr<PricingEngine>(
-                                         new AnalyticEuropeanEngine(process));
+        return ext::make_shared<AnalyticEuropeanEngine>(process);
     }
 
     template <class RNG, class S, class RNG_Calibration>
@@ -253,8 +249,7 @@ namespace QuantLib {
 
         auto* controlArguments = dynamic_cast<VanillaOption::arguments*>(controlPE->getArguments());
         *controlArguments = this->arguments_;
-        controlArguments->exercise = ext::shared_ptr<Exercise>(
-             new EuropeanExercise(this->arguments_.exercise->lastDate()));
+        controlArguments->exercise = ext::make_shared<EuropeanExercise>(this->arguments_.exercise->lastDate());
 
         controlPE->calculate();
 
@@ -382,8 +377,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-           MCAmericanEngine<RNG, S, RNG_Calibration>(process_,
+        return ext::make_shared<MCAmericanEngine<RNG, S, RNG_Calibration>>(process_,
                                      steps_,
                                      stepsPerYear_,
                                      antithetic_,
@@ -395,7 +389,7 @@ namespace QuantLib {
                                      polynomialType_,
                                      calibrationSamples_,
                                      antitheticCalibration_,
-                                     seedCalibration_));
+                                     seedCalibration_);
     }
 
 }

--- a/ql/pricingengines/vanilla/mcdigitalengine.hpp
+++ b/ql/pricingengines/vanilla/mcdigitalengine.hpp
@@ -176,13 +176,11 @@ namespace QuantLib {
         PseudoRandom::ursg_type sequenceGen(grid.size()-1,
                                             PseudoRandom::urng_type(76));
 
-        return ext::shared_ptr<
-                        typename MCDigitalEngine<RNG,S>::path_pricer_type>(
-          new DigitalPathPricer(payoff,
+        return ext::make_shared<DigitalPathPricer>(payoff,
                                 exercise,
                                 process->riskFreeRate(),
                                 process,
-                                sequenceGen));
+                                sequenceGen);
     }
 
 
@@ -263,15 +261,14 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCDigitalEngine<RNG,S>(process_,
+        return ext::make_shared<MCDigitalEngine<RNG,S>>(process_,
                                    steps_,
                                    stepsPerYear_,
                                    brownianBridge_,
                                    antithetic_,
                                    samples_, tolerance_,
                                    maxSamples_,
-                                   seed_));
+                                   seed_);
     }
 
 }

--- a/ql/pricingengines/vanilla/mceuropeanengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeanengine.hpp
@@ -144,12 +144,10 @@ namespace QuantLib {
                 this->process_);
         QL_REQUIRE(process, "Black-Scholes process required");
 
-        return ext::shared_ptr<
-                       typename MCEuropeanEngine<RNG,S>::path_pricer_type>(
-          new EuropeanPathPricer(
+        return ext::make_shared<EuropeanPathPricer>(
               payoff->optionType(),
               payoff->strike(),
-              process->riskFreeRate()->discount(this->timeGrid().back())));
+              process->riskFreeRate()->discount(this->timeGrid().back()));
     }
 
 
@@ -230,15 +228,14 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCEuropeanEngine<RNG,S>(process_,
+        return ext::make_shared<MCEuropeanEngine<RNG,S>>(process_,
                                     steps_,
                                     stepsPerYear_,
                                     brownianBridge_,
                                     antithetic_,
                                     samples_, tolerance_,
                                     maxSamples_,
-                                    seed_));
+                                    seed_);
     }
 
 

--- a/ql/pricingengines/vanilla/mceuropeangjrgarchengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeangjrgarchengine.hpp
@@ -119,13 +119,11 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<GJRGARCHProcess>(this->process_);
         QL_REQUIRE(process, "GJRGARCH process required");
 
-        return ext::shared_ptr<
-            typename MCEuropeanGJRGARCHEngine<RNG,S>::path_pricer_type>(
-                   new EuropeanGJRGARCHPathPricer(
+        return ext::make_shared<EuropeanGJRGARCHPathPricer>(
                                         payoff->optionType(),
                                         payoff->strike(),
                                         process->riskFreeRate()->discount(
-                                                   this->timeGrid().back())));
+                                                   this->timeGrid().back()));
     }
 
 
@@ -201,14 +199,13 @@ namespace QuantLib {
     operator ext::shared_ptr<PricingEngine>() const {
         QL_REQUIRE(steps_ != Null<Size>() || stepsPerYear_ != Null<Size>(),
                    "number of steps not given");
-        return ext::shared_ptr<PricingEngine>(
-                 new MCEuropeanGJRGARCHEngine<RNG,S>(process_,
+        return ext::make_shared<MCEuropeanGJRGARCHEngine<RNG,S>>(process_,
                                                    steps_,
                                                    stepsPerYear_,
                                                    antithetic_,
                                                    samples_, tolerance_,
                                                    maxSamples_,
-                                                   seed_));
+                                                   seed_);
     }
 
 

--- a/ql/pricingengines/vanilla/mceuropeanhestonengine.hpp
+++ b/ql/pricingengines/vanilla/mceuropeanhestonengine.hpp
@@ -122,13 +122,11 @@ namespace QuantLib {
             ext::dynamic_pointer_cast<P>(this->process_);
         QL_REQUIRE(process, "Heston like process required");
 
-        return ext::shared_ptr<
-            typename MCEuropeanHestonEngine<RNG,S,P>::path_pricer_type>(
-                   new EuropeanHestonPathPricer(
+        return ext::make_shared<EuropeanHestonPathPricer>(
                                         payoff->optionType(),
                                         payoff->strike(),
                                         process->riskFreeRate()->discount(
-                                                   this->timeGrid().back())));
+                                                   this->timeGrid().back()));
     }
 
 
@@ -204,14 +202,13 @@ namespace QuantLib {
     operator ext::shared_ptr<PricingEngine>() const {
         QL_REQUIRE(steps_ != Null<Size>() || stepsPerYear_ != Null<Size>(),
                    "number of steps not given");
-        return ext::shared_ptr<PricingEngine>(
-               new MCEuropeanHestonEngine<RNG,S,P>(process_,
+        return ext::make_shared<MCEuropeanHestonEngine<RNG,S,P>>(process_,
                                                    steps_,
                                                    stepsPerYear_,
                                                    antithetic_,
                                                    samples_, tolerance_,
                                                    maxSamples_,
-                                                   seed_));
+                                                   seed_);
     }
 
 

--- a/ql/pricingengines/vanilla/mchestonhullwhiteengine.hpp
+++ b/ql/pricingengines/vanilla/mchestonhullwhiteengine.hpp
@@ -146,10 +146,9 @@ namespace QuantLib {
 
         const Time exerciseTime = process_->time(exercise->lastDate());
 
-        return ext::shared_ptr<path_pricer_type>(
-             new HestonHullWhitePathPricer(exerciseTime,
+        return ext::make_shared<HestonHullWhitePathPricer>(exerciseTime,
                                            this->arguments_.payoff,
-                                           process_));
+                                           process_);
     }
 
     template <class RNG, class S> inline
@@ -170,11 +169,10 @@ namespace QuantLib {
 
         const Time exerciseTime = process_->time(exercise->lastDate());
 
-        return ext::shared_ptr<path_pricer_type>(
-             new HestonHullWhitePathPricer(
+        return ext::make_shared<HestonHullWhitePathPricer>(
                   exerciseTime,
                   this->arguments_.payoff,
-                  process_) );
+                  process_);
     }
 
     template <class RNG, class S> inline
@@ -187,15 +185,12 @@ namespace QuantLib {
         ext::shared_ptr<HullWhiteForwardProcess> hullWhiteProcess =
             process_->hullWhiteProcess();
 
-        ext::shared_ptr<HestonModel> hestonModel(
-                                              new HestonModel(hestonProcess));
-        ext::shared_ptr<HullWhite> hwModel(
-                              new HullWhite(hestonProcess->riskFreeRate(),
+        auto hestonModel = ext::make_shared<HestonModel>(hestonProcess);
+        auto hwModel = ext::make_shared<HullWhite>(hestonProcess->riskFreeRate(),
                                             hullWhiteProcess->a(),
-                                            hullWhiteProcess->sigma()));
+                                            hullWhiteProcess->sigma());
 
-        return ext::shared_ptr<PricingEngine>(
-                new AnalyticHestonHullWhiteEngine(hestonModel, hwModel, 144));
+        return ext::make_shared<AnalyticHestonHullWhiteEngine>(hestonModel, hwModel, 144);
     }
 
     template <class RNG, class S> inline
@@ -209,14 +204,12 @@ namespace QuantLib {
             RNG::make_sequence_generator(dimensions*(grid.size()-1),
                                          this->seed_);
 
-        ext::shared_ptr<HybridHestonHullWhiteProcess> cvProcess(
-            new HybridHestonHullWhiteProcess(process_->hestonProcess(),
+        auto cvProcess = ext::make_shared<HybridHestonHullWhiteProcess>(process_->hestonProcess(),
                                              process_->hullWhiteProcess(),
                                              0.0,
-                                             process_->discretization()));
+                                             process_->discretization());
 
-        return ext::shared_ptr<path_generator_type>(
-                  new path_generator_type(cvProcess, grid, generator, false));
+        return ext::make_shared<path_generator_type>(cvProcess, grid, generator, false);
     }
 
 
@@ -297,8 +290,7 @@ namespace QuantLib {
                    "number of steps not given");
         QL_REQUIRE(steps_ == Null<Size>() || stepsPerYear_ == Null<Size>(),
                    "number of steps overspecified");
-        return ext::shared_ptr<PricingEngine>(new
-            MCHestonHullWhiteEngine<RNG,S>(process_,
+        return ext::make_shared<MCHestonHullWhiteEngine<RNG,S>>(process_,
                                            steps_,
                                            stepsPerYear_,
                                            antithetic_,
@@ -306,7 +298,7 @@ namespace QuantLib {
                                            samples_,
                                            tolerance_,
                                            maxSamples_,
-                                           seed_));
+                                           seed_);
     }
 
 }

--- a/ql/pricingengines/vanilla/mcvanillaengine.hpp
+++ b/ql/pricingengines/vanilla/mcvanillaengine.hpp
@@ -75,9 +75,8 @@ namespace QuantLib {
             TimeGrid grid = this->timeGrid();
             typename RNG::rsg_type generator =
                 RNG::make_sequence_generator(dimensions*(grid.size()-1),seed_);
-            return ext::shared_ptr<path_generator_type>(
-                   new path_generator_type(process_, grid,
-                                           generator, brownianBridge_));
+            return ext::make_shared<path_generator_type>(process_, grid,
+                                           generator, brownianBridge_);
         }
         result_type controlVariateValue() const override;
         // data members

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -455,12 +455,14 @@ namespace QuantLib {
         const ext::shared_ptr<DqFpEquation> eqn
             = (fpEquation_ == FP_A
                || (fpEquation_ == Auto && std::abs(r-q) < 0.001))?
-              ext::shared_ptr<DqFpEquation>(new DqFpEquation_A(
-                  K, r, q, vol, B,
-                  iterationScheme_->getFixedPointIntegrator()))
-            : ext::shared_ptr<DqFpEquation>(new DqFpEquation_B(
-                    K, r, q, vol, B,
-                    iterationScheme_->getFixedPointIntegrator()));
+              ext::static_pointer_cast<DqFpEquation>(
+                  ext::make_shared<DqFpEquation_A>(
+                      K, r, q, vol, B,
+                      iterationScheme_->getFixedPointIntegrator()))
+            : ext::static_pointer_cast<DqFpEquation>(
+                  ext::make_shared<DqFpEquation_B>(
+                      K, r, q, vol, B,
+                      iterationScheme_->getFixedPointIntegrator()));
 
         Array y(x.size());
         y[0] = 0.0;
@@ -516,7 +518,6 @@ namespace QuantLib {
     }
 
 }
-
 
 
 

--- a/ql/pricingengines/vanilla/qdfpamericanengine.cpp
+++ b/ql/pricingengines/vanilla/qdfpamericanengine.cpp
@@ -452,8 +452,7 @@ namespace QuantLib {
             return squared(std::log(fv/xmax));
         };
 
-        const ext::shared_ptr<DqFpEquation> eqn
-            = (fpEquation_ == FP_A
+        const auto eqn = (fpEquation_ == FP_A
                || (fpEquation_ == Auto && std::abs(r-q) < 0.001))?
               ext::static_pointer_cast<DqFpEquation>(
                   ext::make_shared<DqFpEquation_A>(
@@ -518,6 +517,5 @@ namespace QuantLib {
     }
 
 }
-
 
 


### PR DESCRIPTION
This PR replaces old-style `ext::shared_ptr<T>(new ...)` constructions with `ext::make_shared<T>(...)` under `ql/pricingengines`.

The change is intended as a mechanical modernization and follows the existing `ext::make_shared` usage in the codebase.

In addition, added some auto declaration when rhs and lhs return types are identical