### PR TITLE
Optimize Jamshidian root finding

### DIFF
--- a/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -20,7 +20,7 @@
 
 #include <ql/math/solvers1d/brent.hpp>
 #include <ql/pricingengines/swaption/jamshidianswaptionengine.hpp>
-#include <utility>
+#include <cmath>
 
 namespace QuantLib {
 
@@ -30,28 +30,39 @@ namespace QuantLib {
                     Real nominal,
                     Time maturity,
                     Time valueTime,
-                    std::vector<Time> fixedPayTimes,
+                    const std::vector<Time>& fixedPayTimes,
                     const std::vector<Real>& amounts)
-        : strike_(nominal), maturity_(maturity), valueTime_(valueTime),
-          times_(std::move(fixedPayTimes)), amounts_(amounts), model_(model) {}
+        : strike_(nominal), discountRatios_(fixedPayTimes.size()),
+          rateCoefficients_(fixedPayTimes.size()), amounts_(amounts) {
+
+            const Real valueDiscount0 = model->discountBond(maturity, valueTime, 0.0);
+            const Real valueDiscount1 = model->discountBond(maturity, valueTime, 1.0);
+
+            // In an affine model, each discount-bond ratio is c * exp(d * x).
+            // Determine c and d once so that root evaluations only need an exponential.
+            for (Size i = 0; i < fixedPayTimes.size(); ++i) {
+                const Real discount0 = model->discountBond(maturity, fixedPayTimes[i], 0.0);
+                const Real discount1 = model->discountBond(maturity, fixedPayTimes[i], 1.0);
+                discountRatios_[i] = discount0 / valueDiscount0;
+                rateCoefficients_[i] =
+                    std::log((discount1 / valueDiscount1) / discountRatios_[i]);
+            }
+        }
+
+        Real discountBondRatio(Size i, Rate x) const {
+            return discountRatios_[i] * std::exp(rateCoefficients_[i] * x);
+        }
 
         Real operator()(Rate x) const {
             Real value = strike_;
-            Real B = model_->discountBond(maturity_, valueTime_, x);
-            Size size = times_.size();
-            for (Size i=0; i<size; i++) {
-                Real dbValue =
-                    model_->discountBond(maturity_, times_[i], x) / B;
-                value -= amounts_[i]*dbValue;
-            }
+            for (Size i = 0; i < discountRatios_.size(); ++i)
+                value -= amounts_[i] * discountBondRatio(i, x);
             return value;
         }
       private:
         Real strike_;
-        Time maturity_,valueTime_;
-        std::vector<Time> times_;
+        std::vector<Real> discountRatios_, rateCoefficients_;
         const std::vector<Real>& amounts_;
-        const ext::shared_ptr<OneFactorAffineModel>& model_;
     };
 
     void JamshidianSwaptionEngine::calculate() const {
@@ -110,14 +121,11 @@ namespace QuantLib {
         Size size = arguments_.fixedCoupons.size();
 
         Real value = 0.0;
-        Real B = model_->discountBond(maturity, valueTime, rStar);
         for (Size i=0; i<size; i++) {
             Real fixedPayTime =
                 dayCounter.yearFraction(referenceDate,
                                         arguments_.fixedPayDates[i]);
-            Real strike = model_->discountBond(maturity,
-                                               fixedPayTime,
-                                               rStar) / B;
+            Real strike = finder.discountBondRatio(i, rStar);
             // Looks like the swaption decomposed into individual options adjusted for maturity. Each individual option is valued by Hull-White (or other one-factor model).
             Real dboValue = model_->discountBondOption(
                                                w, strike, maturity, valueTime,
@@ -128,4 +136,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -35,11 +35,34 @@ namespace QuantLib {
         : strike_(nominal), discountRatios_(fixedPayTimes.size()),
           rateCoefficients_(fixedPayTimes.size()), amounts_(amounts) {
 
+            /* Optimization: Since for exercise time t_e
+
+               P(t_e,T;r) = A(t_e,T) exp(-B(t_e,T) r)
+
+               the bond-price ratios used here in operator() are
+
+               R_i(r) = P(t_e,T_i;r) / P(t_e,T_0;r)
+                      = (A(t_e,T_i) / A(t_e,T_0)) exp(-[B(t_e,T_i)-B(t_e,T_0)] r)
+
+               that is, they have the form
+
+               R_i(r) = c_i exp(d_i r)
+
+               where the c_i (discount ratios) and the d_i (rate coefficients) don't depend on r.
+
+               The loop below determines c_i and d_i for each i by plugging r=0 and r=1
+               in the formula, yielding
+
+               R_i(0) = c_i
+               R_i(1) = c_i exp(d_i)
+
+               from which we get c_i = R_i(0) and d_i = log(R_i(1) / R_i(0)) that can be stored
+               and used in discountBondRatio() to save computation time.
+            */
+
             const Real valueDiscount0 = model->discountBond(maturity, valueTime, 0.0);
             const Real valueDiscount1 = model->discountBond(maturity, valueTime, 1.0);
 
-            // In an affine model, each discount-bond ratio is c * exp(d * x).
-            // Determine c and d once so that root evaluations only need an exponential.
             for (Size i = 0; i < fixedPayTimes.size(); ++i) {
                 const Real discount0 = model->discountBond(maturity, fixedPayTimes[i], 0.0);
                 const Real discount1 = model->discountBond(maturity, fixedPayTimes[i], 1.0);


### PR DESCRIPTION
Optimize `JamshidianSwaptionEngine` by caching affine discount-bond ratio coefficients before running the Brent root solver.

I already patched my engine and works pretty well.

For a one-factor affine model, each discount-bond ratio has the form:

`P(t,T,x) / P(t,S,x) = c * exp(d * x)`

The coefficients are now computed once from rates 0 and 1. Root evaluations therefore require only an exponential instead of repeatedly calling the model for every cash flow.

The cached ratios are also reused when calculating the final bond-option strikes.

Local benchmark using 20,000 recalculations of a 5Y×10Y Hull–White European swaption:

  - Before: 0.489 seconds
  - After: 0.143 seconds