### PR TITLE
Guard against zero leg BPS in `FixedVsFloatingSwap` fair-rate and fair-spread calculations

### DIFF
--- a/ql/instruments/fixedvsfloatingswap.cpp
+++ b/ql/instruments/fixedvsfloatingswap.cpp
@@ -198,12 +198,12 @@ namespace QuantLib {
 
         if (fairRate_ == Null<Rate>()) {
             // calculate it from other results
-            if (legBPS_[0] != Null<Real>())
+            if (legBPS_[0] != Null<Real>() && legBPS_[0] != 0.0)
                 fairRate_ = fixedRate_ - NPV_/(legBPS_[0]/basisPoint);
         }
         if (fairSpread_ == Null<Spread>()) {
             // ditto
-            if (legBPS_[1] != Null<Real>())
+            if (legBPS_[1] != Null<Real>() && legBPS_[1] != 0.0)
                 fairSpread_ = spread_ - NPV_/(legBPS_[1]/basisPoint);
         }
     }

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -661,6 +661,27 @@ BOOST_AUTO_TEST_CASE(testSettlementCalendar) {
                 index->fixingCalendar().advance(today, 2 * Days));
 }
 
+BOOST_AUTO_TEST_CASE(testZeroBpsFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing vanilla swap fair rate/spread calculation with zero BPS...");
+
+    CommonVars vars;
+    vars.nominal = 0.0;
+    ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(10, 0.0, 0.0);
+
+    BOOST_CHECK(!swap->isExpired());
+    BOOST_CHECK_EQUAL(swap->legBPS(0), 0.0);
+    BOOST_CHECK_EQUAL(swap->legBPS(1), 0.0);
+
+    BOOST_CHECK_EXCEPTION(
+        swap->fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
+}
+
 BOOST_AUTO_TEST_CASE(testExpiredSwapFairRateAndSpread) {
 
     BOOST_TEST_MESSAGE(
@@ -671,8 +692,13 @@ BOOST_AUTO_TEST_CASE(testExpiredSwapFairRateAndSpread) {
 
     Settings::instance().evaluationDate() = vars.settlement + Period(20, Years);
 
-    BOOST_CHECK_THROW(swap->fairRate(), Error);
-    BOOST_CHECK_THROW(swap->fairSpread(), Error);
+    BOOST_CHECK(swap->isExpired());
+    BOOST_CHECK_EXCEPTION(
+        swap->fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap->fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/swap.cpp
+++ b/test-suite/swap.cpp
@@ -661,6 +661,20 @@ BOOST_AUTO_TEST_CASE(testSettlementCalendar) {
                 index->fixingCalendar().advance(today, 2 * Days));
 }
 
+BOOST_AUTO_TEST_CASE(testExpiredSwapFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing vanilla swap fair rate/spread for expired swap...");
+
+    CommonVars vars;
+    ext::shared_ptr<VanillaSwap> swap = vars.makeSwap(10, 0.0, 0.0);
+
+    Settings::instance().evaluationDate() = vars.settlement + Period(20, Years);
+
+    BOOST_CHECK_THROW(swap->fairRate(), Error);
+    BOOST_CHECK_THROW(swap->fairSpread(), Error);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Skip fair rate/spread fallback when leg BPS is zero (not only when Null), avoiding division by zero for expired swaps.
- Affects VanillaSwap, OvernightIndexedSwap, and other FixedVsFloatingSwap derivatives.
- Add expired-swap test mirroring FloatFloatSwap PR #2678.

## Test plan
- [ ] CI: test-suite swap tests
- [ ] Expired swap: fairRate()/fairSpread() throw instead of NaN/Inf

Made with [Cursor](https://cursor.com)