### PR TITLE
Stop overnight-index future accrual at holiday maturity

### DIFF
--- a/ql/instruments/overnightindexfuture.cpp
+++ b/ql/instruments/overnightindexfuture.cpp
@@ -107,8 +107,9 @@ namespace QuantLib {
                 Real r = history[today];
                 if (r != Null<Real>()) {
                     Date tomorrow = calendar.advance(today, 1, Days);
-                    prod *= 1 + r * dayCounter.yearFraction(today, tomorrow);
-                    forwardDiscountStart = tomorrow;
+                    Date accrualEnd = std::min(tomorrow, maturityDate_);
+                    prod *= 1 + r * dayCounter.yearFraction(today, accrualEnd);
+                    forwardDiscountStart = accrualEnd;
                 }
             }
         }

--- a/test-suite/sofrfutures.cpp
+++ b/test-suite/sofrfutures.cpp
@@ -23,8 +23,10 @@
 #include <ql/instruments/overnightindexfuture.hpp>
 #include <ql/indexes/ibor/sofr.hpp>
 #include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
 #include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
 #include <ql/termstructures/yield/overnightindexfutureratehelper.hpp>
+#include <ql/time/daycounters/actual360.hpp>
 #include <iomanip>
 
 using namespace QuantLib;
@@ -168,6 +170,38 @@ BOOST_AUTO_TEST_CASE(testBootstrapWithJuneteenth) {
                     << "\n error:           " << error
                     << "\n tolerance:       " << tolerance);
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(testCompoundedRateWithHolidayMaturity) {
+    BOOST_TEST_MESSAGE(
+        "Testing compounded SOFR futures when maturity is a holiday...");
+
+    Date today(18, June, 2024);
+    Settings::instance().evaluationDate() = today;
+
+    Handle<YieldTermStructure> curve(
+        ext::make_shared<FlatForward>(today, 0.0, Actual360()));
+    auto sofr = ext::make_shared<Sofr>(curve);
+
+    Rate previousFixing = 0.03;
+    Rate todaysFixing = 0.09;
+    sofr->addFixing(Date(17, June, 2024), previousFixing);
+    sofr->addFixing(today, todaysFixing);
+
+    Date valueDate(17, June, 2024);
+    Date maturityDate(19, June, 2024); // Juneteenth
+    OvernightIndexFuture future(sofr, valueDate, maturityDate);
+
+    DayCounter dc = sofr->dayCounter();
+    Real compoundFactor =
+        (1.0 + previousFixing * dc.yearFraction(valueDate, today)) *
+        (1.0 + todaysFixing * dc.yearFraction(today, maturityDate));
+    Rate expectedRate =
+        (compoundFactor - 1.0) / dc.yearFraction(valueDate, maturityDate);
+    Real expectedPrice = 100.0 * (1.0 - expectedRate);
+
+    QL_CHECK_SMALL(future.NPV() - expectedPrice, 1.0e-12);
 }
 
 BOOST_AUTO_TEST_CASE(testPillarDates) {


### PR DESCRIPTION
## Summary

- stop a known overnight fixing from accruing past the future's maturity when the next fixing business day is later
- keep the forward-discount start aligned with the capped accrual end
- add a SOFR regression whose maturity falls on Juneteenth

## Root cause

When the evaluation date is inside the reference period and today's fixing is available, `OvernightIndexFuture::compoundedRate()` advances to the next fixing business day. If the contract matures on a holiday before that day, the fixing was compounded beyond maturity and the telescopic forward part started after maturity.

In the regression scenario, the unchanged code mispriced the future by 4.500375 price points. Capping the known-fixing accrual and forward start at maturity removes the over-accrual.

## Validation

- before the production change, the new regression failed with an absolute price error of `4.500375`
- focused regression: passed (1/1 test case, 2/2 assertions)
- complete `SofrFuturesTests` suite: passed (4/4 test cases, 10/10 assertions)
- complete QuantLib test suite: passed (1,433/1,433 test cases, 13,315/13,315 assertions; 15m48s)
- `git diff --check`: passed
