### PR TITLE
Document the meaning of seed = 0 in `SobolRsg`, `HaltonRsg` and `RandomSequenceGenerator`

### DIFF
--- a/ql/math/randomnumbers/haltonrsg.hpp
+++ b/ql/math/randomnumbers/haltonrsg.hpp
@@ -43,6 +43,9 @@ namespace QuantLib {
     class HaltonRsg {
       public:
         typedef Sample<std::vector<Real> > sample_type;
+        /*! if the given seed is 0, a random seed will be chosen
+            based on clock(); the seed is only used when randomStart or
+            randomShift is true */
         explicit HaltonRsg(Size dimensionality,
                            unsigned long seed = 0,
                            bool randomStart = true,

--- a/ql/math/randomnumbers/randomsequencegenerator.hpp
+++ b/ql/math/randomnumbers/randomsequencegenerator.hpp
@@ -59,6 +59,8 @@ namespace QuantLib {
                      "dimensionality must be greater than 0");
         }
 
+        /*! if the given seed is 0, a random seed will be chosen
+            based on clock() */
         explicit RandomSequenceGenerator(Size dimensionality,
                                          BigNatural seed = 0)
         : dimensionality_(dimensionality), rng_(seed),

--- a/ql/math/randomnumbers/sobolrsg.hpp
+++ b/ql/math/randomnumbers/sobolrsg.hpp
@@ -121,6 +121,10 @@ namespace QuantLib {
             underlying SobolRsg not using the Gray code on the other hand due to its specific way of constructing the
             integer sequence.
 
+            If the given seed is 0, a random seed will be chosen based on clock(). The seed
+            only affects the direction integers beyond those tabulated for the chosen
+            DirectionIntegers, so lower dimensionalities give the same sequence for any seed.
+
             \pre dimensionality must be <= PPMT_MAX_DIM
          */
         explicit SobolRsg(Size dimensionality,


### PR DESCRIPTION
Follows up on #2732: adds the missing seed-0 documentation. Comments only, no behaviour change.

`SobolRsg`, `HaltonRsg` and `RandomSequenceGenerator` all default `seed = 0` and forward it to the RNG without documenting it, while the uniform RNGs carry a note. This adds the same note to all three, with the qualifiers that make it true: `SobolRsg` only uses the seed past the tabulated direction integers, `HaltonRsg` only when `randomStart` or `randomShift` is true, `RandomSequenceGenerator` always. I checked each case by comparing draws from two generators seeded differently.

`sobolbrownianbridgersg.hpp` has the same gap, left alone because #2691 is open on that file.
