### PR TITLE
Add optional rounding precision to `OvernightIndexedSwap` and `MakeOIS`

### DIFF
--- a/ql/instruments/makeois.cpp
+++ b/ql/instruments/makeois.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2015 Paolo Mazzocchi
  Copyright (C) 2017 Joseph Jeisman
  Copyright (C) 2017 Fabrice Lecuyer
+ Copyright (C) 2026 Sergio Araujo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -141,7 +142,10 @@ namespace QuantLib {
                                       overnightSchedule,
                                       overnightIndex_, overnightSpread_,
                                       paymentLag_, paymentAdjustment_,
-                                      paymentCalendar_, telescopicValueDates_);
+                                      paymentCalendar_, telescopicValueDates_,
+                                      averagingMethod_, lookbackDays_,
+                                      lockoutDays_, applyObservationShift_,
+                                      roundingPrecision_);
             if (engine_ == nullptr) {
                 Handle<YieldTermStructure> disc =
                                     overnightIndex_->forwardingTermStructure();
@@ -165,9 +169,10 @@ namespace QuantLib {
                                  overnightSchedule,
                                  overnightIndex_, overnightSpread_,
                                  paymentLag_, paymentAdjustment_,
-                                 paymentCalendar_, telescopicValueDates_, 
+                                 paymentCalendar_, telescopicValueDates_,
                                  averagingMethod_, lookbackDays_,
-                                 lockoutDays_, applyObservationShift_));
+                                 lockoutDays_, applyObservationShift_,
+                                 roundingPrecision_));
 
         if (engine_ == nullptr) {
             Handle<YieldTermStructure> disc =
@@ -368,6 +373,11 @@ namespace QuantLib {
 
     MakeOIS& MakeOIS::withObservationShift(bool applyObservationShift) {
         applyObservationShift_ = applyObservationShift;
+        return *this;
+    }
+
+    MakeOIS& MakeOIS::withRoundingPrecision(const std::optional<Integer>& roundingPrecision) {
+        roundingPrecision_ = roundingPrecision;
         return *this;
     }
 

--- a/ql/instruments/makeois.hpp
+++ b/ql/instruments/makeois.hpp
@@ -4,6 +4,7 @@
  Copyright (C) 2009 Ferdinando Ametrano
  Copyright (C) 2017 Joseph Jeisman
  Copyright (C) 2017 Fabrice Lecuyer
+ Copyright (C) 2026 Sergio Araujo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -27,6 +28,7 @@
 #define quantlib_makeois_hpp
 
 #include <ql/instruments/overnightindexedswap.hpp>
+#include <ql/optional.hpp>
 #include <ql/time/dategenerationrule.hpp>
 #include <ql/termstructures/yieldtermstructure.hpp>
 
@@ -92,6 +94,7 @@ namespace QuantLib {
         MakeOIS& withLookbackDays(Natural lookbackDays);
         MakeOIS& withLockoutDays(Natural lockoutDays);
         MakeOIS& withObservationShift(bool applyObservationShift = true);
+        MakeOIS& withRoundingPrecision(const std::optional<Integer>& roundingPrecision);
 
         MakeOIS& withPricingEngine(
                               const ext::shared_ptr<PricingEngine>& engine);
@@ -133,6 +136,7 @@ namespace QuantLib {
         Natural lookbackDays_ = Null<Natural>();
         Natural lockoutDays_ = 0;
         bool applyObservationShift_ = false;
+        std::optional<Integer> roundingPrecision_;
     };
 
 }

--- a/ql/instruments/overnightindexedswap.cpp
+++ b/ql/instruments/overnightindexedswap.cpp
@@ -5,6 +5,7 @@
  Copyright (C) 2009 Ferdinando Ametrano
  Copyright (C) 2017 Joseph Jeisman
  Copyright (C) 2017 Fabrice Lecuyer
+ Copyright (C) 2026 Sergio Araujo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -41,7 +42,8 @@ namespace QuantLib {
                                                RateAveraging::Type averagingMethod,
                                                Natural lookbackDays,
                                                Natural lockoutDays,
-                                               bool applyObservationShift)
+                                               bool applyObservationShift,
+                                               const std::optional<Integer>& roundingPrecision)
     : OvernightIndexedSwap(type,
                            std::vector<Real>(1, nominal),
                            schedule,
@@ -56,7 +58,8 @@ namespace QuantLib {
                            averagingMethod,
                            lookbackDays,
                            lockoutDays,
-                           applyObservationShift) {}
+                           applyObservationShift,
+                           roundingPrecision) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                const std::vector<Real>& nominals,
@@ -72,7 +75,8 @@ namespace QuantLib {
                                                RateAveraging::Type averagingMethod,
                                                Natural lookbackDays,
                                                Natural lockoutDays,
-                                               bool applyObservationShift)
+                                               bool applyObservationShift,
+                                               const std::optional<Integer>& roundingPrecision)
     : OvernightIndexedSwap(type,
                            nominals,
                            schedule,
@@ -86,10 +90,11 @@ namespace QuantLib {
                            paymentAdjustment,
                            paymentCalendar,
                            telescopicValueDates,
-                           averagingMethod, 
-                           lookbackDays, 
-                           lockoutDays, 
-                           applyObservationShift) {}
+                           averagingMethod,
+                           lookbackDays,
+                           lockoutDays,
+                           applyObservationShift,
+                           roundingPrecision) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                Real nominal,
@@ -106,7 +111,8 @@ namespace QuantLib {
                                                RateAveraging::Type averagingMethod,
                                                Natural lookbackDays,
                                                Natural lockoutDays,
-                                               bool applyObservationShift)
+                                               bool applyObservationShift,
+                                               const std::optional<Integer>& roundingPrecision)
     : OvernightIndexedSwap(type,
                            std::vector<Real>(1, nominal),
                            std::move(fixedSchedule),
@@ -123,7 +129,8 @@ namespace QuantLib {
                            averagingMethod,
                            lookbackDays,
                            lockoutDays,
-                           applyObservationShift) {}
+                           applyObservationShift,
+                           roundingPrecision) {}
 
     OvernightIndexedSwap::OvernightIndexedSwap(Type type,
                                                std::vector<Real> fixedNominals,
@@ -141,7 +148,8 @@ namespace QuantLib {
                                                RateAveraging::Type averagingMethod,
                                                Natural lookbackDays,
                                                Natural lockoutDays,
-                                               bool applyObservationShift)
+                                               bool applyObservationShift,
+                                               const std::optional<Integer>& roundingPrecision)
     : FixedVsFloatingSwap(type, std::move(fixedNominals), std::move(fixedSchedule), fixedRate, std::move(fixedDC),
                           overnightNominals, std::move(overnightSchedule), overnightIndex,
                           spread, DayCounter(), paymentAdjustment, paymentLag, paymentCalendar),
@@ -150,9 +158,10 @@ namespace QuantLib {
                           telescopicValueDates_(telescopicValueDates),
                           averagingMethod_(averagingMethod),
                           lookbackDays_(lookbackDays), lockoutDays_(lockoutDays),
-                          applyObservationShift_(applyObservationShift) {
-        legs_[1] =
-            OvernightLeg(floatingSchedule(), overnightIndex_)
+                          applyObservationShift_(applyObservationShift),
+                          roundingPrecision_(roundingPrecision) {
+        OvernightLeg leg(floatingSchedule(), overnightIndex_);
+        leg
                 .withNotionals(overnightNominals)
                 .withSpreads(spread)
                 .withTelescopicValueDates(telescopicValueDates)
@@ -165,6 +174,13 @@ namespace QuantLib {
                 .withLookbackDays(lookbackDays_)
                 .withLockoutDays(lockoutDays_)
                 .withObservationShift(applyObservationShift_);
+        if (roundingPrecision_.has_value()) {
+            QL_REQUIRE(*roundingPrecision_ >= 0 && *roundingPrecision_ <= 16,
+                       "rounding precision (" << *roundingPrecision_ <<
+                       ") must be between 0 and 16");
+            leg.withRoundingPrecision(*roundingPrecision_);
+        }
+        legs_[1] = leg;
         for (const auto& c : legs_[1])
             registerWith(c);
     }

--- a/ql/instruments/overnightindexedswap.hpp
+++ b/ql/instruments/overnightindexedswap.hpp
@@ -5,6 +5,7 @@
  Copyright (C) 2009 Ferdinando Ametrano
  Copyright (C) 2017 Joseph Jeisman
  Copyright (C) 2017 Fabrice Lecuyer
+ Copyright (C) 2026 Sergio Araujo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -29,6 +30,7 @@
 
 #include <ql/cashflows/rateaveraging.hpp>
 #include <ql/instruments/fixedvsfloatingswap.hpp>
+#include <ql/optional.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/daycounter.hpp>
@@ -55,7 +57,8 @@ namespace QuantLib {
                              RateAveraging::Type averagingMethod = RateAveraging::Compound,
                              Natural lookbackDays = Null<Natural>(),
                              Natural lockoutDays = 0,
-                             bool applyObservationShift = false);
+                             bool applyObservationShift = false,
+                             const std::optional<Integer>& roundingPrecision = std::nullopt);
 
         OvernightIndexedSwap(Type type,
                              const std::vector<Real>& nominals,
@@ -71,7 +74,8 @@ namespace QuantLib {
                              RateAveraging::Type averagingMethod = RateAveraging::Compound,
                              Natural lookbackDays = Null<Natural>(),
                              Natural lockoutDays = 0,
-                             bool applyObservationShift = false);
+                             bool applyObservationShift = false,
+                             const std::optional<Integer>& roundingPrecision = std::nullopt);
 
         OvernightIndexedSwap(Type type,
                              Real nominal,
@@ -88,7 +92,8 @@ namespace QuantLib {
                              RateAveraging::Type averagingMethod = RateAveraging::Compound,
                              Natural lookbackDays = Null<Natural>(),
                              Natural lockoutDays = 0,
-                             bool applyObservationShift = false);
+                             bool applyObservationShift = false,
+                             const std::optional<Integer>& roundingPrecision = std::nullopt);
 
         OvernightIndexedSwap(Type type,
                              std::vector<Real> fixedNominals,
@@ -106,7 +111,8 @@ namespace QuantLib {
                              RateAveraging::Type averagingMethod = RateAveraging::Compound,
                              Natural lookbackDays = Null<Natural>(),
                              Natural lockoutDays = 0,
-                             bool applyObservationShift = false);
+                             bool applyObservationShift = false,
+                             const std::optional<Integer>& roundingPrecision = std::nullopt);
 
         //! \name Inspectors
         //@{
@@ -128,6 +134,7 @@ namespace QuantLib {
         Natural lookbackDays() const { return lookbackDays_; }
         Natural lockoutDays() const { return lockoutDays_; }
         bool applyObservationShift() const { return applyObservationShift_; }
+        std::optional<Integer> roundingPrecision() const { return roundingPrecision_; }
         //@}
 
         //! \name Results
@@ -146,6 +153,7 @@ namespace QuantLib {
         Natural lookbackDays_;
         Natural lockoutDays_;
         bool applyObservationShift_;
+        std::optional<Integer> roundingPrecision_;
     };
 
 }

--- a/test-suite/overnightindexedswap.cpp
+++ b/test-suite/overnightindexedswap.cpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2009 Roland Lichters
  Copyright (C) 2014 Peter Caspers
+ Copyright (C) 2026 Sergio Araujo
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -42,6 +43,7 @@
 #include <ql/cashflows/cashflows.hpp>
 #include <ql/cashflows/couponpricer.hpp>
 #include <ql/cashflows/overnightindexedcouponpricer.hpp>
+#include <ql/math/rounding.hpp>
 #include <ql/currencies/europe.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
 #include <ql/utilities/dataformatters.hpp>
@@ -154,7 +156,8 @@ struct CommonVars {
              bool telescopicValueDates,
              Date effectiveDate = Date(),
              Integer paymentLag = 0,
-             RateAveraging::Type averagingMethod = RateAveraging::Compound) {
+             RateAveraging::Type averagingMethod = RateAveraging::Compound,
+             const std::optional<Integer>& roundingPrecision = std::nullopt) {
         return MakeOIS(length, estrIndex, fixedRate, 0 * Days)
             .withEffectiveDate(effectiveDate == Date() ? settlement : effectiveDate)
             .withOvernightLegSpread(spread)
@@ -162,7 +165,8 @@ struct CommonVars {
             .withPaymentLag(paymentLag)
             .withDiscountingTermStructure(estrTermStructure)
             .withTelescopicValueDates(telescopicValueDates)
-            .withAveragingMethod(averagingMethod);
+            .withAveragingMethod(averagingMethod)
+            .withRoundingPrecision(roundingPrecision);
     }
 
     ext::shared_ptr<OvernightIndexedSwap>
@@ -1091,6 +1095,94 @@ BOOST_AUTO_TEST_CASE(testSettlementDaysEffectiveDateConflict) {
     ext::shared_ptr<OvernightIndexedSwap> swap3 =
         MakeOIS(5 * Years, index, 0.03);
     BOOST_CHECK(swap3->startDate() != Date());
+}
+
+BOOST_AUTO_TEST_CASE(testRoundingPrecision) {
+
+    BOOST_TEST_MESSAGE("Testing rounding of the compounded rate in overnight-indexed swaps...");
+
+    CommonVars vars;
+
+    Integer precision = 6;
+    Rate fixedRate = 0.03;
+    Period length = 2 * Years;
+
+    ext::shared_ptr<OvernightIndexedSwap> plainSwap =
+        vars.makeSwap(length, fixedRate, 0.0, false);
+    ext::shared_ptr<OvernightIndexedSwap> roundedSwap =
+        vars.makeSwap(length, fixedRate, 0.0, false, Date(), 0,
+                      RateAveraging::Compound, precision);
+
+    BOOST_CHECK(roundedSwap->roundingPrecision() == std::optional<Integer>(precision));
+    BOOST_CHECK(!plainSwap->roundingPrecision());
+
+    ClosestRounding round(precision);
+    bool anyRoundingApplied = false;
+    for (Size i = 0; i < roundedSwap->overnightLeg().size(); ++i) {
+        auto rounded = ext::dynamic_pointer_cast<Coupon>(roundedSwap->overnightLeg()[i]);
+        auto plain = ext::dynamic_pointer_cast<Coupon>(plainSwap->overnightLeg()[i]);
+
+        // the projected rate is not affected by the rounding...
+        if (std::fabs(rounded->rate() - plain->rate()) > 1.0e-15)
+            BOOST_ERROR("rounding changed the projected rate:"
+                        << std::setprecision(12)
+                        << "\n    without rounding: " << plain->rate()
+                        << "\n    with rounding:    " << rounded->rate());
+
+        // ...but the amount is computed off the rounded rate
+        Real expected = rounded->nominal() * round(rounded->rate()) * rounded->accrualPeriod();
+        if (std::fabs(rounded->amount() - expected) > 1.0e-10)
+            BOOST_ERROR("amount not consistent with the rounded rate:"
+                        << std::setprecision(12)
+                        << "\n    expected:   " << expected
+                        << "\n    calculated: " << rounded->amount());
+
+        if (rounded->amount() != plain->amount())
+            anyRoundingApplied = true;
+    }
+    if (!anyRoundingApplied)
+        BOOST_ERROR("all coupon amounts unchanged; "
+                    "rounding precision was not propagated to the overnight leg");
+
+    // the engine prices off the rounded amounts, so the leg NPV
+    // remains consistent with the discounted sum of the cashflows
+    Real calculated = roundedSwap->overnightLegNPV();
+    Real expectedNPV = 0.0;
+    for (const auto& cf : roundedSwap->overnightLeg())
+        expectedNPV += cf->amount() * vars.estrTermStructure->discount(cf->date());
+    if (std::fabs(calculated - expectedNPV) > 1.0e-10)
+        BOOST_ERROR("overnight-leg NPV inconsistent with discounted rounded cashflows:"
+                    << std::setprecision(12)
+                    << "\n    NPV:            " << calculated
+                    << "\n    discounted sum: " << expectedNPV);
+
+    // MakeOIS solves the ATM rate on the same rounded coupons the
+    // returned swap is built with, so the swap is at market
+    ext::shared_ptr<OvernightIndexedSwap> atmSwap =
+        vars.makeSwap(length, Null<Rate>(), 0.0, false, Date(), 0,
+                      RateAveraging::Compound, precision);
+    if (std::fabs(atmSwap->NPV()) > 1.0e-10)
+        BOOST_ERROR("ATM swap with rounding does not price to zero:"
+                    << std::setprecision(12)
+                    << "\n    NPV: " << atmSwap->NPV());
+
+    // the constructor propagates the rounding precision like MakeOIS
+    OvernightIndexedSwap ctorSwap(Swap::Payer, vars.nominal,
+                                  roundedSwap->fixedSchedule(),
+                                  fixedRate, vars.fixedEstrDayCount,
+                                  roundedSwap->overnightSchedule(),
+                                  vars.estrIndex, 0.0, 0, Following,
+                                  Calendar(), false, RateAveraging::Compound,
+                                  Null<Natural>(), 0, false, precision);
+    for (Size i = 0; i < ctorSwap.overnightLeg().size(); ++i) {
+        Real viaCtor = ctorSwap.overnightLeg()[i]->amount();
+        Real viaMakeOIS = roundedSwap->overnightLeg()[i]->amount();
+        if (viaCtor != viaMakeOIS)
+            BOOST_ERROR("constructor and MakeOIS produce different rounded amounts:"
+                        << std::setprecision(12)
+                        << "\n    constructor: " << viaCtor
+                        << "\n    MakeOIS:     " << viaMakeOIS);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up to #2624, which introduced an optional rounding precision for the compounded rate on `OvernightIndexedCoupon` and `OvernightLeg` (per the ISDA Compounding/Averaging Matrix — e.g. SONIA OIS rounds the period compounded rate to 4 decimal places in percent).

The parameter is currently only reachable at the leg/coupon level, so pricing a rounded OIS requires assembling a generic `Swap` from hand-built `FixedRateLeg`/`OvernightLeg` pieces and giving up the `OvernightIndexedSwap` API (`fairRate`, `fixedLegBPS`, rate-helper compatibility, and the SWIG-exposed constructor).

This PR:
- adds `const std::optional<Integer>& roundingPrecision = std::nullopt` as a trailing parameter on the four `OvernightIndexedSwap` constructors, forwarded to the internal `OvernightLeg` via `withRoundingPrecision` when set, plus a `roundingPrecision()` inspector (note: the precision is in decimal places of the decimal rate, so ISDA's 4 dp of percent for SONIA corresponds to 6);
- validates the precision range (`QL_REQUIRE` 0–16) in the swap constructor — outside \[0, 16\] the underlying `fast_pow10` lookup wraps around and coupon amounts silently become NaN or zero;
- adds `MakeOIS::withRoundingPrecision(const std::optional<Integer>&)` (optional-taking, so a reused builder can also reset it, following `MakeVanillaSwap::withIndexedCoupons`);
- makes the temporary swap used by `MakeOIS` for the ATM fair-rate solve consistent with the returned swap: it now receives `averagingMethod_`, `lookbackDays_`, `lockoutDays_`, `applyObservationShift_` and `roundingPrecision_` (previously it silently used defaults for all of these, so an ATM `MakeOIS` swap with e.g. lookback or rounding did not price to zero at its own fixed rate);
- adds a test case checking that the rounding propagates through both `MakeOIS` and the constructor, that `rate()` stays unrounded while `amount()` uses the rounded rate, that the leg NPV stays consistent with the discounted rounded cashflows, and that an ATM `MakeOIS` swap with rounding prices to zero.

Being a trailing optional parameter, existing code is unaffected (default keeps the current unrounded behaviour).

Built and ran `--run_test=QuantLibTests/OvernightIndexedSwapTests` locally on macOS/arm64 (clang, C++17): no errors detected.

Possible follow-ups (out of scope here, happy to do them next): exposing the parameter on `OISRateHelper` (as was done for lookback in #1998), forwarding `roundingPrecision()` in `FdmAffineModelSwapInnerValue`'s swap reconstruction, and the QuantLib-SWIG change for the language wrappers. One caveat worth noting for review: `fairSpread()` relies on the linear `legBPS` approximation, which under rounding is no longer exact (coupon amount is a step function of the spread), while `fairRate()` remains exact since the fixed leg is unrounded.
