### PR TITLE
Notify observers when an inflation volatility quote changes

### DIFF
--- a/ql/termstructures/volatility/inflation/constantcpivolatility.cpp
+++ b/ql/termstructures/volatility/inflation/constantcpivolatility.cpp
@@ -32,7 +32,9 @@ namespace QuantLib {
                                                   bool indexIsInterpolated)
     : CPIVolatilitySurface(settlementDays, cal, bdc, dc,
                            observationLag, frequency, indexIsInterpolated),
-      volatility_(vol) {}
+      volatility_(vol) {
+        registerWith(volatility_);
+    }
 
     ConstantCPIVolatility:: ConstantCPIVolatility(Volatility vol,
                                                   Natural settlementDays,

--- a/ql/termstructures/volatility/inflation/yoyinflationoptionletvolatilitystructure.cpp
+++ b/ql/termstructures/volatility/inflation/yoyinflationoptionletvolatilitystructure.cpp
@@ -220,7 +220,9 @@ namespace QuantLib {
                                     indexIsInterpolated,
                                     volType,
                                     displacement),
-      volatility_(std::move(v)), minStrike_(minStrike), maxStrike_(maxStrike) {}
+      volatility_(std::move(v)), minStrike_(minStrike), maxStrike_(maxStrike) {
+        registerWith(volatility_);
+    }
 
     Volatility ConstantYoYOptionletVolatility::volatilityImpl(Time, Rate) const {
         return volatility_->value();

--- a/test-suite/inflationcapfloor.cpp
+++ b/test-suite/inflationcapfloor.cpp
@@ -449,6 +449,49 @@ BOOST_AUTO_TEST_CASE(testParity) {
     vars.hy.reset();
 }
 
+BOOST_AUTO_TEST_CASE(testVolatilityQuoteObservability) {
+
+    BOOST_TEST_MESSAGE("Testing yoy inflation cap repricing when its volatility quote moves...");
+
+    CommonVars vars;
+
+    auto quote = ext::make_shared<SimpleQuote>(0.01);
+    Handle<YoYOptionletVolatilitySurface> volatility(
+        ext::make_shared<ConstantYoYOptionletVolatility>(Handle<Quote>(quote),
+                                                         vars.settlementDays,
+                                                         vars.calendar,
+                                                         vars.convention,
+                                                         vars.dc,
+                                                         vars.observationLag,
+                                                         vars.frequency,
+                                                         false));
+
+    Leg leg = vars.makeYoYLeg(vars.evaluationDate, 2);
+    auto cap = ext::make_shared<YoYInflationCap>(leg, std::vector<Rate>(1, 0.0295));
+    cap->setPricingEngine(ext::make_shared<YoYInflationBlackCapFloorEngine>(
+        vars.iir, volatility, vars.nominalTS));
+
+    Real quoted = cap->NPV();
+    quote->setValue(0.02);
+    Real moved = cap->NPV();
+
+    BOOST_CHECK_MESSAGE(moved != quoted,
+                        "yoy cap NPV did not move when its volatility quote did: "
+                        << quoted << " at vol 0.01 and " << moved << " at vol 0.02");
+
+    Leg other = vars.makeYoYLeg(vars.evaluationDate, 2);
+    auto fixed = ext::make_shared<YoYInflationCap>(other, std::vector<Rate>(1, 0.0295));
+    fixed->setPricingEngine(vars.makeEngine(0.02, 0));
+
+    Real expected = fixed->NPV();
+    BOOST_CHECK_MESSAGE(relativeError(moved, expected, expected) < 1.0e-10,
+                        "yoy cap priced off a quote of 0.02 gives " << moved
+                        << ", off a value of 0.02 gives " << expected);
+
+    // remove circular refernce
+    vars.hy.reset();
+}
+
 BOOST_AUTO_TEST_CASE(testCachedValue) {
 
     BOOST_TEST_MESSAGE("Testing Black yoy inflation cap/floor price"

--- a/test-suite/inflationvolatility.cpp
+++ b/test-suite/inflationvolatility.cpp
@@ -29,6 +29,9 @@
 #include <ql/pricingengines/inflation/inflationcapfloorengines.hpp>
 #include <ql/experimental/inflation/yoyoptionletstripper.hpp>
 #include <ql/experimental/inflation/kinterpolatedyoyoptionletvolatilitysurface.hpp>
+#include <ql/quotes/simplequote.hpp>
+#include <ql/termstructures/volatility/inflation/constantcpivolatility.hpp>
+#include <ql/termstructures/volatility/inflation/yoyinflationoptionletvolatilitystructure.hpp>
 #include <ql/experimental/inflation/interpolatedyoyoptionletstripper.hpp>
 #include <ql/cashflows/capflooredinflationcoupon.hpp>
 #include <ql/indexes/inflation/euhicp.hpp>
@@ -388,6 +391,38 @@ BOOST_AUTO_TEST_CASE(testYoYPriceSurfaceToATM) {
                    <<" at "<<yyATMd.first[i]);
     }
     reset();
+}
+
+BOOST_AUTO_TEST_CASE(testConstantVolatilityQuoteIsObserved) {
+
+    BOOST_TEST_MESSAGE("Testing that constant inflation volatility surfaces observe their quote...");
+
+    auto quote = ext::make_shared<SimpleQuote>(0.01);
+    Handle<Quote> handle(quote);
+
+    auto cpi = ext::make_shared<ConstantCPIVolatility>(
+        handle, 0, TARGET(), Following, Actual365Fixed(),
+        Period(3, Months), Monthly, false);
+    auto yoy = ext::make_shared<ConstantYoYOptionletVolatility>(
+        handle, 0, TARGET(), Following, Actual365Fixed(),
+        Period(3, Months), Monthly, false);
+
+    Flag cpiFlag, yoyFlag;
+    cpiFlag.registerWith(cpi);
+    yoyFlag.registerWith(yoy);
+    cpiFlag.lower();
+    yoyFlag.lower();
+
+    quote->setValue(0.02);
+
+    BOOST_CHECK_MESSAGE(cpiFlag.isUp(),
+                        "ConstantCPIVolatility did not notify when its quote moved");
+    BOOST_CHECK_MESSAGE(yoyFlag.isUp(),
+                        "ConstantYoYOptionletVolatility did not notify when its quote moved");
+
+    // volatilityImpl reads the quote on every call, so these pass either way.
+    BOOST_CHECK_CLOSE(cpi->volatility(1.0, 0.02), 0.02, 1.0e-10);
+    BOOST_CHECK_CLOSE(yoy->volatility(1.0, 0.02), 0.02, 1.0e-10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
ConstantYoYOptionletVolatility and ConstantCPIVolatility take a Handle<Quote> volatility and store it without registering with it, so anything holding a cached price off one of them never sees the quote move. A yoy inflation cap on the existing test fixture prices 219.44 at a vol of 0.01 and 219.44 at 0.02, where a surface built from the value 0.02 gives 479.32.

The fix is registerWith(volatility_) in the Handle-taking constructor of each, which is where BlackConstantVol puts it and not in the scalar ones.

Two tests, since only one of the two classes can be reached through a price. testVolatilityQuoteObservability in inflationcapfloor.cpp moves the quote and checks the cap reprices and matches the value-built surface. testConstantVolatilityQuoteIsObserved in inflationvolatility.cpp checks the notification for both classes with Flag; ConstantCPIVolatility had no coverage in test-suite before this, and nothing prices off a CPIVolatilitySurface, so the notification is all there is to assert. Removing either registerWith fails both tests.

Both classes also offer a Volatility constructor, and every construction in test-suite and Examples uses that one, which is why the Handle path went unnoticed.
