### PR TITLE
Reuse iteration workspaces in BiCGstab solver

### DIFF
--- a/ql/math/matrixutilities/bicgstab.cpp
+++ b/ql/math/matrixutilities/bicgstab.cpp
@@ -41,11 +41,28 @@ namespace QuantLib {
             return result;
         }
 
-        Array x = ((!x0.empty()) ? x0 : Array(b.size(), 0.0));
-        Array r = b - A_(x);
+        const Size n = b.size();
+        if (workspaceX_.size() != n) {
+            workspaceX_.resize(n);
+            workspaceR_.resize(n);
+            workspaceRTld_.resize(n);
+            workspaceP_.resize(n);
+            workspacePTld_.resize(n);
+            workspaceV_.resize(n);
+            workspaceS_.resize(n);
+            workspaceSTld_.resize(n);
+            workspaceT_.resize(n);
+        }
 
-        Array rTld = r;
-        Array p, pTld, v, s, sTld, t;
+        Array& x = workspaceX_;
+        x = ((!x0.empty()) ? x0 : Array(n, 0.0));
+        Array& r = workspaceR_;
+        r = b - A_(x);
+
+        Array& rTld = workspaceRTld_;
+        rTld = r;
+        Array &p = workspaceP_, &pTld = workspacePTld_, &v = workspaceV_,
+              &s = workspaceS_, &sTld = workspaceSTld_, &t = workspaceT_;
         Real omega = 1.0;
         Real rho, rhoTld=1.0;
         Real alpha = 0.0, beta;

--- a/ql/math/matrixutilities/bicgstab.hpp
+++ b/ql/math/matrixutilities/bicgstab.hpp
@@ -47,7 +47,9 @@ namespace QuantLib {
       protected:
         const MatrixMult A_, M_;
         const Size maxIter_;
-        const Real relTol_;  
+        const Real relTol_;
+        mutable Array workspaceX_, workspaceR_, workspaceRTld_, workspaceP_,
+            workspacePTld_, workspaceV_, workspaceS_, workspaceSTld_, workspaceT_;
     };
 }
 


### PR DESCRIPTION
## Summary
- Reuse mutable workspace arrays across BiCGstab iterations instead of reallocating each solve.

## Test plan
- [ ] CI tests using BiCGstab (FD schemes); iteration counts and solutions unchanged

Made with [Cursor](https://cursor.com)