### PR TITLE
Make Coupon::accruedDays consistent with accruedPeriod in the ex window

### DIFF
--- a/ql/cashflows/coupon.cpp
+++ b/ql/cashflows/coupon.cpp
@@ -71,6 +71,8 @@ namespace QuantLib {
     Date::serial_type Coupon::accruedDays(const Date& d) const {
         if (d <= accrualStartDate_ || d > paymentDate_) {
             return 0;
+        } else if (tradingExCoupon(d)) {
+            return -dayCounter().dayCount(d, std::max(d, accrualEndDate_));
         } else {
             return dayCounter().dayCount(accrualStartDate_,
                                          std::min(d, accrualEndDate_));


### PR DESCRIPTION
`Coupon::accruedPeriod` returns a negative year fraction between the ex-coupon date and the payment date, but `accruedDays` kept counting positive days from the accrual start, so the two inspectors report opposite signs for the same settlement date inside the ex window.

`accruedDays` now mirrors the `accruedPeriod` branch and returns minus the days from settlement to the accrual end — the day count that corresponds to the negative accrued amount.

Two-line change; the full test suite passes unchanged. Found while auditing ex-coupon behaviour for Australian government bonds (7-day ex-interest window, negative accrual).