### PR TITLE
Fix null-deref crash in `XabrSwaptionVolatilityCube::fillVolatilityCube()`

### DIFF
--- a/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
+++ b/ql/termstructures/volatility/swaption/sabrswaptionvolatilitycube.hpp
@@ -759,6 +759,11 @@ namespace QuantLib {
 
         const ext::shared_ptr<SwaptionVolatilityDiscrete> atmVolStructure =
             ext::dynamic_pointer_cast<SwaptionVolatilityDiscrete>(*atmVol_);
+        QL_REQUIRE(atmVolStructure,
+                   "isAtmCalibrated requires an ATM volatility structure "
+                   "derived from SwaptionVolatilityDiscrete (e.g. "
+                   "SwaptionVolatilityMatrix), but the provided "
+                   "atmVolStructure is not");
 
         std::vector<Time> atmOptionTimes(atmVolStructure->optionTimes());
         std::vector<Time> optionTimes(volCubeAtmCalibrated_.optionTimes());


### PR DESCRIPTION
`isAtmCalibrated=True` dereferences `dynamic_pointer_cast<SwaptionVolatilityDiscrete>(*atmVol_)` without a null check, segfaulting when `atmVolStructure` isn't `SwaptionVolatilityDiscrete`-derived (e.g. a flat `ConstantSwaptionVolatility`). 
This adds a `QL_REQUIRE` so misuse raises a normal exception instead.