### PR TITLE
Add South Korea Constitution Day (from 2026) and June 2026 election holiday

### DIFF
--- a/ql/time/calendars/southkorea.cpp
+++ b/ql/time/calendars/southkorea.cpp
@@ -71,8 +71,8 @@ namespace QuantLib {
             || (w == Monday && (d ==  6 || d ==  7) && m == May && y > 2013)
             // Memorial Day
             || (d == 6 && m == June)
-            // Constitution Day
-            || (d == 17 && m == July && y <= 2007)
+            // Constitution Day (public holiday until 2007; reinstated from 2026)
+            || (d == 17 && m == July && (y <= 2007 || y >= 2026))
             // Liberation Day
             || (d == 15 && m == August)
             || (w == Monday && (d == 16 || d == 17) && m == August && y > 2020)
@@ -152,6 +152,7 @@ namespace QuantLib {
             || (d ==  9 && m == March    && y == 2022) // Presidency
             || (d ==  1 && m == June     && y == 2022) // Local election
             || (d == 10 && m == April    && y == 2024) // National Assembly
+            || (d ==  3 && m == June     && y == 2026) // Local election
             // Buddha's birthday
             || (d == 26 && m == May   && y == 2004)
             || (d == 15 && m == May   && y == 2005)

--- a/ql/time/calendars/southkorea.hpp
+++ b/ql/time/calendars/southkorea.hpp
@@ -42,7 +42,7 @@ namespace QuantLib {
         <li>Labour Day, May 1st</li>
         <li>Children's Day, May 5th</li>
         <li>Memorial Day, June 6th</li>
-        <li>Constitution Day, July 17th (until 2007)</li>
+        <li>Constitution Day, July 17th (until 2007; from 2026)</li>
         <li>Liberation Day, August 15th</li>
         <li>National Fondation Day, October 3th</li>
         <li>Hangeul Day, October 9th (from 2013)</li>

--- a/test-suite/calendars.cpp
+++ b/test-suite/calendars.cpp
@@ -1695,7 +1695,9 @@ BOOST_AUTO_TEST_CASE(testSouthKoreanSettlement) {
     expectedHol.emplace_back(1, May, 2026);
     expectedHol.emplace_back(5, May, 2026);
     expectedHol.emplace_back(25, May, 2026);
+    expectedHol.emplace_back(3, June, 2026); // local election
     // expectedHol.emplace_back(6, June, 2026);    // Saturday
+    expectedHol.emplace_back(17, July, 2026); // Constitution Day reinstated
     expectedHol.emplace_back(17, August, 2026);
     expectedHol.emplace_back(24, September, 2026);
     expectedHol.emplace_back(25, September, 2026);
@@ -2438,7 +2440,9 @@ BOOST_AUTO_TEST_CASE(testKoreaStockExchange) {
     expectedHol.emplace_back(1, May, 2026);
     expectedHol.emplace_back(5, May, 2026);
     expectedHol.emplace_back(25, May, 2026);
+    expectedHol.emplace_back(3, June, 2026); // local election
     // expectedHol.emplace_back(6, June, 2026);    // Saturday
+    expectedHol.emplace_back(17, July, 2026); // Constitution Day reinstated
     expectedHol.emplace_back(17, August, 2026);
     expectedHol.emplace_back(24, September, 2026);
     expectedHol.emplace_back(25, September, 2026);


### PR DESCRIPTION
## Summary
- Reinstate Constitution Day (July 17) as a South Korea public holiday from 2026 onward (it was coded only through 2007).
- Add the 2026-06-03 local election day to the Election Days list.
- Update settlement and KRX expected holiday lists in `test-suite/calendars.cpp`.

KRX closed securities/derivatives markets on both dates after the government reinstated Constitution Day and designated local election day as a public holiday.

## Test plan
- [ ] CI: `testSouthKoreanSettlement` / KRX calendar tests
- [ ] Spot-check: `SouthKorea` treats 2026-06-03 and 2026-07-17 as holidays; 2008-07-17 remains a business day (weekday between 2008 and 2025).
