### PR TITLE
Guard against zero leg BPS in CPI and YoY inflation swap fair-rate and fair-spread calculations

### DIFF
--- a/ql/instruments/cpiswap.cpp
+++ b/ql/instruments/cpiswap.cpp
@@ -194,12 +194,12 @@ namespace QuantLib {
 
         if (fairRate_ == Null<Rate>()) {
             // calculate it from other results
-            if (legBPS_[0] != Null<Real>())
+            if (legBPS_[0] != Null<Real>() && legBPS_[0] != 0.0)
                 fairRate_ = fixedRate_ - NPV_/(legBPS_[0]/basisPoint);
         }
         if (fairSpread_ == Null<Spread>()) {
             // ditto
-            if (legBPS_[1] != Null<Real>())
+            if (legBPS_[1] != Null<Real>() && legBPS_[1] != 0.0)
                 fairSpread_ = spread_ - NPV_/(legBPS_[1]/basisPoint);
         }
 

--- a/ql/instruments/yearonyearinflationswap.cpp
+++ b/ql/instruments/yearonyearinflationswap.cpp
@@ -185,12 +185,12 @@ namespace QuantLib {
 
         if (fairRate_ == Null<Rate>()) {
             // calculate it from other results
-            if (legBPS_[0] != Null<Real>())
+            if (legBPS_[0] != Null<Real>() && legBPS_[0] != 0.0)
                 fairRate_ = fixedRate_ - NPV_/(legBPS_[0]/basisPoint);
         }
         if (fairSpread_ == Null<Spread>()) {
             // ditto
-            if (legBPS_[1] != Null<Real>())
+            if (legBPS_[1] != Null<Real>() && legBPS_[1] != 0.0)
                 fairSpread_ = spread_ - NPV_/(legBPS_[1]/basisPoint);
         }
 

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -28,6 +28,7 @@
 #include <ql/indexes/inflation/aucpi.hpp>
 #include <ql/termstructures/inflation/piecewisezeroinflationcurve.hpp>
 #include <ql/termstructures/inflation/piecewiseyoyinflationcurve.hpp>
+#include <ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/time/date.hpp>
 #include <ql/time/daycounters/actual360.hpp>
@@ -1134,6 +1135,13 @@ BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     CPI::InterpolationType interpolation = CPI::Flat;
 
+    std::vector<Date> yoyDates = {evaluationDate, Date(13, August, 2012)};
+    std::vector<Rate> yoyRates = {0.03, 0.03};
+    auto yoyTs = ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
+        evaluationDate, yoyDates, yoyRates, iir->frequency(), dc);
+    yoyTs->enableExtrapolation();
+    hy.linkTo(yoyTs);
+
     Schedule yoySchedule =
         MakeSchedule().from(nominalTS->referenceDate())
             .to(Date(13, August, 2012))
@@ -1200,6 +1208,13 @@ BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
     DayCounter dc = Thirty360(Thirty360::BondBasis);
     CPI::InterpolationType interpolation = CPI::Flat;
     Date maturity(13, August, 2012);
+
+    std::vector<Date> yoyDates = {evaluationDate, maturity};
+    std::vector<Rate> yoyRates = {0.03, 0.03};
+    auto yoyTs = ext::make_shared<InterpolatedYoYInflationCurve<Linear>>(
+        evaluationDate, yoyDates, yoyRates, iir->frequency(), dc);
+    yoyTs->enableExtrapolation();
+    hy.linkTo(yoyTs);
 
     Schedule yoySchedule =
         MakeSchedule().from(nominalTS->referenceDate())

--- a/test-suite/inflation.cpp
+++ b/test-suite/inflation.cpp
@@ -1096,6 +1096,138 @@ BOOST_AUTO_TEST_CASE(testYYTermStructure) {
     hy.reset();
 }
 
+BOOST_AUTO_TEST_CASE(testZeroBpsYoYInflationSwapFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing YoY inflation swap fair rate/spread with zero BPS...");
+
+    Calendar calendar = UnitedKingdom();
+    Date evaluationDate(13, August, 2007);
+    evaluationDate = calendar.adjust(evaluationDate);
+    Settings::instance().evaluationDate() = evaluationDate;
+
+    Date from(1, January, 2005);
+    Date to(1, July, 2007);
+    Schedule rpiSchedule =
+        MakeSchedule().from(from).to(to)
+            .withTenor(1 * Months)
+            .withCalendar(UnitedKingdom())
+            .withConvention(ModifiedFollowing);
+    Real fixData[] = {
+        189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+        193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+        199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+        207.3};
+
+    RelinkableHandle<YoYInflationTermStructure> hy;
+    auto rpi = ext::make_shared<UKRPI>();
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+    for (Size i = 0; i < std::size(fixData); i++) {
+        rpi->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    ext::shared_ptr<YieldTermStructure> nominalTS = nominalTermStructure();
+    Handle<YieldTermStructure> hTS(nominalTS);
+    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+
+    Period observationLag = Period(2, Months);
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
+    CPI::InterpolationType interpolation = CPI::Flat;
+
+    Schedule yoySchedule =
+        MakeSchedule().from(nominalTS->referenceDate())
+            .to(Date(13, August, 2012))
+            .withConvention(Unadjusted)
+            .withCalendar(calendar)
+            .withTenor(1 * Years)
+            .backwards();
+
+    YearOnYearInflationSwap swap(Swap::Payer, 0.0, yoySchedule, 0.03, dc,
+                                 yoySchedule, iir, observationLag,
+                                 interpolation, 0.0, dc, UnitedKingdom());
+
+    swap.setPricingEngine(sppe);
+
+    BOOST_CHECK(!swap.isExpired());
+    BOOST_CHECK_EQUAL(swap.legBPS(0), 0.0);
+    BOOST_CHECK_EQUAL(swap.legBPS(1), 0.0);
+
+    BOOST_CHECK_EXCEPTION(
+        swap.fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap.fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
+
+    hy.reset();
+}
+
+BOOST_AUTO_TEST_CASE(testExpiredYoYInflationSwapFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing YoY inflation swap fair rate/spread for expired swap...");
+
+    Calendar calendar = UnitedKingdom();
+    Date evaluationDate(13, August, 2007);
+    evaluationDate = calendar.adjust(evaluationDate);
+    Settings::instance().evaluationDate() = evaluationDate;
+
+    Date from(1, January, 2005);
+    Date to(1, July, 2007);
+    Schedule rpiSchedule =
+        MakeSchedule().from(from).to(to)
+            .withTenor(1 * Months)
+            .withCalendar(UnitedKingdom())
+            .withConvention(ModifiedFollowing);
+    Real fixData[] = {
+        189.9, 189.9, 189.6, 190.5, 191.6, 192.0, 192.2, 192.2, 192.6, 193.1,
+        193.3, 193.6, 194.1, 193.4, 194.2, 195.0, 196.5, 197.7, 198.5, 198.5,
+        199.2, 200.1, 200.4, 201.1, 202.7, 201.6, 203.1, 204.4, 205.4, 206.2,
+        207.3};
+
+    RelinkableHandle<YoYInflationTermStructure> hy;
+    auto rpi = ext::make_shared<UKRPI>();
+    auto iir = ext::make_shared<YoYInflationIndex>(rpi, hy);
+    for (Size i = 0; i < std::size(fixData); i++) {
+        rpi->addFixing(rpiSchedule[i], fixData[i]);
+    }
+
+    ext::shared_ptr<YieldTermStructure> nominalTS = nominalTermStructure();
+    Handle<YieldTermStructure> hTS(nominalTS);
+    ext::shared_ptr<PricingEngine> sppe(new DiscountingSwapEngine(hTS));
+
+    Period observationLag = Period(2, Months);
+    DayCounter dc = Thirty360(Thirty360::BondBasis);
+    CPI::InterpolationType interpolation = CPI::Flat;
+    Date maturity(13, August, 2012);
+
+    Schedule yoySchedule =
+        MakeSchedule().from(nominalTS->referenceDate())
+            .to(maturity)
+            .withConvention(Unadjusted)
+            .withCalendar(calendar)
+            .withTenor(1 * Years)
+            .backwards();
+
+    YearOnYearInflationSwap swap(Swap::Payer, 1000000.0, yoySchedule, 0.03, dc,
+                                 yoySchedule, iir, observationLag,
+                                 interpolation, 0.0, dc, UnitedKingdom());
+
+    swap.setPricingEngine(sppe);
+
+    Settings::instance().evaluationDate() = maturity + Period(1, Years);
+
+    BOOST_CHECK(swap.isExpired());
+    BOOST_CHECK_EXCEPTION(
+        swap.fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap.fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
+
+    hy.reset();
+}
+
 BOOST_AUTO_TEST_CASE(testPeriod) {
     BOOST_TEST_MESSAGE("Testing inflation period...");
 

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "toplevelfixture.hpp"
+#include "utilities.hpp"
 #include <ql/types.hpp>
 #include <ql/indexes/inflation/ukrpi.hpp>
 #include <ql/termstructures/bootstraphelper.hpp>
@@ -488,6 +489,131 @@ BOOST_AUTO_TEST_CASE(cpibondconsistency) {
     cpiB.setPricingEngine(dbe);
 
     QL_REQUIRE(fabs(cpiB.NPV() - zisV.legNPV(0))<1e-5,"cpi bond does not equal equivalent cpi swap leg");
+}
+
+BOOST_AUTO_TEST_CASE(testZeroBpsFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing CPI swap fair rate/spread calculation with zero BPS...");
+
+    CommonVars common;
+
+    Swap::Type type = Swap::Payer;
+    Real nominal = 0.0;
+    bool subtractInflationNominal = true;
+    Spread spread = 0.0;
+    DayCounter floatDayCount = Actual365Fixed();
+    BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
+    Natural fixingDays = 0;
+    ext::shared_ptr<IborIndex> floatIndex(
+        new GBPLibor(Period(6, Months), common.nominalTS));
+
+    Rate fixedRate = 0.1;
+    Real baseCPI = 206.1;
+    DayCounter fixedDayCount = Actual365Fixed();
+    BusinessDayConvention fixedPaymentConvention = ModifiedFollowing;
+    ext::shared_ptr<ZeroInflationIndex> fixedIndex = common.ii;
+    Period contractObservationLag = common.contractObservationLag;
+    CPI::InterpolationType observationInterpolation =
+        common.contractObservationInterpolation;
+
+    Date startDate(2, October, 2007);
+    Date endDate(2, October, 2052);
+    Schedule floatSchedule =
+        MakeSchedule().from(startDate).to(endDate)
+            .withTenor(Period(6, Months))
+            .withCalendar(UnitedKingdom())
+            .withConvention(floatPaymentConvention)
+            .backwards();
+    Schedule fixedSchedule =
+        MakeSchedule().from(startDate).to(endDate)
+            .withTenor(Period(6, Months))
+            .withCalendar(UnitedKingdom())
+            .withConvention(Unadjusted)
+            .backwards();
+
+    CPISwap swap(type, nominal, subtractInflationNominal, spread,
+                 floatDayCount, floatSchedule, floatPaymentConvention,
+                 fixingDays, floatIndex, fixedRate, baseCPI, fixedDayCount,
+                 fixedSchedule, fixedPaymentConvention, contractObservationLag,
+                 fixedIndex, observationInterpolation);
+
+    ext::shared_ptr<DiscountingSwapEngine> dse(
+        new DiscountingSwapEngine(common.nominalTS));
+    swap.setPricingEngine(dse);
+
+    BOOST_CHECK(!swap.isExpired());
+    BOOST_CHECK_EQUAL(swap.legBPS(0), 0.0);
+    BOOST_CHECK_EQUAL(swap.legBPS(1), 0.0);
+
+    BOOST_CHECK_EXCEPTION(
+        swap.fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap.fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
+}
+
+BOOST_AUTO_TEST_CASE(testExpiredSwapFairRateAndSpread) {
+
+    BOOST_TEST_MESSAGE(
+        "Testing CPI swap fair rate/spread for expired swap...");
+
+    CommonVars common;
+
+    Swap::Type type = Swap::Payer;
+    Real nominal = 1000000.0;
+    bool subtractInflationNominal = true;
+    Spread spread = 0.0;
+    DayCounter floatDayCount = Actual365Fixed();
+    BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
+    Natural fixingDays = 0;
+    ext::shared_ptr<IborIndex> floatIndex(
+        new GBPLibor(Period(6, Months), common.nominalTS));
+
+    Rate fixedRate = 0.1;
+    Real baseCPI = 206.1;
+    DayCounter fixedDayCount = Actual365Fixed();
+    BusinessDayConvention fixedPaymentConvention = ModifiedFollowing;
+    ext::shared_ptr<ZeroInflationIndex> fixedIndex = common.ii;
+    Period contractObservationLag = common.contractObservationLag;
+    CPI::InterpolationType observationInterpolation =
+        common.contractObservationInterpolation;
+
+    Date startDate(2, October, 2007);
+    Date endDate(2, October, 2052);
+    Schedule floatSchedule =
+        MakeSchedule().from(startDate).to(endDate)
+            .withTenor(Period(6, Months))
+            .withCalendar(UnitedKingdom())
+            .withConvention(floatPaymentConvention)
+            .backwards();
+    Schedule fixedSchedule =
+        MakeSchedule().from(startDate).to(endDate)
+            .withTenor(Period(6, Months))
+            .withCalendar(UnitedKingdom())
+            .withConvention(Unadjusted)
+            .backwards();
+
+    CPISwap swap(type, nominal, subtractInflationNominal, spread,
+                 floatDayCount, floatSchedule, floatPaymentConvention,
+                 fixingDays, floatIndex, fixedRate, baseCPI, fixedDayCount,
+                 fixedSchedule, fixedPaymentConvention, contractObservationLag,
+                 fixedIndex, observationInterpolation);
+
+    ext::shared_ptr<DiscountingSwapEngine> dse(
+        new DiscountingSwapEngine(common.nominalTS));
+    swap.setPricingEngine(dse);
+
+    Settings::instance().evaluationDate() = endDate + Period(1, Years);
+
+    BOOST_CHECK(swap.isExpired());
+    BOOST_CHECK_EXCEPTION(
+        swap.fairRate(), Error,
+        ExpectedErrorMessage("result not available"));
+    BOOST_CHECK_EXCEPTION(
+        swap.fairSpread(), Error,
+        ExpectedErrorMessage("result not available"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test-suite/inflationcpiswap.cpp
+++ b/test-suite/inflationcpiswap.cpp
@@ -500,43 +500,24 @@ BOOST_AUTO_TEST_CASE(testZeroBpsFairRateAndSpread) {
 
     Swap::Type type = Swap::Payer;
     Real nominal = 0.0;
-    bool subtractInflationNominal = true;
-    Spread spread = 0.0;
-    DayCounter floatDayCount = Actual365Fixed();
-    BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
-    Natural fixingDays = 0;
-    ext::shared_ptr<IborIndex> floatIndex(
-        new GBPLibor(Period(6, Months), common.nominalTS));
+    Date startDate(common.evaluationDate);
+    Date endDate(25, November, 2059);
+    Calendar cal = UnitedKingdom();
+    BusinessDayConvention paymentConvention = ModifiedFollowing;
+    DayCounter dummyDC;
+    Period observationLag(2, Months);
+    CPI::InterpolationType interpolation = CPI::Flat;
 
-    Rate fixedRate = 0.1;
-    Real baseCPI = 206.1;
-    DayCounter fixedDayCount = Actual365Fixed();
-    BusinessDayConvention fixedPaymentConvention = ModifiedFollowing;
-    ext::shared_ptr<ZeroInflationIndex> fixedIndex = common.ii;
-    Period contractObservationLag = common.contractObservationLag;
-    CPI::InterpolationType observationInterpolation =
-        common.contractObservationInterpolation;
+    std::vector<Date> oneDate = {endDate};
+    Schedule schOneDate(oneDate, cal, paymentConvention);
 
-    Date startDate(2, October, 2007);
-    Date endDate(2, October, 2052);
-    Schedule floatSchedule =
-        MakeSchedule().from(startDate).to(endDate)
-            .withTenor(Period(6, Months))
-            .withCalendar(UnitedKingdom())
-            .withConvention(floatPaymentConvention)
-            .backwards();
-    Schedule fixedSchedule =
-        MakeSchedule().from(startDate).to(endDate)
-            .withTenor(Period(6, Months))
-            .withCalendar(UnitedKingdom())
-            .withConvention(Unadjusted)
-            .backwards();
+    Real baseCPI = CPI::laggedFixing(common.ii, startDate, observationLag, interpolation);
+    ext::shared_ptr<IborIndex> dummyFloatIndex;
 
-    CPISwap swap(type, nominal, subtractInflationNominal, spread,
-                 floatDayCount, floatSchedule, floatPaymentConvention,
-                 fixingDays, floatIndex, fixedRate, baseCPI, fixedDayCount,
-                 fixedSchedule, fixedPaymentConvention, contractObservationLag,
-                 fixedIndex, observationInterpolation);
+    CPISwap swap(type, nominal, true, 0.0, dummyDC, schOneDate,
+                 paymentConvention, 0, dummyFloatIndex,
+                 0.1, baseCPI, dummyDC, schOneDate, paymentConvention,
+                 observationLag, common.ii, interpolation);
 
     ext::shared_ptr<DiscountingSwapEngine> dse(
         new DiscountingSwapEngine(common.nominalTS));
@@ -563,43 +544,24 @@ BOOST_AUTO_TEST_CASE(testExpiredSwapFairRateAndSpread) {
 
     Swap::Type type = Swap::Payer;
     Real nominal = 1000000.0;
-    bool subtractInflationNominal = true;
-    Spread spread = 0.0;
-    DayCounter floatDayCount = Actual365Fixed();
-    BusinessDayConvention floatPaymentConvention = ModifiedFollowing;
-    Natural fixingDays = 0;
-    ext::shared_ptr<IborIndex> floatIndex(
-        new GBPLibor(Period(6, Months), common.nominalTS));
+    Date startDate(common.evaluationDate);
+    Date endDate(25, November, 2059);
+    Calendar cal = UnitedKingdom();
+    BusinessDayConvention paymentConvention = ModifiedFollowing;
+    DayCounter dummyDC;
+    Period observationLag(2, Months);
+    CPI::InterpolationType interpolation = CPI::Flat;
 
-    Rate fixedRate = 0.1;
-    Real baseCPI = 206.1;
-    DayCounter fixedDayCount = Actual365Fixed();
-    BusinessDayConvention fixedPaymentConvention = ModifiedFollowing;
-    ext::shared_ptr<ZeroInflationIndex> fixedIndex = common.ii;
-    Period contractObservationLag = common.contractObservationLag;
-    CPI::InterpolationType observationInterpolation =
-        common.contractObservationInterpolation;
+    std::vector<Date> oneDate = {endDate};
+    Schedule schOneDate(oneDate, cal, paymentConvention);
 
-    Date startDate(2, October, 2007);
-    Date endDate(2, October, 2052);
-    Schedule floatSchedule =
-        MakeSchedule().from(startDate).to(endDate)
-            .withTenor(Period(6, Months))
-            .withCalendar(UnitedKingdom())
-            .withConvention(floatPaymentConvention)
-            .backwards();
-    Schedule fixedSchedule =
-        MakeSchedule().from(startDate).to(endDate)
-            .withTenor(Period(6, Months))
-            .withCalendar(UnitedKingdom())
-            .withConvention(Unadjusted)
-            .backwards();
+    Real baseCPI = CPI::laggedFixing(common.ii, startDate, observationLag, interpolation);
+    ext::shared_ptr<IborIndex> dummyFloatIndex;
 
-    CPISwap swap(type, nominal, subtractInflationNominal, spread,
-                 floatDayCount, floatSchedule, floatPaymentConvention,
-                 fixingDays, floatIndex, fixedRate, baseCPI, fixedDayCount,
-                 fixedSchedule, fixedPaymentConvention, contractObservationLag,
-                 fixedIndex, observationInterpolation);
+    CPISwap swap(type, nominal, true, 0.0, dummyDC, schOneDate,
+                 paymentConvention, 0, dummyFloatIndex,
+                 0.1, baseCPI, dummyDC, schOneDate, paymentConvention,
+                 observationLag, common.ii, interpolation);
 
     ext::shared_ptr<DiscountingSwapEngine> dse(
         new DiscountingSwapEngine(common.nominalTS));


### PR DESCRIPTION
## Summary
- Apply the same zero leg BPS guard as FloatFloatSwap #2678 and FixedVsFloatingSwap for CPISwap and YearOnYearInflationSwap fair rate/spread fallback.

## Test plan
- [ ] CI inflation swap tests

Made with [Cursor](https://cursor.com)