### PR TITLE
Add explanatory comment to `defaultProbability` calculations

### DIFF
--- a/ql/termstructures/defaulttermstructure.cpp
+++ b/ql/termstructures/defaulttermstructure.cpp
@@ -107,6 +107,12 @@ namespace QuantLib {
         QL_REQUIRE(d1 <= d2,
                    "initial date (" << d1 << ") "
                    "later than final date (" << d2 << ")");
+        // We allow d1 to precede the reference date, which effectively assumes 
+        // that the default probability before the reference date is null. This 
+        // helps in cases where a coupon protection starts a couple of days before 
+        // the reference date due to date adjustments (for instance, when the 
+        // protection starts on a Saturday and the reference is rolled to the 
+        // following Monday).
         Probability p1 = d1 < referenceDate() ? 0.0 :
                                            defaultProbability(d1,extrapolate),
                     p2 = defaultProbability(d2,extrapolate);
@@ -120,6 +126,10 @@ namespace QuantLib {
         QL_REQUIRE(t1 <= t2,
                    "initial time (" << t1 << ") "
                    "later than final time (" << t2 << ")");
+        // We allow t1 to precede 0.0, which effectively assumes that the 
+        // default probability before the reference time is null. This helps in 
+        // cases where a coupon protection starts a couple of days before the 
+        // reference date due to date adjustments.
         Probability p1 = t1 < 0.0 ? 0.0 : defaultProbability(t1,extrapolate),
                     p2 = defaultProbability(t2,extrapolate);
         return p2 - p1;


### PR DESCRIPTION
Addresses issue #2591 by clarifying why the start date/time is allowed to precede the reference date/time.