### PR TITLE
Remove misleading comment

### DIFF
--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -122,7 +122,7 @@ namespace QuantLib {
 
     Real cumOptVal = 0., 
         cumPutVal = 0.;
-    // Vanilla swap so 0 leg is floater
+    // Vanilla swap, so leg 0 is fixed
 
     auto nextFD = 
       arguments_.fixedPayDates.begin();

--- a/ql/pricingengines/swap/cvaswapengine.cpp
+++ b/ql/pricingengines/swap/cvaswapengine.cpp
@@ -122,8 +122,6 @@ namespace QuantLib {
 
     Real cumOptVal = 0., 
         cumPutVal = 0.;
-    // Vanilla swap, so leg 0 is fixed
-
     auto nextFD = 
       arguments_.fixedPayDates.begin();
     Date swapletStart = priceDate;


### PR DESCRIPTION
## Summary

Remove the inaccurate and misplaced leg-order comment in `CounterpartyAdjSwapEngine::calculate()`.

## Why

`FixedVsFloatingSwap` stores the fixed leg at index 0 and the floating leg at index 1, so the original comment stating that leg 0 was floating was incorrect. The first actual access already casts `arguments_.legs[0]` to `FixedRateCoupon` and validates it with a clear error message, making a separate comment redundant.

## Impact

Documentation-only cleanup; there is no runtime behavior change.

## Validation

- Verified the `FixedVsFloatingSwap` leg accessors and constructor ordering.
- Confirmed the final branch diff removes only the inaccurate comment.
- Ran `git diff --check` locally.
