### PR TITLE
Document the current management of bonds with face value other than 100

### DIFF
--- a/ql/instruments/bond.hpp
+++ b/ql/instruments/bond.hpp
@@ -49,6 +49,12 @@ namespace QuantLib {
                  cash flow at the same date. In particular, if there's
                  one single redemption, it must be the last cash flow,
 
+        \note Pricing methods (cleanPrice, dirtyPrice, settlementValue, etc.)
+              assume and return values as a percentage of par (per 100).
+              For bonds with a face value other than 100 (e.g., 25), the actual
+              cash price must be calculated by the user: `cash price = quote * face / 100`.
+              Yield and Z-spread methods also expect prices to be passed per 100.
+
         \ingroup instruments
 
         \test

--- a/ql/pricingengines/bond/bondfunctions.hpp
+++ b/ql/pricingengines/bond/bondfunctions.hpp
@@ -50,6 +50,11 @@ namespace QuantLib {
         ex-dividend days, and excluding any cashflow on the settlement date.
 
         Prices are always clean, as per market convention.
+
+        \note Prices are assumed to be a percentage of par (per 100). For bonds
+              with a face value other than 100 (e.g., 25), any price input (like in
+              zSpread or yield calculations) must be provided per 100:
+              `quote = cash price * 100 / face`. Returned prices are also per 100.
     */
     struct BondFunctions {
         //! \name Date inspectors


### PR DESCRIPTION
## Description

This PR clarifies the documentation regarding the handling of bond prices in QuantLib. 

As discussed in #1768, QuantLib correctly assumes and returns all prices as a percentage of par (per $100), conforming to standard market conventions. However, this causes confusion for users working with bonds that have non-standard face values (e.g. baby bonds with a $25 face value) and trade in cash prices.

To prevent future confusion, I've added explicitly worded `\note` tags to the Doxygen comments in:
- `ql/instruments/bond.hpp` (for `cleanPrice`, `dirtyPrice`, `settlementValue`, etc.)
- `ql/pricingengines/bond/bondfunctions.hpp` (for `zSpread` and related yield functions)

These notes explain that inputs and outputs are per 100 face value, and provide a quick formula for users to manually convert to/from their expected cash prices.

## Type of change

- [x] Documentation update
