### PR TITLE
Return the European value for an American put when early exercise is never optimal

### DIFF
--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -164,9 +164,15 @@ namespace QuantLib {
         BlackCalculator black(payoff, forwardPrice, std::sqrt(variance),
                               riskFreeDiscount);
 
-        if (dividendDiscount>=1.0 && dividendDiscount>=riskFreeDiscount &&
-            payoff->optionType()==Option::Call) {
-            // early exercise never optimal
+        // early exercise never optimal; the put case must be caught here
+        // because criticalPrice() rejects a risk-free discount factor above 1
+        bool earlyExerciseNeverOptimal =
+            (dividendDiscount >= 1.0 && dividendDiscount >= riskFreeDiscount
+             && payoff->optionType() == Option::Call)
+            || (riskFreeDiscount >= 1.0 && riskFreeDiscount >= dividendDiscount
+                && payoff->optionType() == Option::Put);
+
+        if (earlyExerciseNeverOptimal) {
             results_.value        = black.value();
             results_.delta        = black.delta(spot);
             results_.deltaForward = black.deltaForward();

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -181,6 +181,69 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyValues) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyValuesAtNonPositiveRate) {
+
+    BOOST_TEST_MESSAGE("Testing Barone-Adesi and Whaley approximation for "
+                       "American puts at non-positive risk-free rates...");
+
+    // criticalPrice() rejects a discount factor above 1, so these puts were
+    // refused.  Holding dominates; the value is European.
+
+    const Date today = Date(19, August, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const DayCounter dc = Actual360();
+    const auto spot = ext::make_shared<SimpleQuote>(100.0);
+    const auto qRate = ext::make_shared<SimpleQuote>(0.0);
+    const auto qTS = flatRate(today, qRate, dc);
+    const auto rRate = ext::make_shared<SimpleQuote>(0.0);
+    const auto rTS = flatRate(today, rRate, dc);
+    const auto vol = ext::make_shared<SimpleQuote>(0.30);
+    const auto volTS = flatVol(today, vol, dc);
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(qTS),
+        Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS));
+
+    const Date maturity = today + 1 * Years;
+    const auto american = ext::make_shared<AmericanExercise>(today, maturity);
+    const auto european = ext::make_shared<EuropeanExercise>(maturity);
+
+    const Real tolerance = 1.0e-6;
+
+    for (Real r : {0.0, -1.0e-10, -0.05}) {
+        for (Real q : {0.0, 0.04}) {
+            for (Real s : {70.0, 85.0, 100.0, 115.0, 130.0}) {
+
+                spot->setValue(s);
+                qRate->setValue(q);
+                rRate->setValue(r);
+
+                const auto payoff =
+                    ext::make_shared<PlainVanillaPayoff>(Option::Put, 100.0);
+
+                VanillaOption reference(payoff, european);
+                reference.setPricingEngine(
+                    ext::make_shared<AnalyticEuropeanEngine>(process));
+                const Real expected = reference.NPV();
+
+                VanillaOption option(payoff, american);
+                option.setPricingEngine(
+                    ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(
+                        process));
+                const Real calculated = option.NPV();
+
+                const Real error = std::fabs(calculated - expected);
+                if (!(error <= tolerance)) {
+                    REPORT_FAILURE("value at non-positive rate", payoff,
+                                   american, s, q, r, today, vol->value(),
+                                   expected, calculated, error, tolerance);
+                }
+            }
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testBjerksundStenslandValues) {
 
     BOOST_TEST_MESSAGE("Testing Bjerksund and Stensland approximation for American options...");
@@ -2344,8 +2407,17 @@ BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyNegativeRates) {
     option.setPricingEngine(
         ext::make_shared<BaroneAdesiWhaleyApproximationEngine>(stochProcess));
 
-    BOOST_CHECK_EXCEPTION(option.NPV(), Error,
-                          ExpectedErrorMessage("negative interest rates"));
+    // With r <= 0 and q >= r the put takes the European shortcut, not the
+    // critical price.  Ju agrees.
+    VanillaOption europeanPut(payoff,
+                              ext::make_shared<EuropeanExercise>(exDate));
+    europeanPut.setPricingEngine(
+        ext::make_shared<AnalyticEuropeanEngine>(stochProcess));
+    BOOST_CHECK_SMALL(option.NPV() - europeanPut.NPV(), 1.0e-6);
+
+    option.setPricingEngine(
+        ext::make_shared<JuQuadraticApproximationEngine>(stochProcess));
+    BOOST_CHECK_SMALL(option.NPV() - europeanPut.NPV(), 1.0e-6);
 
     // also verify with a call and positive dividends
     auto callPayoff = ext::make_shared<PlainVanillaPayoff>(Option::Call, 40.0);


### PR DESCRIPTION
`BaroneAdesiWhaleyApproximationEngine` carries only the call half of the early-exercise-never-optimal shortcut, so an American put at a negative risk-free rate falls through to `criticalPrice()`, which rejects a risk-free discount factor above 1 and throws. `JuQuadraticApproximationEngine` got both halves in #2739, so the two engines disagree on the same option. On that thread you wrote *"Agreed, BAW should return the European value too."*

Over r, q and spot, master gives 6 of 18 equal to the European value and 12 throwing; with this it is 18 of 18 and none throwing. At a zero rate, where the engine already worked, the value moves 8.5e-8 onto the exact European figure and eleven Greeks arrive, since the shortcut fills twelve result fields where the approximation fills one.

I did not trust the condition I was copying, because holding is worth at least `K*rfd - S*dd` and that only dominates `K-S` everywhere when `rfd >= 1` and `dd <= 1`. Over the 2760 points where the condition fires, none prices above European by more than 10bp of strike, the largest gap being 1.1bp on a three-year 60% option.

`testBaroneAdesiWhaleyNegativeRates` came from #1291 and demanded a throw for exactly this put, so its first case now asserts the European value for both engines. The other two still throw.

This does not address #2749, which is the low-volatility corner rather than the negative-rate one: with `r = 0.05` and `vol = 0.001` both engines still throw here.
