### PR TITLE
Fix parameter order in `CommodityType` constructor

### DIFF
--- a/ql/experimental/commodities/commoditytype.hpp
+++ b/ql/experimental/commodities/commoditytype.hpp
@@ -43,7 +43,7 @@ namespace QuantLib {
           used.
         */
         CommodityType() = default;
-        CommodityType(const std::string& code, const std::string& name);
+        CommodityType(const std::string& name, const std::string& code);
         //! \name Inspectors
         //@{
         //! commodity code, e.g, "HO"

--- a/test-suite/commodityunitofmeasure.cpp
+++ b/test-suite/commodityunitofmeasure.cpp
@@ -19,6 +19,7 @@
 
 #include "toplevelfixture.hpp"
 #include "utilities.hpp"
+#include <ql/experimental/commodities/commoditytype.hpp>
 #include <ql/experimental/commodities/unitofmeasureconversionmanager.hpp>
 #include <ql/experimental/commodities/petroleumunitsofmeasure.hpp>
 
@@ -28,6 +29,14 @@ using namespace boost::unit_test_framework;
 BOOST_FIXTURE_TEST_SUITE(QuantLibTests, TopLevelFixture)
 
 BOOST_AUTO_TEST_SUITE(CommodityUnitOfMeasureTests)
+
+BOOST_AUTO_TEST_CASE(testCommodityType) {
+
+    CommodityType commodityType("Heating Oil", "HO");
+
+    BOOST_CHECK_EQUAL(commodityType.name(), "Heating Oil");
+    BOOST_CHECK_EQUAL(commodityType.code(), "HO");
+}
 
 BOOST_AUTO_TEST_CASE(testDirect) {
 


### PR DESCRIPTION
## Summary

Align the `CommodityType` declaration with its long-standing name-then-code implementation and the neighboring `UnitOfMeasure` API. Add a focused test that pins the intended accessor values.

Fixes #2740

## Validation

- Built `ql_test_suite`
- Focused commodity type test passed
- Full CTest suite passed

## Backward compatibility note

Rather that preserving the existing interface declared in the `.hpp` file (i.e., `CommodityType(code, name)`) this PR chooses to preserve the existing *behavior*; that is, `CommodityType(X, Y)` keeps returning an object with name X and code Y, same as before.