### PR TITLE
Fix convertible-bond dividend indexing after settlement

### DIFF
--- a/ql/pricingengines/bond/discretizedconvertible.cpp
+++ b/ql/pricingengines/bond/discretizedconvertible.cpp
@@ -43,14 +43,10 @@ namespace QuantLib {
 
         dividendValues_ = Array(dividends_.size(), 0.0);
 
-        Date settlementDate = process_->riskFreeRate()->referenceDate();
-        for (Size i=0; i<dividends.size(); i++) {
-            if (dividends[i]->date() >= settlementDate) {
-                dividendValues_[i] =
-                    dividends[i]->amount() *
-                    process_->riskFreeRate()->discount(
-                                             dividends[i]->date());
-            }
+        for (Size i=0; i<dividends_.size(); i++) {
+            dividendValues_[i] =
+                dividends_[i]->amount() *
+                process_->riskFreeRate()->discount(dividendDates_[i]);
         }
 
         DayCounter dayCounter = process_->riskFreeRate()->dayCounter();

--- a/test-suite/convertiblebonds.cpp
+++ b/test-suite/convertiblebonds.cpp
@@ -26,6 +26,7 @@
 #include <ql/instruments/bonds/floatingratebond.hpp>
 #include <ql/instruments/vanillaoption.hpp>
 #include <ql/pricingengines/bond/binomialconvertibleengine.hpp>
+#include <ql/pricingengines/bond/discretizedconvertible.hpp>
 #include <ql/pricingengines/vanilla/binomialengine.hpp>
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
@@ -40,6 +41,7 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <ql/cashflows/couponpricer.hpp>
 #include <ql/cashflows/cashflows.hpp>
+#include <ql/cashflows/simplecashflow.hpp>
 #include <ql/pricingengines/bond/discountingbondengine.hpp>
 
 using namespace QuantLib;
@@ -348,6 +350,40 @@ BOOST_AUTO_TEST_CASE(testOption) {
                     << "\n    error:      " << error
                     << "\n    tolerance:      " << tolerance);
     }
+}
+
+BOOST_AUTO_TEST_CASE(testDividendsSpanningSettlementDate) {
+    BOOST_TEST_MESSAGE(
+        "Testing convertible bond dividend values spanning the settlement date...");
+
+    Settings::instance().evaluationDate() = Date(15, January, 2024);
+    CommonVars vars;
+
+    ConvertibleBond::arguments args;
+    args.exercise = ext::make_shared<EuropeanExercise>(vars.maturityDate);
+    args.conversionRatio = vars.conversionRatio;
+    args.cashflows.push_back(
+        ext::make_shared<SimpleCashFlow>(vars.redemption, vars.maturityDate));
+    args.issueDate = vars.issueDate;
+    args.settlementDate =
+        vars.calendar.advance(vars.today, vars.settlementDays, Days);
+    args.settlementDays = vars.settlementDays;
+    args.redemption = vars.redemption;
+
+    const Date beforeSettlement = vars.calendar.advance(vars.today, 1, Days);
+    const Date afterSettlement = vars.calendar.advance(args.settlementDate, 1, Years);
+    const Real futureAmount = 10.0;
+    const DividendSchedule dividends = {
+        ext::make_shared<FixedDividend>(1.0, beforeSettlement),
+        ext::make_shared<FixedDividend>(futureAmount, afterSettlement)};
+
+    DiscretizedConvertible convertible(args, vars.process, dividends,
+                                       vars.creditSpread);
+
+    const Real expected =
+        futureAmount * vars.riskFreeRate->discount(afterSettlement);
+    BOOST_CHECK_EQUAL(convertible.dividendValues().size(), 1);
+    BOOST_CHECK_CLOSE(convertible.dividendValues()[0], expected, 1.0e-12);
 }
 
 BOOST_AUTO_TEST_CASE(testRegression) {


### PR DESCRIPTION
## Summary

- populate `dividendValues_` from the already settlement-filtered dividend containers
- keep the value and date indices aligned with the destination array
- add a regression test with one dividend before settlement and one after settlement

This addresses **Issue A** in #2701. Issue B is intentionally out of scope because it requires a separate design decision about evaluation-date versus settlement-date spot adjustment.

## Root cause

`dividendValues_` was sized using `dividends_`, which excludes dividends that occurred before the bond settlement date, but populated by iterating the original unfiltered `dividends` schedule. Once an earlier dividend was filtered out, the raw index no longer matched the destination array and could write out of bounds.

## TDD evidence

Before the production change, the regression test failed because the single retained slot contained the discounted pre-settlement dividend instead of the future dividend:

```text
dividendValues()[0] = 0.99986112075572642
expected            = 9.4977726689391169
```

After the fix:

- focused regression test: passed (1/1)
- complete `ConvertibleBondTests` suite: passed (4/4)
- Debug CMake/Ninja build: passed
- `git diff --check`: passed
- independent read-only review: APPROVE, no Critical/Important/Minor findings

A repository-wide Release build and test run also passed: 1,374/1,374 test cases and 12,423/12,423 assertions in 4 minutes 44 seconds.

## Scope

Only these files change:

- `ql/pricingengines/bond/discretizedconvertible.cpp`
- `test-suite/convertiblebonds.cpp`

## AI assistance

AI assistance was used to help draft the initial regression scenario and perform an independent review. The initial test was manually rejected because it mixed Issue B pricing semantics into Issue A; the final test was rewritten to inspect `DiscretizedConvertible::dividendValues()` directly. All changes and test results were reviewed and executed locally by the contributor.

