### PR TITLE
Fix calendar and day-count documentation typos

### DIFF
--- a/ql/time/calendars/argentina.hpp
+++ b/ql/time/calendars/argentina.hpp
@@ -47,7 +47,7 @@ namespace QuantLib {
             or Friday)</li>
         <li>Immaculate Conception, December 8th</li>
         <li>Christmas Eve, December 24th</li>
-        <li>New Year's Eve, December 31th</li>
+        <li>New Year's Eve, December 31st</li>
         </ul>
 
         \ingroup calendars

--- a/ql/time/calendars/sweden.hpp
+++ b/ql/time/calendars/sweden.hpp
@@ -45,7 +45,7 @@ namespace QuantLib {
         <li>Christmas Eve, December 24th</li>
         <li>Christmas Day, December 25th</li>
         <li>Boxing Day, December 26th</li>
-        <li>New Year's Eve, December 31th</li>
+        <li>New Year's Eve, December 31st</li>
         </ul>
 
         \ingroup calendars

--- a/ql/time/calendars/thailand.cpp
+++ b/ql/time/calendars/thailand.cpp
@@ -39,10 +39,10 @@ namespace QuantLib {
             || ((d == 1 || (d == 3 && w == Monday)) && m == January)
             // Chakri Memorial Day
             || ((d == 6 || ((d == 7 || d == 8) && w == Monday)) && m == April)
-            // Songkran Festival (was cancelled in 2020 due to the Covid-19 Pandamic)
+            // Songkran Festival (was cancelled in 2020 due to the Covid-19 Pandemic)
             || ((d == 13 || d == 14 || d == 15) && m == April && y != 2020)
             // Substitution Songkran Festival, usually not more than 5 days in total (was cancelled
-            // in 2020 due to the Covid-19 Pandamic)
+            // in 2020 due to the Covid-19 Pandemic)
             || (d == 16 && (w == Monday || w == Tuesday) && m == April && y != 2020)
             // Labor Day
             || ((d == 1 || ((d == 2 || d == 3) && w == Monday)) && m == May)

--- a/ql/time/calendars/thailand.hpp
+++ b/ql/time/calendars/thailand.hpp
@@ -50,11 +50,11 @@ namespace QuantLib {
         <li>The Passing of H.M. the Late King Bhumibol Adulyadej (Rama IX), October 13th (from 2017) </li>
         <li>H.M. the Late King Bhumibol Adulyadej's Birthday, December 5th</li>
         <li>Constitution Day, December 10th</li>
-        <li>New Year's Eve, December 31th</li>
+        <li>New Year's Eve, December 31st</li>
         </ul>
 
         Other holidays for which no rule is given
-        (data available for 2000-2024 with some years missing)
+        (data available for 2000-2025 with some years missing)
         <ul>
         <li>Makha Bucha Day</li>
         <li>Wisakha Bucha Day</li>

--- a/ql/time/daycounters/thirty360.hpp
+++ b/ql/time/daycounters/thirty360.hpp
@@ -36,7 +36,7 @@ namespace QuantLib {
         US convention: if the starting date is the 31st of a month or
         the last day of February, it becomes equal to the 30th of the
         same month.  If the ending date is the 31st of a month and the
-        starting date is the 30th or 31th of a month, the ending date
+        starting date is the 30th or 31st of a month, the ending date
         becomes equal to the 30th.  If the ending date is the last of
         February and the starting date is also the last of February,
         the ending date becomes equal to the 30th.
@@ -45,7 +45,7 @@ namespace QuantLib {
         Bond Basis convention: if the starting date is the 31st of a
         month, it becomes equal to the 30th of the same month.
         If the ending date is the 31st of a month and the starting
-        date is the 30th or 31th of a month, the ending date
+        date is the 30th or 31st of a month, the ending date
         also becomes equal to the 30th of the month.
         Also known as "US (ISMA)".
 


### PR DESCRIPTION
## Summary
- Replace incorrect ordinal `31th` with `31st` in Thailand, Sweden, Argentina, and Thirty360 docs.
- Fix `Pandamic` -> `Pandemic` in Thailand calendar comments.
- Update Thailand variable-holiday data range note to 2000-2025 (2025 block already present).

Docs-only; no behavior change.

## Test plan
- [ ] Docs review / CI (no numerical change expected)

Made with [Cursor](https://cursor.com)