### PR TITLE
Fix American call approximations with negative risk-free rates

### DIFF
--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -164,7 +164,8 @@ namespace QuantLib {
         BlackCalculator black(payoff, forwardPrice, std::sqrt(variance),
                               riskFreeDiscount);
 
-        if (dividendDiscount>=1.0 && payoff->optionType()==Option::Call) {
+        if (dividendDiscount>=1.0 && dividendDiscount>=riskFreeDiscount &&
+            payoff->optionType()==Option::Call) {
             // early exercise never optimal
             results_.value        = black.value();
             results_.delta        = black.delta(spot);

--- a/ql/pricingengines/vanilla/juquadraticengine.cpp
+++ b/ql/pricingengines/vanilla/juquadraticengine.cpp
@@ -68,7 +68,8 @@ namespace QuantLib {
         BlackCalculator black(payoff, forwardPrice,
                               std::sqrt(variance), riskFreeDiscount);
 
-        if (dividendDiscount>=1.0 && payoff->optionType()==Option::Call) {
+        if (dividendDiscount>=1.0 && dividendDiscount>=riskFreeDiscount &&
+            payoff->optionType()==Option::Call) {
             // early exercise never optimal
             results_.value        = black.value();
             results_.delta        = black.delta(spot);

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -2294,6 +2294,27 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyNegativeRates) {
 
     BOOST_CHECK_EXCEPTION(callOption.NPV(), Error,
                           ExpectedErrorMessage("negative interest rates"));
+
+    // With r < q <= 0 early exercise is optimal, so the European shortcut
+    // must not fire. Ju goes through the same critical price.
+    spot->setValue(100.0);
+    qRate->setValue(0.0);
+    rRate->setValue(-0.05);
+    vol->setValue(0.03);
+
+    auto itmCallPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 80.0);
+    auto longExercise = ext::make_shared<AmericanExercise>(today, today + Period(3, Years));
+    VanillaOption itmCall(itmCallPayoff, longExercise);
+
+    itmCall.setPricingEngine(
+        ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess));
+    BOOST_CHECK_EXCEPTION(itmCall.NPV(), Error,
+                          ExpectedErrorMessage("negative interest rates"));
+
+    itmCall.setPricingEngine(
+        ext::make_shared<JuQuadraticApproximationEngine>(stochProcess));
+    BOOST_CHECK_EXCEPTION(itmCall.NPV(), Error,
+                          ExpectedErrorMessage("negative interest rates"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### The defect

`BaroneAdesiWhaleyApproximationEngine` and `JuQuadraticApproximationEngine` return the European
value for any call whose dividend yield is not positive:

```cpp
if (dividendDiscount>=1.0 && payoff->optionType()==Option::Call) {
    // early exercise never optimal
```

That is half of the condition. Early exercise of a call is never optimal when the underlying pays no
dividend *and* the rate is non-negative. With `r < q <= 0` the discounted strike grows with
maturity, so exercising early is optimal, and both engines return a price below intrinsic.

S=100, K=80, r=-0.05, q=0, vol=0.03, T=3y, evaluation date 15 August 2026, Actual/360, intrinsic 20:

```
  BaroneAdesiWhaley              7.050879903   below intrinsic
  JuQuadratic                    7.050879903   below intrinsic
  BjerksundStensland            20.000000000
  QdPlusAmerican                20.000079592
  QdFpAmerican                  20.000002715
  FdBlackScholes 800            20.000000000
  Binomial CRR 2001             20.000000000

  European analytic              7.050879903
```

Equal to the European price to every digit, which pins the code path.

It is not one corner. Over a 9800-point grid of 7 strikes, 7 rates including 4 negative, 4 dividend
yields, 5 vols, 5 maturities and both types, BAW came back below intrinsic 153 times, every one a
call at a non-positive rate. Bjerksund-Stensland: 0.

### The change

`BjerksundStenslandApproximationEngine` already carries the right condition at
`bjerksundstenslandengine.cpp:470`, so this uses the same one:

```cpp
if (dividendDiscount>=1.0 && dividendDiscount>=riskFreeDiscount &&
    payoff->optionType()==Option::Call) {
```

Behaviour changes only for `r < q <= 0`. Anything with `r >= 0` keeps its old path, since `q <= 0`
and `r >= 0` already give `dividendDiscount >= 1 >= riskFreeDiscount`.

Those inputs now reach `BaroneAdesiWhaleyApproximationEngine::criticalPrice`, which has rejected
negative rates since #1291. Puts and calls with positive dividends went there already; this closes
the path that did not.

### Test

Extends `testBaroneAdesiWhaleyNegativeRates`, added for #1291, which already covers a put and a call
with dividends. Ju is checked alongside because `juquadraticengine.cpp:105` calls the same
`criticalPrice`, so it raises the same error.

Reverting the two engines and keeping the test gives two failures, `americanoption.cpp:2315` and
`:2320`, both `exception Error expected but not raised`.

### Validation

Complete suite 1440 test cases, no errors, 2 m 58 s, Release and C++20. On the 9800-point grid BAW
goes from 153 below intrinsic to 0, worst miss 40.00 to 0. Ju's negative-rate cases close with it,
153 to 0; its remaining 9 are at positive rates and are the approximation's own accuracy. Ju's 1097
`NaN` results, all at exactly `r = 0`, are a separate defect this does not touch.
