### PR TITLE
Reduce temporary allocations in numerical methods

### DIFF
--- a/ql/math/randomnumbers/inversecumulativersg.hpp
+++ b/ql/math/randomnumbers/inversecumulativersg.hpp
@@ -83,10 +83,10 @@ namespace QuantLib {
     template <class USG, class IC>
     inline const typename InverseCumulativeRsg<USG, IC>::sample_type&
     InverseCumulativeRsg<USG, IC>::nextSequence() const {
-        const typename USG::sample_type& sample =
+        const auto& sample =
             uniformSequenceGenerator_.nextSequence();
         x_.weight = sample.weight;
-        for (auto i = 0; i < dimension_; i++) {
+        for (auto i = 0u; i < dimension_; i++) {
             x_.value[i] = ICD_(sample.value[i]);
         }
         return x_;

--- a/ql/math/randomnumbers/inversecumulativersg.hpp
+++ b/ql/math/randomnumbers/inversecumulativersg.hpp
@@ -83,10 +83,10 @@ namespace QuantLib {
     template <class USG, class IC>
     inline const typename InverseCumulativeRsg<USG, IC>::sample_type&
     InverseCumulativeRsg<USG, IC>::nextSequence() const {
-        typename USG::sample_type sample =
+        const typename USG::sample_type& sample =
             uniformSequenceGenerator_.nextSequence();
         x_.weight = sample.weight;
-        for (Size i = 0; i < dimension_; i++) {
+        for (auto i = 0; i < dimension_; i++) {
             x_.value[i] = ICD_(sample.value[i]);
         }
         return x_;

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -37,6 +37,7 @@ namespace QuantLib {
       lower_    (new Real[mesher->layout()->size()]),
       diag_     (new Real[mesher->layout()->size()]),
       upper_    (new Real[mesher->layout()->size()]),
+      temp_     (mesher->layout()->size()),
       mesher_(mesher) {
 
         std::vector<Size> newDim(mesher->layout()->dim());
@@ -45,13 +46,13 @@ namespace QuantLib {
         std::iter_swap(newSpacing.begin(), newSpacing.begin()+direction_);
 
         for (const auto& iter : *mesher->layout()) {
-            const Size i = iter.index();
+            const auto i = iter.index();
 
             i0_[i] = mesher->layout()->neighbourhood(iter, direction, -1);
             i2_[i] = mesher->layout()->neighbourhood(iter, direction,  1);
 
-            const std::vector<Size>& coordinates = iter.coordinates();
-            const Size newIndex =
+            const auto& coordinates = iter.coordinates();
+            const auto newIndex =
                   std::inner_product(coordinates.begin(), coordinates.end(),
                                      newSpacing.begin(), Size(0));
             reverseIndex_[newIndex] = i;
@@ -66,8 +67,9 @@ namespace QuantLib {
       lower_(new Real[m.mesher_->layout()->size()]),
       diag_ (new Real[m.mesher_->layout()->size()]),
       upper_(new Real[m.mesher_->layout()->size()]),
+      temp_ (m.mesher_->layout()->size()),
       mesher_(m.mesher_) {
-        const Size len = m.mesher_->layout()->size();
+        const auto len = m.mesher_->layout()->size();
         std::copy(m.i0_.get(), m.i0_.get() + len, i0_.get());
         std::copy(m.i2_.get(), m.i2_.get() + len, i2_.get());
         std::copy(m.reverseIndex_.get(), m.reverseIndex_.get()+len,
@@ -84,26 +86,27 @@ namespace QuantLib {
         i0_.swap(m.i0_); i2_.swap(m.i2_);
         reverseIndex_.swap(m.reverseIndex_);
         lower_.swap(m.lower_); diag_.swap(m.diag_); upper_.swap(m.upper_);
+        temp_.swap(m.temp_);
     }
 
     void TripleBandLinearOp::axpyb(const Array& a,
                                    const TripleBandLinearOp& x,
                                    const TripleBandLinearOp& y,
                                    const Array& b) {
-        const Size size = mesher_->layout()->size();
+        const auto size = mesher_->layout()->size();
 
         Real *diag(diag_.get());
         Real *lower(lower_.get());
         Real *upper(upper_.get());
 
-        const Real *y_diag (y.diag_.get());
-        const Real *y_lower(y.lower_.get());
-        const Real *y_upper(y.upper_.get());
+        const auto *y_diag (y.diag_.get());
+        const auto *y_lower(y.lower_.get());
+        const auto *y_upper(y.upper_.get());
 
         if (a.empty()) {
             if (b.empty()) {
                 //#pragma omp parallel for
-                for (Size i=0; i < size; ++i) {
+                for (auto i=0; i < size; ++i) {
                     diag[i]  = y_diag[i];
                     lower[i] = y_lower[i];
                     upper[i] = y_upper[i];
@@ -111,9 +114,9 @@ namespace QuantLib {
             }
             else {
                 Array::const_iterator bptr(b.begin());
-                const Size binc = (b.size() > 1) ? 1 : 0;
+                const auto binc = (b.size() > 1) ? 1 : 0;
                 //#pragma omp parallel for
-                for (Size i=0; i < size; ++i) {
+                for (auto i=0; i < size; ++i) {
                     diag[i]  = y_diag[i] + bptr[i*binc];
                     lower[i] = y_lower[i];
                     upper[i] = y_upper[i];
@@ -122,15 +125,15 @@ namespace QuantLib {
         }
         else if (b.empty()) {
             Array::const_iterator aptr(a.begin());
-            const Size ainc = (a.size() > 1) ? 1 : 0;
+            const auto ainc = (a.size() > 1) ? 1 : 0;
 
-            const Real *x_diag (x.diag_.get());
-            const Real *x_lower(x.lower_.get());
-            const Real *x_upper(x.upper_.get());
+            const auto *x_diag (x.diag_.get());
+            const auto *x_lower(x.lower_.get());
+            const auto *x_upper(x.upper_.get());
 
             //#pragma omp parallel for
-            for (Size i=0; i < size; ++i) {
-                const Real s = aptr[i*ainc];
+            for (auto i=0; i < size; ++i) {
+                const auto s = aptr[i*ainc];
                 diag[i]  = y_diag[i]  + s*x_diag[i];
                 lower[i] = y_lower[i] + s*x_lower[i];
                 upper[i] = y_upper[i] + s*x_upper[i];
@@ -138,18 +141,18 @@ namespace QuantLib {
         }
         else {
             Array::const_iterator bptr(b.begin());
-            const Size binc = (b.size() > 1) ? 1 : 0;
+            const auto binc = (b.size() > 1) ? 1 : 0;
 
             Array::const_iterator aptr(a.begin());
-            const Size ainc = (a.size() > 1) ? 1 : 0;
+            const auto ainc = (a.size() > 1) ? 1 : 0;
 
-            const Real *x_diag (x.diag_.get());
-            const Real *x_lower(x.lower_.get());
-            const Real *x_upper(x.upper_.get());
+            const auto *x_diag (x.diag_.get());
+            const auto *x_lower(x.lower_.get());
+            const auto *x_upper(x.upper_.get());
 
             //#pragma omp parallel for
-            for (Size i=0; i < size; ++i) {
-                const Real s = aptr[i*ainc];
+            for (auto i=0; i < size; ++i) {
+                const auto s = aptr[i*ainc];
                 diag[i]  = y_diag[i]  + s*x_diag[i] + bptr[i*binc];
                 lower[i] = y_lower[i] + s*x_lower[i];
                 upper[i] = y_upper[i] + s*x_upper[i];
@@ -160,9 +163,9 @@ namespace QuantLib {
     TripleBandLinearOp TripleBandLinearOp::add(const TripleBandLinearOp& m) const {
 
         TripleBandLinearOp retVal(direction_, mesher_);
-        const Size size = mesher_->layout()->size();
+        const auto size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (Size i=0; i < size; ++i) {
+        for (auto i=0; i < size; ++i) {
             retVal.lower_[i]= lower_[i] + m.lower_[i];
             retVal.diag_[i] = diag_[i]  + m.diag_[i];
             retVal.upper_[i]= upper_[i] + m.upper_[i];
@@ -178,8 +181,8 @@ namespace QuantLib {
 
         const Size size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (Size i=0; i < size; ++i) {
-            const Real s = u[i];
+        for (auto i=0; i < size; ++i) {
+            const auto s = u[i];
             retVal.lower_[i]= lower_[i]*s;
             retVal.diag_[i] = diag_[i]*s;
             retVal.upper_[i]= upper_[i]*s;
@@ -194,10 +197,10 @@ namespace QuantLib {
         TripleBandLinearOp retVal(direction_, mesher_);
 
         #pragma omp parallel for
-        for (long i=0; i < (long)size; ++i) {
-            const Real sm1 = i > 0? u[i-1] : 1.0;
-            const Real s0 = u[i];
-            const Real sp1 = i < (long)size-1? u[i+1] : 1.0;
+        for (auto i=0; i < size; ++i) {
+            const auto sm1 = i > 0? u[i-1] : 1.0;
+            const auto s0 = u[i];
+            const auto sp1 = i < size-1? u[i+1] : 1.0;
             retVal.lower_[i]= lower_[i]*sm1;
             retVal.diag_[i] = diag_[i]*s0;
             retVal.upper_[i]= upper_[i]*sp1;
@@ -210,9 +213,9 @@ namespace QuantLib {
 
         TripleBandLinearOp retVal(direction_, mesher_);
 
-        const Size size = mesher_->layout()->size();
+        const auto size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (Size i=0; i < size; ++i) {
+        for (auto i=0; i < size; ++i) {
             retVal.lower_[i]= lower_[i];
             retVal.upper_[i]= upper_[i];
             retVal.diag_[i] = diag_[i]+u[i];
@@ -224,15 +227,15 @@ namespace QuantLib {
     Array TripleBandLinearOp::apply(const Array& r) const {
         QL_REQUIRE(r.size() == mesher_->layout()->size(), "inconsistent length of r");
 
-        const Real* lptr = lower_.get();
-        const Real* dptr = diag_.get();
-        const Real* uptr = upper_.get();
-        const Size* i0ptr = i0_.get();
-        const Size* i2ptr = i2_.get();
+        const auto* lptr = lower_.get();
+        const auto* dptr = diag_.get();
+        const auto* uptr = upper_.get();
+        const auto* i0ptr = i0_.get();
+        const auto* i2ptr = i2_.get();
 
         array_type retVal(r.size());
         //#pragma omp parallel for
-        for (Size i=0; i < mesher_->layout()->size(); ++i) {
+        for (auto i=0; i < mesher_->layout()->size(); ++i) {
             retVal[i] = r[i0ptr[i]]*lptr[i]+r[i]*dptr[i]+r[i2ptr[i]]*uptr[i];
         }
 
@@ -240,10 +243,10 @@ namespace QuantLib {
     }
 
     SparseMatrix TripleBandLinearOp::toMatrix() const {
-        const Size n = mesher_->layout()->size();
+        const auto n = mesher_->layout()->size();
 
         SparseMatrix retVal(n, n, 3*n);
-        for (Size i=0; i < n; ++i) {
+        for (auto i=0; i < n; ++i) {
             retVal(i, i0_[i]) += lower_[i];
             retVal(i, i     ) += diag_[i];
             retVal(i, i2_[i]) += upper_[i];
@@ -266,36 +269,45 @@ namespace QuantLib {
         }
 #endif
 
-        Array retVal(r.size()), tmp(r.size());
+        const auto* lptr = lower_.get();
+        const auto* dptr = diag_.get();
+        const auto* uptr = upper_.get();
 
-        const Real* lptr = lower_.get();
-        const Real* dptr = diag_.get();
-        const Real* uptr = upper_.get();
+        // Thomas algorithm to solve a tridiagonal system.
+        const auto size = mesher_->layout()->size();
+        const auto solve = [&](const auto& index) {
+            Array result(size);
 
-        // Thomson algorithm to solve a tridiagonal system.
-        // Example code taken from Tridiagonalopertor and
-        // changed to fit for the triple band operator.
-        Size rim1 = reverseIndex_[0];
-        Real bet=1.0/(a*dptr[rim1]+b);
-        QL_REQUIRE(bet != 0.0, "division by zero");
-        retVal[reverseIndex_[0]] = r[rim1]*bet;
+            auto previous = index(0);
+            auto beta = a*dptr[previous] + b;
+            QL_REQUIRE(beta != 0.0, "division by zero");
+            beta = 1.0 / beta;
+            result[previous] = r[previous] * beta;
 
-        for (Size j=1; j<=mesher_->layout()->size()-1; j++){
-            const Size ri = reverseIndex_[j];
-            tmp[j] = a*uptr[rim1]*bet;
+            for (auto j=1; j<size; ++j) {
+                const auto current = index(j);
+                temp_[j] = a * uptr[previous] * beta;
 
-            bet=b+a*(dptr[ri]-tmp[j]*lptr[ri]);
-            QL_ENSURE(bet != 0.0, "division by zero");
-            bet=1.0/bet;
+                beta = b + a * (dptr[current] - temp_[j] * lptr[current]);
+                QL_ENSURE(beta != 0.0, "division by zero");
+                beta = 1.0 / beta;
 
-            retVal[ri] = (r[ri]-a*lptr[ri]*retVal[rim1])*bet;
-            rim1 = ri;
-        }
-        // cannot be j>=0 with Size j
-        for (Size j=mesher_->layout()->size()-2; j>0; --j)
-            retVal[reverseIndex_[j]] -= tmp[j+1]*retVal[reverseIndex_[j+1]];
-        retVal[reverseIndex_[0]] -= tmp[1]*retVal[reverseIndex_[1]];
+                result[current] =
+                    (r[current] - a*lptr[current]*result[previous]) * beta;
+                previous = current;
+            }
 
-        return retVal;
+            // j cannot be greater than or equal to zero when Size is unsigned.
+            for (auto j=size-2; j>0; --j)
+                result[index(j)] -= temp_[j+1] * result[index(j+1)];
+            result[index(0)] -= temp_[1] * result[index(1)];
+
+            return result;
+        };
+
+        // The first direction follows storage order and needs no index lookup.
+        if (direction_ == 0)
+            return solve([](Size i) { return i; });
+        return solve([this](Size i) { return reverseIndex_[i]; });
     }
 }

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.cpp
@@ -106,7 +106,7 @@ namespace QuantLib {
         if (a.empty()) {
             if (b.empty()) {
                 //#pragma omp parallel for
-                for (auto i=0; i < size; ++i) {
+                for (auto i=0u; i < size; ++i) {
                     diag[i]  = y_diag[i];
                     lower[i] = y_lower[i];
                     upper[i] = y_upper[i];
@@ -116,7 +116,7 @@ namespace QuantLib {
                 Array::const_iterator bptr(b.begin());
                 const auto binc = (b.size() > 1) ? 1 : 0;
                 //#pragma omp parallel for
-                for (auto i=0; i < size; ++i) {
+                for (auto i=0u; i < size; ++i) {
                     diag[i]  = y_diag[i] + bptr[i*binc];
                     lower[i] = y_lower[i];
                     upper[i] = y_upper[i];
@@ -132,7 +132,7 @@ namespace QuantLib {
             const auto *x_upper(x.upper_.get());
 
             //#pragma omp parallel for
-            for (auto i=0; i < size; ++i) {
+            for (auto i=0u; i < size; ++i) {
                 const auto s = aptr[i*ainc];
                 diag[i]  = y_diag[i]  + s*x_diag[i];
                 lower[i] = y_lower[i] + s*x_lower[i];
@@ -151,7 +151,7 @@ namespace QuantLib {
             const auto *x_upper(x.upper_.get());
 
             //#pragma omp parallel for
-            for (auto i=0; i < size; ++i) {
+            for (auto i=0u; i < size; ++i) {
                 const auto s = aptr[i*ainc];
                 diag[i]  = y_diag[i]  + s*x_diag[i] + bptr[i*binc];
                 lower[i] = y_lower[i] + s*x_lower[i];
@@ -165,7 +165,7 @@ namespace QuantLib {
         TripleBandLinearOp retVal(direction_, mesher_);
         const auto size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (auto i=0; i < size; ++i) {
+        for (auto i=0u; i < size; ++i) {
             retVal.lower_[i]= lower_[i] + m.lower_[i];
             retVal.diag_[i] = diag_[i]  + m.diag_[i];
             retVal.upper_[i]= upper_[i] + m.upper_[i];
@@ -181,7 +181,7 @@ namespace QuantLib {
 
         const Size size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (auto i=0; i < size; ++i) {
+        for (auto i=0u; i < size; ++i) {
             const auto s = u[i];
             retVal.lower_[i]= lower_[i]*s;
             retVal.diag_[i] = diag_[i]*s;
@@ -197,7 +197,7 @@ namespace QuantLib {
         TripleBandLinearOp retVal(direction_, mesher_);
 
         #pragma omp parallel for
-        for (auto i=0; i < size; ++i) {
+        for (auto i=0u; i < size; ++i) {
             const auto sm1 = i > 0? u[i-1] : 1.0;
             const auto s0 = u[i];
             const auto sp1 = i < size-1? u[i+1] : 1.0;
@@ -215,7 +215,7 @@ namespace QuantLib {
 
         const auto size = mesher_->layout()->size();
         //#pragma omp parallel for
-        for (auto i=0; i < size; ++i) {
+        for (auto i=0u; i < size; ++i) {
             retVal.lower_[i]= lower_[i];
             retVal.upper_[i]= upper_[i];
             retVal.diag_[i] = diag_[i]+u[i];
@@ -235,7 +235,7 @@ namespace QuantLib {
 
         array_type retVal(r.size());
         //#pragma omp parallel for
-        for (auto i=0; i < mesher_->layout()->size(); ++i) {
+        for (auto i=0u; i < mesher_->layout()->size(); ++i) {
             retVal[i] = r[i0ptr[i]]*lptr[i]+r[i]*dptr[i]+r[i2ptr[i]]*uptr[i];
         }
 
@@ -246,7 +246,7 @@ namespace QuantLib {
         const auto n = mesher_->layout()->size();
 
         SparseMatrix retVal(n, n, 3*n);
-        for (auto i=0; i < n; ++i) {
+        for (auto i=0u; i < n; ++i) {
             retVal(i, i0_[i]) += lower_[i];
             retVal(i, i     ) += diag_[i];
             retVal(i, i2_[i]) += upper_[i];
@@ -284,7 +284,7 @@ namespace QuantLib {
             beta = 1.0 / beta;
             result[previous] = r[previous] * beta;
 
-            for (auto j=1; j<size; ++j) {
+            for (auto j=1u; j<size; ++j) {
                 const auto current = index(j);
                 temp_[j] = a * uptr[previous] * beta;
 

--- a/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
+++ b/ql/methods/finitedifferences/operators/triplebandlinearop.hpp
@@ -70,6 +70,7 @@ namespace QuantLib {
         std::unique_ptr<Size[]> i0_, i2_;
         std::unique_ptr<Size[]> reverseIndex_;
         std::unique_ptr<Real[]> lower_, diag_, upper_;
+        mutable Array temp_; // reusable workspace for solve_splitting
 
         ext::shared_ptr<FdmMesher> mesher_;
     };

--- a/ql/methods/finitedifferences/schemes/craigsneydscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/craigsneydscheme.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
 
         auto y0 = y;
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
@@ -51,7 +51,7 @@ namespace QuantLib {
         auto yt = y0 + mu_*dt_*map_->apply_mixed(y-a);
         bcSet_.applyAfterApplying(yt);
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = yt - theta_*dt_*map_->apply_direction(i, a);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }

--- a/ql/methods/finitedifferences/schemes/craigsneydscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/craigsneydscheme.cpp
@@ -40,24 +40,24 @@ namespace QuantLib {
         Array y = a + dt_*map_->apply(a);
         bcSet_.applyAfterApplying(y);
 
-        Array y0 = y;
+        auto y0 = y;
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = y - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
 
         bcSet_.applyBeforeApplying(*map_);
-        Array yt = y0 + mu_*dt_*map_->apply_mixed(y-a);
+        auto yt = y0 + mu_*dt_*map_->apply_mixed(y-a);
         bcSet_.applyAfterApplying(yt);
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = yt - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = yt - theta_*dt_*map_->apply_direction(i, a);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
         bcSet_.applyAfterSolving(yt);
 
-        a = yt;
+        a = std::move(yt);
     }
 
     void CraigSneydScheme::setStep(Time dt) {

--- a/ql/methods/finitedifferences/schemes/douglasscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/douglasscheme.cpp
@@ -37,13 +37,13 @@ namespace QuantLib {
         Array y = a + dt_*map_->apply(a);
         bcSet_.applyAfterApplying(y);
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = y - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
         bcSet_.applyAfterSolving(y);
 
-        a = y;
+        a = std::move(y);
     }
 
     void DouglasScheme::setStep(Time dt) {

--- a/ql/methods/finitedifferences/schemes/douglasscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/douglasscheme.cpp
@@ -37,7 +37,7 @@ namespace QuantLib {
         Array y = a + dt_*map_->apply(a);
         bcSet_.applyAfterApplying(y);
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }

--- a/ql/methods/finitedifferences/schemes/hundsdorferscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/hundsdorferscheme.cpp
@@ -37,27 +37,27 @@ namespace QuantLib {
         bcSet_.setTime(std::max(0.0, t-dt_));
 
         bcSet_.applyBeforeApplying(*map_);
-        Array y = a + dt_*map_->apply(a);
+        auto y = a + dt_*map_->apply(a);
         bcSet_.applyAfterApplying(y);
 
-        Array y0 = y;
+        auto y0 = y;
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = y - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
 
         bcSet_.applyBeforeApplying(*map_);
-        Array yt = y0 + mu_*dt_*map_->apply(y-a);
+        auto yt = y0 + mu_*dt_*map_->apply(y-a);
         bcSet_.applyAfterApplying(yt);
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = yt - theta_*dt_*map_->apply_direction(i, y);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = yt - theta_*dt_*map_->apply_direction(i, y);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
         bcSet_.applyAfterSolving(yt);
 
-        a = yt;
+        a = std::move(yt);
     }
 
     void HundsdorferScheme::setStep(Time dt) {

--- a/ql/methods/finitedifferences/schemes/hundsdorferscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/hundsdorferscheme.cpp
@@ -42,7 +42,7 @@ namespace QuantLib {
 
         auto y0 = y;
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
@@ -51,7 +51,7 @@ namespace QuantLib {
         auto yt = y0 + mu_*dt_*map_->apply(y-a);
         bcSet_.applyAfterApplying(yt);
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = yt - theta_*dt_*map_->apply_direction(i, y);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }

--- a/ql/methods/finitedifferences/schemes/methodoflinesscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/methodoflinesscheme.cpp
@@ -35,15 +35,15 @@ namespace QuantLib {
         map_->setTime(t, t + 0.0001);
         bcSet_.applyBeforeApplying(*map_);
 
-        const Array dxdt = -map_->apply(Array(u.begin(), u.end()));
+        const auto dxdt = -map_->apply(Array(u.begin(), u.end()));
 
-        return std::vector<Real>(dxdt.begin(), dxdt.end());
+        return {dxdt.begin(), dxdt.end()};
     }
 
     void MethodOfLinesScheme::step(array_type& a, Time t) {
         QL_REQUIRE(t-dt_ > -1e-8, "a step towards negative time given");
 
-        const std::vector<Real> v =
+        const auto v =
            AdaptiveRungeKutta<Real>(eps_, relInitStepSize_*dt_)(
                [&](Time _t, const std::vector<Real>& _u){ return apply(_t, _u); },
                std::vector<Real>(a.begin(), a.end()),
@@ -53,7 +53,7 @@ namespace QuantLib {
 
         bcSet_.applyAfterSolving(y);
 
-        a = y;
+        a = std::move(y);
     }
 
     void MethodOfLinesScheme::setStep(Time dt) {

--- a/ql/methods/finitedifferences/schemes/modifiedcraigsneydscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/modifiedcraigsneydscheme.cpp
@@ -34,28 +34,28 @@ namespace QuantLib {
         bcSet_.setTime(std::max(0.0, t-dt_));
 
         bcSet_.applyBeforeApplying(*map_);
-        Array y = a + dt_*map_->apply(a);
+        auto y = a + dt_*map_->apply(a);
         bcSet_.applyAfterApplying(y);
 
-        Array y0 = y;
+        auto y0 = y;
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = y - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
 
         bcSet_.applyBeforeApplying(*map_);
-        Array yt =  y0 + mu_*dt_*map_->apply_mixed(y-a)
+        auto yt =  y0 + mu_*dt_*map_->apply_mixed(y-a)
                   +(0.5-mu_)*dt_*map_->apply(y-a);;
         bcSet_.applyAfterApplying(yt);
 
-        for (Size i=0; i < map_->size(); ++i) {
-            Array rhs = yt - theta_*dt_*map_->apply_direction(i, a);
+        for (auto i=0; i < map_->size(); ++i) {
+            auto rhs = yt - theta_*dt_*map_->apply_direction(i, a);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
         bcSet_.applyAfterSolving(yt);
 
-        a = yt;
+        a = std::move(yt);
     }
 
     void ModifiedCraigSneydScheme::setStep(Time dt) {

--- a/ql/methods/finitedifferences/schemes/modifiedcraigsneydscheme.cpp
+++ b/ql/methods/finitedifferences/schemes/modifiedcraigsneydscheme.cpp
@@ -39,7 +39,7 @@ namespace QuantLib {
 
         auto y0 = y;
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = y - theta_*dt_*map_->apply_direction(i, a);
             y = map_->solve_splitting(i, rhs, -theta_*dt_);
         }
@@ -49,7 +49,7 @@ namespace QuantLib {
                   +(0.5-mu_)*dt_*map_->apply(y-a);;
         bcSet_.applyAfterApplying(yt);
 
-        for (auto i=0; i < map_->size(); ++i) {
+        for (auto i=0u; i < map_->size(); ++i) {
             auto rhs = yt - theta_*dt_*map_->apply_direction(i, a);
             yt = map_->solve_splitting(i, rhs, -theta_*dt_);
         }

--- a/ql/methods/montecarlo/multipathgenerator.hpp
+++ b/ql/methods/montecarlo/multipathgenerator.hpp
@@ -119,7 +119,7 @@ namespace QuantLib {
             auto& path = next_.value;
 
             auto asset = process_->initialValues();
-            for (auto j=0; j<m; j++)
+            for (auto j=0u; j<m; j++)
                 path[j].front() = asset[j];
 
             Array temp(n);
@@ -127,7 +127,7 @@ namespace QuantLib {
 
             const auto& timeGrid = path[0].timeGrid();
             Time t, dt;
-            for (auto i = 1; i < path.pathSize(); i++) {
+            for (auto i = 1u; i < path.pathSize(); i++) {
                 auto offset = (i-1)*n;
                 t = timeGrid[i-1];
                 dt = timeGrid.dt(i-1);
@@ -142,7 +142,7 @@ namespace QuantLib {
                               temp.begin());
 
                 asset = process_->evolve(t, asset, dt, temp);
-                for (auto j=0; j<m; j++)
+                for (auto j=0u; j<m; j++)
                     path[j][i] = asset[j];
             }
             return next_;

--- a/ql/methods/montecarlo/multipathgenerator.hpp
+++ b/ql/methods/montecarlo/multipathgenerator.hpp
@@ -109,27 +109,26 @@ namespace QuantLib {
 
         } else {
 
-            typedef typename GSG::sample_type sequence_type;
-            const sequence_type& sequence_ =
+            const auto& sequence_ =
                 antithetic ? generator_.lastSequence()
                            : generator_.nextSequence();
 
-            Size m = process_->size();
-            Size n = process_->factors();
+            auto m = process_->size();
+            auto n = process_->factors();
 
-            MultiPath& path = next_.value;
+            auto& path = next_.value;
 
-            Array asset = process_->initialValues();
-            for (Size j=0; j<m; j++)
+            auto asset = process_->initialValues();
+            for (auto j=0; j<m; j++)
                 path[j].front() = asset[j];
 
             Array temp(n);
             next_.weight = sequence_.weight;
 
-            const TimeGrid& timeGrid = path[0].timeGrid();
+            const auto& timeGrid = path[0].timeGrid();
             Time t, dt;
-            for (Size i = 1; i < path.pathSize(); i++) {
-                Size offset = (i-1)*n;
+            for (auto i = 1; i < path.pathSize(); i++) {
+                auto offset = (i-1)*n;
                 t = timeGrid[i-1];
                 dt = timeGrid.dt(i-1);
                 if (antithetic)
@@ -143,7 +142,7 @@ namespace QuantLib {
                               temp.begin());
 
                 asset = process_->evolve(t, asset, dt, temp);
-                for (Size j=0; j<m; j++)
+                for (auto j=0; j<m; j++)
                     path[j][i] = asset[j];
             }
             return next_;

--- a/ql/methods/montecarlo/pathgenerator.hpp
+++ b/ql/methods/montecarlo/pathgenerator.hpp
@@ -122,8 +122,7 @@ namespace QuantLib {
     const typename PathGenerator<GSG>::sample_type&
     PathGenerator<GSG>::next(bool antithetic) const {
 
-        typedef typename GSG::sample_type sequence_type;
-        const sequence_type& sequence_ =
+        const auto& sequence_ =
             antithetic ? generator_.lastSequence()
                        : generator_.nextSequence();
 
@@ -131,23 +130,21 @@ namespace QuantLib {
             bb_.transform(sequence_.value.begin(),
                           sequence_.value.end(),
                           temp_.begin());
-        } else {
-            std::copy(sequence_.value.begin(),
-                      sequence_.value.end(),
-                      temp_.begin());
         }
+        const auto& increments =
+            brownianBridge_ ? temp_ : sequence_.value;
 
         next_.weight = sequence_.weight;
 
         Path& path = next_.value;
         path.front() = process_->x0();
 
-        for (Size i=1; i<path.length(); i++) {
-            Time t = timeGrid_[i-1];
-            Time dt = timeGrid_.dt(i-1);
+        for (auto i=1; i<path.length(); i++) {
+            auto t = timeGrid_[i-1];
+            auto dt = timeGrid_.dt(i-1);
             path[i] = process_->evolve(t, path[i-1], dt,
-                                       antithetic ? -temp_[i-1] :
-                                                     temp_[i-1]);
+                                       antithetic ? -increments[i-1] :
+                                                     increments[i-1]);
         }
 
         return next_;

--- a/ql/methods/montecarlo/pathgenerator.hpp
+++ b/ql/methods/montecarlo/pathgenerator.hpp
@@ -139,7 +139,7 @@ namespace QuantLib {
         Path& path = next_.value;
         path.front() = process_->x0();
 
-        for (auto i=1; i<path.length(); i++) {
+        for (auto i=1u; i<path.length(); i++) {
             auto t = timeGrid_[i-1];
             auto dt = timeGrid_.dt(i-1);
             path[i] = process_->evolve(t, path[i-1], dt,


### PR DESCRIPTION
This PR reduces avoidable allocations and copies in frequently used FDM and random-sequence code paths while preserving the numerical algorithms.

when testing 1 year ATM European Call 

engine
                                                                   master median      pr median
FDM, 600 x 600 grid                                   10.881 ms            9.794 ms
Monte Carlo 500,000 paths , 1 step            112.473 ms          101.287 ms

this is effective for mc when paths are big, in small paths we could not see improvement
