### PR TITLE
Use the passed `paymentAdjustment` in the OIS fixed leg

### DIFF
--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -144,7 +144,7 @@ namespace QuantLib {
                                                bool applyObservationShift)
     : FixedVsFloatingSwap(type, std::move(fixedNominals), std::move(fixedSchedule), fixedRate, std::move(fixedDC),
                           overnightNominals, std::move(overnightSchedule), overnightIndex,
-                          spread, DayCounter(), ext::nullopt, paymentLag, paymentCalendar),
+                          spread, DayCounter(), paymentAdjustment, paymentLag, paymentCalendar),
                           overnightIndex_(overnightIndex),
                           paymentLag_(paymentLag), paymentCalendar_(paymentCalendar),
                           telescopicValueDates_(telescopicValueDates),


### PR DESCRIPTION
paymentAdjustment is ignored for the fixed leg in OvernightIndexedSwap
see example below:

import QuantLib as ql

today = ql.Date(27,2,2026)
ql.Settings.instance().evaluationDate = today
  
value_date = ql.Russia().advance(today, 1, ql.Days)
maturiry_date = ql.NullCalendar().advance(value_date, 3, ql.Years)

schedule = ql.MakeSchedule(
    effectiveDate=value_date,
    terminationDate=maturiry_date,
    tenor=ql.Period("3Y"),
    frequency=ql.Monthly,
    calendar=ql.NullCalendar(), #IMPORTANT
    convention=ql.Unadjusted, #IMPORTANT
    rule=ql.DateGeneration.Forward
)

swap = ql.OvernightIndexedSwap(
    ql.Swap.Payer,
    1_000,
    schedule,
    0.0,
    ql.ActualActual(ql.ActualActual.ISDA),
    ql.Sofr(),
    0.0,
    0,
    ql.ModifiedFollowing, #IMPORTANT
    ql.Russia(),
    False,
    ql.RateAveraging.Compound,
    1,
    0,
    False
)

for c in swap.fixedLeg():
    print(f"{c.date().ISO()} {ql.Russia().isBusinessDay(c.date())}")


