### PR TITLE
Fix wedge acceptance test in `ZigguratGaussianRng`

### DIFF
--- a/ql/math/randomnumbers/zigguratgaussianrng.hpp
+++ b/ql/math/randomnumbers/zigguratgaussianrng.hpp
@@ -103,7 +103,14 @@ namespace QuantLib {
                 // compute a random number in the tail by hand
                 return zeroCase(u);
             }
-            if (normF(i + 1) + (normF(i) - normF(i + 1)) * uint64Generator_.nextReal() < pdf(x)) {
+            // Marsaglia-Tsang wedge acceptance: draw uniformly on the interval
+            // between normF(i) and normF(i + 1) and accept if it lands under
+            // the density. Kept in named locals so the inequality reads as the
+            // formula does.
+            const Real fi = normF(i);
+            const Real fiPlus1 = normF(i + 1);
+            const Real w = uint64Generator_.nextReal();
+            if (fiPlus1 + (fi - fiPlus1) * w < pdf(x)) {
                 return x;
             }
         }

--- a/ql/math/randomnumbers/zigguratgaussianrng.hpp
+++ b/ql/math/randomnumbers/zigguratgaussianrng.hpp
@@ -103,7 +103,7 @@ namespace QuantLib {
                 // compute a random number in the tail by hand
                 return zeroCase(u);
             }
-            if (normF(i + 1) + (normF(i) - normF(i + 1) * uint64Generator_.nextReal()) < pdf(x)) {
+            if (normF(i + 1) + (normF(i) - normF(i + 1)) * uint64Generator_.nextReal() < pdf(x)) {
                 return x;
             }
         }

--- a/test-suite/zigguratgaussian.cpp
+++ b/test-suite/zigguratgaussian.cpp
@@ -65,11 +65,23 @@ namespace {
             u = 2*((r >> 11) + 0.5)/2^53 - 1,      i = r & 0xff
 
         so inverting it lets a test ask for a specific (layer, u) pair.
+
+        The preconditions are load-bearing rather than decorative: a layer of
+        256 or more would alias through `r & 0xff` (256 becomes layer 0, the
+        tail case), and u = 1 would round the bucket up to 2^53, whose shift
+        overflows to zero and decodes back as u = -1. Either would silently
+        encode a different draw than the one asked for.
     */
     std::uint64_t drawFor(int layer, Real u) {
-        const Real scaled = (u + 1.0) / 2.0 * Real(1ULL << 53) - 0.5;
-        return (static_cast<std::uint64_t>(std::llround(scaled)) << 11) |
-               static_cast<std::uint64_t>(layer);
+        QL_REQUIRE(layer >= 0 && layer <= 0xFF, "layer " << layer << " outside [0, 255]");
+        QL_REQUIRE(u >= -1.0 && u < 1.0, "u " << u << " outside [-1, 1)");
+
+        const Real twoPow53 = std::ldexp(1.0, 53);
+        const auto bucket =
+            static_cast<std::uint64_t>(std::llround((u + 1.0) / 2.0 * twoPow53 - 0.5));
+        QL_REQUIRE(bucket < (1ULL << 53), "bucket " << bucket << " overflows for u = " << u);
+
+        return (bucket << 11) | static_cast<std::uint64_t>(layer);
     }
 
 }

--- a/test-suite/zigguratgaussian.cpp
+++ b/test-suite/zigguratgaussian.cpp
@@ -21,10 +21,58 @@
 #include <ql/math/randomnumbers/xoshiro256starstaruniformrng.hpp>
 #include <ql/math/randomnumbers/zigguratgaussianrng.hpp>
 #include <ql/math/statistics/incrementalstatistics.hpp>
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <numeric>
+#include <utility>
+#include <vector>
 
 using namespace QuantLib;
+
+namespace {
+
+    /*! Deterministic stand-in for the uniform source.
+
+        ZigguratGaussianRng is a template over its RNG and documents the
+        interface it needs (nextReal / nextInt64), so a scripted source lets a
+        test drive one exact draw instead of relying on aggregate statistics.
+    */
+    class ScriptedRng {
+      public:
+        ScriptedRng(std::vector<std::uint64_t> ints, std::vector<Real> reals)
+        : ints_(std::move(ints)), reals_(std::move(reals)) {}
+
+        std::uint64_t nextInt64() const {
+            BOOST_REQUIRE_MESSAGE(intPos_ < ints_.size(), "scripted nextInt64() exhausted");
+            return ints_[intPos_++];
+        }
+
+        Real nextReal() const {
+            BOOST_REQUIRE_MESSAGE(realPos_ < reals_.size(), "scripted nextReal() exhausted");
+            return reals_[realPos_++];
+        }
+
+      private:
+        std::vector<std::uint64_t> ints_;
+        std::vector<Real> reals_;
+        mutable std::size_t intPos_ = 0;
+        mutable std::size_t realPos_ = 0;
+    };
+
+    /*! nextReal() splits a single 64-bit draw into the ordinate and the layer,
+
+            u = 2*((r >> 11) + 0.5)/2^53 - 1,      i = r & 0xff
+
+        so inverting it lets a test ask for a specific (layer, u) pair.
+    */
+    std::uint64_t drawFor(int layer, Real u) {
+        const Real scaled = (u + 1.0) / 2.0 * Real(1ULL << 53) - 0.5;
+        return (static_cast<std::uint64_t>(std::llround(scaled)) << 11) |
+               static_cast<std::uint64_t>(layer);
+    }
+
+}
 
 BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
 
@@ -61,6 +109,53 @@ BOOST_AUTO_TEST_CASE(testStatisticsOfNextReal) {
     }
     if (std::abs(kurtosis) > 0.03) {
         BOOST_ERROR("Kurtosis " << kurtosis << " for seed " << seed << " is not close to 0.");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testWedgeDrawIsAccepted) {
+    BOOST_TEST_MESSAGE("Testing ZigguratGaussianRng<ScriptedRng>::nextReal() accepts a draw "
+                       "that falls in a wedge...");
+
+    // Layer 1 runs from normX(1) = 3.654152885361008796 down to
+    // normX(2) = 3.449278298560964462. A draw whose |x| lands between the two
+    // misses the rectangle fast path and must go through the wedge acceptance
+    // test, which is the only way such a value can be produced from layer 1.
+    //
+    // Take x = 3.5, comfortably inside that band, and feed the wedge test
+    // u = 0.5. Marsaglia-Tsang acceptance is
+    //
+    //     normF(i+1) + (normF(i) - normF(i+1)) * u  <  pdf(x)
+    //
+    // and with normF(1) = 0.001260285930498598,
+    //          normF(2) = 0.002609072746106363,
+    //          pdf(3.5) = 0.002187491118182889:
+    //
+    //     lhs = 0.001934679338302481  <  pdf(x)     -> accept, margin 2.5e-04
+    //
+    // so the generator must return the wedge draw itself.
+    const int wedgeLayer = 1;
+    const Real normX1 = 3.654152885361008796;
+    const Real wedgeX = 3.5;
+
+    // The generator consumes this second draw only if it rejected the first:
+    // layer 200 with |x| = 0.1035, well inside normX(201), so the rectangle
+    // fast path returns it immediately. It sits 3.4 away from the wedge value,
+    // which makes the two outcomes unambiguous.
+    const int fastPathLayer = 200;
+    const Real fastPathU = 0.1;
+
+    auto scripted =
+        ScriptedRng({drawFor(wedgeLayer, wedgeX / normX1), drawFor(fastPathLayer, fastPathU)},
+                    {0.5});
+    auto random = ZigguratGaussianRng<ScriptedRng>(scripted);
+
+    const Real sample = random.next().value;
+
+    if (std::abs(sample - wedgeX) > 1.0e-12) {
+        BOOST_ERROR("ZigguratGaussianRng rejected a wedge draw that the Marsaglia-Tsang "
+                    "acceptance test accepts.\n"
+                    << "    expected " << wedgeX << " (the wedge draw)\n"
+                    << "    returned " << sample << " (the following fast-path draw)");
     }
 }
 


### PR DESCRIPTION
### The defect

`ZigguratGaussianRng::nextReal()` has a misplaced closing parenthesis in the Marsaglia–Tsang wedge acceptance test (`ql/math/randomnumbers/zigguratgaussianrng.hpp:106`):

```cpp
if (normF(i + 1) + (normF(i) - normF(i + 1) * uint64Generator_.nextReal()) < pdf(x)) {
```

The uniform draw scales only `normF(i + 1)` instead of the whole difference `normF(i) - normF(i + 1)`, so instead of a uniform draw on the interval between `normF(i)` and `normF(i + 1)` the test compares `pdf(x)` against `f[i+1] + f[i] - f[i+1]·U`.

### Consequence

The wedge is accepted far too rarely. Over 2,000,000 draws that actually reach the wedge test — Monte Carlo over the generator's own sampling measure, not a synthetic parameter sweep:

```
current  :    35706 accepts  ( 1.7853%)
corrected:  1090327 accepts  (54.5164%)
```

Roughly a 30× deficit. Rejected draws send the loop back for a fresh `(i, u)` pair, so the emitted stream under-weights the wedge region between `normX(i + 1)` and `normX(i)` at every layer, and costs extra iterations per sample.

### Why the existing test does not catch it

`testStatisticsOfNextReal` checks mean, variance, skewness and kurtosis over 10,000,000 draws and passes both before and after this change.

A Kolmogorov–Smirnov test against the standard normal CDF does not separate them either at practical sample sizes. At `n = 1,000,000`:

```
before : D = 0.00164276
after  : D = 0.00135042
99.9%  : D = 0.00194900   (critical)
```

Both fall below the critical value. (The pre-fix figure is about 1.9× the `0.86/sqrt(n)` expected of a correct sampler, so there is real signal — it would reject at larger `n` — but KS is not a practical regression guard here.)

### The regression test

Since the statistical signal is weak, the added test is deterministic. `ZigguratGaussianRng` is a template over its uniform source and documents the interface it needs, so a scripted RNG can drive one exact draw.

Layer 1 spans `normX(2) = 3.449278` to `normX(1) = 3.654153`. Taking `x = 3.5`, comfortably inside that band, with `u = 0.5`:

| | acceptance threshold | vs `pdf(3.5) = 0.002187491` | outcome |
|---|---|---|---|
| corrected | 0.001934679 | below by 2.5e-04 | accepts |
| current | 0.002564822 | above by 3.8e-04 | rejects |

The generator must therefore return 3.5. The current code falls through to the next scripted draw (layer 200, `x = 0.10350`), which the test distinguishes by value. It fails before the change and passes after; `testStatisticsOfNextReal` continues to pass.

---

Found while porting `ZigguratGaussianRng` to a Java/Python port of QuantLib. Happy to adjust the test's shape if you'd prefer it structured differently.