### PR TITLE
Use Boost for inverse cumulative Student t distribution

### DIFF
--- a/ql/math/distributions/studenttdistribution.cpp
+++ b/ql/math/distributions/studenttdistribution.cpp
@@ -19,7 +19,10 @@
 
 #include <ql/math/distributions/studenttdistribution.hpp>
 #include <ql/math/distributions/gammadistribution.hpp>
+#include <ql/math/comparison.hpp>
 #include <ql/math/beta.hpp>
+
+#include <boost/math/distributions/students_t.hpp>
 
 namespace QuantLib {
 
@@ -42,25 +45,23 @@ namespace QuantLib {
     }
 
     Real InverseCumulativeStudent::operator()(Real y) const {
-        QL_REQUIRE (y >= 0 && y <= 1, "argument out of range [0, 1]");
-
-        Real x = 0;
-        Size count = 0;
-
-        // do a few newton steps to find x
-        do {
-            x -= (f_(x) - y) / d_(x);
-            count++;
+        if (y <= 0.0 || y >= 1.0) {
+            if (close_enough(y, 1.0)) {
+                return QL_MAX_REAL;
+            } else if (std::fabs(y) < QL_EPSILON) {
+                return QL_MIN_REAL;
+            } else {
+                QL_FAIL("InverseCumulativeStudent(" << y
+                        << ") undefined: must be 0 < x < 1");
+            }
         }
-        while (std::fabs(f_(x) - y) > accuracy_ && count < maxIterations_);
 
-        QL_REQUIRE (count < maxIterations_,
-                    "maximum number of iterations " << maxIterations_
-                    << " reached in InverseCumulativeStudent, "
-                    << "y=" << y << ", x=" << x);
+        if (y == 0.5)
+            return 0.0;
 
-        return x;
+        return boost::math::quantile(
+            boost::math::students_t_distribution<Real>(
+                static_cast<Real>(n_)), y);
     }
 
 }
-

--- a/ql/math/distributions/studenttdistribution.hpp
+++ b/ql/math/distributions/studenttdistribution.hpp
@@ -72,23 +72,18 @@ namespace QuantLib {
     };
 
     //! Inverse cumulative Student t-distribution
-    /*! \todo Find/implement an efficient algorithm for evaluating the
-              cumulative Student t-distribution, replacing the Newton
-              iteration
-    */
+    /*! The implementation delegates the calculation to Boost.Math. */
     class InverseCumulativeStudent {
       public:
         InverseCumulativeStudent(Integer n,
-                                 Real accuracy = 1e-6,
-                                 Size maxIterations = 50)
-        : d_(n), f_(n), accuracy_(accuracy),
-          maxIterations_(maxIterations) {}
+                                 Real = 1e-6,
+                                 Size = 50)
+        : n_(n) {
+            QL_REQUIRE(n > 0, "invalid parameter for t-distribution");
+        }
         Real operator()(Real x) const;
       private:
-        StudentDistribution d_;
-        CumulativeStudentDistribution f_;
-        Real accuracy_;
-        Size maxIterations_;
+        Integer n_;
     };
 
 }

--- a/ql/math/distributions/studenttdistribution.hpp
+++ b/ql/math/distributions/studenttdistribution.hpp
@@ -75,12 +75,18 @@ namespace QuantLib {
     /*! The implementation delegates the calculation to Boost.Math. */
     class InverseCumulativeStudent {
       public:
-        InverseCumulativeStudent(Integer n,
-                                 Real = 1e-6,
-                                 Size = 50)
+        InverseCumulativeStudent(Integer n)
         : n_(n) {
             QL_REQUIRE(n > 0, "invalid parameter for t-distribution");
         }
+        /*! \deprecated Use the other overload; the solver parameters are no longer used.
+                        Deprecated in version 1.44.
+        */
+        [[deprecated("Use the other overload; the solver parameters are no longer used.")]]
+        InverseCumulativeStudent(Integer n,
+                                 Real,
+                                 Size = 50)
+        : InverseCumulativeStudent(n) {}
         Real operator()(Real x) const;
       private:
         Integer n_;

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -27,6 +27,7 @@
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/math/distributions/bivariatenormaldistribution.hpp>
 #include <ql/math/distributions/bivariatestudenttdistribution.hpp>
+#include <ql/math/distributions/studenttdistribution.hpp>
 #include <ql/math/distributions/chisquaredistribution.hpp>
 #include <ql/math/distributions/poissondistribution.hpp>
 #include <ql/math/randomnumbers/stochasticcollocationinvcdf.hpp>
@@ -432,6 +433,118 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativePoisson) {
                         << data[i] << "\n"
                         << "    calculated: " << icp(data[i]) << "\n"
                         << "    expected:   " << Real(i));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testInverseCumulativeStudent) {
+
+    BOOST_TEST_MESSAGE("Testing inverse cumulative Student t distribution...");
+
+    Real probabilities[] = { 1.0e-12, 1.0e-9, 1.0e-6, 1.0e-4,
+                             0.001, 0.01, 0.10, 0.25, 0.50, 0.75,
+                             0.90, 0.99, 0.999, 1.0 - 1.0e-4,
+                             1.0 - 1.0e-6, 1.0 - 1.0e-9,
+                             1.0 - 1.0e-12 };
+
+    InverseCumulativeStudent inverseCauchy(1, 1.0e-12, 100);
+    for (Real p : probabilities) {
+        Real calculated = inverseCauchy(p);
+        Real expected;
+        if (p < 0.5)
+            expected = -1.0 / std::tan(M_PI * p);
+        else if (p > 0.5)
+            expected = 1.0 / std::tan(M_PI * (1.0 - p));
+        else
+            expected = 0.0;
+        Real error = std::fabs(calculated - expected);
+        Real tolerance = 1.0e-10 * std::max(1.0, std::fabs(expected));
+        if (error > tolerance)
+            BOOST_ERROR("Failed to reproduce inverse cumulative Cauchy value:"
+                        << "\n    probability: " << p
+                        << "\n    calculated:  " << calculated
+                        << "\n    expected:    " << expected
+                        << "\n    error:       " << error);
+    }
+
+    InverseCumulativeStudent inverseStudent2(2, 1.0e-12, 100);
+    for (Real p : probabilities) {
+        Real calculated = inverseStudent2(p);
+        Real expected = (2.0*p - 1.0) / std::sqrt(2.0*p*(1.0 - p));
+        Real error = std::fabs(calculated - expected);
+        Real tolerance = 1.0e-12 * std::max(1.0, std::fabs(expected));
+        if (error > tolerance)
+            BOOST_ERROR("Failed to reproduce inverse cumulative Student t "
+                        "value for 2 degrees of freedom:"
+                        << "\n    probability: " << p
+                        << "\n    calculated:  " << calculated
+                        << "\n    expected:    " << expected
+                        << "\n    error:       " << error);
+    }
+
+    InverseCumulativeStudent inverse(4, 1.0e-12, 100);
+    if (inverse(0.0) != QL_MIN_REAL)
+        BOOST_ERROR("Inverse cumulative Student t distribution at 0.0 "
+                    "must return QL_MIN_REAL");
+    if (inverse(1.0) != QL_MAX_REAL)
+        BOOST_ERROR("Inverse cumulative Student t distribution at 1.0 "
+                    "must return QL_MAX_REAL");
+    BOOST_CHECK_THROW(inverse(-0.1), Error);
+    BOOST_CHECK_THROW(inverse(1.1), Error);
+
+    Integer ns[] = { 3, 4, 5, 10, 30, 100 };
+    Real roundTripProbabilities[] = { 1.0e-10, 1.0e-8, 1.0e-6,
+                                      1.0e-4, 0.001, 0.01, 0.10,
+                                      0.25, 0.50, 0.75, 0.90, 0.99,
+                                      0.999, 1.0 - 1.0e-4,
+                                      1.0 - 1.0e-6, 1.0 - 1.0e-8,
+                                      1.0 - 1.0e-10 };
+    Real symmetryProbabilities[] = { 1.0e-8, 1.0e-6, 1.0e-4, 0.001,
+                                     0.01, 0.10, 0.25 };
+
+    for (Integer n : ns) {
+        InverseCumulativeStudent inv(n, 1.0e-12, 100);
+        CumulativeStudentDistribution cdf(n);
+
+        Real previous = QL_MIN_REAL;
+        for (Real p : roundTripProbabilities) {
+            Real x = inv(p);
+            if (x <= previous)
+                BOOST_ERROR("Inverse cumulative Student t distribution "
+                            "is not increasing:"
+                            << "\n    n:            " << n
+                            << "\n    probability:  " << p
+                            << "\n    value:        " << x
+                            << "\n    previous:     " << previous);
+            previous = x;
+
+            Real calculated = cdf(x);
+            Real error = std::fabs(calculated - p);
+            Real tolerance = 1.0e-8;
+            if (error > tolerance)
+                BOOST_ERROR("Failed to reproduce Student t distribution "
+                            "round-trip:"
+                            << "\n    n:            " << n
+                            << "\n    probability:  " << p
+                            << "\n    inverse:      " << x
+                            << "\n    calculated:   " << calculated
+                            << "\n    error:        " << error);
+        }
+
+        for (Real p : symmetryProbabilities) {
+            Real lower = inv(p);
+            Real upper = inv(1.0 - p);
+            Real error = std::fabs(lower + upper);
+            Real tolerance = 1.0e-8 *
+                std::max(1.0, std::max(std::fabs(lower), std::fabs(upper)));
+            if (error > tolerance)
+                BOOST_ERROR("Inverse cumulative Student t distribution "
+                            "symmetry failure:"
+                            << "\n    n:            " << n
+                            << "\n    probability:  " << p
+                            << "\n    lower:        " << lower
+                            << "\n    upper:        " << upper
+                            << "\n    error:        " << error);
         }
     }
 }

--- a/test-suite/distributions.cpp
+++ b/test-suite/distributions.cpp
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativeStudent) {
                              1.0 - 1.0e-6, 1.0 - 1.0e-9,
                              1.0 - 1.0e-12 };
 
-    InverseCumulativeStudent inverseCauchy(1, 1.0e-12, 100);
+    InverseCumulativeStudent inverseCauchy(1);
     for (Real p : probabilities) {
         Real calculated = inverseCauchy(p);
         Real expected;
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativeStudent) {
                         << "\n    error:       " << error);
     }
 
-    InverseCumulativeStudent inverseStudent2(2, 1.0e-12, 100);
+    InverseCumulativeStudent inverseStudent2(2);
     for (Real p : probabilities) {
         Real calculated = inverseStudent2(p);
         Real expected = (2.0*p - 1.0) / std::sqrt(2.0*p*(1.0 - p));
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativeStudent) {
                         << "\n    error:       " << error);
     }
 
-    InverseCumulativeStudent inverse(4, 1.0e-12, 100);
+    InverseCumulativeStudent inverse(4);
     if (inverse(0.0) != QL_MIN_REAL)
         BOOST_ERROR("Inverse cumulative Student t distribution at 0.0 "
                     "must return QL_MIN_REAL");
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(testInverseCumulativeStudent) {
                                      0.01, 0.10, 0.25 };
 
     for (Integer n : ns) {
-        InverseCumulativeStudent inv(n, 1.0e-12, 100);
+        InverseCumulativeStudent inv(n);
         CumulativeStudentDistribution cdf(n);
 
         Real previous = QL_MIN_REAL;


### PR DESCRIPTION
## Proposal

This improves `InverseCumulativeStudent` by replacing the current unbracketed Newton iteration with Boost.Math's Student t quantile implementation.

The existing implementation already contains a TODO asking to replace the Newton iteration with a more efficient inverse Student t algorithm:
  https://github.com/lballabio/QuantLib/blob/4567efac4393f56eb52bd4ca5e63a6b1829e0a81/ql/math/distributions/studenttdistribution.hpp#L75-L78

This PR proposes to replace the algorithm with a Boost.Math based implementation:

- Boost.Math implementation, this PR: https://github.com/mpwaser/quant-lib/tree/feature/student-t-inverse-cdf-boost
- Boost.Math diff against QuantLib `master`: https://github.com/lballabio/QuantLib/compare/master...mpwaser:feature/student-t-inverse-cdf-boost

The proposed Boost.Math based implementation:

- fixes failures and large tail errors in the current Newton implementation
- is substantially faster in the tested grids
- keeps the existing Student t input range policy (see implementation note at the end)

In case you prefer not to delegate this calculation to Boost.Math, I also prepared a native QuantLib-only Brent-based alternative. It is also a clear improvement over the current Newton implementation, though the Boost.Math implementation performs better in the benchmarks below.

- Brent alternative: https://github.com/mpwaser/quant-lib/tree/feature/student-t-inverse-cdf
- Brent diff against QuantLib `master`: https://github.com/lballabio/QuantLib/compare/master...mpwaser:feature/student-t-inverse-cdf

The following tables compare all three implementations in terms of accuracy, robustness, and efficiency.

## Benchmark results

### Accuracy and robustness

Absolute and relative errors are measured against Boost.Math quantile. Since this PR delegates to Boost.Math, its absolute and relative errors are zero by construction in this comparison. The CDF residual is included as an additional check using QuantLib's cumulative Student t distribution.

| Method | OK | Failed | max abs error | max rel error | max CDF residual |
| --- | ---: | ---: | ---: | ---: | ---: |
| Newton (current) | 200 | 25 | 3.180619e+14 | 9.984223e-01 | 9.773293e-13 |
| Brent | 225 | 0 | 1.396984e-09 | 1.878553e-12 | 2.997602e-14 |
| Boost.Math | 225 | 0 | 0.000000e+00 | 0.000000e+00 | 3.140960e-13 |

### Timing (ns/call)

| Scenario | Newton (old) | Brent | Boost.Math |
| --- | ---: | ---: | ---: |
| Central | 886.4 | 655.4 | 73.7 |
| Common | 1255.3 | 874.6 | 81.7 |
| Moderate tails | 2621.6 | 1309.2 | 99.5 |
| Mixed deep tails | 3406.1 | 1199.8 | 97.4 |

## Validation

- `ql_test_suite --run_test=QuantLibTests/DistributionTests/testInverseCumulativeStudent`
- `ql_test_suite --run_test=QuantLibTests/DistributionTests`
- `git diff --check`

## Implementation note: Endpoint handling

The previous Student t inverse accepted inputs in `[0, 1]`. At the exact endpoints, the mathematical inverse is not finite. The old Newton iteration therefore returned finite, accuracy-dependent tail values as an artifact of its stopping criterion.

This implementation handles exact and numerically near-endpoint inputs before calling Boost.Math, following the convention already used by QuantLib's `InverseCumulativeNormal::tail_value`:

- inputs close to `0` return `QL_MIN_REAL`
- inputs close to `1` return `QL_MAX_REAL`
- inputs genuinely outside `[0, 1]` still throw

This avoids exposing Boost.Math's endpoint overflow behavior while aligning the Student t inverse with an existing QuantLib inverse-distribution convention.

One detail worth noting is that the inherited normal-inverse convention is slightly asymmetric: the upper endpoint is detected with `close_enough(y, 1.0)`, while the lower endpoint is detected with `std::fabs(y) < QL_EPSILON`. I kept that behavior here for consistency with `InverseCumulativeNormal`.

A cleaner alternative would be a symmetric endpoint policy, for instance using the same style of tolerance check at both endpoints. I did not include that broader policy change in this PR in order to keep the change focused on replacing the Student t Newton iteration.
  
## Appendix: Benchmark details

The benchmark was run outside the PR code, against a Release build with `-O3 -DNDEBUG`.

The implementations compared were:

- current QuantLib Newton implementation, copied into the benchmark
- native QuantLib-only Brent alternative
- this PR's `InverseCumulativeStudent` implementation using Boost.Math
- direct Boost.Math quantile with the distribution object cached per degree of freedom

For the QuantLib implementations, the benchmark used `accuracy = 1e-12` and `maxIterations = 100`.

The accuracy grid used degrees of freedom: `1, 2, 3, 4, 5, 10, 30, 100, 1000`.

The accuracy grid used probabilities: `1e-15, 1e-12, 1e-10, 1e-9, 1e-8, 1e-6, 1e-4, 0.001, 0.01, 0.05, 0.10, 0.25, 0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1-1e-4, 1-1e-6, 1-1e-8, 1-1e-9, 1-1e-10, 1-1e-12, 1-1e-15`.

In the accuracy table, `Failed` means that the implementation either threw or returned a non-finite value for the tested input. In this benchmark, the 25 old-Newton failures were all exceptions for `n = 1000`, caused by non-finite intermediate values in the Newton iteration. This high number of degrees of freedom was included as a stress case to check robustness outside the common parameter range. The large tail errors shown separately are finite results, not counted as failures.

Timing used `std::chrono::steady_clock`; each row reports nanoseconds per call. A volatile checksum was accumulated to prevent calls from being optimized away. Direct Boost.Math with the distribution object cached per degree of freedom gave very similar timings to this PR implementation, so distribution construction was not a material cost in this benchmark.