### PR TITLE
Add Hong Kong holidays for 2026

### DIFF
--- a/ql/time/calendars/hongkong.cpp
+++ b/ql/time/calendars/hongkong.cpp
@@ -413,6 +413,21 @@ namespace QuantLib {
                 return false;
         }
 
+        // data from https://www.gov.hk/en/about/abouthk/holiday/2026.htm
+        if (y == 2026) {
+            if (// Lunar New Year
+                ((d >= 17 && d <= 19) && m == February)
+                // The day following Easter Monday
+                || (d == 7 && m == April)
+                // Buddha's birthday
+                || (d == 25 && m == May)
+                // Tuen Ng festival
+                || (d == 19 && m == June)
+                // Chung Yeung festival
+                || (d == 19 && m == October))
+                return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Adds the 2026 ad-hoc holidays for the Hong Kong calendar, following the pattern of the existing per-year blocks (the latest was 2025).

Dates are from the HK Government's official 2026 general holidays list, cited in a `// data from ...` comment above the block as was done for 2025:

- **Lunar New Year**: Feb 17–19 (Tue–Thu)
- **The day following Easter Monday**: Apr 7 — Ching Ming falls on Sunday Apr 5, so its substitute is Monday Apr 6, which coincides with Easter Monday (already covered by the rule-based section); the government therefore gazetted an additional general holiday on Tue Apr 7. This is the same Easter/Ching Ming overlap as 2015, and the entry uses the same comment wording as the existing 2015 block.
- **Buddha's birthday**: May 25 (Mon substitute; the day itself falls on Sunday May 24)
- **Tuen Ng festival**: Jun 19 (Fri)
- **Chung Yeung festival**: Oct 19 (Mon substitute; the festival falls on Sunday Oct 18)

Omitted, consistent with existing years:

- The day following Good Friday (Sat Apr 4) and the day following Mid-Autumn (Sat Sep 26) fall on Saturdays and are covered by `isWeekend` — matching how earlier year blocks (e.g. 2019, 2025) omit weekend-falling festival days.
- New Year's Day, Good Friday, Easter Monday, Labour Day, SAR Establishment Day, National Day, Christmas and Boxing Day are covered by the rule-based section above the year blocks.

The Apr 7 closure was additionally cross-checked against HKEX's own calendar, which shows it as a non-trading day.

Sources:
- https://www.gov.hk/en/about/abouthk/holiday/2026.htm
- https://www.hkex.com.hk/News/HKEX-Calendar?sc_lang=en&datefrom=2026-04-07
