### PR TITLE
Add Singapore exchange holidays for 2027

### DIFF
--- a/ql/time/calendars/singapore.cpp
+++ b/ql/time/calendars/singapore.cpp
@@ -247,6 +247,22 @@ namespace QuantLib {
                 || (d == 9 && m == November))
                 return false;
         }
+
+        // https://data.gov.sg/datasets/d_0ba69fc6d56717ff0bf8083c6af3bb84/view
+        if (y == 2027)
+        {
+            if (// Chinese New Year (Sat/Sun 6-7 Feb, observed Monday 8 Feb)
+                (d == 8 && m == February)
+                // Hari Raya Puasa
+                || (d == 10 && m == March)
+                // Hari Raya Haji
+                || (d == 17 && m == May)
+                // Vesak Day
+                || (d == 20 && m == May)
+                // Deepavali
+                || (d == 28 && m == October))
+                return false;
+        }
         return true;
     }
 

--- a/ql/time/calendars/singapore.hpp
+++ b/ql/time/calendars/singapore.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2004-2010, 2012-2014, 2019-2026 only:)
+        (data available for 2004-2010, 2012-2014, 2019-2027 only:)
         <ul>
         <li>Chinese New Year</li>
         <li>Hari Raya Haji</li>


### PR DESCRIPTION
## Summary
- Add a 2027 year-specific holiday block for Singapore (SGX) using MOM public holiday dates from data.gov.sg for variable holidays not covered by fixed rules.
- Dates: 8 Feb (CNY observed), 10 Mar (Hari Raya Puasa), 17 May (Hari Raya Haji), 20 May (Vesak), 28 Oct (Deepavali).
- Extend header data range through 2027.

Source: https://data.gov.sg/datasets/d_0ba69fc6d56717ff0bf8083c6af3bb84/view

## Test plan
- [ ] CI calendar suite
- [ ] Spot-check the five dates above are holidays; fixed rules unchanged.

Made with [Cursor](https://cursor.com)