### PR TITLE
Add `DerivedYieldTermStructure` helper classes

### DIFF
--- a/QuantLib.vcxproj
+++ b/QuantLib.vcxproj
@@ -1791,6 +1791,7 @@
     <ClInclude Include="ql\termstructures\yield\bondhelpers.hpp" />
     <ClInclude Include="ql\termstructures\yield\bootstraptraits.hpp" />
     <ClInclude Include="ql\termstructures\yield\compositezeroyieldstructure.hpp" />
+    <ClInclude Include="ql\termstructures\yield\derivedtermstructure.hpp" />
     <ClInclude Include="ql\termstructures\yield\discountcurve.hpp" />
     <ClInclude Include="ql\termstructures\yield\fittedbonddiscountcurve.hpp" />
     <ClInclude Include="ql\termstructures\yield\flatforward.hpp" />

--- a/QuantLib.vcxproj.filters
+++ b/QuantLib.vcxproj.filters
@@ -2205,6 +2205,9 @@
     <ClInclude Include="ql\termstructures\yield\compositezeroyieldstructure.hpp">
       <Filter>termstructures\yield</Filter>
     </ClInclude>
+    <ClInclude Include="ql\termstructures\yield\derivedtermstructure.hpp">
+      <Filter>termstructures\yield</Filter>
+    </ClInclude>
     <ClInclude Include="ql\termstructures\yield\discountcurve.hpp">
       <Filter>termstructures\yield</Filter>
     </ClInclude>

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -2190,6 +2190,7 @@ set(QL_HEADERS
     termstructures/yield/bondhelpers.hpp
     termstructures/yield/bootstraptraits.hpp
     termstructures/yield/compositezeroyieldstructure.hpp
+    termstructures/yield/derivedtermstructure.hpp
     termstructures/yield/discountcurve.hpp
     termstructures/yield/fittedbonddiscountcurve.hpp
     termstructures/yield/flatforward.hpp

--- a/ql/termstructures/yield/Makefile.am
+++ b/ql/termstructures/yield/Makefile.am
@@ -7,6 +7,7 @@ this_include_HEADERS = \
     bondhelpers.hpp \
     bootstraptraits.hpp \
     compositezeroyieldstructure.hpp \
+    derivedtermstructure.hpp \
     discountcurve.hpp \
     fittedbonddiscountcurve.hpp \
     flatforward.hpp \

--- a/ql/termstructures/yield/all.hpp
+++ b/ql/termstructures/yield/all.hpp
@@ -4,6 +4,7 @@
 #include <ql/termstructures/yield/bondhelpers.hpp>
 #include <ql/termstructures/yield/bootstraptraits.hpp>
 #include <ql/termstructures/yield/compositezeroyieldstructure.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/discountcurve.hpp>
 #include <ql/termstructures/yield/fittedbonddiscountcurve.hpp>
 #include <ql/termstructures/yield/flatforward.hpp>

--- a/ql/termstructures/yield/derivedtermstructure.hpp
+++ b/ql/termstructures/yield/derivedtermstructure.hpp
@@ -1,0 +1,120 @@
+#ifndef quantlib_derived_yield_term_structure_hpp
+#define quantlib_derived_yield_term_structure_hpp
+
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <type_traits>
+#include <utility>
+
+namespace QuantLib {
+
+    //! Base class for derived term structures that have their own referenceDate.
+    template <class Base = YieldTermStructure>
+    class DerivedYieldTermStructure : public Base {
+      public:
+        static_assert(std::is_base_of_v<YieldTermStructure, Base>,
+                      "Base must inherit from YieldTermStructure");
+
+        template <class... Args>
+        DerivedYieldTermStructure(Handle<YieldTermStructure> originalCurve,
+                                  Args&&... args);
+        //! \name YieldTermStructure interface
+        //@{
+        DayCounter dayCounter() const override;
+        Date maxDate() const override;
+        //@}
+      protected:
+        //! \name Observer interface
+        //@{
+        void update() override;
+        //@}
+        Handle<YieldTermStructure> originalCurve_;
+      private:
+        void setupExtrapolation();
+    };
+
+    //! Base class for derived term structures that forward referenceDate from
+    //! the underlying term structure.
+    template <class Base = YieldTermStructure>
+    class RelativeDerivedYieldTermStructure : public DerivedYieldTermStructure<Base> {
+      public:
+        using DerivedYieldTermStructure<Base>::DerivedYieldTermStructure;
+        //! \name YieldTermStructure interface
+        //@{
+        const Date& referenceDate() const override;
+        Calendar calendar() const override;
+        Natural settlementDays() const override;
+        //@}
+      protected:
+        //! \name Observer interface
+        //@{
+        void update() override;
+        //@}
+    };
+
+
+    // inline definitions
+
+    template <class Base>
+    template <class... Args>
+    inline DerivedYieldTermStructure<Base>::DerivedYieldTermStructure(
+        Handle<YieldTermStructure> originalCurve,
+        Args&&... args)
+    : Base(std::forward<Args>(args)...), originalCurve_(std::move(originalCurve)) {
+        this->registerWith(originalCurve_);
+        setupExtrapolation();
+    }
+
+    template <class Base>
+    inline DayCounter DerivedYieldTermStructure<Base>::dayCounter() const {
+        return originalCurve_->dayCounter();
+    }
+
+    template <class Base>
+    inline Date DerivedYieldTermStructure<Base>::maxDate() const {
+        return originalCurve_->maxDate();
+    }
+
+    template <class Base>
+    void DerivedYieldTermStructure<Base>::update() {
+        setupExtrapolation();
+        Base::update();
+    }
+
+    template <class Base>
+    inline void DerivedYieldTermStructure<Base>::setupExtrapolation() {
+        if (!originalCurve_.empty())
+            this->enableExtrapolation(originalCurve_->allowsExtrapolation());
+    }
+
+    template <class Base>
+    inline const Date& RelativeDerivedYieldTermStructure<Base>::referenceDate() const {
+        return this->originalCurve_->referenceDate();
+    }
+
+    template <class Base>
+    inline Calendar RelativeDerivedYieldTermStructure<Base>::calendar() const {
+        return this->originalCurve_->calendar();
+    }
+
+    template <class Base>
+    inline Natural RelativeDerivedYieldTermStructure<Base>::settlementDays() const {
+        return this->originalCurve_->settlementDays();
+    }
+
+    template <class Base>
+    void RelativeDerivedYieldTermStructure<Base>::update() {
+        if (!this->originalCurve_.empty()) {
+            DerivedYieldTermStructure<Base>::update();
+        } else {
+            /* The implementation inherited from YieldTermStructure
+               asks for our reference date, which we don't have since
+               the original curve is still not set. Therefore, we skip
+               over that and just call the base-class behavior. */
+            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
+            TermStructure::update();
+        }
+    }
+
+}
+
+#endif

--- a/ql/termstructures/yield/forwardspreadedtermstructure.hpp
+++ b/ql/termstructures/yield/forwardspreadedtermstructure.hpp
@@ -26,6 +26,7 @@
 #define quantlib_forward_spreaded_term_structure_hpp
 
 #include <ql/quote.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/zeroyieldstructure.hpp>
 #include <utility>
 
@@ -44,77 +45,23 @@ namespace QuantLib {
         - observability against changes in the underlying term
           structure and in the added spread is checked.
     */
-    class ForwardSpreadedTermStructure : public ZeroYieldStructure {
+    class ForwardSpreadedTermStructure
+        : public RelativeDerivedYieldTermStructure<ZeroYieldStructure> {
       public:
         ForwardSpreadedTermStructure(Handle<YieldTermStructure>, Handle<Quote> spread);
-        //! \name TermStructure interface
-        //@{
-        DayCounter dayCounter() const override;
-        Date maxDate() const override;
-        Time maxTime() const override;
-        const Date& referenceDate() const override;
-        Calendar calendar() const override;
-        Natural settlementDays() const override;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
-        //@}
       protected:
         //! \name ZeroYieldStructure implementation
         //@{
         Rate zeroYieldImpl(Time t) const override;
         //@}
       private:
-        Handle<YieldTermStructure> originalCurve_;
         Handle<Quote> spread_;
     };
 
     inline ForwardSpreadedTermStructure::ForwardSpreadedTermStructure(Handle<YieldTermStructure> h,
                                                                       Handle<Quote> spread)
-    : originalCurve_(std::move(h)), spread_(std::move(spread)) {
-        if (!originalCurve_.empty())
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        registerWith(originalCurve_);
+    : RelativeDerivedYieldTermStructure(std::move(h)), spread_(std::move(spread)) {
         registerWith(spread_);
-    }
-
-    inline DayCounter ForwardSpreadedTermStructure::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    inline Calendar ForwardSpreadedTermStructure::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    inline Natural ForwardSpreadedTermStructure::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    inline const Date& ForwardSpreadedTermStructure::referenceDate() const {
-        return originalCurve_->referenceDate();
-    }
-
-    inline Date ForwardSpreadedTermStructure::maxDate() const {
-        return originalCurve_->maxDate();
-    }
-
-    inline Time ForwardSpreadedTermStructure::maxTime() const {
-        return originalCurve_->maxTime();
-    }
-
-    inline void ForwardSpreadedTermStructure::update() {
-        if (!originalCurve_.empty()) {
-            YieldTermStructure::update();
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
     }
 
     inline Rate ForwardSpreadedTermStructure::zeroYieldImpl(Time t) const {

--- a/ql/termstructures/yield/impliedtermstructure.hpp
+++ b/ql/termstructures/yield/impliedtermstructure.hpp
@@ -25,7 +25,7 @@
 #ifndef quantlib_implied_term_structure_hpp
 #define quantlib_implied_term_structure_hpp
 
-#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/utilities/null.hpp>
 #include <utility>
 
@@ -46,17 +46,13 @@ namespace QuantLib {
         - observability against changes in the underlying term
           structure is checked.
     */
-    class ImpliedTermStructure : public YieldTermStructure {
+    class ImpliedTermStructure : public DerivedYieldTermStructure<> {
       public:
         ImpliedTermStructure(Handle<YieldTermStructure>, const Date& referenceDate);
+        ImpliedTermStructure(Handle<YieldTermStructure>, Natural settlementDays, Calendar);
+      protected:
         //! \name YieldTermStructure interface
         //@{
-        DayCounter dayCounter() const override;
-        Calendar calendar() const override;
-        Natural settlementDays() const override;
-        Date maxDate() const override;
-
-      protected:
         DiscountFactor discountImpl(Time) const override;
         //@}
         //! \name Observer interface
@@ -64,7 +60,6 @@ namespace QuantLib {
         void update() override;
         //@}
       private:
-        Handle<YieldTermStructure> originalCurve_;
         mutable DiscountFactor refDf_ = Null<DiscountFactor>();
         mutable Time refTime_ = Null<Time>();
     };
@@ -74,34 +69,17 @@ namespace QuantLib {
 
     inline ImpliedTermStructure::ImpliedTermStructure(Handle<YieldTermStructure> h,
                                                       const Date& referenceDate)
-    : YieldTermStructure(referenceDate), originalCurve_(std::move(h)) {
-        if (!originalCurve_.empty())
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        registerWith(originalCurve_);
-    }
+    : DerivedYieldTermStructure(std::move(h), referenceDate) {}
 
-    inline DayCounter ImpliedTermStructure::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    inline Calendar ImpliedTermStructure::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    inline Natural ImpliedTermStructure::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    inline Date ImpliedTermStructure::maxDate() const {
-        return originalCurve_->maxDate();
-    }
+    inline ImpliedTermStructure::ImpliedTermStructure(Handle<YieldTermStructure> h,
+                                                      Natural settlementDays,
+                                                      Calendar calendar)
+    : DerivedYieldTermStructure(std::move(h), settlementDays, std::move(calendar)) {}
 
     inline void ImpliedTermStructure::update() {
         refDf_ = Null<DiscountFactor>();
         refTime_ = Null<Time>();
-        if (!originalCurve_.empty())
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        YieldTermStructure::update();
+        DerivedYieldTermStructure::update();
     }
 
     inline DiscountFactor ImpliedTermStructure::discountImpl(Time t) const {

--- a/ql/termstructures/yield/piecewiseforwardspreadedtermstructure.hpp
+++ b/ql/termstructures/yield/piecewiseforwardspreadedtermstructure.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/math/interpolation.hpp>
 #include <ql/quote.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/zeroyieldstructure.hpp>
 #include <utility>
 #include <vector>
@@ -46,7 +47,8 @@ namespace QuantLib {
   */
 
   template <class Interpolator>
-  class InterpolatedPiecewiseForwardSpreadedTermStructure : public ZeroYieldStructure {
+  class InterpolatedPiecewiseForwardSpreadedTermStructure
+        : public RelativeDerivedYieldTermStructure<ZeroYieldStructure> {
     public:
       InterpolatedPiecewiseForwardSpreadedTermStructure(Handle<YieldTermStructure>,
                                                      std::vector<Handle<Quote>> spreads,
@@ -64,10 +66,6 @@ namespace QuantLib {
                                                      Interpolator factory = Interpolator());
       //! \name YieldTermStructure interface
       //@{
-      DayCounter dayCounter() const override;
-      Natural settlementDays() const override;
-      Calendar calendar() const override;
-      const Date& referenceDate() const override;
       Date maxDate() const override;
       //@}
     protected:
@@ -79,7 +77,6 @@ namespace QuantLib {
       void updateInterpolation();
       Real calcSpread(Time t) const;
       Real calcSpreadPrimitive(Time t) const;
-      Handle<YieldTermStructure> originalCurve_;
       std::vector<Handle<Quote> > spreads_;
       std::vector<Date> dates_;
       std::vector<Time> times_;
@@ -100,12 +97,12 @@ namespace QuantLib {
                                                            std::vector<Handle<Quote>> spreads,
                                                            std::vector<Date> dates,
                                                            T factory)
-    : originalCurve_(std::move(h)), spreads_(std::move(spreads)), dates_(std::move(dates)),
-    times_(dates_.size()), spreadValues_(dates_.size()), factory_(std::move(factory)) {
+    : RelativeDerivedYieldTermStructure(std::move(h)), spreads_(std::move(spreads)),
+      dates_(std::move(dates)), times_(dates_.size()), spreadValues_(dates_.size()),
+      factory_(std::move(factory)) {
         QL_REQUIRE(!spreads_.empty(), "no spreads given");
         QL_REQUIRE(spreads_.size() == dates_.size(),
                    "spread and date vector have different sizes");
-        registerWith(originalCurve_);
         for (auto& spread : spreads_)
             registerWith(spread);
         interpolator_ = detail::interpolateWithoutUpdate(
@@ -126,27 +123,6 @@ namespace QuantLib {
     ) {}
 
     #endif
-
-    template <class T>
-    inline DayCounter InterpolatedPiecewiseForwardSpreadedTermStructure<T>::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    template <class T>
-    inline Calendar InterpolatedPiecewiseForwardSpreadedTermStructure<T>::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    template <class T>
-    inline Natural InterpolatedPiecewiseForwardSpreadedTermStructure<T>::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    template <class T>
-    inline const Date&
-    InterpolatedPiecewiseForwardSpreadedTermStructure<T>::referenceDate() const {
-        return originalCurve_->referenceDate();
-    }
 
     template <class T>
     inline Date InterpolatedPiecewiseForwardSpreadedTermStructure<T>::maxDate() const {
@@ -191,17 +167,9 @@ namespace QuantLib {
 
     template <class T>
     inline void InterpolatedPiecewiseForwardSpreadedTermStructure<T>::update() {
-        if (!originalCurve_.empty()) {
+        if (!originalCurve_.empty())
             updateInterpolation();
-            YieldTermStructure::update();
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
+        RelativeDerivedYieldTermStructure::update();
     }
 
     template <class T>

--- a/ql/termstructures/yield/piecewisezerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/piecewisezerospreadedtermstructure.hpp
@@ -28,6 +28,7 @@
 
 #include <ql/math/interpolations/linearinterpolation.hpp>
 #include <ql/quote.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/zeroyieldstructure.hpp>
 #include <utility>
 #include <vector>
@@ -46,7 +47,8 @@ namespace QuantLib {
   */
 
   template <class Interpolator>
-  class InterpolatedPiecewiseZeroSpreadedTermStructure : public ZeroYieldStructure {
+  class InterpolatedPiecewiseZeroSpreadedTermStructure
+        : public RelativeDerivedYieldTermStructure<ZeroYieldStructure> {
     public:
       InterpolatedPiecewiseZeroSpreadedTermStructure(Handle<YieldTermStructure>,
                                                      std::vector<Handle<Quote>> spreads,
@@ -68,10 +70,6 @@ namespace QuantLib {
                                                      Interpolator factory = Interpolator());
       //! \name YieldTermStructure interface
       //@{
-      DayCounter dayCounter() const override;
-      Natural settlementDays() const override;
-      Calendar calendar() const override;
-      const Date& referenceDate() const override;
       Date maxDate() const override;
       //@}
     protected:
@@ -82,7 +80,6 @@ namespace QuantLib {
     private:
       void updateInterpolation();
       Real calcSpread(Time t) const;
-      Handle<YieldTermStructure> originalCurve_;
       std::vector<Handle<Quote> > spreads_;
       std::vector<Date> dates_;
       std::vector<Time> times_;
@@ -111,13 +108,12 @@ namespace QuantLib {
                                                            Compounding comp,
                                                            Frequency freq,
                                                            T factory)
-    : originalCurve_(std::move(h)), spreads_(std::move(spreads)), dates_(std::move(dates)),
-      times_(dates_.size()), spreadValues_(dates_.size()), comp_(comp), freq_(freq),
-      factory_(std::move(factory)) {
+    : RelativeDerivedYieldTermStructure(std::move(h)), spreads_(std::move(spreads)),
+      dates_(std::move(dates)), times_(dates_.size()), spreadValues_(dates_.size()),
+      comp_(comp), freq_(freq), factory_(std::move(factory)) {
         QL_REQUIRE(!spreads_.empty(), "no spreads given");
         QL_REQUIRE(spreads_.size() == dates_.size(),
                    "spread and date vector have different sizes");
-        registerWith(originalCurve_);
         for (auto& spread : spreads_)
             registerWith(spread);
         interpolator_ = detail::interpolateWithoutUpdate(
@@ -140,27 +136,6 @@ namespace QuantLib {
     ) {}
 
     #endif
-
-    template <class T>
-    inline DayCounter InterpolatedPiecewiseZeroSpreadedTermStructure<T>::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    template <class T>
-    inline Calendar InterpolatedPiecewiseZeroSpreadedTermStructure<T>::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    template <class T>
-    inline Natural InterpolatedPiecewiseZeroSpreadedTermStructure<T>::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    template <class T>
-    inline const Date&
-    InterpolatedPiecewiseZeroSpreadedTermStructure<T>::referenceDate() const {
-        return originalCurve_->referenceDate();
-    }
 
     template <class T>
     inline Date InterpolatedPiecewiseZeroSpreadedTermStructure<T>::maxDate() const {
@@ -193,17 +168,9 @@ namespace QuantLib {
 
     template <class T>
     inline void InterpolatedPiecewiseZeroSpreadedTermStructure<T>::update() {
-        if (!originalCurve_.empty()) {
+        if (!originalCurve_.empty())
             updateInterpolation();
-            ZeroYieldStructure::update();
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
+        RelativeDerivedYieldTermStructure::update();
     }
 
     template <class T>

--- a/ql/termstructures/yield/spreaddiscountcurve.hpp
+++ b/ql/termstructures/yield/spreaddiscountcurve.hpp
@@ -3,8 +3,9 @@
 #ifndef quantlib_spread_discount_curve_hpp
 #define quantlib_spread_discount_curve_hpp
 
-#include <ql/termstructures/yieldtermstructure.hpp>
 #include <ql/termstructures/interpolatedcurve.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/math/interpolations/loginterpolation.hpp>
 #include <utility>
 
@@ -24,7 +25,7 @@ namespace QuantLib {
 
     template <class Interpolator>
     class InterpolatedSpreadDiscountCurve
-        : public YieldTermStructure,
+        : public RelativeDerivedYieldTermStructure<>,
           protected InterpolatedCurve<Interpolator> {
       public:
         InterpolatedSpreadDiscountCurve(
@@ -34,10 +35,6 @@ namespace QuantLib {
             const Interpolator& interpolator = {});
         //! \name YieldTermStructure interface
         //@{
-        DayCounter dayCounter() const override;
-        Natural settlementDays() const override;
-        Calendar calendar() const override;
-        const Date& referenceDate() const override;
         Date maxDate() const override;
         //@}
         //@}
@@ -64,7 +61,6 @@ namespace QuantLib {
         void updateInterpolation();
         DiscountFactor calcSpread(Time t) const;
 
-        Handle<YieldTermStructure> baseCurve_;
         DayCounter prevDayCount_;
     };
 
@@ -86,8 +82,9 @@ namespace QuantLib {
         std::vector<Date> dates,
         std::vector<DiscountFactor> dfs,
         const T& interpolator)
-    : InterpolatedCurve<T>({}, std::move(dfs), interpolator),
-      dates_(std::move(dates)), baseCurve_(std::move(baseCurve)) {
+    : RelativeDerivedYieldTermStructure(std::move(baseCurve)),
+      InterpolatedCurve<T>({}, std::move(dfs), interpolator),
+      dates_(std::move(dates)) {
         QL_REQUIRE(dates_.size() >= T::requiredPoints,
                    "not enough input dates given");
         QL_REQUIRE(this->data_.size() == dates_.size(),
@@ -99,11 +96,10 @@ namespace QuantLib {
             QL_REQUIRE(this->data_[i] > 0.0, "negative discount");
         }
 
-        registerWith(baseCurve_);
         this->times_.resize(dates_.size());
         this->interpolation_ = detail::interpolateWithoutUpdate(
             this->interpolator_, this->times_.begin(), this->times_.end(), this->data_.begin());
-        if (!baseCurve_.empty())
+        if (!originalCurve_.empty())
             updateInterpolation();
     }
 
@@ -111,43 +107,21 @@ namespace QuantLib {
     inline InterpolatedSpreadDiscountCurve<T>::InterpolatedSpreadDiscountCurve(
         Handle<YieldTermStructure> baseCurve,
         const T& interpolator)
-    : InterpolatedCurve<T>(interpolator), baseCurve_(std::move(baseCurve))
-    {
-        registerWith(baseCurve_);
-    }
+    : RelativeDerivedYieldTermStructure(std::move(baseCurve)),
+      InterpolatedCurve<T>(interpolator) {}
 
     #endif
 
     template <class T>
-    inline DayCounter InterpolatedSpreadDiscountCurve<T>::dayCounter() const {
-        return baseCurve_->dayCounter();
-    }
-
-    template <class T>
-    inline Calendar InterpolatedSpreadDiscountCurve<T>::calendar() const {
-        return baseCurve_->calendar();
-    }
-
-    template <class T>
-    inline Natural InterpolatedSpreadDiscountCurve<T>::settlementDays() const {
-        return baseCurve_->settlementDays();
-    }
-
-    template <class T>
-    inline const Date& InterpolatedSpreadDiscountCurve<T>::referenceDate() const {
-        return baseCurve_->referenceDate();
-    }
-
-    template <class T>
     inline Date InterpolatedSpreadDiscountCurve<T>::maxDate() const {
         Date maxDate = this->maxDate_ != Date() ? this->maxDate_ : dates_.back();
-        return std::min(baseCurve_->maxDate(), maxDate);
+        return std::min(originalCurve_->maxDate(), maxDate);
     }
 
     template <class T>
     inline const Handle<YieldTermStructure>&
     InterpolatedSpreadDiscountCurve<T>::baseCurve() const {
-        return baseCurve_;
+        return originalCurve_;
     }
 
     template <class T>
@@ -180,7 +154,7 @@ namespace QuantLib {
     template <class T>
     inline DiscountFactor
     InterpolatedSpreadDiscountCurve<T>::discountImpl(Time t) const {
-        return baseCurve_->discount(t) * calcSpread(t);
+        return originalCurve_->discount(t) * calcSpread(t);
     }
 
     template <class T>
@@ -198,18 +172,9 @@ namespace QuantLib {
 
     template <class T>
     inline void InterpolatedSpreadDiscountCurve<T>::update() {
-        if (!baseCurve_.empty()) {
-            if (!dates_.empty())
-                updateInterpolation();
-            YieldTermStructure::update();
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
+        if (!originalCurve_.empty() && !dates_.empty())
+            updateInterpolation();
+        RelativeDerivedYieldTermStructure::update();
     }
 
     template <class T>

--- a/ql/termstructures/yield/ultimateforwardtermstructure.hpp
+++ b/ql/termstructures/yield/ultimateforwardtermstructure.hpp
@@ -27,6 +27,7 @@
 #include <ql/math/rounding.hpp>
 #include <ql/optional.hpp>
 #include <ql/quote.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/zeroyieldstructure.hpp>
 #include <utility>
 
@@ -75,7 +76,8 @@ namespace QuantLib {
         - rounding of output rate with predefined compounding.
     */
 
-    class UltimateForwardTermStructure : public ZeroYieldStructure {
+    class UltimateForwardTermStructure
+        : public RelativeDerivedYieldTermStructure<ZeroYieldStructure> {
       public:
         UltimateForwardTermStructure(Handle<YieldTermStructure>,
                                      Handle<Quote> lastLiquidForwardRate,
@@ -87,15 +89,7 @@ namespace QuantLib {
                                      Frequency frequency = Annual);
         //! \name YieldTermStructure interface
         //@{
-        DayCounter dayCounter() const override;
-        Calendar calendar() const override;
-        Natural settlementDays() const override;
-        const Date& referenceDate() const override;
         Date maxDate() const override;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
         //@}
       protected:
         //! returns the UFR extended zero yield rate
@@ -106,7 +100,6 @@ namespace QuantLib {
         Rate applyRounding(Rate r, Time t) const;
         //@}
 
-        Handle<YieldTermStructure> originalCurve_;
         Handle<Quote> llfr_;
         Handle<Quote> ufr_;
         Period fsp_;
@@ -127,49 +120,16 @@ namespace QuantLib {
         const std::optional<Integer>& roundingDigits,
         Compounding compounding,
         Frequency frequency)
-    : originalCurve_(std::move(h)), llfr_(std::move(lastLiquidForwardRate)),
+    : RelativeDerivedYieldTermStructure(std::move(h)), llfr_(std::move(lastLiquidForwardRate)),
       ufr_(std::move(ultimateForwardRate)), fsp_(firstSmoothingPoint), alpha_(alpha),
       roundingDigits_(roundingDigits), compounding_(compounding), frequency_(frequency) {
         QL_REQUIRE(fsp_.length() > 0,
                    "first smoothing point must be a period with positive length");
-        if (!originalCurve_.empty())
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        registerWith(originalCurve_);
         registerWith(llfr_);
         registerWith(ufr_);
     }
 
-    inline DayCounter UltimateForwardTermStructure::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    inline Calendar UltimateForwardTermStructure::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    inline Natural UltimateForwardTermStructure::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    inline const Date& UltimateForwardTermStructure::referenceDate() const {
-        return originalCurve_->referenceDate();
-    }
-
     inline Date UltimateForwardTermStructure::maxDate() const { return Date::maxDate(); }
-
-    inline void UltimateForwardTermStructure::update() {
-        if (!originalCurve_.empty()) {
-            YieldTermStructure::update();
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
-    }
 
     inline Rate UltimateForwardTermStructure::applyRounding(Rate r, Time t) const {
         if (!roundingDigits_.has_value()) {

--- a/ql/termstructures/yield/zerospreadedtermstructure.hpp
+++ b/ql/termstructures/yield/zerospreadedtermstructure.hpp
@@ -26,6 +26,7 @@
 #define quantlib_zero_spreaded_term_structure_hpp
 
 #include <ql/quote.hpp>
+#include <ql/termstructures/yield/derivedtermstructure.hpp>
 #include <ql/termstructures/yield/zeroyieldstructure.hpp>
 #include <utility>
 
@@ -44,7 +45,8 @@ namespace QuantLib {
         - observability against changes in the underlying term
           structure and in the added spread is checked.
     */
-    class ZeroSpreadedTermStructure : public ZeroYieldStructure {
+    class ZeroSpreadedTermStructure
+        : public RelativeDerivedYieldTermStructure<ZeroYieldStructure> {
       public:
         ZeroSpreadedTermStructure(Handle<YieldTermStructure>,
                                   Handle<Quote> spread,
@@ -60,24 +62,10 @@ namespace QuantLib {
                                   Compounding comp,
                                   Frequency freq,
                                   const DayCounter& dc);
-        //! \name YieldTermStructure interface
-        //@{
-        DayCounter dayCounter() const override;
-        Calendar calendar() const override;
-        Natural settlementDays() const override;
-        const Date& referenceDate() const override;
-        Date maxDate() const override;
-        Time maxTime() const override;
-        //@}
-        //! \name Observer interface
-        //@{
-        void update() override;
-        //@}
       protected:
         //! returns the spreaded zero yield rate
         Rate zeroYieldImpl(Time) const override;
       private:
-        Handle<YieldTermStructure> originalCurve_;
         Handle<Quote> spread_;
         Compounding comp_;
         Frequency freq_;
@@ -87,10 +75,8 @@ namespace QuantLib {
                                                                 Handle<Quote> spread,
                                                                 Compounding comp,
                                                                 Frequency freq)
-    : originalCurve_(std::move(h)), spread_(std::move(spread)), comp_(comp), freq_(freq) {
-        if (!originalCurve_.empty())
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        registerWith(originalCurve_);
+    : RelativeDerivedYieldTermStructure(std::move(h)), spread_(std::move(spread)),
+      comp_(comp), freq_(freq) {
         registerWith(spread_);
     }
 
@@ -100,44 +86,6 @@ namespace QuantLib {
                                                                 Frequency freq,
                                                                 const DayCounter& dc)
     : ZeroSpreadedTermStructure(std::move(h), std::move(spread), comp, freq) {}
-
-    inline DayCounter ZeroSpreadedTermStructure::dayCounter() const {
-        return originalCurve_->dayCounter();
-    }
-
-    inline Calendar ZeroSpreadedTermStructure::calendar() const {
-        return originalCurve_->calendar();
-    }
-
-    inline Natural ZeroSpreadedTermStructure::settlementDays() const {
-        return originalCurve_->settlementDays();
-    }
-
-    inline const Date& ZeroSpreadedTermStructure::referenceDate() const {
-        return originalCurve_->referenceDate();
-    }
-
-    inline Date ZeroSpreadedTermStructure::maxDate() const {
-        return originalCurve_->maxDate();
-    }
-
-    inline Time ZeroSpreadedTermStructure::maxTime() const {
-        return originalCurve_->maxTime();
-    }
-
-    inline void ZeroSpreadedTermStructure::update() {
-        if (!originalCurve_.empty()) {
-            YieldTermStructure::update();
-            enableExtrapolation(originalCurve_->allowsExtrapolation());
-        } else {
-            /* The implementation inherited from YieldTermStructure
-               asks for our reference date, which we don't have since
-               the original curve is still not set. Therefore, we skip
-               over that and just call the base-class behavior. */
-            // NOLINTNEXTLINE(bugprone-parent-virtual-call)
-            TermStructure::update();
-        }
-    }
 
     inline Rate ZeroSpreadedTermStructure::zeroYieldImpl(Time t) const {
         InterestRate zeroRate =

--- a/ql/termstructures/yieldtermstructure.cpp
+++ b/ql/termstructures/yieldtermstructure.cpp
@@ -173,25 +173,19 @@ namespace QuantLib {
 
     void YieldTermStructure::update() {
         TermStructure::update();
-        Date newReference = Date();
+        Date newReference;
         try {
             newReference = referenceDate();
-            if (newReference != latestReference_)
-                setJumps(newReference);
         } catch (Error&) {
-            if (newReference == Date()) {
-                // the curve couldn't calculate the reference
-                // date. Most of the times, this is because some
-                // underlying handle wasn't set, so we can just absorb
-                // the exception and continue; the jumps will be set
-                // correctly when a valid underlying is set.
-                return;
-            } else {
-                // something else happened during the call to
-                // setJumps(), so we let the exception bubble up.
-                throw;
-            }
+            // the curve couldn't calculate the reference
+            // date. Most of the times, this is because some
+            // underlying handle wasn't set, so we can just absorb
+            // the exception and continue; the jumps will be set
+            // correctly when a valid underlying is set.
+            return;
         }
+        if (newReference != latestReference_)
+            setJumps(newReference);
     }
 
 }


### PR DESCRIPTION
Factor out common code from multiple derived term structure classes (mostly spreaded curves) into two common classes:

* DerivedYieldTermStructure for term structures that have their own referenceDate
* RelativeDerivedYieldTermStructure for term structures that forward referenceDate from the underlying term structure