### PR TITLE
Introduce `CashFlow::isCoupon()` and `coupon_cast` to replace dynamic casts

### DIFF
--- a/Examples/BermudanSwaption/BermudanSwaption.cpp
+++ b/Examples/BermudanSwaption/BermudanSwaption.cpp
@@ -255,7 +255,7 @@ int main(int, char* []) {
         const std::vector<ext::shared_ptr<CashFlow>>& leg =
             swap->fixedLeg();
         for (i=0; i<leg.size(); i++) {
-            auto coupon = ext::dynamic_pointer_cast<Coupon>(leg[i]);
+            auto coupon = coupon_cast(leg[i]);
             bermudanDates.push_back(coupon->accrualStartDate());
         }
 

--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -33,6 +33,8 @@
 
 namespace QuantLib {
 
+    class Coupon;
+
     //! Base class for cash flows
     /*! This class is purely virtual and acts as a base class for the
         actual cash flow implementations.
@@ -66,14 +68,15 @@ namespace QuantLib {
         virtual Date exCouponDate() const { return {}; };
         //! returns true if the cashflow is trading ex-coupon on the refDate
         bool tradingExCoupon(const Date& refDate = Date()) const;
-        //! returns true if the cashflow is a coupon
-        virtual bool isCoupon() const { return false; }
-
         //@}
         //! \name Visitability
         //@{
         void accept(AcyclicVisitor&) override;
         //@}
+      private:
+        friend void coupon_cast(const ext::shared_ptr<Coupon>&);
+        //! returns true if the cashflow is a coupon
+        virtual bool isCoupon() const { return false; }
     };
 
     //! Sequence of cash-flows

--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -74,7 +74,7 @@ namespace QuantLib {
         void accept(AcyclicVisitor&) override;
         //@}
       private:
-        friend void coupon_cast(const ext::shared_ptr<Coupon>&);
+        friend ext::shared_ptr<Coupon> coupon_cast(const ext::shared_ptr<CashFlow>&);
         //! returns true if the cashflow is a coupon
         virtual bool isCoupon() const { return false; }
     };

--- a/ql/cashflow.hpp
+++ b/ql/cashflow.hpp
@@ -66,6 +66,8 @@ namespace QuantLib {
         virtual Date exCouponDate() const { return {}; };
         //! returns true if the cashflow is trading ex-coupon on the refDate
         bool tradingExCoupon(const Date& refDate = Date()) const;
+        //! returns true if the cashflow is a coupon
+        virtual bool isCoupon() const { return false; }
 
         //@}
         //! \name Visitability

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -40,7 +40,7 @@ namespace QuantLib {
 
         Date d = Date::maxDate();
         for (const auto& i : leg) {
-            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+            ext::shared_ptr<Coupon> c = coupon_cast(i);
             if (c != nullptr)
                 d = std::min(d, c->accrualStartDate());
             else
@@ -54,7 +54,7 @@ namespace QuantLib {
 
         Date d = Date::minDate();
         for (const auto& i : leg) {
-            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+            ext::shared_ptr<Coupon> c = coupon_cast(i);
             if (c != nullptr)
                 d = std::max(d, c->accrualEndDate());
             else
@@ -187,7 +187,7 @@ namespace QuantLib {
             DayCounter dc;
             Rate result = 0.0;
             for (; first<last && (*first)->date()==paymentDate; ++first) {
-                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*first);
+                ext::shared_ptr<Coupon> cp = coupon_cast(*first);
                 if (cp) {
                     if (firstCouponFound) {
                         QL_REQUIRE(nominal       == cp->nominal() &&
@@ -236,7 +236,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->nominal();
         }
@@ -252,7 +252,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accrualStartDate();
         }
@@ -268,7 +268,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accrualEndDate();
         }
@@ -284,7 +284,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->referencePeriodStart();
         }
@@ -300,7 +300,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->referencePeriodEnd();
         }
@@ -315,7 +315,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accrualPeriod();
         }
@@ -330,7 +330,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accrualDays();
         }
@@ -348,7 +348,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accruedPeriod(settlementDate);
         }
@@ -366,7 +366,7 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 return cp->accruedDays(settlementDate);
         }
@@ -385,7 +385,7 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            ext::shared_ptr<Coupon> cp = coupon_cast(*cf);
             if (cp != nullptr)
                 result += cp->accruedAmount(settlementDate);
         }
@@ -492,7 +492,7 @@ namespace QuantLib {
             if (!cf.hasOccurred(settlementDate,
                                 includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
-                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(i);
+                ext::shared_ptr<Coupon> cp = coupon_cast(i);
                 Real df = discountCurve.discount(cf.date());
                 npv += cf.amount() * df;
                 if (cp != nullptr)
@@ -572,7 +572,7 @@ namespace QuantLib {
             Date cashFlowDate = cashFlow->date();
             Date refStartDate, refEndDate;
             ext::shared_ptr<Coupon> coupon =
-                    ext::dynamic_pointer_cast<Coupon>(cashFlow);
+                    coupon_cast(cashFlow);
             if (coupon != nullptr) {
                 refStartDate = coupon->referencePeriodStart();
                 refEndDate = coupon->referencePeriodEnd();

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -40,9 +40,8 @@ namespace QuantLib {
 
         Date d = Date::maxDate();
         for (const auto& i : leg) {
-            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
-            if (c != nullptr)
-                d = std::min(d, c->accrualStartDate());
+            if (i->isCoupon())
+                d = std::min(d, ext::static_pointer_cast<Coupon>(i)->accrualStartDate());
             else
                 d = std::min(d, i->date());
         }
@@ -54,9 +53,8 @@ namespace QuantLib {
 
         Date d = Date::minDate();
         for (const auto& i : leg) {
-            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
-            if (c != nullptr)
-                d = std::max(d, c->accrualEndDate());
+            if (i->isCoupon())
+                d = std::max(d, ext::static_pointer_cast<Coupon>(i)->accrualEndDate());
             else
                 d = std::max(d, i->date());
         }
@@ -187,8 +185,8 @@ namespace QuantLib {
             DayCounter dc;
             Rate result = 0.0;
             for (; first<last && (*first)->date()==paymentDate; ++first) {
-                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*first);
-                if (cp) {
+                if ((*first)->isCoupon()) {
+                    auto cp = ext::static_pointer_cast<Coupon>(*first);
                     if (firstCouponFound) {
                         QL_REQUIRE(nominal       == cp->nominal() &&
                                    accrualPeriod == cp->accrualPeriod() &&
@@ -236,9 +234,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->nominal();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->nominal();
         }
         return 0.0;
     }
@@ -252,9 +249,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accrualStartDate();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accrualStartDate();
         }
         return {};
     }
@@ -268,9 +264,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accrualEndDate();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accrualEndDate();
         }
         return {};
     }
@@ -284,9 +279,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->referencePeriodStart();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->referencePeriodStart();
         }
         return {};
     }
@@ -300,9 +294,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->referencePeriodEnd();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->referencePeriodEnd();
         }
         return {};
     }
@@ -315,9 +308,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accrualPeriod();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accrualPeriod();
         }
         return 0;
     }
@@ -330,9 +322,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accrualDays();
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accrualDays();
         }
         return 0;
     }
@@ -348,9 +339,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accruedPeriod(settlementDate);
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accruedPeriod(settlementDate);
         }
         return 0;
     }
@@ -366,9 +356,8 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                return cp->accruedDays(settlementDate);
+            if ((*cf)->isCoupon())
+                return ext::static_pointer_cast<Coupon>(*cf)->accruedDays(settlementDate);
         }
         return 0;
     }
@@ -385,9 +374,8 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
-            if (cp != nullptr)
-                result += cp->accruedAmount(settlementDate);
+            if ((*cf)->isCoupon())
+                result += ext::static_pointer_cast<Coupon>(*cf)->accruedAmount(settlementDate);
         }
         return result;
     }
@@ -492,11 +480,12 @@ namespace QuantLib {
             if (!cf.hasOccurred(settlementDate,
                                 includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
-                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(i);
                 Real df = discountCurve.discount(cf.date());
                 npv += cf.amount() * df;
-                if (cp != nullptr)
+                if (cf.isCoupon()) {
+                    auto const& cp = ext::static_pointer_cast<Coupon>(i);
                     bps += cp->nominal() * cp->accrualPeriod() * df;
+                }
             }
         }
         DiscountFactor d = discountCurve.discount(npvDate);
@@ -571,9 +560,9 @@ namespace QuantLib {
                                      Date lastDate) {
             Date cashFlowDate = cashFlow->date();
             Date refStartDate, refEndDate;
-            ext::shared_ptr<Coupon> coupon =
-                    ext::dynamic_pointer_cast<Coupon>(cashFlow);
-            if (coupon != nullptr) {
+            ext::shared_ptr<Coupon> coupon;
+            if (cashFlow->isCoupon()) {
+                coupon = ext::static_pointer_cast<Coupon>(cashFlow);
                 refStartDate = coupon->referencePeriodStart();
                 refEndDate = coupon->referencePeriodEnd();
             } else {

--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -40,8 +40,9 @@ namespace QuantLib {
 
         Date d = Date::maxDate();
         for (const auto& i : leg) {
-            if (i->isCoupon())
-                d = std::min(d, ext::static_pointer_cast<Coupon>(i)->accrualStartDate());
+            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+            if (c != nullptr)
+                d = std::min(d, c->accrualStartDate());
             else
                 d = std::min(d, i->date());
         }
@@ -53,8 +54,9 @@ namespace QuantLib {
 
         Date d = Date::minDate();
         for (const auto& i : leg) {
-            if (i->isCoupon())
-                d = std::max(d, ext::static_pointer_cast<Coupon>(i)->accrualEndDate());
+            ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+            if (c != nullptr)
+                d = std::max(d, c->accrualEndDate());
             else
                 d = std::max(d, i->date());
         }
@@ -185,8 +187,8 @@ namespace QuantLib {
             DayCounter dc;
             Rate result = 0.0;
             for (; first<last && (*first)->date()==paymentDate; ++first) {
-                if ((*first)->isCoupon()) {
-                    auto cp = ext::static_pointer_cast<Coupon>(*first);
+                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*first);
+                if (cp) {
                     if (firstCouponFound) {
                         QL_REQUIRE(nominal       == cp->nominal() &&
                                    accrualPeriod == cp->accrualPeriod() &&
@@ -234,8 +236,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->nominal();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->nominal();
         }
         return 0.0;
     }
@@ -249,8 +252,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accrualStartDate();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accrualStartDate();
         }
         return {};
     }
@@ -264,8 +268,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accrualEndDate();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accrualEndDate();
         }
         return {};
     }
@@ -279,8 +284,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->referencePeriodStart();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->referencePeriodStart();
         }
         return {};
     }
@@ -294,8 +300,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->referencePeriodEnd();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->referencePeriodEnd();
         }
         return {};
     }
@@ -308,8 +315,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accrualPeriod();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accrualPeriod();
         }
         return 0;
     }
@@ -322,8 +330,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accrualDays();
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accrualDays();
         }
         return 0;
     }
@@ -339,8 +348,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accruedPeriod(settlementDate);
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accruedPeriod(settlementDate);
         }
         return 0;
     }
@@ -356,8 +366,9 @@ namespace QuantLib {
 
         Date paymentDate = (*cf)->date();
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                return ext::static_pointer_cast<Coupon>(*cf)->accruedDays(settlementDate);
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                return cp->accruedDays(settlementDate);
         }
         return 0;
     }
@@ -374,8 +385,9 @@ namespace QuantLib {
         Date paymentDate = (*cf)->date();
         Real result = 0.0;
         for (; cf<leg.end() && (*cf)->date()==paymentDate; ++cf) {
-            if ((*cf)->isCoupon())
-                result += ext::static_pointer_cast<Coupon>(*cf)->accruedAmount(settlementDate);
+            ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(*cf);
+            if (cp != nullptr)
+                result += cp->accruedAmount(settlementDate);
         }
         return result;
     }
@@ -480,12 +492,11 @@ namespace QuantLib {
             if (!cf.hasOccurred(settlementDate,
                                 includeSettlementDateFlows) &&
                 !cf.tradingExCoupon(settlementDate)) {
+                ext::shared_ptr<Coupon> cp = ext::dynamic_pointer_cast<Coupon>(i);
                 Real df = discountCurve.discount(cf.date());
                 npv += cf.amount() * df;
-                if (cf.isCoupon()) {
-                    auto const& cp = ext::static_pointer_cast<Coupon>(i);
+                if (cp != nullptr)
                     bps += cp->nominal() * cp->accrualPeriod() * df;
-                }
             }
         }
         DiscountFactor d = discountCurve.discount(npvDate);
@@ -560,9 +571,9 @@ namespace QuantLib {
                                      Date lastDate) {
             Date cashFlowDate = cashFlow->date();
             Date refStartDate, refEndDate;
-            ext::shared_ptr<Coupon> coupon;
-            if (cashFlow->isCoupon()) {
-                coupon = ext::static_pointer_cast<Coupon>(cashFlow);
+            ext::shared_ptr<Coupon> coupon =
+                    ext::dynamic_pointer_cast<Coupon>(cashFlow);
+            if (coupon != nullptr) {
                 refStartDate = coupon->referencePeriodStart();
                 refEndDate = coupon->referencePeriodEnd();
             } else {

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -664,7 +664,7 @@ namespace QuantLib {
         accruals_.reserve(n);
         for (Size i=0; i<n; ++i) {
             ext::shared_ptr<Coupon> cpn =
-                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
+                coupon_cast(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
         }
     }
@@ -765,7 +765,7 @@ namespace QuantLib {
         swapPaymentDiscounts_.reserve(n);
         for(Size i=0; i<n; ++i) {
             ext::shared_ptr<Coupon> cpn =
-                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
+                coupon_cast(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
             const Date paymentDate(cpn->date());
             const Real swapPaymentTime(dc.yearFraction(rateCurve->referenceDate(), paymentDate));

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -663,8 +663,8 @@ namespace QuantLib {
         Size n = fixedLeg.size();
         accruals_.reserve(n);
         for (Size i=0; i<n; ++i) {
-            ext::shared_ptr<Coupon> cpn =
-                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
+            QL_REQUIRE(fixedLeg[i]->isCoupon(), "expected Coupon");
+            auto const& cpn = ext::static_pointer_cast<Coupon>(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
         }
     }
@@ -764,8 +764,8 @@ namespace QuantLib {
         shapedSwapPaymentTimes_.reserve(n);
         swapPaymentDiscounts_.reserve(n);
         for(Size i=0; i<n; ++i) {
-            ext::shared_ptr<Coupon> cpn =
-                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
+            QL_REQUIRE(fixedLeg[i]->isCoupon(), "expected Coupon");
+            auto const& cpn = ext::static_pointer_cast<Coupon>(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
             const Date paymentDate(cpn->date());
             const Real swapPaymentTime(dc.yearFraction(rateCurve->referenceDate(), paymentDate));

--- a/ql/cashflows/conundrumpricer.cpp
+++ b/ql/cashflows/conundrumpricer.cpp
@@ -663,8 +663,8 @@ namespace QuantLib {
         Size n = fixedLeg.size();
         accruals_.reserve(n);
         for (Size i=0; i<n; ++i) {
-            QL_REQUIRE(fixedLeg[i]->isCoupon(), "expected Coupon");
-            auto const& cpn = ext::static_pointer_cast<Coupon>(fixedLeg[i]);
+            ext::shared_ptr<Coupon> cpn =
+                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
         }
     }
@@ -764,8 +764,8 @@ namespace QuantLib {
         shapedSwapPaymentTimes_.reserve(n);
         swapPaymentDiscounts_.reserve(n);
         for(Size i=0; i<n; ++i) {
-            QL_REQUIRE(fixedLeg[i]->isCoupon(), "expected Coupon");
-            auto const& cpn = ext::static_pointer_cast<Coupon>(fixedLeg[i]);
+            ext::shared_ptr<Coupon> cpn =
+                ext::dynamic_pointer_cast<Coupon>(fixedLeg[i]);
             accruals_.push_back(cpn->accrualPeriod());
             const Date paymentDate(cpn->date());
             const Real swapPaymentTime(dc.yearFraction(rateCurve->referenceDate(), paymentDate));

--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -85,4 +85,7 @@ namespace QuantLib {
             CashFlow::accept(v);
     }
 
+    ext::shared_ptr<Coupon> coupon_cast(const ext::shared_ptr<CashFlow>& cf) {
+        return cf->isCoupon() ? ext::static_pointer_cast<Coupon>(cf) : nullptr;
+    }
 }

--- a/ql/cashflows/coupon.hpp
+++ b/ql/cashflows/coupon.hpp
@@ -55,7 +55,6 @@ namespace QuantLib {
         //! \name CashFlow interface
         //@{
         Date exCouponDate() const override { return exCouponDate_; }
-        bool isCoupon() const override { return true; }
         //@}
         //! \name Inspectors
         //@{
@@ -93,8 +92,11 @@ namespace QuantLib {
         Date accrualStartDate_,accrualEndDate_, refPeriodStart_,refPeriodEnd_;
         Date exCouponDate_;
         mutable Real accrualPeriod_;
+      private:
+        bool isCoupon() const override { return true; }
     };
 
+    ext::shared_ptr<Coupon> coupon_cast(const ext::shared_ptr<CashFlow>& cf);
 
     // inline definitions
 

--- a/ql/cashflows/coupon.hpp
+++ b/ql/cashflows/coupon.hpp
@@ -55,6 +55,7 @@ namespace QuantLib {
         //! \name CashFlow interface
         //@{
         Date exCouponDate() const override { return exCouponDate_; }
+        bool isCoupon() const override { return true; }
         //@}
         //! \name Inspectors
         //@{

--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -184,8 +184,7 @@ namespace QuantLib {
 
             Real gx = 0.0, gy = 0.0;
             for (const auto& i : swapFixedLeg) {
-                QL_REQUIRE(i->isCoupon(), "expected Coupon");
-                auto const& c = ext::static_pointer_cast<Coupon>(i);
+                ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
                 Real yf = c->accrualPeriod();
                 Date d = c->date();
                 Real pv = yf * discountCurve_->discount(d);

--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -184,7 +184,7 @@ namespace QuantLib {
 
             Real gx = 0.0, gy = 0.0;
             for (const auto& i : swapFixedLeg) {
-                ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+                ext::shared_ptr<Coupon> c = coupon_cast(i);
                 Real yf = c->accrualPeriod();
                 Date d = c->date();
                 Real pv = yf * discountCurve_->discount(d);

--- a/ql/cashflows/lineartsrpricer.cpp
+++ b/ql/cashflows/lineartsrpricer.cpp
@@ -184,7 +184,8 @@ namespace QuantLib {
 
             Real gx = 0.0, gy = 0.0;
             for (const auto& i : swapFixedLeg) {
-                ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+                QL_REQUIRE(i->isCoupon(), "expected Coupon");
+                auto const& c = ext::static_pointer_cast<Coupon>(i);
                 Real yf = c->accrualPeriod();
                 Date d = c->date();
                 Real pv = yf * discountCurve_->discount(d);

--- a/ql/experimental/basismodels/swaptioncfs.cpp
+++ b/ql/experimental/basismodels/swaptioncfs.cpp
@@ -38,20 +38,20 @@ namespace QuantLib {
         // we need to find the first coupon for initial payment
         Size floatIdx = 0;
         while (
-            (floatIdx + 1 < iborLeg.size()) && iborLeg[floatIdx]->isCoupon() &&
-            (refDate_ > (ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]))->accrualStartDate()))
+            (floatIdx + 1 < iborLeg.size()) &&
+            (refDate_ > (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))->accrualStartDate()))
             ++floatIdx;
-        QL_REQUIRE(iborLeg[floatIdx]->isCoupon(), "expected Coupon");
-        if (refDate_ <= (ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]))
+        if (refDate_ <= (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))
                             ->accrualStartDate()) { // otherwise there is no floating coupon left
-            auto const& firstFloatCoupon =
-                ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]);
+            ext::shared_ptr<Coupon> firstFloatCoupon =
+                ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]);
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 firstFloatCoupon->nominal(), firstFloatCoupon->accrualStartDate())));
             // calculate spread payments
             for (Size k = floatIdx; k < iborLeg.size(); ++k) {
-                QL_REQUIRE(iborLeg[k]->isCoupon(), "FloatingLeg CashFlow is no Coupon.");
-                auto const &coupon = ext::static_pointer_cast<Coupon>(iborLeg[k]);
+                ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(iborLeg[k]);
+                if (!coupon)
+                    QL_FAIL("FloatingLeg CashFlow is no Coupon.");
                 Date startDate = coupon->accrualStartDate();
                 Date endDate = coupon->accrualEndDate();
                 Rate liborForwardRate = coupon->rate();
@@ -77,8 +77,8 @@ namespace QuantLib {
                     payDate, coupon->nominal(), spread, coupon->dayCounter(), startDate, endDate)));
             } // for ...
               // finally, add the notional at the last date
-            auto const& lastFloatCoupon =
-                ext::static_pointer_cast<Coupon>(iborLeg.back());
+            ext::shared_ptr<Coupon> lastFloatCoupon =
+                ext::dynamic_pointer_cast<Coupon>(iborLeg.back());
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 -1.0 * lastFloatCoupon->nominal(), lastFloatCoupon->accrualEndDate())));
         } // if ...
@@ -98,8 +98,7 @@ namespace QuantLib {
         // copy fixed leg coupons
         Leg fixedLeg = swap->fixedLeg();
         for (auto& k : fixedLeg) {
-            QL_REQUIRE(k->isCoupon(), "expected Coupon");
-            if (ext::static_pointer_cast<Coupon>(k)->accrualStartDate() >= refDate_)
+            if (ext::dynamic_pointer_cast<Coupon>(k)->accrualStartDate() >= refDate_)
                 fixedLeg_.push_back(k);
         }
         Actual365Fixed dc;
@@ -109,10 +108,9 @@ namespace QuantLib {
         for (auto& k : fixedLeg_)
             fixedWeights_.push_back(k->amount());
         for (auto& k : fixedLeg_) {
-            if (k->isCoupon()) {
-                const auto& coupon = ext::static_pointer_cast<Coupon>(k);
+            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(k);
+            if (coupon != nullptr)
                 annuityWeights_.push_back(coupon->nominal() * coupon->accrualPeriod());
-            }
         }
     }
 

--- a/ql/experimental/basismodels/swaptioncfs.cpp
+++ b/ql/experimental/basismodels/swaptioncfs.cpp
@@ -38,20 +38,20 @@ namespace QuantLib {
         // we need to find the first coupon for initial payment
         Size floatIdx = 0;
         while (
-            (floatIdx + 1 < iborLeg.size()) &&
-            (refDate_ > (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))->accrualStartDate()))
+            (floatIdx + 1 < iborLeg.size()) && iborLeg[floatIdx]->isCoupon() &&
+            (refDate_ > (ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]))->accrualStartDate()))
             ++floatIdx;
-        if (refDate_ <= (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))
+        QL_REQUIRE(iborLeg[floatIdx]->isCoupon(), "expected Coupon");
+        if (refDate_ <= (ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]))
                             ->accrualStartDate()) { // otherwise there is no floating coupon left
-            ext::shared_ptr<Coupon> firstFloatCoupon =
-                ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]);
+            auto const& firstFloatCoupon =
+                ext::static_pointer_cast<Coupon>(iborLeg[floatIdx]);
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 firstFloatCoupon->nominal(), firstFloatCoupon->accrualStartDate())));
             // calculate spread payments
             for (Size k = floatIdx; k < iborLeg.size(); ++k) {
-                ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(iborLeg[k]);
-                if (!coupon)
-                    QL_FAIL("FloatingLeg CashFlow is no Coupon.");
+                QL_REQUIRE(iborLeg[k]->isCoupon(), "FloatingLeg CashFlow is no Coupon.");
+                auto const &coupon = ext::static_pointer_cast<Coupon>(iborLeg[k]);
                 Date startDate = coupon->accrualStartDate();
                 Date endDate = coupon->accrualEndDate();
                 Rate liborForwardRate = coupon->rate();
@@ -77,8 +77,8 @@ namespace QuantLib {
                     payDate, coupon->nominal(), spread, coupon->dayCounter(), startDate, endDate)));
             } // for ...
               // finally, add the notional at the last date
-            ext::shared_ptr<Coupon> lastFloatCoupon =
-                ext::dynamic_pointer_cast<Coupon>(iborLeg.back());
+            auto const& lastFloatCoupon =
+                ext::static_pointer_cast<Coupon>(iborLeg.back());
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 -1.0 * lastFloatCoupon->nominal(), lastFloatCoupon->accrualEndDate())));
         } // if ...
@@ -98,7 +98,8 @@ namespace QuantLib {
         // copy fixed leg coupons
         Leg fixedLeg = swap->fixedLeg();
         for (auto& k : fixedLeg) {
-            if (ext::dynamic_pointer_cast<Coupon>(k)->accrualStartDate() >= refDate_)
+            QL_REQUIRE(k->isCoupon(), "expected Coupon");
+            if (ext::static_pointer_cast<Coupon>(k)->accrualStartDate() >= refDate_)
                 fixedLeg_.push_back(k);
         }
         Actual365Fixed dc;
@@ -108,9 +109,10 @@ namespace QuantLib {
         for (auto& k : fixedLeg_)
             fixedWeights_.push_back(k->amount());
         for (auto& k : fixedLeg_) {
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(k);
-            if (coupon != nullptr)
+            if (k->isCoupon()) {
+                const auto& coupon = ext::static_pointer_cast<Coupon>(k);
                 annuityWeights_.push_back(coupon->nominal() * coupon->accrualPeriod());
+            }
         }
     }
 

--- a/ql/experimental/basismodels/swaptioncfs.cpp
+++ b/ql/experimental/basismodels/swaptioncfs.cpp
@@ -39,17 +39,17 @@ namespace QuantLib {
         Size floatIdx = 0;
         while (
             (floatIdx + 1 < iborLeg.size()) &&
-            (refDate_ > (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))->accrualStartDate()))
+            (refDate_ > (coupon_cast(iborLeg[floatIdx]))->accrualStartDate()))
             ++floatIdx;
-        if (refDate_ <= (ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]))
+        if (refDate_ <= (coupon_cast(iborLeg[floatIdx]))
                             ->accrualStartDate()) { // otherwise there is no floating coupon left
             ext::shared_ptr<Coupon> firstFloatCoupon =
-                ext::dynamic_pointer_cast<Coupon>(iborLeg[floatIdx]);
+                coupon_cast(iborLeg[floatIdx]);
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 firstFloatCoupon->nominal(), firstFloatCoupon->accrualStartDate())));
             // calculate spread payments
             for (Size k = floatIdx; k < iborLeg.size(); ++k) {
-                ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(iborLeg[k]);
+                ext::shared_ptr<Coupon> coupon = coupon_cast(iborLeg[k]);
                 if (!coupon)
                     QL_FAIL("FloatingLeg CashFlow is no Coupon.");
                 Date startDate = coupon->accrualStartDate();
@@ -78,7 +78,7 @@ namespace QuantLib {
             } // for ...
               // finally, add the notional at the last date
             ext::shared_ptr<Coupon> lastFloatCoupon =
-                ext::dynamic_pointer_cast<Coupon>(iborLeg.back());
+                coupon_cast(iborLeg.back());
             floatLeg_.push_back(ext::shared_ptr<CashFlow>(new SimpleCashFlow(
                 -1.0 * lastFloatCoupon->nominal(), lastFloatCoupon->accrualEndDate())));
         } // if ...
@@ -98,7 +98,7 @@ namespace QuantLib {
         // copy fixed leg coupons
         Leg fixedLeg = swap->fixedLeg();
         for (auto& k : fixedLeg) {
-            if (ext::dynamic_pointer_cast<Coupon>(k)->accrualStartDate() >= refDate_)
+            if (coupon_cast(k)->accrualStartDate() >= refDate_)
                 fixedLeg_.push_back(k);
         }
         Actual365Fixed dc;
@@ -108,7 +108,7 @@ namespace QuantLib {
         for (auto& k : fixedLeg_)
             fixedWeights_.push_back(k->amount());
         for (auto& k : fixedLeg_) {
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(k);
+            ext::shared_ptr<Coupon> coupon = coupon_cast(k);
             if (coupon != nullptr)
                 annuityWeights_.push_back(coupon->nominal() * coupon->accrualPeriod());
         }

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -457,8 +457,9 @@ namespace QuantLib {
                     Real callAccrued = 0.0;
                     for (const auto& cf : cashflows_) {
                         if (!cf->hasOccurred(callDate, false)) {
-                            if (cf->isCoupon()) {
-                                const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
+                            QL_REQUIRE(cf->isCoupon(), "expected Coupon");
+                            const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
+                            if (coupon != nullptr) {
                                 Real acc = coupon->accruedAmount(callDate);
                                 if (coupon->tradingExCoupon(callDate))
                                     acc = coupon->amount() + acc;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -457,9 +457,8 @@ namespace QuantLib {
                     Real callAccrued = 0.0;
                     for (const auto& cf : cashflows_) {
                         if (!cf->hasOccurred(callDate, false)) {
-                            QL_REQUIRE(cf->isCoupon(), "expected Coupon");
-                            const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
-                            if (coupon != nullptr) {
+                            if (cf->isCoupon()) {
+                                const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
                                 Real acc = coupon->accruedAmount(callDate);
                                 if (coupon->tradingExCoupon(callDate))
                                     acc = coupon->amount() + acc;

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -457,8 +457,7 @@ namespace QuantLib {
                     Real callAccrued = 0.0;
                     for (const auto& cf : cashflows_) {
                         if (!cf->hasOccurred(callDate, false)) {
-                            QL_REQUIRE(cf->isCoupon(), "expected Coupon");
-                            const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
+                            auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
                             if (coupon != nullptr) {
                                 Real acc = coupon->accruedAmount(callDate);
                                 if (coupon->tradingExCoupon(callDate))

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -457,7 +457,7 @@ namespace QuantLib {
                     Real callAccrued = 0.0;
                     for (const auto& cf : cashflows_) {
                         if (!cf->hasOccurred(callDate, false)) {
-                            auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+                            auto coupon = coupon_cast(cf);
                             if (coupon != nullptr) {
                                 Real acc = coupon->accruedAmount(callDate);
                                 if (coupon->tradingExCoupon(callDate))

--- a/ql/experimental/callablebonds/callablebond.cpp
+++ b/ql/experimental/callablebonds/callablebond.cpp
@@ -457,7 +457,8 @@ namespace QuantLib {
                     Real callAccrued = 0.0;
                     for (const auto& cf : cashflows_) {
                         if (!cf->hasOccurred(callDate, false)) {
-                            auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+                            QL_REQUIRE(cf->isCoupon(), "expected Coupon");
+                            const auto& coupon = ext::static_pointer_cast<Coupon>(cf);
                             if (coupon != nullptr) {
                                 Real acc = coupon->accruedAmount(callDate);
                                 if (coupon->tradingExCoupon(callDate))

--- a/ql/experimental/credit/integralcdoengine.cpp
+++ b/ql/experimental/credit/integralcdoengine.cpp
@@ -45,11 +45,13 @@ namespace QuantLib {
         // compute expected loss at the beginning of first relevant period
         Real e1 = 0;
         // todo add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) 
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
+            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
              // cast to fixed rate coupon?
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::dynamic_pointer_cast<Coupon>(
-                    arguments_.normalizedLeg[0])->accrualStartDate()); 
+                ext::static_pointer_cast<Coupon>(
+                    arguments_.normalizedLeg[0])->accrualStartDate());
+        }
         results_.expectedTrancheLoss.push_back(e1);// zero or realized losses?
 
         for (auto& i : arguments_.normalizedLeg) {
@@ -59,7 +61,8 @@ namespace QuantLib {
                 continue;
             }
 
-            const ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
+            QL_REQUIRE(i->isCoupon(), "expected Coupon");
+            const auto& coupon = ext::static_pointer_cast<Coupon>(i);
 
             Date d1 = coupon->accrualStartDate();
             Date d2 = coupon->date();
@@ -95,12 +98,14 @@ namespace QuantLib {
         }
 
         // add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
+            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             results_.upfrontPremiumValue
                 = inceptionTrancheNotional * arguments_.upfrontRate
                     * discountCurve_->discount(
-                        ext::dynamic_pointer_cast<Coupon>(
+                        ext::static_pointer_cast<Coupon>(
                             arguments_.normalizedLeg[0])->accrualStartDate());
+        }
 
         if (arguments_.side == Protection::Buyer) {
             results_.protectionValue *= -1;

--- a/ql/experimental/credit/integralcdoengine.cpp
+++ b/ql/experimental/credit/integralcdoengine.cpp
@@ -48,7 +48,7 @@ namespace QuantLib {
         if (!arguments_.normalizedLeg[0]->hasOccurred(today)) 
              // cast to fixed rate coupon?
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::dynamic_pointer_cast<Coupon>(
+                coupon_cast(
                     arguments_.normalizedLeg[0])->accrualStartDate()); 
         results_.expectedTrancheLoss.push_back(e1);// zero or realized losses?
 
@@ -59,7 +59,7 @@ namespace QuantLib {
                 continue;
             }
 
-            const ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
+            const ext::shared_ptr<Coupon> coupon = coupon_cast(i);
 
             Date d1 = coupon->accrualStartDate();
             Date d2 = coupon->date();
@@ -99,7 +99,7 @@ namespace QuantLib {
             results_.upfrontPremiumValue
                 = inceptionTrancheNotional * arguments_.upfrontRate
                     * discountCurve_->discount(
-                        ext::dynamic_pointer_cast<Coupon>(
+                        coupon_cast(
                             arguments_.normalizedLeg[0])->accrualStartDate());
 
         if (arguments_.side == Protection::Buyer) {

--- a/ql/experimental/credit/integralcdoengine.cpp
+++ b/ql/experimental/credit/integralcdoengine.cpp
@@ -45,13 +45,11 @@ namespace QuantLib {
         // compute expected loss at the beginning of first relevant period
         Real e1 = 0;
         // todo add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
-            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) 
              // cast to fixed rate coupon?
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::static_pointer_cast<Coupon>(
-                    arguments_.normalizedLeg[0])->accrualStartDate());
-        }
+                ext::dynamic_pointer_cast<Coupon>(
+                    arguments_.normalizedLeg[0])->accrualStartDate()); 
         results_.expectedTrancheLoss.push_back(e1);// zero or realized losses?
 
         for (auto& i : arguments_.normalizedLeg) {
@@ -61,8 +59,7 @@ namespace QuantLib {
                 continue;
             }
 
-            QL_REQUIRE(i->isCoupon(), "expected Coupon");
-            const auto& coupon = ext::static_pointer_cast<Coupon>(i);
+            const ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
 
             Date d1 = coupon->accrualStartDate();
             Date d2 = coupon->date();
@@ -98,14 +95,12 @@ namespace QuantLib {
         }
 
         // add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
-            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
             results_.upfrontPremiumValue
                 = inceptionTrancheNotional * arguments_.upfrontRate
                     * discountCurve_->discount(
-                        ext::static_pointer_cast<Coupon>(
+                        ext::dynamic_pointer_cast<Coupon>(
                             arguments_.normalizedLeg[0])->accrualStartDate());
-        }
 
         if (arguments_.side == Protection::Buyer) {
             results_.protectionValue *= -1;

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -51,7 +51,7 @@ namespace QuantLib {
             // the tranche loss on that date might not be contingent but 
             // realized:
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::dynamic_pointer_cast<Coupon>(
+                coupon_cast(
                     arguments_.normalizedLeg[0])->accrualStartDate());
         results_.expectedTrancheLoss.push_back(e1);
         //'e1'  should contain the existing loses.....? use remaining amounts?
@@ -60,7 +60,7 @@ namespace QuantLib {
                 results_.expectedTrancheLoss.push_back(0.);
                 continue;
             }
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
+            ext::shared_ptr<Coupon> coupon = coupon_cast(i);
             Date paymentDate = coupon->date();
             Date startDate = std::max(coupon->accrualStartDate(),
                                       discountCurve_->referenceDate());
@@ -95,7 +95,7 @@ namespace QuantLib {
             results_.upfrontPremiumValue 
                 = inceptionTrancheNotional * arguments_.upfrontRate 
                     * discountCurve_->discount(
-                        ext::dynamic_pointer_cast<Coupon>(
+                        coupon_cast(
                             arguments_.normalizedLeg[0])->accrualStartDate());
             /* use it in a future version for coherence with the integral engine
                 arguments_.leverageFactor * ;

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
                 results_.expectedTrancheLoss.push_back(0.);
                 continue;
             }
-            QL_REQUIRE(i->isCoupon, "expected Coupon");
+            QL_REQUIRE(i->isCoupon(), "expected Coupon");
             auto const& coupon = ext::static_pointer_cast<Coupon>(i);
             Date paymentDate = coupon->date();
             Date startDate = std::max(coupon->accrualStartDate(),

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -61,7 +61,7 @@ namespace QuantLib {
                 results_.expectedTrancheLoss.push_back(0.);
                 continue;
             }
-            QL_REQUIRE(i->isCoupon(), "expected Coupon");
+            QL_REQUIRE(i->isCoupon, "expected Coupon");
             auto const& coupon = ext::static_pointer_cast<Coupon>(i);
             Date paymentDate = coupon->date();
             Date startDate = std::max(coupon->accrualStartDate(),

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -45,15 +45,15 @@ namespace QuantLib {
         // compute expected loss at the beginning of first relevant period
         Real e1 = 0;
         // todo add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
-            // Notice that since there might be a gap between the end of
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
+            // Notice that since there might be a gap between the end of 
             // acrrual and payment dates and today be in between
-            // the tranche loss on that date might not be contingent but
+            // the tranche loss on that date might not be contingent but 
             // realized:
             QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::static_pointer_cast<Coupon>(arguments_.normalizedLeg[0])->accrualStartDate());
-        }
+                ext::static_pointer_cast<Coupon>(
+                    arguments_.normalizedLeg[0])->accrualStartDate());
         results_.expectedTrancheLoss.push_back(e1);
         //'e1'  should contain the existing loses.....? use remaining amounts?
         for (auto& i : arguments_.normalizedLeg) {

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -45,15 +45,15 @@ namespace QuantLib {
         // compute expected loss at the beginning of first relevant period
         Real e1 = 0;
         // todo add includeSettlement date flows variable to engine.
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
-            // Notice that since there might be a gap between the end of 
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
+            // Notice that since there might be a gap between the end of
             // acrrual and payment dates and today be in between
-            // the tranche loss on that date might not be contingent but 
+            // the tranche loss on that date might not be contingent but
             // realized:
             QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::static_pointer_cast<Coupon>(
-                    arguments_.normalizedLeg[0])->accrualStartDate());
+                ext::static_pointer_cast<Coupon>(arguments_.normalizedLeg[0])->accrualStartDate());
+        }
         results_.expectedTrancheLoss.push_back(e1);
         //'e1'  should contain the existing loses.....? use remaining amounts?
         for (auto& i : arguments_.normalizedLeg) {

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -50,8 +50,9 @@ namespace QuantLib {
             // acrrual and payment dates and today be in between
             // the tranche loss on that date might not be contingent but 
             // realized:
+            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::dynamic_pointer_cast<Coupon>(
+                ext::static_pointer_cast<Coupon>(
                     arguments_.normalizedLeg[0])->accrualStartDate());
         results_.expectedTrancheLoss.push_back(e1);
         //'e1'  should contain the existing loses.....? use remaining amounts?
@@ -60,7 +61,8 @@ namespace QuantLib {
                 results_.expectedTrancheLoss.push_back(0.);
                 continue;
             }
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
+            QL_REQUIRE(i->isCoupon, "expected Coupon");
+            auto const& coupon = ext::static_pointer_cast<Coupon>(i);
             Date paymentDate = coupon->date();
             Date startDate = std::max(coupon->accrualStartDate(),
                                       discountCurve_->referenceDate());
@@ -91,15 +93,17 @@ namespace QuantLib {
 
         //\todo treat upfron tnow as in the new CDS (see March 2014)
         // add includeSettlement date flows variable to engine ?
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
+            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             results_.upfrontPremiumValue 
                 = inceptionTrancheNotional * arguments_.upfrontRate 
                     * discountCurve_->discount(
-                        ext::dynamic_pointer_cast<Coupon>(
+                        ext::static_pointer_cast<Coupon>(
                             arguments_.normalizedLeg[0])->accrualStartDate());
             /* use it in a future version for coherence with the integral engine
                 arguments_.leverageFactor * ;
             */
+        }
         if (arguments_.side == Protection::Buyer) {
             results_.protectionValue *= -1;
             results_.premiumValue *= -1;

--- a/ql/experimental/credit/midpointcdoengine.cpp
+++ b/ql/experimental/credit/midpointcdoengine.cpp
@@ -50,9 +50,8 @@ namespace QuantLib {
             // acrrual and payment dates and today be in between
             // the tranche loss on that date might not be contingent but 
             // realized:
-            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
             e1 = arguments_.basket->expectedTrancheLoss(
-                ext::static_pointer_cast<Coupon>(
+                ext::dynamic_pointer_cast<Coupon>(
                     arguments_.normalizedLeg[0])->accrualStartDate());
         results_.expectedTrancheLoss.push_back(e1);
         //'e1'  should contain the existing loses.....? use remaining amounts?
@@ -61,8 +60,7 @@ namespace QuantLib {
                 results_.expectedTrancheLoss.push_back(0.);
                 continue;
             }
-            QL_REQUIRE(i->isCoupon, "expected Coupon");
-            auto const& coupon = ext::static_pointer_cast<Coupon>(i);
+            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
             Date paymentDate = coupon->date();
             Date startDate = std::max(coupon->accrualStartDate(),
                                       discountCurve_->referenceDate());
@@ -93,17 +91,15 @@ namespace QuantLib {
 
         //\todo treat upfron tnow as in the new CDS (see March 2014)
         // add includeSettlement date flows variable to engine ?
-        if (!arguments_.normalizedLeg[0]->hasOccurred(today)) {
-            QL_REQUIRE(arguments_.normalizedLeg[0]->isCoupon(), "expected Coupon");
+        if (!arguments_.normalizedLeg[0]->hasOccurred(today))
             results_.upfrontPremiumValue 
                 = inceptionTrancheNotional * arguments_.upfrontRate 
                     * discountCurve_->discount(
-                        ext::static_pointer_cast<Coupon>(
+                        ext::dynamic_pointer_cast<Coupon>(
                             arguments_.normalizedLeg[0])->accrualStartDate());
             /* use it in a future version for coherence with the integral engine
                 arguments_.leverageFactor * ;
             */
-        }
         if (arguments_.side == Protection::Buyer) {
             results_.protectionValue *= -1;
             results_.premiumValue *= -1;

--- a/ql/instruments/assetswap.cpp
+++ b/ql/instruments/assetswap.cpp
@@ -112,7 +112,7 @@ namespace QuantLib {
         // if we're skipping a cashflow before the redemption
         // and it's a coupon, then add the accrued coupon.
         if (i < bondLeg.end()-1) {
-            auto c = ext::dynamic_pointer_cast<Coupon>(*i);
+            auto c = coupon_cast(*i);
             if (c != nullptr) {
                 Real accruedAmount = c->accruedAmount(dealMaturity);
                 auto accruedCoupon =

--- a/ql/instruments/assetswap.cpp
+++ b/ql/instruments/assetswap.cpp
@@ -112,10 +112,11 @@ namespace QuantLib {
         // if we're skipping a cashflow before the redemption
         // and it's a coupon, then add the accrued coupon.
         if (i < bondLeg.end()-1) {
-            if ((*i)->isCoupon()) {
-                auto const& c = ext::static_pointer_cast<Coupon>(*i);
+            auto c = ext::dynamic_pointer_cast<Coupon>(*i);
+            if (c != nullptr) {
                 Real accruedAmount = c->accruedAmount(dealMaturity);
-                auto accruedCoupon = ext::make_shared<SimpleCashFlow>(accruedAmount, finalDate);
+                auto accruedCoupon =
+                    ext::make_shared<SimpleCashFlow>(accruedAmount, finalDate);
                 legs_[0].push_back(accruedCoupon);
             }
         }

--- a/ql/instruments/assetswap.cpp
+++ b/ql/instruments/assetswap.cpp
@@ -112,11 +112,10 @@ namespace QuantLib {
         // if we're skipping a cashflow before the redemption
         // and it's a coupon, then add the accrued coupon.
         if (i < bondLeg.end()-1) {
-            auto c = ext::dynamic_pointer_cast<Coupon>(*i);
-            if (c != nullptr) {
+            if ((*i)->isCoupon()) {
+                auto const& c = ext::static_pointer_cast<Coupon>(*i);
                 Real accruedAmount = c->accruedAmount(dealMaturity);
-                auto accruedCoupon =
-                    ext::make_shared<SimpleCashFlow>(accruedAmount, finalDate);
+                auto accruedCoupon = ext::make_shared<SimpleCashFlow>(accruedAmount, finalDate);
                 legs_[0].push_back(accruedCoupon);
             }
         }

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -367,7 +367,7 @@ namespace QuantLib {
         Date lastPaymentDate = Date();
         notionalSchedule_.emplace_back();
         for (auto& cashflow : cashflows_) {
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(cashflow);
+            ext::shared_ptr<Coupon> coupon = coupon_cast(cashflow);
             if (!coupon)
                 continue;
 

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -367,9 +367,9 @@ namespace QuantLib {
         Date lastPaymentDate = Date();
         notionalSchedule_.emplace_back();
         for (auto& cashflow : cashflows_) {
-            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(cashflow);
-            if (!coupon)
+            if (!cashflow->isCoupon())
                 continue;
+            auto const& coupon = ext::static_pointer_cast<Coupon>(cashflow);
 
             Real notional = coupon->nominal();
             // we add the notional only if it is the first one...

--- a/ql/instruments/bond.cpp
+++ b/ql/instruments/bond.cpp
@@ -367,9 +367,9 @@ namespace QuantLib {
         Date lastPaymentDate = Date();
         notionalSchedule_.emplace_back();
         for (auto& cashflow : cashflows_) {
-            if (!cashflow->isCoupon())
+            ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(cashflow);
+            if (!coupon)
                 continue;
-            auto const& coupon = ext::static_pointer_cast<Coupon>(cashflow);
 
             Real notional = coupon->nominal();
             // we add the notional only if it is the first one...

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -428,8 +428,8 @@ namespace QuantLib {
     }
 
     const Date& CreditDefaultSwap::protectionEndDate() const {
-        QL_REQUIRE(leg_.back()->isCoupon(), "expected Coupon");
-        return ext::static_cast<Coupon>(leg_.back())->accrualEndDate();
+        return ext::dynamic_pointer_cast<Coupon>(leg_.back())
+            ->accrualEndDate();
     }
 
     const ext::shared_ptr<SimpleCashFlow>& CreditDefaultSwap::upfrontPayment() const {

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -429,7 +429,7 @@ namespace QuantLib {
 
     const Date& CreditDefaultSwap::protectionEndDate() const {
         QL_REQUIRE(leg_.back()->isCoupon(), "expected Coupon");
-        return ext::static_cast<Coupon>(leg_.back())->accrualEndDate();
+        return ext::static_pointer_cast<Coupon>(leg_.back())->accrualEndDate();
     }
 
     const ext::shared_ptr<SimpleCashFlow>& CreditDefaultSwap::upfrontPayment() const {

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -428,8 +428,8 @@ namespace QuantLib {
     }
 
     const Date& CreditDefaultSwap::protectionEndDate() const {
-        return ext::dynamic_pointer_cast<Coupon>(leg_.back())
-            ->accrualEndDate();
+        QL_REQUIRE(leg_.back()->isCoupon(), "expected Coupon");
+        return ext::static_cast<Coupon>(leg_.back())->accrualEndDate();
     }
 
     const ext::shared_ptr<SimpleCashFlow>& CreditDefaultSwap::upfrontPayment() const {

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -429,7 +429,7 @@ namespace QuantLib {
 
     const Date& CreditDefaultSwap::protectionEndDate() const {
         QL_REQUIRE(leg_.back()->isCoupon(), "expected Coupon");
-        return ext::static_pointer_cast<Coupon>(leg_.back())->accrualEndDate();
+        return ext::static_cast<Coupon>(leg_.back())->accrualEndDate();
     }
 
     const ext::shared_ptr<SimpleCashFlow>& CreditDefaultSwap::upfrontPayment() const {

--- a/ql/instruments/creditdefaultswap.cpp
+++ b/ql/instruments/creditdefaultswap.cpp
@@ -428,7 +428,7 @@ namespace QuantLib {
     }
 
     const Date& CreditDefaultSwap::protectionEndDate() const {
-        return ext::dynamic_pointer_cast<Coupon>(leg_.back())
+        return coupon_cast(leg_.back())
             ->accrualEndDate();
     }
 

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -151,8 +151,9 @@ namespace QuantLib {
         Real npv = 0.0;
         for (Size j = 0; j < 2; j++) {
             for (const auto& i : swap_->leg(j)) {
+                QL_REQUIRE(i->isCoupon(), "expected Coupon");
                 npv +=
-                    ext::dynamic_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
+                    ext::static_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
                         Real(i->amount() * disTs_->discount(i->date())) :
                         0.0;
             }

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -152,7 +152,7 @@ namespace QuantLib {
         for (Size j = 0; j < 2; j++) {
             for (const auto& i : swap_->leg(j)) {
                 npv +=
-                    ext::dynamic_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
+                    coupon_cast(i)->accrualStartDate() >= iterExerciseDate ?
                         Real(i->amount() * disTs_->discount(i->date())) :
                         0.0;
             }

--- a/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
+++ b/ql/methods/finitedifferences/utilities/fdmaffinemodelswapinnervalue.hpp
@@ -151,9 +151,8 @@ namespace QuantLib {
         Real npv = 0.0;
         for (Size j = 0; j < 2; j++) {
             for (const auto& i : swap_->leg(j)) {
-                QL_REQUIRE(i->isCoupon(), "expected Coupon");
                 npv +=
-                    ext::static_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
+                    ext::dynamic_pointer_cast<Coupon>(i)->accrualStartDate() >= iterExerciseDate ?
                         Real(i->amount() * disTs_->discount(i->date())) :
                         0.0;
             }

--- a/ql/pricingengines/bond/riskybondengine.cpp
+++ b/ql/pricingengines/bond/riskybondengine.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
                     settlementValue += weightedCouponAmount * yieldTS()->discount(d2);
 
                 if (cf->isCoupon()) {
-                    auto const& coupon = ext::static_pointer_cast<Coupon>(cf);
+                    auto const& coupon ) ext::static_pointer_cast<Coupon>(cf);
                     Date defaultDate = d1 + (d2 - d1) / 2;
                     Real weightedRecovery = coupon->nominal() * recoveryRate() *
                                     (defaultTS()->survivalProbability(d1) -

--- a/ql/pricingengines/bond/riskybondengine.cpp
+++ b/ql/pricingengines/bond/riskybondengine.cpp
@@ -53,8 +53,8 @@ namespace QuantLib {
                 if (d2 > settlementDate)
                     settlementValue += weightedCouponAmount * yieldTS()->discount(d2);
 
-                if (cf->isCoupon()) {
-                    auto const& coupon ) ext::static_pointer_cast<Coupon>(cf);
+                auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+                if (coupon != nullptr) {
                     Date defaultDate = d1 + (d2 - d1) / 2;
                     Real weightedRecovery = coupon->nominal() * recoveryRate() *
                                     (defaultTS()->survivalProbability(d1) -

--- a/ql/pricingengines/bond/riskybondengine.cpp
+++ b/ql/pricingengines/bond/riskybondengine.cpp
@@ -54,7 +54,7 @@ namespace QuantLib {
                     settlementValue += weightedCouponAmount * yieldTS()->discount(d2);
 
                 if (cf->isCoupon()) {
-                    auto const& coupon ) ext::static_pointer_cast<Coupon>(cf);
+                    auto const& coupon = ext::static_pointer_cast<Coupon>(cf);
                     Date defaultDate = d1 + (d2 - d1) / 2;
                     Real weightedRecovery = coupon->nominal() * recoveryRate() *
                                     (defaultTS()->survivalProbability(d1) -

--- a/ql/pricingengines/bond/riskybondengine.cpp
+++ b/ql/pricingengines/bond/riskybondengine.cpp
@@ -53,7 +53,7 @@ namespace QuantLib {
                 if (d2 > settlementDate)
                     settlementValue += weightedCouponAmount * yieldTS()->discount(d2);
 
-                auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+                auto coupon = coupon_cast(cf);
                 if (coupon != nullptr) {
                     Date defaultDate = d1 + (d2 - d1) / 2;
                     Real weightedRecovery = coupon->nominal() * recoveryRate() *

--- a/ql/pricingengines/bond/riskybondengine.cpp
+++ b/ql/pricingengines/bond/riskybondengine.cpp
@@ -53,8 +53,8 @@ namespace QuantLib {
                 if (d2 > settlementDate)
                     settlementValue += weightedCouponAmount * yieldTS()->discount(d2);
 
-                auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
-                if (coupon != nullptr) {
+                if (cf->isCoupon()) {
+                    auto const& coupon ) ext::static_pointer_cast<Coupon>(cf);
                     Date defaultDate = d1 + (d2 - d1) / 2;
                     Real weightedRecovery = coupon->nominal() * recoveryRate() *
                                     (defaultTS()->survivalProbability(d1) -

--- a/test-suite/bermudanswaption.cpp
+++ b/test-suite/bermudanswaption.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(testCachedValues) {
     std::vector<Date> exerciseDates;
     const Leg& leg = atmSwap->fixedLeg();
     for (const auto& i : leg) {
-        ext::shared_ptr<Coupon> coupon = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> coupon = coupon_cast(i);
         exerciseDates.push_back(coupon->accrualStartDate());
     }
     ext::shared_ptr<Exercise> exercise(new BermudanExercise(exerciseDates));
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(testCachedG2Values) {
 
         std::vector<Date> exerciseDates;
         for (const auto& i : swap->fixedLeg()) {
-            exerciseDates.push_back(ext::dynamic_pointer_cast<Coupon>(i)->accrualStartDate());
+            exerciseDates.push_back(coupon_cast(i)->accrualStartDate());
         }
 
         swaptions.push_back(ext::make_shared<Swaption>(swap,
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionWithHW) {
     // Build Bermudan exercise from fixed leg
     std::vector<Date> exerciseDates;
     for (const auto& cf : atmOIS->fixedLeg()) {
-        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        auto coupon = coupon_cast(cf);
         exerciseDates.push_back(coupon->accrualStartDate());
     }
     auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionWithG2) {
 
     std::vector<Date> exerciseDates;
     for (const auto& cf : atmOIS->fixedLeg()) {
-        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        auto coupon = coupon_cast(cf);
         exerciseDates.push_back(coupon->accrualStartDate());
     }
     auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE(testBermudanOISSwaptionPreservesFeatures) {
     auto refOIS = makeOIS(RateAveraging::Compound, 0);
     std::vector<Date> exerciseDates;
     for (const auto& cf : refOIS->fixedLeg()) {
-        auto coupon = ext::dynamic_pointer_cast<Coupon>(cf);
+        auto coupon = coupon_cast(cf);
         exerciseDates.push_back(coupon->accrualStartDate());
     }
     auto exercise = ext::make_shared<BermudanExercise>(exerciseDates);

--- a/test-suite/cashflows.cpp
+++ b/test-suite/cashflows.cpp
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
     // no ex-coupon dates
     Leg l1 = FixedRateLeg(schedule).withNotionals(100.0).withCouponRates(0.03, Actual360());
     for (auto& i : l1) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         if (c->exCouponDate() != Date()) {
             BOOST_ERROR("ex-coupon date found (none expected)");
         }
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
     ext::shared_ptr<IborIndex> index(new Euribor3M);
     Leg l2 = IborLeg(schedule, index).withNotionals(100.0);
     for (auto& i : l2) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         if (c->exCouponDate() != Date()) {
             BOOST_ERROR("ex-coupon date found (none expected)");
         }
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
                  .withCouponRates(0.03, Actual360())
                  .withExCouponPeriod(Period(2, Days), NullCalendar(), Unadjusted, false);
     for (auto& i : l5) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         Date expected = c->accrualEndDate() - 2;
         if (c->exCouponDate() != expected) {
             BOOST_ERROR("ex-coupon date = " << c->exCouponDate() << " (" << expected
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
                  .withNotionals(100.0)
                  .withExCouponPeriod(Period(2, Days), NullCalendar(), Unadjusted, false);
     for (auto& i : l6) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         Date expected = c->accrualEndDate() - 2;
         if (c->exCouponDate() != expected) {
             BOOST_ERROR("ex-coupon date = " << c->exCouponDate() << " (" << expected
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
                  .withCouponRates(0.03, Actual360())
                  .withExCouponPeriod(Period(2, Days), TARGET(), Preceding, false);
     for (auto& i : l7) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         Date expected = TARGET().advance(c->accrualEndDate(), -2, Days);
         if (c->exCouponDate() != expected) {
             BOOST_ERROR("ex-coupon date = " << c->exCouponDate() << " (" << expected
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(testExCouponDates) {
                  .withNotionals(100.0)
                  .withExCouponPeriod(Period(2, Days), TARGET(), Preceding, false);
     for (auto& i : l8) {
-        ext::shared_ptr<Coupon> c = ext::dynamic_pointer_cast<Coupon>(i);
+        ext::shared_ptr<Coupon> c = coupon_cast(i);
         Date expected = TARGET().advance(c->accrualEndDate(), -2, Days);
         if (c->exCouponDate() != expected) {
             BOOST_ERROR("ex-coupon date = " << c->exCouponDate() << " (" << expected
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfMonth) {
         .withCouponRates(0.01, Actual360());
 
     ext::shared_ptr<Coupon> firstCoupon =
-        ext::dynamic_pointer_cast<Coupon>(leg.front());
+        coupon_cast(leg.front());
 
     if (firstCoupon->referencePeriodStart() != Date(31, August, 2016))
         BOOST_ERROR("Expected reference start date at end of month, "
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(testIrregularFirstCouponReferenceDatesAtEndOfCalendarMonth)
         .withCouponRates(0.01875, ActualActual(ActualActual::ISMA));
 
     ext::shared_ptr<Coupon> firstCoupon =
-        ext::dynamic_pointer_cast<Coupon>(leg.front());
+        coupon_cast(leg.front());
     if (firstCoupon->referencePeriodStart() != Date(30, September, 2017))
         BOOST_ERROR("Expected reference start date at end of calendar day of the month, "
                     "got " << firstCoupon->referencePeriodStart());
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(testIrregularLastCouponReferenceDatesAtEndOfMonth) {
             .withCouponRates(0.01, Actual360());
 
     ext::shared_ptr<Coupon> lastCoupon =
-            ext::dynamic_pointer_cast<Coupon>(leg.back());
+            coupon_cast(leg.back());
 
     if (lastCoupon->referencePeriodEnd() != Date(31, August, 2018))
         BOOST_ERROR("Expected reference end date at end of month, "

--- a/test-suite/creditdefaultswap.cpp
+++ b/test-suite/creditdefaultswap.cpp
@@ -987,8 +987,8 @@ BOOST_AUTO_TEST_CASE(testDefaultConventions) {
     BOOST_CHECK_EQUAL(cds->paysAtDefaultTime(), true);
     BOOST_CHECK_EQUAL(cds->rebatesAccrual(), true);
 
-    auto first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
-    auto last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+    auto first = coupon_cast(cds->coupons().front());
+    auto last = coupon_cast(cds->coupons().back());
 
     BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/360");
     BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/360 (inc)");
@@ -1011,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(testDefaultConventions) {
         .withUpfrontRate(0.02);
 
     BOOST_CHECK_EQUAL(cds->notional(), 10000.0);
-    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
+    first = coupon_cast(cds->coupons().front());
     BOOST_CHECK_EQUAL(first->nominal(), 10000.0);
 
     BOOST_CHECK(cds->upfront().has_value());
@@ -1060,8 +1060,8 @@ BOOST_AUTO_TEST_CASE(testDefaultConventions) {
     cds = MakeCreditDefaultSwap(5 * Years, 0.01)
         .withDayCounter(Actual365Fixed());
 
-    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
-    last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+    first = coupon_cast(cds->coupons().front());
+    last = coupon_cast(cds->coupons().back());
 
     BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/365 (Fixed)");
     BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/360 (inc)");
@@ -1069,8 +1069,8 @@ BOOST_AUTO_TEST_CASE(testDefaultConventions) {
     cds = MakeCreditDefaultSwap(5 * Years, 0.01)
         .withLastPeriodDayCounter(Actual365Fixed());
 
-    first = ext::dynamic_pointer_cast<Coupon>(cds->coupons().front());
-    last = ext::dynamic_pointer_cast<Coupon>(cds->coupons().back());
+    first = coupon_cast(cds->coupons().front());
+    last = coupon_cast(cds->coupons().back());
 
     BOOST_CHECK_EQUAL(first->dayCounter().name(), "Actual/360");
     BOOST_CHECK_EQUAL(last->dayCounter().name(), "Actual/365 (Fixed)");


### PR DESCRIPTION
addresses #2622 