### PR TITLE
Add Thailand financial-institution holidays for 2026

### DIFF
--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -305,6 +305,13 @@ namespace QuantLib {
             ))
             return false;
 
+        if ((y == 2026) && ((d == 2 && m == January)     // Additional special holiday
+                            || (d == 3 && m == March)    // Makha Bucha Day
+                            || (d == 1 && m == June)     // Substitution for Visakha Bucha Day (Sunday 31st May 2026)
+                            || (d == 29 && m == July)    // Asarnha Bucha Day
+            ))
+            return false;
+
         return true;
     }
 

--- a/ql/time/calendars/thailand.hpp
+++ b/ql/time/calendars/thailand.hpp
@@ -54,7 +54,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2000-2024 with some years missing)
+        (data available for 2000-2026 with some years missing)
         <ul>
         <li>Makha Bucha Day</li>
         <li>Wisakha Bucha Day</li>


### PR DESCRIPTION
## Summary
- Add a 2026 year-specific holiday block to the Thailand calendar for dates not covered by fixed rules: 2 Jan (additional special), 3 Mar (Makha Bucha), 1 Jun (Visakha Bucha substitute), 29 Jul (Asarnha Bucha).
- Extend the header note for variable-holiday data through 2026.

Sources: Bank of Thailand / Bangkok Bank 2026 financial institutions holiday lists.

## Test plan
- [ ] CI calendar suite
- [ ] Spot-check `Thailand` treats the four dates above as holidays; fixed-rule days (Songkran, Coronation, etc.) unchanged.