### PR TITLE
Check for non-zero leg BPS in `FloatFloatSwap` fair-spread calculations

### DIFF
--- a/ql/instruments/floatfloatswap.cpp
+++ b/ql/instruments/floatfloatswap.cpp
@@ -557,13 +557,13 @@ namespace QuantLib {
         }
 
         if (fairSpread1_ == Null<Spread>()) {
-            if (!legBPS_.empty() && legBPS_[0] != Null<Real>()) {
+            if (!legBPS_.empty() && legBPS_[0] != Null<Real>() && legBPS_[0] != 0.0) {
                 Real currentSpread = spread1_.empty() ? 0.0 : spread1_[0];
                 fairSpread1_ = currentSpread - NPV_/(legBPS_[0]/basisPoint);
             }
         }
         if (fairSpread2_ == Null<Spread>()) {
-            if (legBPS_.size() > 1 && legBPS_[1] != Null<Real>()) {
+            if (legBPS_.size() > 1 && legBPS_[1] != Null<Real>() && legBPS_[1] != 0.0) {
                 Real currentSpread = spread2_.empty() ? 0.0 : spread2_[0];
                 fairSpread2_ = currentSpread - NPV_/(legBPS_[1]/basisPoint);
             }

--- a/test-suite/floatfloatswap.cpp
+++ b/test-suite/floatfloatswap.cpp
@@ -247,6 +247,26 @@ BOOST_AUTO_TEST_CASE(testZeroBpsFairSpread) {
 }
 
 
+BOOST_AUTO_TEST_CASE(testExpiredSwapFairSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing float-float swap fair spread calculation for expired swap...");
+
+    CommonVars vars;
+    auto swap = vars.makeSwap(Swap::Payer, 0.0, 0.0, 10);
+
+    Settings::instance().evaluationDate() = vars.settlement + Period(20, Years);
+
+    BOOST_CHECK(swap->isExpired());
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread1(), Error,
+        ExpectedErrorMessage("fair spread 1 not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread2(), Error,
+        ExpectedErrorMessage("fair spread 2 not available"));
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/floatfloatswap.cpp
+++ b/test-suite/floatfloatswap.cpp
@@ -225,18 +225,25 @@ BOOST_AUTO_TEST_CASE(testFairSpreadPayerReceiverConsistency) {
 }
 
 
-BOOST_AUTO_TEST_CASE(testExpiredSwapFairSpread) {
+BOOST_AUTO_TEST_CASE(testZeroBpsFairSpread) {
 
     BOOST_TEST_MESSAGE(
-        "Testing float-float swap fair spread calculation for expired swap...");
+        "Testing float-float swap fair spread calculation with zero BPS...");
 
     CommonVars vars;
-    auto swap = vars.makeSwap(Swap::Payer, 0.0, 0.0, 10);
+    vars.nominal = 0.0;
+    auto swap = vars.makeSwap(Swap::Payer, 0.0, 0.0);
 
-    Settings::instance().evaluationDate() = vars.settlement + Period(20, Years);
+    BOOST_CHECK(!swap->isExpired());
+    BOOST_CHECK_EQUAL(swap->legBPS(0), 0.0);
+    BOOST_CHECK_EQUAL(swap->legBPS(1), 0.0);
 
-    BOOST_CHECK_THROW(swap->fairSpread1(), Error);
-    BOOST_CHECK_THROW(swap->fairSpread2(), Error);
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread1(), Error,
+        ExpectedErrorMessage("fair spread 1 not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread2(), Error,
+        ExpectedErrorMessage("fair spread 2 not available"));
 }
 
 

--- a/test-suite/floatfloatswap.cpp
+++ b/test-suite/floatfloatswap.cpp
@@ -225,6 +225,22 @@ BOOST_AUTO_TEST_CASE(testFairSpreadPayerReceiverConsistency) {
 }
 
 
+BOOST_AUTO_TEST_CASE(testExpiredSwapFairSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing float-float swap fair spread calculation for expired swap...");
+
+    CommonVars vars;
+    auto swap = vars.makeSwap(Swap::Payer, 0.0, 0.0, 10);
+
+    Settings::instance().evaluationDate() = vars.settlement + Period(20, Years);
+
+    BOOST_CHECK_THROW(swap->fairSpread1(), Error);
+    BOOST_CHECK_THROW(swap->fairSpread2(), Error);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
### Description
In `FloatFloatSwap::fetchResults()`, the fallback calculations for `fairSpread1_` and `fairSpread2_` check `!legBPS_.empty() && legBPS_[0] != Null<Real>()`. However, when a `FloatFloatSwap` is expired or has zero leg BPS (`legBPS_[0] == 0.0`), `legBPS_[0]` equals `0.0`. Dividing `NPV_` by `(legBPS_[0] / basisPoint)` results in division by zero (`NaN` / `-Inf`), causing `fairSpread1()` and `fairSpread2()` to return `NaN` or `-Inf` instead of throwing `"fair spread not available"`.

This PR adds `&& legBPS_[0] != 0.0` and `&& legBPS_[1] != 0.0` checks to prevent division by zero in `FloatFloatSwap::fetchResults()`, matching the safeguard pattern used in `FixedVsFloatingSwap`.

### Issue Fixed
Fixes division-by-zero bug in `FloatFloatSwap::fairSpread1()` and `FloatFloatSwap::fairSpread2()` when evaluating expired swaps or swaps with zero leg BPS.

### Changes
- **Core Fix**: Updated `ql/instruments/floatfloatswap.cpp` to check `legBPS_[0] != 0.0` and `legBPS_[1] != 0.0` before calculating fallback fair spreads.
- **Unit Test**: Added `testExpiredSwapFairSpread` test case in `test-suite/floatfloatswap.cpp` asserting that `fairSpread1()` and `fairSpread2()` throw `Error` for an expired swap.
