### PR TITLE
Don't enable OpenMP `parallel-for` for small tree steps in `TreeLattice::stepback`

### DIFF
--- a/ql/methods/lattices/lattice.hpp
+++ b/ql/methods/lattices/lattice.hpp
@@ -166,7 +166,11 @@ namespace QuantLib {
     template <class Impl>
     void TreeLattice<Impl>::stepback(Size i, const Array& values,
                                      Array& newValues) const {
-        #pragma omp parallel for
+        // Early tree steps can have very few nodes, where the cost of
+        // spawning an OpenMP thread team outweighs the work being
+        // parallelized. Only parallelize once there's enough work to
+        // amortize that overhead.
+        #pragma omp parallel for if(this->impl().size(i) >= 1024)
         for (long j=0; j<(long)this->impl().size(i); j++) {
             Real value = 0.0;
             for (Size l=0; l<n_; l++) {


### PR DESCRIPTION
`TreeLattice::stepback`'s OpenMP `parallel for` was unconditional, so early tree steps with only a handful of nodes pay the cost of spawning a thread team for negligible work. This adds an `if` clause so it only parallelizes once `size(i)` is large enough to amortize that overhead, using the threshold from #2632.

Rebased onto master and dropped the `CommodityType` commit now that #2742 has landed.

Note #2643 proposes essentially the same change (with an added `num_threads` heuristic and a nested-parallel guard); it's been stalled on a CLA question since June. Happy to defer to that one if you'd rather - this is just the minimal version of the guard.

`lattice.hpp` compiles clean with `-fopenmp -Wall -Wextra`.
