### PR TITLE
Use the default calculation of the trade date in CDS helpers

### DIFF
--- a/ql/termstructures/credit/defaultprobabilityhelpers.cpp
+++ b/ql/termstructures/credit/defaultprobabilityhelpers.cpp
@@ -138,7 +138,7 @@ namespace QuantLib {
         swap_ = ext::make_shared<CreditDefaultSwap>(
             Protection::Buyer, 100.0, 0.01, schedule_, paymentConvention_,
             dayCounter_, settlesAccrual_, paysAtDefaultTime_, protectionStart_,
-            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_, evaluationDate_);
+            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_);
 
         switch (model_) {
           case CreditDefaultSwap::ISDA:
@@ -197,8 +197,7 @@ namespace QuantLib {
             Protection::Buyer, 100.0, 0.01, runningSpread_, schedule_,
             paymentConvention_, dayCounter_, settlesAccrual_,
             paysAtDefaultTime_, protectionStart_, upfrontDate_,
-            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_,
-            evaluationDate_);
+            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_);
 
         switch (model_) {
           case CreditDefaultSwap::ISDA:

--- a/ql/termstructures/credit/defaultprobabilityhelpers.cpp
+++ b/ql/termstructures/credit/defaultprobabilityhelpers.cpp
@@ -44,13 +44,14 @@ namespace QuantLib {
                          const Date& startDate,
                          DayCounter lastPeriodDayCounter,
                          const bool rebatesAccrual,
-                         const CreditDefaultSwap::PricingModel model)
+                         const CreditDefaultSwap::PricingModel model,
+                         const Date& tradeDate)
     : RelativeDateDefaultProbabilityHelper(quote), tenor_(tenor), settlementDays_(settlementDays),
       calendar_(std::move(calendar)), frequency_(frequency), paymentConvention_(paymentConvention),
       rule_(rule), dayCounter_(std::move(dayCounter)), recoveryRate_(recoveryRate),
       discountCurve_(discountCurve), settlesAccrual_(settlesAccrual),
       paysAtDefaultTime_(paysAtDefaultTime), lastPeriodDC_(std::move(lastPeriodDayCounter)),
-      rebatesAccrual_(rebatesAccrual), model_(model), startDate_(startDate) {
+      rebatesAccrual_(rebatesAccrual), model_(model), startDate_(startDate), tradeDate_(tradeDate) {
 
         CdsHelper::initializeDates();
 
@@ -123,11 +124,12 @@ namespace QuantLib {
                               const Date& startDate,
                               const DayCounter& lastPeriodDayCounter,
                               const bool rebatesAccrual,
-                              const CreditDefaultSwap::PricingModel model)
+                              const CreditDefaultSwap::PricingModel model,
+                              const Date& tradeDate)
     : CdsHelper(runningSpread, tenor, settlementDays, calendar,
                 frequency, paymentConvention, rule, dayCounter,
                 recoveryRate, discountCurve, settlesAccrual, paysAtDefaultTime,
-                startDate, lastPeriodDayCounter, rebatesAccrual, model) {}
+                startDate, lastPeriodDayCounter, rebatesAccrual, model, tradeDate) {}
 
     Real SpreadCdsHelper::impliedQuote() const {
         swap_->recalculate();
@@ -138,7 +140,7 @@ namespace QuantLib {
         swap_ = ext::make_shared<CreditDefaultSwap>(
             Protection::Buyer, 100.0, 0.01, schedule_, paymentConvention_,
             dayCounter_, settlesAccrual_, paysAtDefaultTime_, protectionStart_,
-            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_);
+            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_, tradeDate_);
 
         switch (model_) {
           case CreditDefaultSwap::ISDA:
@@ -174,11 +176,12 @@ namespace QuantLib {
                               const Date& startDate,
                               const DayCounter& lastPeriodDayCounter,
                               const bool rebatesAccrual,
-                              const CreditDefaultSwap::PricingModel model)
+                              const CreditDefaultSwap::PricingModel model,
+                              const Date& tradeDate)
     : CdsHelper(upfront, tenor, settlementDays, calendar,
                 frequency, paymentConvention, rule, dayCounter,
                 recoveryRate, discountCurve, settlesAccrual, paysAtDefaultTime,
-                startDate, lastPeriodDayCounter, rebatesAccrual, model),
+                startDate, lastPeriodDayCounter, rebatesAccrual, model, tradeDate),
       upfrontSettlementDays_(upfrontSettlementDays),
       upfrontDate_(upfrontDate()),
       runningSpread_(runningSpread) {}
@@ -197,7 +200,7 @@ namespace QuantLib {
             Protection::Buyer, 100.0, 0.01, runningSpread_, schedule_,
             paymentConvention_, dayCounter_, settlesAccrual_,
             paysAtDefaultTime_, protectionStart_, upfrontDate_,
-            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_);
+            ext::shared_ptr<Claim>(), lastPeriodDC_, rebatesAccrual_, tradeDate_);
 
         switch (model_) {
           case CreditDefaultSwap::ISDA:

--- a/ql/termstructures/credit/defaultprobabilityhelpers.hpp
+++ b/ql/termstructures/credit/defaultprobabilityhelpers.hpp
@@ -92,7 +92,8 @@ namespace QuantLib {
                   const Date& startDate = Date(),
                   DayCounter lastPeriodDayCounter = DayCounter(),
                   bool rebatesAccrual = true,
-                  CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+                  CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint,
+                  const Date& tradeDate = Date());
 
         void setTermStructure(DefaultProbabilityTermStructure*) override;
         // NOLINTNEXTLINE(cppcoreguidelines-noexcept-swap,performance-noexcept-swap)
@@ -125,6 +126,7 @@ namespace QuantLib {
         //! protection effective date.
         Date protectionStart_;
         Date startDate_;
+        Date tradeDate_;
     };
 
     //! Spread-quoted CDS hazard rate bootstrap helper.
@@ -145,7 +147,8 @@ namespace QuantLib {
                         const Date& startDate = Date(),
                         const DayCounter& lastPeriodDayCounter = DayCounter(),
                         bool rebatesAccrual = true,
-                        CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+                        CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint,
+                        const Date& tradeDate = Date());
 
         Real impliedQuote() const override;
 
@@ -174,7 +177,8 @@ namespace QuantLib {
                          const Date& startDate = Date(),
                          const DayCounter& lastPeriodDayCounter = DayCounter(),
                          bool rebatesAccrual = true,
-                         CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint);
+                         CreditDefaultSwap::PricingModel model = CreditDefaultSwap::Midpoint,
+                         const Date& tradeDate = Date());
 
         Real impliedQuote() const override;
 

--- a/test-suite/defaultprobabilitycurves.cpp
+++ b/test-suite/defaultprobabilitycurves.cpp
@@ -298,7 +298,7 @@ void testBootstrapFromUpfront() {
                                   upfrontDate,
                                   ext::shared_ptr<Claim>(),
                                   Actual360(true),
-                                  true, today);
+                                  true);
             cds.setPricingEngine(ext::shared_ptr<PricingEngine>(
                            new MidPointCdsEngine(piecewiseCurve, recoveryRate,
                                                  discountCurve, true)));


### PR DESCRIPTION
Previously, it was set to the evaluation date, which would cause quoted CDS created with the default arguments (setting it at evaluation date + 1) to price off-par.

Optionally, the trade date can now also be passed explicitly to the helper.