### PR TITLE
Use HTTPS for external links in example and test-suite READMEs

### DIFF
--- a/Examples/DiscreteHedging/DiscreteHedging.cpp
+++ b/Examples/DiscreteHedging/DiscreteHedging.cpp
@@ -22,7 +22,7 @@
     strategy and compares with the results of Derman & Kamal's (Goldman Sachs
     Equity Derivatives Research) Research Note: "When You Cannot Hedge
     Continuously: The Corrections to Black-Scholes"
-    http://www.ederman.com/emanuelderman/GSQSpapers/when_you_cannot_hedge.pdf
+    https://emanuelderman.com/wp-content/uploads/1998/12/risk-non_continuous_hedge.pdf
 
     Suppose an option hedger sells an European option and receives the
     Black-Scholes value as the options premium.

--- a/Examples/README.txt
+++ b/Examples/README.txt
@@ -60,7 +60,7 @@ It computes profit and loss of a discrete interval hedging strategy and compares
 with the results of Derman & Kamal's (Goldman Sachs Equity Derivatives Research)
 Research Note: "When You Cannot Hedge Continuously: The Corrections to
 Black-Scholes"
-https://www.ederman.com/emanuelderman/GSQSpapers/when_you_cannot_hedge.pdf
+https://emanuelderman.com/wp-content/uploads/1998/12/risk-non_continuous_hedge.pdf
 
 
 EquityOption

--- a/Examples/README.txt
+++ b/Examples/README.txt
@@ -60,7 +60,7 @@ It computes profit and loss of a discrete interval hedging strategy and compares
 with the results of Derman & Kamal's (Goldman Sachs Equity Derivatives Research)
 Research Note: "When You Cannot Hedge Continuously: The Corrections to
 Black-Scholes"
-http://www.ederman.com/emanuelderman/GSQSpapers/when_you_cannot_hedge.pdf
+https://www.ederman.com/emanuelderman/GSQSpapers/when_you_cannot_hedge.pdf
 
 
 EquityOption

--- a/test-suite/README.txt
+++ b/test-suite/README.txt
@@ -1,5 +1,5 @@
 
 The QuantLib test suite is implemented on top of the Boost unit-test
-framework, available from http://www.boost.org. Version 1.30.2 or later
+framework, available from https://www.boost.org. Version 1.30.2 or later
 of Boost is required.
 


### PR DESCRIPTION
Update the Derman/Kamal reference and Boost links to HTTPS in the example
and test-suite README files.

No code or documentation content is changed.

Validation:
- Both HTTPS URLs returned HTTP 200.
- git diff --check