### PR TITLE
Fix lost coupon when a callability falls on a coupon date

### DIFF
--- a/ql/experimental/callablebonds/discretizedcallablefixedratebond.cpp
+++ b/ql/experimental/callablebonds/discretizedcallablefixedratebond.cpp
@@ -97,6 +97,15 @@ namespace QuantLib {
             adjustedCallabilityPrices_[i] *= arguments_.faceAmount / 100.0;
             callabilityTimes_[i] = callabilityTime;
         }
+
+        // not snapped itself, but a snapped neighbour may have moved this coupon ahead
+        for (Size i = 0; i < callabilityTimes_.size(); ++i) {
+            for (Size j = 0; j < couponTimes_.size(); ++j) {
+                if (couponAdjustments_[j] == CouponAdjustment::pre &&
+                    args.callabilityDates[i] == args.couponDates[j])
+                    adjustedCallabilityPrices_[i] += args.couponAmounts[j];
+            }
+        }
     }
 
 

--- a/test-suite/callablebonds.cpp
+++ b/test-suite/callablebonds.cpp
@@ -670,6 +670,70 @@ BOOST_AUTO_TEST_CASE(testSnappingExerciseDate2ClosestCouponDate) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testUnexercisableCallability) {
+
+    BOOST_TEST_MESSAGE("Testing that an unexercisable callability leaves the price alone...");
+
+    Globals vars;
+
+    vars.today = Date(3, June, 2004);
+    Settings::instance().evaluationDate() = vars.today;
+    vars.settlement = vars.calendar.advance(vars.today, 3, Days);
+
+    vars.termStructure.linkTo(vars.makeFlatCurve(0.032));
+    vars.model.linkTo(ext::make_shared<HullWhite>(vars.termStructure));
+
+    Schedule schedule = MakeSchedule()
+                            .from(vars.issueDate())
+                            .to(vars.maturityDate())
+                            .withCalendar(vars.calendar)
+                            .withFrequency(Semiannual)
+                            .withConvention(vars.rollingConvention)
+                            .withRule(DateGeneration::Backward);
+
+    Size timeSteps = 240;
+
+    auto engine = ext::make_shared<TreeCallableFixedRateBondEngine>(*(vars.model), timeSteps,
+                                                                    vars.termStructure);
+
+    auto price = [&](const CallabilitySchedule& exercises) {
+        CallableFixedRateBond bond(3, 10000.0, schedule, std::vector<Rate>(1, 0.05),
+                                   Thirty360(Thirty360::BondBasis), vars.rollingConvention, 100.0,
+                                   vars.issueDate(), exercises);
+        bond.setPricingEngine(engine);
+        return bond.cleanPrice();
+    };
+
+    Date couponDate = schedule.date(8);
+    Real tolerance = 1e-10;
+
+    for (auto type : {Callability::Call, Callability::Put}) {
+        Real strike = (type == Callability::Call) ? 100.0 : 110.0;
+        Real unreachable = (type == Callability::Call) ? 200.0 : 0.0;
+
+        CallabilitySchedule onCouponDate;
+        onCouponDate.push_back(ext::make_shared<Callability>(
+            Bond::Price(strike, Bond::Price::Clean), type, couponDate));
+
+        Real expected = price(onCouponDate);
+
+        for (Integer days = 1; days <= 7; ++days) {
+            CallabilitySchedule exercises;
+            exercises.push_back(ext::make_shared<Callability>(
+                Bond::Price(unreachable, Bond::Price::Dirty), type, couponDate - days));
+            exercises.push_back(onCouponDate.front());
+
+            Real calculated = price(exercises);
+            if (std::fabs(calculated - expected) > tolerance)
+                BOOST_ERROR("unexercisable "
+                            << ((type == Callability::Call) ? "call" : "put") << " on "
+                            << io::iso_date(couponDate - days) << " changed the price:\n"
+                            << std::setprecision(12) << "    calculated: " << calculated << "\n"
+                            << "    expected:   " << expected);
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testBlackEngine) {
 
     BOOST_TEST_MESSAGE("Testing Black engine for European callable bonds...");


### PR DESCRIPTION
Splits the snapping fix out of the #837 discussion as requested.

`DiscretizedCallableFixedRateBond` snaps a callability in the week before a coupon onto that
coupon's node and moves the coupon ahead of the callabilities. An entry dated on the coupon date
itself is not snapped and carries no accrued, so it caps a value that already includes the coupon:
`min(V + C, P)` where the answer is `min(V, P) + C`. A call three days before a coupon at a dirty
price of 200, which can never be exercised, moves a 10y 5% bond from 105.9228 to 103.8271.

The constructor now adds the coupon to the price of any on-coupon-date callability that was moved
ahead. `min(V + C, P + C)` is `min(V, P) + C`, and the same holds for puts. Snapped entries and the
discount-factor rescaling are untouched.

`testUnexercisableCallability` sweeps an unexercisable entry over the seven days before a coupon.


Fixes all failing tests
