### PR TITLE
Add date-generation rule to SwapRateHelper

### DIFF
--- a/ql/termstructures/yield/ratehelpers.cpp
+++ b/ql/termstructures/yield/ratehelpers.cpp
@@ -465,12 +465,13 @@ namespace QuantLib {
                                    Date customPillarDate,
                                    bool endOfMonth,
                                    const std::optional<bool>& useIndexedCoupons,
-                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer,
+                                   DateGeneration::Rule rule)
     : SwapRateHelper(rate, swapIndex->tenor(), swapIndex->fixingCalendar(),
         swapIndex->fixedLegTenor().frequency(), swapIndex->fixedLegConvention(),
         swapIndex->dayCounter(), swapIndex->iborIndex(), std::move(spread), fwdStart,
         std::move(discount), Null<Natural>(), pillarChoice, customPillarDate, endOfMonth,
-        useIndexedCoupons, std::nullopt, couponPricer) {}
+        useIndexedCoupons, std::nullopt, couponPricer, rule) {}
 
     SwapRateHelper::SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                                    const Period& tenor,
@@ -488,14 +489,15 @@ namespace QuantLib {
                                    bool endOfMonth,
                                    const std::optional<bool>& useIndexedCoupons,
                                    const std::optional<BusinessDayConvention>& floatConvention,
-                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer,
+                                   DateGeneration::Rule rule)
     : RelativeDateRateHelper(rate), settlementDays_(settlementDays), tenor_(tenor),
       pillarChoice_(pillarChoice), calendar_(std::move(calendar)),
       fixedConvention_(fixedConvention), fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)), spread_(std::move(spread)), endOfMonth_(endOfMonth),
       fwdStart_(fwdStart), discountHandle_(std::move(discount)),
       useIndexedCoupons_(useIndexedCoupons), floatConvention_(floatConvention),
-      couponPricer_(couponPricer) {
+      couponPricer_(couponPricer), rule_(rule) {
         initialize(iborIndex, customPillarDate);
     }
 
@@ -514,13 +516,14 @@ namespace QuantLib {
                                    bool endOfMonth,
                                    const std::optional<bool>& useIndexedCoupons,
                                    const std::optional<BusinessDayConvention>& floatConvention,
-                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer)
+                                   const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer,
+                                   DateGeneration::Rule rule)
     : RelativeDateRateHelper(rate, false), startDate_(startDate), endDate_(endDate),
       pillarChoice_(pillarChoice), calendar_(std::move(calendar)),
       fixedConvention_(fixedConvention), fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)), spread_(std::move(spread)), endOfMonth_(endOfMonth),
       discountHandle_(std::move(discount)), useIndexedCoupons_(useIndexedCoupons),
-      floatConvention_(floatConvention), couponPricer_(couponPricer) {
+      floatConvention_(floatConvention), couponPricer_(couponPricer), rule_(rule) {
         QL_REQUIRE(fixedFrequency != Once,
             "fixedFrequency == Once is not supported when passing explicit "
             "startDate and endDate");
@@ -554,6 +557,7 @@ namespace QuantLib {
         auto tmp = MakeVanillaSwap(tenor_, iborIndex_, 0.0, fwdStart_)
             .withEffectiveDate(startDate_)
             .withTerminationDate(endDate_)
+            .withRule(rule_)
             .withDiscountingTermStructure(discountRelinkableHandle_)
             .withFixedLegDayCount(fixedDayCount_)
             .withFixedLegTenor(fixedFrequency_ == Once ? tenor_ : Period(fixedFrequency_))

--- a/ql/termstructures/yield/ratehelpers.hpp
+++ b/ql/termstructures/yield/ratehelpers.hpp
@@ -36,6 +36,7 @@
 #include <ql/instruments/futures.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/daycounter.hpp>
+#include <ql/time/dategenerationrule.hpp>
 #include <ql/optional.hpp>
 
 namespace QuantLib {
@@ -208,7 +209,8 @@ namespace QuantLib {
                        Date customPillarDate = Date(),
                        bool endOfMonth = false,
                        const std::optional<bool>& useIndexedCoupons = std::nullopt,
-                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {},
+                       DateGeneration::Rule rule = DateGeneration::Backward);
         SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                        const Period& tenor,
                        Calendar calendar,
@@ -228,7 +230,8 @@ namespace QuantLib {
                        bool endOfMonth = false,
                        const std::optional<bool>& useIndexedCoupons = std::nullopt,
                        const std::optional<BusinessDayConvention>& floatConvention = std::nullopt,
-                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {},
+                       DateGeneration::Rule rule = DateGeneration::Backward);
         SwapRateHelper(const std::variant<Rate, Handle<Quote>>& rate,
                        const Date& startDate,
                        const Date& endDate,
@@ -247,7 +250,8 @@ namespace QuantLib {
                        bool endOfMonth = false,
                        const std::optional<bool>& useIndexedCoupons = std::nullopt,
                        const std::optional<BusinessDayConvention>& floatConvention = std::nullopt,
-                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {});
+                       const ext::shared_ptr<FloatingRateCouponPricer>& couponPricer = {},
+                       DateGeneration::Rule rule = DateGeneration::Backward);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -287,6 +291,7 @@ namespace QuantLib {
         std::optional<bool> useIndexedCoupons_;
         std::optional<BusinessDayConvention> floatConvention_;
         ext::shared_ptr<FloatingRateCouponPricer> couponPricer_;
+        DateGeneration::Rule rule_ = DateGeneration::Backward;
     };
 
 

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -2388,6 +2388,52 @@ BOOST_AUTO_TEST_CASE(testHelperDatesFromNonBusinessEvaluationDate) {
                     "    obtained: " << bmaHelper->earliestDate());
 }
 
+BOOST_AUTO_TEST_CASE(testSwapRateHelperDateGenerationRule) {
+    BOOST_TEST_MESSAGE("Testing SwapRateHelper date-generation rule...");
+
+    const Date startDate(20, March, 2026);
+    const Date endDate(20, March, 2031);
+    auto index = ext::make_shared<Euribor6M>();
+
+    auto defaultHelper = ext::make_shared<SwapRateHelper>(
+        0.02, startDate, endDate, TARGET(), Annual, ModifiedFollowing,
+        Thirty360(Thirty360::BondBasis), index);
+
+    auto forwardHelper = ext::make_shared<SwapRateHelper>(
+        0.02, startDate, endDate, TARGET(), Annual, ModifiedFollowing,
+        Thirty360(Thirty360::BondBasis), index, Handle<Quote>(),
+        Handle<YieldTermStructure>(), Pillar::LastRelevantDate, Date(),
+        false, std::nullopt, std::nullopt,
+        ext::shared_ptr<FloatingRateCouponPricer>(),
+        DateGeneration::Forward);
+
+    BOOST_CHECK(defaultHelper->swap()->fixedSchedule().rule() ==
+                DateGeneration::Backward);
+    BOOST_CHECK(defaultHelper->swap()->floatingSchedule().rule() ==
+                DateGeneration::Backward);
+
+    BOOST_CHECK(forwardHelper->swap()->fixedSchedule().rule() ==
+                DateGeneration::Forward);
+    BOOST_CHECK(forwardHelper->swap()->floatingSchedule().rule() ==
+                DateGeneration::Forward);
+
+    auto tenorForwardHelper = ext::make_shared<SwapRateHelper>(
+        0.02, 5 * Years, TARGET(), Annual, ModifiedFollowing,
+        Thirty360(Thirty360::BondBasis), index, Handle<Quote>(), 0 * Days,
+        Handle<YieldTermStructure>(), Null<Natural>(),
+        Pillar::LastRelevantDate, Date(), false, std::nullopt, std::nullopt,
+        ext::shared_ptr<FloatingRateCouponPricer>(),
+        DateGeneration::Forward);
+
+    BOOST_CHECK(tenorForwardHelper->swap()->fixedSchedule().rule() ==
+                DateGeneration::Forward);
+    BOOST_CHECK(tenorForwardHelper->swap()->floatingSchedule().rule() ==
+                DateGeneration::Forward);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
+
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds an optional `DateGeneration::Rule` parameter to `SwapRateHelper`, addressing the remaining part of #1393.

The new parameter:

- is available on all three `SwapRateHelper` constructors
- defaults to `DateGeneration::Backward`, preserving existing behavior
- is passed to `MakeVanillaSwap::withRule`
- applies to both the fixed and floating schedules

Regression coverage verifies the default backward rule and an explicitly supplied forward rule for both the tenor-based and explicit-date constructors.

Fixes #1393

## Tests

- Focused `SwapRateHelper` date-generation regression test
- `PiecewiseYieldCurveTests`: 34/34 passed
- Full optimized test suite: 1367/1367 test cases and 12413/12413 assertions passed