### PR TITLE
Add September 28 2026 Chuseok substitute holiday to South Korean calendar

### DIFF
--- a/ql/time/calendars/southkorea.cpp
+++ b/ql/time/calendars/southkorea.cpp
@@ -234,7 +234,7 @@ namespace QuantLib {
             || ((d == 28 || d == 29 || d == 30) && m == September && y == 2023)
             || ((d == 16 || d == 17 || d == 18) && m == September && y == 2024)
             || ((d ==  6 || d ==  7 || d ==  8) && m == October   && y == 2025)
-            || ((d == 24 || d == 25 || d == 26) && m == September && y == 2026)
+            || ((d >= 24 && d <= 28)            && m == September && y == 2026)
             || ((d == 14 || d == 15 || d == 16) && m == September && y == 2027)
             || ((d >=  2 && d <=  5)            && m == October   && y == 2028)
             || ((d >= 21 && d <= 24)            && m == September && y == 2029)

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -1700,6 +1700,7 @@ BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
     expectedHol.emplace_back(24, September, 2026);
     expectedHol.emplace_back(25, September, 2026);
     // expectedHol.emplace_back(26, September, 2026);    // Saturday
+    expectedHol.emplace_back(28, September, 2026);
     expectedHol.emplace_back(5, October, 2026);
     expectedHol.emplace_back(9, October, 2026);
     expectedHol.emplace_back(25, December, 2026);

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -2444,6 +2444,7 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(24, September, 2026);
     expectedHol.emplace_back(25, September, 2026);
     // expectedHol.emplace_back(26, September, 2026);    // Saturday
+    expectedHol.emplace_back(28, September, 2026);
     expectedHol.emplace_back(5, October, 2026);
     expectedHol.emplace_back(9, October, 2026);
     expectedHol.emplace_back(25, December, 2026);


### PR DESCRIPTION
### Description
In 2026, Harvest Moon Day (Chuseok) in South Korea falls on September 24, 25, and 26. Because September 26 falls on a Saturday, under South Korean public holiday regulations, September 28, 2026 (Monday) is designated as the official substitute public holiday (Alternative Holiday).

### Changes
- Updated `SouthKorea::SettlementImpl::isBusinessDay()` in `ql/time/calendars/southkorea.cpp` to include September 28, 2026 (`d >= 24 && d <= 28`).
- Updated expected settlement holiday test list in `test-suite/calendars.cpp` (`BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement)`).
