### PR TITLE
Fix NaN from `JuQuadraticApproximationEngine` at zero risk-free rate

### DIFF
--- a/ql/pricingengines/vanilla/juquadraticengine.cpp
+++ b/ql/pricingengines/vanilla/juquadraticengine.cpp
@@ -69,16 +69,20 @@ namespace QuantLib {
         BlackCalculator black(payoff, forwardPrice,
                               std::sqrt(variance), riskFreeDiscount);
 
-        // Besides the well-known case of a call on a non-dividend-paying
-        // stock, early exercise is never optimal for a put when the
-        // risk-free rate is null or negative and the dividend yield is not
-        // negative: exercising yields K-S, while just holding the option is
-        // worth at least K*riskFreeDiscount - S*dividendDiscount >= K-S.
-        // The critical price would be 0 in that case and the approximation
-        // below would break down.
+        // For a call, exercising yields S-K while holding is worth at least
+        // S*dividendDiscount - K*riskFreeDiscount, so early exercise is never
+        // optimal when dividendDiscount >= 1 and dividendDiscount >=
+        // riskFreeDiscount.  The mirror image holds for a put: exercising
+        // yields K-S and holding is worth at least K*riskFreeDiscount -
+        // S*dividendDiscount, so early exercise is never optimal when
+        // riskFreeDiscount >= 1 and riskFreeDiscount >= dividendDiscount.
+        // The put case also has to be caught here because the critical price
+        // is 0 when the risk-free rate is null, which would make hA vanish
+        // and break down the approximation below.
         bool earlyExerciseNeverOptimal =
-            (dividendDiscount >= 1.0 && payoff->optionType() == Option::Call)
-            || (riskFreeDiscount >= 1.0 && dividendDiscount <= 1.0
+            (dividendDiscount >= 1.0 && dividendDiscount >= riskFreeDiscount
+             && payoff->optionType() == Option::Call)
+            || (riskFreeDiscount >= 1.0 && riskFreeDiscount >= dividendDiscount
                 && payoff->optionType() == Option::Put);
 
         if (earlyExerciseNeverOptimal) {

--- a/ql/pricingengines/vanilla/juquadraticengine.cpp
+++ b/ql/pricingengines/vanilla/juquadraticengine.cpp
@@ -20,6 +20,7 @@
 */
 
 #include <ql/exercise.hpp>
+#include <ql/math/comparison.hpp>
 #include <ql/math/distributions/normaldistribution.hpp>
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/blackformula.hpp>
@@ -68,8 +69,19 @@ namespace QuantLib {
         BlackCalculator black(payoff, forwardPrice,
                               std::sqrt(variance), riskFreeDiscount);
 
-        if (dividendDiscount>=1.0 && payoff->optionType()==Option::Call) {
-            // early exercise never optimal
+        // Besides the well-known case of a call on a non-dividend-paying
+        // stock, early exercise is never optimal for a put when the
+        // risk-free rate is null or negative and the dividend yield is not
+        // negative: exercising yields K-S, while just holding the option is
+        // worth at least K*riskFreeDiscount - S*dividendDiscount >= K-S.
+        // The critical price would be 0 in that case and the approximation
+        // below would break down.
+        bool earlyExerciseNeverOptimal =
+            (dividendDiscount >= 1.0 && payoff->optionType() == Option::Call)
+            || (riskFreeDiscount >= 1.0 && dividendDiscount <= 1.0
+                && payoff->optionType() == Option::Put);
+
+        if (earlyExerciseNeverOptimal) {
             results_.value        = black.value();
             results_.delta        = black.delta(spot);
             results_.deltaForward = black.deltaForward();
@@ -123,10 +135,24 @@ namespace QuantLib {
                 default:
                   QL_FAIL("unknown option type");
             }
-            //it can throw: to be fixed
-            Real temp_root = std::sqrt ((beta-1)*(beta-1) + (4*alpha)/h);
+            // When the risk-free rate goes to 0, both alpha and h go to 0
+            // as well; their ratio, though, tends to the finite limit
+            // 2/variance (the same limit already used inside
+            // BaroneAdesiWhaleyApproximationEngine::criticalPrice above).
+            // The formulas below are therefore written in terms of
+            // alpha/h, alpha*lambda_prime and alpha*V_E_h so that no
+            // intermediate quantity diverges in that case.
+            Real alphaOverH = (!close(riskFreeDiscount, 1.0, 1000))
+                              ? Real(alpha/h)
+                              : Real(2.0/variance);
+
+            Real temp_root = std::sqrt ((beta-1)*(beta-1) + 4*alphaOverH);
             Real lambda = (-(beta-1) + phi * temp_root) / 2;
-            Real lambda_prime = - phi * alpha / (h*h * temp_root);
+            // lambda_prime = -phi*alpha/(h*h*temp_root) diverges when the
+            // risk-free rate goes to 0, but it only ever enters the formulas
+            // below multiplied by alpha, and that product doesn't.
+            Real alpha_lambda_prime =
+                - phi * alphaOverH * alphaOverH / temp_root;
 
             Real black_Sk = blackFormula(payoff->optionType(), payoff->strike(),
                                          forwardSk, std::sqrt(variance)) * riskFreeDiscount;
@@ -135,16 +161,20 @@ namespace QuantLib {
             Real d1_Sk = (std::log(forwardSk/payoff->strike()) + 0.5*variance)
                 /std::sqrt(variance);
             Real d2_Sk = d1_Sk - std::sqrt(variance);
-            Real part1 = forwardSk * normalDist(d1_Sk) /
-                                        (alpha * std::sqrt(variance));
-            Real part2 = - phi * forwardSk * cumNormalDist(phi * d1_Sk) *
-                      std::log(dividendDiscount) / std::log(riskFreeDiscount);
-            Real part3 = + phi * payoff->strike() * cumNormalDist(phi * d2_Sk);
-            Real V_E_h = part1 + part2 + part3;
+            // the three terms below are alpha times the corresponding
+            // terms of V_E_h; in part2, alpha/std::log(riskFreeDiscount)
+            // simplifies exactly to -2/variance.
+            Real part1 = forwardSk * normalDist(d1_Sk) / std::sqrt(variance);
+            Real part2 = 2.0 * phi * forwardSk * cumNormalDist(phi * d1_Sk) *
+                      std::log(dividendDiscount) / variance;
+            Real part3 = + phi * alpha * payoff->strike() *
+                                        cumNormalDist(phi * d2_Sk);
+            Real alpha_V_E_h = part1 + part2 + part3;
 
-            Real b = (1-h) * alpha * lambda_prime / (2*(2*lambda + beta - 1));
-            Real c = - ((1 - h) * alpha / (2 * lambda + beta - 1)) *
-                (V_E_h / (hA) + 1 / h + lambda_prime / (2*lambda + beta - 1));
+            Real b = (1-h) * alpha_lambda_prime / (2*(2*lambda + beta - 1));
+            Real c = - ((1 - h) / (2 * lambda + beta - 1)) *
+                (alpha_V_E_h / (hA) + alphaOverH +
+                 alpha_lambda_prime / (2*lambda + beta - 1));
             Real temp_spot_ratio = std::log(spot / Sk);
             Real chi = temp_spot_ratio * (b * temp_spot_ratio + c);
 

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -372,6 +372,68 @@ BOOST_AUTO_TEST_CASE(testJuValues) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testJuValuesAtZeroRate) {
+
+    BOOST_TEST_MESSAGE("Testing Ju approximation for American options "
+                       "at zero risk-free rate...");
+
+    // The approximation used to return NaN when the risk-free rate was
+    // exactly 0; see <https://github.com/lballabio/QuantLib/issues/2737>.
+    // The results are compared against those for a negligible but non-null
+    // rate, of which they are the limit.
+
+    const Date today = Date(19, August, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const DayCounter dc = Actual360();
+    const auto spot = ext::make_shared<SimpleQuote>(100.0);
+    const auto qRate = ext::make_shared<SimpleQuote>(0.04);
+    const auto qTS = flatRate(today, qRate, dc);
+    const auto rRate = ext::make_shared<SimpleQuote>(0.0);
+    const auto rTS = flatRate(today, rRate, dc);
+    const auto vol = ext::make_shared<SimpleQuote>(0.30);
+    const auto volTS = flatVol(today, vol, dc);
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(qTS),
+        Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS));
+    const auto engine =
+        ext::make_shared<JuQuadraticApproximationEngine>(process);
+
+    const auto exercise =
+        ext::make_shared<AmericanExercise>(today, today + 1 * Years);
+
+    const Real tolerance = 1.0e-6;
+
+    for (auto type : {Option::Call, Option::Put}) {
+        for (Real q : {0.04, 0.0}) {
+            for (Real s : {70.0, 85.0, 100.0, 115.0, 130.0}) {
+
+                const auto payoff =
+                    ext::make_shared<PlainVanillaPayoff>(type, 100.0);
+                VanillaOption option(payoff, exercise);
+                option.setPricingEngine(engine);
+
+                spot->setValue(s);
+                qRate->setValue(q);
+
+                rRate->setValue(0.0);
+                const Real calculated = option.NPV();
+
+                rRate->setValue(1.0e-10);
+                const Real expected = option.NPV();
+
+                const Real error = std::fabs(calculated - expected);
+                if (!(error <= tolerance)) {
+                    REPORT_FAILURE("value at zero rate", payoff, exercise, s, q,
+                                   0.0, today, vol->value(), expected,
+                                   calculated, error, tolerance);
+                }
+            }
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testFdValues) {
 
     BOOST_TEST_MESSAGE("Testing finite-difference and QR+ engine for American options...");


### PR DESCRIPTION
When the risk-free rate is exactly 0, the discount factor is 1.0 and both alpha and h vanish, so the four quotients that divide by them evaluated to 0/0 and the engine returned NaN.

Their ratio alpha/h has the finite limit 2/variance -- the same limit that BaroneAdesiWhaleyApproximationEngine::criticalPrice already special-cases. Each of the other divergent quantities only ever enters the formulas multiplied by alpha, so the block is rewritten in terms of alpha/h, alpha*lambda_prime and alpha*V_E_h, none of which diverge. In part2, alpha/log(riskFreeDiscount) simplifies exactly to -2/variance. The results are algebraically unchanged for a non-null rate.

Puts hit a second, unrelated failure at a null rate: early exercise is never optimal there, so the critical price is 0, which makes hA vanish and log(forwardSk/strike) undefined. The existing "early exercise never optimal" branch is extended with the symmetric condition for puts.

Fixes #2737.