### PR TITLE
Fix binomial trees silently returning zero or NaN prices

### DIFF
--- a/ql/experimental/lattices/extendedbinomialtree.cpp
+++ b/ql/experimental/lattices/extendedbinomialtree.cpp
@@ -69,9 +69,12 @@ namespace QuantLib {
     : ExtendedEqualProbabilitiesBinomialTree<ExtendedAdditiveEQPBinomialTree>(
                                                         process, end, steps) {
 
-          up_ = - 0.5 * this->driftStep(0.0) + 0.5 *
-            std::sqrt(4.0*process->variance(0.0, x0_, dt_)-
-                      3.0*this->driftStep(0.0)*this->driftStep(0.0));
+        Real radicand = 4.0*process->variance(0.0, x0_, dt_)-
+                        3.0*this->driftStep(0.0)*this->driftStep(0.0);
+        QL_REQUIRE(radicand >= 0.0,
+                   "drift per step too large for the additive EQP tree: "
+                   "more steps are needed");
+        up_ = - 0.5 * this->driftStep(0.0) + 0.5 * std::sqrt(radicand);
     }
 
     Real ExtendedAdditiveEQPBinomialTree::upStep(Time stepTime) const {
@@ -173,6 +176,7 @@ namespace QuantLib {
             std::sqrt(variance);
 
         pu_ = PeizerPrattMethod2Inversion(d2, oddSteps_);
+        QL_REQUIRE(pu_ > 0.0 && pu_ < 1.0, "invalid up probability: " << pu_);
         pd_ = 1.0 - pu_;
         Real pdash = PeizerPrattMethod2Inversion(d2+std::sqrt(variance),
                                                  oddSteps_);
@@ -247,6 +251,7 @@ namespace QuantLib {
             std::sqrt(variance);
 
         pu_ = computeUpProb((oddSteps_-1.0)/2.0,d2 );
+        QL_REQUIRE(pu_ > 0.0 && pu_ < 1.0, "invalid up probability: " << pu_);
         pd_ = 1.0 - pu_;
         Real pdash = computeUpProb((oddSteps_-1.0)/2.0,d2+std::sqrt(variance));
         up_ = ermqdt * pdash / pu_;

--- a/ql/math/distributions/binomialdistribution.hpp
+++ b/ql/math/distributions/binomialdistribution.hpp
@@ -141,8 +141,12 @@ namespace QuantLib {
         Real result = (z/(n+1.0/3.0+0.1/(n+1.0)));
         result *= result;
         result = std::exp(-result*(n+1.0/6.0));
-        result = 0.5 + (z>0 ? 1 : -1) * std::sqrt((0.25 * (1.0-result)));
-        return result;
+        Real root = std::sqrt(1.0-result);
+        // 0.5*(1.0-root) rewritten to keep its digits as root nears 1
+        if (z > 0.0)
+            return 0.5*(1.0+root);
+        else
+            return 0.5*result/(1.0+root);
     }
 
 }

--- a/ql/methods/lattices/binomialtree.cpp
+++ b/ql/methods/lattices/binomialtree.cpp
@@ -53,9 +53,12 @@ namespace QuantLib {
                         Time end, Size steps, Real)
     : EqualProbabilitiesBinomialTree<AdditiveEQPBinomialTree>(process,
                                                               end, steps) {
-        up_ = - 0.5 * driftPerStep_ + 0.5 *
-            std::sqrt(4.0*process->variance(0.0, x0_, dt_)-
-                      3.0*driftPerStep_*driftPerStep_);
+        Real radicand = 4.0*process->variance(0.0, x0_, dt_)-
+                        3.0*driftPerStep_*driftPerStep_;
+        QL_REQUIRE(radicand >= 0.0,
+                   "drift per step too large for the additive EQP tree: "
+                   "more steps are needed");
+        up_ = - 0.5 * driftPerStep_ + 0.5 * std::sqrt(radicand);
     }
 
 
@@ -109,6 +112,7 @@ namespace QuantLib {
         Real d2 = (std::log(x0_/strike) + driftPerStep_*oddSteps ) /
                                                           std::sqrt(variance);
         pu_ = PeizerPrattMethod2Inversion(d2, oddSteps);
+        QL_REQUIRE(pu_ > 0.0 && pu_ < 1.0, "invalid up probability: " << pu_);
         pd_ = 1.0 - pu_;
         Real pdash = PeizerPrattMethod2Inversion(d2+std::sqrt(variance),
                                                  oddSteps);
@@ -150,6 +154,7 @@ namespace QuantLib {
         Real d2 = (std::log(x0_/strike) + driftPerStep_*oddSteps ) /
                                                           std::sqrt(variance);
         pu_ = computeUpProb((oddSteps-1.0)/2.0,d2 );
+        QL_REQUIRE(pu_ > 0.0 && pu_ < 1.0, "invalid up probability: " << pu_);
         pd_ = 1.0 - pu_;
         Real pdash = computeUpProb((oddSteps-1.0)/2.0,d2+std::sqrt(variance));
         up_ = ermqdt * pdash / pu_;

--- a/test-suite/europeanoption.cpp
+++ b/test-suite/europeanoption.cpp
@@ -1238,6 +1238,109 @@ BOOST_AUTO_TEST_CASE(testJOSHIBinomialEngines) {
     testEngineConsistency(engine,steps,samples,relativeTol,true);
 }
 
+BOOST_AUTO_TEST_CASE(testFarOutOfTheMoneyBinomialEngines) {
+
+    BOOST_TEST_MESSAGE("Testing binomial European engines "
+                       "far out of the money...");
+
+    DayCounter dc = Actual365Fixed();
+    Date today = Date(15, August, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    auto spot = ext::make_shared<SimpleQuote>(100.0);
+    auto qRate = ext::make_shared<SimpleQuote>(0.01);
+    auto rRate = ext::make_shared<SimpleQuote>(0.03);
+    auto vol = ext::make_shared<SimpleQuote>(0.15);
+
+    auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot),
+        Handle<YieldTermStructure>(flatRate(today, qRate, dc)),
+        Handle<YieldTermStructure>(flatRate(today, rRate, dc)),
+        Handle<BlackVolTermStructure>(flatVol(today, vol, dc)));
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Put, 500.0);
+    auto exercise = ext::make_shared<EuropeanExercise>(today + Period(1, Days));
+    EuropeanOption option(payoff, exercise);
+
+    Size steps = 801;
+
+    option.setPricingEngine(
+        ext::make_shared<AnalyticEuropeanEngine>(stochProcess));
+    Real expected = option.NPV();
+
+    option.setPricingEngine(
+        ext::make_shared<BinomialVanillaEngine<LeisenReimer> >(stochProcess, steps));
+    Real calculated = option.NPV();
+    Real tolerance = 1.0e-6;
+    if (std::fabs(calculated - expected) > tolerance*expected)
+        REPORT_FAILURE("value", payoff, exercise, spot->value(), qRate->value(),
+                       rRate->value(), today, vol->value(), expected, calculated,
+                       std::fabs(calculated-expected), tolerance);
+
+    // the Joshi up probability is an asymptotic series, and diverges this
+    // far from the money
+    option.setPricingEngine(
+        ext::make_shared<BinomialVanillaEngine<Joshi4> >(stochProcess, steps));
+    BOOST_CHECK_EXCEPTION(option.NPV(), Error,
+                          ExpectedErrorMessage("invalid up probability"));
+
+    // the other direction rounds the Leisen-Reimer up probability to one,
+    // leaving the tree without a down step
+    auto deepPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 20.0);
+    EuropeanOption deepOption(deepPayoff, exercise);
+    deepOption.setPricingEngine(
+        ext::make_shared<BinomialVanillaEngine<LeisenReimer> >(stochProcess, steps));
+    BOOST_CHECK_EXCEPTION(deepOption.NPV(), Error,
+                          ExpectedErrorMessage("invalid up probability"));
+}
+
+BOOST_AUTO_TEST_CASE(testLargeDriftBinomialEngines) {
+
+    BOOST_TEST_MESSAGE("Testing binomial European engines "
+                       "with a large drift per step...");
+
+    DayCounter dc = Actual365Fixed();
+    Date today = Date(15, August, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    auto spot = ext::make_shared<SimpleQuote>(100.0);
+    auto qRate = ext::make_shared<SimpleQuote>(0.0);
+    auto rRate = ext::make_shared<SimpleQuote>(0.10);
+    auto vol = ext::make_shared<SimpleQuote>(0.02);
+
+    auto stochProcess = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot),
+        Handle<YieldTermStructure>(flatRate(today, qRate, dc)),
+        Handle<YieldTermStructure>(flatRate(today, rRate, dc)),
+        Handle<BlackVolTermStructure>(flatVol(today, vol, dc)));
+
+    auto payoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 100.0);
+    auto exercise = ext::make_shared<EuropeanExercise>(today + Period(1, Years));
+    EuropeanOption option(payoff, exercise);
+
+    option.setPricingEngine(
+        ext::make_shared<AnalyticEuropeanEngine>(stochProcess));
+    Real expected = option.NPV();
+
+    // at ten steps 4*variance is below 3*drift^2, so the equal-probability
+    // up step has no real solution
+    option.setPricingEngine(
+        ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree> >(
+            stochProcess, 10));
+    BOOST_CHECK_EXCEPTION(option.NPV(), Error,
+                          ExpectedErrorMessage("more steps are needed"));
+
+    option.setPricingEngine(
+        ext::make_shared<BinomialVanillaEngine<AdditiveEQPBinomialTree> >(
+            stochProcess, 501));
+    Real calculated = option.NPV();
+    Real tolerance = 0.02;
+    if (std::fabs(calculated - expected) > tolerance*expected)
+        REPORT_FAILURE("value", payoff, exercise, spot->value(), qRate->value(),
+                       rRate->value(), today, vol->value(), expected, calculated,
+                       std::fabs(calculated-expected), tolerance);
+}
+
 BOOST_AUTO_TEST_CASE(testFdEngines) {
 
     BOOST_TEST_MESSAGE("Testing finite-difference European engines "


### PR DESCRIPTION
### The defect

Three of the seven trees in `ql/methods/lattices/binomialtree.cpp` check their branch probabilities:

```cpp
QL_REQUIRE(pu_<=1.0, "negative probability");
QL_REQUIRE(pu_>=0.0, "negative probability");
```

Four do not, and two of those four divide by the number they skipped, four lines on:

```cpp
pu_ = PeizerPrattMethod2Inversion(d2, oddSteps);   // line 111, unchecked
pd_ = 1.0 - pu_;
Real pdash = PeizerPrattMethod2Inversion(d2+std::sqrt(variance), oddSteps);
up_ = ermqdt * pdash / pu_;                        // line 115
```

`Joshi4` has the same shape at 152 and 155.

**LeisenReimer.** `PeizerPrattMethod2Inversion` computes `0.5 - sqrt(0.25*(1-exp(-x)))`. Once
`exp(-x)` falls below machine epsilon, `1-exp(-x)` rounds to 1 and the expression cancels to exactly
0, so `up_` is `0.0/0.0`. At the other end `pu_` rounds to 1 and `down_` goes the same way, leaving
the grid `NaN` except the top node. The NPV still looks plausible, because
`DiscretizedVanillaOption::applySpecificCondition` calls `std::max(0.0, NaN)` and quietly erases the
`NaN` payoffs. Delta and gamma come back `NaN`.

**Joshi4.** `computeUpProb` is a truncated asymptotic series dominated by its `alpha^7` term for
large `|d2|`, with nothing holding it inside [0,1].

Neither is reachable from the tests.

`europeanoption.cpp` fixes moneyness to 0.75-1.25, vol to 0.11 and above, and maturity to one year,
so the region where these trees degenerate sits outside every parameter it sweeps.

### The change

Check the radicand and the up probability, the way `CoxRossRubinstein`, `Trigeorgis` and `Tian`
already check theirs.

The new checks are strict and the three existing ones are not. That is deliberate: `pu_` of exactly
0 or exactly 1 is what breaks Leisen-Reimer, both pass a non-strict bound, and the next lines divide
by `pu_` and by `1.0 - pu_`.

For Leisen-Reimer a check alone would be a poor answer, since the inputs are ordinary and the tree
can price them. The cancellation goes instead:

```cpp
Real root = std::sqrt(1.0-result);
if (z > 0.0)
    return 0.5*(1.0+root);
else
    return 0.5*result/(1.0+root);
```

`0.5*(1-root)` is `0.5*(1-root^2)/(1+root)`, and `1-root^2` is `result`. Same quantity, digits kept.
The `z > 0` branch is unchanged. `PeizerPrattMethod2Inversion(-96.839, 201)` goes from `0` to
`1.534713e-21`, while `(0, 201)`, `(1, 201)` and `(-1, 201)` are identical before and after.

The three matching trees in `ql/experimental/lattices/extendedbinomialtree.cpp` get the same checks.

### Effect

3360 points: moneyness 0.2 to 5.0, 4 rates, 2 dividend yields, vol 0.01 to 0.50, one day to ten
years, both types, 801 steps, European exercise against the analytic price.

```
tree                      ok wrong>1%  nan or inf  NaN Greeks   threw
--- before
JarrowRudd              3139      221           0           0       0
CoxRossRubinstein       3095      265           0           0       0
AdditiveEQP             2730      630           0           0       0
Trigeorgis              3098      262           0           0       0
Tian                    3131      229           0           0       0
LeisenReimer            3052        0           0         308       0
Joshi4                  3068       16         258          18       0
--- after
LeisenReimer            3168        0           0          16     176
Joshi4                  2815        7           0           0     538
```

The five trees not listed after are identical row for row, including `AdditiveEQP`, whose radicand
never goes negative on this grid, so its check rests on the argument rather than the table. The
`wrong>1%` column is ordinary convergence error at 801 steps and does not move.

One number here looks bad and should not be buried.

Joshi4 loses 253 cases that priced within 1% of analytic. Read straight off the unfixed tree, its
`pu_` is either a real probability or outside [0,1] by more than 0.1, with nothing in between and a
worst of `6.68e11`, so those prices came off a lattice built from a probability of several hundred
billion and were right by cancellation rather than by construction.

### Tests

Two cases in `test-suite/europeanoption.cpp`, where the tests for these trees already live.
Reverting the three sources and keeping the tests gives four failures, at `europeanoption.cpp:1278`,
`:1285`, `:1294` and `:1331`.

Complete suite 1442 test cases, no errors, 3 m 1 s, Release and C++20; master is 1440.

Sixteen Leisen-Reimer cases still return `NaN` Greeks, with a valid `pu_` but `up_` and `down_`
rounding to the same double, so `BinomialVanillaEngine::calculate` divides by `s2u - s2m == 0`. That
is the engine's Greek calculation, not the tree, and it is left alone.
