### PR TITLE
More conventions for const-notional XCCY swap and helper

### DIFF
--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -137,10 +137,12 @@ namespace QuantLib {
         BusinessDayConvention convention,
         bool endOfMonth,
         Handle<YieldTermStructure> collateralCurve,
-        Integer paymentLag)
+        Integer paymentLag,
+        bool paymentLagOnNotionalExchanges)
     : RelativeDateRateHelper(quote), tenor_(tenor), fixingDays_(fixingDays),
       calendar_(std::move(calendar)), convention_(convention), endOfMonth_(endOfMonth),
-      paymentLag_(paymentLag), collateralHandle_(std::move(collateralCurve)) {
+      paymentLag_(paymentLag), paymentLagOnNotionalExchanges_(paymentLagOnNotionalExchanges),
+      collateralHandle_(std::move(collateralCurve)) {
         registerWith(collateralHandle_);
     }
 
@@ -163,10 +165,15 @@ namespace QuantLib {
         maturityDate_ = std::max(CashFlows::maturityDate(firstLeg),
                                  CashFlows::maturityDate(secondLeg));
 
-        // Principal exchanges settle on the effective and maturity dates;
-        // payment lag applies only to coupons.
-        initialNotionalExchangeDate_ = calendar_.adjust(earliestDate_, convention_);
-        finalNotionalExchangeDate_   = calendar_.adjust(maturityDate_, convention_);
+        // Principal exchanges settle on the effective and maturity dates:
+        // the payment lag applies only to coupons -- unless the swap's
+        // convention lags the principal flows too, in which case both
+        // exchanges move by the same lag as the coupons and the final
+        // exchange settles together with the final coupon.  advance() with
+        // zero days reduces to adjust(), preserving the default behaviour.
+        Integer exchangeLag = paymentLagOnNotionalExchanges_ ? paymentLag_ : 0;
+        initialNotionalExchangeDate_ = calendar_.advance(earliestDate_, exchangeLag, Days, convention_);
+        finalNotionalExchangeDate_   = calendar_.advance(maturityDate_, exchangeLag, Days, convention_);
 
         Date lastPaymentDate =
             std::max(firstLeg.back()->date(),
@@ -192,9 +199,11 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        bool paymentLagOnNotionalExchanges)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
-                                      std::move(collateralCurve), paymentLag),
+                                      std::move(collateralCurve), paymentLag,
+                                      paymentLagOnNotionalExchanges),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
       isFxBaseCurrencyCollateralCurrency_(isFxBaseCurrencyCollateralCurrency),
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
@@ -253,7 +262,8 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        bool paymentLagOnNotionalExchanges)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -268,7 +278,8 @@ namespace QuantLib {
                                            paymentFrequency,
                                            paymentLag,
                                            quoteCurrencyPaymentFrequency,
-                                           useIndexedCoupons) {
+                                           useIndexedCoupons,
+                                           paymentLagOnNotionalExchanges) {
         buildSwap();
     }
 
@@ -286,7 +297,8 @@ namespace QuantLib {
             1.0, quoteCcyIdx_->currency(), quoteCcySchedule_, quoteCcyIdx_, 0.0, 1.0,
             paymentLag_, paymentLag_, false, Null<Natural>(), false, 0,
             RateAveraging::Compound, false, Null<Natural>(), false, 0,
-            RateAveraging::Compound, false, useIndexedCoupons_);
+            RateAveraging::Compound, false, useIndexedCoupons_,
+            paymentLagOnNotionalExchanges_);
         swap_->setPricingEngine(ext::make_shared<DiscountingConstNotionalCrossCurrencySwapEngine>(
             quoteCcyIdx_->currency(), quoteCcyLegDiscountHandle(),
             baseCcyIdx_->currency(), baseCcyLegDiscountHandle(),

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -411,14 +411,16 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& collateralCurve,
         bool collateralOnFixedLeg,
         Integer paymentLag,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        std::optional<BusinessDayConvention> floatingLegConvention)
     : CrossCurrencySwapRateHelperBase(fixedRate, tenor, fixingDays, calendar, convention, endOfMonth,
                                       collateralCurve, paymentLag),
       fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)),
       floatIndex_(floatIndex),
       collateralOnFixedLeg_(collateralOnFixedLeg),
-      useIndexedCoupons_(useIndexedCoupons) {
+      useIndexedCoupons_(useIndexedCoupons),
+      floatingLegConvention_(floatingLegConvention) {
 
         QL_REQUIRE(floatIndex_, "floating index required");
         registerWith(floatIndex_);
@@ -438,10 +440,12 @@ namespace QuantLib {
         }
 
         Real nominal = 1.0;
+        BusinessDayConvention floatingConvention =
+            floatingLegConvention_.value_or(floatIndex_->businessDayConvention());
         Schedule fixedSch = legSchedule(evaluationDate_, tenor_, Period(fixedFrequency_), fixingDays_, calendar_,
                                        convention_, endOfMonth_);
-        Schedule floatSch = legSchedule(evaluationDate_, tenor_, floatFreqPeriod, fixingDays_, floatIndex_->fixingCalendar(),
-                                    floatIndex_->businessDayConvention(), endOfMonth_);
+        Schedule floatSch = legSchedule(evaluationDate_, tenor_, floatFreqPeriod, fixingDays_,
+                                        floatIndex_->fixingCalendar(), floatingConvention, endOfMonth_);
 
         xccySwap_ = ext::make_shared<ConstNotionalCrossCurrencyFixedVsFloatingSwap>(
             Swap::Payer,
@@ -458,7 +462,7 @@ namespace QuantLib {
             floatSch,
             floatIndex_,
             Spread(0.0),
-            floatIndex_->businessDayConvention(),
+            floatingConvention,
             paymentLag_,
             calendar_,
             false, false, Null<Natural>(), false, 0,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -192,9 +192,7 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons,
-        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
-        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
+        std::optional<bool> useIndexedCoupons)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
@@ -202,9 +200,7 @@ namespace QuantLib {
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
       paymentFrequency_(normalizedPaymentFrequency(paymentFrequency)),
       quoteCcyPaymentFrequency_(normalizedPaymentFrequency(quoteCurrencyPaymentFrequency)),
-      useIndexedCoupons_(useIndexedCoupons),
-      baseCcyLegConvention_(baseCurrencyLegConvention),
-      quoteCcyLegConvention_(quoteCurrencyLegConvention) {
+      useIndexedCoupons_(useIndexedCoupons) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 
@@ -213,7 +209,7 @@ namespace QuantLib {
 
     void CrossCurrencyBasisSwapRateHelperBase::initializeDates() {
         baseCcySchedule_ = floatingLegSchedule(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                               baseCcyConvention(), endOfMonth_, baseCcyIdx_,
+                                               convention_, endOfMonth_, baseCcyIdx_,
                                                paymentFrequency_);
         baseCcyIborLeg_ = buildFloatingLeg(
             baseCcySchedule_, baseCcyIdx_, paymentLag_, useIndexedCoupons_);
@@ -224,7 +220,7 @@ namespace QuantLib {
         std::optional<Frequency> effectiveQuoteCcyFreq =
             quoteCcyPaymentFrequency_ ? quoteCcyPaymentFrequency_ : paymentFrequency_;
         quoteCcySchedule_ = floatingLegSchedule(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                                quoteCcyConvention(), endOfMonth_, quoteCcyIdx_,
+                                                convention_, endOfMonth_, quoteCcyIdx_,
                                                 effectiveQuoteCcyFreq);
         quoteCcyIborLeg_ = buildFloatingLeg(
             quoteCcySchedule_, quoteCcyIdx_, paymentLag_, useIndexedCoupons_);
@@ -257,9 +253,7 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons,
-        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
-        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
+        std::optional<bool> useIndexedCoupons)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -274,9 +268,7 @@ namespace QuantLib {
                                            paymentFrequency,
                                            paymentLag,
                                            quoteCurrencyPaymentFrequency,
-                                           useIndexedCoupons,
-                                           baseCurrencyLegConvention,
-                                           quoteCurrencyLegConvention) {
+                                           useIndexedCoupons) {
         buildSwap();
     }
 
@@ -342,9 +334,7 @@ namespace QuantLib {
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
         Natural fxResetFixingDays,
         Calendar fxResetFixingCalendar,
-        std::optional<bool> useIndexedCoupons,
-        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
-        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
+        std::optional<bool> useIndexedCoupons)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -359,9 +349,7 @@ namespace QuantLib {
                                            paymentFrequency,
                                            paymentLag,
                                            quoteCurrencyPaymentFrequency,
-                                           useIndexedCoupons,
-                                           baseCurrencyLegConvention,
-                                           quoteCurrencyLegConvention),
+                                           useIndexedCoupons),
       isFxBaseCurrencyLegResettable_(isFxBaseCurrencyLegResettable),
       fxResetFixingDays_(fxResetFixingDays), fxResetFixingCalendar_(fxResetFixingCalendar) {
         buildSwap();
@@ -382,7 +370,7 @@ namespace QuantLib {
             1.0, quoteCcyIdx_->currency(), quoteCcySchedule_, quoteCcyIdx_, 0.0, 1.0,
             isFxBaseCurrencyLegResettable_, fxResetFixingDays_,
             fxResetFixingCalendar_, paymentLag_, paymentLag_,
-            baseCcyConvention(), quoteCcyConvention(), false, Null<Natural>(), false, 0,
+            convention_, convention_, false, Null<Natural>(), false, 0,
             RateAveraging::Compound, false, Null<Natural>(), false, 0,
             RateAveraging::Compound, false, useIndexedCoupons_);
         swap_->setPricingEngine(ext::make_shared<DiscountingMtMCrossCurrencyBasisSwapEngine>(
@@ -423,16 +411,14 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& collateralCurve,
         bool collateralOnFixedLeg,
         Integer paymentLag,
-        std::optional<bool> useIndexedCoupons,
-        std::optional<BusinessDayConvention> floatingLegConvention)
+        std::optional<bool> useIndexedCoupons)
     : CrossCurrencySwapRateHelperBase(fixedRate, tenor, fixingDays, calendar, convention, endOfMonth,
                                       collateralCurve, paymentLag),
       fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)),
       floatIndex_(floatIndex),
       collateralOnFixedLeg_(collateralOnFixedLeg),
-      useIndexedCoupons_(useIndexedCoupons),
-      floatingLegConvention_(floatingLegConvention) {
+      useIndexedCoupons_(useIndexedCoupons) {
 
         QL_REQUIRE(floatIndex_, "floating index required");
         registerWith(floatIndex_);
@@ -452,16 +438,14 @@ namespace QuantLib {
         }
 
         Real nominal = 1.0;
-        // Both legs roll on the helper's calendar and, unless explicitly
-        // overridden, on the helper's convention.  The floating index supplies
-        // its fixing calendar for its fixings, not for the accrual schedule.
-        // taking the roll convention or calendar from the index would make the
+        // Both legs roll on the helper's calendar and convention.  The floating
+        // index supplies its fixing calendar for fixings, not for the accrual schedule.
+        // Taking the roll convention or calendar from the index would make the
         // two legs diverge at a month-end roll and move the implied pillar.
-        BusinessDayConvention floatingConvention = floatingLegConvention_.value_or(convention_);
         Schedule fixedSch = legSchedule(evaluationDate_, tenor_, Period(fixedFrequency_), fixingDays_, calendar_,
                                        convention_, endOfMonth_);
         Schedule floatSch = legSchedule(evaluationDate_, tenor_, floatFreqPeriod, fixingDays_,
-                                        calendar_, floatingConvention, endOfMonth_);
+                                        calendar_, convention_, endOfMonth_);
 
         xccySwap_ = ext::make_shared<ConstNotionalCrossCurrencyFixedVsFloatingSwap>(
             Swap::Payer,
@@ -478,7 +462,7 @@ namespace QuantLib {
             floatSch,
             floatIndex_,
             Spread(0.0),
-            floatingConvention,
+            convention_,
             paymentLag_,
             calendar_,
             false, false, Null<Natural>(), false, 0,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -411,14 +411,16 @@ namespace QuantLib {
         const Handle<YieldTermStructure>& collateralCurve,
         bool collateralOnFixedLeg,
         Integer paymentLag,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        std::optional<Frequency> floatPaymentFrequency)
     : CrossCurrencySwapRateHelperBase(fixedRate, tenor, fixingDays, calendar, convention, endOfMonth,
                                       collateralCurve, paymentLag),
       fixedFrequency_(fixedFrequency),
       fixedDayCount_(std::move(fixedDayCount)),
       floatIndex_(floatIndex),
       collateralOnFixedLeg_(collateralOnFixedLeg),
-      useIndexedCoupons_(useIndexedCoupons) {
+      useIndexedCoupons_(useIndexedCoupons),
+      floatPaymentFrequency_(normalizedPaymentFrequency(floatPaymentFrequency)) {
 
         QL_REQUIRE(floatIndex_, "floating index required");
         registerWith(floatIndex_);
@@ -427,16 +429,6 @@ namespace QuantLib {
     }
 
     void ConstNotionalCrossCurrencySwapRateHelper::initializeDates() {
-        auto overnightIndex = ext::dynamic_pointer_cast<OvernightIndex>(floatIndex_);
-
-        Period floatFreqPeriod;
-        if (floatIndex_->tenor().frequency() == NoFrequency) {
-            QL_REQUIRE(!overnightIndex, "Require payment frequency for overnight indices.");
-            floatFreqPeriod = floatIndex_->tenor();
-        } else {
-            floatFreqPeriod = Period(floatIndex_->tenor().frequency());
-        }
-
         Real nominal = 1.0;
         // Both legs roll on the helper's calendar and convention.  The floating
         // index supplies its fixing calendar for fixings, not for the accrual schedule.
@@ -444,8 +436,11 @@ namespace QuantLib {
         // two legs diverge at a month-end roll and move the implied pillar.
         Schedule fixedSch = legSchedule(evaluationDate_, tenor_, Period(fixedFrequency_), fixingDays_, calendar_,
                                        convention_, endOfMonth_);
-        Schedule floatSch = legSchedule(evaluationDate_, tenor_, floatFreqPeriod, fixingDays_,
-                                        calendar_, convention_, endOfMonth_);
+        // An overnight index has no payment frequency of its own, so
+        // floatingLegSchedule requires one to have been supplied.
+        Schedule floatSch = floatingLegSchedule(evaluationDate_, tenor_, fixingDays_, calendar_,
+                                                convention_, endOfMonth_, floatIndex_,
+                                                floatPaymentFrequency_);
 
         xccySwap_ = ext::make_shared<ConstNotionalCrossCurrencyFixedVsFloatingSwap>(
             Swap::Payer,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.cpp
@@ -192,7 +192,9 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
+        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
     : CrossCurrencySwapRateHelperBase(basis, tenor, fixingDays, std::move(calendar), convention, endOfMonth,
                                       std::move(collateralCurve), paymentLag),
       baseCcyIdx_(std::move(baseCurrencyIndex)), quoteCcyIdx_(std::move(quoteCurrencyIndex)),
@@ -200,7 +202,9 @@ namespace QuantLib {
       isBasisOnFxBaseCurrencyLeg_(isBasisOnFxBaseCurrencyLeg),
       paymentFrequency_(normalizedPaymentFrequency(paymentFrequency)),
       quoteCcyPaymentFrequency_(normalizedPaymentFrequency(quoteCurrencyPaymentFrequency)),
-      useIndexedCoupons_(useIndexedCoupons) {
+      useIndexedCoupons_(useIndexedCoupons),
+      baseCcyLegConvention_(baseCurrencyLegConvention),
+      quoteCcyLegConvention_(quoteCurrencyLegConvention) {
         registerWith(baseCcyIdx_);
         registerWith(quoteCcyIdx_);
 
@@ -209,7 +213,7 @@ namespace QuantLib {
 
     void CrossCurrencyBasisSwapRateHelperBase::initializeDates() {
         baseCcySchedule_ = floatingLegSchedule(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                               convention_, endOfMonth_, baseCcyIdx_,
+                                               baseCcyConvention(), endOfMonth_, baseCcyIdx_,
                                                paymentFrequency_);
         baseCcyIborLeg_ = buildFloatingLeg(
             baseCcySchedule_, baseCcyIdx_, paymentLag_, useIndexedCoupons_);
@@ -220,7 +224,7 @@ namespace QuantLib {
         std::optional<Frequency> effectiveQuoteCcyFreq =
             quoteCcyPaymentFrequency_ ? quoteCcyPaymentFrequency_ : paymentFrequency_;
         quoteCcySchedule_ = floatingLegSchedule(evaluationDate_, tenor_, fixingDays_, calendar_,
-                                                convention_, endOfMonth_, quoteCcyIdx_,
+                                                quoteCcyConvention(), endOfMonth_, quoteCcyIdx_,
                                                 effectiveQuoteCcyFreq);
         quoteCcyIborLeg_ = buildFloatingLeg(
             quoteCcySchedule_, quoteCcyIdx_, paymentLag_, useIndexedCoupons_);
@@ -253,7 +257,9 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency,
         Integer paymentLag,
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
+        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -268,7 +274,9 @@ namespace QuantLib {
                                            paymentFrequency,
                                            paymentLag,
                                            quoteCurrencyPaymentFrequency,
-                                           useIndexedCoupons) {
+                                           useIndexedCoupons,
+                                           baseCurrencyLegConvention,
+                                           quoteCurrencyLegConvention) {
         buildSwap();
     }
 
@@ -334,7 +342,9 @@ namespace QuantLib {
         std::optional<Frequency> quoteCurrencyPaymentFrequency,
         Natural fxResetFixingDays,
         Calendar fxResetFixingCalendar,
-        std::optional<bool> useIndexedCoupons)
+        std::optional<bool> useIndexedCoupons,
+        std::optional<BusinessDayConvention> baseCurrencyLegConvention,
+        std::optional<BusinessDayConvention> quoteCurrencyLegConvention)
     : CrossCurrencyBasisSwapRateHelperBase(basis,
                                            tenor,
                                            fixingDays,
@@ -349,7 +359,9 @@ namespace QuantLib {
                                            paymentFrequency,
                                            paymentLag,
                                            quoteCurrencyPaymentFrequency,
-                                           useIndexedCoupons),
+                                           useIndexedCoupons,
+                                           baseCurrencyLegConvention,
+                                           quoteCurrencyLegConvention),
       isFxBaseCurrencyLegResettable_(isFxBaseCurrencyLegResettable),
       fxResetFixingDays_(fxResetFixingDays), fxResetFixingCalendar_(fxResetFixingCalendar) {
         buildSwap();
@@ -370,7 +382,7 @@ namespace QuantLib {
             1.0, quoteCcyIdx_->currency(), quoteCcySchedule_, quoteCcyIdx_, 0.0, 1.0,
             isFxBaseCurrencyLegResettable_, fxResetFixingDays_,
             fxResetFixingCalendar_, paymentLag_, paymentLag_,
-            convention_, convention_, false, Null<Natural>(), false, 0,
+            baseCcyConvention(), quoteCcyConvention(), false, Null<Natural>(), false, 0,
             RateAveraging::Compound, false, Null<Natural>(), false, 0,
             RateAveraging::Compound, false, useIndexedCoupons_);
         swap_->setPricingEngine(ext::make_shared<DiscountingMtMCrossCurrencyBasisSwapEngine>(
@@ -440,12 +452,16 @@ namespace QuantLib {
         }
 
         Real nominal = 1.0;
-        BusinessDayConvention floatingConvention =
-            floatingLegConvention_.value_or(floatIndex_->businessDayConvention());
+        // Both legs roll on the helper's calendar and, unless explicitly
+        // overridden, on the helper's convention.  The floating index supplies
+        // its fixing calendar for its fixings, not for the accrual schedule.
+        // taking the roll convention or calendar from the index would make the
+        // two legs diverge at a month-end roll and move the implied pillar.
+        BusinessDayConvention floatingConvention = floatingLegConvention_.value_or(convention_);
         Schedule fixedSch = legSchedule(evaluationDate_, tenor_, Period(fixedFrequency_), fixingDays_, calendar_,
                                        convention_, endOfMonth_);
         Schedule floatSch = legSchedule(evaluationDate_, tenor_, floatFreqPeriod, fixingDays_,
-                                        floatIndex_->fixingCalendar(), floatingConvention, endOfMonth_);
+                                        calendar_, floatingConvention, endOfMonth_);
 
         xccySwap_ = ext::make_shared<ConstNotionalCrossCurrencyFixedVsFloatingSwap>(
             Swap::Payer,

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -46,7 +46,8 @@ namespace QuantLib {
                                         BusinessDayConvention convention,
                                         bool endOfMonth,
                                         Handle<YieldTermStructure> collateralCurve,
-                                        Integer paymentLag);
+                                        Integer paymentLag,
+                                        bool paymentLagOnNotionalExchanges = false);
 
         void initializeDatesFromLegs(const Leg& firstLeg, const Leg& secondLeg);
 
@@ -56,6 +57,7 @@ namespace QuantLib {
         BusinessDayConvention convention_;
         bool endOfMonth_;
         Integer paymentLag_;
+        bool paymentLagOnNotionalExchanges_;
 
         Handle<YieldTermStructure> collateralHandle_;
 
@@ -83,7 +85,8 @@ namespace QuantLib {
                                              std::optional<Frequency> paymentFrequency = std::nullopt,
                                              Integer paymentLag = 0,
                                              std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-                                             std::optional<bool> useIndexedCoupons = std::nullopt);
+                                             std::optional<bool> useIndexedCoupons = std::nullopt,
+                                             bool paymentLagOnNotionalExchanges = false);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
@@ -134,13 +137,19 @@ namespace QuantLib {
                 default) the schedule is derived from the base-currency index tenor.
             \param paymentLag
                 coupon payment lag, in days, applied to both legs (default: 0).
-                Notional exchanges remain on the effective and maturity dates.
+                Notional exchanges remain on the effective and maturity dates
+                unless \c paymentLagOnNotionalExchanges is set.
             \param quoteCurrencyPaymentFrequency
                 payment frequency of the quote-currency leg; if left unset (the
                 default) it defaults to \c paymentFrequency, and if that is unset as
                 well the schedule is derived from the quote-currency index tenor.
             \param useIndexedCoupons
                 if provided, overrides the global IborCoupon setting for both legs.
+            \param paymentLagOnNotionalExchanges
+                if true, both notional exchanges are lagged by \c paymentLag like
+                the coupons: the final exchange settles together with the final
+                coupon and the initial exchange falls on the lagged settlement
+                date (default: false).
             In both frequency parameters, \c NoFrequency is accepted as a synonym for
             an unset (null) value.
         */
@@ -159,7 +168,8 @@ namespace QuantLib {
             std::optional<Frequency> paymentFrequency = std::nullopt,
             Integer paymentLag = 0,
             std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-            std::optional<bool> useIndexedCoupons = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt,
+            bool paymentLagOnNotionalExchanges = false);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -275,8 +275,13 @@ namespace QuantLib {
     The paymentLag parameter, in days, applies to the coupons of both legs;
     notional exchanges remain on the effective and maturity dates.
 
+    The convention parameter applies to the fixed-leg schedule and payments.
+
     If provided, the useIndexedCoupons parameter overrides the global
     IborCoupon setting for the floating leg.
+
+    If provided, the floatingLegConvention parameter applies to the floating-leg
+    schedule and payments.  Otherwise, the convention of the floating index is used.
     */
     class ConstNotionalCrossCurrencySwapRateHelper : public CrossCurrencySwapRateHelperBase {
       public:
@@ -293,7 +298,8 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& collateralCurve,
             bool collateralOnFixedLeg,
             Integer paymentLag = 0,
-            std::optional<bool> useIndexedCoupons = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt,
+            std::optional<BusinessDayConvention> floatingLegConvention = std::nullopt);
 
         Real impliedQuote() const override;
         void accept(AcyclicVisitor&) override;
@@ -312,6 +318,7 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> floatIndex_;
         bool collateralOnFixedLeg_;
         std::optional<bool> useIndexedCoupons_;
+        std::optional<BusinessDayConvention> floatingLegConvention_;
 
         ext::shared_ptr<ConstNotionalCrossCurrencyFixedVsFloatingSwap> xccySwap_;
     };

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -276,8 +276,7 @@ namespace QuantLib {
     notional exchanges remain on the effective and maturity dates.
 
     The convention parameter applies to the schedule and payments of both legs,
-    and the calendar parameter is used to roll and to pay on both legs; the
-    floating index only supplies its own fixing calendar for its fixings.
+    and the calendar parameter is used to roll and to pay on both legs.
 
     If provided, the useIndexedCoupons parameter overrides the global
     IborCoupon setting for the floating leg.

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -83,22 +83,11 @@ namespace QuantLib {
                                              std::optional<Frequency> paymentFrequency = std::nullopt,
                                              Integer paymentLag = 0,
                                              std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-                                             std::optional<bool> useIndexedCoupons = std::nullopt,
-                                             std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
-                                             std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
+                                             std::optional<bool> useIndexedCoupons = std::nullopt);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
         const Handle<YieldTermStructure>& quoteCcyLegDiscountHandle() const;
-
-        //! convention of the base-currency leg; \c convention if not overridden
-        BusinessDayConvention baseCcyConvention() const {
-            return baseCcyLegConvention_.value_or(convention_);
-        }
-        //! convention of the quote-currency leg; \c convention if not overridden
-        BusinessDayConvention quoteCcyConvention() const {
-            return quoteCcyLegConvention_.value_or(convention_);
-        }
 
         ext::shared_ptr<IborIndex> baseCcyIdx_;
         ext::shared_ptr<IborIndex> quoteCcyIdx_;
@@ -107,8 +96,6 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency_;
         std::optional<Frequency> quoteCcyPaymentFrequency_;
         std::optional<bool> useIndexedCoupons_;
-        std::optional<BusinessDayConvention> baseCcyLegConvention_;
-        std::optional<BusinessDayConvention> quoteCcyLegConvention_;
 
         Schedule baseCcySchedule_;
         Schedule quoteCcySchedule_;
@@ -154,12 +141,6 @@ namespace QuantLib {
                 well the schedule is derived from the quote-currency index tenor.
             \param useIndexedCoupons
                 if provided, overrides the global IborCoupon setting for both legs.
-            \param baseCurrencyLegConvention
-                if provided, the roll and payment convention of the base-currency
-                leg; otherwise \p convention is used.
-            \param quoteCurrencyLegConvention
-                if provided, the roll and payment convention of the quote-currency
-                leg; otherwise \p convention is used.
             In both frequency parameters, \c NoFrequency is accepted as a synonym for
             an unset (null) value.
         */
@@ -178,9 +159,7 @@ namespace QuantLib {
             std::optional<Frequency> paymentFrequency = std::nullopt,
             Integer paymentLag = 0,
             std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-            std::optional<bool> useIndexedCoupons = std::nullopt,
-            std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
-            std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -233,12 +212,6 @@ namespace QuantLib {
                 \p calendar is used if this is empty.
             \param useIndexedCoupons
                 if provided, overrides the global IborCoupon setting for both legs.
-            \param baseCurrencyLegConvention
-                if provided, the roll and payment convention of the base-currency
-                leg; otherwise \p convention is used.
-            \param quoteCurrencyLegConvention
-                if provided, the roll and payment convention of the quote-currency
-                leg; otherwise \p convention is used.
             In both frequency parameters, \c NoFrequency is accepted as a synonym for
             an unset (null) value.
         */
@@ -259,9 +232,7 @@ namespace QuantLib {
                                             std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
                                             Natural fxResetFixingDays = 0,
                                             Calendar fxResetFixingCalendar = Calendar(),
-                                            std::optional<bool> useIndexedCoupons = std::nullopt,
-                                            std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
-                                            std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
+                                            std::optional<bool> useIndexedCoupons = std::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -310,10 +281,6 @@ namespace QuantLib {
 
     If provided, the useIndexedCoupons parameter overrides the global
     IborCoupon setting for the floating leg.
-
-    If provided, the floatingLegConvention parameter overrides convention on the
-    floating-leg schedule and payments; this is only needed when the two legs are
-    meant to roll differently.
     */
     class ConstNotionalCrossCurrencySwapRateHelper : public CrossCurrencySwapRateHelperBase {
       public:
@@ -330,8 +297,7 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& collateralCurve,
             bool collateralOnFixedLeg,
             Integer paymentLag = 0,
-            std::optional<bool> useIndexedCoupons = std::nullopt,
-            std::optional<BusinessDayConvention> floatingLegConvention = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt);
 
         Real impliedQuote() const override;
         void accept(AcyclicVisitor&) override;
@@ -350,7 +316,6 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> floatIndex_;
         bool collateralOnFixedLeg_;
         std::optional<bool> useIndexedCoupons_;
-        std::optional<BusinessDayConvention> floatingLegConvention_;
 
         ext::shared_ptr<ConstNotionalCrossCurrencyFixedVsFloatingSwap> xccySwap_;
     };

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -280,6 +280,12 @@ namespace QuantLib {
 
     If provided, the useIndexedCoupons parameter overrides the global
     IborCoupon setting for the floating leg.
+
+    The floatPaymentFrequency parameter is the payment frequency of the floating
+    leg.  If left unset (the default) the schedule is derived from the floating
+    index tenor, which is only meaningful for an ibor index; an overnight index
+    has no payment frequency of its own, so one must be given explicitly.
+    \c NoFrequency is accepted as a synonym for an unset (null) value.
     */
     class ConstNotionalCrossCurrencySwapRateHelper : public CrossCurrencySwapRateHelperBase {
       public:
@@ -296,7 +302,8 @@ namespace QuantLib {
             const Handle<YieldTermStructure>& collateralCurve,
             bool collateralOnFixedLeg,
             Integer paymentLag = 0,
-            std::optional<bool> useIndexedCoupons = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt,
+            std::optional<Frequency> floatPaymentFrequency = std::nullopt);
 
         Real impliedQuote() const override;
         void accept(AcyclicVisitor&) override;
@@ -315,6 +322,7 @@ namespace QuantLib {
         ext::shared_ptr<IborIndex> floatIndex_;
         bool collateralOnFixedLeg_;
         std::optional<bool> useIndexedCoupons_;
+        std::optional<Frequency> floatPaymentFrequency_;
 
         ext::shared_ptr<ConstNotionalCrossCurrencyFixedVsFloatingSwap> xccySwap_;
     };

--- a/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
+++ b/ql/experimental/termstructures/crosscurrencyratehelpers.hpp
@@ -83,11 +83,22 @@ namespace QuantLib {
                                              std::optional<Frequency> paymentFrequency = std::nullopt,
                                              Integer paymentLag = 0,
                                              std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-                                             std::optional<bool> useIndexedCoupons = std::nullopt);
+                                             std::optional<bool> useIndexedCoupons = std::nullopt,
+                                             std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
+                                             std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
 
         void initializeDates() override;
         const Handle<YieldTermStructure>& baseCcyLegDiscountHandle() const;
         const Handle<YieldTermStructure>& quoteCcyLegDiscountHandle() const;
+
+        //! convention of the base-currency leg; \c convention if not overridden
+        BusinessDayConvention baseCcyConvention() const {
+            return baseCcyLegConvention_.value_or(convention_);
+        }
+        //! convention of the quote-currency leg; \c convention if not overridden
+        BusinessDayConvention quoteCcyConvention() const {
+            return quoteCcyLegConvention_.value_or(convention_);
+        }
 
         ext::shared_ptr<IborIndex> baseCcyIdx_;
         ext::shared_ptr<IborIndex> quoteCcyIdx_;
@@ -96,6 +107,8 @@ namespace QuantLib {
         std::optional<Frequency> paymentFrequency_;
         std::optional<Frequency> quoteCcyPaymentFrequency_;
         std::optional<bool> useIndexedCoupons_;
+        std::optional<BusinessDayConvention> baseCcyLegConvention_;
+        std::optional<BusinessDayConvention> quoteCcyLegConvention_;
 
         Schedule baseCcySchedule_;
         Schedule quoteCcySchedule_;
@@ -141,6 +154,12 @@ namespace QuantLib {
                 well the schedule is derived from the quote-currency index tenor.
             \param useIndexedCoupons
                 if provided, overrides the global IborCoupon setting for both legs.
+            \param baseCurrencyLegConvention
+                if provided, the roll and payment convention of the base-currency
+                leg; otherwise \p convention is used.
+            \param quoteCurrencyLegConvention
+                if provided, the roll and payment convention of the quote-currency
+                leg; otherwise \p convention is used.
             In both frequency parameters, \c NoFrequency is accepted as a synonym for
             an unset (null) value.
         */
@@ -159,7 +178,9 @@ namespace QuantLib {
             std::optional<Frequency> paymentFrequency = std::nullopt,
             Integer paymentLag = 0,
             std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
-            std::optional<bool> useIndexedCoupons = std::nullopt);
+            std::optional<bool> useIndexedCoupons = std::nullopt,
+            std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
+            std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -212,6 +233,12 @@ namespace QuantLib {
                 \p calendar is used if this is empty.
             \param useIndexedCoupons
                 if provided, overrides the global IborCoupon setting for both legs.
+            \param baseCurrencyLegConvention
+                if provided, the roll and payment convention of the base-currency
+                leg; otherwise \p convention is used.
+            \param quoteCurrencyLegConvention
+                if provided, the roll and payment convention of the quote-currency
+                leg; otherwise \p convention is used.
             In both frequency parameters, \c NoFrequency is accepted as a synonym for
             an unset (null) value.
         */
@@ -232,7 +259,9 @@ namespace QuantLib {
                                             std::optional<Frequency> quoteCurrencyPaymentFrequency = std::nullopt,
                                             Natural fxResetFixingDays = 0,
                                             Calendar fxResetFixingCalendar = Calendar(),
-                                            std::optional<bool> useIndexedCoupons = std::nullopt);
+                                            std::optional<bool> useIndexedCoupons = std::nullopt,
+                                            std::optional<BusinessDayConvention> baseCurrencyLegConvention = std::nullopt,
+                                            std::optional<BusinessDayConvention> quoteCurrencyLegConvention = std::nullopt);
         //! \name RateHelper interface
         //@{
         Real impliedQuote() const override;
@@ -275,13 +304,16 @@ namespace QuantLib {
     The paymentLag parameter, in days, applies to the coupons of both legs;
     notional exchanges remain on the effective and maturity dates.
 
-    The convention parameter applies to the fixed-leg schedule and payments.
+    The convention parameter applies to the schedule and payments of both legs,
+    and the calendar parameter is used to roll and to pay on both legs; the
+    floating index only supplies its own fixing calendar for its fixings.
 
     If provided, the useIndexedCoupons parameter overrides the global
     IborCoupon setting for the floating leg.
 
-    If provided, the floatingLegConvention parameter applies to the floating-leg
-    schedule and payments.  Otherwise, the convention of the floating index is used.
+    If provided, the floatingLegConvention parameter overrides convention on the
+    floating-leg schedule and payments; this is only needed when the two legs are
+    meant to roll differently.
     */
     class ConstNotionalCrossCurrencySwapRateHelper : public CrossCurrencySwapRateHelperBase {
       public:

--- a/ql/instruments/constnotionalcrosscurrencybasisswap.cpp
+++ b/ql/instruments/constnotionalcrosscurrencybasisswap.cpp
@@ -39,12 +39,14 @@ ConstNotionalCrossCurrencyBasisSwap::ConstNotionalCrossCurrencyBasisSwap(
                                      bool recCompoundSpread, Natural recLookbackDays, bool recObservationShift,
                                      Natural recLockoutDays, RateAveraging::Type recAveragingMethod,
                                      const bool telescopicValueDates,
-                                     std::optional<bool> useIndexedCoupons)
+                                     std::optional<bool> useIndexedCoupons,
+                                     const bool paymentLagOnNotionalExchanges)
     : ConstNotionalCrossCurrencySwap(2), payNominal_(payNominal), payCurrency_(std::move(payCurrency)), paySchedule_(std::move(paySchedule)),
       payIndex_(payIndex), paySpread_(paySpread), payGearing_(payGearing), recNominal_(recNominal),
       recCurrency_(std::move(recCurrency)), recSchedule_(std::move(recSchedule)), recIndex_(recIndex), recSpread_(recSpread),
       recGearing_(recGearing), payPaymentLag_(payPaymentLag), recPaymentLag_(recPaymentLag),
       useIndexedCoupons_(useIndexedCoupons),
+      paymentLagOnNotionalExchanges_(paymentLagOnNotionalExchanges),
       payCompoundSpread_(payCompoundSpread), payLookbackDays_(payLookbackDays),
       payObservationShift_(payObservationShift), payLockoutDays_(payLockoutDays),
       payAveragingMethod_(payAveragingMethod), recCompoundSpread_(recCompoundSpread),
@@ -117,13 +119,15 @@ void ConstNotionalCrossCurrencyBasisSwap::initialize() {
     ConstNotionalCrossCurrencySwap::addNotionalExchangesToLeg(legs_[0], paySchedule_.calendar(),
                                                               earliestDate, maturityDate,
                                                               paySchedule_.businessDayConvention(),
-                                                              payNominal_);
+                                                              payNominal_,
+                                                              paymentLagOnNotionalExchanges_ ? payPaymentLag_ : 0);
 
     // Add notional exchanges on recLeg
     ConstNotionalCrossCurrencySwap::addNotionalExchangesToLeg(legs_[1], recSchedule_.calendar(),
                                                               earliestDate, maturityDate,
                                                               recSchedule_.businessDayConvention(),
-                                                              recNominal_);
+                                                              recNominal_,
+                                                              paymentLagOnNotionalExchanges_ ? recPaymentLag_ : 0);
 
     // Register the instrument with all cashflows on each leg.
     for (Size legNo = 0; legNo < 2; legNo++) {

--- a/ql/instruments/constnotionalcrosscurrencybasisswap.hpp
+++ b/ql/instruments/constnotionalcrosscurrencybasisswap.hpp
@@ -53,8 +53,11 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
         First leg holds the pay currency cashflows and the second leg holds the receive currency cashflows.
 
         Payment lags apply only to coupon payments.  Notional exchanges remain
-        on the effective and maturity dates.
-        
+        on the effective and maturity dates, unless paymentLagOnNotionalExchanges
+        is set, in which case each leg's exchanges are lagged by that leg's
+        coupon payment lag: the final exchange settles together with the final
+        coupon and the initial exchange falls on the lagged settlement date.
+
         \param payNominal         Notional amount for the pay leg.
         \param payCurrency        Currency of the pay leg.
         \param paySchedule        Payment schedule for the pay leg.
@@ -81,6 +84,7 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
         \param recAveragingMethod   Averaging method for the receive leg if overnight (default: compounding).
         \param telescopicValueDates Flag indicating whether telescopic value dates are used if overnight (default: false).
         \param useIndexedCoupons If provided, overrides the global IborCoupon setting for both legs.
+        \param paymentLagOnNotionalExchanges Whether the notional exchanges are lagged by each leg's coupon payment lag (default: false).
     */
     ConstNotionalCrossCurrencyBasisSwap(
         Real payNominal, Currency  payCurrency, Schedule  paySchedule,
@@ -92,7 +96,8 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
         bool recCompoundSpread = false, Natural recLookbackDays = Null<Natural>(), bool recObservationShift = false,
         Natural recLockoutDays = 0, RateAveraging::Type recAveragingMethod = RateAveraging::Compound,
         bool telescopicValueDates = false,
-        std::optional<bool> useIndexedCoupons = std::nullopt);
+        std::optional<bool> useIndexedCoupons = std::nullopt,
+        bool paymentLagOnNotionalExchanges = false);
     //@}
     //! \name Instrument interface
     //@{
@@ -156,6 +161,7 @@ class ConstNotionalCrossCurrencyBasisSwap : public ConstNotionalCrossCurrencySwa
     Integer payPaymentLag_;
     Integer recPaymentLag_;
     std::optional<bool> useIndexedCoupons_;
+    bool paymentLagOnNotionalExchanges_;
 
     // OIS only
     bool payCompoundSpread_;

--- a/ql/instruments/crosscurrencyswap.cpp
+++ b/ql/instruments/crosscurrencyswap.cpp
@@ -118,17 +118,22 @@ void CrossCurrencySwap::addNotionalExchangesToLeg(Leg& leg,
                                                   const Date earliestDate,
                                                   const Date maturityDate,
                                                   const BusinessDayConvention legBdc,
-                                                  Real nominal) {
-    // Principal exchanges settle on the effective and maturity dates: the
-    // payment lag belongs to coupon payments only.  The dates are adjusted
-    // with the leg's payment convention.
+                                                  Real nominal,
+                                                  Integer paymentLag) {
+    // By default principal exchanges settle on the effective and maturity
+    // dates: the payment lag belongs to coupon payments only, and the dates
+    // are adjusted with the leg's payment convention.  A non-zero paymentLag
+    // instead lags both exchanges like the coupons, so the final exchange
+    // settles together with the final coupon and the initial exchange falls
+    // on the lagged settlement date.  (advance() with zero days reduces to
+    // adjust(), so the default keeps the effective/maturity behaviour.)
     // Initial notional exchange
-    Date aDate = calendar.adjust(earliestDate, legBdc);
+    Date aDate = calendar.advance(earliestDate, paymentLag, Days, legBdc);
     ext::shared_ptr<CashFlow> aCashflow = ext::make_shared<SimpleCashFlow>(-nominal, aDate);
     leg.insert(leg.begin(), aCashflow);
 
     // Final notional exchange
-    aDate = calendar.adjust(maturityDate, legBdc);
+    aDate = calendar.advance(maturityDate, paymentLag, Days, legBdc);
     aCashflow = ext::make_shared<SimpleCashFlow>(nominal, aDate);
     leg.push_back(aCashflow);
 

--- a/ql/instruments/crosscurrencyswap.hpp
+++ b/ql/instruments/crosscurrencyswap.hpp
@@ -129,7 +129,8 @@ class CrossCurrencySwap : public Swap {
                                           Date earliestDate,
                                           Date maturityDate,
                                           BusinessDayConvention legBdc,
-                                          Real nominal);
+                                          Real nominal,
+                                          Integer paymentLag = 0);
     static void sortLegByDate(Leg& leg);
 
     std::vector<Currency> currencies_;

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -926,18 +926,6 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperFloatingLegConvention) {
     BOOST_CHECK_EQUAL(helper.swap()->floatSchedule().endDate(), expectedMaturity);
     BOOST_CHECK_EQUAL(helper.swap()->fixedPaymentBdc(), ModifiedFollowing);
     BOOST_CHECK_EQUAL(helper.swap()->floatPaymentBdc(), ModifiedFollowing);
-
-    // The override is only needed when the legs are meant to roll differently.
-    ConstNotionalCrossCurrencySwapRateHelper overriddenHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false, 0,
-        std::nullopt, Following);
-
-    BOOST_CHECK_EQUAL(overriddenHelper.swap()->fixedSchedule().endDate(), expectedMaturity);
-    BOOST_CHECK_EQUAL(overriddenHelper.swap()->floatSchedule().endDate(), Date(2, August, 2027));
-    BOOST_CHECK_EQUAL(overriddenHelper.swap()->floatPaymentBdc(), Following);
-    // The pillar is the later of the two legs.
-    BOOST_CHECK_EQUAL(overriddenHelper.maturityDate(), Date(2, August, 2027));
 }
 
 BOOST_AUTO_TEST_CASE(testConstNotionalHelperIgnoresIndexFixingCalendar) {
@@ -978,69 +966,6 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperIgnoresIndexFixingCalendar) {
     BOOST_CHECK_EQUAL(usHelper.maturityDate(), weekendHelper.maturityDate());
     // The index keeps its own calendar for its fixings.
     BOOST_CHECK(usIndex->fixingCalendar() != weekendIndex->fixingCalendar());
-}
-
-BOOST_AUTO_TEST_CASE(testBasisHelperPerLegConventions) {
-    BOOST_TEST_MESSAGE("Testing per-leg conventions of cross-currency basis helpers...");
-
-    SavedSettings backup;
-    Date today(29, July, 2026);
-    Settings::instance().evaluationDate() = today;
-
-    Calendar calendar = WeekendsOnly();
-    Handle<YieldTermStructure> collateralCurve(
-        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
-    auto baseIndex = ext::make_shared<OvernightIndex>(
-        "ON base", 2, EURCurrency(), calendar, Actual360(), collateralCurve);
-    auto quoteIndex = ext::make_shared<OvernightIndex>(
-        "ON quote", 2, USDCurrency(), calendar, Actual360(), collateralCurve);
-
-    Date modifiedFollowingMaturity(30, July, 2027);
-    Date followingMaturity(2, August, 2027);
-
-    // Both legs follow the helper convention unless overridden.
-    ConstNotionalCrossCurrencyBasisSwapRateHelper constNotionalHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        baseIndex, quoteIndex, collateralCurve, true, true, Semiannual, 0, Semiannual,
-        std::nullopt);
-
-    BOOST_CHECK_EQUAL(constNotionalHelper.swap()->paySchedule().endDate(),
-                      modifiedFollowingMaturity);
-    BOOST_CHECK_EQUAL(constNotionalHelper.swap()->recSchedule().endDate(),
-                      modifiedFollowingMaturity);
-
-    ConstNotionalCrossCurrencyBasisSwapRateHelper overriddenConstNotionalHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        baseIndex, quoteIndex, collateralCurve, true, true, Semiannual, 0, Semiannual,
-        std::nullopt, std::nullopt, Following);
-
-    BOOST_CHECK_EQUAL(overriddenConstNotionalHelper.swap()->paySchedule().endDate(),
-                      modifiedFollowingMaturity);
-    BOOST_CHECK_EQUAL(overriddenConstNotionalHelper.swap()->recSchedule().endDate(),
-                      followingMaturity);
-
-    // The MtM helper carries its conventions into the swap's payment
-    // conventions as well as its schedules.
-    MtMCrossCurrencyBasisSwapRateHelper mtmHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        baseIndex, quoteIndex, collateralCurve, true, true, true, Semiannual, 0, Semiannual,
-        0, Calendar(), std::nullopt);
-
-    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxBaseSchedule().endDate(), modifiedFollowingMaturity);
-    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxQuoteSchedule().endDate(), modifiedFollowingMaturity);
-    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxBasePaymentConvention(), ModifiedFollowing);
-    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxQuotePaymentConvention(), ModifiedFollowing);
-
-    MtMCrossCurrencyBasisSwapRateHelper overriddenMtMHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        baseIndex, quoteIndex, collateralCurve, true, true, true, Semiannual, 0, Semiannual,
-        0, Calendar(), std::nullopt, Following);
-
-    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxBaseSchedule().endDate(), followingMaturity);
-    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxQuoteSchedule().endDate(),
-                      modifiedFollowingMaturity);
-    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxBasePaymentConvention(), Following);
-    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxQuotePaymentConvention(), ModifiedFollowing);
 }
 
 BOOST_AUTO_TEST_CASE(testPaymentLagDoesNotDelayNotionalExchanges) {
@@ -1164,11 +1089,11 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperCollateralOnFixedLeg) {
                             cal, bdc, bdc,
                             DateGeneration::Forward, endOfMonth);
 
+        // The helper rolls both legs on its own calendar and convention; the
+        // index only supplies its fixing calendar for fixings.
         Schedule floatSched(settlement, maturity,
                             euribor3m->tenor(),
-                            euribor3m->fixingCalendar(),
-                            euribor3m->businessDayConvention(),
-                            euribor3m->businessDayConvention(),
+                            cal, bdc, bdc,
                             DateGeneration::Forward, false);
 
         Leg fixedLeg = FixedRateLeg(fixedSched)
@@ -1261,11 +1186,11 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperCollateralOnFloatingLeg) {
                             cal, bdc, bdc,
                             DateGeneration::Forward, endOfMonth);
 
+        // The helper rolls both legs on its own calendar and convention; the
+        // index only supplies its fixing calendar for fixings.
         Schedule floatSched(settlement, maturity,
                             euribor3m->tenor(),
-                            euribor3m->fixingCalendar(),
-                            euribor3m->businessDayConvention(),
-                            euribor3m->businessDayConvention(),
+                            cal, bdc, bdc,
                             DateGeneration::Forward, false);
 
         Leg fixedLeg = FixedRateLeg(fixedSched)
@@ -1279,7 +1204,7 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperCollateralOnFloatingLeg) {
                        .withNotionals(1.0)
                        .withSpreads(0.0)
                        .withPaymentLag(paymentLag)
-                       .withPaymentAdjustment(euribor3m->businessDayConvention())
+                       .withPaymentAdjustment(bdc)
                        .withPaymentCalendar(cal);
 
         Date initialPaymentDate = CashFlows::startDate(fixedLeg);

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -907,24 +907,140 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperFloatingLegConvention) {
     Calendar calendar = WeekendsOnly();
     Handle<YieldTermStructure> collateralCurve(
         ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+    // An overnight index reports Following regardless of the market it models,
+    // so the helper convention has to drive both legs.
     auto overnightIndex = ext::make_shared<OvernightIndex>(
         "ON", 2, USDCurrency(), calendar, Actual360(), collateralCurve);
+    BOOST_CHECK_EQUAL(overnightIndex->businessDayConvention(), Following);
 
-    ConstNotionalCrossCurrencySwapRateHelper defaultConventionHelper(
+    // The helper convention alone, as passed by an ordinary caller, must reach
+    // the floating leg: 31st July 2027 is a Saturday, so ModifiedFollowing
+    // rolls back to the 30th instead of forward into August.
+    ConstNotionalCrossCurrencySwapRateHelper helper(
         makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
         Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false);
-    ConstNotionalCrossCurrencySwapRateHelper overriddenConventionHelper(
-        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false, 0,
-        std::nullopt, ModifiedFollowing);
 
     Date expectedMaturity(30, July, 2027);
-    BOOST_CHECK_EQUAL(defaultConventionHelper.maturityDate(), Date(2, August, 2027));
-    BOOST_CHECK_EQUAL(defaultConventionHelper.swap()->floatPaymentBdc(), Following);
-    BOOST_CHECK_EQUAL(overriddenConventionHelper.maturityDate(), expectedMaturity);
-    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->fixedSchedule().endDate(), expectedMaturity);
-    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->floatSchedule().endDate(), expectedMaturity);
-    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->floatPaymentBdc(), ModifiedFollowing);
+    BOOST_CHECK_EQUAL(helper.maturityDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(helper.swap()->fixedSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(helper.swap()->floatSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(helper.swap()->fixedPaymentBdc(), ModifiedFollowing);
+    BOOST_CHECK_EQUAL(helper.swap()->floatPaymentBdc(), ModifiedFollowing);
+
+    // The override is only needed when the legs are meant to roll differently.
+    ConstNotionalCrossCurrencySwapRateHelper overriddenHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false, 0,
+        std::nullopt, Following);
+
+    BOOST_CHECK_EQUAL(overriddenHelper.swap()->fixedSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(overriddenHelper.swap()->floatSchedule().endDate(), Date(2, August, 2027));
+    BOOST_CHECK_EQUAL(overriddenHelper.swap()->floatPaymentBdc(), Following);
+    // The pillar is the later of the two legs.
+    BOOST_CHECK_EQUAL(overriddenHelper.maturityDate(), Date(2, August, 2027));
+}
+
+BOOST_AUTO_TEST_CASE(testConstNotionalHelperIgnoresIndexFixingCalendar) {
+    BOOST_TEST_MESSAGE("Testing that fixed-vs-floating helpers roll both legs on the helper calendar...");
+
+    SavedSettings backup;
+    Date today(1, July, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = WeekendsOnly();
+    Handle<YieldTermStructure> collateralCurve(
+        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+
+    // Same index in every respect but the fixing calendar.  A fixing calendar
+    // governs where the rate fixes, not where the accrual schedule rolls, so
+    // neither the schedules nor the pillar may depend on it: 3rd July 2027 is a
+    // Saturday and the 5th is the observed US Independence Day, so leaking the
+    // index calendar into the schedule would push the floating leg to the 6th.
+    auto weekendIndex = ext::make_shared<OvernightIndex>(
+        "ON weekend", 2, USDCurrency(), calendar, Actual360(), collateralCurve);
+    auto usIndex = ext::make_shared<OvernightIndex>(
+        "ON US", 2, USDCurrency(), UnitedStates(UnitedStates::GovernmentBond), Actual360(),
+        collateralCurve);
+    BOOST_CHECK(usIndex->fixingCalendar().isHoliday(Date(5, July, 2027)));
+
+    auto makeHelper = [&](const ext::shared_ptr<IborIndex>& index) {
+        return ConstNotionalCrossCurrencySwapRateHelper(
+            makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+            Semiannual, Actual365Fixed(), index, collateralCurve, false);
+    };
+    auto weekendHelper = makeHelper(weekendIndex);
+    auto usHelper = makeHelper(usIndex);
+
+    Date expectedMaturity(5, July, 2027);
+    BOOST_CHECK_EQUAL(weekendHelper.swap()->floatSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(usHelper.swap()->floatSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(usHelper.swap()->fixedSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(usHelper.maturityDate(), weekendHelper.maturityDate());
+    // The index keeps its own calendar for its fixings.
+    BOOST_CHECK(usIndex->fixingCalendar() != weekendIndex->fixingCalendar());
+}
+
+BOOST_AUTO_TEST_CASE(testBasisHelperPerLegConventions) {
+    BOOST_TEST_MESSAGE("Testing per-leg conventions of cross-currency basis helpers...");
+
+    SavedSettings backup;
+    Date today(29, July, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = WeekendsOnly();
+    Handle<YieldTermStructure> collateralCurve(
+        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+    auto baseIndex = ext::make_shared<OvernightIndex>(
+        "ON base", 2, EURCurrency(), calendar, Actual360(), collateralCurve);
+    auto quoteIndex = ext::make_shared<OvernightIndex>(
+        "ON quote", 2, USDCurrency(), calendar, Actual360(), collateralCurve);
+
+    Date modifiedFollowingMaturity(30, July, 2027);
+    Date followingMaturity(2, August, 2027);
+
+    // Both legs follow the helper convention unless overridden.
+    ConstNotionalCrossCurrencyBasisSwapRateHelper constNotionalHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        baseIndex, quoteIndex, collateralCurve, true, true, Semiannual, 0, Semiannual,
+        std::nullopt);
+
+    BOOST_CHECK_EQUAL(constNotionalHelper.swap()->paySchedule().endDate(),
+                      modifiedFollowingMaturity);
+    BOOST_CHECK_EQUAL(constNotionalHelper.swap()->recSchedule().endDate(),
+                      modifiedFollowingMaturity);
+
+    ConstNotionalCrossCurrencyBasisSwapRateHelper overriddenConstNotionalHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        baseIndex, quoteIndex, collateralCurve, true, true, Semiannual, 0, Semiannual,
+        std::nullopt, std::nullopt, Following);
+
+    BOOST_CHECK_EQUAL(overriddenConstNotionalHelper.swap()->paySchedule().endDate(),
+                      modifiedFollowingMaturity);
+    BOOST_CHECK_EQUAL(overriddenConstNotionalHelper.swap()->recSchedule().endDate(),
+                      followingMaturity);
+
+    // The MtM helper carries its conventions into the swap's payment
+    // conventions as well as its schedules.
+    MtMCrossCurrencyBasisSwapRateHelper mtmHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        baseIndex, quoteIndex, collateralCurve, true, true, true, Semiannual, 0, Semiannual,
+        0, Calendar(), std::nullopt);
+
+    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxBaseSchedule().endDate(), modifiedFollowingMaturity);
+    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxQuoteSchedule().endDate(), modifiedFollowingMaturity);
+    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxBasePaymentConvention(), ModifiedFollowing);
+    BOOST_CHECK_EQUAL(mtmHelper.swap()->fxQuotePaymentConvention(), ModifiedFollowing);
+
+    MtMCrossCurrencyBasisSwapRateHelper overriddenMtMHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        baseIndex, quoteIndex, collateralCurve, true, true, true, Semiannual, 0, Semiannual,
+        0, Calendar(), std::nullopt, Following);
+
+    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxBaseSchedule().endDate(), followingMaturity);
+    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxQuoteSchedule().endDate(),
+                      modifiedFollowingMaturity);
+    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxBasePaymentConvention(), Following);
+    BOOST_CHECK_EQUAL(overriddenMtMHelper.swap()->fxQuotePaymentConvention(), ModifiedFollowing);
 }
 
 BOOST_AUTO_TEST_CASE(testPaymentLagDoesNotDelayNotionalExchanges) {

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -42,6 +42,7 @@
 #include <ql/time/calendars/target.hpp>
 #include <ql/time/calendars/jointcalendar.hpp>
 #include <ql/time/calendars/unitedstates.hpp>
+#include <ql/time/calendars/weekendsonly.hpp>
 #include <ql/time/daycounters/thirty360.hpp>
 #include <ql/currencies/all.hpp>
 
@@ -894,6 +895,36 @@ BOOST_AUTO_TEST_CASE(testConstNotionalCrossCurrencySwapRateHelperRelinking) {
     Real newQuote = h.impliedQuote();
 
     BOOST_CHECK(oldQuote != newQuote);
+}
+
+BOOST_AUTO_TEST_CASE(testConstNotionalHelperFloatingLegConvention) {
+    BOOST_TEST_MESSAGE("Testing the floating-leg convention of fixed-vs-floating helpers...");
+
+    SavedSettings backup;
+    Date today(29, July, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = WeekendsOnly();
+    Handle<YieldTermStructure> collateralCurve(
+        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+    auto overnightIndex = ext::make_shared<OvernightIndex>(
+        "ON", 2, USDCurrency(), calendar, Actual360(), collateralCurve);
+
+    ConstNotionalCrossCurrencySwapRateHelper defaultConventionHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false);
+    ConstNotionalCrossCurrencySwapRateHelper overriddenConventionHelper(
+        makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
+        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false, 0,
+        std::nullopt, ModifiedFollowing);
+
+    Date expectedMaturity(30, July, 2027);
+    BOOST_CHECK_EQUAL(defaultConventionHelper.maturityDate(), Date(2, August, 2027));
+    BOOST_CHECK_EQUAL(defaultConventionHelper.swap()->floatPaymentBdc(), Following);
+    BOOST_CHECK_EQUAL(overriddenConventionHelper.maturityDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->fixedSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->floatSchedule().endDate(), expectedMaturity);
+    BOOST_CHECK_EQUAL(overriddenConventionHelper.swap()->floatPaymentBdc(), ModifiedFollowing);
 }
 
 BOOST_AUTO_TEST_CASE(testPaymentLagDoesNotDelayNotionalExchanges) {

--- a/test-suite/crosscurrencyratehelpers.cpp
+++ b/test-suite/crosscurrencyratehelpers.cpp
@@ -918,7 +918,8 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperFloatingLegConvention) {
     // rolls back to the 30th instead of forward into August.
     ConstNotionalCrossCurrencySwapRateHelper helper(
         makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false);
+        Semiannual, Actual365Fixed(), overnightIndex, collateralCurve, false, 0,
+        std::nullopt, Semiannual);
 
     Date expectedMaturity(30, July, 2027);
     BOOST_CHECK_EQUAL(helper.maturityDate(), expectedMaturity);
@@ -954,7 +955,8 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperIgnoresIndexFixingCalendar) {
     auto makeHelper = [&](const ext::shared_ptr<IborIndex>& index) {
         return ConstNotionalCrossCurrencySwapRateHelper(
             makeQuoteHandle(0.0), 1 * Years, 2, calendar, ModifiedFollowing, false,
-            Semiannual, Actual365Fixed(), index, collateralCurve, false);
+            Semiannual, Actual365Fixed(), index, collateralCurve, false, 0,
+            std::nullopt, Semiannual);
     };
     auto weekendHelper = makeHelper(weekendIndex);
     auto usHelper = makeHelper(usIndex);
@@ -966,6 +968,50 @@ BOOST_AUTO_TEST_CASE(testConstNotionalHelperIgnoresIndexFixingCalendar) {
     BOOST_CHECK_EQUAL(usHelper.maturityDate(), weekendHelper.maturityDate());
     // The index keeps its own calendar for its fixings.
     BOOST_CHECK(usIndex->fixingCalendar() != weekendIndex->fixingCalendar());
+}
+
+BOOST_AUTO_TEST_CASE(testConstNotionalHelperFloatingPaymentFrequency) {
+    BOOST_TEST_MESSAGE("Testing the floating-leg payment frequency of fixed-vs-floating helpers...");
+
+    SavedSettings backup;
+    Date today(15, July, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    Calendar calendar = TARGET();
+    Handle<YieldTermStructure> collateralCurve(
+        ext::make_shared<FlatForward>(today, 0.04, Actual360()));
+    auto overnightIndex = ext::make_shared<OvernightIndex>(
+        "ON", 0, EURCurrency(), calendar, Actual360(), collateralCurve);
+    auto euribor3m = ext::make_shared<Euribor3M>(collateralCurve);
+
+    auto makeHelper = [&](const ext::shared_ptr<IborIndex>& index,
+                          std::optional<Frequency> floatFrequency) {
+        return ConstNotionalCrossCurrencySwapRateHelper(
+            makeQuoteHandle(0.01), 1 * Years, 2, calendar, Following, false,
+            Annual, Actual365Fixed(), index, collateralCurve, false, 0,
+            std::nullopt, floatFrequency);
+    };
+
+    // An overnight index has a one-day tenor, which is not a payment frequency;
+    // asking it for one would silently produce a daily-paying leg.
+    BOOST_CHECK_THROW(makeHelper(overnightIndex, std::nullopt), Error);
+
+    // Given a frequency, the overnight leg pays on that schedule.
+    auto overnightHelper = makeHelper(overnightIndex, Semiannual);
+    BOOST_CHECK_EQUAL(overnightHelper.swap()->floatSchedule().size(), 3);
+    BOOST_CHECK_EQUAL(overnightHelper.swap()->fixedSchedule().size(), 2);
+
+    // An ibor index still falls back to its own tenor.
+    auto iborHelper = makeHelper(euribor3m, std::nullopt);
+    BOOST_CHECK_EQUAL(iborHelper.swap()->floatSchedule().size(), 5);
+
+    // An explicit frequency overrides the ibor tenor.
+    auto iborSemiannualHelper = makeHelper(euribor3m, Semiannual);
+    BOOST_CHECK_EQUAL(iborSemiannualHelper.swap()->floatSchedule().size(), 3);
+
+    // NoFrequency is a synonym for an unset value, as in the basis helpers.
+    auto iborNoFrequencyHelper = makeHelper(euribor3m, NoFrequency);
+    BOOST_CHECK_EQUAL(iborNoFrequencyHelper.swap()->floatSchedule().size(), 5);
 }
 
 BOOST_AUTO_TEST_CASE(testPaymentLagDoesNotDelayNotionalExchanges) {


### PR DESCRIPTION
1. Roll both legs of ConstNotionalCrossCurrencySwapRateHelper on the helper's calendar and convention - this is for https://github.com/lballabio/QuantLib/issues/2710
2. Require an explicit floating payment frequency for overnight indices in ConstNotionalCrossCurrencySwapRateHelper - this is a bug where the floating leg freq is always 1D for overnight indices
3. Adding paymentLagOnNotionalExchanges (defaulting to False). Typically for MtM swaps the notional exchange occurs on its own schedule without taking into account the coupon payment lag. However for CN xccy swaps this is not the case (at least for the only major market where they dominate - HKD, due to the currency peg). For convenience of settlement reasons, the notional exchange occurs on the coupon payment date). So in this case paymentLagOnNotionalExchanges should be set to true. Since this branch is improving ConstNotionalCrossCurrencySwapRateHelper , this is a useful improvement.
