### PR TITLE
Add Padé approximation for the Riccati equation in the rough Heston model

### DIFF
--- a/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
@@ -88,14 +88,17 @@ namespace QuantLib {
 
     AnalyticRoughHestonEngine::AnalyticRoughHestonEngine(
         const ext::shared_ptr<RoughHestonModel>& model,
-        Size integrationOrder, Size timeSteps)
+        Size integrationOrder, 
+        Size timeSteps,
+        RoughHestonApproximation approximation)
     : GenericModelEngine<RoughHestonModel,
                          VanillaOption::arguments,
                          VanillaOption::results>(model),
       timeSteps_(timeSteps),
       integration_(Integration::gaussLaguerre(integrationOrder)),
       andersenPiterbargEpsilon_(1e-25),
-      alpha_(-0.5) {
+      alpha_(-0.5),
+      approximation_(approximation) {
         QL_REQUIRE(timeSteps > 0, "at least one time step required");
     }
 
@@ -104,14 +107,16 @@ namespace QuantLib {
         const Integration& integration,
         Size timeSteps,
         Real andersenPiterbargEpsilon,
-        Real alpha)
+        Real alpha,
+        RoughHestonApproximation approximation)
     : GenericModelEngine<RoughHestonModel,
                          VanillaOption::arguments,
                          VanillaOption::results>(model),
       timeSteps_(timeSteps),
       integration_(integration),
       andersenPiterbargEpsilon_(andersenPiterbargEpsilon),
-      alpha_(alpha) {
+      alpha_(alpha),
+      approximation_(approximation) {
         QL_REQUIRE(timeSteps > 0, "at least one time step required");
         QL_REQUIRE(alpha > -1.0 && alpha < 0.0,
                    "alpha (" << alpha << ") must be in (-1, 0)");
@@ -126,32 +131,212 @@ namespace QuantLib {
 
     std::complex<Real> AnalyticRoughHestonEngine::lnChF(
         const std::complex<Real>& z, Time t) const {
+        return approximation_ == Pade ? lnChFPade(z, t) : lnChFAdams(z, t);
+    }
+
+    // Coefficients of the non-fractional Riccati equation satisfied by the
+    // rough Heston h(z, t), shared by the Adams and Padè routes
+    AnalyticRoughHestonEngine::RiccatiCoefficients
+    AnalyticRoughHestonEngine::riccatiCoefficients(
+        const std::complex<Real>& z) const {
+
+        const Real kappa = model_->kappa();
+        const Real sigma = model_->sigma();
+        const Real rho   = model_->rho();
+
+        const std::complex<Real> i{0.0, 1.0};
+
+        const std::complex<Real> c0{-0.5 * z * (z + i)};
+        const std::complex<Real> c1{i * (rho * sigma) * z - kappa};
+        const Real c2{0.5 * sigma * sigma};
+
+        return {c0, c1, std::complex<Real>(c2)};
+    }
+
+    std::vector<std::complex<Real>> AnalyticRoughHestonEngine::solveAdamsRiccati(
+        const std::complex<Real>& z, Time t) const {
+
+        const Real a{model_->hurst() + 0.5};
+        const RiccatiCoefficients c{riccatiCoefficients(z)};
+
+        return FractionalAdams<std::complex<Real>>(a).solve(
+            [&](Real, const std::complex<Real>& x) -> std::complex<Real> {
+                return c.c0 + (c.c1 + c.c2 * x) * x;
+            },
+            std::complex<Real>(0.0), t, timeSteps_);
+    }
+
+    std::complex<Real> AnalyticRoughHestonEngine::lnChFAdams(
+        const std::complex<Real>& z, Time t) const {
 
         const Real kappa = model_->kappa();
         const Real theta = model_->theta();
-        const Real sigma = model_->sigma();
-        const Real rho   = model_->rho();
         const Real v0    = model_->v0();
         const Real a     = model_->hurst() + 0.5;
 
-        const std::complex<Real> c0{
-            -0.5 * z * (z + std::complex<Real>(0.0, 1.0))};
-
-        const std::complex<Real> c1{
-            std::complex<Real>(0.0, rho * sigma) * z - kappa};
-
-        const Real c2{0.5 * sigma * sigma};
-
-        const std::vector<std::complex<Real>> h{
-            FractionalAdams<std::complex<Real>>(a).solve(
-                [&](Real, const std::complex<Real>& x)
-                    -> std::complex<Real> { return c0 + (c1 + c2 * x) * x; },
-                std::complex<Real>(0.0), t, timeSteps_)};
+        const std::vector<std::complex<Real>> h{solveAdamsRiccati(z, t)};
 
         const Real dt{t / timeSteps_};
 
         return kappa * theta * riemannLiouvilleIntegral(h, 1.0, dt)
             + v0 * riemannLiouvilleIntegral(h, 1.0 - a, dt);
+    }
+
+    std::complex<Real> AnalyticRoughHestonEngine::lnChFPade(
+        const std::complex<Real>& z, Time t) const {
+
+        const Real kappa = model_->kappa();
+        const Real theta = model_->theta();
+        const Real sigma = model_->sigma();
+        const Real v0    = model_->v0();
+        const Real a     = model_->hurst() + 0.5;
+
+        const PadeCoefficients c{padeCoefficients(z)};
+
+        const Real dt{t / timeSteps_};
+
+        std::vector<std::complex<Real>> h(timeSteps_ + 1);
+        for (Size j{0}; j <= timeSteps_; ++j) {
+            h[j] = evaluatePade(c, sigma * std::pow(Real(j) * dt, a));
+        }
+
+        return kappa * theta * riemannLiouvilleIntegral(h, 1.0, dt)
+            + v0 * riemannLiouvilleIntegral(h, 1.0 - a, dt);
+    }
+
+    // (3, 3) global rational approximation of Gatheral-Radoicic
+    AnalyticRoughHestonEngine::PadeCoefficients
+    AnalyticRoughHestonEngine::padeCoefficients(
+        const std::complex<Real>& z) const {
+
+        const Real kappa = model_->kappa();
+        const Real sigma = model_->sigma();
+        const Real rho   = model_->rho();
+        const Real a     = model_->hurst() + 0.5;
+
+        const std::complex<Real> i{0.0, 1.0};
+
+        const RiccatiCoefficients rc{riccatiCoefficients(z)};
+        const std::complex<Real>& c0{rc.c0};
+        const std::complex<Real>& c1{rc.c1};
+        const Real c2{rc.c2.real()};
+
+        // c0 = -z(z+i)/2 vanishes exactly at z = 0 and z = -i. There,
+        // v = 0 solves the Riccati equation identically, so h is exactly 
+        // zero for all t. It also makes the long-time root gamma0 below 
+        // vanish, which degenerates the (3, 3) denominator system.
+        if (std::abs(c0) < 1e-14)
+            return {std::complex<Real>(0.0), std::complex<Real>(0.0),
+                    std::complex<Real>(0.0), std::complex<Real>(0.0),
+                    std::complex<Real>(0.0), std::complex<Real>(0.0)};
+
+        const GammaFunction g;
+
+        // reciprocal gamma 1 / Gamma(x), which vanishes at the poles
+        // 0, -1, -2, ...; keeps the long-time coefficients finite as
+        // a -> 1
+        const auto rGamma
+            = [&g](Real x) -> Real { return 1.0 / g.value(x); };
+
+        // Short-time Taylor coefficients beta_k = b_k / sigma^k of
+        // h = sum_k b_k t^(k a), rescaled to the variable y = sigma t^a
+        const std::complex<Real> b1{c0 * rGamma(1.0 + a)};
+        const std::complex<Real> b2{
+            c1 * b1 * (g.value(1.0 + a) / g.value(1.0 + 2.0 * a))};
+        const std::complex<Real> b3{
+            (c1 * b2 + c2 * b1 * b1)
+            * (g.value(1.0 + 2.0 * a) / g.value(1.0 + 3.0 * a))};
+
+        const std::complex<Real> beta1{b1 / sigma};
+        const std::complex<Real> beta2{b2 / (sigma * sigma)};
+        const std::complex<Real> beta3{b3 / (sigma * sigma * sigma)};
+
+        // Long-time coefficients gamma_k = g_k sigma^k: h -> r_- / sigma,
+        // the attracting root of the Riccati quadratic, with algebraic
+        // corrections in 1 / y.
+        const std::complex<Real> w{kappa / sigma - i * (rho * z)};
+        const std::complex<Real> A{std::sqrt(z * (z + i) + w * w)};
+
+        // A is the discriminant root separating the two fixed points of the
+        // Riccati quadratic; near z where they coincide (A -> 0), gamma_1 and
+        // gamma_2 below are ill-conditioned and the (3, 3) approximant is not
+        // reliable at this z.
+        QL_REQUIRE(std::abs(A) > 1e-8,
+                   "Padè approximation is singular at z = " << z
+                   << " (degenerate Riccati root); use the Adams "
+                   "predictor-corrector engine for this contour point");
+
+        const std::complex<Real> rMinus{w - A};
+
+        const std::complex<Real> gamma0{rMinus / sigma};
+        const std::complex<Real> gamma1{-gamma0 * rGamma(1.0 - a) / A};
+        const std::complex<Real> gamma2{
+            gamma0 * rGamma(1.0 - 2.0 * a) / (A * A)
+            + 0.5 * sigma * gamma1 * gamma1 / A};
+
+        // The two matching sets pin down the denominator (q_1, q_2, q_3)
+        // through a 3x3 complex linear system.
+        const auto det3
+            = [](const std::complex<Real>& a11, const std::complex<Real>& a12,
+                 const std::complex<Real>& a13, const std::complex<Real>& a21,
+                 const std::complex<Real>& a22, const std::complex<Real>& a23,
+                 const std::complex<Real>& a31, const std::complex<Real>& a32,
+                 const std::complex<Real>& a33) -> std::complex<Real> {
+            return a11 * (a22 * a33 - a23 * a32)
+                 - a12 * (a21 * a33 - a23 * a31)
+                 + a13 * (a21 * a32 - a22 * a31);
+        };
+
+        const std::complex<Real> det{det3(
+            gamma0, gamma1, gamma2, -beta1, gamma0, gamma1, -beta2, -beta1,
+            gamma0)};
+
+        QL_REQUIRE(std::abs(det) > 1e-12,
+                   "Padè denominator system is ill-conditioned at z = " << z
+                   << "; use the Adams predictor-corrector engine for this "
+                   "contour point");
+
+        const std::complex<Real> q1{det3(
+            beta1, gamma1, gamma2, beta2, gamma0, gamma1, beta3, -beta1,
+            gamma0) / det};
+        const std::complex<Real> q2{det3(
+            gamma0, beta1, gamma2, -beta1, beta2, gamma1, -beta2, beta3,
+            gamma0) / det};
+        const std::complex<Real> q3{det3(
+            gamma0, gamma1, beta1, -beta1, gamma0, beta2, -beta2, -beta1,
+            beta3) / det};
+
+        const std::complex<Real> p1{beta1};
+        const std::complex<Real> p2{beta2 + beta1 * q1};
+        const std::complex<Real> p3{beta3 + beta2 * q1 + beta1 * q2};
+
+        return {p1, p2, p3, q1, q2, q3};
+    }
+
+    std::complex<Real> AnalyticRoughHestonEngine::evaluatePade(
+        const PadeCoefficients& c, Real y) {
+        const std::complex<Real> num{y * (c.p1 + y * (c.p2 + y * c.p3))};
+        const std::complex<Real> den{1.0 + y * (c.q1 + y * (c.q2 + y * c.q3))};
+        return num / den;
+    }
+
+    std::complex<Real> AnalyticRoughHestonEngine::padeRiccati(
+        const std::complex<Real>& z, Time t) const {
+        const Real sigma = model_->sigma();
+        const Real a     = model_->hurst() + 0.5;
+        
+        return evaluatePade(padeCoefficients(z), sigma * std::pow(t, a));
+    }
+
+    std::complex<Real> AnalyticRoughHestonEngine::riccatiSolution(
+        const std::complex<Real>& z, Time t) const {
+
+        QL_REQUIRE(t > 0.0, "maturity must be positive");
+
+        if (approximation_ == Pade)
+            return padeRiccati(z, t);
+
+        return solveAdamsRiccati(z, t).back();
     }
 
     std::complex<Real> AnalyticRoughHestonEngine::chF(

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
@@ -90,7 +90,7 @@ namespace QuantLib {
         const ext::shared_ptr<RoughHestonModel>& model,
         Size integrationOrder, 
         Size timeSteps,
-        RoughHestonApproximation approximation)
+        Approximation approximation)
     : GenericModelEngine<RoughHestonModel,
                          VanillaOption::arguments,
                          VanillaOption::results>(model),
@@ -108,7 +108,7 @@ namespace QuantLib {
         Size timeSteps,
         Real andersenPiterbargEpsilon,
         Real alpha,
-        RoughHestonApproximation approximation)
+        Approximation approximation)
     : GenericModelEngine<RoughHestonModel,
                          VanillaOption::arguments,
                          VanillaOption::results>(model),
@@ -131,7 +131,7 @@ namespace QuantLib {
 
     std::complex<Real> AnalyticRoughHestonEngine::lnChF(
         const std::complex<Real>& z, Time t) const {
-        return approximation_ == RoughHestonApproximation::Pade
+        return approximation_ == Approximation::Pade
             ? lnChFPade(z, t) : lnChFAdams(z, t);
     }
 
@@ -339,7 +339,7 @@ namespace QuantLib {
 
         QL_REQUIRE(t > 0.0, "maturity must be positive");
 
-        if (approximation_ == RoughHestonApproximation::Pade) {
+        if (approximation_ == Approximation::Pade) {
             return padeRiccati(z, t);
         }
 

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
@@ -131,7 +131,8 @@ namespace QuantLib {
 
     std::complex<Real> AnalyticRoughHestonEngine::lnChF(
         const std::complex<Real>& z, Time t) const {
-        return approximation_ == Pade ? lnChFPade(z, t) : lnChFAdams(z, t);
+        return approximation_ == RoughHestonApproximation::Pade
+            ? lnChFPade(z, t) : lnChFAdams(z, t);
     }
 
     // Coefficients of the non-fractional Riccati equation satisfied by the
@@ -338,7 +339,7 @@ namespace QuantLib {
 
         QL_REQUIRE(t > 0.0, "maturity must be positive");
 
-        if (approximation_ == Pade) {
+        if (approximation_ == RoughHestonApproximation::Pade) {
             return padeRiccati(z, t);
         }
 

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.cpp
@@ -217,18 +217,19 @@ namespace QuantLib {
         const std::complex<Real> i{0.0, 1.0};
 
         const RiccatiCoefficients rc{riccatiCoefficients(z)};
-        const std::complex<Real>& c0{rc.c0};
-        const std::complex<Real>& c1{rc.c1};
+        const std::complex<Real> c0{rc.c0};
+        const std::complex<Real> c1{rc.c1};
         const Real c2{rc.c2.real()};
 
-        // c0 = -z(z+i)/2 vanishes exactly at z = 0 and z = -i. There,
+        // c0 = -z * (z + i) / 2 vanishes exactly at z = 0 and z = -i. There,
         // v = 0 solves the Riccati equation identically, so h is exactly 
-        // zero for all t. It also makes the long-time root gamma0 below 
-        // vanish, which degenerates the (3, 3) denominator system.
-        if (std::abs(c0) < 1e-14)
+        // zero for all t. It also makes the long-time root gamma0 vanish,
+        // which degenerates the (3, 3) system.
+        if (std::abs(c0) < 1e-14) {
             return {std::complex<Real>(0.0), std::complex<Real>(0.0),
                     std::complex<Real>(0.0), std::complex<Real>(0.0),
                     std::complex<Real>(0.0), std::complex<Real>(0.0)};
+        }
 
         const GammaFunction g;
 
@@ -260,10 +261,10 @@ namespace QuantLib {
         // A is the discriminant root separating the two fixed points of the
         // Riccati quadratic; near z where they coincide (A -> 0), gamma_1 and
         // gamma_2 below are ill-conditioned and the (3, 3) approximant is not
-        // reliable at this z.
+        // reliable here.
         QL_REQUIRE(std::abs(A) > 1e-8,
                    "Padè approximation is singular at z = " << z
-                   << " (degenerate Riccati root); use the Adams "
+                   << "; use the Adams "
                    "predictor-corrector engine for this contour point");
 
         const std::complex<Real> rMinus{w - A};
@@ -275,7 +276,10 @@ namespace QuantLib {
             + 0.5 * sigma * gamma1 * gamma1 / A};
 
         // The two matching sets pin down the denominator (q_1, q_2, q_3)
-        // through a 3x3 complex linear system.
+        // through a 3x3 complex linear system. QuantLib::determinant()
+        // only accepts a real-valued Matrix, so this closed-form cofactor
+        // expansion is used instead of routing through a boost::ublas LU
+        // decomposition for what is a fixed, known 3x3 size.
         const auto det3
             = [](const std::complex<Real>& a11, const std::complex<Real>& a12,
                  const std::complex<Real>& a13, const std::complex<Real>& a21,
@@ -317,6 +321,7 @@ namespace QuantLib {
         const PadeCoefficients& c, Real y) {
         const std::complex<Real> num{y * (c.p1 + y * (c.p2 + y * c.p3))};
         const std::complex<Real> den{1.0 + y * (c.q1 + y * (c.q2 + y * c.q3))};
+        
         return num / den;
     }
 
@@ -333,8 +338,9 @@ namespace QuantLib {
 
         QL_REQUIRE(t > 0.0, "maturity must be positive");
 
-        if (approximation_ == Pade)
+        if (approximation_ == Pade) {
             return padeRiccati(z, t);
+        }
 
         return solveAdamsRiccati(z, t).back();
     }

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -85,14 +85,15 @@ namespace QuantLib {
         typedef FourierIntegration Integration;
 
         //! route used to solve the fractional Riccati equation
-        enum RoughHestonApproximation { AdamsPredictorCorrector, Pade };
+        enum class RoughHestonApproximation { AdamsPredictorCorrector, Pade };
 
         //! Constructor using Gauss-Laguerre integration
         explicit AnalyticRoughHestonEngine(
             const ext::shared_ptr<RoughHestonModel>& model,
             Size integrationOrder = 128,
             Size timeSteps = 256,
-            RoughHestonApproximation approximation = AdamsPredictorCorrector);
+            RoughHestonApproximation approximation
+                = RoughHestonApproximation::AdamsPredictorCorrector);
 
         /*! Constructor giving full control over the Fourier integration
             algorithm. alpha is the payoff dampening exponent, which must
@@ -104,7 +105,8 @@ namespace QuantLib {
             Size timeSteps = 256,
             Real andersenPiterbargEpsilon = 1e-25,
             Real alpha = -0.5,
-            RoughHestonApproximation approximation = AdamsPredictorCorrector);
+            RoughHestonApproximation approximation
+                = RoughHestonApproximation::AdamsPredictorCorrector);
 
         void update() override;
         void calculate() const override;

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -31,6 +31,7 @@
 #include <complex>
 #include <map>
 #include <tuple>
+#include <vector>
 
 namespace QuantLib {
 
@@ -128,6 +129,15 @@ namespace QuantLib {
       private:
         class AP_Helper;
 
+        //! Coefficients c0, c1, c2 of the Riccati equation h' = c0 + c1 h + c2 h^2
+        struct RiccatiCoefficients {
+            std::complex<Real> c0, c1, c2;
+        };
+        RiccatiCoefficients riccatiCoefficients(const std::complex<Real>& z) const;
+
+        // fractional Adams solution grid h(z, j dt), j = 0, ..., timeSteps_
+        std::vector<std::complex<Real>> solveAdamsRiccati(const std::complex<Real>& z, Time t) const;
+
         /*! Coefficients of the (3, 3) Gatheral-Radoicic rational
             approximation \f$ h(z, t) = N(y) / D(y) \f$ with
             \f$ y = \sigma t^a \f$, matching the short-time series and
@@ -138,7 +148,7 @@ namespace QuantLib {
         };
         PadeCoefficients padeCoefficients(const std::complex<Real>& z) const;
         std::complex<Real> padeRiccati(const std::complex<Real>& z, Time t) const;
-        static std::complex<Real> evaluatePade( const PadeCoefficients& c, Real y);
+        static std::complex<Real> evaluatePade(const PadeCoefficients& c, Real y);
 
         std::complex<Real> lnChFAdams(const std::complex<Real>& z, Time t) const;
         std::complex<Real> lnChFPade(const std::complex<Real>& z, Time t) const;

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -48,9 +48,12 @@ namespace QuantLib {
         \note The fractional Adams scheme is the reference-quality but
               \f$ O(N^2) \f$ route to the characteristic function.  The
               Padè approximation is a closed form matching the short
-              and long-time asymptotics of the Riccati solution.  Future
-              pull requests will add other approximations, lifted Heston,
-              and forward-variance term structures.
+              and long-time asymptotics of the Riccati solution; it is
+              most precise for the strongly negative correlation typical of
+              equity indices and loses a few percent of accuracy as the
+              correlation moves towards zero or positive.  Future pull
+              requests will add other approximations, lifted Heston, and
+              forward-variance term structures.
 
         References:
 

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -85,15 +85,15 @@ namespace QuantLib {
         typedef FourierIntegration Integration;
 
         //! route used to solve the fractional Riccati equation
-        enum class RoughHestonApproximation { AdamsPredictorCorrector, Pade };
+        enum class Approximation { AdamsPredictorCorrector, Pade };
 
         //! Constructor using Gauss-Laguerre integration
         explicit AnalyticRoughHestonEngine(
             const ext::shared_ptr<RoughHestonModel>& model,
             Size integrationOrder = 128,
             Size timeSteps = 256,
-            RoughHestonApproximation approximation
-                = RoughHestonApproximation::AdamsPredictorCorrector);
+            Approximation approximation
+                = Approximation::AdamsPredictorCorrector);
 
         /*! Constructor giving full control over the Fourier integration
             algorithm. alpha is the payoff dampening exponent, which must
@@ -105,8 +105,8 @@ namespace QuantLib {
             Size timeSteps = 256,
             Real andersenPiterbargEpsilon = 1e-25,
             Real alpha = -0.5,
-            RoughHestonApproximation approximation
-                = RoughHestonApproximation::AdamsPredictorCorrector);
+            Approximation approximation
+                = Approximation::AdamsPredictorCorrector);
 
         void update() override;
         void calculate() const override;
@@ -165,7 +165,7 @@ namespace QuantLib {
         const Size timeSteps_;
         const Integration integration_;
         const Real andersenPiterbargEpsilon_, alpha_;
-        const RoughHestonApproximation approximation_;
+        const Approximation approximation_;
 
         mutable Size evaluations_{0};
         mutable std::map<std::tuple<Real, Real, Time>, std::complex<Real>>

--- a/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
+++ b/ql/pricingengines/vanilla/analyticroughhestonengine.hpp
@@ -38,15 +38,18 @@ namespace QuantLib {
     /*! The log-price characteristic function of the rough Heston model
         retains the affine structure of the classical Heston model, with
         the Riccati ODE replaced by a fractional Riccati equation.  This
-        engine solves the latter numerically with the Diethelm-Ford-Freed
-        Adams predictor-corrector scheme and prices European options with
-        the Andersen-Piterbarg Fourier integral and a Black-Scholes
-        control variate.
+        engine solves the latter either numerically with the reference
+        Diethelm-Ford-Freed Adams predictor-corrector scheme or the 
+        Padè approximation.  European options are priced with the
+        Andersen-Piterbarg Fourier integral and a Black-Scholes control
+        variate.
 
         \note The fractional Adams scheme is the reference-quality but
-              \f$ O(N^2) \f$ route to the characteristic function.  Future
-              pull requests will add faster approximations like Padè, 
-              lifted Heston, and forward-variance term structures.
+              \f$ O(N^2) \f$ route to the characteristic function.  The
+              Padè approximation is a closed form matching the short
+              and long-time asymptotics of the Riccati solution.  Future
+              pull requests will add other approximations, lifted Heston,
+              and forward-variance term structures.
 
         References:
 
@@ -57,13 +60,18 @@ namespace QuantLib {
         for the Numerical Solution of Fractional Differential Equations,
         Nonlinear Dynamics 29, 3-22 (2002).
 
+        J. Gatheral and R. Radoicic, Rational approximation of the rough
+        Heston solution, International Journal of Theoretical and Applied
+        Finance 22(3), 1950010 (2019).
+
         \ingroup vanillaengines
 
         \test the correctness of the returned value is tested by comparison
               against the classical Heston model for Hurst exponent
               \f$ H = \frac{1}{2} \f$, against values from an independent
               implementation, and by checking known qualitative properties
-              of rough volatility.
+              of rough volatility.  The Padè path is validated against the
+              Adams reference across the pricing contour.
     */
     class AnalyticRoughHestonEngine
         : public GenericModelEngine<RoughHestonModel,
@@ -72,11 +80,15 @@ namespace QuantLib {
       public:
         typedef FourierIntegration Integration;
 
+        //! route used to solve the fractional Riccati equation
+        enum RoughHestonApproximation { AdamsPredictorCorrector, Pade };
+
         //! Constructor using Gauss-Laguerre integration
         explicit AnalyticRoughHestonEngine(
             const ext::shared_ptr<RoughHestonModel>& model,
             Size integrationOrder = 128,
-            Size timeSteps = 256);
+            Size timeSteps = 256,
+            RoughHestonApproximation approximation = AdamsPredictorCorrector);
 
         /*! Constructor giving full control over the Fourier integration
             algorithm. alpha is the payoff dampening exponent, which must
@@ -87,7 +99,8 @@ namespace QuantLib {
             const Integration& integration,
             Size timeSteps = 256,
             Real andersenPiterbargEpsilon = 1e-25,
-            Real alpha = -0.5);
+            Real alpha = -0.5,
+            RoughHestonApproximation approximation = AdamsPredictorCorrector);
 
         void update() override;
         void calculate() const override;
@@ -105,10 +118,30 @@ namespace QuantLib {
         std::complex<Real> chF(const std::complex<Real>& z, Time t) const;
         std::complex<Real> lnChF(const std::complex<Real>& z, Time t) const;
 
+        /*! solution \f$ h(z, t) \f$ of the fractional Riccati equation,
+            computed by the route configured at construction
+        */
+        std::complex<Real> riccatiSolution(const std::complex<Real>& z, Time t) const;
+
         Size numberOfEvaluations() const;
 
       private:
         class AP_Helper;
+
+        /*! Coefficients of the (3, 3) Gatheral-Radoicic rational
+            approximation \f$ h(z, t) = N(y) / D(y) \f$ with
+            \f$ y = \sigma t^a \f$, matching the short-time series and
+            the long-time root of the Riccati solution
+        */
+        struct PadeCoefficients {
+            std::complex<Real> p1, p2, p3, q1, q2, q3;
+        };
+        PadeCoefficients padeCoefficients(const std::complex<Real>& z) const;
+        std::complex<Real> padeRiccati(const std::complex<Real>& z, Time t) const;
+        static std::complex<Real> evaluatePade( const PadeCoefficients& c, Real y);
+
+        std::complex<Real> lnChFAdams(const std::complex<Real>& z, Time t) const;
+        std::complex<Real> lnChFPade(const std::complex<Real>& z, Time t) const;
 
         Real priceVanillaPayoff(
             const ext::shared_ptr<PlainVanillaPayoff>& payoff,
@@ -117,6 +150,7 @@ namespace QuantLib {
         const Size timeSteps_;
         const Integration integration_;
         const Real andersenPiterbargEpsilon_, alpha_;
+        const RoughHestonApproximation approximation_;
 
         mutable Size evaluations_{0};
         mutable std::map<std::tuple<Real, Real, Time>, std::complex<Real>>

--- a/test-suite/roughhestonmodel.cpp
+++ b/test-suite/roughhestonmodel.cpp
@@ -743,7 +743,8 @@ BOOST_AUTO_TEST_CASE(testPadeRiccatiAsymptotics) {
         const auto model{ext::make_shared<RoughHestonModel>(
             rTS, qTS, s0, 0.04, kappa, 0.04, sigma, rho, hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
-            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+            model, 128, 256,
+            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
         for (const Real u : {0.5, 2.0, 5.0}) {
             const std::complex<Real> z(u, -0.5);
@@ -812,7 +813,8 @@ BOOST_AUTO_TEST_CASE(testPadeTrivialContour) {
         const auto model{ext::make_shared<RoughHestonModel>(
             rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
-            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+            model, 128, 256,
+            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
         for (const std::complex<Real> z :
              {std::complex<Real>(0.0, 0.0), std::complex<Real>(0.0, -1.0)}) {
@@ -859,9 +861,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsRiccati) {
 
             const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 1024,
-                AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
+                AnalyticRoughHestonEngine::RoughHestonApproximation::AdamsPredictorCorrector)};
             const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
-                model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+                model, 128, 256,
+                AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
             Real maxError{0.0};
             // pricing contour z = u - i/2 over the calibration-relevant band
@@ -912,9 +915,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsPricing) {
 
         const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 512,
-            AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
+            AnalyticRoughHestonEngine::RoughHestonApproximation::AdamsPredictorCorrector)};
         const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
-            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+            model, 128, 256,
+            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
         for (const auto& optionType : {Option::Call, Option::Put}) {
             for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
@@ -970,7 +974,7 @@ BOOST_AUTO_TEST_CASE(testPadeHestonLimit) {
     const auto roughModel{ext::make_shared<RoughHestonModel>(
         rTS, qTS, s0, v0, kappa, theta, sigma, rho, 0.5)};
     const auto padeEngine{ext::make_shared<AnalyticRoughHestonEngine>(
-        roughModel, 128, 256, AnalyticRoughHestonEngine::Pade)};
+        roughModel, 128, 256, AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
     const auto hestonModel{ext::make_shared<HestonModel>(
         ext::make_shared<HestonProcess>(
@@ -1035,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(testPadeMonotonicityAndBounds) {
     const auto model{ext::make_shared<RoughHestonModel>(
         rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, 0.1)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
-        model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+        model, 128, 256, AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
     // call prices stay monotone, convex and within the no-arbitrage box
     const Time t{1.0};
@@ -1101,7 +1105,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         rTS, qTS, s0, v0, kappa, theta, sigma, rho, hurst)};
     const auto trueEngine{ext::make_shared<AnalyticRoughHestonEngine>(
         trueModel, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Pade)};
+        AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
     std::vector<ext::shared_ptr<CalibrationHelper>> helpers;
     for (const Size months : {3, 6, 12, 24}) {
@@ -1131,7 +1135,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         rTS, qTS, s0, 0.04, 1.0, 0.02, 0.25, -0.4, 0.2)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
         model, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::Pade)};
+        AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
 
     for (const auto& helper : helpers)
         ext::static_pointer_cast<BlackCalibrationHelper>(helper)

--- a/test-suite/roughhestonmodel.cpp
+++ b/test-suite/roughhestonmodel.cpp
@@ -720,6 +720,455 @@ BOOST_AUTO_TEST_CASE(testCalibration) {
                     << "\n    tolerance:  " << hurstTol);
 }
 
+BOOST_AUTO_TEST_CASE(testPadeRiccatiAsymptotics) {
+    BOOST_TEST_MESSAGE(
+        "Testing short- and long-time asymptotics of the Pade Riccati "
+        "solution...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    const Real kappa{0.3}, sigma{0.4}, rho{-0.7};
+
+    for (const Real hurst : {0.1, 0.3}) {
+        const Real a{hurst + 0.5};
+
+        const auto model{ext::make_shared<RoughHestonModel>(
+            rTS, qTS, s0, 0.04, kappa, 0.04, sigma, rho, hurst)};
+        const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
+            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+        for (const Real u : {0.5, 2.0, 5.0}) {
+            const std::complex<Real> z(u, -0.5);
+            const std::complex<Real> i{0.0, 1.0};
+
+            // short-time leading term h(z, t) -> b_1 t^a with
+            // b_1 = -z * (z + i) / (2 * \Gamma(1 + a)); check the ratio h / t^a
+            const std::complex<Real> b1{
+                -0.5 * z * (z + i) / GammaFunction().value(1.0 + a)};
+
+            const Time tShort{1e-7};
+            const std::complex<Real> hShort{
+                engine->riccatiSolution(z, tShort)};
+            const std::complex<Real> ratio{hShort / std::pow(tShort, a)};
+
+            const Real shortTol{1e-3};
+            if (std::abs(ratio - b1) / std::abs(b1) > shortTol)
+                BOOST_ERROR("Pade Riccati short-time limit off"
+                            << "\n    u:          " << u
+                            << "\n    hurst:      " << hurst
+                            << "\n    h / t^a:    " << ratio
+                            << "\n    b_1:        " << b1
+                            << "\n    rel. tol.:  " << shortTol);
+
+            // long-time limit h(z, t) -> r_- / \sigma, the attracting root
+            // of the Riccati quadratic
+            const std::complex<Real> w{kappa / sigma - i * (rho * z)};
+            const std::complex<Real> A{std::sqrt(z * (z + i) + w * w)};
+            const std::complex<Real> g0{(w - A) / sigma};
+
+            const Time tLong{1e8};
+            const std::complex<Real> hLong{engine->riccatiSolution(z, tLong)};
+
+            const Real longTol{1e-3};
+            if (std::abs(hLong - g0) / std::abs(g0) > longTol)
+                BOOST_ERROR("Pade Riccati long-time limit off"
+                            << "\n    u:          " << u
+                            << "\n    hurst:      " << hurst
+                            << "\n    h(inf):     " << hLong
+                            << "\n    r_-/sigma:  " << g0
+                            << "\n    rel. tol.:  " << longTol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeTrivialContour) {
+    BOOST_TEST_MESSAGE(
+        "Testing the Pade Riccati solution against the exact solution on "
+        "the contour where the Riccati equation degenerates...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    // at z = 0 or z = -i, the Riccati forcing term c0 = -z * (z + i) / 2 vanishes
+    // identically, so h' = c_1 * h + c_2 * h^2 with h(0) = 0 has the exact,
+    // Pade-construction-independent solution h ≡ 0. This checks the (3, 3)
+    // approximation against ground truth derived directly from the ODE.
+    for (const Real hurst : {0.05, 0.2, 0.4}) {
+        const auto model{ext::make_shared<RoughHestonModel>(
+            rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, hurst)};
+        const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
+            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+        for (const std::complex<Real> z :
+             {std::complex<Real>(0.0, 0.0), std::complex<Real>(0.0, -1.0)}) {
+            for (const Time t : {0.01, 1.0, 5.0}) {
+                const std::complex<Real> h{engine->riccatiSolution(z, t)};
+
+                const Real tol{1e-10};
+                if (std::abs(h) > tol)
+                    BOOST_ERROR("Pade Riccati solution is not exactly zero "
+                                "on the degenerate contour"
+                                << "\n    hurst:      " << hurst
+                                << "\n    z:          " << z
+                                << "\n    maturity:   " << t
+                                << "\n    h:          " << h
+                                << "\n    tolerance:  " << tol);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsRiccati) {
+    BOOST_TEST_MESSAGE(
+        "Testing the Pade Riccati solution against the Adams reference...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    // The rational approximation is sharpest for small Hurst exponents,
+    // the empirically relevant regime; rho is swept through both signs
+    // since the long-time coefficients hinge on a root selection
+    // (w -/+ A) that could plausibly flip sign for some (kappa, sigma,
+    // rho) combinations
+    for (const Real hurst : {0.05, 0.1, 0.2}) {
+        for (const Real rho : {-0.7, 0.3}) {
+            const auto model{ext::make_shared<RoughHestonModel>(
+                rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, rho, hurst)};
+
+            const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
+                model, 128, 1024,
+                AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
+            const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
+                model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+            Real maxError{0.0};
+            // pricing contour z = u - i/2 over the calibration-relevant band
+            for (const Real u : {0.5, 1.0, 2.0, 5.0, 10.0, 20.0}) {
+                for (const Time t : {0.25, 1.0, 2.0}) {
+                    const std::complex<Real> z(u, -0.5);
+
+                    const std::complex<Real> ref{
+                        adams->riccatiSolution(z, t)};
+                    const std::complex<Real> approx{
+                        pade->riccatiSolution(z, t)};
+
+                    maxError = std::max(maxError,
+                                        std::abs(approx - ref) / std::abs(ref));
+                }
+            }
+
+            const Real tol{2e-2};
+            if (maxError > tol)
+                BOOST_ERROR("Pade Riccati solution deviates from the Adams "
+                            "reference"
+                            << "\n    hurst:          " << hurst
+                            << "\n    rho:            " << rho
+                            << "\n    max rel. error: " << maxError
+                            << "\n    tolerance:      " << tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsPricing) {
+    BOOST_TEST_MESSAGE(
+        "Testing Pade rough Heston prices against the Adams reference...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.03, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.01, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    for (const Real hurst : {0.05, 0.1, 0.2}) {
+      for (const Real rho : {-0.7, 0.3}) {
+        const auto model{ext::make_shared<RoughHestonModel>(
+            rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, rho, hurst)};
+
+        const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
+            model, 128, 512,
+            AnalyticRoughHestonEngine::AdamsPredictorCorrector)};
+        const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
+            model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+        for (const auto& optionType : {Option::Call, Option::Put}) {
+            for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
+                for (const Time t : {0.25, 1.0, 2.0}) {
+                    const auto payoff{ext::make_shared<PlainVanillaPayoff>(
+                        optionType, strike)};
+
+                    const Real ref{adams->priceVanillaPayoff(payoff, t)};
+                    const Real approx{pade->priceVanillaPayoff(payoff, t)};
+
+                    // a few basis points of the spot on prices of order
+                    // 1 to 30 for the strongly negative correlation the
+                    // approximation is designed for (rho = -0.7); the
+                    // wider tolerance accommodates the observed ~4x
+                    // larger error at rho = 0.3, still a few percent of
+                    // the spot, not a sign of a wrong root being picked
+                    const Real tol{5e-2};
+                    if (std::fabs(approx - ref) > tol)
+                        BOOST_ERROR("Pade price deviates from the Adams "
+                                    "reference"
+                                    << "\n    hurst:      " << hurst
+                                    << "\n    rho:        " << rho
+                                    << "\n    option:     " << optionType
+                                    << "\n    strike:     " << strike
+                                    << "\n    maturity:   " << t
+                                    << "\n    Pade:       " << approx
+                                    << "\n    Adams:      " << ref
+                                    << "\n    tolerance:  " << tol);
+                }
+            }
+        }
+      }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeHestonLimit) {
+    BOOST_TEST_MESSAGE(
+        "Testing the Pade rough Heston engine against classical Heston "
+        "for H = 0.5...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.05, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.02, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    const Real v0{0.05}, kappa{1.5}, theta{0.04}, sigma{0.5}, rho{-0.75};
+
+    const auto roughModel{ext::make_shared<RoughHestonModel>(
+        rTS, qTS, s0, v0, kappa, theta, sigma, rho, 0.5)};
+    const auto padeEngine{ext::make_shared<AnalyticRoughHestonEngine>(
+        roughModel, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+    const auto hestonModel{ext::make_shared<HestonModel>(
+        ext::make_shared<HestonProcess>(
+            rTS, qTS, s0, v0, kappa, theta, sigma, rho))};
+    const auto hestonEngine{
+        ext::make_shared<AnalyticHestonEngine>(hestonModel, 192)};
+
+    // the (3, 3) rational approximation is built for the rough regime and
+    // degrades towards the classical limit
+    for (const auto& optionType : {Option::Call, Option::Put}) {
+        for (const Real strike : {80.0, 90.0, 100.0, 110.0, 125.0}) {
+            for (const Size months : {6, 12, 24}) {
+                const Date maturity{today + Period(months, Months)};
+
+                VanillaOption option(
+                    ext::make_shared<PlainVanillaPayoff>(optionType, strike),
+                    ext::make_shared<EuropeanExercise>(maturity));
+
+                option.setPricingEngine(padeEngine);
+                const Real calculated{option.NPV()};
+
+                option.setPricingEngine(hestonEngine);
+                const Real expected{option.NPV()};
+
+                const Real tol{std::max(0.05, 0.04 * expected)};
+                if (std::fabs(calculated - expected) > tol)
+                    BOOST_ERROR("Pade limit fails to match classical Heston"
+                                << "\n    option:     " << optionType
+                                << "\n    strike:     " << strike
+                                << "\n    maturity:   " << maturity
+                                << "\n    Pade:       " << calculated
+                                << "\n    Heston:     " << expected
+                                << "\n    tolerance:  " << tol);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeMonotonicityAndBounds) {
+    BOOST_TEST_MESSAGE(
+        "Testing no-arbitrage bounds of the Pade engine...");
+
+    // put-call parity is exact by construction of priceVanillaPayoff (the
+    // call and put branches share cvValue + h_cv and differ only by the
+    // constant (fwd - strike) * df), independently of which route computes
+    // chF; it is already covered for that shared code path by the Adams
+    // testPutCallParity, so is not repeated here. Monotonicity and
+    // convexity, in contrast, depend on chF actually being numerically
+    // well-behaved across the whole integration contour, which is
+    // specific to the (3, 3) approximation and worth checking directly.
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.03, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.01, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    const auto model{ext::make_shared<RoughHestonModel>(
+        rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, 0.1)};
+    const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
+        model, 128, 256, AnalyticRoughHestonEngine::Pade)};
+
+    // call prices stay monotone, convex and within the no-arbitrage box
+    const Time t{1.0};
+    const Real fwd{s0->value() * qTS->discount(t) / rTS->discount(t)};
+    const Real df{rTS->discount(t)};
+
+    const std::vector<Real> strikes{
+        70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0};
+    std::vector<Real> prices;
+    for (Real k : strikes)
+        prices.push_back(engine->priceVanillaPayoff(
+            ext::make_shared<PlainVanillaPayoff>(Option::Call, k), t));
+
+    for (Size i{0}; i < strikes.size(); ++i) {
+        const Real lower{std::max(fwd - strikes[i], 0.0) * df};
+        const Real upper{fwd * df};
+
+        if (prices[i] < lower - 1e-8 || prices[i] > upper + 1e-8)
+            BOOST_ERROR("Pade call price violates no-arbitrage bounds"
+                        << "\n    strike: " << strikes[i]
+                        << "\n    price:  " << prices[i]);
+
+        if (i > 0 && prices[i] > prices[i - 1] + 1e-8)
+            BOOST_ERROR("Pade call price not decreasing in strike"
+                        << "\n    strike: " << strikes[i - 1] << " -> "
+                        << strikes[i]);
+
+        if (i > 0 && i + 1 < strikes.size()) {
+            const Real secondDiff{
+                prices[i + 1] - 2 * prices[i] + prices[i - 1]};
+            if (secondDiff < -1e-6)
+                BOOST_ERROR("Pade call price not convex in strike"
+                            << "\n    strike:            " << strikes[i]
+                            << "\n    second difference: " << secondDiff);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testPadeCalibration) {
+    BOOST_TEST_MESSAGE(
+        "Testing rough Heston calibration through the fast Pade engine...");
+
+    const Date today(2, July, 2026);
+    Settings::instance().evaluationDate() = today;
+    const DayCounter dc{Actual365Fixed()};
+    const Calendar calendar{NullCalendar()};
+
+    const Handle<YieldTermStructure> rTS(
+        ext::make_shared<FlatForward>(today, 0.02, dc));
+    const Handle<YieldTermStructure> qTS(
+        ext::make_shared<FlatForward>(today, 0.0, dc));
+    const Handle<Quote> s0(ext::make_shared<SimpleQuote>(100.0));
+
+    const Real v0{0.0225}, kappa{0.6}, theta{0.04};
+    const Real sigma{0.35}, rho{-0.65}, hurst{0.12};
+
+    const Size integrationOrder{64}, timeSteps{256};
+
+    // the synthetic surface is generated with the same Pade engine, so the
+    // round trip isolates the optimizer's ability to recover parameters
+    // from the fast approximation itself
+    const auto trueModel{ext::make_shared<RoughHestonModel>(
+        rTS, qTS, s0, v0, kappa, theta, sigma, rho, hurst)};
+    const auto trueEngine{ext::make_shared<AnalyticRoughHestonEngine>(
+        trueModel, integrationOrder, timeSteps,
+        AnalyticRoughHestonEngine::Pade)};
+
+    std::vector<ext::shared_ptr<CalibrationHelper>> helpers;
+    for (const Size months : {3, 6, 12, 24}) {
+        const Period maturity(months, Months);
+        const Date maturityDate{today + maturity};
+        const Time t{dc.yearFraction(today, maturityDate)};
+
+        const Real fwd{s0->value() * qTS->discount(maturityDate)
+            / rTS->discount(maturityDate)};
+        const DiscountFactor df{rTS->discount(maturityDate)};
+
+        for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
+            const Real price{trueEngine->priceVanillaPayoff(
+                ext::make_shared<PlainVanillaPayoff>(Option::Call, strike),
+                maturityDate)};
+            const Volatility impliedVol{blackFormulaImpliedStdDev(
+                Option::Call, strike, fwd, price, df) / std::sqrt(t)};
+
+            helpers.push_back(ext::make_shared<HestonModelHelper>(
+                maturity, calendar, s0, strike,
+                Handle<Quote>(ext::make_shared<SimpleQuote>(impliedVol)),
+                rTS, qTS, BlackCalibrationHelper::ImpliedVolError));
+        }
+    }
+
+    const auto model{ext::make_shared<RoughHestonModel>(
+        rTS, qTS, s0, 0.04, 1.0, 0.02, 0.25, -0.4, 0.2)};
+    const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
+        model, integrationOrder, timeSteps,
+        AnalyticRoughHestonEngine::Pade)};
+
+    for (const auto& helper : helpers)
+        ext::static_pointer_cast<BlackCalibrationHelper>(helper)
+            ->setPricingEngine(engine);
+
+    LevenbergMarquardt om(1e-8, 1e-8, 1e-8);
+    model->calibrate(helpers, om,
+                     EndCriteria(400, 40, 1.0e-8, 1.0e-8, 1.0e-8));
+
+    Real sse{0.0};
+    for (const auto& helper : helpers) {
+        const Real error{
+            ext::static_pointer_cast<BlackCalibrationHelper>(helper)
+                ->calibrationError()};
+        sse += error * error;
+    }
+
+    const Real expectedSse{1e-8};
+    if (sse > expectedSse)
+        BOOST_ERROR("failed to calibrate the Pade rough Heston model"
+                    << "\n    sse:      " << sse
+                    << "\n    expected: less than " << expectedSse
+                    << "\n    v0:    " << model->v0()    << " vs " << v0
+                    << "\n    kappa: " << model->kappa() << " vs " << kappa
+                    << "\n    theta: " << model->theta() << " vs " << theta
+                    << "\n    sigma: " << model->sigma() << " vs " << sigma
+                    << "\n    rho:   " << model->rho()   << " vs " << rho
+                    << "\n    hurst: " << model->hurst() << " vs " << hurst);
+
+    const Real hurstTol{0.02};
+    if (std::fabs(model->hurst() - hurst) > hurstTol)
+        BOOST_ERROR("failed to recover the Hurst exponent through Pade"
+                    << "\n    calculated: " << model->hurst()
+                    << "\n    expected:   " << hurst
+                    << "\n    tolerance:  " << hurstTol);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/roughhestonmodel.cpp
+++ b/test-suite/roughhestonmodel.cpp
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE(testPadeRiccatiAsymptotics) {
             rTS, qTS, s0, 0.04, kappa, 0.04, sigma, rho, hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+            AnalyticRoughHestonEngine::Approximation::Pade)};
 
         for (const Real u : {0.5, 2.0, 5.0}) {
             const std::complex<Real> z(u, -0.5);
@@ -814,7 +814,7 @@ BOOST_AUTO_TEST_CASE(testPadeTrivialContour) {
             rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, hurst)};
         const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+            AnalyticRoughHestonEngine::Approximation::Pade)};
 
         for (const std::complex<Real> z :
              {std::complex<Real>(0.0, 0.0), std::complex<Real>(0.0, -1.0)}) {
@@ -861,10 +861,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsRiccati) {
 
             const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 1024,
-                AnalyticRoughHestonEngine::RoughHestonApproximation::AdamsPredictorCorrector)};
+                AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
             const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
                 model, 128, 256,
-                AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+                AnalyticRoughHestonEngine::Approximation::Pade)};
 
             Real maxError{0.0};
             // pricing contour z = u - i/2 over the calibration-relevant band
@@ -915,10 +915,10 @@ BOOST_AUTO_TEST_CASE(testPadeAgainstAdamsPricing) {
 
         const auto adams{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 512,
-            AnalyticRoughHestonEngine::RoughHestonApproximation::AdamsPredictorCorrector)};
+            AnalyticRoughHestonEngine::Approximation::AdamsPredictorCorrector)};
         const auto pade{ext::make_shared<AnalyticRoughHestonEngine>(
             model, 128, 256,
-            AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+            AnalyticRoughHestonEngine::Approximation::Pade)};
 
         for (const auto& optionType : {Option::Call, Option::Put}) {
             for (const Real strike : {80.0, 90.0, 100.0, 110.0, 120.0}) {
@@ -974,7 +974,7 @@ BOOST_AUTO_TEST_CASE(testPadeHestonLimit) {
     const auto roughModel{ext::make_shared<RoughHestonModel>(
         rTS, qTS, s0, v0, kappa, theta, sigma, rho, 0.5)};
     const auto padeEngine{ext::make_shared<AnalyticRoughHestonEngine>(
-        roughModel, 128, 256, AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+        roughModel, 128, 256, AnalyticRoughHestonEngine::Approximation::Pade)};
 
     const auto hestonModel{ext::make_shared<HestonModel>(
         ext::make_shared<HestonProcess>(
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(testPadeMonotonicityAndBounds) {
     const auto model{ext::make_shared<RoughHestonModel>(
         rTS, qTS, s0, 0.04, 0.3, 0.04, 0.4, -0.7, 0.1)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
-        model, 128, 256, AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+        model, 128, 256, AnalyticRoughHestonEngine::Approximation::Pade)};
 
     // call prices stay monotone, convex and within the no-arbitrage box
     const Time t{1.0};
@@ -1105,7 +1105,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         rTS, qTS, s0, v0, kappa, theta, sigma, rho, hurst)};
     const auto trueEngine{ext::make_shared<AnalyticRoughHestonEngine>(
         trueModel, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+        AnalyticRoughHestonEngine::Approximation::Pade)};
 
     std::vector<ext::shared_ptr<CalibrationHelper>> helpers;
     for (const Size months : {3, 6, 12, 24}) {
@@ -1135,7 +1135,7 @@ BOOST_AUTO_TEST_CASE(testPadeCalibration) {
         rTS, qTS, s0, 0.04, 1.0, 0.02, 0.25, -0.4, 0.2)};
     const auto engine{ext::make_shared<AnalyticRoughHestonEngine>(
         model, integrationOrder, timeSteps,
-        AnalyticRoughHestonEngine::RoughHestonApproximation::Pade)};
+        AnalyticRoughHestonEngine::Approximation::Pade)};
 
     for (const auto& helper : helpers)
         ext::static_pointer_cast<BlackCalibrationHelper>(helper)


### PR DESCRIPTION
Adds a closed-form Gatheral-Radoicic rational Padé approximation as a second route to solve the fractional Riccati equation in `AnalyticRoughHestonEngine` alongside the existing fractional Adams predictor-corrector. Shared Riccati-coefficient logic is factored out so both routes reuse the same c0, c1, c2 derivation; the Padé path is closed-form rather than an ODE solve, trading small accuracy degredation for faster characteristic-function evaluation.

Tests validate the Padé Riccati solution against its known short-/long-time asymptotics and its exact zero on the degenerate contour, cross-check it against the Adams reference at both the Riccati and priced-option level, confirm it recovers classical Heston at $H = 0.5$, verify prices stay monotone/convex/arbitrage-free, and confirm calibration can recover model parameters through the fast engine.