### PR TITLE
Reuse step buffer in SobolBrownianBridge random sequence generators

### DIFF
--- a/ql/math/randomnumbers/sobolbrownianbridgersg.cpp
+++ b/ql/math/randomnumbers/sobolbrownianbridgersg.cpp
@@ -27,9 +27,11 @@
 namespace QuantLib {
 
     namespace {
-        void setNextSequence(SobolBrownianGeneratorBase& gen, std::vector<Real>& seq) {
+        void setNextSequence(SobolBrownianGeneratorBase& gen,
+                             std::vector<Real>& seq,
+                             std::vector<Real>& output) {
+            output.resize(gen.numberOfFactors());
             gen.nextPath();
-            std::vector<Real> output(gen.numberOfFactors());
             for (Size i = 0; i < gen.numberOfSteps(); ++i) {
                 gen.nextStep(output);
                 std::copy(output.begin(), output.end(), seq.begin() + i * gen.numberOfFactors());
@@ -47,7 +49,7 @@ namespace QuantLib {
 
     const SobolBrownianBridgeRsg::sample_type&
     SobolBrownianBridgeRsg::nextSequence() const {
-        setNextSequence(gen_, seq_.value);
+        setNextSequence(gen_, seq_.value, stepBuffer_);
         return seq_;
 
     }
@@ -73,7 +75,7 @@ namespace QuantLib {
 
     const Burley2020SobolBrownianBridgeRsg::sample_type&
     Burley2020SobolBrownianBridgeRsg::nextSequence() const {
-        setNextSequence(gen_, seq_.value);
+        setNextSequence(gen_, seq_.value, stepBuffer_);
         return seq_;
     }
 

--- a/ql/math/randomnumbers/sobolbrownianbridgersg.hpp
+++ b/ql/math/randomnumbers/sobolbrownianbridgersg.hpp
@@ -46,6 +46,7 @@ namespace QuantLib {
 
       private:
         mutable sample_type seq_;
+        mutable std::vector<Real> stepBuffer_;
         mutable SobolBrownianGenerator gen_;
     };
 
@@ -67,6 +68,7 @@ namespace QuantLib {
 
       private:
         mutable sample_type seq_;
+        mutable std::vector<Real> stepBuffer_;
         mutable Burley2020SobolBrownianGenerator gen_;
     };
 }


### PR DESCRIPTION
## Summary
- Avoid heap allocation of a factors-sized vector on every nextSequence() call in SobolBrownianBridgeRsg and Burley2020SobolBrownianBridgeRsg.
- Reuse mutable stepBuffer_ resized once per path.

## Test plan
- [ ] CI (existing Sobol/Brownian-bridge MC tests; sequences unchanged)

Made with [Cursor](https://cursor.com)