### PR TITLE
Pseudo-deprecate `QL_DEPRECATED`

### DIFF
--- a/ql/qldefines.hpp
+++ b/ql/qldefines.hpp
@@ -182,30 +182,29 @@
 /*! @}  */
 
 
-// For the time being we're keeping a QL_DEPRECATED macro because
-// of <https://stackoverflow.com/questions/38378693/>.  We need to
-// use it to deprecate constructors until we drop support for VC++2015.
-// Other features (methods, typedefs etc.) can use [[deprecated]] and
-// possibly add a message.
+/*! Once we needed to keep this macro around for compatibility
+    with older compiler.  It's no longer needed.
+
+    \deprecated Use `[[deprecated("message")]]` and suggest an alternative in the message.
+                Deprecated in version 1.44.
+*/
+#define QL_DEPRECATED [[deprecated]]
 
 // emit warning when using deprecated features
 // clang-format off
 #if defined(BOOST_MSVC)       // Microsoft Visual C++
-#    define QL_DEPRECATED __declspec(deprecated)
 #    define QL_DEPRECATED_DISABLE_WARNING \
         __pragma(warning(push))           \
         __pragma(warning(disable : 4996))
 #    define QL_DEPRECATED_ENABLE_WARNING \
         __pragma(warning(pop))
 #elif defined(__clang__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                                 \
         _Pragma("clang diagnostic push")                                  \
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #    define QL_DEPRECATED_ENABLE_WARNING \
         _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__)
-#    define QL_DEPRECATED __attribute__((deprecated))
 #    define QL_DEPRECATED_DISABLE_WARNING                               \
         _Pragma("GCC diagnostic push")                                  \
         _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
@@ -213,7 +212,6 @@
         _Pragma("GCC diagnostic pop")
 #else
 // we don't know how to enable it, just define the macros away
-#    define QL_DEPRECATED
 #    define QL_DEPRECATED_DISABLE_WARNING
 #    define QL_DEPRECATED_ENABLE_WARNING
 #endif


### PR DESCRIPTION
It's not possible to deprecate a macro; the deprecation is only documented in Doxygen.