### PR TITLE
Fix BondForward::spotIncome ex-coupon entitlement at both boundaries

### DIFF
--- a/ql/instruments/bondforward.cpp
+++ b/ql/instruments/bondforward.cpp
@@ -66,16 +66,20 @@ namespace QuantLib {
         /*
           the following assumes
           1. cashflows are in ascending order !
-          2. considers as income: all coupons paid between settlementDate()
-          and contract delivery/maturity date
+          2. considers as income: all coupons the holder is entitled to
+          between settlementDate() and contract delivery/maturity date.
+          When an ex-coupon date is given, entitlement follows it: a coupon
+          trading ex at spot settlement belongs to the seller, while a
+          coupon whose ex date has been reached by delivery belongs to the
+          holder even though it pays after delivery.
         */
         for (auto& i : cf) {
-            if (!i->hasOccurred(settlement, false)) {
-                if (i->hasOccurred(maturityDate_, false)) {
-                    income += i->amount() * incomeDiscountCurve->discount(i->date());
-                } else {
-                    break;
-                }
+            if (i->hasOccurred(settlement, false) || i->tradingExCoupon(settlement))
+                continue;
+            if (i->hasOccurred(maturityDate_, false) || i->tradingExCoupon(maturityDate_)) {
+                income += i->amount() * incomeDiscountCurve->discount(i->date());
+            } else {
+                break;
             }
         }
 


### PR DESCRIPTION
`BondForward::spotIncome` filtered income coupons with `hasOccurred` only. When the underlying bond carries an ex-coupon period (e.g. Australian ACGBs with their 7-day ex-interest window) this misattributes entitlement at both boundaries:

- a coupon trading **ex at spot settlement** was counted as income although the buyer never receives it (overstating carry and distorting implied repo rates);
- a coupon whose **ex date has been reached by the delivery date** was omitted although the holder receives it after delivery.

Both boundaries now consult `CashFlow::tradingExCoupon`, consistent with the treatment everywhere else in `CashFlows`. The dirty spot value and the negative accrued used by `cleanForwardPrice` were already ex-correct, so this only changes the income leg.

The full test suite passes unchanged. Found while validating ACGB forward pricing (negative accrual through the ex window) against exchange settlement prices; happy to add a test-suite case with an ex-coupon bond forward if that would help review.