### PR TITLE
Add `<vector>` header to `time/calendars/islamicholidays.cpp`

### DIFF
--- a/ql/time/calendars/islamicholidays.cpp
+++ b/ql/time/calendars/islamicholidays.cpp
@@ -19,6 +19,7 @@
 
 #include <ql/time/calendars/islamicholidays.hpp>
 #include <algorithm>
+#include <vector>
 
 namespace QuantLib {
 


### PR DESCRIPTION
A derived project of mine ([qlcal](https://github.com/qlcal/qlcal-r), an R package) failed compilation on a somewhat obscure / old / outdated platform (namely a macOS x86_64 that forces itself to keep an older SDK) which, sadly, is part of CRAN.  

I have been glancing at the error for a moment (see 'details' below) and it eventually dawned on me that it is simply missing the header `vector`.  Other files in the same directory get it by including `calendar.hpp`, here only `data.hpp` is included.  I do not have access to the test machine so at this point I cannot "prove" this fixes it yet I am fairly certain that this may address this cause of compilation failure.

<details>

```c++
clang++ -arch x86_64 -std=gnu++17 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I. -I../inst/include/ -DQL_USE_STD_SHARED_PTR -DQL_HIGH_RESOLUTION_DATE -DQL_USE_STD_OPTIONAL -I'/Volumes/Builds/packages/big-sur-x86_64/Rlib/4.5/Rcpp/include' -I'/Volumes/Builds/packages/big-sur-x86_64/Rlib/4.5/BH/include' -I/opt/R/x86_64/include    -fPIC  -falign-functions=64 -Wall -g -O2   -c ql/time/calendars/japan.cpp -o ql/time/calendars/japan.o
ql/time/calendars/islamicholidays.cpp:28:38: error: implicit instantiation of undefined template 'std::vector<QuantLib::Date>'
            static std::vector<Date> dates = {
                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/c++/v1/iosfwd:216:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
ql/time/calendars/islamicholidays.cpp:51:38: error: implicit instantiation of undefined template 'std::vector<QuantLib::Date>'
            static std::vector<Date> dates = {
                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/c++/v1/iosfwd:216:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
                           ^
2 errors generated.
make: *** [ql/time/calendars/islamicholidays.o] Error 1
make: *** Waiting for unfinished jobs....
ERROR: compilation failed for package ‘qlcal’
```

</details>