### PR TITLE
Fix concurrent LazyObject calculations

### DIFF
--- a/ql/instrument.hpp
+++ b/ql/instrument.hpp
@@ -3,6 +3,7 @@
 /*
  Copyright (C) 2000, 2001, 2002, 2003 RiskMap srl
  Copyright (C) 2003, 2004, 2005, 2006, 2007 StatPro Italia srl
+ Copyright (C) 2026 Musawer Ahmad Saqif
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -128,6 +129,9 @@ namespace QuantLib {
     // inline definitions
 
     inline void Instrument::calculate() const {
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(calculationMutex());
+#endif
         if (!calculated_) {
             if (isExpired()) {
                 setupExpired();

--- a/ql/patterns/lazyobject.hpp
+++ b/ql/patterns/lazyobject.hpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2003 RiskMap srl
+ Copyright (C) 2026 Musawer Ahmad Saqif
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -26,6 +27,10 @@
 
 #include <ql/patterns/observable.hpp>
 #include <ql/shared_ptr.hpp>
+
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+#include <mutex>
+#endif
 
 namespace QuantLib {
 
@@ -89,6 +94,12 @@ namespace QuantLib {
             \warning Should this method be redefined in derived
                      classes, LazyObject::calculate() should be called
                      in the overriding method.
+
+            \note When the thread-safe observer pattern is enabled,
+                  concurrent calculations of the same object are
+                  serialized. Mutating the object's dependencies while
+                  it is being calculated still requires external
+                  synchronization.
         */
         virtual void calculate() const;
         /*! This method must implement any calculations which must be
@@ -128,8 +139,25 @@ namespace QuantLib {
         //@}
 
       protected:
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::recursive_mutex& calculationMutex() const;
+#endif
         mutable bool calculated_ = false, frozen_ = false, failed_ = false, alwaysForward_;
       private:
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        class CalculationMutex { // NOLINT(cppcoreguidelines-special-member-functions)
+          public:
+            CalculationMutex() = default;
+            CalculationMutex(const CalculationMutex&) {}
+            CalculationMutex& operator=(const CalculationMutex&) {
+                return *this;
+            }
+
+            std::recursive_mutex mutex;
+        };
+
+        mutable CalculationMutex calculationMutex_;
+#endif
         bool updating_ = false;
         class UpdateChecker {  // NOLINT(cppcoreguidelines-special-member-functions)
             LazyObject* subject_;
@@ -254,6 +282,9 @@ namespace QuantLib {
     }
 
     inline void LazyObject::calculate() const {
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(calculationMutex());
+#endif
         if (!calculated_ && !frozen_) {
             calculated_ = true;   // prevent infinite recursion in
                                   // case of bootstrapping
@@ -270,12 +301,24 @@ namespace QuantLib {
     }
 
     inline bool LazyObject::isCalculated() const {
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(calculationMutex());
+#endif
         return calculated_;
     }
 
     inline void LazyObject::setCalculated(const bool c) const {
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+        std::lock_guard<std::recursive_mutex> lock(calculationMutex());
+#endif
         calculated_ = c;
     }
+
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+    inline std::recursive_mutex& LazyObject::calculationMutex() const {
+        return calculationMutex_.mutex;
+    }
+#endif
 }
 
 #endif

--- a/test-suite/lazyobject.cpp
+++ b/test-suite/lazyobject.cpp
@@ -2,6 +2,7 @@
 
 /*
  Copyright (C) 2016 StatPro Italia srl
+ Copyright (C) 2026 Musawer Ahmad Saqif
 
  This file is part of QuantLib, a free-software/open-source library
  for financial quantitative analysts and developers - http://quantlib.org/
@@ -21,6 +22,13 @@
 #include "utilities.hpp"
 #include <ql/instruments/stock.hpp>
 #include <ql/quotes/simplequote.hpp>
+
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+#endif
 
 using namespace QuantLib;
 using namespace boost::unit_test_framework;
@@ -271,6 +279,212 @@ BOOST_AUTO_TEST_CASE(testNotificationAfterFailedCalculation) {
     if (f.isUp())
         BOOST_FAIL("Observer was notified of second change without recalculation");
 }
+
+#ifdef QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN
+
+class BlockingLazyObject : public LazyObject {
+  public:
+    explicit BlockingLazyObject(bool failFirst = false) : failFirst_(failFirst) {}
+
+    Real value() const {
+        calculate();
+        return value_;
+    }
+
+    void waitUntilCalculationStarts() const {
+        while (!calculationStarted_.load(std::memory_order_acquire))
+            std::this_thread::yield();
+    }
+
+    void releaseCalculation() const {
+        calculationMayFinish_.store(true, std::memory_order_release);
+    }
+
+    Size calculationCount() const {
+        return calculationCount_.load(std::memory_order_relaxed);
+    }
+
+  protected:
+    void performCalculations() const override {
+        const Size count = calculationCount_.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (count == 1) {
+            calculationStarted_.store(true, std::memory_order_release);
+            while (!calculationMayFinish_.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            if (failFirst_)
+                QL_FAIL("intentional failure");
+        }
+        value_ = 42.0;
+    }
+
+  private:
+    bool failFirst_;
+    mutable std::atomic<bool> calculationStarted_{false};
+    mutable std::atomic<bool> calculationMayFinish_{false};
+    mutable std::atomic<Size> calculationCount_{0};
+    mutable Real value_ = Null<Real>();
+};
+
+BOOST_AUTO_TEST_CASE(testConcurrentCalculation) {
+    BOOST_TEST_MESSAGE("Testing concurrent calculation of a lazy object...");
+
+    BlockingLazyObject object;
+
+    auto first = std::async(std::launch::async, [&object] { return object.value(); });
+    object.waitUntilCalculationStarts();
+
+    auto second = std::async(std::launch::async, [&object] { return object.value(); });
+    const auto status = second.wait_for(std::chrono::milliseconds(20));
+    object.releaseCalculation();
+
+    BOOST_CHECK(status == std::future_status::timeout);
+    BOOST_CHECK_EQUAL(first.get(), 42.0);
+    BOOST_CHECK_EQUAL(second.get(), 42.0);
+    BOOST_CHECK_EQUAL(object.calculationCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(testConcurrentCalculationAfterFailure) {
+    BOOST_TEST_MESSAGE("Testing concurrent calculation after a failure...");
+
+    BlockingLazyObject object(true);
+
+    auto first = std::async(std::launch::async, [&object] {
+        try {
+            object.value();
+            return false;
+        } catch (const Error&) {
+            return true;
+        }
+    });
+    object.waitUntilCalculationStarts();
+
+    auto second = std::async(std::launch::async, [&object] { return object.value(); });
+    const auto status = second.wait_for(std::chrono::milliseconds(20));
+    object.releaseCalculation();
+
+    BOOST_CHECK(status == std::future_status::timeout);
+    BOOST_CHECK(first.get());
+    BOOST_CHECK_EQUAL(second.get(), 42.0);
+    BOOST_CHECK_EQUAL(object.calculationCount(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(testConcurrentExpiredInstrumentCalculation) {
+    BOOST_TEST_MESSAGE("Testing concurrent calculation of an expired instrument...");
+
+    class ExpiredInstrument : public Instrument {
+      public:
+        bool isExpired() const override {
+            return true;
+        }
+
+        void waitUntilCalculationStarts() const {
+            while (!calculationStarted_.load(std::memory_order_acquire))
+                std::this_thread::yield();
+        }
+
+        void releaseCalculation() const {
+            calculationMayFinish_.store(true, std::memory_order_release);
+        }
+
+        Size calculationCount() const {
+            return calculationCount_.load(std::memory_order_relaxed);
+        }
+
+      protected:
+        void setupExpired() const override {
+            const Size count = calculationCount_.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (count == 1) {
+                calculationStarted_.store(true, std::memory_order_release);
+                while (!calculationMayFinish_.load(std::memory_order_acquire))
+                    std::this_thread::yield();
+            }
+            Instrument::setupExpired();
+        }
+
+      private:
+        mutable std::atomic<bool> calculationStarted_{false};
+        mutable std::atomic<bool> calculationMayFinish_{false};
+        mutable std::atomic<Size> calculationCount_{0};
+    } object;
+
+    auto first = std::async(std::launch::async, [&object] { return object.NPV(); });
+    object.waitUntilCalculationStarts();
+
+    auto second = std::async(std::launch::async, [&object] { return object.NPV(); });
+    const auto status = second.wait_for(std::chrono::milliseconds(20));
+    object.releaseCalculation();
+
+    BOOST_CHECK(status == std::future_status::timeout);
+    BOOST_CHECK_EQUAL(first.get(), 0.0);
+    BOOST_CHECK_EQUAL(second.get(), 0.0);
+    BOOST_CHECK_EQUAL(object.calculationCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(testRecursiveCalculation) {
+    BOOST_TEST_MESSAGE("Testing recursive calculation of a lazy object...");
+
+    class RecursiveLazyObject : public LazyObject {
+      public:
+        Real value() const {
+            calculate();
+            return value_;
+        }
+
+        Size calculationCount() const {
+            return calculationCount_;
+        }
+
+      protected:
+        void performCalculations() const override {
+            ++calculationCount_;
+            calculate();
+            value_ = 42.0;
+        }
+
+      private:
+        mutable Size calculationCount_ = 0;
+        mutable Real value_ = Null<Real>();
+    };
+
+    RecursiveLazyObject object;
+    BOOST_CHECK_EQUAL(object.value(), 42.0);
+    BOOST_CHECK_EQUAL(object.calculationCount(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(testCopyingWithThreadSafeCalculations) {
+    BOOST_TEST_MESSAGE("Testing copies of lazy objects with thread-safe calculations...");
+
+    class CopyableLazyObject : public LazyObject {
+      public:
+        explicit CopyableLazyObject(Real value = 0.0) : input_(value) {}
+
+        Real value() const {
+            calculate();
+            return result_;
+        }
+
+      protected:
+        void performCalculations() const override {
+            result_ = input_;
+        }
+
+      private:
+        Real input_;
+        mutable Real result_ = Null<Real>();
+    };
+
+    CopyableLazyObject original(42.0);
+    BOOST_CHECK_EQUAL(original.value(), 42.0);
+
+    CopyableLazyObject copied(original);
+    BOOST_CHECK_EQUAL(copied.value(), 42.0);
+
+    CopyableLazyObject assigned;
+    assigned = original;
+    BOOST_CHECK_EQUAL(assigned.value(), 42.0);
+}
+
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Fixes #2633.

When the thread-safe observer pattern is enabled, concurrent callers can currently see `calculated_ == true` while the first caller is still writing cached results. In a focused reproducer on current master, the second caller returned `Null<Real>()` instead of the completed value; the failure path also skipped the required retry, and expired instruments ran `setupExpired()` twice.

This change:

- serializes calculations of the same `LazyObject` with a recursive mutex when `QL_ENABLE_THREAD_SAFE_OBSERVER_PATTERN` is enabled;
- protects the separate expired-instrument path in `Instrument::calculate()`;
- preserves same-thread recursive calculation used by bootstrapping; and
- keeps lazy objects copyable by giving each copy its own mutex.

A recursive blocking mutex is intentional. `LazyObject::calculate()` marks the object calculated before calling `performCalculations()` to break recursive bootstrapping. A non-recursive lock, or a three-state protocol that waits whenever it sees "computing", would deadlock when `performCalculations()` recursively calls `calculate()` on the same object. The mutex also blocks waiters instead of spin-waiting and lets a waiter retry normally after the first calculation throws.

There is no mutex or generated-code change when the thread-safe observer pattern is disabled. As before, mutating an object's dependencies while it is calculating requires external synchronization.

Validation:

- thread-safe focused LazyObject suite: 11/11 passed;
- thread-safe complete suite: 1,416/1,416 passed;
- AppleClang ThreadSanitizer focused LazyObject suite: 11/11 passed with no race report;
- default focused LazyObject suite: 6/6 passed;
- default complete suite: 1,409/1,409 passed; and
- `git diff --check` passed.
