### PR TITLE
Handle vanishing volatility in the Barone-Adesi-Whaley and Ju American engines

### DIFF
--- a/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
+++ b/ql/pricingengines/vanilla/baroneadesiwhaleyengine.cpp
@@ -24,6 +24,8 @@
 #include <ql/pricingengines/blackcalculator.hpp>
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
+#include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace QuantLib {
@@ -68,6 +70,10 @@ namespace QuantLib {
             h = (bT - 2.0*std::sqrt(variance)) * payoff->strike() /
                 (payoff->strike() - Su);
             Si = Su + (payoff->strike() - Su) * std::exp(h);
+            // for a vanishing variance h diverges and the seed overflows; Su is
+            // its finite limit (the critical price tends to the strike)
+            if (!(Si > 0.0) || !std::isfinite(Si))
+                Si = Su;
             break;
           default:
             QL_FAIL("unknown option type");
@@ -193,6 +199,10 @@ namespace QuantLib {
 
             results_.strikeSensitivity  = black.strikeSensitivity();
             results_.itmCashProbability = black.itmCashProbability();
+        } else if (variance < QL_EPSILON) {
+            // no time value: the critical-price calculation degenerates, and the
+            // American price is just the European one floored at intrinsic
+            results_.value = std::max(black.value(), (*payoff)(spot));
         } else {
             // early exercise can be optimal
             CumulativeNormalDistribution cumNormalDist;

--- a/ql/pricingengines/vanilla/juquadraticengine.cpp
+++ b/ql/pricingengines/vanilla/juquadraticengine.cpp
@@ -26,6 +26,7 @@
 #include <ql/pricingengines/blackformula.hpp>
 #include <ql/pricingengines/vanilla/baroneadesiwhaleyengine.hpp>
 #include <ql/pricingengines/vanilla/juquadraticengine.hpp>
+#include <algorithm>
 #include <utility>
 
 namespace QuantLib {
@@ -112,6 +113,10 @@ namespace QuantLib {
 
             results_.strikeSensitivity  = black.strikeSensitivity();
             results_.itmCashProbability = black.itmCashProbability();
+        } else if (variance < QL_EPSILON) {
+            // no time value: the critical-price calculation degenerates, and the
+            // American price is just the European one floored at intrinsic
+            results_.value = std::max(black.value(), (*payoff)(spot));
         } else {
             // early exercise can be optimal
             CumulativeNormalDistribution cumNormalDist;

--- a/test-suite/americanoption.cpp
+++ b/test-suite/americanoption.cpp
@@ -434,6 +434,76 @@ BOOST_AUTO_TEST_CASE(testJuValuesAtZeroRate) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(testBaroneAdesiWhaleyAndJuAtLowVolatility) {
+
+    BOOST_TEST_MESSAGE("Testing Barone-Adesi-Whaley and Ju approximations "
+                       "at very low volatility...");
+
+    // Both engines used to throw an uncaught error for an American put once
+    // sigma*sqrt(T) dropped below roughly 7e-4, for ordinary positive rates;
+    // see <https://github.com/lballabio/QuantLib/issues/2749>. With no time
+    // value the American price is the European one floored at intrinsic.
+
+    const Date today = Date(15, May, 2026);
+    Settings::instance().evaluationDate() = today;
+
+    const DayCounter dc = Actual365Fixed();
+    const auto spot = ext::make_shared<SimpleQuote>(100.0);
+    const auto qTS = flatRate(today, 0.02, dc);
+    const auto rTS = flatRate(today, 0.05, dc);
+    const auto vol = ext::make_shared<SimpleQuote>(0.20);
+    const auto volTS = flatVol(today, vol, dc);
+
+    const auto process = ext::make_shared<BlackScholesMertonProcess>(
+        Handle<Quote>(spot), Handle<YieldTermStructure>(qTS),
+        Handle<YieldTermStructure>(rTS), Handle<BlackVolTermStructure>(volTS));
+
+    const Date exDate = today + 180 * Days;
+    const auto exercise = ext::make_shared<AmericanExercise>(today, exDate);
+    const auto euExercise = ext::make_shared<EuropeanExercise>(exDate);
+
+    // as the volatility vanishes the early-exercise premium does too, so the
+    // approximation should land between the floor and a small band above it
+    const Real tolerance = 1.0e-6;
+    const Real band = 1.0e-2;
+
+    for (auto type : {Option::Put, Option::Call}) {
+        for (Real s : {80.0, 100.0, 120.0}) {
+            for (Real v : {1.0e-3, 5.0e-4, 0.0}) {
+                spot->setValue(s);
+                vol->setValue(v);
+
+                const auto payoff =
+                    ext::make_shared<PlainVanillaPayoff>(type, 100.0);
+                const Real intrinsic = (*payoff)(s);
+
+                VanillaOption european(payoff, euExercise);
+                european.setPricingEngine(
+                    ext::make_shared<AnalyticEuropeanEngine>(process));
+                const Real floor = std::max(european.NPV(), intrinsic);
+
+                for (const ext::shared_ptr<PricingEngine>& engine :
+                     {ext::shared_ptr<PricingEngine>(
+                          new BaroneAdesiWhaleyApproximationEngine(process)),
+                      ext::shared_ptr<PricingEngine>(
+                          new JuQuadraticApproximationEngine(process))}) {
+
+                    VanillaOption option(payoff, exercise);
+                    option.setPricingEngine(engine);
+
+                    const Real calculated = option.NPV();
+                    if (!(calculated >= floor - tolerance &&
+                          calculated <= floor + band)) {
+                        REPORT_FAILURE("low-volatility value", payoff, exercise,
+                                       s, 0.02, 0.05, today, v, floor,
+                                       calculated, calculated - floor, band);
+                    }
+                }
+            }
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(testFdValues) {
 
     BOOST_TEST_MESSAGE("Testing finite-difference and QR+ engine for American options...");


### PR DESCRIPTION
Fixes #2749.

`BaroneAdesiWhaleyApproximationEngine` and `JuQuadraticApproximationEngine` threw an uncaught error for an American put once `sigma*sqrt(T)` dropped below roughly 7e-4, for ordinary positive rates. `BjerksundStensland` priced the same inputs fine.

In `criticalPrice`, the put seed collapses onto the strike as the variance vanishes, so `h = (bT - 2*sqrt(v)) * K / (K - Su)` diverges and `Si` goes to inf/nan, which then reaches `blackFormula` and throws. Two changes:

- clamp the put seed to its finite limit `Su` when it overflows, so the Newton step still runs for a genuinely small but positive volatility
- in both engines' `calculate()`, when `variance < QL_EPSILON` there is no time value left, so return `max(black.value(), intrinsic)` directly - the vanishing-variance limit, and what `BjerksundStensland` effectively gives

Same family as #2737 (Ju at zero rate) and #1291 (BAW at negative rates).

Repro grid, put at K=100, q=2%, r=5%, T=0.5:

```
        before                  after      (BjerksundStensland)
vol=1e-3 S=80    throws          20.000     20.000
vol=1e-3 S=100   throws          0.0006     0.000
vol=1e-3 S=120   throws          0.000      0.000
vol=5e-4 S=80    throws          20.000     20.000
vol=0    S=80    throws          20.000     nan
vol=0    S=100 C throws          1.454      nan   (= European)
```

Added `testBaroneAdesiWhaleyAndJuAtLowVolatility` in `americanoption.cpp`. The full test-suite doesn't link in my environment (pre-existing `-O3 -std=c++20` failures in `hestonmodel`/`hestonslvmodel` under MinGW), so I built and ran the americanoption cases against `libQuantLib.a` with header-only Boost.Test: the new case passes and the 6 existing BAW/Ju/BS cases (`testBaroneAdesiWhaleyValues`, `testJuValues`, `testBjerksundStenslandValues`, `testJuValuesAtZeroRate`, `testBaroneAdesiWhaleyNegativeRates`, `testCallPutParity`) still pass.
