### PR TITLE
Allow defining `globalGuess()` in bootstrap traits

### DIFF
--- a/ql/termstructures/globalbootstrap.hpp
+++ b/ql/termstructures/globalbootstrap.hpp
@@ -31,6 +31,8 @@
 #include <ql/utilities/dataformatters.hpp>
 #include <algorithm>
 #include <functional>
+#include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace QuantLib {
@@ -98,21 +100,23 @@ class AdditionalBootstrapVariables {
   for a concrete implementation of this interface.
 
   WARNING: This class is known to work with Traits Discount, ZeroYield, Forward,
-  i.e. the usual IR curves traits in QL. It requires Traits::transformDirect()
-  and Traits::transformInverse() to be implemented. Also, check the usage of
-  Traits::updateGuess(), Traits::guess() in this class.
+  i.e. the usual IR curves traits in QL. For new Traits you may want to implement
+  Traits::transformDirect()/transformInverse()/globalGuess().
 */
 template <class Curve> class GlobalBootstrap final : public MultiCurveBootstrapContributor {
     typedef typename Curve::traits_type Traits;             // ZeroYield, Discount, ForwardRate
     typedef typename Curve::interpolator_type Interpolator; // Linear, LogLinear, ...
     typedef std::function<Array(const std::vector<Time>&, const std::vector<Real>&)>
         AdditionalPenalties;
+    typedef std::function<Array(const std::vector<Time>&, const std::vector<Real>&)>
+        InitialGuessFn;
 
   public:
     GlobalBootstrap(Real accuracy = Null<Real>(),
                     ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
-                    std::vector<Real> instrumentWeights = {});
+                    std::vector<Real> instrumentWeights = {},
+                    InitialGuessFn initialGuessFn = nullptr);
     GlobalBootstrap(std::vector<ext::shared_ptr<typename Traits::helper>> additionalHelpers,
                     std::function<std::vector<Date>()> additionalDates,
                     AdditionalPenalties additionalPenalties,
@@ -120,7 +124,8 @@ template <class Curve> class GlobalBootstrap final : public MultiCurveBootstrapC
                     ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
                     ext::shared_ptr<AdditionalBootstrapVariables> additionalVariables = nullptr,
-                    std::vector<Real> instrumentWeights = {});
+                    std::vector<Real> instrumentWeights = {},
+                    InitialGuessFn initialGuessFn = nullptr);
     GlobalBootstrap(std::vector<ext::shared_ptr<typename Traits::helper>> additionalHelpers,
                     std::function<std::vector<Date>()> additionalDates,
                     std::function<Array()> additionalPenalties,
@@ -128,15 +133,23 @@ template <class Curve> class GlobalBootstrap final : public MultiCurveBootstrapC
                     ext::shared_ptr<OptimizationMethod> optimizer = nullptr,
                     ext::shared_ptr<EndCriteria> endCriteria = nullptr,
                     ext::shared_ptr<AdditionalBootstrapVariables> additionalVariables = nullptr,
-                    std::vector<Real> instrumentWeights = {});
+                    std::vector<Real> instrumentWeights = {},
+                    InitialGuessFn initialGuessFn = nullptr);
     void setup(Curve *ts);
     void calculate() const;
 
   private:
+    template <class T, class = void>
+    static constexpr bool hasTransform = false;
+
+    template <class T, class = void>
+    static constexpr bool hasGlobalGuess = false;
+
     void initialize() const;
     void
     setParentBootstrapper(const ext::shared_ptr<MultiCurveBootstrap>& b) const override;
     Array setupCostFunction() const override;
+    Array makeInitialGuess() const;
     void setCostFunctionArgument(const Array& v) const override;
     Array evaluateCostFunction() const override;
     void setToValid() const override;
@@ -152,6 +165,7 @@ template <class Curve> class GlobalBootstrap final : public MultiCurveBootstrapC
     ext::shared_ptr<AdditionalBootstrapVariables> additionalVariables_;
     mutable std::vector<Real> instrumentWeights_;
     mutable std::vector<Real> aliveInstrumentWeights_;
+    InitialGuessFn initialGuessFn_;
     mutable bool initialized_ = false, validCurve_ = false;
     mutable ext::shared_ptr<MultiCurveBootstrap> parentBootstrapper_ = nullptr;
 };
@@ -159,12 +173,26 @@ template <class Curve> class GlobalBootstrap final : public MultiCurveBootstrapC
 // template definitions
 
 template <class Curve>
+template <class T>
+constexpr bool GlobalBootstrap<Curve>::hasTransform<
+    T,
+    std::void_t<decltype(T::transformDirect(Real(), Size(), std::declval<const Curve*>()))>> = true;
+
+template <class Curve>
+template <class T>
+constexpr bool GlobalBootstrap<Curve>::hasGlobalGuess<
+    T,
+    std::void_t<decltype(T::globalGuess(std::declval<const Curve*>(), true))>> = true;
+
+template <class Curve>
 GlobalBootstrap<Curve>::GlobalBootstrap(Real accuracy,
                                         ext::shared_ptr<OptimizationMethod> optimizer,
                                         ext::shared_ptr<EndCriteria> endCriteria,
-                                        std::vector<Real> instrumentWeights)
+                                        std::vector<Real> instrumentWeights,
+                                        InitialGuessFn initialGuessFn)
 : ts_(nullptr), accuracy_(accuracy), optimizer_(std::move(optimizer)),
-  endCriteria_(std::move(endCriteria)), instrumentWeights_(std::move(instrumentWeights)) {}
+  endCriteria_(std::move(endCriteria)), instrumentWeights_(std::move(instrumentWeights)),
+  initialGuessFn_(std::move(initialGuessFn)) {}
 
 template <class Curve>
 GlobalBootstrap<Curve>::GlobalBootstrap(
@@ -175,13 +203,15 @@ GlobalBootstrap<Curve>::GlobalBootstrap(
     ext::shared_ptr<OptimizationMethod> optimizer,
     ext::shared_ptr<EndCriteria> endCriteria,
     ext::shared_ptr<AdditionalBootstrapVariables> additionalVariables,
-    std::vector<Real> instrumentWeights)
+    std::vector<Real> instrumentWeights,
+    InitialGuessFn initialGuessFn)
 : ts_(nullptr), accuracy_(accuracy), optimizer_(std::move(optimizer)),
   endCriteria_(std::move(endCriteria)), additionalHelpers_(std::move(additionalHelpers)),
   additionalDates_(std::move(additionalDates)),
   additionalPenalties_(std::move(additionalPenalties)),
   additionalVariables_(std::move(additionalVariables)),
-  instrumentWeights_(std::move(instrumentWeights)) {}
+  instrumentWeights_(std::move(instrumentWeights)),
+  initialGuessFn_(std::move(initialGuessFn)) {}
 
 template <class Curve>
 GlobalBootstrap<Curve>::GlobalBootstrap(
@@ -192,7 +222,8 @@ GlobalBootstrap<Curve>::GlobalBootstrap(
     ext::shared_ptr<OptimizationMethod> optimizer,
     ext::shared_ptr<EndCriteria> endCriteria,
     ext::shared_ptr<AdditionalBootstrapVariables> additionalVariables,
-    std::vector<Real> instrumentWeights)
+    std::vector<Real> instrumentWeights,
+    InitialGuessFn initialGuessFn)
 : GlobalBootstrap(std::move(additionalHelpers),
                   std::move(additionalDates),
                   additionalPenalties ?
@@ -203,7 +234,8 @@ GlobalBootstrap<Curve>::GlobalBootstrap(
                   std::move(optimizer),
                   std::move(endCriteria),
                   std::move(additionalVariables),
-                  std::move(instrumentWeights)) {}
+                  std::move(instrumentWeights),
+                  std::move(initialGuessFn)) {}
 
 template <class Curve>
 void GlobalBootstrap<Curve>::setParentBootstrapper(const ext::shared_ptr<MultiCurveBootstrap>& b) const {
@@ -353,25 +385,53 @@ template <class Curve> Array GlobalBootstrap<Curve>::setupCostFunction() const {
 
     // setup interpolation
     if (!validCurve_) {
-        ts_->interpolation_ = ts_->interpolator_.interpolate(ts_->times_.begin(), ts_->times_.end(),
-                                                             ts_->data_.begin());
+        ts_->interpolation_ = detail::interpolateWithoutUpdate(
+            ts_->interpolator_, ts_->times_.begin(), ts_->times_.end(), ts_->data_.begin());
     }
 
     // Initial guess. We have guesses for the curve values first (numberPillars),
     // followed by guesses for the additional variables.
-    Array additionalGuesses;
+    Array guess = makeInitialGuess();
     if (additionalVariables_) {
-        additionalGuesses = additionalVariables_->initialize(validCurve_);
+        Array additionalGuesses = additionalVariables_->initialize(validCurve_);
+        Size oldSize = guess.size();
+        guess.resize(oldSize + additionalGuesses.size());
+        std::copy(additionalGuesses.begin(), additionalGuesses.end(), guess.begin() + oldSize);
     }
-    Array guess(ts_->times_.size() - 1 + additionalGuesses.size());
-    for (Size i = 0; i < ts_->times_.size() - 1; ++i) {
-        // just pass zero as the first alive helper, it's not used in the standard QL traits anyway
-        // update ts_->data_ since Traits::guess() usually depends on previous values
-        Traits::updateGuess(ts_->data_, Traits::guess(i + 1, ts_, validCurve_, 0), i + 1);
-        guess[i] = Traits::transformInverse(ts_->data_[i + 1], i + 1, ts_);
+    return guess;
+}
+
+template <class Curve> Array GlobalBootstrap<Curve>::makeInitialGuess() const {
+    Array guess;
+    bool needsTransform = true;
+    if (initialGuessFn_) {
+        const std::vector<Real> noData;
+        guess = initialGuessFn_(ts_->times_, validCurve_ ? ts_->data_ : noData);
+    } else if constexpr (hasGlobalGuess<Traits>) {
+        std::tie(guess, needsTransform) = Traits::globalGuess(ts_, validCurve_);
+    } else {
+        // Update interpolation because Traits::guess() might rely on it. This is not quite
+        // correct -- we need to call update() in the loop after every Traits::updateGuess().
+        // This is probably much slower and was not done before, so we keep the existing
+        // behavior. Implementing Traits::globalGuess() is a more efficient option.
+        if (!validCurve_)
+            ts_->interpolation_.update();
+
+        guess.resize(ts_->times_.size() - 1);
+        for (Size i = 0, size = guess.size(); i < size; ++i) {
+            // Just pass zero as the first alive helper, it's not used in the standard QL traits
+            // anyway. Update ts_->data_ since Traits::guess() usually depends on previous values.
+            Traits::updateGuess(ts_->data_, Traits::guess(i + 1, ts_, validCurve_, 0), i + 1);
+            guess[i] = ts_->data_[i + 1];
+        }
     }
-    std::copy(additionalGuesses.begin(), additionalGuesses.end(),
-              guess.begin() + ts_->times_.size() - 1);
+    if constexpr (hasTransform<Traits>) {
+        if (needsTransform) {
+            for (Size i = 0, size = guess.size(); i < size; ++i) {
+                guess[i] = Traits::transformInverse(guess[i], i + 1, ts_);
+            }
+        }
+    }
     return guess;
 }
 
@@ -380,7 +440,11 @@ void GlobalBootstrap<Curve>::setCostFunctionArgument(const Array& x) const {
     // x has the same layout as guess above: the first numberPillars values go into
     // the curve, while the rest are new values for the additional variables.
     for (Size i = 0; i < ts_->times_.size() - 1; ++i) {
-        Traits::updateGuess(ts_->data_, Traits::transformDirect(x[i], i + 1, ts_), i + 1);
+        Real value = x[i];
+        if constexpr (hasTransform<Traits>) {
+            value = Traits::transformDirect(value, i + 1, ts_);
+        }
+        Traits::updateGuess(ts_->data_, value, i + 1);
     }
     ts_->interpolation_.update();
     if (additionalVariables_) {

--- a/ql/termstructures/inflation/inflationtraits.hpp
+++ b/ql/termstructures/inflation/inflationtraits.hpp
@@ -26,9 +26,11 @@
 #ifndef ql_inflation_bootstrap_traits_hpp
 #define ql_inflation_bootstrap_traits_hpp
 
+#include <ql/math/array.hpp>
 #include <ql/termstructures/inflation/interpolatedzeroinflationcurve.hpp>
 #include <ql/termstructures/inflation/interpolatedyoyinflationcurve.hpp>
 #include <ql/termstructures/bootstraphelper.hpp>
+#include <utility>
 
 namespace QuantLib {
 
@@ -63,6 +65,16 @@ namespace QuantLib {
                 return c->data()[i];
 
             return detail::avgInflation;
+        }
+
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            return {Array(c->times().size() - 1, detail::avgInflation), true};
         }
 
         // constraints
@@ -101,15 +113,6 @@ namespace QuantLib {
             if (i==1)
                 data[0] = level; // the first point is updated as well
         }
-        // transformation to add constraints to an unconstrained optimization
-        template <class C>
-        static Real transformDirect(Real x, Size, const C*) {
-            return x;
-        }
-        template <class C>
-        static Real transformInverse(Real x, Size, const C*) {
-            return x;
-        }
         // upper bound for convergence loop
         static Size maxIterations() { return 40; }
     };
@@ -141,6 +144,16 @@ namespace QuantLib {
                 return c->data()[i];
 
             return detail::avgInflation;
+        }
+
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            return {Array(c->times().size() - 1, detail::avgInflation), true};
         }
 
         // constraints
@@ -176,15 +189,6 @@ namespace QuantLib {
                                 Rate level,
                                 Size i) {
             data[i] = level;
-        }
-        // transformation to add constraints to an unconstrained optimization
-        template <class C>
-        static Real transformDirect(Real x, Size, const C*) {
-            return x;
-        }
-        template <class C>
-        static Real transformInverse(Real x, Size, const C*) {
-            return x;
         }
         // upper bound for convergence loop
         static Size maxIterations() { return 40; }

--- a/ql/termstructures/yield/bootstraptraits.hpp
+++ b/ql/termstructures/yield/bootstraptraits.hpp
@@ -27,11 +27,13 @@
 #ifndef ql_bootstrap_traits_hpp
 #define ql_bootstrap_traits_hpp
 
+#include <ql/math/array.hpp>
 #include <ql/termstructures/yield/discountcurve.hpp>
 #include <ql/termstructures/yield/zerocurve.hpp>
 #include <ql/termstructures/yield/interpolatedsimplezerocurve.hpp>
 #include <ql/termstructures/yield/forwardcurve.hpp>
 #include <ql/termstructures/bootstraphelper.hpp>
+#include <utility>
 
 namespace QuantLib {
 
@@ -75,6 +77,21 @@ namespace QuantLib {
             // flat rate extrapolation
             Real r = -std::log(c->data()[i-1])/c->times()[i-1];
             return std::exp(-r * c->times()[i]);
+        }
+
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            Array guess(c->times().begin() + 1, c->times().end());
+            guess *= -detail::avgRate;
+            // Discount::transformInverse() is log(), so we simply don't call exp() here
+            // and return false for needsTransform. This saves one pair of exp()/log()
+            // calls per pillar.
+            return {std::move(guess), false};
         }
 
         // possible constraints based on previous values
@@ -162,6 +179,16 @@ namespace QuantLib {
                                Continuous, Annual, true);
         }
 
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            return {Array(c->times().size() - 1, detail::avgRate), true};
+        }
+
         // possible constraints based on previous values
         template <class C>
         static Real minValueAfter(Size,
@@ -190,18 +217,6 @@ namespace QuantLib {
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
             return detail::maxRate;
-        }
-
-        // transformation to add constraints to an unconstrained optimization
-        template <class C>
-        static Real transformDirect(Real x, Size i, const C* c)
-        {
-            return x;
-        }
-        template <class C>
-        static Real transformInverse(Real x, Size i, const C* c)
-        {
-            return x;
         }
 
         // root-finding update
@@ -255,6 +270,16 @@ namespace QuantLib {
                                   Continuous, Annual, true);
         }
 
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            return {Array(c->times().size() - 1, detail::avgRate), true};
+        }
+
         // possible constraints based on previous values
         template <class C>
         static Real minValueAfter(Size,
@@ -283,18 +308,6 @@ namespace QuantLib {
             // no constraints.
             // We choose as max a value very unlikely to be exceeded.
             return detail::maxRate;
-        }
-
-        // transformation to add constraints to an unconstrained optimization
-        template <class C>
-        static Real transformDirect(Real x, Size i, const C* c)
-        {
-            return x;
-        }
-        template <class C>
-        static Real transformInverse(Real x, Size i, const C* c)
-        {
-            return x;
         }
 
         // root-finding update
@@ -345,6 +358,16 @@ namespace QuantLib {
             Date d = c->dates()[i];
             return c->zeroRate(d, c->dayCounter(),
                                Simple, Annual, true);
+        }
+
+        // guess for the whole curve and whether it needs to be transformed
+        template <class C>
+        static std::pair<Array, bool> globalGuess(const C* c, bool validData)
+        {
+            if (validData)
+                return {Array(c->data().begin() + 1, c->data().end()), true};
+
+            return {Array(c->times().size() - 1, detail::avgRate), true};
         }
 
         // possible constraints based on previous values

--- a/test-suite/piecewiseyieldcurve.cpp
+++ b/test-suite/piecewiseyieldcurve.cpp
@@ -1544,6 +1544,77 @@ BOOST_AUTO_TEST_CASE(testGlobalBootstrapVariables) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testGlobalBootstrapInitialGuessFn, *precondition(usingAtParCoupons())) {
+
+    CommonVars vars(Date(25, Sep, 2019));
+
+    // Create a setup that is sensitive to the initial guess.
+    auto calendar = Euribor6M().fixingCalendar();
+    std::vector<Date> pillarDates = {Date(1, Oct, 2019)};
+    for (Size i = 0; i < 8; ++i) {
+        pillarDates.push_back(calendar.adjust(pillarDates.back() + 45));
+    }
+    for (const auto& helper : vars.instruments) {
+        if (helper->pillarDate() > pillarDates.back())
+            pillarDates.push_back(helper->pillarDate());
+    }
+
+    auto penalties = [&](const std::vector<Time>& times, const std::vector<Real>& data) {
+        const Size nInst = vars.instruments.size();
+        Array errors(nInst + times.size() - 2);
+        // instruments errors
+        std::transform(
+            vars.instruments.begin(), vars.instruments.end(), errors.begin(),
+            [](const ext::shared_ptr<RateHelper>& h) { return h->quoteError(); });
+        // gradient penalties
+        Array rates(data.size() - 1);
+        for (Size i = 0; i < times.size() - 1; ++i) {
+            rates[i] = (data[i] / data[i+1] - 1.0) / (times[i+1] - times[i]);
+        }
+        for (Size i = 0; i < times.size() - 2; ++i) {
+            errors[nInst + i] = 1e-2 * (rates[i+1] - rates[i]) / (times[i+1] - times[i]);
+        }
+        return errors;
+    };
+
+    int initialGuessCalls = 0;
+    auto initialGuessFn = [&](const std::vector<Time>& times, const std::vector<Real>& data) {
+        initialGuessCalls++;
+        return Array(times.size() - 1, 1.0);
+    };
+
+    typedef PiecewiseYieldCurve<Discount, LogLinear, GlobalBootstrap> Curve;
+    auto curve = ext::make_shared<Curve>(
+        vars.settlement, std::vector<ext::shared_ptr<RateHelper>>(), Actual365Fixed(),
+        Curve::bootstrap_type(vars.instruments, [&]() { return pillarDates; }, penalties,
+                              1e-12, nullptr, nullptr, nullptr, {}, initialGuessFn));
+
+    static const Date expectedDates[] = {
+        Date(27, Sep, 2019), Date(1, Oct, 2019), Date(15, Nov, 2019), Date(30, Dec, 2019),
+        Date(13, Feb, 2020), Date(30, Mar, 2020), Date(14, May, 2020), Date(29, Jun, 2020),
+        Date(13, Aug, 2020), Date(28, Sep, 2020), Date(27, Sep, 2021), Date(27, Sep, 2022),
+        Date(27, Sep, 2023), Date(27, Sep, 2024), Date(29, Sep, 2025), Date(28, Sep, 2026),
+        Date(27, Sep, 2027), Date(27, Sep, 2028), Date(27, Sep, 2029), Date(29, Sep, 2031),
+        Date(27, Sep, 2034), Date(27, Sep, 2039), Date(27, Sep, 2044), Date(27, Sep, 2049)
+    };
+    static const DiscountFactor expectedDFs[] = {
+        1.0,                0.9994923431162580, 0.9938069118457880, 0.9882401711181712,
+        0.9828381250775845, 0.9774079566030049, 0.9721182498392723, 0.9667951580943512,
+        0.9617336341824015, 0.9564548068987965, 0.9135007024272714, 0.8698607442445871,
+        0.8266650007699866, 0.7829682196126155, 0.7399209887960153, 0.6973589159124343,
+        0.6565792747227167, 0.6180250998622848, 0.5818438569698231, 0.5127051907762759,
+        0.4218543471337612, 0.3050840671400172, 0.2225943633033588, 0.165544906093695
+    };
+
+    auto nodes = curve->nodes();
+    BOOST_REQUIRE_EQUAL(nodes.size(), std::size(expectedDates));
+    for (Size i = 0; i < nodes.size(); ++i) {
+        BOOST_CHECK_EQUAL(nodes[i].first, expectedDates[i]);
+        QL_CHECK_SMALL(nodes[i].second - expectedDFs[i], 1e-10);
+    }
+    BOOST_CHECK_EQUAL(initialGuessCalls, 1);
+}
+
 BOOST_AUTO_TEST_CASE(testMultiCurveTwoPiecewiseYieldCurves) {
 
     BOOST_TEST_MESSAGE("Testing multicurve bootstrap with two piecewise yield curves...");


### PR DESCRIPTION
Currently, GlobalBootstrap uses the regular Traits::guess() method. This method was designed for IterativeBootstrap and usually uses previous points to make the guess for the next point. In some traits (ZeroYield, ForwardRate, SimpleZeroYield) it also uses methods that rely on curve's interpolation (zeroRate(), forwardRate()). However, GlobalBootstrap does NOT update interpolation while computing initial guess, so the result is not well defined. We could update interpolation before calling guess() but:

1. This would add significant overhead.

2. Since GlobalBootstrap doesn't run optimizations until it got initial guesses for all points, the guesses are basically constant, so this seems excessive.

Instead, add a new method, globalGuess(), which returns the whole array of guesses in one call without using interpolation or data in the curve. It also returns a flag: whether the guesses need to be transformed. This allows skipping exp() in guesses for Discount, because transformInverse is log(). So we avoid one pair of exp()/log calls per pillar.

For traits that don't define globalGuess(), we keep using the old logic.

Also, allow passing a custom function to generate the initial guess. This is mostly useful in SWIG bindings where you cannot define new traits.

Also, make Traits::transformDirect()/transformInverse() methods optional so we don't have to define them for traits that don't need them.